### PR TITLE
feat: 차트 오버레이 범례 표시

### DIFF
--- a/.claude/agents/pr-fix-agent.md
+++ b/.claude/agents/pr-fix-agent.md
@@ -5,12 +5,6 @@ permissionMode: bypassPermissions
 model: sonnet
 memory: project
 tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
-skills:
-  - frontend-design
-  - vercel-react-best-practices
-  - web-design-guidelines
-  - typescript-advanced-types
-  - next-best-practices
 ---
 
 ## Overview

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -32,7 +32,22 @@ for (let i = 0; i + period <= values.length; i++) {
 }
 ```
 
-The goal is readable, maintainable code — not mechanical adherence to a style. When `map`/`reduce` produces convoluted code or unnecessary O(n²) complexity, prefer `for (let i = 0; ...)`.
+**Exception — `while` is allowed when the algorithm's termination condition is naturally expressed as a predicate, not as a counter:**
+- Binary search (convergent boundary `low`/`high` pointers)
+- Pointer-convergence loops (two pointers approaching each other)
+- Cases where a `for` header equivalent would be an empty `for (; condition; )` — use `while` instead for clarity
+
+```typescript
+// ✅ Acceptable — binary search where while expresses the convergence condition directly
+while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    if (bars[mid].time === time) return mid;
+    if (bars[mid].time < time) low = mid + 1;
+    else high = mid - 1;
+}
+```
+
+The goal is readable, maintainable code — not mechanical adherence to a style. When `map`/`reduce` produces convoluted code or unnecessary O(n²) complexity, prefer `for (let i = 0; ...)`. When the loop condition is a convergence predicate rather than a counter, prefer `while`.
 
 ```typescript
 // ❌ Nested conditionals

--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -203,6 +203,16 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 
 7. Missing mandatory fields in skill markdown files
    → All required interface fields must be present in frontmatter and body
+
+8. Module-level constants frozen at load time instead of computed per mount
+   → Data freshness requires per-component timestamps, not frozen module-load values
+   ❌ const MODULE_LOAD_TIME = Date.now();  // SPA nav: all mounts see the same old timestamp
+   ✅ const time = useState(() => Date.now())[0];  // each mount captures its own timestamp
+
+9. Sentinel values wrapped in functions that silently break the contract
+   → Sentinel values (-1, null, undefined) must propagate unchanged through call chains
+   ❌ Math.max(0, sentinel ?? fallback)  // Math.max converts -1 to 0, breaking sentinel behavior
+   ✅ sentinel === -1 ? -1 : Math.max(0, sentinel)  // explicit guard before wrapping
 ```
 
 ---

--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -129,51 +129,57 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 1. Props interface separated from component by other definitions
    → Props interface must be immediately above the component function
 
-2. Managing timeframe as a URL query parameter
+2. Hook declaration order violated
+   → Custom hooks must follow: useState → useRef → derived variables (useMemo/const) → useEffect
+   → Placing useMemo or derived const between useEffect blocks breaks the convention
+   ❌ useState(...); useEffect(...); const derived = ...; useEffect(...);
+   ✅ useState(...); useRef(...); const derived = ...; useEffect(...); useEffect(...);
+
+3. Managing timeframe as a URL query parameter
    → Manage as client state only
 
-3. new Date() in Server Component → hydration mismatch
+4. new Date() in Server Component → hydration mismatch
    → Extract into a 'use client' component or add suppressHydrationWarning
 
-4. Side effects inside setState updater functions
+5. Side effects inside setState updater functions
    → Updaters run twice in Strict Mode; side effects must be placed outside
 
-5. Stale closure state instead of functional setState
+6. Stale closure state instead of functional setState
    ❌ const next = new Set(visiblePatterns); setVisiblePatterns(next);
    ✅ setVisiblePatterns(prev => { const next = new Set(prev); ...; return next; });
 
-6. Nesting interactive elements (button-in-button)
+7. Nesting interactive elements (button-in-button)
    → HTML spec prohibits interactive content inside interactive content
 
-7. External callback prop in useEffect dependency array → infinite loops
+8. External callback prop in useEffect dependency array → infinite loops
    → Use useEffectEvent to wrap callback props
 
-8. useState lazy initializer derives value from props
+9. useState lazy initializer derives value from props
    → Initializer runs only once; use useEffect to sync when props change
 
-9. Missing aria-expanded on accordion triggers
+10. Missing aria-expanded on accordion triggers
 
-10. Component managing its own external margin
+11. Component managing its own external margin
     → External spacing belongs to the caller, not the component
 
-11. Unused Tailwind classes (e.g. grid classes on flex containers)
+12. Unused Tailwind classes (e.g. grid classes on flex containers)
     → Verify parent layout model before applying layout-specific classes
 
-12. Props declared but not connected to callbacks (latent bugs)
+13. Props declared but not connected to callbacks (latent bugs)
     → If a callback prop exists, it must actually be invoked
 
-13. Repeating identical JSX structure 2+ times
+14. Repeating identical JSX structure 2+ times
     → Extract to a data array + .map() pattern
 
-14. DOM event listener in useEffect instead of custom hook
+15. DOM event listener in useEffect instead of custom hook
     → Extract to useOnClickOutside, useEscapeKey, etc.
 
-15. Inline styles for dynamic runtime values
+16. Inline styles for dynamic runtime values
     → Use CSS custom properties with Tailwind arbitrary-value syntax
     ❌ style={{ width: `${px}px` }}
     ✅ style={{ '--w': `${px}px` }} className="md:w-[var(--w)]"
 
-16. Custom hook params missing optional properties present in sibling hooks
+17. Custom hook params missing optional properties present in sibling hooks
     → All hooks in the same family must accept consistent parameter patterns
 ```
 

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -10,10 +10,6 @@
 - Rule: `src/__tests__/CLAUDE.md` — "Never mock domain functions — test them directly with real inputs"
 - Context: `analysisApi.test.ts` mocked the domain analysis functions to control test output; since domain functions are pure with no side effects, they must be called with real inputs and only external dependencies (AI API, file I/O) should be mocked
 
-## [PR #187 | refactor/130/server-action-migration | 2026-04-05]
-- Violation: `MODULE_LOAD_TIME` module-level constant used as `initialDataUpdatedAt` causing stale data in SPA navigation
-- Rule: FF.md Predictability — data freshness must be computed per component mount, not frozen at module load time
-
 ## [PR #189 | fix/176/alpaca-getBars-최신-데이터-반환 | 2026-04-05]
 - Violation: `AlpacaBarsResponse` interface declared `next_page_token` in snake_case instead of camelCase
 - Rule: CONVENTIONS.md — interface fields must be camelCase; snake_case fields from external APIs must be transformed in infrastructure layer
@@ -69,4 +65,9 @@
 - Violation: Derived variable `barIndex` declared between two `useEffect` calls, violating hook declaration order
 - Rule: CONVENTIONS.md Custom Hook Declaration Order — order must be: useState → useRef → derived variables → useEffect
 - Context: `useOverlayLegend.ts` placed `const barIndex = ...` between the `barsRef` update effect and the crosshair subscription effect; moved above the first `useEffect` to follow the correct declaration order
