### PR TITLE
fix: 뒤로가기 시 Object is disposed 에러 수정

### DIFF
--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -166,14 +166,19 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 
 ## Lightweight Charts
 
-1. Missing chart.remove() cleanup
-   → Duplicate canvas on component remount
+1. Missing chart.remove() cleanup or listener unsubscribe before chart.remove()
+   → Always call unsubscribeVisibleLogicalRangeChange before chart.remove() to prevent "Object is disposed" errors
+   → Use a ref pattern for onChartRemove callback to capture cleanup logic and guard chartRef.current in ResizeObserver
 
 2. Passing domain null values directly to setData
    → Convert to WhitespaceData({ time })
 
 3. Adding volume/RSI to the main pane
    → Always add to a separate pane (index 1, 2, ...)
+
+4. Derived className or style objects recreated on every render without memoization
+   → Props-derived objects (inputClass, buttonClass computed from size prop) must use useMemo to prevent recreation
+   → Prevents unnecessary re-renders when object identity is compared
 
 ---
 
@@ -202,4 +207,13 @@ This file contains only **recurring gotchas** that agents keep missing despite e
    → Cache resource creation or check for duplicates before creating
    ❌ const reader = new Redis(config); const writer = new Redis(config);
    ✅ const writer = new Redis(config); const reader = !token ? writer : new Redis(altConfig);
