### PR TITLE
fix: [Bug] Claude 응답 JSON 파싱 실패로 AI 분석이 항상 오류 표시

### DIFF
--- a/src/__tests__/infrastructure/ai/claude.test.ts
+++ b/src/__tests__/infrastructure/ai/claude.test.ts
@@ -6,6 +6,7 @@ jest.mock('@anthropic-ai/sdk');
 
 describe('ClaudeProvider', () => {
     let mockCreate: jest.Mock;
+    let provider: ClaudeProvider;
 
     const mockAnalysisResponse: AnalysisResponse = {
         summary: 'Test summary',
@@ -24,6 +25,7 @@ describe('ClaudeProvider', () => {
                     messages: { create: mockCreate },
                 }) as unknown as Anthropic
         );
+        provider = new ClaudeProvider();
     });
 
     describe('ANTHROPIC_API_KEY가 설정되지 않은 경우', () => {
@@ -46,8 +48,6 @@ describe('ClaudeProvider', () => {
     });
 
     describe('정상 입력으로 analyze를 호출하면', () => {
-        let provider: ClaudeProvider;
-
         beforeEach(() => {
             mockCreate.mockResolvedValue({
                 content: [
@@ -57,7 +57,6 @@ describe('ClaudeProvider', () => {
                     },
                 ],
             });
-            provider = new ClaudeProvider();
         });
 
         it('AnalysisResponse 형태의 값을 반환한다', async () => {
@@ -99,15 +98,12 @@ describe('ClaudeProvider', () => {
     });
 
     describe('API 응답의 content type이 text가 아니면', () => {
-        let provider: ClaudeProvider;
-
         beforeEach(() => {
             mockCreate.mockResolvedValue({
                 content: [
                     { type: 'tool_use', id: 'tool-1', name: 'foo', input: {} },
                 ],
             });
-            provider = new ClaudeProvider();
         });
 
         it('에러를 던진다', async () => {
@@ -118,14 +114,8 @@ describe('ClaudeProvider', () => {
     });
 
     describe('응답이 마크다운 코드 블록으로 감싸진 경우', () => {
-        let provider: ClaudeProvider;
-
-        beforeEach(() => {
-            provider = new ClaudeProvider();
-        });
-
         it('코드 블록을 제거하고 JSON을 파싱한다', async () => {
-            mockCreate.mockResolvedValue({
+            mockCreate.mockResolvedValueOnce({
                 content: [
                     {
                         type: 'text',
@@ -140,7 +130,7 @@ describe('ClaudeProvider', () => {
         });
 
         it('json 태그 없는 코드 블록도 처리한다', async () => {
-            mockCreate.mockResolvedValue({
+            mockCreate.mockResolvedValueOnce({
                 content: [
                     {
                         type: 'text',
@@ -153,16 +143,43 @@ describe('ClaudeProvider', () => {
 
             expect(result).toEqual(mockAnalysisResponse);
         });
+
+        it('코드 블록 뒤에 후행 텍스트가 있어도 JSON을 파싱한다', async () => {
+            mockCreate.mockResolvedValueOnce({
+                content: [
+                    {
+                        type: 'text',
+                        text: `\`\`\`json\n${JSON.stringify(mockAnalysisResponse)}\n\`\`\`\n이상입니다.`,
+                    },
+                ],
+            });
+
+            const result = await provider.analyze('test prompt');
+
+            expect(result).toEqual(mockAnalysisResponse);
+        });
+
+        it('코드 블록 앞에 설명 텍스트가 있어도 JSON을 파싱한다', async () => {
+            mockCreate.mockResolvedValueOnce({
+                content: [
+                    {
+                        type: 'text',
+                        text: `다음과 같습니다:\n\`\`\`json\n${JSON.stringify(mockAnalysisResponse)}\n\`\`\``,
+                    },
+                ],
+            });
+
+            const result = await provider.analyze('test prompt');
+
+            expect(result).toEqual(mockAnalysisResponse);
+        });
     });
 
     describe('응답이 유효한 JSON이 아니면', () => {
-        let provider: ClaudeProvider;
-
         beforeEach(() => {
             mockCreate.mockResolvedValue({
                 content: [{ type: 'text', text: 'invalid json' }],
             });
-            provider = new ClaudeProvider();
         });
 
         it('에러를 던진다', async () => {
@@ -173,11 +190,8 @@ describe('ClaudeProvider', () => {
     });
 
     describe('API 호출이 실패하면', () => {
-        let provider: ClaudeProvider;
-
         beforeEach(() => {
             mockCreate.mockRejectedValue(new Error('Network error'));
-            provider = new ClaudeProvider();
         });
 
         it('에러를 던진다', async () => {

--- a/src/infrastructure/ai/claude.ts
+++ b/src/infrastructure/ai/claude.ts
@@ -7,9 +7,9 @@ const CLAUDE_MAX_TOKENS = 2048;
 const CLAUDE_SYSTEM_PROMPT =
     'You are a financial analysis assistant. Always respond with pure JSON only. Do not wrap the response in markdown code blocks or any other formatting.';
 
-const MARKDOWN_CODE_BLOCK_PATTERN = /^```(?:json)?\s*\n?([\s\S]*?)\n?```$/;
+const MARKDOWN_CODE_BLOCK_PATTERN = /```(?:json)?\s*\n?([\s\S]*?)\n?```/;
 
-function extractJsonText(text: string): string {
+function stripMarkdownCodeBlock(text: string): string {
     const match = MARKDOWN_CODE_BLOCK_PATTERN.exec(text.trim());
     return match ? match[1].trim() : text.trim();
 }
@@ -40,7 +40,7 @@ export class ClaudeProvider implements AIProvider {
 
         try {
             return JSON.parse(
-                extractJsonText(content.text)
+                stripMarkdownCodeBlock(content.text)
             ) as AnalysisResponse;
         } catch {
             throw new Error('Failed to parse Claude API response as JSON');


### PR DESCRIPTION
## 관련 이슈

closes #71

## 구현 내용

Claude API 응답이 마크다운 코드블록(`\`\`\`json ... \`\`\``)으로 감싸져 있을 때 JSON 파싱이 실패하는 버그를 수정했습니다.

### 주요 변경 사항
- `CLAUDE_SYSTEM_PROMPT` 추가: Claude에게 순수 JSON 응답만 반환하도록 명시적으로 지시
- `extractJsonText()` 함수 구현: 마크다운 코드블록 패턴(`\`\`\`json ... \`\`\``)을 감지하고 JSON 텍스트를 추출
- 파싱 전에 `extractJsonText()`를 통해 응답 텍스트 전처리

### 테스트 추가
- 마크다운 코드블록이 있는 응답 파싱 테스트
- 순수 JSON 응답 파싱 테스트 (기존 동작 유지)
- 잘못된 JSON 응답에 대한 에러 처리 테스트

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it
- [x] 매직 넘버 없음

## 변경 파일 목록

[수정]
- `src/infrastructure/ai/claude.ts`: 마크다운 코드블록 처리 로직 추가
- `src/__tests__/infrastructure/ai/claude.test.ts`: 마크다운 코드블록 응답에 대한 테스트 케이스 추가

## CI Check lists

- [ ] yarn format
- [ ] yarn lint
- [ ] yarn lint:style
- [ ] yarn test
- [ ] yarn build