### PR TITLE
feat: SEO 종합 개선

### DIFF
--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -30,22 +30,29 @@ This file contains only **recurring gotchas** that agents keep missing despite e
    ❌ data.flatMap(...).filter(x => x.id === uniqueId)  // uniqueId guaranteed from flatMap
    ✅ data.flatMap(...)
 
-5. Repeating identical filtering/calculation logic across multiple useEffect/useMemo blocks
+5. Array/object mutation via push/splice or direct property assignment
+   → Use spread syntax for arrays; destructure and spread for objects
+   ❌ keywords.push(value)  // direct mutation
+   ❌ obj.property = newValue  // direct mutation of object created moments before
+   ✅ const keywords = [...keywordList, value]
+   ✅ const obj = { ...source, property: newValue }
+
+6. Repeating identical filtering/calculation logic across multiple useEffect/useMemo blocks
    → Extract to useMemo (hooks) or const (regular code)
 
-6. Repeating identical className ternary 3+ times
+7. Repeating identical className ternary 3+ times
    → Extract to a helper function
 
-7. Tight coupling between interface props and dependent files
+8. Tight coupling between interface props and dependent files
    → Group related prop pairs into a single type (e.g. IndicatorToggleGroup { visible, onToggle })
 
-8. Complex anonymous expressions (IIFE, multi-statement ternary)
+9. Complex anonymous expressions (IIFE, multi-statement ternary)
    → Extract to a named helper function
 
-9. Derived constants recreated on every render without memoization
-   → Wrap with useMemo for objects/maps derived from props/state
+10. Derived constants recreated on every render without memoization
+    → Wrap with useMemo for objects/maps derived from props/state
 
-10. Function/interface names become inaccurate after architectural changes
+11. Function/interface names become inaccurate after architectural changes
     → When replacing HTTP calls with Server Actions, renaming patterns, or moving code, update the names
     ❌ fetchBars (no longer a fetch — now a Server Action)
     ✅ getBarsAction (accurate to new implementation)

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,10 +1,6 @@
 # Fix Log
 
 ## [PR #222 Round 5 | feat/221/심볼-페이지-회사명-표시 | 2026-04-10]
-- Violation: 테스트에서 `makeFmpResult("AAPL.A")`로 생성 직후 `otherResult.symbol = "AAPL.A"` 재할당 — dead code 뮤테이션
-- Rule: CONVENTIONS.md FP 불변성 — 객체 생성 후 직접 뮤테이션 금지; 이미 설정된 값을 재할당하는 것은 효과 없는 코드
-- Context: `makeFmpResult`가 이미 `symbol: "AAPL.A"`로 생성하므로 다음 줄 재할당은 무의미; 삭제
-
 - Violation: `!!assetInfo?.name`이 `AssetInfo.name`이 required 필드임에도 불필요하게 `.name` 접근
 - Rule: FF.md Predictability — 타입 시스템이 보장하는 사실을 조건식에 명시적으로 표현해야 함
 - Context: `assetInfo`가 정의되어 있으면 `name`은 항상 truthy이므로 `!!assetInfo`로 단순화

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,26 @@ const nextConfig: NextConfig = {
     turbopack: {
         root: import.meta.dirname,
     },
+
+    headers: async () => [
+        {
+            source: '/(.*)',
+            headers: [
+                {
+                    key: 'X-Content-Type-Options',
+                    value: 'nosniff',
+                },
+                {
+                    key: 'X-Frame-Options',
+                    value: 'DENY',
+                },
+                {
+                    key: 'Referrer-Policy',
+                    value: 'strict-origin-when-cross-origin',
+                },
+            ],
+        },
+    ],
 };
 
 export default nextConfig;

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -9,7 +9,7 @@ import type { AnalysisResponse, AssetInfo } from '@/domain/types';
 import { fetchBarsWithIndicators } from '@/infrastructure/market/barsApi';
 import { getAssetInfoAction } from '@/infrastructure/ticker/getAssetInfoAction';
 import { QUERY_KEYS, QUERY_STALE_TIME_MS } from '@/lib/queryConfig';
