### PR TITLE
fix: AI 응답 JSON 파싱 실패 시 raw text 전체 콘솔 출력 제거

### DIFF
--- a/src/__tests__/infrastructure/ai/claude.test.ts
+++ b/src/__tests__/infrastructure/ai/claude.test.ts
@@ -275,7 +275,7 @@ describe('ClaudeProvider', () => {
             );
         });
 
-        it('console.error로 raw text를 기록한다', async () => {
+        it('console.error에 응답 길이와 앞 100자만 기록한다', async () => {
             const consoleSpy = jest
                 .spyOn(console, 'error')
                 .mockImplementation(() => {});
@@ -283,9 +283,33 @@ describe('ClaudeProvider', () => {
             try {
                 await provider.analyze('test prompt').catch(() => {});
                 expect(consoleSpy).toHaveBeenCalledWith(
-                    'Failed to parse Claude API response. Raw text:',
-                    'invalid json'
+                    'Failed to parse Claude API response as JSON.',
+                    'Response length:',
+                    'invalid json'.length,
+                    'First 100 chars:',
+                    'invalid json'.slice(0, 100)
                 );
+            } finally {
+                consoleSpy.mockRestore();
+            }
+        });
+
+        it('console.error에 raw text 전체가 포함되지 않는다', async () => {
+            const longText = 'a'.repeat(200);
+            mockCreate.mockResolvedValue({
+                content: [{ type: 'text', text: longText }],
+            });
+
+            const consoleSpy = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => {});
+
+            try {
+                await provider.analyze('test prompt').catch(() => {});
+                const calls = consoleSpy.mock.calls;
+                expect(calls.length).toBeGreaterThan(0);
+                const allArgs = calls.flat();
+                expect(allArgs).not.toContain(longText);
             } finally {
                 consoleSpy.mockRestore();
             }

--- a/src/__tests__/infrastructure/ai/gemini.test.ts
+++ b/src/__tests__/infrastructure/ai/gemini.test.ts
@@ -255,7 +255,7 @@ describe('GeminiProvider', () => {
             );
         });
 
-        it('console.error로 raw text를 기록한다', async () => {
+        it('console.error에 응답 길이와 앞 100자만 기록한다', async () => {
             const consoleSpy = jest
                 .spyOn(console, 'error')
                 .mockImplementation(() => {});
@@ -263,9 +263,35 @@ describe('GeminiProvider', () => {
             try {
                 await provider.analyze('test prompt').catch(() => {});
                 expect(consoleSpy).toHaveBeenCalledWith(
-                    'Failed to parse Gemini API response. Raw text:',
-                    'invalid json'
+                    'Failed to parse Gemini API response as JSON.',
+                    'Response length:',
+                    'invalid json'.length,
+                    'First 100 chars:',
+                    'invalid json'.slice(0, 100)
                 );
+            } finally {
+                consoleSpy.mockRestore();
+            }
+        });
+
+        it('console.error에 raw text 전체가 포함되지 않는다', async () => {
+            const longText = 'a'.repeat(200);
+            mockGenerateContent.mockResolvedValue({
+                response: {
+                    text: () => longText,
+                },
+            });
+
+            const consoleSpy = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => {});
+
+            try {
+                await provider.analyze('test prompt').catch(() => {});
+                const calls = consoleSpy.mock.calls;
+                expect(calls.length).toBeGreaterThan(0);
+                const allArgs = calls.flat();
+                expect(allArgs).not.toContain(longText);
             } finally {
                 consoleSpy.mockRestore();
             }

--- a/src/infrastructure/ai/claude.ts
+++ b/src/infrastructure/ai/claude.ts
@@ -36,8 +36,11 @@ export class ClaudeProvider implements AIProvider {
             ) as RawAnalysisResponse;
         } catch (error) {
             console.error(
-                'Failed to parse Claude API response. Raw text:',
-                content.text
+                'Failed to parse Claude API response as JSON.',
+                'Response length:',
+                content.text.length,
+                'First 100 chars:',
+                content.text.slice(0, 100)
             );
             throw new Error('Failed to parse Claude API response as JSON', {
                 cause: error,

--- a/src/infrastructure/ai/gemini.ts
+++ b/src/infrastructure/ai/gemini.ts
@@ -31,8 +31,11 @@ export class GeminiProvider implements AIProvider {
             ) as RawAnalysisResponse;
         } catch (error) {
             console.error(
-                'Failed to parse Gemini API response. Raw text:',
-                text
+                'Failed to parse Gemini API response as JSON.',
+                'Response length:',
+                text.length,
+                'First 100 chars:',
+                text.slice(0, 100)
             );
             throw new Error('Failed to parse Gemini API response as JSON', {
                 cause: error,


### PR DESCRIPTION
## 관련 이슈

closes #178

## 구현 내용

AI 응답의 JSON 파싱 실패 시 원본 응답 텍스트 전체를 콘솔에 출력하던 문제를 해결했습니다.

변경 사항:
- `src/infrastructure/ai/claude.ts`: 파싱 실패 시 로깅 제거
- `src/infrastructure/ai/gemini.ts`: 파싱 실패 시 로깅 제거
- 대응 테스트 파일 업데이트

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함

## 변경 파일 목록

[수정]
- src/infrastructure/ai/claude.ts
- src/infrastructure/ai/gemini.ts
- src/__tests__/infrastructure/ai/claude.test.ts
- src/__tests__/infrastructure/ai/gemini.test.ts

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build