### PR TITLE
feat: [Feature] 미감지된 스킬(패턴)은 AI 분석 패널에서 숨기기

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -60,18 +60,18 @@
 - Rule: MISTAKES.md TypeScript #6 — 구현 코드의 하드코딩 리터럴은 상수로 추출
 - Context: `paneLabelUtils.ts`에 `MACD_SIGNAL_LABEL`, `MACD_HISTOGRAM_LABEL` 상수로 추출
 
-## [Issue #132 | fix/132/pane-indicator-동적-index-계산 | 2026-04-01]
-- Violation: `INACTIVE_PANE_INDEX = -1`이 StockChart.tsx, paneLabelUtils.ts, 테스트 파일 3곳에서 각각 별도 정의
-- Rule: MISTAKES.md #0 / FF.md Cohesion 3-B — 동일 값이 여러 위치에 정의되면 단일 상수로 추출해야 함
-- Context: `components/chart/constants.ts`에 `INACTIVE_PANE_INDEX`를 단일 정의하고, StockChart.tsx, paneLabelUtils.ts, paneLabelUtils.test.ts에서 import하도록 변경
-
 ## [PR #138 | fix/132/pane-indicator-동적-index-계산 | 2026-04-01]
 - Violation: `paneIndices` useMemo 내부에서 `let next` + `next++` 재할당 사용
 - Rule: MISTAKES.md #3 — let 재할당 금지, const + 새 변수 사용
 - Context: `StockChart.tsx`의 `paneIndices` useMemo에서 `let next`를 `visibles.slice(0, pos).filter(Boolean).length` 기반의 순수 함수 `indexFor`로 교체
 
-## [PR #138 | fix/132/pane-indicator-동적-index-계산 | 2026-04-01]
-- Violation: `buildPaneLabels`에서 `rsiVisible && paneIndices.rsi !== INACTIVE_PANE_INDEX` 이중 조건 — visibility가 true면 paneIndex는 항상 active이므로 효과 없는 중복 로직
-- Rule: MISTAKES.md #9.5 — 효과 없는 로직은 노이즈이므로 제거
-- Context: `paneLabelUtils.ts`에서 `PaneVisibility` 인터페이스의 visibility 플래그를 제거하고 `paneIndices`만으로 활성 여부를 판단하도록 단순화
+## [PR #139 | feat/136/미감지-스킬-숨기기 | 2026-04-02]
+- Violation: 스킬 분석 섹션이 차트 패턴 섹션과 동일한 항목을 중복 표시 — 모든 스킬이 type: pattern이므로 patternSummaries와 skillResults가 같은 스킬을 보여줌
+- Rule: FF.md Cohesion 3-B — 동일한 데이터가 두 섹션에서 중복 표시되면 사용자에게 혼동을 주고 UI 정보의 단일 출처 원칙 위반
+- Context: `AnalysisPanel.tsx`에서 `patternSkillNames` Set을 생성하여 `detectedSkillResults`와 `detectedSkillSignals` 필터링 시 patternSummaries에 이미 포함된 스킬을 제외
+
+## [PR #139 | feat/136/미감지-스킬-숨기기 | 2026-04-02]
+- Violation: `detectedSkillSignals` 필터에서 `!patternSkillNames.has(s.skillName)` 조건이 중복 — `detectedSkillNames`는 이미 `patternSkillNames`를 제외한 `detectedSkillResults`에서 생성되므로 효과 없는 로직
+- Rule: MISTAKES.md Coding Paradigm #9.5 — 실질적 효과 없는 로직은 노이즈이므로 제거
+- Context: `AnalysisPanel.tsx`의 `detectedSkillSignals` 필터에서 `&& !patternSkillNames.has(s.skillName)` 조건을 제거하고 `detectedSkillNames.has(s.skillName)` 단일 조건으로 단순화
 

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -14,7 +14,10 @@ import type {
     Trend,
 } from '@/domain/types';
 import { findCandlePatternLabel } from '@/domain/analysis/candle-labels';
-import { HIGH_CONFIDENCE_WEIGHT } from '@/domain/indicators/constants';
+import {
+    HIGH_CONFIDENCE_WEIGHT,
+    MIN_CONFIDENCE_WEIGHT,
+} from '@/domain/indicators/constants';
 import { cn } from '@/lib/cn';
 
 const TREND_COLOR: Record<Trend, string> = {
@@ -463,11 +466,21 @@ export function AnalysisPanel({
     const detectedPatterns = analysis.patternSummaries.filter(p => p.detected);
     const hasDetectedPatterns = detectedPatterns.length > 0;
 
-    const detectedSkillNames = new Set(detectedPatterns.map(p => p.skillName));
-    const detectedSkillSignals = analysis.skillSignals.filter(s =>
-        detectedSkillNames.has(s.skillName)
+    const patternSkillNames = new Set(
+        analysis.patternSummaries.map(p => p.skillName)
     );
-    const detectedSkillResults = analysis.skillResults.filter(s =>
+
+    const detectedSkillResults = analysis.skillResults.filter(
+        s =>
+            s.confidenceWeight >= MIN_CONFIDENCE_WEIGHT &&
+            !patternSkillNames.has(s.skillName)
+    );
+
+    const detectedSkillNames = new Set(
+        detectedSkillResults.map(s => s.skillName)
+    );
+
+    const detectedSkillSignals = analysis.skillSignals.filter(s =>
         detectedSkillNames.has(s.skillName)
     );
 


### PR DESCRIPTION
## 관련 이슈

closes #136

## 구현 내용

미감지된 스킬(패턴)을 AI 분석 패널에서 숨김. Skills 섹션에서 confidence_weight가 0.5 미만인 스킬들은 표시하지 않음.

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] any 타입 없음
- [x] 매직 넘버 없음

## 변경 파일 목록

[수정]
- src/components/analysis/AnalysisPanel.tsx: confidence_weight 필터링 로직 추가

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build