### PR TITLE
feat: 심볼 페이지 티커에 회사명 표시

### DIFF
--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -190,6 +190,12 @@ This file contains only **recurring gotchas** that agents keep missing despite e
    → Include guards for both lower bounds (null, negative) and upper bounds (array length, max values)
    ❌ function resolveBarIndex(index) { if (index < 0) return 0; return index; }  // missing upper bound
    ✅ function resolveBarIndex(index) { if (index < 0) return 0; if (index >= length) return length - 1; return index; }
+
+2. External dependencies must fail gracefully consistently across the module
+   → All calls to the same external service should use identical error handling patterns
+   → If one call uses try-catch, all calls to that service should be wrapped identically
+   ❌ cache.get(key)  // no try-catch, but cache.set(key, val) has try-catch
+   ✅ const value = await cache.get(key).catch(error => { console.error(...); return null; });
 ```
 
 ---
@@ -201,6 +207,11 @@ This file contains only **recurring gotchas** that agents keep missing despite e
    → Each commit/PR should focus on a single concern
    → Unrelated changes must be moved to separate PRs or reverted
    → If a related change is necessary, document the reason in a comment or commit message
+
+2. Conditional checks that duplicate type system guarantees
+   → If a type system guarantees a field is present, do not add optional chaining or truthiness checks
+   ❌ !!assetInfo?.name  // when AssetInfo.name is required
+   ✅ !!assetInfo  // sufficient when name is guaranteed
 ```
 
 ---
@@ -227,4 +238,8 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 4. Deleting code marked with TODO without updating all references
    → TODO comments indicate intentional preservation for future references
    → Removing such code breaks commented-out code that still references it; restore or update all references first
+
+5. Domain logic conditions differ between server and client
+   → When the same business rule applies in both layers, ensure identical conditions on both sides
+   → Example: if client uses `name !== ticker` guard, server `buildDisplayName` must use the same guard
 ```

--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -189,6 +189,17 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 
 ---
 
+## Predictability
+
+```
+1. Including unrelated changes in a PR without documented justification
+   → Each commit/PR should focus on a single concern
+   → Unrelated changes must be moved to separate PRs or reverted
+   → If a related change is necessary, document the reason in a comment or commit message
+```
+
+---
+
 ## Design & Cohesion
 
 ```

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -89,11 +89,6 @@
 - Rule: MISTAKES.md Layer Dependencies #3 — `lightweight-charts` import(타입 포함)는 `components/chart/` 내부로 제한됨
 - Context: visible range 동기화를 위해 `stockChartRef`, `volumeChartRef`, 콜백 2개가 모두 `IChartApi`에 의존했음; `components/chart/hooks/useChartSync.ts`로 추출하여 `ChartContent.tsx`에서 `IChartApi` import 제거
 
-## [PR #205 | fix/204/모바일-UI-캐시-메시지-버그-수정 | 2026-04-07]
-- Violation: TODO 주석으로 명시적 보존이 지시된 `EyeIcon` 컴포넌트가 삭제됨; commented-out 버튼 코드에서 여전히 `EyeIcon`을 참조하고 있어 주석 해제 시 불일치 발생
-- Rule: FF.md Predictability — TODO로 유지 의도가 명시된 코드를 삭제하면 향후 주석 해제 시 참조 오류가 발생하여 예측 가능성을 해침
-- Context: `AnalysisPanel.tsx`에서 `EyeIcon` 컴포넌트가 제거되었으나 3곳의 commented-out 버튼에서 여전히 `<EyeIcon>`을 참조; 원본 코드를 복원하여 해결
-
 ## [PR #208 | feat/185/seo-최적화 | 2026-04-07]
 - Violation: `POPULAR_TICKERS` (비즈니스 도메인 지식)가 `src/lib/seo.ts`에 정의되어 lib 레이어 허용 범위를 벗어남
 - Rule: lib/CLAUDE.md — lib 레이어는 utility wrappers, React Query key factories, config constants, chart color constants만 허용; 도메인 비즈니스 상수는 금지

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,14 @@
 # Fix Log
 
+## [PR #222 | feat/221/심볼-페이지-회사명-표시 | 2026-04-10]
+- Violation: components/hooks/ 파일에 'use client' 선언 누락
+- Rule: CONVENTIONS.md — components/ 아래 커스텀 훅은 무조건 'use client' 선언
+- Context: useAssetInfo.ts 작성 시 useTimeframeChange 등 기존 훅 파일에서 패턴을 확인하지 않아 누락
+
+- Violation: 서버 prefetchQuery 키와 클라이언트 훅 키 불일치 (hydration 캐시 미스)
+- Rule: React Query Hydration 패턴 — prefetchQuery 키와 useQuery 키가 정확히 일치해야 함
+- Context: 서버는 ticker(대문자)로 키를 만들고 클라이언트는 symbol(원본)로 키를 만들어 소문자 URL 진입 시 캐시 미스 발생
+
 ## [Issue #221 | feat/221/심볼-페이지-회사명-표시 | 2026-04-10]
 - Violation: 새 infrastructure Server Action 파일(getAssetInfoAction.ts) 구현 후 테스트 파일 누락
 - Rule: 모든 infrastructure/ 파일은 대응하는 테스트 파일이 있어야 한다 (100% branch coverage target)

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,10 @@
 # Fix Log
 
+## [Issue #221 | feat/221/심볼-페이지-회사명-표시 | 2026-04-10]
+- Violation: 새 infrastructure Server Action 파일(getAssetInfoAction.ts) 구현 후 테스트 파일 누락
+- Rule: 모든 infrastructure/ 파일은 대응하는 테스트 파일이 있어야 한다 (100% branch coverage target)
+- Context: 동일 패턴의 searchTickerAction.test.ts가 존재함에도 getAssetInfoAction.test.ts 작성을 누락
+
 ## [PR #220 | feat/219/action-recommendation | 2026-04-10]
 - Violation: RESPONSE_LANGUAGE_INSTRUCTION의 "Other text fields" 목록에 새 필드(positionAnalysis, entry, exit, riskReward) 누락
 - Rule: Prompt 일관성 — 한국어 작성 지시와 줄바꿈 지시 목록이 동기화되어야 함

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -9,10 +9,6 @@
 - Rule: FF.md Predictability — 타입 시스템이 보장하는 사실을 조건식에 명시적으로 표현해야 함
 - Context: `assetInfo`가 정의되어 있으면 `name`은 항상 truthy이므로 `!!assetInfo`로 단순화
 
