### PR TITLE
feat: DMI 차트 훅 구현

### DIFF
--- a/src/components/chart/constants.ts
+++ b/src/components/chart/constants.ts
@@ -1,3 +1,4 @@
 export const DEFAULT_LINE_WIDTH = 1;
 export const RSI_PANE_INDEX = 2;
 export const MACD_PANE_INDEX = 3;
+export const DMI_PANE_INDEX = 4;

--- a/src/components/chart/hooks/useDMIChart.ts
+++ b/src/components/chart/hooks/useDMIChart.ts
@@ -1,0 +1,179 @@
+import {
+    useCallback,
+    useEffect,
+    useEffectEvent,
+    useRef,
+    useState,
+} from 'react';
+import type { RefObject } from 'react';
+import { LineSeries } from 'lightweight-charts';
+import type {
+    IChartApi,
+    ISeriesApi,
+    LineWidth,
+    UTCTimestamp,
+} from 'lightweight-charts';
+import { CHART_COLORS } from '@/domain/constants/colors';
+import type { Bar, IndicatorResult } from '@/domain/types';
+import {
+    DEFAULT_LINE_WIDTH,
+    DMI_PANE_INDEX,
+} from '@/components/chart/constants';
+
+interface UseDMIChartParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+}
+
+interface UseDMIChartReturn {
+    isVisible: boolean;
+    toggle: () => void;
+}
+
+export function useDMIChart({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+}: UseDMIChartParams): UseDMIChartReturn {
+    const [isVisible, setIsVisible] = useState(false);
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const diPlusSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+    const diMinusSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+    const adxSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+    const toggle = useCallback(() => {
+        setIsVisible(prev => !prev);
+    }, []);
+
+    // chart 인스턴스 교체 시 ref만 초기화 (removeSeries 불필요 — 이전 chart는 부모가 소멸)
+    const clearSeriesRefs = useEffectEvent(() => {
+        diPlusSeriesRef.current = null;
+        diMinusSeriesRef.current = null;
+        adxSeriesRef.current = null;
+    });
+
+    // isVisible false 시 시리즈 제거 및 ref 초기화
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (diPlusSeriesRef.current) {
+            chart.removeSeries(diPlusSeriesRef.current);
+            diPlusSeriesRef.current = null;
+        }
+        if (diMinusSeriesRef.current) {
+            chart.removeSeries(diMinusSeriesRef.current);
+            diMinusSeriesRef.current = null;
+        }
+        if (adxSeriesRef.current) {
+            chart.removeSeries(adxSeriesRef.current);
+            adxSeriesRef.current = null;
+        }
+    });
+
+    // 시리즈 lifecycle 관리 (생성/제거)
+    // bars, indicators는 의존하지 않음 — 데이터 세팅은 아래 effect가 단독 담당
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (!diPlusSeriesRef.current) {
+            diPlusSeriesRef.current = chart.addSeries(
+                LineSeries,
+                {
+                    color: CHART_COLORS.dmiPlus,
+                    lineWidth,
+                    priceLineVisible: false,
+                    lastValueVisible: false,
+                },
+                DMI_PANE_INDEX
+            );
+        }
+
+        if (!diMinusSeriesRef.current) {
+            diMinusSeriesRef.current = chart.addSeries(
+                LineSeries,
+                {
+                    color: CHART_COLORS.dmiMinus,
+                    lineWidth,
+                    priceLineVisible: false,
+                    lastValueVisible: false,
+                },
+                DMI_PANE_INDEX
+            );
+        }
+
+        if (!adxSeriesRef.current) {
+            adxSeriesRef.current = chart.addSeries(
+                LineSeries,
+                {
+                    color: CHART_COLORS.dmiAdx,
+                    lineWidth,
+                    priceLineVisible: false,
+                    lastValueVisible: false,
+                },
+                DMI_PANE_INDEX
+            );
+        }
+
+        diPlusSeriesRef.current.applyOptions({ lineWidth });
+        diMinusSeriesRef.current.applyOptions({ lineWidth });
+        adxSeriesRef.current.applyOptions({ lineWidth });
+    }, [chartRef, isVisible, lineWidth]);
+
+    // 데이터 동기화: 시리즈가 보이는 동안 bars/indicators 변경 시 업데이트
+    // isVisible이 true로 바뀔 때도 실행되어 새로 생성된 시리즈에 초기 데이터를 세팅함
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { dmi } = indicators;
+        if (!dmi.length) return;
+
+        if (
+            !diPlusSeriesRef.current ||
+            !diMinusSeriesRef.current ||
+            !adxSeriesRef.current
+        )
+            return;
+
+        const count = Math.min(bars.length, dmi.length);
+
+        const diPlusData = bars.slice(0, count).map((bar, i) => {
+            const value = dmi[i]?.diPlus;
+            return value !== null && value !== undefined
+                ? { time: bar.time as UTCTimestamp, value }
+                : { time: bar.time as UTCTimestamp };
+        });
+
+        const diMinusData = bars.slice(0, count).map((bar, i) => {
+            const value = dmi[i]?.diMinus;
+            return value !== null && value !== undefined
+                ? { time: bar.time as UTCTimestamp, value }
+                : { time: bar.time as UTCTimestamp };
+        });
+
+        const adxData = bars.slice(0, count).map((bar, i) => {
+            const value = dmi[i]?.adx;
+            return value !== null && value !== undefined
+                ? { time: bar.time as UTCTimestamp, value }
+                : { time: bar.time as UTCTimestamp };
+        });
+
+        diPlusSeriesRef.current.setData(diPlusData);
+        diMinusSeriesRef.current.setData(diMinusData);
+        adxSeriesRef.current.setData(adxData);
+    }, [indicators, bars, isVisible]);
+
+    return { isVisible, toggle };
+}


### PR DESCRIPTION
## 관련 이슈

closes #29

## 구현 내용

DMI(Directional Movement Index) 인디케이터를 차트에 표시하기 위한 React 훅을 구현했습니다.

### 주요 기능

- `useDMIChart` 훅: DI+, DI-, ADX 세 개의 라인 시리즈를 관리
- `isVisible` 상태로 DMI 표시/숨김 제어
- `toggle` 함수로 토글 기능 제공
- 기존 MACD, RSI 훅과 동일한 패턴 적용 (React 19의 `useEffectEvent` 사용)

### 구현 상세

1. **`src/components/chart/hooks/useDMIChart.ts`** (신규)
   - ref 기반 시리즈 라이프사이클 관리
   - 차트 인스턴스 교체 시 ref 초기화
   - isVisible false 시 시리즈 자동 제거
   - bars/indicators 변경 시 데이터 동기화

2. **`src/components/chart/constants.ts`** (수정)
   - `DMI_PANE_INDEX = 4` 상수 추가 (RSI: 2, MACD: 3과 별개 pane)

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] components/: domain만 import (infrastructure 직접 import 없음)
- [x] 반환 타입 명시 (UseDMIChartReturn)
- [x] map 사용으로 배열 처리
- [x] any 타입 없음
- [x] useEffectEvent 활용으로 클로저 안정성 확보

## 변경 파일 목록

[생성]
- `src/components/chart/hooks/useDMIChart.ts`

[수정] 
- `src/components/chart/constants.ts`

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build