### PR TITLE
fix: 보조지표 pane 제거 실패 및 label 위치 미갱신 문제 해결

### DIFF
--- a/src/components/chart/StockChart.tsx
+++ b/src/components/chart/StockChart.tsx
@@ -41,8 +41,12 @@ import {
 import { OverlayLegend } from '@/components/chart/OverlayLegend';
 import { buildPaneLabels } from '@/components/chart/utils/paneLabelUtils';
 import { buildOverlayLabelConfigs } from '@/components/chart/utils/overlayLabelUtils';
-import {EMA_DEFAULT_PERIODS, EMPTY_INDICATOR_RESULT, MA_DEFAULT_PERIODS} from '@/domain/indicators/constants';
-import {IndicatorToolbar} from "@/components/chart/IndicatorToolbar";
+import {
+    EMA_DEFAULT_PERIODS,
+    EMPTY_INDICATOR_RESULT,
+    MA_DEFAULT_PERIODS,
+} from '@/domain/indicators/constants';
+import { IndicatorToolbar } from '@/components/chart/IndicatorToolbar';
 
 const FIRST_INDICATOR_PANE_INDEX = 1;
 const EMPTY_KEY_LEVELS: KeyLevels = { support: [], resistance: [] };
@@ -405,42 +409,42 @@ export function StockChart({
             <div ref={containerRef} className="h-full w-full" />
             <div className="pointer-events-none absolute top-2 left-2 z-10 flex flex-col gap-1">
                 <div className="pointer-events-auto">
-                <IndicatorToolbar
-                    maVisiblePeriods={maVisiblePeriods}
-                    maAvailablePeriods={MA_DEFAULT_PERIODS}
-                    onMAToggle={toggleMAPeriod}
-                    emaVisiblePeriods={emaVisiblePeriods}
-                    emaAvailablePeriods={EMA_DEFAULT_PERIODS}
-                    onEMAToggle={toggleEMAPeriod}
-                    bollinger={{
-                        visible: bollingerVisible,
-                        onToggle: toggleBollinger,
-                    }}
-                    macd={{ visible: macdVisible, onToggle: toggleMACD }}
-                    rsi={{ visible: rsiVisible, onToggle: toggleRSI }}
-                    dmi={{ visible: dmiVisible, onToggle: toggleDMI }}
-                    stochastic={{
-                        visible: stochasticVisible,
-                        onToggle: toggleStochastic,
-                    }}
-                    stochRsi={{
-                        visible: stochRsiVisible,
-                        onToggle: toggleStochRSI,
-                    }}
-                    cci={{ visible: cciVisible, onToggle: toggleCCI }}
-                    volumeProfile={{
-                        visible: vpVisible,
-                        onToggle: toggleVP,
-                    }}
-                    ichimoku={{
-                        visible: ichimokuVisible,
-                        onToggle: toggleIchimoku,
-                    }}
-                    candlePatterns={{
-                        visible: candlePatternsVisible,
-                        onToggle: toggleCandlePatterns,
-                    }}
-                />
+                    <IndicatorToolbar
+                        maVisiblePeriods={maVisiblePeriods}
+                        maAvailablePeriods={MA_DEFAULT_PERIODS}
+                        onMAToggle={toggleMAPeriod}
+                        emaVisiblePeriods={emaVisiblePeriods}
+                        emaAvailablePeriods={EMA_DEFAULT_PERIODS}
+                        onEMAToggle={toggleEMAPeriod}
+                        bollinger={{
+                            visible: bollingerVisible,
+                            onToggle: toggleBollinger,
+                        }}
+                        macd={{ visible: macdVisible, onToggle: toggleMACD }}
+                        rsi={{ visible: rsiVisible, onToggle: toggleRSI }}
+                        dmi={{ visible: dmiVisible, onToggle: toggleDMI }}
+                        stochastic={{
+                            visible: stochasticVisible,
+                            onToggle: toggleStochastic,
+                        }}
+                        stochRsi={{
+                            visible: stochRsiVisible,
+                            onToggle: toggleStochRSI,
+                        }}
+                        cci={{ visible: cciVisible, onToggle: toggleCCI }}
+                        volumeProfile={{
+                            visible: vpVisible,
+                            onToggle: toggleVP,
+                        }}
+                        ichimoku={{
+                            visible: ichimokuVisible,
+                            onToggle: toggleIchimoku,
+                        }}
+                        candlePatterns={{
+                            visible: candlePatternsVisible,
+                            onToggle: toggleCandlePatterns,
+                        }}
+                    />
                 </div>
                 <OverlayLegend items={overlayLegendItems} />
             </div>

--- a/src/components/chart/StockChart.tsx
+++ b/src/components/chart/StockChart.tsx
@@ -41,9 +41,9 @@ import {
 import { OverlayLegend } from '@/components/chart/OverlayLegend';
 import { buildPaneLabels } from '@/components/chart/utils/paneLabelUtils';
 import { buildOverlayLabelConfigs } from '@/components/chart/utils/overlayLabelUtils';
-import { EMPTY_INDICATOR_RESULT } from '@/domain/indicators/constants';
+import {EMA_DEFAULT_PERIODS, EMPTY_INDICATOR_RESULT, MA_DEFAULT_PERIODS} from '@/domain/indicators/constants';
+import {IndicatorToolbar} from "@/components/chart/IndicatorToolbar";
 
-const CANDLESTICK_PANE_INDEX = 0;
 const FIRST_INDICATOR_PANE_INDEX = 1;
 const EMPTY_KEY_LEVELS: KeyLevels = { support: [], resistance: [] };
 
@@ -312,19 +312,33 @@ export function StockChart({
     //     lineWidth: DEFAULT_LINE_WIDTH,
     // });
 
-    // LWC DOM 레이아웃 강제 갱신
-    // indicator hook의 removeSeries 후 LWC가 빈 pane을 내부적으로 제거하지만
-    // DOM 레이아웃(높이 배분)을 즉시 갱신하지 않아 빈 공간이 남는다.
-    // cleanup 없는 RAF로 다음 페인트 직전에 레이아웃을 강제 갱신한다.
+    // 레이아웃 강제 갱신
+    // indicator hook이 removeSeries로 마지막 series를 제거하면 LWC v5는 논리적
+    // pane을 panes() 배열에서 빼지만, 일부 indicator(MACD/Stochastic/CCI 등)에서
+    // DOM 레이아웃 재계산이 트리거되지 않아 빈 공간이 남는다. AI 패널 리사이즈로
+    // wrapper 크기가 변하면 LWC autoSize ResizeObserver가 발화해 정리된다.
+    // autoSize: true 상태에서는 명시 chart.resize() 호출이 무시되므로,
+    // autoSize를 잠시 끄고 → 1px 차이로 강제 resize → autoSize 복원 순서로
+    // ResizeObserver 발화와 동일한 layout invalidate를 일으킨다.
     // cleanup이 있으면 후속 리렌더에 의해 RAF가 취소될 수 있으므로 의도적으로 생략한다.
     useEffect(() => {
         const chart = chartRef.current;
-        if (!chart) return;
+        const wrapper = wrapperRef.current;
+        if (!chart || !wrapper) return;
 
         requestAnimationFrame(() => {
-            // chart가 이미 소멸했을 수 있으므로 재확인
-            if (!chartRef.current) return;
-            chartRef.current.timeScale().fitContent();
+            const currentChart = chartRef.current;
+            const currentWrapper = wrapperRef.current;
+            if (!currentChart || !currentWrapper) return;
+
+            const { clientWidth, clientHeight } = currentWrapper;
+            if (clientWidth === 0 || clientHeight === 0) return;
+
+            currentChart.applyOptions({ autoSize: false });
+            currentChart.resize(clientWidth - 1, clientHeight);
+            currentChart.resize(clientWidth, clientHeight);
+            currentChart.applyOptions({ autoSize: true });
+            currentChart.timeScale().fitContent();
         });
     }, [paneIndices]);
 
@@ -390,44 +404,44 @@ export function StockChart({
         <div ref={wrapperRef} className="relative h-full w-full">
             <div ref={containerRef} className="h-full w-full" />
             <div className="pointer-events-none absolute top-2 left-2 z-10 flex flex-col gap-1">
-                {/*<div className="pointer-events-auto">*/}
-                {/*<IndicatorToolbar*/}
-                {/*    maVisiblePeriods={maVisiblePeriods}*/}
-                {/*    maAvailablePeriods={MA_DEFAULT_PERIODS}*/}
-                {/*    onMAToggle={toggleMAPeriod}*/}
-                {/*    emaVisiblePeriods={emaVisiblePeriods}*/}
-                {/*    emaAvailablePeriods={EMA_DEFAULT_PERIODS}*/}
-                {/*    onEMAToggle={toggleEMAPeriod}*/}
-                {/*    bollinger={{*/}
-                {/*        visible: bollingerVisible,*/}
-                {/*        onToggle: toggleBollinger,*/}
-                {/*    }}*/}
-                {/*    macd={{ visible: macdVisible, onToggle: toggleMACD }}*/}
-                {/*    rsi={{ visible: rsiVisible, onToggle: toggleRSI }}*/}
-                {/*    dmi={{ visible: dmiVisible, onToggle: toggleDMI }}*/}
-                {/*    stochastic={{*/}
-                {/*        visible: stochasticVisible,*/}
-                {/*        onToggle: toggleStochastic,*/}
-                {/*    }}*/}
-                {/*    stochRsi={{*/}
-                {/*        visible: stochRsiVisible,*/}
-                {/*        onToggle: toggleStochRSI,*/}
-                {/*    }}*/}
-                {/*    cci={{ visible: cciVisible, onToggle: toggleCCI }}*/}
-                {/*    volumeProfile={{*/}
-                {/*        visible: vpVisible,*/}
-                {/*        onToggle: toggleVP,*/}
-                {/*    }}*/}
-                {/*    ichimoku={{*/}
-                {/*        visible: ichimokuVisible,*/}
-                {/*        onToggle: toggleIchimoku,*/}
-                {/*    }}*/}
-                {/*    candlePatterns={{*/}
-                {/*        visible: candlePatternsVisible,*/}
-                {/*        onToggle: toggleCandlePatterns,*/}
-                {/*    }}*/}
-                {/*/>*/}
-                {/*</div>*/}
+                <div className="pointer-events-auto">
+                <IndicatorToolbar
+                    maVisiblePeriods={maVisiblePeriods}
+                    maAvailablePeriods={MA_DEFAULT_PERIODS}
+                    onMAToggle={toggleMAPeriod}
+                    emaVisiblePeriods={emaVisiblePeriods}
+                    emaAvailablePeriods={EMA_DEFAULT_PERIODS}
+                    onEMAToggle={toggleEMAPeriod}
+                    bollinger={{
+                        visible: bollingerVisible,
+                        onToggle: toggleBollinger,
+                    }}
+                    macd={{ visible: macdVisible, onToggle: toggleMACD }}
+                    rsi={{ visible: rsiVisible, onToggle: toggleRSI }}
+                    dmi={{ visible: dmiVisible, onToggle: toggleDMI }}
+                    stochastic={{
+                        visible: stochasticVisible,
+                        onToggle: toggleStochastic,
+                    }}
+                    stochRsi={{
+                        visible: stochRsiVisible,
+                        onToggle: toggleStochRSI,
+                    }}
+                    cci={{ visible: cciVisible, onToggle: toggleCCI }}
+                    volumeProfile={{
+                        visible: vpVisible,
+                        onToggle: toggleVP,
+                    }}
+                    ichimoku={{
+                        visible: ichimokuVisible,
+                        onToggle: toggleIchimoku,
+                    }}
+                    candlePatterns={{
+                        visible: candlePatternsVisible,
+                        onToggle: toggleCandlePatterns,
+                    }}
+                />
+                </div>
                 <OverlayLegend items={overlayLegendItems} />
             </div>
         </div>

--- a/src/components/chart/hooks/usePaneLabels.ts
+++ b/src/components/chart/hooks/usePaneLabels.ts
@@ -90,16 +90,32 @@ export function usePaneLabels({
 
         labelElementsRef.current = labelPairs.map(({ el }) => el);
 
-        const observer = new ResizeObserver(() => {
+        const recomputeTops = () => {
             for (const { config, el } of labelPairs) {
                 const top = getTopOffset(chart, config.paneIndex);
                 el.style.top = `${top + LABEL_OFFSET_PX}px`;
             }
-        });
+        };
+
+        // pane 추가/제거 직후에는 LWC가 아직 pane 높이를 갱신하지 않은 상태일 수
+        // 있어 effect 동기 실행 시점에 잡은 top 값이 stale하다. 다음 페인트 직전
+        // RAF에서 한 번 더 재계산해 정렬을 맞춘다.
+        const rafId = requestAnimationFrame(recomputeTops);
+
+        // pane 높이 변화 추적: wrapper container 자체는 pane 재분배 시 크기가
+        // 변하지 않으므로 observer가 발화하지 않는다. LWC가 각 pane을 별도
+        // canvas로 렌더하므로, container 내부 canvas들을 직접 observe해 pane
+        // 높이가 변할 때마다 label top을 재계산한다.
+        const observer = new ResizeObserver(recomputeTops);
 
         observer.observe(container);
+        const canvases = container.querySelectorAll('canvas');
+        for (const canvas of canvases) {
+            observer.observe(canvas);
+        }
 
         return () => {
+            cancelAnimationFrame(rafId);
             observer.disconnect();
             clearLabelElements(labelPairs.map(({ el }) => el));
             labelElementsRef.current = [];


### PR DESCRIPTION
## 관련 이슈

Closes #201
Closes #212

## 구현 내용

### Bug #1: 보조지표 pane 제거 실패 (#201)
MACD/Stochastic/CCI 단독 토글 off 시 LWC v5가 빈 pane DOM 레이아웃을 즉시 갱신하지 않아 빈 공간이 남던 문제.

**원인 분석:**
- LWC v5는 마지막 series가 removeSeries될 때 논리적 pane은 panes() 배열에서 빼지만, 일부 indicator 종류에서 DOM 레이아웃 재계산이 트리거되지 않음
- AI 패널 리사이즈가 우연히 고치는 이유는 wrapper 크기 변화로 LWC autoSize ResizeObserver가 발화되기 때문
- `chart.resize()` 명시 호출은 `autoSize: true` 상태에서 무시됨

**수정:**
- StockChart.tsx의 paneIndices 변경 보정 effect에서 `applyOptions({ autoSize: false })` → 1px 차이로 `chart.resize()` 두 번 → `applyOptions({ autoSize: true })` 시퀀스로 ResizeObserver 발화와 동일한 layout invalidate를 강제
- 미사용이 된 CANDLESTICK_PANE_INDEX 상수 제거

### Bug #2: pane label 위치 미갱신 (#212)
보조 pane 크기가 변할 때 label top 위치가 따라가지 않던 문제.

**원인:**
- usePaneLabels의 ResizeObserver가 wrapper container에만 attach되어 있는데, pane 재분배 시 wrapper 크기는 변하지 않으므로 observer가 발화하지 않음

**수정:**
- usePaneLabels에서 wrapper container 외에 container 내부 모든 `<canvas>` 요소를 동일 ResizeObserver에 등록 (LWC는 pane마다 canvas를 별도 렌더)
- pane 추가/제거 직후 LWC pane 높이가 stale일 수 있어 RAF에서 한 번 더 recomputeTops 호출하는 보정 추가

## 변경 파일 목록

[수정]
- src/components/chart/StockChart.tsx
- src/components/chart/hooks/usePaneLabels.ts

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음

## CI Check lists

- [ ] yarn format
- [ ] yarn lint
- [ ] yarn lint:style
- [ ] yarn test
- [ ] yarn build