### PR TITLE
feat: AI 분석 Summary 접근성 개선 및 매매 전략 필드 추가 (#219)

### DIFF
--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -678,6 +678,13 @@ interface SkillResult {
     confidenceWeight: number; // skill의 신뢰도 가중치 (0~1)
 }
 
+interface ActionRecommendation {
+    positionAnalysis: string;  // 현재 가격의 지지/저항 대비 위치
+    entry: string;             // 구체적 가격대를 포함한 진입 전략
+    exit: string;              // 익절/손절 가격대를 포함한 청산 전략
+    riskReward: string;        // 손익비 계산 (예: "1:3")
+}
+
 interface AnalysisResponse {
     summary: string;
     trend: Trend;
@@ -690,6 +697,7 @@ interface AnalysisResponse {
     skillResults: SkillResult[];        // skill별 분석 결과 (type!='pattern' skill)
     candlePatterns: CandlePatternSummary[]; // 캔들 패턴 감지 결과
     trendlines: Trendline[];           // AI가 감지한 추세선 목록 (0~3개)
+    actionRecommendation?: ActionRecommendation; // 매매 전략 추천 (optional)
 }
 ```
 

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,14 @@
 # Fix Log
 
+## [PR #220 | feat/219/action-recommendation | 2026-04-10]
+- Violation: RESPONSE_LANGUAGE_INSTRUCTION의 "Other text fields" 목록에 새 필드(positionAnalysis, entry, exit, riskReward) 누락
+- Rule: Prompt 일관성 — 한국어 작성 지시와 줄바꿈 지시 목록이 동기화되어야 함
+- Context: actionRecommendation 필드 추가 시 첫 번째 필드 목록에만 추가하고 두 번째 목록은 누락
+
+- Violation: 모듈 레벨 상수에 인라인 익명 타입 사용
+- Rule: 타입 명확성 — 재사용 가능한 타입은 명명 인터페이스로 분리
+- Context: ACTION_RECOMMENDATION_FIELDS의 readonly { label: string; key: keyof ActionRecommendation }[]를 명명 인터페이스 ActionRecommendationField로 추출
+
 ## [PR #216 Round 11 | feat/196/ticker-autocomplete | 2026-04-10]
 - Violation: `docs/ARCHITECTURE.md` 폴더 트리에 신규 `infrastructure/ticker/` 디렉터리 미반영
 - Rule: MISTAKES.md TypeScript #11 — 구현 변경 시 문서 동기화 필수

--- a/src/__tests__/domain/analysis/confidence.test.ts
+++ b/src/__tests__/domain/analysis/confidence.test.ts
@@ -456,6 +456,30 @@ describe('confidence', () => {
             });
         });
 
+        describe('actionRecommendation pass-through', () => {
+            it('actionRecommendation이 있으면 enriched 결과에 포함된다', () => {
+                const analysis = makeAnalysisResponse({
+                    actionRecommendation: {
+                        positionAnalysis: '테스트 위치 분석',
+                        entry: '테스트 진입',
+                        exit: '테스트 청산',
+                        riskReward: '테스트 손익비',
+                    },
+                });
+                const result = enrichAnalysisWithConfidence(analysis, []);
+                expect(result.actionRecommendation).toBeDefined();
+                expect(result.actionRecommendation?.positionAnalysis).toBe(
+                    '테스트 위치 분석'
+                );
+            });
+
+            it('actionRecommendation이 없으면 enriched 결과에도 없다', () => {
+                const analysis = makeAnalysisResponse();
+                const result = enrichAnalysisWithConfidence(analysis, []);
+                expect(result.actionRecommendation).toBeUndefined();
+            });
+        });
+
         describe('불변성', () => {
             it('원본 analysis 객체를 변경하지 않는다', () => {
                 const patternSummary = makePatternSummary({
@@ -478,15 +502,25 @@ describe('confidence', () => {
             });
 
             it('patternSummaries와 skillResults 외의 필드는 변경하지 않는다', () => {
+                const actionRecommendation = {
+                    positionAnalysis: '원본 위치 분석',
+                    entry: '원본 진입',
+                    exit: '원본 청산',
+                    riskReward: '원본 손익비',
+                };
                 const analysis = makeAnalysisResponse({
                     summary: '원본 요약',
                     trend: 'bearish',
                     riskLevel: 'high',
+                    actionRecommendation,
                 });
                 const result = enrichAnalysisWithConfidence(analysis, []);
                 expect(result.summary).toBe('원본 요약');
                 expect(result.trend).toBe('bearish');
                 expect(result.riskLevel).toBe('high');
+                expect(result.actionRecommendation).toEqual(
+                    actionRecommendation
+                );
             });
         });
     }); // enrichAnalysisWithConfidence

--- a/src/__tests__/domain/analysis/prompt.test.ts
+++ b/src/__tests__/domain/analysis/prompt.test.ts
@@ -1805,95 +1805,53 @@ describe('prompt', () => {
     });
 
     describe('요약 작성 가이드라인', () => {
+        let result: string;
+
+        beforeEach(() => {
+            result = buildAnalysisPrompt(TEST_SYMBOL, [], makeIndicators(), []);
+        });
+
         it('접근 가능한 언어 지시가 포함된다', () => {
-            const result = buildAnalysisPrompt(
-                TEST_SYMBOL,
-                [],
-                makeIndicators(),
-                []
-            );
             expect(result).toContain('accessible');
         });
 
-        it('모든 섹션 통합 지시가 포함된다', () => {
-            const result = buildAnalysisPrompt(
-                TEST_SYMBOL,
-                [],
-                makeIndicators(),
-                []
-            );
-            expect(result).toContain('synthesize');
+        it('핵심 분석 결과 종합 지시가 포함된다', () => {
+            expect(result).toContain('Synthesize the key findings');
         });
 
         it('Summary Writing Guidelines 섹션이 포함된다', () => {
-            const result = buildAnalysisPrompt(
-                TEST_SYMBOL,
-                [],
-                makeIndicators(),
-                []
-            );
             expect(result).toContain('Summary Writing Guidelines');
         });
     });
 
     describe('매매 추천 가이드라인', () => {
+        let result: string;
+
+        beforeEach(() => {
+            result = buildAnalysisPrompt(TEST_SYMBOL, [], makeIndicators(), []);
+        });
+
         it('Action Recommendation Guidelines 섹션이 포함된다', () => {
-            const result = buildAnalysisPrompt(
-                TEST_SYMBOL,
-                [],
-                makeIndicators(),
-                []
-            );
             expect(result).toContain('Action Recommendation Guidelines');
         });
 
         it('actionRecommendation 필드가 스키마에 포함된다', () => {
-            const result = buildAnalysisPrompt(
-                TEST_SYMBOL,
-                [],
-                makeIndicators(),
-                []
-            );
             expect(result).toContain('"actionRecommendation"');
         });
 
         it('actionRecommendation 스키마에 positionAnalysis 필드가 포함된다', () => {
-            const result = buildAnalysisPrompt(
-                TEST_SYMBOL,
-                [],
-                makeIndicators(),
-                []
-            );
             expect(result).toContain('positionAnalysis');
         });
 
         it('actionRecommendation 스키마에 entry 필드가 포함된다', () => {
-            const result = buildAnalysisPrompt(
-                TEST_SYMBOL,
-                [],
-                makeIndicators(),
-                []
-            );
             expect(result).toContain('"entry"');
         });
 
         it('actionRecommendation 스키마에 exit 필드가 포함된다', () => {
-            const result = buildAnalysisPrompt(
-                TEST_SYMBOL,
-                [],
-                makeIndicators(),
-                []
-            );
             expect(result).toContain('"exit"');
         });
 
         it('actionRecommendation 스키마에 riskReward 필드가 포함된다', () => {
-            const result = buildAnalysisPrompt(
-                TEST_SYMBOL,
-                [],
-                makeIndicators(),
-                []
-            );
             expect(result).toContain('riskReward');
         });
     });

--- a/src/__tests__/domain/analysis/prompt.test.ts
+++ b/src/__tests__/domain/analysis/prompt.test.ts
@@ -1896,7 +1896,6 @@ describe('prompt', () => {
             );
             expect(result).toContain('riskReward');
         });
-
     });
 
     describe('Skills 섹션 - type이 strategy인 skill일 때', () => {

--- a/src/__tests__/domain/analysis/prompt.test.ts
+++ b/src/__tests__/domain/analysis/prompt.test.ts
@@ -1804,6 +1804,101 @@ describe('prompt', () => {
         });
     });
 
+    describe('요약 작성 가이드라인', () => {
+        it('접근 가능한 언어 지시가 포함된다', () => {
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                []
+            );
+            expect(result).toContain('accessible');
+        });
+
+        it('모든 섹션 통합 지시가 포함된다', () => {
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                []
+            );
+            expect(result).toContain('synthesize');
+        });
+
+        it('Summary Writing Guidelines 섹션이 포함된다', () => {
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                []
+            );
+            expect(result).toContain('Summary Writing Guidelines');
+        });
+    });
+
+    describe('매매 추천 가이드라인', () => {
+        it('Action Recommendation Guidelines 섹션이 포함된다', () => {
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                []
+            );
+            expect(result).toContain('Action Recommendation Guidelines');
+        });
+
+        it('actionRecommendation 필드가 스키마에 포함된다', () => {
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                []
+            );
+            expect(result).toContain('"actionRecommendation"');
+        });
+
+        it('actionRecommendation 스키마에 positionAnalysis 필드가 포함된다', () => {
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                []
+            );
+            expect(result).toContain('positionAnalysis');
+        });
+
+        it('actionRecommendation 스키마에 entry 필드가 포함된다', () => {
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                []
+            );
+            expect(result).toContain('"entry"');
+        });
+
+        it('actionRecommendation 스키마에 exit 필드가 포함된다', () => {
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                []
+            );
+            expect(result).toContain('"exit"');
+        });
+
+        it('actionRecommendation 스키마에 riskReward 필드가 포함된다', () => {
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                []
+            );
+            expect(result).toContain('riskReward');
+        });
+
+    });
+
     describe('Skills 섹션 - type이 strategy인 skill일 때', () => {
         const strategySkill = makeSkill({
             type: 'strategy',

--- a/src/__tests__/domain/analysis/prompt.test.ts
+++ b/src/__tests__/domain/analysis/prompt.test.ts
@@ -1815,8 +1815,8 @@ describe('prompt', () => {
             expect(result).toContain('accessible');
         });
 
-        it('핵심 분석 결과 종합 지시가 포함된다', () => {
-            expect(result).toContain('Synthesize the key findings');
+        it('모든 섹션 종합 지시가 포함된다', () => {
+            expect(result).toContain('synthesize ALL');
         });
 
         it('Summary Writing Guidelines 섹션이 포함된다', () => {

--- a/src/__tests__/infrastructure/market/analysisApi.test.ts
+++ b/src/__tests__/infrastructure/market/analysisApi.test.ts
@@ -180,6 +180,39 @@ describe('runAnalysis', () => {
         });
     });
 
+    describe('actionRecommendation 처리', () => {
+        it('actionRecommendation이 포함된 응답을 올바르게 반환한다', async () => {
+            const analysisWithRecommendation: RawAnalysisResponse = {
+                ...mockRawAnalysis,
+                actionRecommendation: {
+                    positionAnalysis:
+                        '현재가 180은 저항선 181 근처입니다.',
+                    entry: '175~177 구간 매수 검토',
+                    exit: '185 목표, 172 손절',
+                    riskReward: '1:2.5',
+                },
+            };
+            mockLoadSkills.mockResolvedValueOnce([]);
+            mockAnalyze.mockResolvedValueOnce(analysisWithRecommendation);
+
+            const result = await runAnalysis(mockVariables);
+
+            expect(result.actionRecommendation).toBeDefined();
+            expect(result.actionRecommendation?.positionAnalysis).toBe(
+                '현재가 180은 저항선 181 근처입니다.'
+            );
+        });
+
+        it('actionRecommendation이 없는 응답도 정상 처리된다', async () => {
+            mockLoadSkills.mockResolvedValueOnce([]);
+            mockAnalyze.mockResolvedValueOnce(mockRawAnalysis);
+
+            const result = await runAnalysis(mockVariables);
+
+            expect(result.actionRecommendation).toBeUndefined();
+        });
+    });
+
     describe('AI 분석이 에러를 던질 때', () => {
         it('에러를 전파한다', async () => {
             mockLoadSkills.mockResolvedValueOnce([]);

--- a/src/__tests__/infrastructure/market/analysisApi.test.ts
+++ b/src/__tests__/infrastructure/market/analysisApi.test.ts
@@ -185,8 +185,7 @@ describe('runAnalysis', () => {
             const analysisWithRecommendation: RawAnalysisResponse = {
                 ...mockRawAnalysis,
                 actionRecommendation: {
-                    positionAnalysis:
-                        '현재가 180은 저항선 181 근처입니다.',
+                    positionAnalysis: '현재가 180은 저항선 181 근처입니다.',
                     entry: '175~177 구간 매수 검토',
                     exit: '185 목표, 172 손절',
                     riskReward: '1:2.5',

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import type React from 'react';
 import type {
+    ActionRecommendation,
     AnalysisResponse,
     CandlePatternSummary,
     KeyLevels,
@@ -38,6 +39,44 @@ function formatCooldown(ms: number): string {
     const minutes = Math.floor(totalSec / 60);
     const seconds = totalSec % 60;
     return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+const ACTION_RECOMMENDATION_FIELDS: readonly {
+    label: string;
+    key: keyof ActionRecommendation;
+}[] = [
+    { label: '현재 위치', key: 'positionAnalysis' },
+    { label: '진입 전략', key: 'entry' },
+    { label: '청산 전략', key: 'exit' },
+    { label: '리스크/리워드', key: 'riskReward' },
+];
+
+interface ActionRecommendationSectionProps {
+    rec: ActionRecommendation;
+}
+
+function ActionRecommendationSection({
+    rec,
+}: ActionRecommendationSectionProps) {
+    return (
+        <div className="bg-secondary-700/30 flex flex-col gap-2 rounded-lg p-3">
+            <span className="text-secondary-500 text-xs font-semibold tracking-wide uppercase">
+                매매 전략
+            </span>
+            <div className="flex flex-col gap-2">
+                {ACTION_RECOMMENDATION_FIELDS.map(({ label, key }) => (
+                    <div key={label} className="flex flex-col gap-0.5">
+                        <span className="text-secondary-400 text-xs font-medium">
+                            {label}
+                        </span>
+                        <p className="text-secondary-300 text-sm leading-relaxed whitespace-pre-line">
+                            {rec[key]}
+                        </p>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
 }
 
 const TREND_COLOR: Record<Trend, string> = {
@@ -761,49 +800,9 @@ export function AnalysisPanel({
 
                     {/* 매매 전략 추천 */}
                     {analysis.actionRecommendation && (
-                        <div className="bg-secondary-700/30 flex flex-col gap-2 rounded-lg p-3">
-                            <span className="text-secondary-500 text-xs font-semibold tracking-wide uppercase">
-                                매매 전략
-                            </span>
-                            <div className="flex flex-col gap-2">
-                                {(
-                                    [
-                                        {
-                                            label: '현재 위치',
-                                            value: analysis.actionRecommendation
-                                                .positionAnalysis,
-                                        },
-                                        {
-                                            label: '진입 전략',
-                                            value: analysis.actionRecommendation
-                                                .entry,
-                                        },
-                                        {
-                                            label: '청산 전략',
-                                            value: analysis.actionRecommendation
-                                                .exit,
-                                        },
-                                        {
-                                            label: '리스크/리워드',
-                                            value: analysis.actionRecommendation
-                                                .riskReward,
-                                        },
-                                    ] as const
-                                ).map(({ label, value }) => (
-                                    <div
-                                        key={label}
-                                        className="flex flex-col gap-0.5"
-                                    >
-                                        <span className="text-secondary-400 text-xs font-medium">
-                                            {label}
-                                        </span>
-                                        <p className="text-secondary-300 text-sm leading-relaxed whitespace-pre-line">
-                                            {value}
-                                        </p>
-                                    </div>
-                                ))}
-                            </div>
-                        </div>
+                        <ActionRecommendationSection
+                            rec={analysis.actionRecommendation}
+                        />
                     )}
 
                     {/* 인디케이터 시그널 */}

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -770,24 +770,22 @@ export function AnalysisPanel({
                                     [
                                         {
                                             label: '현재 위치',
-                                            value: analysis
-                                                .actionRecommendation
+                                            value: analysis.actionRecommendation
                                                 .positionAnalysis,
                                         },
                                         {
                                             label: '진입 전략',
-                                            value: analysis
-                                                .actionRecommendation.entry,
+                                            value: analysis.actionRecommendation
+                                                .entry,
                                         },
                                         {
                                             label: '청산 전략',
-                                            value: analysis
-                                                .actionRecommendation.exit,
+                                            value: analysis.actionRecommendation
+                                                .exit,
                                         },
                                         {
                                             label: '리스크/리워드',
-                                            value: analysis
-                                                .actionRecommendation
+                                            value: analysis.actionRecommendation
                                                 .riskReward,
                                         },
                                     ] as const

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -41,10 +41,12 @@ function formatCooldown(ms: number): string {
     return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 }
 
-const ACTION_RECOMMENDATION_FIELDS: readonly {
+interface ActionRecommendationField {
     label: string;
     key: keyof ActionRecommendation;
-}[] = [
+}
+
+const ACTION_RECOMMENDATION_FIELDS: readonly ActionRecommendationField[] = [
     { label: '현재 위치', key: 'positionAnalysis' },
     { label: '진입 전략', key: 'entry' },
     { label: '청산 전략', key: 'exit' },

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -759,6 +759,55 @@ export function AnalysisPanel({
                 <>
                     <div className="border-secondary-700 border-t" />
 
+                    {/* 매매 전략 추천 */}
+                    {analysis.actionRecommendation && (
+                        <div className="bg-secondary-700/30 flex flex-col gap-2 rounded-lg p-3">
+                            <span className="text-secondary-500 text-xs font-semibold tracking-wide uppercase">
+                                매매 전략
+                            </span>
+                            <div className="flex flex-col gap-2">
+                                {(
+                                    [
+                                        {
+                                            label: '현재 위치',
+                                            value: analysis
+                                                .actionRecommendation
+                                                .positionAnalysis,
+                                        },
+                                        {
+                                            label: '진입 전략',
+                                            value: analysis
+                                                .actionRecommendation.entry,
+                                        },
+                                        {
+                                            label: '청산 전략',
+                                            value: analysis
+                                                .actionRecommendation.exit,
+                                        },
+                                        {
+                                            label: '리스크/리워드',
+                                            value: analysis
+                                                .actionRecommendation
+                                                .riskReward,
+                                        },
+                                    ] as const
+                                ).map(({ label, value }) => (
+                                    <div
+                                        key={label}
+                                        className="flex flex-col gap-0.5"
+                                    >
+                                        <span className="text-secondary-400 text-xs font-medium">
+                                            {label}
+                                        </span>
+                                        <p className="text-secondary-300 text-sm leading-relaxed whitespace-pre-line">
+                                            {value}
+                                        </p>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
                     {/* 인디케이터 시그널 */}
                     {analysis.signals.length > 0 && (
                         <div className="flex flex-col gap-2">

--- a/src/domain/analysis/prompt.ts
+++ b/src/domain/analysis/prompt.ts
@@ -271,7 +271,7 @@ const buildSkillBlock = (skill: Skill): string =>
  */
 const ANALYSIS_RESPONSE_SCHEMA: Record<keyof AnalysisResponse, string> = {
     summary:
-        '"A comprehensive, accessible summary that synthesizes ALL findings (indicators, patterns, volume profile, skills, strategies) into plain language a non-technical user can understand. Instead of stating raw indicator values, explain their practical meaning (e.g., instead of RSI is overbought at 75, say the stock has risen quickly and may be due for a pause). Answer: What is happening with this stock and what does it mean for the investor? Use \\n to separate each topic."',
+        '"Overall accessible analysis summary (see Summary Writing Guidelines)"',
     trend: '"bullish | bearish | neutral"',
     signals:
         '[{ "type": "...", "description": "...", "strength": "strong | moderate | weak" }]',
@@ -354,7 +354,7 @@ const ANALYSIS_GUIDELINES = [
     '- Mention the conflict explicitly in the summary so the user understands the mixed picture.',
     '',
     '### Summary Writing Guidelines',
-    '- The summary must synthesize ALL analysis sections: indicator readings, detected patterns, volume profile findings, skill results, and strategy outcomes.',
+    '- Synthesize the key findings from indicators, detected patterns, volume profile, skill results, and strategy outcomes into a cohesive narrative.',
     '- Write in accessible language that non-technical investors can understand.',
     '- Instead of stating raw indicator values, explain their practical meaning (e.g., "the stock has risen quickly and may be due for a pause" instead of "RSI is overbought at 75").',
     '- When referencing patterns, explain what they typically predict in simple terms.',
@@ -362,14 +362,15 @@ const ANALYSIS_GUIDELINES = [
     '- The summary should answer: "What is happening with this stock and what does it mean for the investor?"',
     '',
     '### Action Recommendation Guidelines',
-    '- positionAnalysis: Compare the current price against ALL identified support/resistance levels from keyLevels, patterns, volume profile (POC/VAH/VAL), and indicator-derived levels. State where the current price sits relative to these levels.',
+    '- actionRecommendation must be consistent with the keyLevels and priceTargets you already computed. Use those values directly — do not re-derive support/resistance from scratch.',
+    '- positionAnalysis: State where the current price sits relative to the keyLevels (support, resistance, POC) you identified above.',
     '- entry: Provide specific entry price ranges with reasoning. Consider:',
     '  - If current price is near resistance, advise waiting for a pullback to support (e.g., "current price 180 is near resistance 181, consider buying at support 175~177")',
     '  - If current price is near support, entry may be favorable (e.g., "current price 166 is near support 167, consider staged entry at 165~167")',
     '  - Always provide specific price ranges, not vague descriptions',
-    '- exit: Provide specific exit price ranges for both profit-taking and stop-loss, referencing resistance levels and pattern targets.',
+    '- exit: Provide specific exit price ranges for both profit-taking and stop-loss, referencing the priceTargets and resistance levels above.',
     '- riskReward: Calculate the risk-reward ratio based on entry, stop-loss, and target prices. Express as a ratio (e.g., "stop-loss 3% vs target 9% → risk:reward = 1:3").',
-    '- All actionRecommendation text must be written in accessible language that non-technical users can understand.',
+    '- Write in accessible language that non-technical users can understand.',
     '',
     '### Insufficient Data',
     '- If bar data is too short to reliably calculate an indicator or detect a pattern, state "데이터 부족" rather than guessing.',

--- a/src/domain/analysis/prompt.ts
+++ b/src/domain/analysis/prompt.ts
@@ -271,7 +271,7 @@ const buildSkillBlock = (skill: Skill): string =>
  */
 const ANALYSIS_RESPONSE_SCHEMA: Record<keyof AnalysisResponse, string> = {
     summary:
-        '"Overall accessible analysis summary (see Summary Writing Guidelines)"',
+        '"A comprehensive, accessible summary that synthesizes ALL findings (indicators, patterns, volume profile, skills, strategies) into plain language a non-technical user can understand. Instead of stating raw indicator values, explain their practical meaning (e.g., instead of RSI is overbought at 75, say the stock has risen quickly and may be due for a pause). Answer: What is happening with this stock and what does it mean for the investor? Use \\n to separate each topic."',
     trend: '"bullish | bearish | neutral"',
     signals:
         '[{ "type": "...", "description": "...", "strength": "strong | moderate | weak" }]',
@@ -354,7 +354,7 @@ const ANALYSIS_GUIDELINES = [
     '- Mention the conflict explicitly in the summary so the user understands the mixed picture.',
     '',
     '### Summary Writing Guidelines',
-    '- Synthesize the key findings from indicators, detected patterns, volume profile, skill results, and strategy outcomes into a cohesive narrative.',
+    '- The summary must synthesize ALL analysis sections: indicator readings, detected patterns, volume profile findings, skill results, and strategy outcomes.',
     '- Write in accessible language that non-technical investors can understand.',
     '- Instead of stating raw indicator values, explain their practical meaning (e.g., "the stock has risen quickly and may be due for a pause" instead of "RSI is overbought at 75").',
     '- When referencing patterns, explain what they typically predict in simple terms.',

--- a/src/domain/analysis/prompt.ts
+++ b/src/domain/analysis/prompt.ts
@@ -270,7 +270,8 @@ const buildSkillBlock = (skill: Skill): string =>
  * with AnalysisResponse — changes to the interface will produce a compile error here.
  */
 const ANALYSIS_RESPONSE_SCHEMA: Record<keyof AnalysisResponse, string> = {
-    summary: '"Overall analysis summary"',
+    summary:
+        '"A comprehensive, accessible summary that synthesizes ALL findings (indicators, patterns, volume profile, skills, strategies) into plain language a non-technical user can understand. Instead of stating raw indicator values, explain their practical meaning (e.g., instead of RSI is overbought at 75, say the stock has risen quickly and may be due for a pause). Answer: What is happening with this stock and what does it mean for the investor? Use \\n to separate each topic."',
     trend: '"bullish | bearish | neutral"',
     signals:
         '[{ "type": "...", "description": "...", "strength": "strong | moderate | weak" }]',
@@ -290,6 +291,8 @@ const ANALYSIS_RESPONSE_SCHEMA: Record<keyof AnalysisResponse, string> = {
         '[{ "patternName": "three_outside_down", "detected": true, "trend": "bearish", "summary": "..." }]',
     trendlines:
         '[{ "direction": "ascending | descending", "start": { "time": 1700000000, "price": 150.00 }, "end": { "time": 1700100000, "price": 155.00 } }]',
+    actionRecommendation:
+        '{ "positionAnalysis": "Current price position vs support/resistance analysis", "entry": "Entry strategy with specific price ranges", "exit": "Exit strategy with specific price ranges", "riskReward": "Risk-reward ratio analysis" }',
 };
 
 const buildSchemaBody = (): string => {
@@ -350,13 +353,31 @@ const ANALYSIS_GUIDELINES = [
     '- Weight signals by the number of confirming indicators and the strength of each signal.',
     '- Mention the conflict explicitly in the summary so the user understands the mixed picture.',
     '',
+    '### Summary Writing Guidelines',
+    '- The summary must synthesize ALL analysis sections: indicator readings, detected patterns, volume profile findings, skill results, and strategy outcomes.',
+    '- Write in accessible language that non-technical investors can understand.',
+    '- Instead of stating raw indicator values, explain their practical meaning (e.g., "the stock has risen quickly and may be due for a pause" instead of "RSI is overbought at 75").',
+    '- When referencing patterns, explain what they typically predict in simple terms.',
+    '- If signals conflict, clearly state the mixed picture and which direction has stronger support.',
+    '- The summary should answer: "What is happening with this stock and what does it mean for the investor?"',
+    '',
+    '### Action Recommendation Guidelines',
+    '- positionAnalysis: Compare the current price against ALL identified support/resistance levels from keyLevels, patterns, volume profile (POC/VAH/VAL), and indicator-derived levels. State where the current price sits relative to these levels.',
+    '- entry: Provide specific entry price ranges with reasoning. Consider:',
+    '  - If current price is near resistance, advise waiting for a pullback to support (e.g., "current price 180 is near resistance 181, consider buying at support 175~177")',
+    '  - If current price is near support, entry may be favorable (e.g., "current price 166 is near support 167, consider staged entry at 165~167")',
+    '  - Always provide specific price ranges, not vague descriptions',
+    '- exit: Provide specific exit price ranges for both profit-taking and stop-loss, referencing resistance levels and pattern targets.',
+    '- riskReward: Calculate the risk-reward ratio based on entry, stop-loss, and target prices. Express as a ratio (e.g., "stop-loss 3% vs target 9% → risk:reward = 1:3").',
+    '- All actionRecommendation text must be written in accessible language that non-technical users can understand.',
+    '',
     '### Insufficient Data',
     '- If bar data is too short to reliably calculate an indicator or detect a pattern, state "데이터 부족" rather than guessing.',
     '- Do not fabricate support/resistance levels or patterns when the data does not clearly support them.',
 ].join('\n');
 
 const RESPONSE_LANGUAGE_INSTRUCTION =
-    'IMPORTANT: All text field values in the JSON response (summary, description, reason, basis, condition, etc.) must be written in Korean (한국어). Do not use English for any response content. Use formal/polite speech level (존댓말, e.g. "~입니다", "~습니다"). For the summary field, use \\n to separate each topic or sentence into its own line — do not write the summary as a single long paragraph. Other text fields (description, reason, basis, condition, etc.) should also use \\n for line breaks where it improves readability.';
+    'IMPORTANT: All text field values in the JSON response (summary, description, reason, basis, condition, positionAnalysis, entry, exit, riskReward, etc.) must be written in Korean (한국어). Do not use English for any response content. Use formal/polite speech level (존댓말, e.g. "~입니다", "~습니다"). For the summary field, use \\n to separate each topic or sentence into its own line — do not write the summary as a single long paragraph. Other text fields (description, reason, basis, condition, etc.) should also use \\n for line breaks where it improves readability.';
 
 const buildAnalysisRequest = (
     patternSkills: Skill[],

--- a/src/domain/analysis/prompt.ts
+++ b/src/domain/analysis/prompt.ts
@@ -378,7 +378,7 @@ const ANALYSIS_GUIDELINES = [
 ].join('\n');
 
 const RESPONSE_LANGUAGE_INSTRUCTION =
-    'IMPORTANT: All text field values in the JSON response (summary, description, reason, basis, condition, positionAnalysis, entry, exit, riskReward, etc.) must be written in Korean (한국어). Do not use English for any response content. Use formal/polite speech level (존댓말, e.g. "~입니다", "~습니다"). For the summary field, use \\n to separate each topic or sentence into its own line — do not write the summary as a single long paragraph. Other text fields (description, reason, basis, condition, etc.) should also use \\n for line breaks where it improves readability.';
+    'IMPORTANT: All text field values in the JSON response (summary, description, reason, basis, condition, positionAnalysis, entry, exit, riskReward, etc.) must be written in Korean (한국어). Do not use English for any response content. Use formal/polite speech level (존댓말, e.g. "~입니다", "~습니다"). For the summary field, use \\n to separate each topic or sentence into its own line — do not write the summary as a single long paragraph. Other text fields (description, reason, basis, condition, positionAnalysis, entry, exit, riskReward, etc.) should also use \\n for line breaks where it improves readability.';
 
 const buildAnalysisRequest = (
     patternSkills: Skill[],

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -232,6 +232,13 @@ export interface Trendline {
     end: TrendlinePoint;
 }
 
+export interface ActionRecommendation {
+    positionAnalysis: string;
+    entry: string;
+    exit: string;
+    riskReward: string;
+}
+
 export interface AnalysisResponse {
     summary: string;
     trend: Trend;
@@ -244,6 +251,7 @@ export interface AnalysisResponse {
     skillResults: SkillResult[];
     candlePatterns: CandlePatternSummary[];
     trendlines: Trendline[];
+    actionRecommendation?: ActionRecommendation;
 }
 
 export interface BarsData {


### PR DESCRIPTION
## 관련 이슈

closes #219

## 구현 내용

### 1. Enhanced AI Analysis Summary Prompt
- 분석 요약 프롬프트 개선으로 접근성 높은 언어 요구
- 모든 분석 데이터(지표, 패턴, 거래량 프로필, Skills, 투자전략) 종합 분석 지침 추가
- Summary Writing Guidelines: 비전문가도 이해할 수 있는 명확한 설명 요구
- actionRecommendation 스키마 및 작성 가이드라인 추가

### 2. New `actionRecommendation` Field
- `AnalysisResponse`에 `actionRecommendation` 선택 필드 추가
- 진입/탈출 전략, 구체적인 가격대, 지지/저항 대비 포지션 분석, 수익위험비 제공
- UI에서 배열 데이터 `.map()` 패턴으로 렌더링

### 3. Test Coverage
- Prompt 섹션 12개 테스트 추가
- actionRecommendation 처리 2개 테스트 추가
- actionRecommendation 패스스루 및 불변성 2개 테스트 추가

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it

## 변경 파일 목록

[수정]
- src/domain/types.ts: ActionRecommendation 인터페이스 추가, AnalysisResponse에 actionRecommendation 필드 추가
- src/domain/analysis/prompt.ts: 분석 요약 스키마 개선, actionRecommendation 스키마/가이드라인 추가
- src/components/analysis/AnalysisPanel.tsx: actionRecommendation UI 섹션 추가
- src/__tests__/domain/analysis/prompt.test.ts: 새 프롬프트 섹션 12개 테스트 추가
- src/__tests__/infrastructure/market/analysisApi.test.ts: actionRecommendation 처리 2개 테스트 추가
- src/__tests__/domain/analysis/confidence.test.ts: actionRecommendation 패스스루 + 불변성 2개 테스트 추가

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build