-import { SITE_NAME, SITE_URL } from '@/lib/seo';
+import { buildSymbolKeywords, SITE_NAME, SITE_URL } from '@/lib/seo';
 import { SymbolPageClient } from '@/components/symbol-page/SymbolPageClient';
 
 const FALLBACK_ANALYSIS: AnalysisResponse = {
@@ -56,10 +56,16 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const title = `${displayName} 기술적 분석`;
     const description = `${displayName} 실시간 차트와 AI 기반 기술적 분석 — 보조지표, 캔들 패턴, 지지/저항 레벨을 한 번에 확인하세요.`;
     const url = `${SITE_URL}/${ticker}`;
+    const keywords = buildSymbolKeywords(
+        ticker,
+        displayName,
+        assetInfo.koreanName
+    );
 
     return {
         title,
         description,
+        keywords,
         alternates: {
             canonical: url,
         },
@@ -92,11 +98,32 @@ export default async function SymbolPage({ params }: Props) {
         name: `${displayName} 기술적 분석 | ${SITE_NAME}`,
         description: `${displayName} 실시간 차트와 AI 기반 기술적 분석 — 보조지표, 캔들 패턴, 지지/저항 레벨을 한 번에 확인하세요.`,
         url: `${SITE_URL}/${ticker}`,
+        inLanguage: 'ko',
         about: {
             '@type': 'FinancialProduct',
             name: displayName,
+            tickerSymbol: ticker,
             category: 'Stock',
         },
+    };
+
+    const breadcrumbJsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+            {
+                '@type': 'ListItem',
+                position: 1,
+                name: SITE_NAME,
+                item: SITE_URL,
+            },
+            {
+                '@type': 'ListItem',
+                position: 2,
+                name: `${displayName} 기술적 분석`,
+                item: `${SITE_URL}/${ticker}`,
+            },
+        ],
     };
 
     const queryClient = new QueryClient({
@@ -120,6 +147,15 @@ export default async function SymbolPage({ params }: Props) {
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{
                     __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c'),
+                }}
+            />
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{
+                    __html: JSON.stringify(breadcrumbJsonLd).replace(
+                        /</g,
+                        '\\u003c'
+                    ),
                 }}
             />
             <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -102,7 +102,7 @@ export default async function SymbolPage({ params }: Props) {
         about: {
             '@type': 'FinancialProduct',
             name: displayName,
-            tickerSymbol: ticker,
+            identifier: ticker,
             category: 'Stock',
         },
     };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,13 @@
 import type { Metadata, Viewport } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { ReactQueryProvider } from '@/components/providers/ReactQueryProvider';
-import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from '@/lib/seo';
+import {
+    ROOT_KEYWORDS,
+    ROOT_TITLE,
+    SITE_DESCRIPTION,
+    SITE_NAME,
+    SITE_URL,
+} from '@/lib/seo';
 import './globals.css';
 
 const geistSans = Geist({
@@ -14,8 +20,6 @@ const geistMono = Geist_Mono({
     subsets: ['latin'],
 });
 
-const ROOT_TITLE = `${SITE_NAME} | AI 기술적 주가 분석`;
-
 export const metadata: Metadata = {
     metadataBase: new URL(SITE_URL),
     title: {
@@ -23,7 +27,10 @@ export const metadata: Metadata = {
         template: `%s | ${SITE_NAME}`,
     },
     description: SITE_DESCRIPTION,
+    keywords: ROOT_KEYWORDS,
     applicationName: SITE_NAME,
+    authors: [{ name: SITE_NAME, url: SITE_URL }],
+    creator: SITE_NAME,
     openGraph: {
         type: 'website',
         siteName: SITE_NAME,
@@ -40,6 +47,16 @@ export const metadata: Metadata = {
     robots: {
         index: true,
         follow: true,
+        googleBot: {
+            index: true,
+            follow: true,
+            'max-video-preview': -1,
+            'max-image-preview': 'large',
+            'max-snippet': -1,
+        },
+    },
+    alternates: {
+        canonical: SITE_URL,
     },
 };
 

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next';
+import { SITE_DESCRIPTION, SITE_NAME } from '@/lib/seo';
+
+export default function manifest(): MetadataRoute.Manifest {
+    return {
+        name: `${SITE_NAME} — 미국 주식 AI 기술적 분석`,
+        short_name: SITE_NAME,
+        description: SITE_DESCRIPTION,
+        start_url: '/',
+        display: 'standalone',
+        background_color: '#0f172a',
+        theme_color: '#0f172a',
+        icons: [{ src: '/icon.png', sizes: '512x512', type: 'image/png' }],
+    };
+}

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -10,6 +10,9 @@ export default function manifest(): MetadataRoute.Manifest {
         display: 'standalone',
         background_color: '#0f172a',
         theme_color: '#0f172a',
-        icons: [{ src: '/icon.png', sizes: '512x512', type: 'image/png' }],
+        icons: [
+            { src: '/icon.png', sizes: '192x192', type: 'image/png' },
+            { src: '/icon.png', sizes: '512x512', type: 'image/png' },
+        ],
     };
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,9 +1,16 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { POPULAR_TICKERS, SITE_NAME } from '@/lib/seo';
+import {
+    POPULAR_TICKERS,
+    POPULAR_TICKERS_DISPLAY_COUNT,
+    SITE_NAME,
+} from '@/lib/seo';
 import { Footer } from '@/components/layout/Footer';
 
-const SUGGESTED_TICKERS = POPULAR_TICKERS.slice(0, 6);
+const SUGGESTED_TICKERS = POPULAR_TICKERS.slice(
+    0,
+    POPULAR_TICKERS_DISPLAY_COUNT
+);
 
 export const metadata: Metadata = {
     title: '페이지를 찾을 수 없습니다',

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { POPULAR_TICKERS, SITE_NAME } from '@/lib/seo';
+import { Footer } from '@/components/layout/Footer';
+
+const SUGGESTED_TICKERS = POPULAR_TICKERS.slice(0, 6);
+
+export const metadata: Metadata = {
+    title: '페이지를 찾을 수 없습니다',
+    robots: { index: false, follow: true },
+};
+
+export default function NotFound() {
+    return (
+        <>
+            <main className="flex flex-1 flex-col items-center justify-center px-6 py-20 text-center">
+                <p className="text-primary-400 font-mono text-sm tracking-widest">
+                    404
+                </p>
+                <h1 className="text-secondary-100 mt-4 text-2xl font-bold sm:text-3xl">
+                    페이지를 찾을 수 없습니다
+                </h1>
+                <p className="text-secondary-400 mt-3 max-w-md text-sm leading-relaxed">
+                    요청하신 페이지가 존재하지 않거나 이동되었을 수 있습니다.
+                    아래에서 종목을 검색하거나, 인기 종목을 확인해 보세요.
+                </p>
+
+                <Link
+                    href="/"
+                    className="bg-primary-600 hover:bg-primary-700 mt-8 rounded-lg px-6 py-2.5 text-sm font-medium text-white transition-colors"
+                >
+                    {SITE_NAME} 홈으로 돌아가기
+                </Link>
+
+                <div className="mt-8">
+                    <p className="text-secondary-500 mb-3 text-xs">인기 종목</p>
+                    <div className="flex flex-wrap justify-center gap-2">
+                        {SUGGESTED_TICKERS.map(ticker => (
+                            <Link
+                                key={ticker}
+                                href={`/${ticker}`}
+                                className="border-secondary-700 text-secondary-300 hover:border-primary-600/40 hover:text-primary-400 rounded-full border px-3 py-1 text-xs transition-colors"
+                            >
+                                {ticker}
+                            </Link>
+                        ))}
+                    </div>
+                </div>
+            </main>
+            <Footer />
+        </>
+    );
+}

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,57 @@
+import { ImageResponse } from 'next/og';
+import { SITE_DESCRIPTION, SITE_NAME } from '@/lib/seo';
+
+export const runtime = 'edge';
+export const alt = '미국 주식 AI 기술적 분석 플랫폼';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default async function Image() {
+    return new ImageResponse(
+        <div
+            style={{
+                background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 100%)',
+                width: '100%',
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontFamily: 'sans-serif',
+            }}
+        >
+            <div
+                style={{
+                    fontSize: 72,
+                    fontWeight: 700,
+                    color: '#e2e8f0',
+                    letterSpacing: '-0.02em',
+                }}
+            >
+                {SITE_NAME}
+            </div>
+            <div
+                style={{
+                    fontSize: 28,
+                    color: '#60a5fa',
+                    marginTop: 16,
+                }}
+            >
+                AI 기술적 주가 분석
+            </div>
+            <div
+                style={{
+                    fontSize: 18,
+                    color: '#94a3b8',
+                    marginTop: 12,
+                    maxWidth: 800,
+                    textAlign: 'center',
+                    lineHeight: 1.5,
+                }}
+            >
+                {SITE_DESCRIPTION}
+            </div>
+        </div>,
+        { ...size }
+    );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 
 import {
     POPULAR_TICKERS,
+    POPULAR_TICKERS_DISPLAY_COUNT,
     SITE_DESCRIPTION,
     SITE_NAME,
     SITE_URL,
@@ -13,8 +14,10 @@ import { StatsBar } from '@/components/home/StatsBar';
 import { HowItWorks } from '@/components/home/HowItWorks';
 import { SkillsShowcase } from '@/components/home/SkillsShowcase';
 
-const HOMEPAGE_TICKER_COUNT = 6;
-const HOMEPAGE_TICKERS = POPULAR_TICKERS.slice(0, HOMEPAGE_TICKER_COUNT);
+const HOMEPAGE_TICKERS = POPULAR_TICKERS.slice(
+    0,
+    POPULAR_TICKERS_DISPLAY_COUNT
+);
 
 export default async function Home() {
     const loader = new FileSkillsLoader();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,11 @@
 import Link from 'next/link';
 
-import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from '@/lib/seo';
+import {
+    POPULAR_TICKERS,
+    SITE_DESCRIPTION,
+    SITE_NAME,
+    SITE_URL,
+} from '@/lib/seo';
 import { FileSkillsLoader } from '@/infrastructure/skills/loader';
 import { Footer } from '@/components/layout/Footer';
 import { SymbolSearchPanel } from '@/components/search/SymbolSearchPanel';
@@ -8,14 +13,8 @@ import { StatsBar } from '@/components/home/StatsBar';
 import { HowItWorks } from '@/components/home/HowItWorks';
 import { SkillsShowcase } from '@/components/home/SkillsShowcase';
 
-const POPULAR_TICKERS = [
-    'AAPL',
-    'TSLA',
-    'NVDA',
-    'MSFT',
-    'GOOGL',
-    'AMZN',
-] as const;
+const HOMEPAGE_TICKER_COUNT = 6;
+const HOMEPAGE_TICKERS = POPULAR_TICKERS.slice(0, HOMEPAGE_TICKER_COUNT);
 
 export default async function Home() {
     const loader = new FileSkillsLoader();
@@ -27,6 +26,7 @@ export default async function Home() {
         name: SITE_NAME,
         description: SITE_DESCRIPTION,
         url: SITE_URL,
+        inLanguage: 'ko',
         applicationCategory: 'FinanceApplication',
         operatingSystem: 'Web',
         offers: {
@@ -36,12 +36,31 @@ export default async function Home() {
         },
     };
 
+    const organizationJsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'Organization',
+        name: SITE_NAME,
+        url: SITE_URL,
+        logo: `${SITE_URL}/icon.png`,
+        description: SITE_DESCRIPTION,
+        sameAs: ['https://github.com/y0ngha/siglens'],
+    };
+
     return (
         <>
             <script
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{
                     __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c'),
+                }}
+            />
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{
+                    __html: JSON.stringify(organizationJsonLd).replace(
+                        /</g,
+                        '\\u003c'
+                    ),
                 }}
             />
             <a
@@ -83,7 +102,7 @@ export default async function Home() {
                             <span className="text-secondary-500 text-xs">
                                 인기 종목
                             </span>
-                            {POPULAR_TICKERS.map(ticker => (
+                            {HOMEPAGE_TICKERS.map(ticker => (
                                 <Link
                                     key={ticker}
                                     href={`/${ticker}`}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,14 +1,5 @@
 import type { MetadataRoute } from 'next';
-import { SITE_URL } from '@/lib/seo';
-
-const POPULAR_TICKERS = [
-    'AAPL',
-    'TSLA',
-    'NVDA',
-    'MSFT',
-    'GOOGL',
-    'AMZN',
-] as const;
+import { POPULAR_TICKERS, SITE_URL } from '@/lib/seo';
 
 export default function sitemap(): MetadataRoute.Sitemap {
     const now = new Date();
@@ -23,7 +14,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
         ...POPULAR_TICKERS.map(ticker => ({
             url: `${SITE_URL}/${ticker}`,
             lastModified: now,
-            changeFrequency: 'hourly' as const,
+            changeFrequency: 'daily' as const,
             priority: 0.8,
         })),
     ];

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -4,4 +4,67 @@ export const SITE_URL =
 export const SITE_NAME = 'Siglens';
 
 export const SITE_DESCRIPTION =
-    '미국 주식 AI 기술적 분석 플랫폼 — 인디케이터, 패턴, 스킬 기반 종합 분석';
+    '미국 주식 AI 기술적 분석 — RSI, MACD, 볼린저밴드 등 13종 보조지표와 캔들 패턴을 자동 분석합니다. 무료.';
+
+export const ROOT_TITLE = `미국 주식 AI 기술적 분석 — ${SITE_NAME}`;
+
+export const ROOT_KEYWORDS = [
+    '미국 주식 기술적 분석',
+    'AI 주식 분석',
+    '미국 주식 차트 분석',
+    '주식 보조지표',
+    '무료 주식 분석',
+    'RSI',
+    'MACD',
+    '볼린저밴드',
+    '이동평균선',
+    '캔들패턴',
+    '지지 저항',
+    '골든크로스',
+    '데드크로스',
+    'AI technical analysis',
+    'stock chart analysis',
+];
+
+export function buildSymbolKeywords(
+    ticker: string,
+    displayName: string,
+    koreanName?: string
+): string[] {
+    const keywords = [
+        `${displayName} 기술적 분석`,
+        `${displayName} 차트 분석`,
+        `${ticker} 주가`,
+        `${ticker} 기술적 분석`,
+        `${ticker} chart analysis`,
+    ];
+
+    if (koreanName) {
+        keywords.push(`${koreanName} 주가 분석`, `${koreanName} 차트 분석`);
+    }
+
+    return keywords;
+}
+
+export const POPULAR_TICKERS = [
+    'AAPL',
+    'TSLA',
+    'NVDA',
+    'MSFT',
+    'GOOGL',
+    'AMZN',
+    'META',
+    'NFLX',
+    'AMD',
+    'INTC',
+    'PLTR',
+    'COIN',
+    'SOFI',
+    'NIO',
+    'RIVN',
+    'SNOW',
+    'CRM',
+    'UBER',
+    'COST',
+    'JPM',
+] as const;

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -31,20 +31,19 @@ export function buildSymbolKeywords(
     displayName: string,
     koreanName?: string
 ): string[] {
-    const keywords = [
+    return [
         `${displayName} 기술적 분석`,
         `${displayName} 차트 분석`,
         `${ticker} 주가`,
         `${ticker} 기술적 분석`,
         `${ticker} chart analysis`,
+        ...(koreanName
+            ? [`${koreanName} 주가 분석`, `${koreanName} 차트 분석`]
+            : []),
     ];
-
-    if (koreanName) {
-        keywords.push(`${koreanName} 주가 분석`, `${koreanName} 차트 분석`);
-    }
-
-    return keywords;
 }
+
+export const POPULAR_TICKERS_DISPLAY_COUNT = 6;
 
 export const POPULAR_TICKERS = [
     'AAPL',


### PR DESCRIPTION
## 관련 이슈

closes #225

## 구현 내용

포괄적인 SEO 개선 사항을 구현했습니다.

- **SEO 상수 확장**: 키워드 우선 제목, 메타 키워드, buildSymbolKeywords 함수, 20개 인기 티커 포함
- **Root layout**: 메타 키워드, canonical 태그, googleBot 지시문, authors 속성
- **Symbol 페이지**: 동적 키워드 생성, BreadcrumbList JSON-LD, 향상된 FinancialProduct 스키마
- **동적 OG 이미지**: Next.js ImageResponse를 통한 동적 OG 이미지 생성
- **Sitemap 확대**: 6개에서 20개 티커로, hourly→daily 업데이트 빈도
- **Homepage**: Organization JSON-LD, WebApplication의 inLanguage 추가
- **SEO 친화적 404 페이지**: noindex + 내부 링크
- **Web App Manifest**: manifest.webmanifest 라우팅 수정
- **보안 헤더**: next.config.ts에 보안 헤더 추가

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음

## 변경 파일 목록

[생성]
- src/app/manifest.ts
- src/app/not-found.tsx
- src/app/opengraph-image.tsx

[수정]
- next.config.ts (보안 헤더 추가)
- src/app/[symbol]/page.tsx (동적 메타데이터, JSON-LD)
- src/app/layout.tsx (메타 키워드, canonical, authors)
- src/app/page.tsx (Organization JSON-LD, inLanguage)
- src/app/sitemap.ts (20개 티커, daily 빈도)
- src/lib/seo.ts (SEO 상수 확장, buildSymbolKeywords)

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build