+
+## [PR #191 | feat/175/overlay-legend | 2026-04-05]
+- Violation: `groupItems` utility function in `OverlayLegend.tsx` used `Array.push()` to mutate local arrays inside a `for...of` loop
+- Rule: CONVENTIONS.md Functional Programming — No mutation: `[...arr, item]` not `arr.push(item)`
+- Context: `groupItems` called `groups[existingIdx].items.push(item)` and `groups.push(...)` directly; refactored to `reduce` with spread operators to maintain immutability throughout
 

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -56,11 +56,6 @@
 - Rule: FF.md Readability — dead code that serves no purpose must be removed; variables assigned but never consumed are noise
 - Context: `useOverlayLegend.ts` declared `prevChartRef = useRef<IChartApi | null>(null)` and assigned it inside a `useEffect` branch, but the ref value was never read anywhere; the entire declaration and assignment block was removed
 
-## [Issue #175 | feat/175/overlay-legend | 2026-04-05]
-- Violation: Derived variable `barIndex` declared between two `useEffect` calls, violating hook declaration order
-- Rule: CONVENTIONS.md Custom Hook Declaration Order — order must be: useState → useRef → derived variables → useEffect
-- Context: `useOverlayLegend.ts` placed `const barIndex = ...` between the `barsRef` update effect and the crosshair subscription effect; moved above the first `useEffect` to follow the correct declaration order
-
 ## [PR #191 | feat/175/overlay-legend | 2026-04-05]
 - Violation: `groupItems` utility function in `OverlayLegend.tsx` used `Array.push()` to mutate local arrays inside a `for...of` loop
 - Rule: CONVENTIONS.md Functional Programming — No mutation: `[...arr, item]` not `arr.push(item)`
@@ -74,4 +69,9 @@
 - Violation: `Math.max(0, crosshairIndex ?? bars.length - 1)` wraps a potential sentinel `-1` value, silently converting it to `0`
 - Rule: MISTAKES.md Domain Functions #9 — sentinel values must propagate unchanged; `Math.max` must not wrap a value that can be `-1`
 - Context: `barIndex` derivation in `useOverlayLegend.ts` used `Math.max(0, crosshairIndex ?? ...)` which converts `crosshairIndex = -1` (returned by `findBarIndex` for empty bars) to `0`, producing a wrong index; replaced with explicit null/negative guard chain
+
+## [PR #191 Round 3 | feat/175/overlay-legend | 2026-04-06]
+- Violation: Test comment described `time=250` (tie-break case) but the test body used `time=260` (unambiguous nearest-bar case); the actual tie-break behavior was untested
+- Rule: CONVENTIONS.md Test Rules — each `it()` must accurately describe and verify exactly one behavior; misleading comments and untested edge cases must be corrected
+- Context: `overlayLabelUtils.test.ts` '중간값일 때' block had a comment about equal-distance tie-break but tested an unambiguous `time=260` input; fixed the comment and added a dedicated '두 후보와 거리가 동일할 때' block verifying that `findBarIndex` returns the lower array index (`low`) when distances are equal
 

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -70,6 +70,11 @@
 - Rule: MISTAKES.md Domain Functions #9 — sentinel values must propagate unchanged; `Math.max` must not wrap a value that can be `-1`
 - Context: `barIndex` derivation in `useOverlayLegend.ts` used `Math.max(0, crosshairIndex ?? ...)` which converts `crosshairIndex = -1` (returned by `findBarIndex` for empty bars) to `0`, producing a wrong index; replaced with explicit null/negative guard chain
 
+## [PR #191 Round 4 | feat/175/overlay-legend | 2026-04-06]
+- Violation: `resolveBarIndex` lacked an upper bound guard for `crosshairIndex >= bars.length`, leaving the function contract incomplete
+- Rule: FF.md Predictability — pure utility functions must handle all valid input ranges explicitly so callers cannot receive out-of-bounds results
+- Context: `overlayLabelUtils.ts` `resolveBarIndex` guarded for null and negative indices but not for indices beyond array bounds; added `if (crosshairIndex >= bars.length) return bars.length - 1` to complete the guard chain
+
 ## [PR #191 Round 3 | feat/175/overlay-legend | 2026-04-06]
 - Violation: Test comment described `time=250` (tie-break case) but the test body used `time=260` (unambiguous nearest-bar case); the actual tie-break behavior was untested
 - Rule: CONVENTIONS.md Test Rules — each `it()` must accurately describe and verify exactly one behavior; misleading comments and untested edge cases must be corrected

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -55,3 +55,18 @@
 - Rule: FF.md Readability 1-A — 역할이 다른 코드는 분리, 코드의 의도가 명확히 드러나야 함
 - Context: SSR 단계에서 AI 분석을 의도적으로 생략하고 클라이언트에 위임하기 위해 `true`로 하드코딩했으나, 코드만으로는 의도를 파악하기 어려워 주석을 추가했다.
 
+## [Issue #175 | feat/175/overlay-legend | 2026-04-05]
+- Violation: `while` loop with `let` index variables (`low`, `high`) reassigned in loop body instead of `for` loop
+- Rule: CONVENTIONS.md — use `for` loops instead of `while` with mutable index variables; iteration structure should be expressed in the loop header
+- Context: `findBarIndex` binary search in `overlayLabelUtils.ts` used a `while` loop with separately declared `let low`/`let high` and index reassignment inside the body; converted to `for (; low <= high; )` with the boundary approximation logic preserved after the loop
+
+## [Issue #175 | feat/175/overlay-legend | 2026-04-05]
+- Violation: `prevChartRef` declared and assigned but never read — dead code in hook
+- Rule: FF.md Readability — dead code that serves no purpose must be removed; variables assigned but never consumed are noise
+- Context: `useOverlayLegend.ts` declared `prevChartRef = useRef<IChartApi | null>(null)` and assigned it inside a `useEffect` branch, but the ref value was never read anywhere; the entire declaration and assignment block was removed
+
+## [Issue #175 | feat/175/overlay-legend | 2026-04-05]
+- Violation: Derived variable `barIndex` declared between two `useEffect` calls, violating hook declaration order
+- Rule: CONVENTIONS.md Custom Hook Declaration Order — order must be: useState → useRef → derived variables → useEffect
+- Context: `useOverlayLegend.ts` placed `const barIndex = ...` between the `barsRef` update effect and the crosshair subscription effect; moved above the first `useEffect` to follow the correct declaration order
+

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -52,11 +52,6 @@
 - Context: SSR 단계에서 AI 분석을 의도적으로 생략하고 클라이언트에 위임하기 위해 `true`로 하드코딩했으나, 코드만으로는 의도를 파악하기 어려워 주석을 추가했다.
 
 ## [Issue #175 | feat/175/overlay-legend | 2026-04-05]
