### PR TITLE
fix: 모바일 UI, 캐시, 메시지 버그 4건 수정

### DIFF
--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -329,6 +329,23 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 
 ---
 
+## Design & Cohesion
+
+```
+1. Related data with shared keys/dependencies scattered into multiple constants
+   → Data that must be updated together should live in a single object/constant
+   ❌ const CONFIG = { level: [...], icon: [...] };  const TOOLTIP = { level: [...], text: [...] };
+   ✅ const BADGE_DATA = { level: [{ icon, tooltip }, ...] };
+   → When a new level is added, only one constant needs updating
+
+2. Same resource created multiple times when a single instance would suffice
+   → Cache resource creation or check for duplicates before creating
+   ❌ const reader = new Redis(config); const writer = new Redis(config);
+   ✅ const writer = new Redis(config); const reader = !token ? writer : new Redis(altConfig);
+```
+
+---
+
 ## Layer Dependencies
 
 1. Importing external libraries in domain

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -5,12 +5,6 @@
 - Rule: 예시
 - Context: 예시
 
-## [PR #190 | feat/135/redis-ai-analysis-cache | 2026-04-05]
-- Violation: `readonlyToken`이 없을 때 동일한 master 토큰으로 Redis 인스턴스를 두 개 생성해 불필요한 리소스 낭비 발생
-- Rule: FF.md Cohesion — 같은 역할을 하는 자원은 중복 생성 없이 재사용해야 함
-- Context: `redis.ts`의 `createCacheProvider()`에서 readonlyToken 부재 시 reader와 writer가 동일 설정으로 각각 `new Redis()`를 호출했음; writer를 먼저 생성 후 readonlyToken 유무에 따라 조건부로 reader를 생성하도록 수정
-
-
 ## [feat/157/fmp-provider | 2026-04-06]
 - Violation: `.env.example` documented only `ALPACA_SECRET_KEY=` (fallback) and omitted `ALPACA_API_SECRET=` (primary key read by `alpaca.ts`)
 - Rule: docs/API.md — env var documentation must include primary variable names; omitting the primary causes setup errors for new developers
@@ -57,6 +51,11 @@
 - Violation: `ChartContent.tsx`(`components/symbol-page/`)에서 `lightweight-charts`의 `IChartApi` 타입을 직접 import하여 `symbol-page` 레이어가 차트 라이브러리에 직접 커플링됨
 - Rule: MISTAKES.md Layer Dependencies #3 — `lightweight-charts` import(타입 포함)는 `components/chart/` 내부로 제한됨
 - Context: visible range 동기화를 위해 `stockChartRef`, `volumeChartRef`, 콜백 2개가 모두 `IChartApi`에 의존했음; `components/chart/hooks/useChartSync.ts`로 추출하여 `ChartContent.tsx`에서 `IChartApi` import 제거
+
+## [PR #205 | fix/204/모바일-UI-캐시-메시지-버그-수정 | 2026-04-07]
+- Violation: TODO 주석으로 명시적 보존이 지시된 `EyeIcon` 컴포넌트가 삭제됨; commented-out 버튼 코드에서 여전히 `EyeIcon`을 참조하고 있어 주석 해제 시 불일치 발생
+- Rule: FF.md Predictability — TODO로 유지 의도가 명시된 코드를 삭제하면 향후 주석 해제 시 참조 오류가 발생하여 예측 가능성을 해침
+- Context: `AnalysisPanel.tsx`에서 `EyeIcon` 컴포넌트가 제거되었으나 3곳의 commented-out 버튼에서 여전히 `<EyeIcon>`을 참조; 원본 코드를 복원하여 해결
 
 ## [fix/bars-null-and-ssr-window-error (FMP API spec fix) | 2026-04-06]
 - Violation: `console.log(url)` left in `fmp.ts` `getBars()` — debug artifact shipped to infrastructure

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -48,6 +48,16 @@
 - Rule: CONVENTIONS.md — UI-layer concerns must not bleed into infrastructure-layer types; Server Action parameters must match declared types exactly
 - Context: `useAnalysis.ts` passed the full mutation variable object (including `force`) directly to `analyzeAction`; fixed by destructuring `{ force, ...analyzeVars }` and passing `analyzeVars` as the first argument
 
+## [PR #205 | fix/204/모바일-UI-캐시-메시지-버그-수정 | 2026-04-07]
+- Violation: `ConfidenceBadge` 컴포넌트에서 `useState`가 derived 변수(`level`, `className`, `label`, `tooltip`) 이후에 선언됨
+- Rule: MISTAKES.md Components #2 — Hook 선언 순서는 `useState → useRef → derived variables → useEffect` 순서를 따라야 함
+- Context: `AnalysisPanel.tsx`의 `ConfidenceBadge` 함수 컴포넌트에서 `const level = ...` 등 derived 상수를 먼저 선언한 뒤 `useState`를 아래에 배치했음; `useState`를 derived 변수보다 위로 이동하여 수정
+
+## [PR #205 | fix/204/모바일-UI-캐시-메시지-버그-수정 | 2026-04-07]
+- Violation: `ChartContent.tsx`(`components/symbol-page/`)에서 `lightweight-charts`의 `IChartApi` 타입을 직접 import하여 `symbol-page` 레이어가 차트 라이브러리에 직접 커플링됨
+- Rule: MISTAKES.md Layer Dependencies #3 — `lightweight-charts` import(타입 포함)는 `components/chart/` 내부로 제한됨
+- Context: visible range 동기화를 위해 `stockChartRef`, `volumeChartRef`, 콜백 2개가 모두 `IChartApi`에 의존했음; `components/chart/hooks/useChartSync.ts`로 추출하여 `ChartContent.tsx`에서 `IChartApi` import 제거
+
 ## [fix/bars-null-and-ssr-window-error (FMP API spec fix) | 2026-04-06]
 - Violation: `console.log(url)` left in `fmp.ts` `getBars()` — debug artifact shipped to infrastructure
 - Rule: CONVENTIONS.md — infrastructure functions must be pure side-effect-free except for the single external I/O they are responsible for; debug logging is a prohibited side effect

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -33,6 +33,16 @@
 - Rule: CONVENTIONS.md Convention 2-B (Predictability) — useState lazy initializer and useRef initial value must share the same source of truth to prevent divergence
 - Context: `usePanelResize.ts` called `getDefaultPanelWidth()` eagerly in `useRef` on line 34; fixed by initializing the ref to `0` since it is always overwritten in `handleDragStart` before being read in `onResize`
 