+
+3. Implicit divergence between ref initialization and state lazy initializer
+   → useState lazy initializer and useRef initial value must share same source of truth
+   ❌ useRef(getDefaultValue()) eager call vs useState(() => getDefaultValue()) lazy call diverges if getDefaultValue() returns different results
+   ✅ If ref is overwritten before read, initialize to null; if read first, share source with useState
+
+4. Deleting code marked with TODO without updating all references
+   → TODO comments indicate intentional preservation for future references
+   → Removing such code breaks commented-out code that still references it; restore or update all references first
 ```

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -14,10 +14,6 @@
 - Rule: MISTAKES.md TypeScript #11 — 구현 변경 시 문서 동기화 필수
 - Context: PR #216에서 `src/infrastructure/ticker/`가 신규 추가됐으나 ARCHITECTURE.md 폴더 트리에 누락
 
-- Violation: `inputClass`, `buttonClass`가 `size` prop 파생값임에도 useMemo 없이 매 렌더마다 재계산
-- Rule: MISTAKES.md Components #11 — props/state에서 파생된 객체는 useMemo로 메모이제이션 필요
-- Context: `TickerAutocomplete.tsx`의 두 className 상수가 `size`에만 의존하므로 `useMemo([size])`로 감쌈
-
 ## [PR #216 Round 7 | feat/196/ticker-autocomplete | 2026-04-09]
 - Violation: `{isOpen && ...}` 블록 내부에서 `hasQuery`가 항상 `true`임에도 `&& hasQuery` 조건 유지 (dead code)
 - Rule: MISTAKES.md Coding Paradigm #4 — 결과를 변경하지 않는 조건(효과 없는 로직) 제거
@@ -55,10 +51,6 @@
 - Rule: MISTAKES.md Components #5 — Side effects inside setState updater functions; 더 나아가 render 중 setState 자체가 React 19 concurrent mode + startTransition 조합에서 Next.js Router 업데이트 충돌을 일으킬 수 있음
 - Context: `useTimeframeChange`의 `startTransition` 내부에서 Suspense가 트리거되는 동안 render-phase setState가 Router context 업데이트와 충돌했음; `timeframeChangeCount` 관리를 `handleTimeframeChange` 이벤트 핸들러 안으로 이동하여 해결
 
-## [fix/bars-null-and-ssr-window-error | 2026-04-06]
-- Violation: `panelWidthAtDragStartRef` was initialized by eagerly calling `getDefaultPanelWidth()` while `panelWidth` state used the lazy initializer form; the two initial values diverge if `getDefaultPanelWidth()` returns different results on successive calls
-- Rule: CONVENTIONS.md Convention 2-B (Predictability) — useState lazy initializer and useRef initial value must share the same source of truth to prevent divergence
-- Context: `usePanelResize.ts` called `getDefaultPanelWidth()` eagerly in `useRef` on line 34; fixed by initializing the ref to `0` since it is always overwritten in `handleDragStart` before being read in `onResize`
 
 ## [fix/204/모바일-UI-캐시-메시지-버그-수정 | 2026-04-07]
 - Violation: `mutationFn` passed `AnalyzeMutationVariables` (which includes `force: boolean`) directly to `analyzeAction`, whose first parameter is typed as `AnalyzeVariables` (no `force` field), causing a TypeScript excess property error
@@ -70,10 +62,6 @@
 - Rule: MISTAKES.md Layer Dependencies #3 — `lightweight-charts` import(타입 포함)는 `components/chart/` 내부로 제한됨
 - Context: visible range 동기화를 위해 `stockChartRef`, `volumeChartRef`, 콜백 2개가 모두 `IChartApi`에 의존했음; `components/chart/hooks/useChartSync.ts`로 추출하여 `ChartContent.tsx`에서 `IChartApi` import 제거
 
-## [PR #205 | fix/204/모바일-UI-캐시-메시지-버그-수정 | 2026-04-07]
-- Violation: TODO 주석으로 명시적 보존이 지시된 `EyeIcon` 컴포넌트가 삭제됨; commented-out 버튼 코드에서 여전히 `EyeIcon`을 참조하고 있어 주석 해제 시 불일치 발생
-- Rule: FF.md Predictability — TODO로 유지 의도가 명시된 코드를 삭제하면 향후 주석 해제 시 참조 오류가 발생하여 예측 가능성을 해침
-- Context: `AnalysisPanel.tsx`에서 `EyeIcon` 컴포넌트가 제거되었으나 3곳의 commented-out 버튼에서 여전히 `<EyeIcon>`을 참조; 원본 코드를 복원하여 해결
 
 ## [PR #208 | feat/185/seo-최적화 | 2026-04-07]
 - Violation: `POPULAR_TICKERS` (비즈니스 도메인 지식)가 `src/lib/seo.ts`에 정의되어 lib 레이어 허용 범위를 벗어남
@@ -85,10 +73,6 @@
 - Rule: FF.md Cohesion — 동일한 도메인 정보(종목 설명)는 코드베이스 전반에서 일관되게 유지되어야 함
 - Context: `[symbol]/page.tsx`에서 `generateMetadata`의 description과 `jsonLd.description`이 서로 다른 문자열을 사용했음; jsonLd를 generateMetadata와 동일한 전체 문장으로 통일하여 해결
 
-## [PR #218 | feat/217/재분석-버튼-활성화 | 2026-04-09]
-- Violation: `ChartContent.tsx`에서 `useEffect` 내 `if (isAnalyzing) setDisplayAnalyzing(true)` 직접 setState 호출이 cascading renders 경고(`react-hooks/set-state-in-effect`)를 유발함
-- Rule: React 공식 권장 — prop 변화에 반응한 state 동기화는 `useEffect` 대신 렌더링 중 state 업데이트 패턴(`prevProp` state로 이전 값 추적)을 사용해야 함
-- Context: `isAnalyzing`이 true로 변할 때 `displayAnalyzing`을 true로 동기화하기 위해 `useEffect`를 사용했으나, `prevIsAnalyzing` state를 추가하고 렌더링 중 비교하는 패턴으로 교체하여 해결
 
 ## [fix/bars-null-and-ssr-window-error (FMP API spec fix) | 2026-04-06]
 - Violation: `console.log(url)` left in `fmp.ts` `getBars()` — debug artifact shipped to infrastructure

--- a/src/components/chart/StockChart.tsx
+++ b/src/components/chart/StockChart.tsx
@@ -73,6 +73,8 @@ interface StockChartProps {
     ) => void;
     /** 차트 인스턴스가 준비되면 호출된다. 거래량 차트와 visible range 동기화에 사용된다. */
     onChartReady?: (chart: IChartApi) => void;
+    /** 차트가 제거되기 직전에 호출된다. 구독 해제에 사용된다. */
+    onChartRemove?: () => void;
 }
 
 export function StockChart({
@@ -89,6 +91,7 @@ export function StockChart({
     keyLevelsVisible: _keyLevelsVisible = false,
     onPatternOverlayChange: _onPatternOverlayChange,
     onChartReady,
+    onChartRemove,
 }: StockChartProps) {
     const [rsiVisible, setRsiVisible] = useState(false);
     const [macdVisible, setMacdVisible] = useState(false);
@@ -104,6 +107,7 @@ export function StockChart({
         null
     );
     const onChartReadyRef = useRef(onChartReady);
+    const onChartRemoveRef = useRef(onChartRemove);
 
     const paneIndices: PaneIndices = useMemo(() => {
         const visibles = [
@@ -172,6 +176,7 @@ export function StockChart({
 
     useEffect(() => {
         onChartReadyRef.current = onChartReady;
+        onChartRemoveRef.current = onChartRemove;
     });
 
     useEffect(() => {
@@ -204,6 +209,7 @@ export function StockChart({
         onChartReadyRef.current?.(chart);
 
         return () => {
+            onChartRemoveRef.current?.();
             chart.remove();
             chartRef.current = null;
             seriesRef.current = null;

--- a/src/components/chart/VolumeChart.tsx
+++ b/src/components/chart/VolumeChart.tsx
@@ -14,7 +14,11 @@ interface VolumeChartProps {
     onChartRemove?: () => void;
 }
 
-export function VolumeChart({ bars, onChartReady, onChartRemove }: VolumeChartProps) {
+export function VolumeChart({
+    bars,
+    onChartReady,
+    onChartRemove,
+}: VolumeChartProps) {
     const containerRef = useRef<HTMLDivElement>(null);
     const chartRef = useRef<IChartApi | null>(null);
     const seriesRef = useRef<ISeriesApi<'Histogram'> | null>(null);

--- a/src/components/chart/VolumeChart.tsx
+++ b/src/components/chart/VolumeChart.tsx
@@ -10,16 +10,20 @@ interface VolumeChartProps {
     bars: Bar[];
     /** 차트 인스턴스가 준비되면 호출된다. 캔들차트와 visible range 동기화에 사용된다. */
     onChartReady?: (chart: IChartApi) => void;
+    /** 차트가 제거되기 직전에 호출된다. 구독 해제에 사용된다. */
+    onChartRemove?: () => void;
 }
 
-export function VolumeChart({ bars, onChartReady }: VolumeChartProps) {
+export function VolumeChart({ bars, onChartReady, onChartRemove }: VolumeChartProps) {
     const containerRef = useRef<HTMLDivElement>(null);
     const chartRef = useRef<IChartApi | null>(null);
     const seriesRef = useRef<ISeriesApi<'Histogram'> | null>(null);
     const onChartReadyRef = useRef(onChartReady);
+    const onChartRemoveRef = useRef(onChartRemove);
 
     useEffect(() => {
         onChartReadyRef.current = onChartReady;
+        onChartRemoveRef.current = onChartRemove;
     });
 
     useEffect(() => {
@@ -45,6 +49,7 @@ export function VolumeChart({ bars, onChartReady }: VolumeChartProps) {
         onChartReadyRef.current?.(chart);
 
         return () => {
+            onChartRemoveRef.current?.();
             chart.remove();
             chartRef.current = null;
             seriesRef.current = null;

--- a/src/components/chart/hooks/useChartSync.ts
+++ b/src/components/chart/hooks/useChartSync.ts
@@ -13,8 +13,12 @@ interface ChartSyncHandlers {
 export function useChartSync(): ChartSyncHandlers {
     const stockChartRef = useRef<IChartApi | null>(null);
     const volumeChartRef = useRef<IChartApi | null>(null);
-    const stockHandlerRef = useRef<((range: LogicalRange | null) => void) | null>(null);
-    const volumeHandlerRef = useRef<((range: LogicalRange | null) => void) | null>(null);
+    const stockHandlerRef = useRef<
+        ((range: LogicalRange | null) => void) | null
+    >(null);
+    const volumeHandlerRef = useRef<
+        ((range: LogicalRange | null) => void) | null
+    >(null);
 
     const handleStockChartReady = useCallback((chart: IChartApi): void => {
         stockChartRef.current = chart;
@@ -43,9 +47,7 @@ export function useChartSync(): ChartSyncHandlers {
         volumeChartRef.current = chart;
         const handler = (range: LogicalRange | null) => {
             if (range !== null && stockChartRef.current !== null) {
-                stockChartRef.current
-                    .timeScale()
-                    .setVisibleLogicalRange(range);
+                stockChartRef.current.timeScale().setVisibleLogicalRange(range);
             }
         };
         volumeHandlerRef.current = handler;

--- a/src/components/chart/hooks/useChartSync.ts
+++ b/src/components/chart/hooks/useChartSync.ts
@@ -1,36 +1,71 @@
 'use client';
 
 import { useCallback, useRef } from 'react';
-import type { IChartApi } from 'lightweight-charts';
+import type { IChartApi, LogicalRange } from 'lightweight-charts';
 
 interface ChartSyncHandlers {
     handleStockChartReady: (chart: IChartApi) => void;
+    handleStockChartRemove: () => void;
     handleVolumeChartReady: (chart: IChartApi) => void;
+    handleVolumeChartRemove: () => void;
 }
 
 export function useChartSync(): ChartSyncHandlers {
     const stockChartRef = useRef<IChartApi | null>(null);
     const volumeChartRef = useRef<IChartApi | null>(null);
+    const stockHandlerRef = useRef<((range: LogicalRange | null) => void) | null>(null);
+    const volumeHandlerRef = useRef<((range: LogicalRange | null) => void) | null>(null);
 
     const handleStockChartReady = useCallback((chart: IChartApi): void => {
         stockChartRef.current = chart;
-        chart.timeScale().subscribeVisibleLogicalRangeChange(range => {
+        const handler = (range: LogicalRange | null) => {
             if (range !== null && volumeChartRef.current !== null) {
                 volumeChartRef.current
                     .timeScale()
                     .setVisibleLogicalRange(range);
             }
-        });
+        };
+        stockHandlerRef.current = handler;
+        chart.timeScale().subscribeVisibleLogicalRangeChange(handler);
+    }, []);
+
+    const handleStockChartRemove = useCallback((): void => {
+        const chart = stockChartRef.current;
+        const handler = stockHandlerRef.current;
+        if (chart && handler) {
+            chart.timeScale().unsubscribeVisibleLogicalRangeChange(handler);
+        }
+        stockChartRef.current = null;
+        stockHandlerRef.current = null;
     }, []);
 
     const handleVolumeChartReady = useCallback((chart: IChartApi): void => {
         volumeChartRef.current = chart;
-        chart.timeScale().subscribeVisibleLogicalRangeChange(range => {
+        const handler = (range: LogicalRange | null) => {
             if (range !== null && stockChartRef.current !== null) {
-                stockChartRef.current.timeScale().setVisibleLogicalRange(range);
+                stockChartRef.current
+                    .timeScale()
+                    .setVisibleLogicalRange(range);
             }
-        });
+        };
+        volumeHandlerRef.current = handler;
+        chart.timeScale().subscribeVisibleLogicalRangeChange(handler);
     }, []);
 
-    return { handleStockChartReady, handleVolumeChartReady };
+    const handleVolumeChartRemove = useCallback((): void => {
+        const chart = volumeChartRef.current;
+        const handler = volumeHandlerRef.current;
+        if (chart && handler) {
+            chart.timeScale().unsubscribeVisibleLogicalRangeChange(handler);
+        }
+        volumeChartRef.current = null;
+        volumeHandlerRef.current = null;
+    }, []);
+
+    return {
+        handleStockChartReady,
+        handleStockChartRemove,
+        handleVolumeChartReady,
+        handleVolumeChartRemove,
+    };
 }

--- a/src/components/chart/hooks/usePaneLabels.ts
+++ b/src/components/chart/hooks/usePaneLabels.ts
@@ -91,8 +91,10 @@ export function usePaneLabels({
         labelElementsRef.current = labelPairs.map(({ el }) => el);
 
         const recomputeTops = () => {
+            const currentChart = chartRef.current;
+            if (!currentChart) return;
             for (const { config, el } of labelPairs) {
-                const top = getTopOffset(chart, config.paneIndex);
+                const top = getTopOffset(currentChart, config.paneIndex);
                 el.style.top = `${top + LABEL_OFFSET_PX}px`;
             }
         };

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -102,7 +102,12 @@ export function ChartContent({
     const { panelWidth, isDragging, handleDragStart, handleKeyDown } =
         usePanelResize();
 
-    const { handleStockChartReady, handleVolumeChartReady } = useChartSync();
+    const {
+        handleStockChartReady,
+        handleStockChartRemove,
+        handleVolumeChartReady,
+        handleVolumeChartRemove,
+    } = useChartSync();
 
     const [chartVisiblePatterns, setChartVisiblePatterns] = useState<
         Set<string>
@@ -165,6 +170,7 @@ export function ChartContent({
                         keyLevelsVisible={keyLevelsVisible}
                         onPatternOverlayChange={handlePatternOverlayChange}
                         onChartReady={handleStockChartReady}
+                        onChartRemove={handleStockChartRemove}
                     />
                 </div>
 
@@ -173,6 +179,7 @@ export function ChartContent({
                     <VolumeChart
                         bars={bars}
                         onChartReady={handleVolumeChartReady}
+                        onChartRemove={handleVolumeChartRemove}
                     />
                 </div>
             </div>


### PR DESCRIPTION
## 관련 이슈

closes #223

## 구현 내용

chart 인스턴스가 dispose된 후에 구독(subscription)을 해제하려고 시도할 때 발생하는 "Object is disposed" 에러를 해결합니다.

### 수정 내용
- `useChartSync.ts`: chart.remove() 호출 전에 구독 해제 (unsubscribe)
- `usePaneLabels.ts`: chart.remove() 호출 전에 구독 해제 (unsubscribe)
- `StockChart.tsx`: chart 인스턴스 정리 시 구독 해제 순서 조정
- `VolumeChart.tsx`: chart 인스턴스 정리 시 구독 해제 순서 조정
- `ChartContent.tsx`: cleanup 함수에서 구독 해제 시점 최적화

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음

## 변경 파일 목록

[수정]
- src/components/chart/hooks/useChartSync.ts
- src/components/chart/hooks/usePaneLabels.ts
- src/components/chart/StockChart.tsx
- src/components/chart/VolumeChart.tsx
- src/components/symbol-page/ChartContent.tsx

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build