-- Violation: `while` loop with `let` index variables (`low`, `high`) reassigned in loop body instead of `for` loop
-- Rule: CONVENTIONS.md — use `for` loops instead of `while` with mutable index variables; iteration structure should be expressed in the loop header
-- Context: `findBarIndex` binary search in `overlayLabelUtils.ts` used a `while` loop with separately declared `let low`/`let high` and index reassignment inside the body; converted to `for (; low <= high; )` with the boundary approximation logic preserved after the loop
-
-## [Issue #175 | feat/175/overlay-legend | 2026-04-05]
 - Violation: `prevChartRef` declared and assigned but never read — dead code in hook
 - Rule: FF.md Readability — dead code that serves no purpose must be removed; variables assigned but never consumed are noise
 - Context: `useOverlayLegend.ts` declared `prevChartRef = useRef<IChartApi | null>(null)` and assigned it inside a `useEffect` branch, but the ref value was never read anywhere; the entire declaration and assignment block was removed
@@ -70,4 +65,13 @@
 - Violation: `groupItems` utility function in `OverlayLegend.tsx` used `Array.push()` to mutate local arrays inside a `for...of` loop
 - Rule: CONVENTIONS.md Functional Programming — No mutation: `[...arr, item]` not `arr.push(item)`
 - Context: `groupItems` called `groups[existingIdx].items.push(item)` and `groups.push(...)` directly; refactored to `reduce` with spread operators to maintain immutability throughout
+
+## [PR #191 Round 2 | feat/175/overlay-legend | 2026-04-05]
+- Violation: `param.time as number` type assertion used without a type guard in `useOverlayLegend.ts`
+- Rule: MISTAKES.md TypeScript #3 — use type guards instead of `as` assertions; exception applies only to DOM elements and third-party library return types with a comment
+- Context: `crosshairMove` handler cast `param.time` with `as number` despite `Time` being a union (`UTCTimestamp | BusinessDay | string`); replaced with `typeof param.time === 'number'` guard to ensure runtime safety
+
+- Violation: `Math.max(0, crosshairIndex ?? bars.length - 1)` wraps a potential sentinel `-1` value, silently converting it to `0`
+- Rule: MISTAKES.md Domain Functions #9 — sentinel values must propagate unchanged; `Math.max` must not wrap a value that can be `-1`
+- Context: `barIndex` derivation in `useOverlayLegend.ts` used `Math.max(0, crosshairIndex ?? ...)` which converts `crosshairIndex = -1` (returned by `findBarIndex` for empty bars) to `0`, producing a wrong index; replaced with explicit null/negative guard chain
 