-- Violation: `AssetInfo` 인터페이스가 `BarsData`와 `TickerBase` 사이에 위치하여 ticker 관련 타입군과 분리됨
-- Rule: FF.md Cohesion — 같은 개념 군의 타입은 인접 배치
-- Context: `AssetInfo`는 ticker 관련 타입(`TickerBase`, `KoreanTickerEntry`, `TickerSearchResult`) 근처로 이동
-
 ## [PR #222 Round 3 | feat/221/심볼-페이지-회사명-표시 | 2026-04-10]
 - Violation: SymbolPageClient.tsx에서 symbol.toUpperCase()를 3회, assetInfo.name !== symbol.toUpperCase() 조건을 2회 반복
 - Rule: MISTAKES.md Coding Paradigm #2 — 동일한 값은 한 번만 계산하고 const로 추출
@@ -62,10 +58,6 @@
 - Rule: 코드베이스에 import되지 않는 파일은 데드 코드 — PR에서 교체 시 구 파일 삭제 필수
 - Context: `SymbolSearch`가 `TickerAutocomplete`로 교체됐지만 `src/components/search/SymbolSearch.tsx`가 미삭제 상태로 남아 있었음
 
-- Violation: `cache.get()` 호출 시 예외 처리 누락으로 Redis 장애 시 액션 전체 실패
-- Rule: CONVENTIONS.md Graceful Degradation — 외부 의존성 호출은 동일 파일 내 다른 패턴과 일관되게 try-catch로 감싸야 함
-- Context: `searchTickerAction.ts`의 캐시 조회는 try-catch 없었으나, 동일 파일의 캐시 set과 `koreanNameStore.ts`의 `loadAllEntries()`는 모두 try-catch 처리됨
-
 ## [예시 항목 | 브랜치명 | 날짜]
 - Violation: 예시
 - Rule: 예시
@@ -84,33 +76,18 @@
 - Context: `useTimeframeChange`의 `startTransition` 내부에서 Suspense가 트리거되는 동안 render-phase setState가 Router context 업데이트와 충돌했음; `timeframeChangeCount` 관리를 `handleTimeframeChange` 이벤트 핸들러 안으로 이동하여 해결
 
 
-## [fix/204/모바일-UI-캐시-메시지-버그-수정 | 2026-04-07]
-- Violation: `mutationFn` passed `AnalyzeMutationVariables` (which includes `force: boolean`) directly to `analyzeAction`, whose first parameter is typed as `AnalyzeVariables` (no `force` field), causing a TypeScript excess property error
-- Rule: CONVENTIONS.md — UI-layer concerns must not bleed into infrastructure-layer types; Server Action parameters must match declared types exactly
-- Context: `useAnalysis.ts` passed the full mutation variable object (including `force`) directly to `analyzeAction`; fixed by destructuring `{ force, ...analyzeVars }` and passing `analyzeVars` as the first argument
-
 ## [PR #205 | fix/204/모바일-UI-캐시-메시지-버그-수정 | 2026-04-07]
 - Violation: `ChartContent.tsx`(`components/symbol-page/`)에서 `lightweight-charts`의 `IChartApi` 타입을 직접 import하여 `symbol-page` 레이어가 차트 라이브러리에 직접 커플링됨
 - Rule: MISTAKES.md Layer Dependencies #3 — `lightweight-charts` import(타입 포함)는 `components/chart/` 내부로 제한됨
 - Context: visible range 동기화를 위해 `stockChartRef`, `volumeChartRef`, 콜백 2개가 모두 `IChartApi`에 의존했음; `components/chart/hooks/useChartSync.ts`로 추출하여 `ChartContent.tsx`에서 `IChartApi` import 제거
 
-<<<<<<< HEAD
-=======
-
->>>>>>> master
 ## [PR #208 | feat/185/seo-최적화 | 2026-04-07]
 - Violation: `POPULAR_TICKERS` (비즈니스 도메인 지식)가 `src/lib/seo.ts`에 정의되어 lib 레이어 허용 범위를 벗어남
 - Rule: lib/CLAUDE.md — lib 레이어는 utility wrappers, React Query key factories, config constants, chart color constants만 허용; 도메인 비즈니스 상수는 금지
 - Context: `POPULAR_TICKERS`는 `sitemap.ts`에서만 사용되는 상수로 lib이 아닌 사용처(sitemap.ts) 내부로 인라인 이동하여 해결
 
-## [PR #208 | feat/185/seo-최적화 | 2026-04-07]
-- Violation: JSON-LD `description`이 `generateMetadata`와 `jsonLd` 사이에서 불일치 — jsonLd는 짧은 버전, generateMetadata는 전체 문장 사용
-- Rule: FF.md Cohesion — 동일한 도메인 정보(종목 설명)는 코드베이스 전반에서 일관되게 유지되어야 함
-- Context: `[symbol]/page.tsx`에서 `generateMetadata`의 description과 `jsonLd.description`이 서로 다른 문자열을 사용했음; jsonLd를 generateMetadata와 동일한 전체 문장으로 통일하여 해결
-
-
 ## [fix/bars-null-and-ssr-window-error (FMP API spec fix) | 2026-04-06]
 - Violation: `console.log(url)` left in `fmp.ts` `getBars()` — debug artifact shipped to infrastructure
 - Rule: CONVENTIONS.md — infrastructure functions must be pure side-effect-free except for the single external I/O they are responsible for; debug logging is a prohibited side effect
 - Context: `fmp.ts` line 85 had `console.log(url)` after constructing the request URL; removed as part of FMP API spec correction
