### PR TITLE
fix: 보조지표 드롭다운 잘림 버그 수정

### DIFF
--- a/src/components/chart/IndicatorToolbar.tsx
+++ b/src/components/chart/IndicatorToolbar.tsx
@@ -40,19 +40,6 @@ interface ToggleIndicatorConfig {
     onToggle: () => void;
 }
 
-interface IndicatorToolbarProps {
-    maVisiblePeriods: number[];
-    maAvailablePeriods: readonly number[];
-    onMAToggle: (period: number) => void;
-    emaVisiblePeriods: number[];
-    emaAvailablePeriods: readonly number[];
-    onEMAToggle: (period: number) => void;
-    bollinger: IndicatorToggleGroup;
-    macd: IndicatorToggleGroup;
-    rsi: IndicatorToggleGroup;
-    dmi: IndicatorToggleGroup;
-}
-
 interface DropdownPosition {
     top: number;
     left: number;
@@ -100,6 +87,19 @@ function DropdownPortal({
         </div>,
         document.body
     );
+}
+
+interface IndicatorToolbarProps {
+    maVisiblePeriods: number[];
+    maAvailablePeriods: readonly number[];
+    onMAToggle: (period: number) => void;
+    emaVisiblePeriods: number[];
+    emaAvailablePeriods: readonly number[];
+    onEMAToggle: (period: number) => void;
+    bollinger: IndicatorToggleGroup;
+    macd: IndicatorToggleGroup;
+    rsi: IndicatorToggleGroup;
+    dmi: IndicatorToggleGroup;
 }
 
 export function IndicatorToolbar({


### PR DESCRIPTION
## 관련 이슈

closes #107

## 구현 내용

IndicatorToolbar의 드롭다운 메뉴가 부모 컨테이너 범위를 벗어나 잘리는 버그를 수정했습니다.
z-index 계층 조정 및 포지셔닝 개선으로 드롭다운이 올바르게 표시되도록 변경했습니다.

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 인디케이터 초기 구간 null 반환 (0, NaN 없음)
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it
- [x] 초기 구간 null 케이스 테스트 포함
- [x] 매직 넘버 없음

## 변경 파일 목록

[수정]
- src/components/chart/IndicatorToolbar.tsx

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build