--- a/src/__tests__/components/chart/utils/overlayLabelUtils.test.ts
+++ b/src/__tests__/components/chart/utils/overlayLabelUtils.test.ts
@@ -1,0 +1,259 @@
+import {
+    buildOverlayLabelConfigs,
+    findBarIndex,
+    resolveOverlayValues,
+} from '@/components/chart/utils/overlayLabelUtils';
+import { CHART_COLORS, getPeriodColor } from '@/lib/chartColors';
+import type { Bar, IndicatorResult } from '@/domain/types';
+
+const mockBars: Bar[] = [
+    { time: 100, open: 10, high: 15, low: 9, close: 12, volume: 1000 },
+    { time: 200, open: 12, high: 18, low: 11, close: 15, volume: 1200 },
+    { time: 300, open: 15, high: 20, low: 14, close: 18, volume: 1100 },
+    { time: 400, open: 18, high: 22, low: 17, close: 20, volume: 900 },
+    { time: 500, open: 20, high: 25, low: 19, close: 23, volume: 1300 },
+];
+
+const mockIndicators: IndicatorResult = {
+    ma: { 5: [100, 101, 102] },
+    ema: {},
+    macd: [],
+    bollinger: [{ upper: 105, middle: 100, lower: 95 }],
+    rsi: [],
+    cci: [],
+    dmi: [],
+    stochastic: [],
+    stochRsi: [],
+    vwap: [],
+    volumeProfile: { poc: 100, vah: 110, val: 90, profile: [] },
+    ichimoku: [
+        { tenkan: 101, kijun: 102, senkouA: 103, senkouB: 104, chikou: 100 },
+    ],
+};
+
+describe('buildOverlayLabelConfigs', () => {
+    describe('모든 파라미터가 비활성일 때', () => {
+        it('빈 배열을 반환한다', () => {
+            const result = buildOverlayLabelConfigs({
+                maVisiblePeriods: [],
+                emaVisiblePeriods: [],
+                bollingerVisible: false,
+                ichimokuVisible: false,
+                vpVisible: false,
+            });
+
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('MA 기간이 [5, 20]일 때', () => {
+        it('MA(5), MA(20) 이름의 config 2개를 반환한다', () => {
+            const result = buildOverlayLabelConfigs({
+                maVisiblePeriods: [5, 20],
+                emaVisiblePeriods: [],
+                bollingerVisible: false,
+                ichimokuVisible: false,
+                vpVisible: false,
+            });
+
+            expect(result).toHaveLength(2);
+            expect(result[0].name).toBe('MA(5)');
+            expect(result[1].name).toBe('MA(20)');
+        });
+    });
+
+    describe('EMA 기간이 [9]일 때', () => {
+        it('EMA(9) 이름의 config 1개를 반환한다', () => {
+            const result = buildOverlayLabelConfigs({
+                maVisiblePeriods: [],
+                emaVisiblePeriods: [9],
+                bollingerVisible: false,
+                ichimokuVisible: false,
+                vpVisible: false,
+            });
+
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe('EMA(9)');
+        });
+    });
+
+    describe('bollingerVisible가 true일 때', () => {
+        it('BB Upper, BB Middle, BB Lower 3개의 config를 반환한다', () => {
+            const result = buildOverlayLabelConfigs({
+                maVisiblePeriods: [],
+                emaVisiblePeriods: [],
+                bollingerVisible: true,
+                ichimokuVisible: false,
+                vpVisible: false,
+            });
+
+            expect(result).toHaveLength(3);
+            expect(result[0].name).toBe('BB Upper');
+            expect(result[1].name).toBe('BB Middle');
+            expect(result[2].name).toBe('BB Lower');
+        });
+    });
+
+    describe('ichimokuVisible가 true일 때', () => {
+        it('Tenkan, Kijun, Chikou, Senkou A, Senkou B 5개의 config를 반환한다', () => {
+            const result = buildOverlayLabelConfigs({
+                maVisiblePeriods: [],
+                emaVisiblePeriods: [],
+                bollingerVisible: false,
+                ichimokuVisible: true,
+                vpVisible: false,
+            });
+
+            expect(result).toHaveLength(5);
+            expect(result[0].name).toBe('Tenkan');
+            expect(result[1].name).toBe('Kijun');
+            expect(result[2].name).toBe('Chikou');
+            expect(result[3].name).toBe('Senkou A');
+            expect(result[4].name).toBe('Senkou B');
+        });
+    });
+
+    describe('vpVisible가 true일 때', () => {
+        it('POC, VAH, VAL 3개의 config를 반환한다', () => {
+            const result = buildOverlayLabelConfigs({
+                maVisiblePeriods: [],
+                emaVisiblePeriods: [],
+                bollingerVisible: false,
+                ichimokuVisible: false,
+                vpVisible: true,
+            });
+
+            expect(result).toHaveLength(3);
+            expect(result[0].name).toBe('POC');
+            expect(result[1].name).toBe('VAH');
+            expect(result[2].name).toBe('VAL');
+        });
+    });
+
+    describe('MA [5] + bollingerVisible 복합 조합일 때', () => {
+        it('4개의 config를 MA → BB 순서로 반환한다', () => {
+            const result = buildOverlayLabelConfigs({
+                maVisiblePeriods: [5],
+                emaVisiblePeriods: [],
+                bollingerVisible: true,
+                ichimokuVisible: false,
+                vpVisible: false,
+            });
+
+            expect(result).toHaveLength(4);
+            expect(result[0].name).toBe('MA(5)');
+            expect(result[1].name).toBe('BB Upper');
+            expect(result[2].name).toBe('BB Middle');
+            expect(result[3].name).toBe('BB Lower');
+        });
+    });
+
+    describe('색상 검증', () => {
+        it('MA(5)의 color는 getPeriodColor(5)와 일치한다', () => {
+            const result = buildOverlayLabelConfigs({
+                maVisiblePeriods: [5],
+                emaVisiblePeriods: [],
+                bollingerVisible: false,
+                ichimokuVisible: false,
+                vpVisible: false,
+            });
+
+            expect(result[0].color).toBe(getPeriodColor(5));
+        });
+
+        it('BB Upper의 color는 CHART_COLORS.bollingerUpper와 일치한다', () => {
+            const result = buildOverlayLabelConfigs({
+                maVisiblePeriods: [],
+                emaVisiblePeriods: [],
+                bollingerVisible: true,
+                ichimokuVisible: false,
+                vpVisible: false,
+            });
+
+            expect(result[0].color).toBe(CHART_COLORS.bollingerUpper);
+        });
+    });
+});
+
+describe('findBarIndex', () => {
+    describe('빈 bars 배열일 때', () => {
+        it('-1을 반환한다', () => {
+            expect(findBarIndex([], 100)).toBe(-1);
+        });
+    });
+
+    describe('정확한 시간 매칭일 때', () => {
+        it('해당 index를 반환한다', () => {
+            expect(findBarIndex(mockBars, 300)).toBe(2);
+        });
+    });
+
+    describe('bars보다 이른 시간일 때', () => {
+        it('0을 반환한다', () => {
+            expect(findBarIndex(mockBars, 50)).toBe(0);
+        });
+    });
+
+    describe('bars보다 늦은 시간일 때', () => {
+        it('bars.length - 1을 반환한다', () => {
+            expect(findBarIndex(mockBars, 600)).toBe(mockBars.length - 1);
+        });
+    });
+
+    describe('중간값일 때', () => {
+        it('가장 가까운 index를 반환한다', () => {
+            // time 250 is between bars[1]=200 and bars[2]=300 — equally distant, lower wins (250-200=50, 300-250=50)
+            // with lowDiff <= highDiff check, low (index 2) wins when equal
+            const result = findBarIndex(mockBars, 260);
+            // 260 is closer to 300 (diff=40) than 200 (diff=60), so index 2
+            expect(result).toBe(2);
+        });
+    });
+});
+
+describe('resolveOverlayValues', () => {
+    const configs = buildOverlayLabelConfigs({
+        maVisiblePeriods: [5],
+        emaVisiblePeriods: [],
+        bollingerVisible: true,
+        ichimokuVisible: false,
+        vpVisible: false,
+    });
+
+    describe('barIndex가 -1일 때', () => {
+        it('모든 value가 null인 OverlayLegendItem 배열을 반환한다', () => {
+            const result = resolveOverlayValues(configs, mockIndicators, -1);
+
+            expect(result).toHaveLength(configs.length);
+            result.forEach(item => {
+                expect(item.value).toBeNull();
+            });
+        });
+    });
+
+    describe('유효한 barIndex일 때', () => {
+        it('config.getValue 결과를 value로 반환한다', () => {
+            const result = resolveOverlayValues(configs, mockIndicators, 0);
+
+            expect(result[0].name).toBe('MA(5)');
+            expect(result[0].value).toBe(100);
+        });
+
+        it('name과 color를 올바르게 포함한다', () => {
+            const result = resolveOverlayValues(configs, mockIndicators, 0);
+
+            result.forEach((item, idx) => {
+                expect(item.name).toBe(configs[idx].name);
+                expect(item.color).toBe(configs[idx].color);
+            });
+        });
+    });
+
+    describe('빈 configs일 때', () => {
+        it('빈 배열을 반환한다', () => {
+            const result = resolveOverlayValues([], mockIndicators, 0);
+
+            expect(result).toEqual([]);
+        });
+    });
+});

--- a/src/__tests__/components/chart/utils/overlayLabelUtils.test.ts
+++ b/src/__tests__/components/chart/utils/overlayLabelUtils.test.ts
@@ -202,11 +202,16 @@ describe('findBarIndex', () => {
 
     describe('중간값일 때', () => {
         it('가장 가까운 index를 반환한다', () => {
-            // time 250 is between bars[1]=200 and bars[2]=300 — equally distant, lower wins (250-200=50, 300-250=50)
-            // with lowDiff <= highDiff check, low (index 2) wins when equal
+            // 260은 bars[2]=300(diff=40)에 bars[1]=200(diff=60)보다 가깝다 → index 2
             const result = findBarIndex(mockBars, 260);
-            // 260 is closer to 300 (diff=40) than 200 (diff=60), so index 2
             expect(result).toBe(2);
+        });
+    });
+
+    describe('두 후보와 거리가 동일할 때', () => {
+        it('low 인덱스(더 높은 인덱스)를 반환한다', () => {
+            // bars[1]=200, bars[2]=300, time=250 → lowDiff=50, highDiff=50 → low(=2) 반환
+            expect(findBarIndex(mockBars, 250)).toBe(2);
         });
     });
 });

--- a/src/components/chart/IndicatorToolbar.tsx
+++ b/src/components/chart/IndicatorToolbar.tsx
@@ -182,7 +182,7 @@ export function IndicatorToolbar({
     ichimoku,
     candlePatterns,
 }: IndicatorToolbarProps) {
-    const [isExpanded, setIsExpanded] = useState(true);
+    const [isExpanded, setIsExpanded] = useState(false);
     const [openDropdown, setOpenDropdown] = useState<DropdownType>(null);
     const [dropdownPosition, setDropdownPosition] =
         useState<DropdownPosition | null>(null);
@@ -283,7 +283,7 @@ export function IndicatorToolbar({
                 }
                 className={cn(
                     indicatorButtonClass(COLLAPSE_BUTTON_ACTIVE),
-                    'flex items-center justify-center'
+                    'flex w-12 items-center justify-center'
                 )}
             >
                 <CollapseToggleIcon isExpanded={isExpanded} />
@@ -294,7 +294,7 @@ export function IndicatorToolbar({
                     {dropdownIndicators.map(indicator => (
                         <div
                             key={indicator.type}
-                            className="flex items-start gap-1"
+                            className="flex min-w-12 items-start gap-1"
                         >
                             <button
                                 ref={buttonRefMap[indicator.type]}
@@ -303,7 +303,7 @@ export function IndicatorToolbar({
                                 aria-expanded={openDropdown === indicator.type}
                                 className={cn(
                                     indicatorButtonClass(indicator.active),
-                                    'min-w-12 shrink-0'
+                                    'shrink-0'
                                 )}
                             >
                                 {indicator.label}
@@ -326,17 +326,21 @@ export function IndicatorToolbar({
                         )}
 
                     {toggleIndicators.map(indicator => (
-                        <button
+                        <div
                             key={indicator.label}
-                            type="button"
-                            onClick={indicator.onToggle}
-                            className={cn(
-                                indicatorButtonClass(indicator.visible),
-                                'min-w-12 shrink-0'
-                            )}
+                            className="flex min-w-12 items-start gap-1"
                         >
-                            {indicator.label}
-                        </button>
+                            <button
+                                type="button"
+                                onClick={indicator.onToggle}
+                                className={cn(
+                                    indicatorButtonClass(indicator.visible),
+                                    'shrink-0'
+                                )}
+                            >
+                                {indicator.label}
+                            </button>
+                        </div>
                     ))}
                 </>
             )}

--- a/src/components/chart/OverlayLegend.tsx
+++ b/src/components/chart/OverlayLegend.tsx
@@ -1,0 +1,84 @@
+import type React from 'react';
+import type { OverlayLegendItem } from '@/components/chart/types';
+
+interface OverlayLegendProps {
+    items: OverlayLegendItem[];
+}
+
+interface OverlayGroup {
+    key: string;
+    items: OverlayLegendItem[];
+}
+
+const ICHIMOKU_NAMES = new Set([
+    'Tenkan',
+    'Kijun',
+    'Chikou',
+    'Senkou A',
+    'Senkou B',
+]);
+const VP_NAMES = new Set(['POC', 'VAH', 'VAL']);
+
+function getGroupKey(name: string): string {
+    if (name.startsWith('MA(')) return 'MA';
+    if (name.startsWith('EMA(')) return 'EMA';
+    if (name.startsWith('BB ')) return 'BB';
+    if (ICHIMOKU_NAMES.has(name)) return 'Ichimoku';
+    if (VP_NAMES.has(name)) return 'VP';
+    return name;
+}
+
+function groupItems(items: OverlayLegendItem[]): OverlayGroup[] {
+    const groups: OverlayGroup[] = [];
+    const seen = new Map<string, number>();
+
+    for (const item of items) {
+        const key = getGroupKey(item.name);
+        const existingIdx = seen.get(key);
+
+        if (existingIdx !== undefined) {
+            groups[existingIdx].items.push(item);
+        } else {
+            seen.set(key, groups.length);
+            groups.push({ key, items: [item] });
+        }
+    }
+
+    return groups;
+}
+
+function formatValue(value: number | null): string {
+    if (value === null) return '-';
+    return value.toFixed(2);
+}
+
+export function OverlayLegend({ items }: OverlayLegendProps) {
+    if (items.length === 0) return null;
+
+    const groups = groupItems(items);
+
+    return (
+        <div className="pointer-events-none flex flex-col gap-[6px]">
+            {groups.map(group => (
+                <div
+                    key={group.key}
+                    className="flex flex-wrap gap-x-3 gap-y-[6px]"
+                >
+                    {group.items.map(item => (
+                        <span
+                            key={item.name}
+                            className="font-mono text-[11px] leading-none text-[color:var(--legend-color)]"
+                            style={
+                                {
+                                    '--legend-color': item.color,
+                                } as React.CSSProperties
+                            }
+                        >
+                            {'\u25CF'} {item.name} {formatValue(item.value)}
+                        </span>
+                    ))}
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/components/chart/OverlayLegend.tsx
+++ b/src/components/chart/OverlayLegend.tsx
@@ -1,10 +1,6 @@
 import type React from 'react';
 import type { OverlayLegendItem } from '@/components/chart/types';
 
-interface OverlayLegendProps {
-    items: OverlayLegendItem[];
-}
-
 interface OverlayGroup {
     key: string;
     items: OverlayLegendItem[];
@@ -54,6 +50,10 @@ function groupItems(items: OverlayLegendItem[]): OverlayGroup[] {
 function formatValue(value: number | null): string {
     if (value === null) return '-';
     return value.toFixed(2);
+}
+
+interface OverlayLegendProps {
+    items: OverlayLegendItem[];
 }
 
 export function OverlayLegend({ items }: OverlayLegendProps) {

--- a/src/components/chart/OverlayLegend.tsx
+++ b/src/components/chart/OverlayLegend.tsx
@@ -29,22 +29,26 @@ function getGroupKey(name: string): string {
 }
 
 function groupItems(items: OverlayLegendItem[]): OverlayGroup[] {
-    const groups: OverlayGroup[] = [];
-    const seen = new Map<string, number>();
+    return items.reduce<{ groups: OverlayGroup[]; seen: Map<string, number> }>(
+        ({ groups, seen }, item) => {
+            const key = getGroupKey(item.name);
+            const existingIdx = seen.get(key);
 
-    for (const item of items) {
-        const key = getGroupKey(item.name);
-        const existingIdx = seen.get(key);
+            if (existingIdx !== undefined) {
+                const updatedGroups = groups.map((g, i) =>
+                    i === existingIdx ? { ...g, items: [...g.items, item] } : g
+                );
+                return { groups: updatedGroups, seen };
+            }
 
-        if (existingIdx !== undefined) {
-            groups[existingIdx].items.push(item);
-        } else {
-            seen.set(key, groups.length);
-            groups.push({ key, items: [item] });
-        }
-    }
-
-    return groups;
+            const nextSeen = new Map(seen).set(key, groups.length);
+            return {
+                groups: [...groups, { key, items: [item] }],
+                seen: nextSeen,
+            };
+        },
+        { groups: [], seen: new Map() }
+    ).groups;
 }
 
 function formatValue(value: number | null): string {

--- a/src/components/chart/StockChart.tsx
+++ b/src/components/chart/StockChart.tsx
@@ -43,12 +43,15 @@ import { useTrendlineOverlay } from '@/components/chart/hooks/useTrendlineOverla
 import { useCandlePatternMarkers } from '@/components/chart/hooks/useCandlePatternMarkers';
 import { useKeyLevelsOverlay } from '@/components/chart/hooks/useKeyLevelsOverlay';
 import { usePaneLabels } from '@/components/chart/hooks/usePaneLabels';
+import { useOverlayLegend } from '@/components/chart/hooks/useOverlayLegend';
 import {
     DEFAULT_LINE_WIDTH,
     INACTIVE_PANE_INDEX,
 } from '@/components/chart/constants';
 import { IndicatorToolbar } from '@/components/chart/IndicatorToolbar';
+import { OverlayLegend } from '@/components/chart/OverlayLegend';
 import { buildPaneLabels } from '@/components/chart/utils/paneLabelUtils';
+import { buildOverlayLabelConfigs } from '@/components/chart/utils/overlayLabelUtils';
 import {
     MA_DEFAULT_PERIODS,
     EMA_DEFAULT_PERIODS,
@@ -312,6 +315,31 @@ export function StockChart({
         notifyPatternOverlayChange();
     }, [visiblePatterns]);
 
+    const overlayLabelConfigs = useMemo(
+        () =>
+            buildOverlayLabelConfigs({
+                maVisiblePeriods,
+                emaVisiblePeriods,
+                bollingerVisible,
+                ichimokuVisible,
+                vpVisible,
+            }),
+        [
+            maVisiblePeriods,
+            emaVisiblePeriods,
+            bollingerVisible,
+            ichimokuVisible,
+            vpVisible,
+        ]
+    );
+
+    const overlayLegendItems = useOverlayLegend({
+        chartRef,
+        bars,
+        indicators,
+        labelConfigs: overlayLabelConfigs,
+    });
+
     const paneLabels = useMemo(
         () => buildPaneLabels(paneIndices),
         [paneIndices]
@@ -356,40 +384,46 @@ export function StockChart({
     return (
         <div ref={wrapperRef} className="relative h-full w-full">
             <div ref={containerRef} className="h-full w-full" />
-            <div className="absolute top-2 left-2 z-10">
-                <IndicatorToolbar
-                    maVisiblePeriods={maVisiblePeriods}
-                    maAvailablePeriods={MA_DEFAULT_PERIODS}
-                    onMAToggle={toggleMAPeriod}
-                    emaVisiblePeriods={emaVisiblePeriods}
-                    emaAvailablePeriods={EMA_DEFAULT_PERIODS}
-                    onEMAToggle={toggleEMAPeriod}
-                    bollinger={{
-                        visible: bollingerVisible,
-                        onToggle: toggleBollinger,
-                    }}
-                    macd={{ visible: macdVisible, onToggle: toggleMACD }}
-                    rsi={{ visible: rsiVisible, onToggle: toggleRSI }}
-                    dmi={{ visible: dmiVisible, onToggle: toggleDMI }}
-                    stochastic={{
-                        visible: stochasticVisible,
-                        onToggle: toggleStochastic,
-                    }}
-                    stochRsi={{
-                        visible: stochRsiVisible,
-                        onToggle: toggleStochRSI,
-                    }}
-                    cci={{ visible: cciVisible, onToggle: toggleCCI }}
-                    volumeProfile={{ visible: vpVisible, onToggle: toggleVP }}
-                    ichimoku={{
-                        visible: ichimokuVisible,
-                        onToggle: toggleIchimoku,
-                    }}
-                    candlePatterns={{
-                        visible: candlePatternsVisible,
-                        onToggle: toggleCandlePatterns,
-                    }}
-                />
+            <div className="pointer-events-none absolute top-2 left-2 z-10 flex flex-col gap-1">
+                <div className="pointer-events-auto">
+                    <IndicatorToolbar
+                        maVisiblePeriods={maVisiblePeriods}
+                        maAvailablePeriods={MA_DEFAULT_PERIODS}
+                        onMAToggle={toggleMAPeriod}
+                        emaVisiblePeriods={emaVisiblePeriods}
+                        emaAvailablePeriods={EMA_DEFAULT_PERIODS}
+                        onEMAToggle={toggleEMAPeriod}
+                        bollinger={{
+                            visible: bollingerVisible,
+                            onToggle: toggleBollinger,
+                        }}
+                        macd={{ visible: macdVisible, onToggle: toggleMACD }}
+                        rsi={{ visible: rsiVisible, onToggle: toggleRSI }}
+                        dmi={{ visible: dmiVisible, onToggle: toggleDMI }}
+                        stochastic={{
+                            visible: stochasticVisible,
+                            onToggle: toggleStochastic,
+                        }}
+                        stochRsi={{
+                            visible: stochRsiVisible,
+                            onToggle: toggleStochRSI,
+                        }}
+                        cci={{ visible: cciVisible, onToggle: toggleCCI }}
+                        volumeProfile={{
+                            visible: vpVisible,
+                            onToggle: toggleVP,
+                        }}
+                        ichimoku={{
+                            visible: ichimokuVisible,
+                            onToggle: toggleIchimoku,
+                        }}
+                        candlePatterns={{
+                            visible: candlePatternsVisible,
+                            onToggle: toggleCandlePatterns,
+                        }}
+                    />
+                </div>
+                <OverlayLegend items={overlayLegendItems} />
             </div>
         </div>
     );

--- a/src/components/chart/hooks/useOverlayLegend.ts
+++ b/src/components/chart/hooks/useOverlayLegend.ts
@@ -5,9 +5,10 @@ import type { RefObject } from 'react';
 import type { IChartApi } from 'lightweight-charts';
 import type { Bar, IndicatorResult } from '@/domain/types';
 import type { OverlayLegendItem } from '@/components/chart/types';
-import type { OverlayLabelConfig } from '@/components/chart/utils/overlayLabelUtils';
 import {
     findBarIndex,
+    OverlayLabelConfig,
+    resolveBarIndex,
     resolveOverlayValues,
 } from '@/components/chart/utils/overlayLabelUtils';
 
@@ -28,14 +29,7 @@ export function useOverlayLegend({
 
     const barsRef = useRef<Bar[]>(bars);
 
-    const barIndex =
-        bars.length === 0
-            ? -1
-            : crosshairIndex === null
-              ? bars.length - 1
-              : crosshairIndex < 0
-                ? 0
-                : crosshairIndex;
+    const barIndex = resolveBarIndex(bars, crosshairIndex);
 
     const legendItems = useMemo(
         () => resolveOverlayValues(labelConfigs, indicators, barIndex),

--- a/src/components/chart/hooks/useOverlayLegend.ts
+++ b/src/components/chart/hooks/useOverlayLegend.ts
@@ -7,7 +7,7 @@ import type { Bar, IndicatorResult } from '@/domain/types';
 import type { OverlayLegendItem } from '@/components/chart/types';
 import {
     findBarIndex,
-    OverlayLabelConfig,
+    type OverlayLabelConfig,
     resolveBarIndex,
     resolveOverlayValues,
 } from '@/components/chart/utils/overlayLabelUtils';

--- a/src/components/chart/hooks/useOverlayLegend.ts
+++ b/src/components/chart/hooks/useOverlayLegend.ts
@@ -28,7 +28,8 @@ export function useOverlayLegend({
 
     const barsRef = useRef<Bar[]>(bars);
 
-    const barIndex = Math.max(0, crosshairIndex ?? bars.length - 1);
+    const barIndex =
+        bars.length === 0 ? -1 : Math.max(0, crosshairIndex ?? bars.length - 1);
 
     useEffect(() => {
         barsRef.current = bars;

--- a/src/components/chart/hooks/useOverlayLegend.ts
+++ b/src/components/chart/hooks/useOverlayLegend.ts
@@ -29,7 +29,13 @@ export function useOverlayLegend({
     const barsRef = useRef<Bar[]>(bars);
 
     const barIndex =
-        bars.length === 0 ? -1 : Math.max(0, crosshairIndex ?? bars.length - 1);
+        bars.length === 0
+            ? -1
+            : crosshairIndex === null
+              ? bars.length - 1
+              : crosshairIndex < 0
+                ? 0
+                : crosshairIndex;
 
     useEffect(() => {
         barsRef.current = bars;
@@ -40,8 +46,8 @@ export function useOverlayLegend({
         if (!chart) return;
 
         const handler = (param: { time?: unknown }): void => {
-            if (param.time !== undefined && param.time !== null) {
-                const idx = findBarIndex(barsRef.current, param.time as number);
+            if (typeof param.time === 'number') {
+                const idx = findBarIndex(barsRef.current, param.time);
                 setCrosshairIndex(idx);
             } else {
                 setCrosshairIndex(null);
@@ -55,8 +61,10 @@ export function useOverlayLegend({
         };
     }, [chartRef]);
 
-    return useMemo(
+    const legendItems = useMemo(
         () => resolveOverlayValues(labelConfigs, indicators, barIndex),
         [labelConfigs, indicators, barIndex]
     );
+
+    return legendItems;
 }

--- a/src/components/chart/hooks/useOverlayLegend.ts
+++ b/src/components/chart/hooks/useOverlayLegend.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+import type { IChartApi } from 'lightweight-charts';
+import type { Bar, IndicatorResult } from '@/domain/types';
+import type { OverlayLegendItem } from '@/components/chart/types';
+import type { OverlayLabelConfig } from '@/components/chart/utils/overlayLabelUtils';
+import {
+    findBarIndex,
+    resolveOverlayValues,
+} from '@/components/chart/utils/overlayLabelUtils';
+
+interface UseOverlayLegendParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    labelConfigs: OverlayLabelConfig[];
+}
+
+export function useOverlayLegend({
+    chartRef,
+    bars,
+    indicators,
+    labelConfigs,
+}: UseOverlayLegendParams): OverlayLegendItem[] {
+    const [crosshairIndex, setCrosshairIndex] = useState<number | null>(null);
+
+    const barsRef = useRef<Bar[]>(bars);
+
+    const barIndex = Math.max(0, crosshairIndex ?? bars.length - 1);
+
+    useEffect(() => {
+        barsRef.current = bars;
+    });
+
+    useEffect(() => {
+        const chart = chartRef.current;
+        if (!chart) return;
+
+        const handler = (param: { time?: unknown }): void => {
+            if (param.time !== undefined && param.time !== null) {
+                const idx = findBarIndex(barsRef.current, param.time as number);
+                setCrosshairIndex(idx);
+            } else {
+                setCrosshairIndex(null);
+            }
+        };
+
+        chart.subscribeCrosshairMove(handler);
+
+        return () => {
+            chart.unsubscribeCrosshairMove(handler);
+        };
+    }, [chartRef]);
+
+    return useMemo(
+        () => resolveOverlayValues(labelConfigs, indicators, barIndex),
+        [labelConfigs, indicators, barIndex]
+    );
+}

--- a/src/components/chart/hooks/useOverlayLegend.ts
+++ b/src/components/chart/hooks/useOverlayLegend.ts
@@ -37,6 +37,11 @@ export function useOverlayLegend({
                 ? 0
                 : crosshairIndex;
 
+    const legendItems = useMemo(
+        () => resolveOverlayValues(labelConfigs, indicators, barIndex),
+        [labelConfigs, indicators, barIndex]
+    );
+
     useEffect(() => {
         barsRef.current = bars;
     });
@@ -60,11 +65,6 @@ export function useOverlayLegend({
             chart.unsubscribeCrosshairMove(handler);
         };
     }, [chartRef]);
-
-    const legendItems = useMemo(
-        () => resolveOverlayValues(labelConfigs, indicators, barIndex),
-        [labelConfigs, indicators, barIndex]
-    );
 
     return legendItems;
 }

--- a/src/components/chart/hooks/useOverlayLegend.ts
+++ b/src/components/chart/hooks/useOverlayLegend.ts
@@ -44,7 +44,7 @@ export function useOverlayLegend({
 
     useEffect(() => {
         barsRef.current = bars;
-    });
+    }, [bars]);
 
     useEffect(() => {
         const chart = chartRef.current;

--- a/src/components/chart/types.ts
+++ b/src/components/chart/types.ts
@@ -1,3 +1,9 @@
+export interface OverlayLegendItem {
+    name: string;
+    color: string;
+    value: number | null;
+}
+
 export interface PaneSubLabel {
     name: string;
     color: string;

--- a/src/components/chart/types.ts
+++ b/src/components/chart/types.ts
@@ -1,6 +1,9 @@
-export interface OverlayLegendItem {
+export interface OverlayItemBase {
     name: string;
     color: string;
+}
+
+export interface OverlayLegendItem extends OverlayItemBase {
     value: number | null;
 }
 

--- a/src/components/chart/utils/overlayLabelUtils.ts
+++ b/src/components/chart/utils/overlayLabelUtils.ts
@@ -170,3 +170,14 @@ export function resolveOverlayValues(
         value: config.getValue(indicators, barIndex),
     }));
 }
+
+export function resolveBarIndex(
+    bars: Bar[],
+    crosshairIndex: number | null
+): number {
+    if (bars.length === 0) return -1;
+    if (crosshairIndex === null) return bars.length - 1;
+    if (crosshairIndex < 0) return 0;
+
+    return crosshairIndex;
+}

--- a/src/components/chart/utils/overlayLabelUtils.ts
+++ b/src/components/chart/utils/overlayLabelUtils.ts
@@ -135,7 +135,7 @@ export function findBarIndex(bars: Bar[], time: number): number {
     let low = 0;
     let high = bars.length - 1;
 
-    for (; low <= high; ) {
+    while (low <= high) {
         const mid = Math.floor((low + high) / 2);
         const midTime = bars[mid].time;
 

--- a/src/components/chart/utils/overlayLabelUtils.ts
+++ b/src/components/chart/utils/overlayLabelUtils.ts
@@ -1,0 +1,171 @@
+import { CHART_COLORS, getPeriodColor } from '@/lib/chartColors';
+import type { Bar, IndicatorResult } from '@/domain/types';
+import type { OverlayLegendItem } from '@/components/chart/types';
+
+export interface OverlayLabelConfig {
+    name: string;
+    color: string;
+    getValue: (indicators: IndicatorResult, barIndex: number) => number | null;
+}
+
+interface BuildOverlayLabelConfigsParams {
+    maVisiblePeriods: number[];
+    emaVisiblePeriods: number[];
+    bollingerVisible: boolean;
+    ichimokuVisible: boolean;
+    vpVisible: boolean;
+}
+
+export function buildOverlayLabelConfigs({
+    maVisiblePeriods,
+    emaVisiblePeriods,
+    bollingerVisible,
+    ichimokuVisible,
+    vpVisible,
+}: BuildOverlayLabelConfigsParams): OverlayLabelConfig[] {
+    const maConfigs: OverlayLabelConfig[] = maVisiblePeriods.map(period => ({
+        name: `MA(${period})`,
+        color: getPeriodColor(period),
+        getValue: (ind: IndicatorResult, i: number): number | null =>
+            ind.ma[period]?.[i] ?? null,
+    }));
+
+    const emaConfigs: OverlayLabelConfig[] = emaVisiblePeriods.map(period => ({
+        name: `EMA(${period})`,
+        color: getPeriodColor(period),
+        getValue: (ind: IndicatorResult, i: number): number | null =>
+            ind.ema[period]?.[i] ?? null,
+    }));
+
+    const bollingerConfigs: OverlayLabelConfig[] = bollingerVisible
+        ? [
+              {
+                  name: 'BB Upper',
+                  color: CHART_COLORS.bollingerUpper,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.bollinger[i]?.upper ?? null,
+              },
+              {
+                  name: 'BB Middle',
+                  color: CHART_COLORS.bollingerMiddle,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.bollinger[i]?.middle ?? null,
+              },
+              {
+                  name: 'BB Lower',
+                  color: CHART_COLORS.bollingerLower,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.bollinger[i]?.lower ?? null,
+              },
+          ]
+        : [];
+
+    const ichimokuConfigs: OverlayLabelConfig[] = ichimokuVisible
+        ? [
+              {
+                  name: 'Tenkan',
+                  color: CHART_COLORS.ichimokuTenkan,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.ichimoku[i]?.tenkan ?? null,
+              },
+              {
+                  name: 'Kijun',
+                  color: CHART_COLORS.ichimokuKijun,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.ichimoku[i]?.kijun ?? null,
+              },
+              {
+                  name: 'Chikou',
+                  color: CHART_COLORS.ichimokuChikou,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.ichimoku[i]?.chikou ?? null,
+              },
+              {
+                  name: 'Senkou A',
+                  color: CHART_COLORS.ichimokuSenkouA,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.ichimoku[i]?.senkouA ?? null,
+              },
+              {
+                  name: 'Senkou B',
+                  color: CHART_COLORS.ichimokuSenkouB,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.ichimoku[i]?.senkouB ?? null,
+              },
+          ]
+        : [];
+
+    const vpConfigs: OverlayLabelConfig[] = vpVisible
+        ? [
+              {
+                  name: 'POC',
+                  color: CHART_COLORS.vpPoc,
+                  getValue: (ind: IndicatorResult): number | null =>
+                      ind.volumeProfile?.poc ?? null,
+              },
+              {
+                  name: 'VAH',
+                  color: CHART_COLORS.vpVah,
+                  getValue: (ind: IndicatorResult): number | null =>
+                      ind.volumeProfile?.vah ?? null,
+              },
+              {
+                  name: 'VAL',
+                  color: CHART_COLORS.vpVal,
+                  getValue: (ind: IndicatorResult): number | null =>
+                      ind.volumeProfile?.val ?? null,
+              },
+          ]
+        : [];
+
+    return [
+        ...maConfigs,
+        ...emaConfigs,
+        ...bollingerConfigs,
+        ...ichimokuConfigs,
+        ...vpConfigs,
+    ];
+}
+
+export function findBarIndex(bars: Bar[], time: number): number {
+    if (bars.length === 0) return -1;
+    if (time <= bars[0].time) return 0;
+    if (time >= bars[bars.length - 1].time) return bars.length - 1;
+
+    let low = 0;
+    let high = bars.length - 1;
+
+    for (; low <= high; ) {
+        const mid = Math.floor((low + high) / 2);
+        const midTime = bars[mid].time;
+
+        if (midTime === time) return mid;
+        if (midTime < time) low = mid + 1;
+        else high = mid - 1;
+    }
+
+    // low and high crossed — find the closer one
+    const lowDiff = Math.abs(bars[low]?.time - time);
+    const highDiff = Math.abs(bars[high]?.time - time);
+    return lowDiff <= highDiff ? low : high;
+}
+
+export function resolveOverlayValues(
+    configs: OverlayLabelConfig[],
+    indicators: IndicatorResult,
+    barIndex: number
+): OverlayLegendItem[] {
+    if (barIndex === -1) {
+        return configs.map(config => ({
+            name: config.name,
+            color: config.color,
+            value: null,
+        }));
+    }
+
+    return configs.map(config => ({
+        name: config.name,
+        color: config.color,
+        value: config.getValue(indicators, barIndex),
+    }));
+}

--- a/src/components/chart/utils/overlayLabelUtils.ts
+++ b/src/components/chart/utils/overlayLabelUtils.ts
@@ -1,10 +1,11 @@
 import { CHART_COLORS, getPeriodColor } from '@/lib/chartColors';
 import type { Bar, IndicatorResult } from '@/domain/types';
-import type { OverlayLegendItem } from '@/components/chart/types';
+import type {
+    OverlayItemBase,
+    OverlayLegendItem,
+} from '@/components/chart/types';
 
-export interface OverlayLabelConfig {
-    name: string;
-    color: string;
+export interface OverlayLabelConfig extends OverlayItemBase {
     getValue: (indicators: IndicatorResult, barIndex: number) => number | null;
 }
 

--- a/src/components/chart/utils/overlayLabelUtils.ts
+++ b/src/components/chart/utils/overlayLabelUtils.ts
@@ -178,6 +178,7 @@ export function resolveBarIndex(
     if (bars.length === 0) return -1;
     if (crosshairIndex === null) return bars.length - 1;
     if (crosshairIndex < 0) return 0;
+    if (crosshairIndex >= bars.length) return bars.length - 1;
 
     return crosshairIndex;
 }


### PR DESCRIPTION
## 관련 이슈

closes #175

## 구현 내용

차트 위에 각 라인(이동평균선, 볼린저밴드, Ichimoku, 키 레벨 등)에 대한 범례/레이블을 명확하게 표시합니다.

### 주요 변경 사항
- **OverlayLegend.tsx**: 차트 위 범례를 렌더링하는 메인 컴포넌트
- **useOverlayLegend.ts**: 범례 표시 상태 관리 훅
- **overlayLabelUtils.ts**: 범례 텍스트 포맷팅 및 포지셔닝 유틸 함수
- **overlayLabelUtils.test.ts**: 유틸 함수 단위 테스트 (100% 커버리지)
- **StockChart.tsx**: OverlayLegend 컴포넌트 통합
- **types.ts**: 오버레이 범례 관련 타입 추가

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it

## 변경 파일 목록

[생성]
- src/components/chart/OverlayLegend.tsx
- src/components/chart/hooks/useOverlayLegend.ts
- src/components/chart/utils/overlayLabelUtils.ts
- src/__tests__/components/chart/utils/overlayLabelUtils.test.ts

[수정]
- src/components/chart/StockChart.tsx
- src/components/chart/types.ts

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build