-
+- 

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,10 @@
 # Fix Log
 
+## [PR #222 Round 3 | feat/221/심볼-페이지-회사명-표시 | 2026-04-10]
+- Violation: SymbolPageClient.tsx에서 symbol.toUpperCase()를 3회, assetInfo.name !== symbol.toUpperCase() 조건을 2회 반복
+- Rule: MISTAKES.md Coding Paradigm #2 — 동일한 값은 한 번만 계산하고 const로 추출
+- Context: JSX 렌더 함수 내에서 파생 상수를 추출하지 않고 동일 표현식을 인라인으로 반복
+
 ## [PR #222 | feat/221/심볼-페이지-회사명-표시 | 2026-04-10]
 - Violation: components/hooks/ 파일에 'use client' 선언 누락
 - Rule: CONVENTIONS.md — components/ 아래 커스텀 훅은 무조건 'use client' 선언

--- a/src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts
+++ b/src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts
@@ -235,6 +235,21 @@ describe('getAssetInfoAction', () => {
             ]);
         });
 
+        it('번역 완료 후 AssetInfo 캐시를 koreanName과 함께 갱신한다', async () => {
+            mockSearchBySymbol.mockResolvedValueOnce([makeFmpResult('IONQ')]);
+            mockGetKoreanNames.mockResolvedValueOnce({});
+            mockTranslateCompanyNames.mockResolvedValue({ IONQ: '아이온큐' });
+
+            await getAssetInfoAction('IONQ');
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(mockCacheSet).toHaveBeenCalledWith(
+                expect.stringContaining('IONQ'),
+                expect.objectContaining({ koreanName: '아이온큐' }),
+                expect.any(Number)
+            );
+        });
+
         it('번역 결과가 비어있으면 setKoreanTickers를 호출하지 않는다', async () => {
             mockSearchBySymbol.mockResolvedValueOnce([makeFmpResult('IONQ')]);
             mockGetKoreanNames.mockResolvedValueOnce({});

--- a/src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts
+++ b/src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts
@@ -140,7 +140,6 @@ describe('getAssetInfoAction', () => {
     describe('FMP 결과에 정확히 일치하는 심볼이 없을 때', () => {
         it('첫 번째 US 거래소 결과를 사용한다', async () => {
             const otherResult = makeFmpResult('AAPL.A');
-            otherResult.symbol = 'AAPL.A';
             mockSearchBySymbol.mockResolvedValueOnce([otherResult]);
             mockGetKoreanNames.mockResolvedValueOnce({});
 

--- a/src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts
+++ b/src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts
@@ -1,0 +1,249 @@
+import type { AssetInfo } from '@/domain/types';
+
+jest.mock('react', () => ({
+    cache: (fn: unknown) => fn,
+}));
+
+const mockCacheGet = jest.fn();
+const mockCacheSet = jest.fn();
+const mockCacheDelete = jest.fn();
+
+jest.mock('@/infrastructure/cache/redis', () => ({
+    createCacheProvider: jest.fn(),
+}));
+
+jest.mock('@/infrastructure/ticker/fmpTickerApi', () => ({
+    searchBySymbol: jest.fn(),
+    filterUsExchanges: jest.fn((results: unknown[]) => results),
+}));
+
+jest.mock('@/infrastructure/ticker/koreanNameStore', () => ({
+    getKoreanNames: jest.fn(),
+    setKoreanTickers: jest.fn(),
+}));
+
+jest.mock('@/infrastructure/ticker/koreanTranslator', () => ({
+    translateCompanyNames: jest.fn(),
+}));
+
+import { getAssetInfoAction } from '@/infrastructure/ticker/getAssetInfoAction';
+import { createCacheProvider } from '@/infrastructure/cache/redis';
+import {
+    searchBySymbol,
+    filterUsExchanges,
+} from '@/infrastructure/ticker/fmpTickerApi';
+import {
+    getKoreanNames,
+    setKoreanTickers,
+} from '@/infrastructure/ticker/koreanNameStore';
+import { translateCompanyNames } from '@/infrastructure/ticker/koreanTranslator';
+
+const mockCreateCacheProvider = createCacheProvider as jest.Mock;
+const mockSearchBySymbol = searchBySymbol as jest.Mock;
+const mockFilterUsExchanges = filterUsExchanges as jest.Mock;
+const mockGetKoreanNames = getKoreanNames as jest.Mock;
+const mockSetKoreanTickers = setKoreanTickers as jest.Mock;
+const mockTranslateCompanyNames = translateCompanyNames as jest.Mock;
+
+const makeFmpResult = (symbol: string) => ({
+    symbol,
+    name: `${symbol} Inc`,
+    exchange: 'NASDAQ',
+    exchangeFullName: 'NASDAQ Global Select',
+});
+
+describe('getAssetInfoAction', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockCreateCacheProvider.mockReturnValue({
+            get: mockCacheGet,
+            set: mockCacheSet,
+            delete: mockCacheDelete,
+        });
+        mockFilterUsExchanges.mockImplementation(
+            (results: unknown[]) => results
+        );
+        mockSearchBySymbol.mockResolvedValue([]);
+        mockGetKoreanNames.mockResolvedValue({});
+        mockTranslateCompanyNames.mockResolvedValue({});
+        mockSetKoreanTickers.mockResolvedValue(undefined);
+        mockCacheGet.mockResolvedValue(null);
+        mockCacheSet.mockResolvedValue(undefined);
+    });
+
+    describe('캐시 히트일 때', () => {
+        it('캐시된 결과를 즉시 반환한다', async () => {
+            const cached: AssetInfo = {
+                symbol: 'AAPL',
+                name: 'Apple Inc',
+                koreanName: '애플',
+            };
+            mockCacheGet.mockResolvedValueOnce(cached);
+
+            const result = await getAssetInfoAction('AAPL');
+            expect(result).toEqual(cached);
+            expect(mockSearchBySymbol).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('캐시 미스이고 FMP에서 정확히 매칭되는 심볼이 있을 때', () => {
+        it('한국어명이 있으면 koreanName을 포함해서 반환한다', async () => {
+            mockSearchBySymbol.mockResolvedValueOnce([makeFmpResult('AAPL')]);
+            mockGetKoreanNames.mockResolvedValueOnce({ AAPL: '애플' });
+
+            const result = await getAssetInfoAction('AAPL');
+            expect(result.symbol).toBe('AAPL');
+            expect(result.name).toBe('AAPL Inc');
+            expect(result.koreanName).toBe('애플');
+        });
+
+        it('한국어명이 없으면 koreanName 없이 반환한다', async () => {
+            mockSearchBySymbol.mockResolvedValueOnce([makeFmpResult('IONQ')]);
+            mockGetKoreanNames.mockResolvedValueOnce({});
+
+            const result = await getAssetInfoAction('IONQ');
+            expect(result.symbol).toBe('IONQ');
+            expect(result.koreanName).toBeUndefined();
+        });
+
+        it('한국어명이 없으면 translateAndCache를 fire-and-forget으로 호출한다', async () => {
+            mockSearchBySymbol.mockResolvedValueOnce([makeFmpResult('IONQ')]);
+            mockGetKoreanNames.mockResolvedValueOnce({});
+            mockTranslateCompanyNames.mockResolvedValue({ IONQ: '아이온큐' });
+
+            await getAssetInfoAction('IONQ');
+
+            await new Promise(resolve => setTimeout(resolve, 0));
+            expect(mockTranslateCompanyNames).toHaveBeenCalledWith([
+                { symbol: 'IONQ', name: 'IONQ Inc' },
+            ]);
+        });
+
+        it('결과를 캐시에 저장한다', async () => {
+            mockSearchBySymbol.mockResolvedValueOnce([makeFmpResult('AAPL')]);
+            mockGetKoreanNames.mockResolvedValueOnce({ AAPL: '애플' });
+
+            await getAssetInfoAction('AAPL');
+            expect(mockCacheSet).toHaveBeenCalled();
+        });
+
+        it('소문자 심볼 입력을 대문자로 정규화한다', async () => {
+            mockSearchBySymbol.mockResolvedValueOnce([makeFmpResult('AAPL')]);
+            mockGetKoreanNames.mockResolvedValueOnce({});
+
+            const result = await getAssetInfoAction('aapl');
+            expect(result.symbol).toBe('AAPL');
+            expect(mockSearchBySymbol).toHaveBeenCalledWith('AAPL');
+        });
+    });
+
+    describe('FMP 결과에 정확히 일치하는 심볼이 없을 때', () => {
+        it('첫 번째 US 거래소 결과를 사용한다', async () => {
+            const otherResult = makeFmpResult('AAPL.A');
+            otherResult.symbol = 'AAPL.A';
+            mockSearchBySymbol.mockResolvedValueOnce([otherResult]);
+            mockGetKoreanNames.mockResolvedValueOnce({});
+
+            const result = await getAssetInfoAction('AAPL');
+            expect(result.name).toBe('AAPL.A Inc');
+        });
+    });
+
+    describe('FMP 결과가 없을 때', () => {
+        it('symbol을 name 폴백으로 사용한다', async () => {
+            mockSearchBySymbol.mockResolvedValueOnce([]);
+
+            const result = await getAssetInfoAction('UNKNOWN');
+            expect(result.symbol).toBe('UNKNOWN');
+            expect(result.name).toBe('UNKNOWN');
+            expect(result.koreanName).toBeUndefined();
+        });
+
+        it('translateAndCache를 호출하지 않는다', async () => {
+            mockSearchBySymbol.mockResolvedValueOnce([]);
+
+            await getAssetInfoAction('UNKNOWN');
+            await new Promise(resolve => setTimeout(resolve, 0));
+            expect(mockTranslateCompanyNames).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('캐시 provider를 사용할 수 없을 때', () => {
+        it('FMP 결과를 직접 반환한다', async () => {
+            mockCreateCacheProvider.mockReturnValue(null);
+            mockSearchBySymbol.mockResolvedValueOnce([makeFmpResult('AAPL')]);
+            mockGetKoreanNames.mockResolvedValueOnce({ AAPL: '애플' });
+
+            const result = await getAssetInfoAction('AAPL');
+            expect(result.symbol).toBe('AAPL');
+            expect(result.koreanName).toBe('애플');
+        });
+    });
+
+    describe('캐시 GET 중 에러가 발생할 때', () => {
+        it('에러를 삼키고 FMP API를 호출한다', async () => {
+            mockCacheGet.mockRejectedValueOnce(new Error('Redis error'));
+            mockSearchBySymbol.mockResolvedValueOnce([makeFmpResult('AAPL')]);
+            mockGetKoreanNames.mockResolvedValueOnce({});
+
+            const result = await getAssetInfoAction('AAPL');
+            expect(result.symbol).toBe('AAPL');
+            expect(mockSearchBySymbol).toHaveBeenCalled();
+        });
+    });
+
+    describe('캐시 SET 중 에러가 발생할 때', () => {
+        it('에러를 삼키고 결과를 정상 반환한다', async () => {
+            mockCacheSet.mockRejectedValueOnce(new Error('Redis write error'));
+            mockSearchBySymbol.mockResolvedValueOnce([makeFmpResult('AAPL')]);
+            mockGetKoreanNames.mockResolvedValueOnce({});
+
+            const result = await getAssetInfoAction('AAPL');
+            await new Promise(resolve => setTimeout(resolve, 0));
+            expect(result.symbol).toBe('AAPL');
+        });
+    });
+
+    describe('translateAndCache 중 에러가 발생할 때', () => {
+        it('에러를 삼키고 결과를 정상 반환한다', async () => {
+            mockSearchBySymbol.mockResolvedValueOnce([makeFmpResult('IONQ')]);
+            mockGetKoreanNames.mockResolvedValueOnce({});
+            mockTranslateCompanyNames.mockRejectedValueOnce(
+                new Error('translation failed')
+            );
+
+            const result = await getAssetInfoAction('IONQ');
+            await new Promise(resolve => setTimeout(resolve, 0));
+            expect(result.symbol).toBe('IONQ');
+        });
+    });
+
+    describe('번역 후 setKoreanTickers 호출', () => {
+        it('번역 결과를 KoreanTickerEntry로 저장한다', async () => {
+            mockSearchBySymbol.mockResolvedValueOnce([makeFmpResult('IONQ')]);
+            mockGetKoreanNames.mockResolvedValueOnce({});
+            mockTranslateCompanyNames.mockResolvedValue({ IONQ: '아이온큐' });
+
+            await getAssetInfoAction('IONQ');
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(mockSetKoreanTickers).toHaveBeenCalledWith([
+                expect.objectContaining({
+                    symbol: 'IONQ',
+                    koreanName: '아이온큐',
+                }),
+            ]);
+        });
+
+        it('번역 결과가 비어있으면 setKoreanTickers를 호출하지 않는다', async () => {
+            mockSearchBySymbol.mockResolvedValueOnce([makeFmpResult('IONQ')]);
+            mockGetKoreanNames.mockResolvedValueOnce({});
+            mockTranslateCompanyNames.mockResolvedValue({});
+
+            await getAssetInfoAction('IONQ');
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(mockSetKoreanTickers).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -99,10 +99,7 @@ export default async function SymbolPage({ params }: Props) {
         },
     });
 
-    await queryClient.prefetchQuery({
-        queryKey: QUERY_KEYS.assetInfo(symbol),
-        queryFn: () => getAssetInfoAction(ticker),
-    });
+    queryClient.setQueryData(QUERY_KEYS.assetInfo(symbol), assetInfo);
 
     await queryClient.prefetchQuery({
         queryKey: QUERY_KEYS.bars(symbol, DEFAULT_TIMEFRAME),

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -5,8 +5,9 @@ import {
     HydrationBoundary,
 } from '@tanstack/react-query';
 import { DEFAULT_TIMEFRAME } from '@/domain/constants/market';
-import type { AnalysisResponse } from '@/domain/types';
+import type { AnalysisResponse, AssetInfo } from '@/domain/types';
 import { fetchBarsWithIndicators } from '@/infrastructure/market/barsApi';
+import { getAssetInfoAction } from '@/infrastructure/ticker/getAssetInfoAction';
 import { QUERY_KEYS, QUERY_STALE_TIME_MS } from '@/lib/queryConfig';
 import { SITE_NAME, SITE_URL } from '@/lib/seo';
 import { SymbolPageClient } from '@/components/symbol-page/SymbolPageClient';
@@ -32,11 +33,20 @@ interface Props {
     params: Promise<{ symbol: string }>;
 }
 
+function buildDisplayName(assetInfo: AssetInfo, ticker: string): string {
+    return assetInfo.koreanName
+        ? `${assetInfo.koreanName} ${assetInfo.name} (${ticker})`
+        : `${assetInfo.name} (${ticker})`;
+}
+
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const { symbol } = await params;
     const ticker = symbol.toUpperCase();
-    const title = `${ticker} 기술적 분석`;
-    const description = `${ticker} 실시간 차트와 AI 기반 기술적 분석 — 보조지표, 캔들 패턴, 지지/저항 레벨을 한 번에 확인하세요.`;
+    const assetInfo = await getAssetInfoAction(ticker);
+
+    const displayName = buildDisplayName(assetInfo, ticker);
+    const title = `${displayName} 기술적 분석`;
+    const description = `${displayName} 실시간 차트와 AI 기반 기술적 분석 — 보조지표, 캔들 패턴, 지지/저항 레벨을 한 번에 확인하세요.`;
     const url = `${SITE_URL}/${ticker}`;
 
     return {
@@ -64,16 +74,19 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function SymbolPage({ params }: Props) {
     const { symbol } = await params;
     const ticker = symbol.toUpperCase();
+    const assetInfo = await getAssetInfoAction(ticker);
+
+    const displayName = buildDisplayName(assetInfo, ticker);
 
     const jsonLd = {
         '@context': 'https://schema.org',
         '@type': 'WebPage',
-        name: `${ticker} 기술적 분석 | ${SITE_NAME}`,
-        description: `${ticker} 실시간 차트와 AI 기반 기술적 분석 — 보조지표, 캔들 패턴, 지지/저항 레벨을 한 번에 확인하세요.`,
+        name: `${displayName} 기술적 분석 | ${SITE_NAME}`,
+        description: `${displayName} 실시간 차트와 AI 기반 기술적 분석 — 보조지표, 캔들 패턴, 지지/저항 레벨을 한 번에 확인하세요.`,
         url: `${SITE_URL}/${ticker}`,
         about: {
             '@type': 'FinancialProduct',
-            name: ticker,
+            name: displayName,
             category: 'Stock',
         },
     };
@@ -84,6 +97,11 @@ export default async function SymbolPage({ params }: Props) {
                 staleTime: QUERY_STALE_TIME_MS,
             },
         },
+    });
+
+    await queryClient.prefetchQuery({
+        queryKey: QUERY_KEYS.assetInfo(ticker),
+        queryFn: () => getAssetInfoAction(ticker),
     });
 
     await queryClient.prefetchQuery({

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -34,9 +34,17 @@ interface Props {
 }
 
 function buildDisplayName(assetInfo: AssetInfo, ticker: string): string {
-    return assetInfo.koreanName
-        ? `${assetInfo.koreanName}, ${assetInfo.name} (${ticker})`
-        : `${assetInfo.name} (${ticker})`;
+    const namePart = assetInfo.name !== ticker ? assetInfo.name : null;
+    if (assetInfo.koreanName && namePart) {
+        return `${assetInfo.koreanName}, ${namePart} (${ticker})`;
+    }
+    if (assetInfo.koreanName) {
+        return `${assetInfo.koreanName} (${ticker})`;
+    }
+    if (namePart) {
+        return `${namePart} (${ticker})`;
+    }
+    return ticker;
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -35,7 +35,7 @@ interface Props {
 
 function buildDisplayName(assetInfo: AssetInfo, ticker: string): string {
     return assetInfo.koreanName
-        ? `${assetInfo.koreanName} ${assetInfo.name} (${ticker})`
+        ? `${assetInfo.koreanName}, ${assetInfo.name} (${ticker})`
         : `${assetInfo.name} (${ticker})`;
 }
 
@@ -100,7 +100,7 @@ export default async function SymbolPage({ params }: Props) {
     });
 
     await queryClient.prefetchQuery({
-        queryKey: QUERY_KEYS.assetInfo(ticker),
+        queryKey: QUERY_KEYS.assetInfo(symbol),
         queryFn: () => getAssetInfoAction(ticker),
     });
 

--- a/src/components/symbol-page/SymbolPageClient.tsx
+++ b/src/components/symbol-page/SymbolPageClient.tsx
@@ -32,7 +32,7 @@ export function SymbolPageClient({
         useTimeframeChange(symbol);
     const assetInfo = useAssetInfo(symbol);
     const ticker = symbol.toUpperCase();
-    const hasCompanyName = !!assetInfo?.name && assetInfo.name !== ticker;
+    const hasCompanyName = !!assetInfo && assetInfo.name !== ticker;
 
     return (
         <div className="bg-secondary-900 text-secondary-200 flex h-screen flex-col overflow-hidden">

--- a/src/components/symbol-page/SymbolPageClient.tsx
+++ b/src/components/symbol-page/SymbolPageClient.tsx
@@ -48,7 +48,10 @@ export function SymbolPageClient({
                         <h1 className="text-secondary-100 text-lg font-semibold tracking-wide">
                             {assetInfo?.koreanName && (
                                 <span className="text-secondary-300">
-                                    {assetInfo.koreanName},{' '}
+                                    {assetInfo.koreanName}
+                                    {assetInfo.name !== symbol.toUpperCase()
+                                        ? ', '
+                                        : ' '}
                                 </span>
                             )}
                             {assetInfo?.name &&

--- a/src/components/symbol-page/SymbolPageClient.tsx
+++ b/src/components/symbol-page/SymbolPageClient.tsx
@@ -31,6 +31,8 @@ export function SymbolPageClient({
     const { timeframe, timeframeChangeCount, handleTimeframeChange } =
         useTimeframeChange(symbol);
     const assetInfo = useAssetInfo(symbol);
+    const ticker = symbol.toUpperCase();
+    const hasCompanyName = !!assetInfo?.name && assetInfo.name !== ticker;
 
     return (
         <div className="bg-secondary-900 text-secondary-200 flex h-screen flex-col overflow-hidden">
@@ -49,18 +51,15 @@ export function SymbolPageClient({
                             {assetInfo?.koreanName && (
                                 <span className="text-secondary-300">
                                     {assetInfo.koreanName}
-                                    {assetInfo.name !== symbol.toUpperCase()
-                                        ? ', '
-                                        : ' '}
+                                    {hasCompanyName ? ', ' : ' '}
                                 </span>
                             )}
-                            {assetInfo?.name &&
-                                assetInfo.name !== symbol.toUpperCase() && (
-                                    <span className="text-secondary-200">
-                                        {assetInfo.name}{' '}
-                                    </span>
-                                )}
-                            ({symbol.toUpperCase()})
+                            {hasCompanyName && (
+                                <span className="text-secondary-200">
+                                    {assetInfo!.name}{' '}
+                                </span>
+                            )}
+                            ({ticker})
                         </h1>
                     </div>
                     <div className="flex items-center gap-3">

--- a/src/components/symbol-page/SymbolPageClient.tsx
+++ b/src/components/symbol-page/SymbolPageClient.tsx
@@ -56,7 +56,7 @@ export function SymbolPageClient({
                             )}
                             {hasCompanyName && (
                                 <span className="text-secondary-200">
-                                    {assetInfo!.name}{' '}
+                                    {assetInfo?.name}{' '}
                                 </span>
                             )}
                             ({ticker})

--- a/src/components/symbol-page/SymbolPageClient.tsx
+++ b/src/components/symbol-page/SymbolPageClient.tsx
@@ -54,9 +54,9 @@ export function SymbolPageClient({
                                     {hasCompanyName ? ', ' : ' '}
                                 </span>
                             )}
-                            {hasCompanyName && (
+                            {assetInfo && hasCompanyName && (
                                 <span className="text-secondary-200">
-                                    {assetInfo?.name}{' '}
+                                    {assetInfo.name}{' '}
                                 </span>
                             )}
                             ({ticker})

--- a/src/components/symbol-page/SymbolPageClient.tsx
+++ b/src/components/symbol-page/SymbolPageClient.tsx
@@ -10,6 +10,7 @@ import { ChartErrorFallback } from '@/components/chart/ChartErrorFallback';
 import { TickerAutocomplete } from '@/components/search/TickerAutocomplete';
 import { ChartContent } from '@/components/symbol-page/ChartContent';
 import { useTimeframeChange } from '@/components/symbol-page/hooks/useTimeframeChange';
+import { useAssetInfo } from '@/components/symbol-page/hooks/useAssetInfo';
 
 interface SymbolPageClientProps {
     symbol: string;
@@ -29,6 +30,7 @@ export function SymbolPageClient({
     // 충돌을 유발할 수 있으므로, handleTimeframeChange 이벤트 핸들러 안에서 카운터를 갱신한다.
     const { timeframe, timeframeChangeCount, handleTimeframeChange } =
         useTimeframeChange(symbol);
+    const assetInfo = useAssetInfo(symbol);
 
     return (
         <div className="bg-secondary-900 text-secondary-200 flex h-screen flex-col overflow-hidden">
@@ -44,7 +46,18 @@ export function SymbolPageClient({
                         </Link>
                         <span className="text-secondary-700">/</span>
                         <h1 className="text-secondary-100 text-lg font-semibold tracking-wide">
-                            {symbol}
+                            {assetInfo?.koreanName && (
+                                <span className="text-secondary-300">
+                                    {assetInfo.koreanName},{' '}
+                                </span>
+                            )}
+                            {assetInfo?.name &&
+                                assetInfo.name !== symbol.toUpperCase() && (
+                                    <span className="text-secondary-200">
+                                        {assetInfo.name}{' '}
+                                    </span>
+                                )}
+                            ({symbol.toUpperCase()})
                         </h1>
                     </div>
                     <div className="flex items-center gap-3">

--- a/src/components/symbol-page/hooks/useAssetInfo.ts
+++ b/src/components/symbol-page/hooks/useAssetInfo.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useQuery } from '@tanstack/react-query';
 import { getAssetInfoAction } from '@/infrastructure/ticker/getAssetInfoAction';
 import { QUERY_KEYS, QUERY_STALE_TIME_MS } from '@/lib/queryConfig';

--- a/src/components/symbol-page/hooks/useAssetInfo.ts
+++ b/src/components/symbol-page/hooks/useAssetInfo.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { getAssetInfoAction } from '@/infrastructure/ticker/getAssetInfoAction';
+import { QUERY_KEYS, QUERY_STALE_TIME_MS } from '@/lib/queryConfig';
+import type { AssetInfo } from '@/domain/types';
+
+export function useAssetInfo(symbol: string): AssetInfo | undefined {
+    const { data } = useQuery({
+        queryKey: QUERY_KEYS.assetInfo(symbol),
+        queryFn: () => getAssetInfoAction(symbol),
+        staleTime: QUERY_STALE_TIME_MS,
+    });
+    return data;
+}

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -259,6 +259,12 @@ export interface BarsData {
     indicators: IndicatorResult;
 }
 
+export interface AssetInfo {
+    symbol: string;
+    name: string;
+    koreanName?: string;
+}
+
 export interface TickerBase {
     symbol: string;
     name: string;

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -259,12 +259,6 @@ export interface BarsData {
     indicators: IndicatorResult;
 }
 
-export interface AssetInfo {
-    symbol: string;
-    name: string;
-    koreanName?: string;
-}
-
 export interface TickerBase {
     symbol: string;
     name: string;
@@ -277,6 +271,12 @@ export interface KoreanTickerEntry extends TickerBase {
 }
 
 export interface TickerSearchResult extends TickerBase {
+    koreanName?: string;
+}
+
+export interface AssetInfo {
+    symbol: string;
+    name: string;
     koreanName?: string;
 }
 

--- a/src/infrastructure/cache/config.ts
+++ b/src/infrastructure/cache/config.ts
@@ -9,7 +9,7 @@ export const ANALYSIS_CACHE_TTL: Record<Timeframe, number> = {
     '1Day': 24 * 60 * 60,
 };
 
-export const TICKER_SEARCH_CACHE_TTL = 365 * 24 * 60 * 60;
+export const TICKER_SEARCH_CACHE_TTL = 24 * 60 * 60;
 
 // 한국어 이름 매핑은 장기 보존 (1년). sync 스크립트로 주기적 갱신.
 export const KOREAN_NAMES_CACHE_TTL = 365 * 24 * 60 * 60;

--- a/src/infrastructure/cache/config.ts
+++ b/src/infrastructure/cache/config.ts
@@ -26,3 +26,9 @@ export function buildAnalysisCacheKey(
 export function buildTickerSearchCacheKey(query: string): string {
     return `ticker:search:${query.toLowerCase()}`;
 }
+
+export const ASSET_INFO_CACHE_TTL = 24 * 60 * 60;
+
+export function buildAssetInfoCacheKey(symbol: string): string {
+    return `asset-info:${symbol.toUpperCase()}`;
+}

--- a/src/infrastructure/cache/config.ts
+++ b/src/infrastructure/cache/config.ts
@@ -9,7 +9,7 @@ export const ANALYSIS_CACHE_TTL: Record<Timeframe, number> = {
     '1Day': 24 * 60 * 60,
 };
 
-export const TICKER_SEARCH_CACHE_TTL = 24 * 60 * 60;
+export const TICKER_SEARCH_CACHE_TTL = 365 * 24 * 60 * 60;
 
 // 한국어 이름 매핑은 장기 보존 (1년). sync 스크립트로 주기적 갱신.
 export const KOREAN_NAMES_CACHE_TTL = 365 * 24 * 60 * 60;
@@ -27,7 +27,7 @@ export function buildTickerSearchCacheKey(query: string): string {
     return `ticker:search:${query.toLowerCase()}`;
 }
 
-export const ASSET_INFO_CACHE_TTL = 24 * 60 * 60;
+export const ASSET_INFO_CACHE_TTL = 365 * 24 * 60 * 60;
 
 export function buildAssetInfoCacheKey(symbol: string): string {
     return `asset-info:${symbol.toUpperCase()}`;

--- a/src/infrastructure/ticker/getAssetInfoAction.ts
+++ b/src/infrastructure/ticker/getAssetInfoAction.ts
@@ -42,7 +42,10 @@ async function translateAndCache(
         cacheProvider
             .set(cacheKey, { symbol, name, koreanName }, ASSET_INFO_CACHE_TTL)
             .catch(error =>
-                console.error('Asset info cache update after translation failed:', error)
+                console.error(
+                    'Asset info cache update after translation failed:',
+                    error
+                )
             );
     }
 }

--- a/src/infrastructure/ticker/getAssetInfoAction.ts
+++ b/src/infrastructure/ticker/getAssetInfoAction.ts
@@ -35,6 +35,16 @@ async function translateAndCache(
         exchangeFullName,
     };
     await setKoreanTickers([entry]);
+
+    const cacheProvider = createCacheProvider();
+    if (cacheProvider) {
+        const cacheKey = buildAssetInfoCacheKey(symbol);
+        cacheProvider
+            .set(cacheKey, { symbol, name, koreanName }, ASSET_INFO_CACHE_TTL)
+            .catch(error =>
+                console.error('Asset info cache update after translation failed:', error)
+            );
+    }
 }
 
 const resolveAssetInfo = cache(async (symbol: string): Promise<AssetInfo> => {
@@ -87,5 +97,5 @@ const resolveAssetInfo = cache(async (symbol: string): Promise<AssetInfo> => {
 });
 
 export async function getAssetInfoAction(symbol: string): Promise<AssetInfo> {
-    return resolveAssetInfo(symbol);
+    return resolveAssetInfo(symbol.toUpperCase());
 }

--- a/src/infrastructure/ticker/getAssetInfoAction.ts
+++ b/src/infrastructure/ticker/getAssetInfoAction.ts
@@ -1,0 +1,91 @@
+'use server';
+
+import { cache } from 'react';
+import { createCacheProvider } from '@/infrastructure/cache/redis';
+import {
+    ASSET_INFO_CACHE_TTL,
+    buildAssetInfoCacheKey,
+} from '@/infrastructure/cache/config';
+import {
+    searchBySymbol,
+    filterUsExchanges,
+} from '@/infrastructure/ticker/fmpTickerApi';
+import {
+    getKoreanNames,
+    setKoreanTickers,
+} from '@/infrastructure/ticker/koreanNameStore';
+import { translateCompanyNames } from '@/infrastructure/ticker/koreanTranslator';
+import type { AssetInfo, KoreanTickerEntry } from '@/domain/types';
+
+async function translateAndCache(
+    symbol: string,
+    name: string,
+    exchange: string,
+    exchangeFullName: string
+): Promise<void> {
+    const translated = await translateCompanyNames([{ symbol, name }]);
+    const koreanName = translated[symbol];
+    if (!koreanName) return;
+
+    const entry: KoreanTickerEntry = {
+        symbol,
+        name,
+        koreanName,
+        exchange,
+        exchangeFullName,
+    };
+    await setKoreanTickers([entry]);
+}
+
+const resolveAssetInfo = cache(async (symbol: string): Promise<AssetInfo> => {
+    const upper = symbol.toUpperCase();
+    const cacheProvider = createCacheProvider();
+    const cacheKey = buildAssetInfoCacheKey(upper);
+
+    if (cacheProvider) {
+        try {
+            const cached = await cacheProvider.get<AssetInfo>(cacheKey);
+            if (cached) return cached;
+        } catch (error) {
+            console.error('Asset info cache get failed:', error);
+        }
+    }
+
+    const fmpResults = await searchBySymbol(upper);
+    const usResults = filterUsExchanges(fmpResults);
+    const match = usResults.find(r => r.symbol === upper) ?? usResults[0];
+
+    const name = match?.name ?? upper;
+    const exchange = match?.exchange ?? '';
+    const exchangeFullName = match?.exchangeFullName ?? '';
+
+    const koreanNames = await getKoreanNames([upper]);
+    const koreanName = koreanNames[upper];
+
+    const info: AssetInfo = {
+        symbol: upper,
+        name,
+        ...(koreanName && { koreanName }),
+    };
+
+    if (!koreanName && match) {
+        translateAndCache(upper, name, exchange, exchangeFullName).catch(
+            error =>
+                console.error('Asset info translateAndCache failed:', error)
+        );
+    }
+
+    if (cacheProvider) {
+        cacheProvider
+            .set(cacheKey, info, ASSET_INFO_CACHE_TTL)
+            .catch(error =>
+                console.error('Asset info cache set failed:', error)
+            );
+    }
+
+    return info;
+});
+
+export async function getAssetInfoAction(symbol: string): Promise<AssetInfo> {
+    return resolveAssetInfo(symbol);
+}

--- a/src/lib/queryConfig.ts
+++ b/src/lib/queryConfig.ts
@@ -7,4 +7,5 @@ export const QUERY_KEYS = {
     bars: (symbol: string, timeframe: Timeframe) =>
         ['bars', symbol, timeframe] as const,
     tickerSearch: (query: string) => ['ticker-search', query] as const,
+    assetInfo: (symbol: string) => ['asset-info', symbol] as const,
 } as const;


### PR DESCRIPTION
## 관련 이슈

closes #221

## 구현 내용

심볼 페이지의 헤더에 티커 심볼 다음에 회사명(한국어, 영어)을 함께 표시합니다.

### 주요 기능
- **AssetInfo 타입**: 회사명을 저장하는 새로운 도메인 타입 추가
- **getAssetInfoAction**: FMP API를 통해 회사명 조회 (캐시 활용, 한국어 이름 병렬 조회, fire-and-forget 번역)
- **useAssetInfo**: React Query를 활용한 회사명 조회 훅
- **헤더 표시**: SymbolPageClient에서 "AAPL Apple Inc. 애플"과 같이 표시
- **SEO 최적화**: generateMetadata, jsonLd에 회사명 포함
- **캐시 설정**: 회사 정보는 365일 TTL로 캐시

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it

## 변경 파일 목록

[생성]
- `src/infrastructure/ticker/getAssetInfoAction.ts`
- `src/components/symbol-page/hooks/useAssetInfo.ts`
- `src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts`

[수정]
- `src/domain/types.ts` — AssetInfo 타입 추가
- `src/infrastructure/cache/config.ts` — ASSET_INFO_CACHE_TTL, buildAssetInfoCacheKey 추가
- `src/lib/queryConfig.ts` — QUERY_KEYS.assetInfo 추가
- `src/app/[symbol]/page.tsx` — prefetch 추가, generateMetadata/jsonLd에 회사명 포함
- `src/components/symbol-page/SymbolPageClient.tsx` — 헤더 h1에 회사명 표시

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build