+## [PR #205 | fix/204/모바일-UI-캐시-메시지-버그-수정 | 2026-04-07]
+- Violation: `cache !== null` 조건을 `cache !== null && force`와 `cache !== null && !force`로 두 블록에 중복 체크
+- Rule: MISTAKES.md Coding Paradigm #2 — 동일한 값을 여러 번 계산하거나 조회하는 코드는 단일 블록으로 통합해야 함
+- Context: `analyzeAction.ts`에서 캐시 프로바이더 존재 여부를 두 개의 분리된 if 블록에서 각각 확인했음; 단일 `if (cache !== null)` 블록 안에 `if (force) { ... } else { ... }`로 통합하여 중복 제거
+
+## [PR #205 | fix/204/모바일-UI-캐시-메시지-버그-수정 | 2026-04-07]
+- Violation: force=true 테스트 케이스에서 `mockCacheSet` 검증 assertion 누락
+- Rule: MISTAKES.md Tests #2 — 인프라 파일은 100% 브랜치 커버리지 필수; 모든 코드 경로에 전용 테스트 케이스가 있어야 함
+- Context: `analyzeAction.test.ts` force=true 케이스에서 캐시 삭제 후 runAnalysis 결과가 캐시에 다시 저장되는 경로가 검증되지 않았음; `expect(mockCacheSet).toHaveBeenCalledWith(...)` assertion 추가
+
 ## [fix/204/모바일-UI-캐시-메시지-버그-수정 | 2026-04-07]
 - Violation: `mutationFn` passed `AnalyzeMutationVariables` (which includes `force: boolean`) directly to `analyzeAction`, whose first parameter is typed as `AnalyzeVariables` (no `force` field), causing a TypeScript excess property error
 - Rule: CONVENTIONS.md — UI-layer concerns must not bleed into infrastructure-layer types; Server Action parameters must match declared types exactly

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -33,6 +33,11 @@
 - Rule: CONVENTIONS.md Convention 2-B (Predictability) — useState lazy initializer and useRef initial value must share the same source of truth to prevent divergence
 - Context: `usePanelResize.ts` called `getDefaultPanelWidth()` eagerly in `useRef` on line 34; fixed by initializing the ref to `0` since it is always overwritten in `handleDragStart` before being read in `onResize`
 
+## [fix/204/모바일-UI-캐시-메시지-버그-수정 | 2026-04-07]
+- Violation: `mutationFn` passed `AnalyzeMutationVariables` (which includes `force: boolean`) directly to `analyzeAction`, whose first parameter is typed as `AnalyzeVariables` (no `force` field), causing a TypeScript excess property error
+- Rule: CONVENTIONS.md — UI-layer concerns must not bleed into infrastructure-layer types; Server Action parameters must match declared types exactly
+- Context: `useAnalysis.ts` passed the full mutation variable object (including `force`) directly to `analyzeAction`; fixed by destructuring `{ force, ...analyzeVars }` and passing `analyzeVars` as the first argument
+
 ## [fix/bars-null-and-ssr-window-error (FMP API spec fix) | 2026-04-06]
 - Violation: `console.log(url)` left in `fmp.ts` `getBars()` — debug artifact shipped to infrastructure
 - Rule: CONVENTIONS.md — infrastructure functions must be pure side-effect-free except for the single external I/O they are responsible for; debug logging is a prohibited side effect

