### PR TITLE
fix: EMA 기간 선택 시 버튼 크기 자동 증가 문제

### DIFF
--- a/src/components/chart/IndicatorToolbar.tsx
+++ b/src/components/chart/IndicatorToolbar.tsx
@@ -238,7 +238,7 @@ export function IndicatorToolbar({
                         aria-expanded={openDropdown === indicator.type}
                         className={cn(
                             indicatorButtonClass(indicator.active),
-                            'shrink-0'
+                            'w-12 shrink-0'
                         )}
                     >
                         {indicator.label}


### PR DESCRIPTION
## 관련 이슈

closes #146

## 구현 내용

EMA 기간 선택 시 드롭다운 버튼의 크기가 계속 늘어나는 문제를 수정했습니다.
버튼 너비를 고정값으로 지정하여 선택된 기간 텍스트 변화에 따른 리플로우 방지.

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] any 타입 없음

## 변경 파일 목록

[수정] src/components/chart/IndicatorToolbar.tsx

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build