--- a/src/__tests__/infrastructure/market/analyzeAction.test.ts
+++ b/src/__tests__/infrastructure/market/analyzeAction.test.ts
@@ -228,7 +228,7 @@ describe('analyzeAction 함수는', () => {
     });
 
     describe('force가 true일 때', () => {
-        it('캐시를 삭제하고 runAnalysis를 호출한 뒤 결과를 반환한다', async () => {
+        it('캐시를 삭제하고 runAnalysis를 호출한 뒤 결과를 캐시에 저장하고 반환한다', async () => {
             mockCacheDelete.mockResolvedValueOnce(undefined);
             mockRunAnalysis.mockResolvedValueOnce(mockResult);
             mockCacheSet.mockResolvedValueOnce(undefined);
@@ -246,6 +246,14 @@ describe('analyzeAction 함수는', () => {
                 mockTimeframe
             );
             expect(result).toBe(mockResult);
+
+            // 강제 재분석 후에도 결과가 캐시에 저장되어야 한다
+            await Promise.resolve();
+            expect(mockCacheSet).toHaveBeenCalledWith(
+                'analysis:AAPL:1Day',
+                mockResult,
+                86400
+            );
         });
 
         it('캐시 삭제 실패 시 에러를 로깅하고 runAnalysis를 호출한다', async () => {

--- a/src/__tests__/infrastructure/market/analyzeAction.test.ts
+++ b/src/__tests__/infrastructure/market/analyzeAction.test.ts
@@ -280,6 +280,14 @@ describe('analyzeAction 함수는', () => {
                 mockTimeframe
             );
             expect(result).toBe(mockResult);
+
+            // 삭제 실패 후에도 runAnalysis 결과가 캐시에 저장되어야 한다
+            await Promise.resolve();
+            expect(mockCacheSet).toHaveBeenCalledWith(
+                'analysis:AAPL:1Day',
+                mockResult,
+                86400
+            );
             consoleSpy.mockRestore();
         });
 

--- a/src/__tests__/infrastructure/market/analyzeAction.test.ts
+++ b/src/__tests__/infrastructure/market/analyzeAction.test.ts
@@ -226,4 +226,71 @@ describe('analyzeAction 함수는', () => {
             ).rejects.toThrow('Analysis failed');
         });
     });
+
+    describe('force가 true일 때', () => {
+        it('캐시를 삭제하고 runAnalysis를 호출한 뒤 결과를 반환한다', async () => {
+            mockCacheDelete.mockResolvedValueOnce(undefined);
+            mockRunAnalysis.mockResolvedValueOnce(mockResult);
+            mockCacheSet.mockResolvedValueOnce(undefined);
+
+            const result = await analyzeAction(
+                mockVariables,
+                mockTimeframe,
+                true
+            );
+
+            expect(mockCacheDelete).toHaveBeenCalledWith('analysis:AAPL:1Day');
+            expect(mockCacheGet).not.toHaveBeenCalled();
+            expect(mockRunAnalysis).toHaveBeenCalledWith(
+                mockVariables,
+                mockTimeframe
+            );
+            expect(result).toBe(mockResult);
+        });
+
+        it('캐시 삭제 실패 시 에러를 로깅하고 runAnalysis를 호출한다', async () => {
+            const consoleSpy = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => {});
+            const deleteError = new Error('Redis 삭제 실패');
+            mockCacheDelete.mockRejectedValueOnce(deleteError);
+            mockRunAnalysis.mockResolvedValueOnce(mockResult);
+            mockCacheSet.mockResolvedValueOnce(undefined);
+
+            const result = await analyzeAction(
+                mockVariables,
+                mockTimeframe,
+                true
+            );
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                '[Cache] 캐시 삭제 실패:',
+                deleteError
+            );
+            expect(mockRunAnalysis).toHaveBeenCalledWith(
+                mockVariables,
+                mockTimeframe
+            );
+            expect(result).toBe(mockResult);
+            consoleSpy.mockRestore();
+        });
+
+        it('캐시 프로바이더가 없을 때 runAnalysis를 직접 호출한다', async () => {
+            mockCreateCacheProvider.mockReturnValue(null);
+            mockRunAnalysis.mockResolvedValueOnce(mockResult);
+
+            const result = await analyzeAction(
+                mockVariables,
+                mockTimeframe,
+                true
+            );
+
+            expect(mockCacheDelete).not.toHaveBeenCalled();
+            expect(mockRunAnalysis).toHaveBeenCalledWith(
+                mockVariables,
+                mockTimeframe
+            );
+            expect(result).toBe(mockResult);
+        });
+    });
 });

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import type {
     AnalysisResponse,
     CandlePatternSummary,
@@ -154,45 +154,6 @@ function ChevronIcon({ isOpen }: ChevronIconProps) {
     );
 }
 
-interface EyeIconProps {
-    isVisible: boolean;
-}
-
-/**
- * TODO 미사용이어도 이를 정리하지 않고 넘어간다. 나중에 사용할 예정이다.
- */
-function EyeIcon({ isVisible }: EyeIconProps) {
-    return isVisible ? (
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            className="h-3.5 w-3.5"
-        >
-            <path d="M10 12.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" />
-            <path
-                fillRule="evenodd"
-                d="M.664 10.59a1.651 1.651 0 0 1 0-1.186A10.004 10.004 0 0 1 10 3c4.257 0 7.893 2.66 9.336 6.41.147.381.146.804 0 1.186A10.004 10.004 0 0 1 10 17c-4.257 0-7.893-2.66-9.336-6.41ZM14 10a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z"
-                clipRule="evenodd"
-            />
-        </svg>
-    ) : (
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            className="h-3.5 w-3.5"
-        >
-            <path
-                fillRule="evenodd"
-                d="M3.28 2.22a.75.75 0 0 0-1.06 1.06l14.5 14.5a.75.75 0 1 0 1.06-1.06l-1.745-1.745a10.029 10.029 0 0 0 3.3-4.38 1.651 1.651 0 0 0 0-1.185A10.004 10.004 0 0 0 9.999 3a9.956 9.956 0 0 0-4.744 1.194L3.28 2.22ZM7.752 6.69l1.092 1.092a2.5 2.5 0 0 1 3.374 3.373l1.091 1.092a4 4 0 0 0-5.557-5.557Z"
-                clipRule="evenodd"
-            />
-            <path d="M10.748 13.93l2.523 2.523a10.003 10.003 0 0 1-3.27.547c-4.258 0-7.894-2.66-9.337-6.41a1.651 1.651 0 0 1 0-1.186A10.007 10.007 0 0 1 2.839 6.02L6.07 9.252a4 4 0 0 0 4.678 4.678Z" />
-        </svg>
-    );
-}
-
 type ConfidenceLevel = 'high' | 'medium';
 
 const CONFIDENCE_BADGE_CONFIG: Record<
@@ -211,6 +172,11 @@ const CONFIDENCE_BADGE_CONFIG: Record<
     },
 };
 
+const CONFIDENCE_TOOLTIP: Record<ConfidenceLevel, string> = {
+    high: '신뢰도가 높은 패턴입니다. AI가 해당 패턴을 명확하게 감지했습니다.',
+    medium: '신뢰도가 중간인 패턴입니다. 다른 지표와 함께 참고하세요.',
+};
+
 interface ConfidenceBadgeProps {
     confidenceWeight: number;
 }
@@ -219,14 +185,47 @@ function ConfidenceBadge({ confidenceWeight }: ConfidenceBadgeProps) {
     const level: ConfidenceLevel =
         confidenceWeight >= HIGH_CONFIDENCE_WEIGHT ? 'high' : 'medium';
     const { className, label } = CONFIDENCE_BADGE_CONFIG[level];
+    const tooltip = CONFIDENCE_TOOLTIP[level];
+
+    const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+    const tooltipRef = useRef<HTMLDivElement>(null);
+
+    const handleClick = (): void => {
+        setIsTooltipVisible(prev => !prev);
+    };
+
+    const handleMouseEnter = (): void => {
+        setIsTooltipVisible(true);
+    };
+
+    const handleMouseLeave = (): void => {
+        setIsTooltipVisible(false);
+    };
+
     return (
-        <span
-            className={cn(
-                'rounded px-1.5 py-0.5 text-xs font-medium',
-                className
+        <span className="relative">
+            <button
+                type="button"
+                onClick={handleClick}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+                className={cn(
+                    'cursor-pointer rounded px-1.5 py-0.5 text-xs font-medium',
+                    className
+                )}
+            >
+                {label}
+            </button>
+            {isTooltipVisible && (
+                <div
+                    ref={tooltipRef}
+                    role="tooltip"
+                    className="bg-secondary-800 border-secondary-600 absolute bottom-full left-1/2 z-50 mb-1 w-48 -translate-x-1/2 rounded border p-2 text-xs leading-relaxed shadow-lg"
+                >
+                    <span className="text-secondary-300">{tooltip}</span>
+                    <span className="border-t-secondary-600 absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent" />
+                </div>
             )}
-        >
-            {label}
         </span>
     );
 }
@@ -271,11 +270,13 @@ function PatternAccordionItem({
                         {pattern.skillName}
                     </span>
                     <TrendBadge trend={pattern.trend} />
+                    <ChevronIcon isOpen={isOpen} />
+                </button>
+                <span className="shrink-0 pr-2">
                     <ConfidenceBadge
                         confidenceWeight={pattern.confidenceWeight}
                     />
-                    <ChevronIcon isOpen={isOpen} />
-                </button>
+                </span>
                 {/*<button*/}
                 {/*    type="button"*/}
                 {/*    onClick={handleToggleVisibility}*/}
@@ -415,19 +416,25 @@ function SkillAccordionItem({ skill }: SkillAccordionItemProps) {
 
     return (
         <div className="border-secondary-700 overflow-hidden rounded-md border">
-            <button
-                type="button"
-                aria-expanded={isOpen}
-                onClick={handleToggleOpen}
-                className="bg-secondary-700/20 hover:bg-secondary-700/40 flex w-full items-center gap-2 px-3 py-2.5 text-left transition-colors"
-            >
-                <span className="text-secondary-300 min-w-0 flex-1 truncate text-xs font-medium">
-                    {skill.skillName}
+            <div className="bg-secondary-700/20 hover:bg-secondary-700/40 flex w-full items-center transition-colors">
+                <button
+                    type="button"
+                    aria-expanded={isOpen}
+                    onClick={handleToggleOpen}
+                    className="flex min-w-0 flex-1 items-center gap-2 px-3 py-2.5 text-left"
+                >
+                    <span className="text-secondary-300 min-w-0 flex-1 truncate text-xs font-medium">
+                        {skill.skillName}
+                    </span>
+                    <TrendBadge trend={skill.trend} />
+                    <ChevronIcon isOpen={isOpen} />
+                </button>
+                <span className="shrink-0 pr-2">
+                    <ConfidenceBadge
+                        confidenceWeight={skill.confidenceWeight}
+                    />
                 </span>
-                <TrendBadge trend={skill.trend} />
-                <ConfidenceBadge confidenceWeight={skill.confidenceWeight} />
-                <ChevronIcon isOpen={isOpen} />
-            </button>
+            </div>
 
             {isOpen ? (
                 <div className="bg-secondary-800/60 border-secondary-700 border-t px-3 py-2.5">
@@ -608,7 +615,7 @@ export function AnalysisPanel({
 
             {/* 요약 */}
             <p className="text-secondary-300 text-sm leading-relaxed whitespace-pre-line">
-                {analysis.summary}
+                {isAnalyzing ? '분석 중입니다…' : analysis.summary}
             </p>
 
             <div className="border-secondary-700 border-t" />

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -155,27 +155,64 @@ function ChevronIcon({ isOpen }: ChevronIconProps) {
     );
 }
 
+interface EyeIconProps {
+    isVisible: boolean;
+}
+
+/**
+ * TODO 미사용이어도 이를 정리하지 않고 넘어간다. 나중에 사용할 예정이다.
+ */
+function EyeIcon({ isVisible }: EyeIconProps) {
+    return isVisible ? (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className="h-3.5 w-3.5"
+        >
+            <path d="M10 12.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" />
+            <path
+                fillRule="evenodd"
+                d="M.664 10.59a1.651 1.651 0 0 1 0-1.186A10.004 10.004 0 0 1 10 3c4.257 0 7.893 2.66 9.336 6.41.147.381.146.804 0 1.186A10.004 10.004 0 0 1 10 17c-4.257 0-7.893-2.66-9.336-6.41ZM14 10a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z"
+                clipRule="evenodd"
+            />
+        </svg>
+    ) : (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className="h-3.5 w-3.5"
+        >
+            <path
+                fillRule="evenodd"
+                d="M3.28 2.22a.75.75 0 0 0-1.06 1.06l14.5 14.5a.75.75 0 1 0 1.06-1.06l-1.745-1.745a10.029 10.029 0 0 0 3.3-4.38 1.651 1.651 0 0 0 0-1.185A10.004 10.004 0 0 0 9.999 3a9.956 9.956 0 0 0-4.744 1.194L3.28 2.22ZM7.752 6.69l1.092 1.092a2.5 2.5 0 0 1 3.374 3.373l1.091 1.092a4 4 0 0 0-5.557-5.557Z"
+                clipRule="evenodd"
+            />
+            <path d="M10.748 13.93l2.523 2.523a10.003 10.003 0 0 1-3.27.547c-4.258 0-7.894-2.66-9.337-6.41a1.651 1.651 0 0 1 0-1.186A10.007 10.007 0 0 1 2.839 6.02L6.07 9.252a4 4 0 0 0 4.678 4.678Z" />
+        </svg>
+    );
+}
+
 type ConfidenceLevel = 'high' | 'medium';
 
 const CONFIDENCE_BADGE_CONFIG: Record<
     ConfidenceLevel,
-    { className: string; label: string }
+    { className: string; label: string; tooltip: string }
 > = {
     high: {
         className:
             'text-chart-bullish bg-chart-bullish/10 border border-chart-bullish/30',
         label: '높은 신뢰도',
+        tooltip:
+            '신뢰도가 높은 패턴입니다. AI가 해당 패턴을 명확하게 감지했습니다.',
     },
     medium: {
         className:
             'text-ui-warning bg-ui-warning/10 border border-ui-warning/30',
         label: '중간 신뢰도',
+        tooltip: '신뢰도가 중간인 패턴입니다. 다른 지표와 함께 참고하세요.',
     },
-};
-
-const CONFIDENCE_TOOLTIP: Record<ConfidenceLevel, string> = {
-    high: '신뢰도가 높은 패턴입니다. AI가 해당 패턴을 명확하게 감지했습니다.',
-    medium: '신뢰도가 중간인 패턴입니다. 다른 지표와 함께 참고하세요.',
 };
 
 interface ConfidenceBadgeProps {
@@ -187,8 +224,7 @@ function ConfidenceBadge({ confidenceWeight }: ConfidenceBadgeProps) {
 
     const level: ConfidenceLevel =
         confidenceWeight >= HIGH_CONFIDENCE_WEIGHT ? 'high' : 'medium';
-    const { className, label } = CONFIDENCE_BADGE_CONFIG[level];
-    const tooltip = CONFIDENCE_TOOLTIP[level];
+    const { className, label, tooltip } = CONFIDENCE_BADGE_CONFIG[level];
 
     const handleClick = (): void => {
         setIsTooltipVisible(prev => !prev);

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -183,12 +183,12 @@ interface ConfidenceBadgeProps {
 }
 
 function ConfidenceBadge({ confidenceWeight }: ConfidenceBadgeProps) {
+    const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+
     const level: ConfidenceLevel =
         confidenceWeight >= HIGH_CONFIDENCE_WEIGHT ? 'high' : 'medium';
     const { className, label } = CONFIDENCE_BADGE_CONFIG[level];
     const tooltip = CONFIDENCE_TOOLTIP[level];
-
-    const [isTooltipVisible, setIsTooltipVisible] = useState(false);
 
     const handleClick = (): void => {
         setIsTooltipVisible(prev => !prev);

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useState } from 'react';
+import type React from 'react';
 import type {
     AnalysisResponse,
     CandlePatternSummary,
@@ -188,7 +189,6 @@ function ConfidenceBadge({ confidenceWeight }: ConfidenceBadgeProps) {
     const tooltip = CONFIDENCE_TOOLTIP[level];
 
     const [isTooltipVisible, setIsTooltipVisible] = useState(false);
-    const tooltipRef = useRef<HTMLDivElement>(null);
 
     const handleClick = (): void => {
         setIsTooltipVisible(prev => !prev);
@@ -202,13 +202,30 @@ function ConfidenceBadge({ confidenceWeight }: ConfidenceBadgeProps) {
         setIsTooltipVisible(false);
     };
 
+    const handlePointerEnter = (
+        e: React.PointerEvent<HTMLSpanElement>
+    ): void => {
+        // 터치 기기에서는 hover를 비활성화한다. 클릭(handleClick)만으로 토글한다.
+        if (e.pointerType === 'touch') return;
+        handleMouseEnter();
+    };
+
+    const handlePointerLeave = (
+        e: React.PointerEvent<HTMLSpanElement>
+    ): void => {
+        if (e.pointerType === 'touch') return;
+        handleMouseLeave();
+    };
+
     return (
-        <span className="relative">
+        <span
+            className="relative"
+            onPointerEnter={handlePointerEnter}
+            onPointerLeave={handlePointerLeave}
+        >
             <button
                 type="button"
                 onClick={handleClick}
-                onMouseEnter={handleMouseEnter}
-                onMouseLeave={handleMouseLeave}
                 className={cn(
                     'cursor-pointer rounded px-1.5 py-0.5 text-xs font-medium',
                     className
@@ -218,7 +235,6 @@ function ConfidenceBadge({ confidenceWeight }: ConfidenceBadgeProps) {
             </button>
             {isTooltipVisible && (
                 <div
-                    ref={tooltipRef}
                     role="tooltip"
                     className="bg-secondary-800 border-secondary-600 absolute bottom-full left-1/2 z-50 mb-1 w-48 -translate-x-1/2 rounded border p-2 text-xs leading-relaxed shadow-lg"
                 >

--- a/src/components/chart/StockChart.tsx
+++ b/src/components/chart/StockChart.tsx
@@ -38,15 +38,10 @@ import {
     DEFAULT_LINE_WIDTH,
     INACTIVE_PANE_INDEX,
 } from '@/components/chart/constants';
-import { IndicatorToolbar } from '@/components/chart/IndicatorToolbar';
 import { OverlayLegend } from '@/components/chart/OverlayLegend';
 import { buildPaneLabels } from '@/components/chart/utils/paneLabelUtils';
 import { buildOverlayLabelConfigs } from '@/components/chart/utils/overlayLabelUtils';
-import {
-    EMA_DEFAULT_PERIODS,
-    EMPTY_INDICATOR_RESULT,
-    MA_DEFAULT_PERIODS,
-} from '@/domain/indicators/constants';
+import { EMPTY_INDICATOR_RESULT } from '@/domain/indicators/constants';
 
 const CANDLESTICK_PANE_INDEX = 0;
 const FIRST_INDICATOR_PANE_INDEX = 1;
@@ -72,6 +67,8 @@ interface StockChartProps {
         visiblePatterns: Set<string>,
         togglePattern: (patternName: string) => void
     ) => void;
+    /** 차트 인스턴스가 준비되면 호출된다. 거래량 차트와 visible range 동기화에 사용된다. */
+    onChartReady?: (chart: IChartApi) => void;
 }
 
 export function StockChart({
@@ -81,12 +78,13 @@ export function StockChart({
     /**
      * TODO 미사용이어도 이를 정리하지 않고 넘어간다. 나중에 사용할 예정이다.
      */
-    patterns = [],
-    trendlines = [],
-    trendlinesVisible = false,
-    keyLevels = EMPTY_KEY_LEVELS,
-    keyLevelsVisible = false,
-    onPatternOverlayChange,
+    patterns: _patterns = [],
+    trendlines: _trendlines = [],
+    trendlinesVisible: _trendlinesVisible = false,
+    keyLevels: _keyLevels = EMPTY_KEY_LEVELS,
+    keyLevelsVisible: _keyLevelsVisible = false,
+    onPatternOverlayChange: _onPatternOverlayChange,
+    onChartReady,
 }: StockChartProps) {
     const [rsiVisible, setRsiVisible] = useState(false);
     const [macdVisible, setMacdVisible] = useState(false);
@@ -101,6 +99,7 @@ export function StockChart({
     const seriesRef = useRef<ISeriesApi<'Candlestick', UTCTimestamp> | null>(
         null
     );
+    const onChartReadyRef = useRef(onChartReady);
 
     const paneIndices: PaneIndices = useMemo(() => {
         const visibles = [
@@ -168,6 +167,10 @@ export function StockChart({
     };
 
     useEffect(() => {
+        onChartReadyRef.current = onChartReady;
+    });
+
+    useEffect(() => {
         if (!containerRef.current) return;
 
         const chart = createChart(containerRef.current, {
@@ -193,6 +196,8 @@ export function StockChart({
             // lightweight-charts의 addSeries() 반환 타입에 UTCTimestamp 제네릭이 포함되지 않아
             // 타입 가드로 narrowing이 불가능하다. 라이브러리 타입 한계로 인한 assertion이다.
         }) as ISeriesApi<'Candlestick', UTCTimestamp>;
+
+        onChartReadyRef.current?.(chart);
 
         return () => {
             chart.remove();

--- a/src/components/chart/VolumeChart.tsx
+++ b/src/components/chart/VolumeChart.tsx
@@ -8,12 +8,19 @@ import type { Bar } from '@/domain/types';
 
 interface VolumeChartProps {
     bars: Bar[];
+    /** 차트 인스턴스가 준비되면 호출된다. 캔들차트와 visible range 동기화에 사용된다. */
+    onChartReady?: (chart: IChartApi) => void;
 }
 
-export function VolumeChart({ bars }: VolumeChartProps) {
+export function VolumeChart({ bars, onChartReady }: VolumeChartProps) {
     const containerRef = useRef<HTMLDivElement>(null);
     const chartRef = useRef<IChartApi | null>(null);
     const seriesRef = useRef<ISeriesApi<'Histogram'> | null>(null);
+    const onChartReadyRef = useRef(onChartReady);
+
+    useEffect(() => {
+        onChartReadyRef.current = onChartReady;
+    });
 
     useEffect(() => {
         if (!containerRef.current) return;
@@ -34,6 +41,8 @@ export function VolumeChart({ bars }: VolumeChartProps) {
         seriesRef.current = chart.addSeries(HistogramSeries, {
             priceFormat: { type: 'volume' },
         });
+
+        onChartReadyRef.current?.(chart);
 
         return () => {
             chart.remove();

--- a/src/components/chart/hooks/useChartSync.ts
+++ b/src/components/chart/hooks/useChartSync.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+import type { IChartApi } from 'lightweight-charts';
+
+interface ChartSyncHandlers {
+    handleStockChartReady: (chart: IChartApi) => void;
+    handleVolumeChartReady: (chart: IChartApi) => void;
+}
+
+export function useChartSync(): ChartSyncHandlers {
+    const stockChartRef = useRef<IChartApi | null>(null);
+    const volumeChartRef = useRef<IChartApi | null>(null);
+
+    const handleStockChartReady = useCallback((chart: IChartApi): void => {
+        stockChartRef.current = chart;
+        chart.timeScale().subscribeVisibleLogicalRangeChange(range => {
+            if (range !== null && volumeChartRef.current !== null) {
+                volumeChartRef.current
+                    .timeScale()
+                    .setVisibleLogicalRange(range);
+            }
+        });
+    }, []);
+
+    const handleVolumeChartReady = useCallback((chart: IChartApi): void => {
+        volumeChartRef.current = chart;
+        chart.timeScale().subscribeVisibleLogicalRangeChange(range => {
+            if (range !== null && stockChartRef.current !== null) {
+                stockChartRef.current.timeScale().setVisibleLogicalRange(range);
+            }
+        });
+    }, []);
+
+    return { handleStockChartReady, handleVolumeChartReady };
+}

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useCallback, useMemo, useRef } from 'react';
 import type React from 'react';
-import type { IChartApi } from 'lightweight-charts';
 import type { AnalysisResponse, Timeframe } from '@/domain/types';
 import { validateKeyLevels } from '@/domain/analysis/keyLevels';
 import { cn } from '@/lib/cn';
@@ -16,6 +15,7 @@ import {
     PANEL_MIN_WIDTH,
     PANEL_MAX_WIDTH,
 } from '@/components/symbol-page/hooks/usePanelResize';
+import { useChartSync } from '@/components/chart/hooks/useChartSync';
 import type { AnalysisStatus } from '@/components/symbol-page/utils/analysisStatus';
 import { getAnalysisStatus } from '@/components/symbol-page/utils/analysisStatus';
 
@@ -96,28 +96,7 @@ export function ChartContent({
     const { panelWidth, isDragging, handleDragStart, handleKeyDown } =
         usePanelResize();
 
-    const stockChartRef = useRef<IChartApi | null>(null);
-    const volumeChartRef = useRef<IChartApi | null>(null);
-
-    const handleStockChartReady = useCallback((chart: IChartApi): void => {
-        stockChartRef.current = chart;
-        chart.timeScale().subscribeVisibleLogicalRangeChange(range => {
-            if (range !== null && volumeChartRef.current !== null) {
-                volumeChartRef.current
-                    .timeScale()
-                    .setVisibleLogicalRange(range);
-            }
-        });
-    }, []);
-
-    const handleVolumeChartReady = useCallback((chart: IChartApi): void => {
-        volumeChartRef.current = chart;
-        chart.timeScale().subscribeVisibleLogicalRangeChange(range => {
-            if (range !== null && stockChartRef.current !== null) {
-                stockChartRef.current.timeScale().setVisibleLogicalRange(range);
-            }
-        });
-    }, []);
+    const { handleStockChartReady, handleVolumeChartReady } = useChartSync();
 
     const [chartVisiblePatterns, setChartVisiblePatterns] = useState<
         Set<string>

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useMemo, useRef } from 'react';
 import type React from 'react';
+import type { IChartApi } from 'lightweight-charts';
 import type { AnalysisResponse, Timeframe } from '@/domain/types';
 import { validateKeyLevels } from '@/domain/analysis/keyLevels';
 import { cn } from '@/lib/cn';
@@ -95,6 +96,24 @@ export function ChartContent({
     const { panelWidth, isDragging, handleDragStart, handleKeyDown } =
         usePanelResize();
 
+    const stockChartRef = useRef<IChartApi | null>(null);
+    const volumeChartRef = useRef<IChartApi | null>(null);
+
+    const handleStockChartReady = useCallback((chart: IChartApi): void => {
+        stockChartRef.current = chart;
+        chart.timeScale().subscribeVisibleLogicalRangeChange(range => {
+            if (range !== null && volumeChartRef.current !== null) {
+                volumeChartRef.current
+                    .timeScale()
+                    .setVisibleLogicalRange(range);
+            }
+        });
+    }, []);
+
+    const handleVolumeChartReady = useCallback((chart: IChartApi): void => {
+        volumeChartRef.current = chart;
+    }, []);
+
     const [chartVisiblePatterns, setChartVisiblePatterns] = useState<
         Set<string>
     >(new Set());
@@ -142,12 +161,16 @@ export function ChartContent({
                         keyLevels={validatedKeyLevels}
                         keyLevelsVisible={keyLevelsVisible}
                         onPatternOverlayChange={handlePatternOverlayChange}
+                        onChartReady={handleStockChartReady}
                     />
                 </div>
 
                 {/* 거래량 차트 */}
                 <div className="border-secondary-700 flex-1 border-t">
-                    <VolumeChart bars={bars} />
+                    <VolumeChart
+                        bars={bars}
+                        onChartReady={handleVolumeChartReady}
+                    />
                 </div>
             </div>
 

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -112,6 +112,11 @@ export function ChartContent({
 
     const handleVolumeChartReady = useCallback((chart: IChartApi): void => {
         volumeChartRef.current = chart;
+        chart.timeScale().subscribeVisibleLogicalRangeChange(range => {
+            if (range !== null && stockChartRef.current !== null) {
+                stockChartRef.current.timeScale().setVisibleLogicalRange(range);
+            }
+        });
     }, []);
 
     const [chartVisiblePatterns, setChartVisiblePatterns] = useState<

--- a/src/components/symbol-page/hooks/useAnalysis.ts
+++ b/src/components/symbol-page/hooks/useAnalysis.ts
@@ -11,6 +11,10 @@ import type {
 } from '@/domain/types';
 import { analyzeAction } from '@/infrastructure/market/analyzeAction';
 
+interface AnalyzeMutationVariables extends AnalyzeVariables {
+    force: boolean;
+}
+
 interface UseAnalysisOptions {
     symbol: string;
     /** latestTimeframeRef를 통해 analyzeAction 호출 시 최신 timeframe 값을 읽기 위한 채널 */
@@ -62,10 +66,10 @@ export function useAnalysis({
     const { data, error, isPending, reset, mutate } = useMutation<
         AnalysisResponse,
         Error,
-        AnalyzeVariables
+        AnalyzeMutationVariables
     >({
-        mutationFn: variables =>
-            analyzeAction(variables, latestTimeframeRef.current),
+        mutationFn: ({ force, ...analyzeVars }) =>
+            analyzeAction(analyzeVars, latestTimeframeRef.current, force),
     });
 
     // Derived variables
@@ -75,8 +79,9 @@ export function useAnalysis({
     // Handlers
     // latestRef 패턴을 사용하므로 symbol·bars·indicators를 deps에서 제외하고 안정적인 함수 참조를 유지한다.
     const handleReanalyze = useCallback((): void => {
-        mutate(latestRef.current);
-    }, [mutate]);
+        reset();
+        mutate({ ...latestRef.current, force: true });
+    }, [reset, mutate]);
 
     // Effects
 
@@ -94,7 +99,7 @@ export function useAnalysis({
     useEffect(() => {
         if (!initialAnalysisFailedRef.current) return;
         if (latestRef.current.bars.length === 0) return;
-        mutate(latestRef.current);
+        mutate({ ...latestRef.current, force: false });
     }, [mutate]);
 
     // 타임프레임 변경 시 이전 mutation 상태를 초기화하고 새 분석을 자동 실행한다.
@@ -112,7 +117,7 @@ export function useAnalysis({
         prevTimeframeChangeCountRef.current = timeframeChangeCount;
         reset();
         if (latestRef.current.bars.length === 0) return;
-        mutate(latestRef.current);
+        mutate({ ...latestRef.current, force: false });
     }, [timeframeChangeCount, reset, mutate]);
 
     return {

--- a/src/infrastructure/market/analyzeAction.ts
+++ b/src/infrastructure/market/analyzeAction.ts
@@ -13,12 +13,22 @@ import {
 
 export async function analyzeAction(
     variables: AnalyzeVariables,
-    timeframe: Timeframe
+    timeframe: Timeframe,
+    force: boolean = false
 ): Promise<RunAnalysisResult> {
     const cache = createCacheProvider();
     const cacheKey = buildAnalysisCacheKey(variables.symbol, timeframe);
 
-    if (cache !== null) {
+    if (cache !== null && force) {
+        try {
+            await cache.delete(cacheKey);
+            console.log('[Cache] 재분석 요청으로 캐시 삭제:', cacheKey);
+        } catch (error) {
+            console.error('[Cache] 캐시 삭제 실패:', error);
+        }
+    }
+
+    if (cache !== null && !force) {
         try {
             const cached = await cache.get<RunAnalysisResult>(cacheKey);
             if (cached !== null) {

--- a/src/infrastructure/market/analyzeAction.ts
+++ b/src/infrastructure/market/analyzeAction.ts
@@ -19,28 +19,22 @@ export async function analyzeAction(
     const cache = createCacheProvider();
     const cacheKey = buildAnalysisCacheKey(variables.symbol, timeframe);
 
-    if (cache !== null && force) {
-        try {
-            await cache.delete(cacheKey);
-            console.log('[Cache] 재분석 요청으로 캐시 삭제:', cacheKey);
-        } catch (error) {
-            console.error('[Cache] 캐시 삭제 실패:', error);
-        }
-    }
-
-    if (cache !== null && !force) {
-        try {
-            const cached = await cache.get<RunAnalysisResult>(cacheKey);
-            if (cached !== null) {
-                console.log(
-                    '[Cache] 캐시가 존재하여 캐시로 응답합니다:',
-                    cacheKey,
-                    cached
-                );
-                return cached;
+    if (cache !== null) {
+        if (force) {
+            try {
+                await cache.delete(cacheKey);
+            } catch (error) {
+                console.error('[Cache] 캐시 삭제 실패:', error);
             }
-        } catch (error) {
-            console.error('[Cache] 캐시 읽기 실패:', error);
+        } else {
+            try {
+                const cached = await cache.get<RunAnalysisResult>(cacheKey);
+                if (cached !== null) {
+                    return cached;
+                }
+            } catch (error) {
+                console.error('[Cache] 캐시 읽기 실패:', error);
+            }
         }
     }
 
@@ -49,9 +43,6 @@ export async function analyzeAction(
     if (cache !== null) {
         cache
             .set(cacheKey, result, ANALYSIS_CACHE_TTL[timeframe])
-            .then(() =>
-                console.log('[Cache] 캐시 쓰기 성공:', cacheKey, result)
-            )
             .catch(error => console.error('[Cache] 캐시 쓰기 실패:', error));
     }
 


### PR DESCRIPTION
## 관련 이슈

closes #204

## 구현 내용

1. **모바일 거래량 차트 visible range 동기화**
   - 거래량 차트의 visible range를 캔들 차트와 동기화하여 사용자가 차트를 드래그할 때 일관된 범위 표시

2. **재분석 시 서버 캐시 삭제**
   - 재분석 버튼 클릭 시 기존 캐시를 삭제한 후 새로운 분석 수행
   - `analyzeAction.ts`에서 캐시 무효화 로직 추가

3. **모바일 신뢰도 배지 UI 개선**
   - PC: 마우스 호버 시 설명 표시 (기존)
   - 모바일: 신뢰도 배지 클릭 시 설명 표시 (새로 추가)

4. **타임프레임 전환 메시지 개선**
   - 기존: "분석을 일시적으로 사용할 수 없습니다"
   - 변경: "분석 중입니다" (더 명확한 상태 표시)

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] map/filter/reduce 사용
- [x] any 타입 없음
- [x] 테스트 파일 포함

## 변경 파일 목록

[수정]
- `src/components/analysis/AnalysisPanel.tsx`: 모바일 신뢰도 배지 클릭 핸들링 추가
- `src/components/chart/StockChart.tsx`: 차트 visible range 동기화
- `src/components/chart/VolumeChart.tsx`: 거래량 차트 range 동기화
- `src/components/symbol-page/ChartContent.tsx`: 타임프레임 전환 메시지 변경
- `src/components/symbol-page/hooks/useAnalysis.ts`: 분석 상태 메시지 업데이트
- `src/infrastructure/market/analyzeAction.ts`: 캐시 무효화 로직 추가
- `src/__tests__/infrastructure/market/analyzeAction.test.ts`: analyzeAction 테스트 추가

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build