### PR TITLE
feat: ActionRecommendation 차트 가격선 오버레이 추가

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -104,4 +104,16 @@
 - Violation: StockChart prop default actionPricesVisible = false contradicted the parent ChartContent's intent (initialized to true). Default off-by-default is misleading when caller explicitly enables the feature.
 - Rule: FF.md Readability 1-C — Design intent must be exposed in code; default values must align with component usage context or caller must explicitly pass the value
 - Context: ChartContent initializes actionPricesVisible={true}, but StockChart defaulted to false when prop was optional, creating contradiction between declaration and runtime behavior. Fixed by changing StockChart default to true to expose the actual design intent.
-- 
+
+## [PR #230 | feat/229/action-recommendation-chart-overlay | 2026-04-10]
+- Violation: `#f87171`(actionStopLoss)과 `#4ade80`(actionTakeProfit)은 디자인 시스템에 없는 임의 hex 값 사용
+- Rule: DESIGN.md — 상승/하락 색상은 `#26a69a`(bullish) / `#ef5350`(bearish) 고정; 임의 hex 금지
+- Context: actionStopLoss에 Tailwind red-400(#f87171), actionTakeProfit에 green-400(#4ade80) 사용; bearish/bullish 시스템 컬러로 교체
+
+- Violation: `ValidatedActionPrices` 인터페이스를 구현 파일(`actionRecommendation.ts`)에 정의
+- Rule: ARCHITECTURE.md — 도메인 결과 타입은 `domain/types.ts`에 정의해야 함
+- Context: 다른 파일(`StockChart.tsx`, `useActionRecommendationOverlay.ts`)에서도 참조하는 타입을 구현 파일에 배치; `domain/types.ts`로 이동
+
+- Violation: `forEach + push`로 배열을 직접 변경(mutation)
+- Rule: MISTAKES.md Coding Paradigm #5 — Array mutation via push/splice; use spread syntax
+- Context: `useActionRecommendationOverlay`에서 `lines.push()`로 IPriceLine 배열 직접 변경; `map` + spread(`[...entryLines, ...stopLossLine, ...takeProfitLines]`)로 교체

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -5,11 +5,6 @@
 - Rule: CONVENTIONS.md Test Rules — "Mock external dependencies only"; @vercel/functions는 외부 패키지이므로 모킹 대상
 - Context: analyzeAction.ts, searchTickerAction.ts, getAssetInfoAction.ts에 waitUntil을 도입하면서 대응 테스트 파일에 jest.mock('@vercel/functions', ...) 추가를 누락
 
-## [PR #222 Round 5 | feat/221/심볼-페이지-회사명-표시 | 2026-04-10]
-- Violation: `!!assetInfo?.name`이 `AssetInfo.name`이 required 필드임에도 불필요하게 `.name` 접근
-- Rule: FF.md Predictability — 타입 시스템이 보장하는 사실을 조건식에 명시적으로 표현해야 함
-- Context: `assetInfo`가 정의되어 있으면 `name`은 항상 truthy이므로 `!!assetInfo`로 단순화
-
 ## [PR #222 Round 3 | feat/221/심볼-페이지-회사명-표시 | 2026-04-10]
 - Violation: SymbolPageClient.tsx에서 symbol.toUpperCase()를 3회, assetInfo.name !== symbol.toUpperCase() 조건을 2회 반복
 - Rule: MISTAKES.md Coding Paradigm #2 — 동일한 값은 한 번만 계산하고 const로 추출
@@ -91,4 +86,17 @@
 - Violation: `console.log(url)` left in `fmp.ts` `getBars()` — debug artifact shipped to infrastructure
 - Rule: CONVENTIONS.md — infrastructure functions must be pure side-effect-free except for the single external I/O they are responsible for; debug logging is a prohibited side effect
 - Context: `fmp.ts` line 85 had `console.log(url)` after constructing the request URL; removed as part of FMP API spec correction
+
+## [PR #229 Round 1 | feat/229/action-recommendation-chart-overlay | 2026-04-10]
+- Violation: ActionRecommendationField.key typed as keyof ActionRecommendation included numeric optional fields, causing rec[key] to fail JSX child type validation
+- Rule: TypeScript Union Type Safety — string literal unions must be narrowed when accessing object properties that will be used in JSX contexts
+- Context: ActionRecommendationField.key was `keyof ActionRecommendation` which included `count?: number` and `updatedAt?: number`; narrowed to `ActionRecommendationTextKey = 'positionAnalysis' | 'entry' | 'exit' | 'riskReward'` to ensure values are text-like for JSX children
+
+- Violation: chartRef (stable RefObject) included in useEffect dependency array for overlay hook
+- Rule: MISTAKES.md Components #2 — stable RefObject references should not be in dependency arrays; only include deps that actually change
+- Context: useCharacterOverlay hook included chartRef alongside dynamic deps like data; removed to match useChartSync pattern of excluding RefObjects
+
+- Violation: Component props with leading underscore used in component body (e.g., _recommendedAction used as recommendedAction)
+- Rule: CONVENTIONS.md Naming — underscore prefix reserved for intentionally-unused destructured parameters; consumed props must not have underscore
+- Context: ActionRecommendationField received _recommendedAction but used it in render; removed underscore to indicate the prop is actually consumed
 - 

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -99,4 +99,9 @@
 - Violation: Component props with leading underscore used in component body (e.g., _recommendedAction used as recommendedAction)
 - Rule: CONVENTIONS.md Naming — underscore prefix reserved for intentionally-unused destructured parameters; consumed props must not have underscore
 - Context: ActionRecommendationField received _recommendedAction but used it in render; removed underscore to indicate the prop is actually consumed
+
+## [PR #229 Round 2 | feat/229/action-recommendation-chart-overlay | 2026-04-10]
+- Violation: StockChart prop default actionPricesVisible = false contradicted the parent ChartContent's intent (initialized to true). Default off-by-default is misleading when caller explicitly enables the feature.
+- Rule: FF.md Readability 1-C — Design intent must be exposed in code; default values must align with component usage context or caller must explicitly pass the value
+- Context: ChartContent initializes actionPricesVisible={true}, but StockChart defaulted to false when prop was optional, creating contradiction between declaration and runtime behavior. Fixed by changing StockChart default to true to expose the actual design intent.
 - 

--- a/src/__tests__/domain/analysis/actionRecommendation.test.ts
+++ b/src/__tests__/domain/analysis/actionRecommendation.test.ts
@@ -1,0 +1,130 @@
+import {
+    validateActionPrices,
+} from '@/domain/analysis/actionRecommendation';
+import type { ActionRecommendation } from '@/domain/types';
+
+const makeRec = (
+    overrides?: Partial<ActionRecommendation>
+): ActionRecommendation => ({
+    positionAnalysis: '현재 가격은 지지선 근처에 위치합니다.',
+    entry: '165~167 구간에서 분할 매수를 고려하세요.',
+    exit: '목표가 180, 손절가 160입니다.',
+    riskReward: '손절 3% vs 목표 9% → 1:3',
+    ...overrides,
+});
+
+describe('validateActionPrices', () => {
+    describe('rec가 undefined일 때', () => {
+        it('undefined를 반환한다', () => {
+            expect(validateActionPrices(undefined)).toBeUndefined();
+        });
+    });
+
+    describe('모든 가격 필드가 없을 때', () => {
+        it('undefined를 반환한다', () => {
+            const rec = makeRec({
+                entryPrices: undefined,
+                stopLoss: undefined,
+                takeProfitPrices: undefined,
+            });
+            expect(validateActionPrices(rec)).toBeUndefined();
+        });
+    });
+
+    describe('빈 배열만 있을 때', () => {
+        it('undefined를 반환한다', () => {
+            const rec = makeRec({
+                entryPrices: [],
+                stopLoss: undefined,
+                takeProfitPrices: [],
+            });
+            expect(validateActionPrices(rec)).toBeUndefined();
+        });
+    });
+
+    describe('유효하지 않은 가격만 있을 때', () => {
+        it('0과 음수를 필터링하고 undefined를 반환한다', () => {
+            const rec = makeRec({
+                entryPrices: [0, -5],
+                stopLoss: 0,
+                takeProfitPrices: [-10],
+            });
+            expect(validateActionPrices(rec)).toBeUndefined();
+        });
+    });
+
+    describe('유효한 entryPrices만 있을 때', () => {
+        it('entryPrices를 포함한 결과를 반환한다', () => {
+            const rec = makeRec({
+                entryPrices: [165, 167],
+                stopLoss: undefined,
+                takeProfitPrices: undefined,
+            });
+            const result = validateActionPrices(rec);
+            expect(result).not.toBeUndefined();
+            expect(result?.entryPrices).toEqual([165, 167]);
+            expect(result?.stopLoss).toBeUndefined();
+            expect(result?.takeProfitPrices).toEqual([]);
+        });
+    });
+
+    describe('유효한 stopLoss만 있을 때', () => {
+        it('stopLoss를 포함한 결과를 반환한다', () => {
+            const rec = makeRec({
+                entryPrices: undefined,
+                stopLoss: 160,
+                takeProfitPrices: undefined,
+            });
+            const result = validateActionPrices(rec);
+            expect(result).not.toBeUndefined();
+            expect(result?.entryPrices).toEqual([]);
+            expect(result?.stopLoss).toBe(160);
+            expect(result?.takeProfitPrices).toEqual([]);
+        });
+    });
+
+    describe('유효한 takeProfitPrices만 있을 때', () => {
+        it('takeProfitPrices를 포함한 결과를 반환한다', () => {
+            const rec = makeRec({
+                entryPrices: undefined,
+                stopLoss: undefined,
+                takeProfitPrices: [180, 195],
+            });
+            const result = validateActionPrices(rec);
+            expect(result).not.toBeUndefined();
+            expect(result?.entryPrices).toEqual([]);
+            expect(result?.stopLoss).toBeUndefined();
+            expect(result?.takeProfitPrices).toEqual([180, 195]);
+        });
+    });
+
+    describe('모든 가격 필드가 유효할 때', () => {
+        it('모든 필드를 포함한 결과를 반환한다', () => {
+            const rec = makeRec({
+                entryPrices: [165, 167],
+                stopLoss: 160,
+                takeProfitPrices: [180, 195],
+            });
+            const result = validateActionPrices(rec);
+            expect(result).toEqual({
+                entryPrices: [165, 167],
+                stopLoss: 160,
+                takeProfitPrices: [180, 195],
+            });
+        });
+    });
+
+    describe('유효한 값과 유효하지 않은 값이 섞여 있을 때', () => {
+        it('유효하지 않은 값(0, 음수)을 필터링한다', () => {
+            const rec = makeRec({
+                entryPrices: [0, 165, -1, 167],
+                stopLoss: 160,
+                takeProfitPrices: [-10, 180, 0, 195],
+            });
+            const result = validateActionPrices(rec);
+            expect(result?.entryPrices).toEqual([165, 167]);
+            expect(result?.stopLoss).toBe(160);
+            expect(result?.takeProfitPrices).toEqual([180, 195]);
+        });
+    });
+});

--- a/src/__tests__/domain/analysis/actionRecommendation.test.ts
+++ b/src/__tests__/domain/analysis/actionRecommendation.test.ts
@@ -1,6 +1,4 @@
-import {
-    validateActionPrices,
-} from '@/domain/analysis/actionRecommendation';
+import { validateActionPrices } from '@/domain/analysis/actionRecommendation';
 import type { ActionRecommendation } from '@/domain/types';
 
 const makeRec = (

--- a/src/__tests__/domain/analysis/prompt.test.ts
+++ b/src/__tests__/domain/analysis/prompt.test.ts
@@ -1854,6 +1854,18 @@ describe('prompt', () => {
         it('actionRecommendation 스키마에 riskReward 필드가 포함된다', () => {
             expect(result).toContain('riskReward');
         });
+
+        it('actionRecommendation 스키마에 entryPrices 필드가 포함된다', () => {
+            expect(result).toContain('entryPrices');
+        });
+
+        it('actionRecommendation 스키마에 stopLoss 필드가 포함된다', () => {
+            expect(result).toContain('stopLoss');
+        });
+
+        it('actionRecommendation 스키마에 takeProfitPrices 필드가 포함된다', () => {
+            expect(result).toContain('takeProfitPrices');
+        });
     });
 
     describe('Skills 섹션 - type이 strategy인 skill일 때', () => {

--- a/src/__tests__/lib/chartColors.test.ts
+++ b/src/__tests__/lib/chartColors.test.ts
@@ -148,6 +148,20 @@ describe('CHART_COLORS', () => {
             expect(CHART_COLORS.vpVal).toBe('#34d399');
         });
     });
+
+    describe('Action Recommendation 가격선 컬러', () => {
+        it('actionEntry는 블루(#60a5fa)이다', () => {
+            expect(CHART_COLORS.actionEntry).toBe('#60a5fa');
+        });
+
+        it('actionStopLoss는 밝은 빨강(#f87171)이다', () => {
+            expect(CHART_COLORS.actionStopLoss).toBe('#f87171');
+        });
+
+        it('actionTakeProfit은 밝은 초록(#4ade80)이다', () => {
+            expect(CHART_COLORS.actionTakeProfit).toBe('#4ade80');
+        });
+    });
 });
 
 describe('getPeriodColor', () => {

--- a/src/__tests__/lib/chartColors.test.ts
+++ b/src/__tests__/lib/chartColors.test.ts
@@ -154,12 +154,12 @@ describe('CHART_COLORS', () => {
             expect(CHART_COLORS.actionEntry).toBe('#60a5fa');
         });
 
-        it('actionStopLoss는 밝은 빨강(#f87171)이다', () => {
-            expect(CHART_COLORS.actionStopLoss).toBe('#f87171');
+        it('actionStopLoss는 bearish 레드(#ef5350)이다', () => {
+            expect(CHART_COLORS.actionStopLoss).toBe('#ef5350');
         });
 
-        it('actionTakeProfit은 밝은 초록(#4ade80)이다', () => {
-            expect(CHART_COLORS.actionTakeProfit).toBe('#4ade80');
+        it('actionTakeProfit은 bullish 틸 그린(#26a69a)이다', () => {
+            expect(CHART_COLORS.actionTakeProfit).toBe('#26a69a');
         });
     });
 });

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -41,9 +41,11 @@ function formatCooldown(ms: number): string {
     return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 }
 
+type ActionRecommendationTextKey = 'positionAnalysis' | 'entry' | 'exit' | 'riskReward';
+
 interface ActionRecommendationField {
     label: string;
-    key: keyof ActionRecommendation;
+    key: ActionRecommendationTextKey;
 }
 
 const ACTION_RECOMMENDATION_FIELDS: readonly ActionRecommendationField[] = [
@@ -55,16 +57,35 @@ const ACTION_RECOMMENDATION_FIELDS: readonly ActionRecommendationField[] = [
 
 interface ActionRecommendationSectionProps {
     rec: ActionRecommendation;
+    isChartVisible: boolean;
+    onToggleChart: () => void;
 }
 
 function ActionRecommendationSection({
     rec,
+    isChartVisible,
+    onToggleChart,
 }: ActionRecommendationSectionProps) {
     return (
         <div className="bg-secondary-700/30 flex flex-col gap-2 rounded-lg p-3">
-            <span className="text-secondary-500 text-xs font-semibold tracking-wide uppercase">
-                매매 전략
-            </span>
+            <div className="flex items-center justify-between">
+                <span className="text-secondary-500 text-xs font-semibold tracking-wide uppercase">
+                    매매 전략
+                </span>
+                <button
+                    type="button"
+                    onClick={onToggleChart}
+                    className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-xs transition-colors ${
+                        isChartVisible
+                            ? 'text-primary-400 hover:text-primary-300'
+                            : 'text-secondary-500 hover:text-secondary-400'
+                    }`}
+                    aria-label={isChartVisible ? '차트 가격선 숨기기' : '차트 가격선 표시'}
+                >
+                    <EyeIcon isVisible={isChartVisible} />
+                    차트
+                </button>
+            </div>
             <div className="flex flex-col gap-2">
                 {ACTION_RECOMMENDATION_FIELDS.map(({ label, key }) => (
                     <div key={label} className="flex flex-col gap-0.5">
@@ -700,6 +721,8 @@ interface AnalysisPanelProps {
     _onKeyLevelsVisibilityChange?: (isVisible: boolean) => void;
     _trendlinesVisible?: boolean;
     _onTrendlinesVisibilityChange?: (isVisible: boolean) => void;
+    actionPricesVisible?: boolean;
+    onActionPricesVisibilityChange?: (isVisible: boolean) => void;
 }
 
 export function AnalysisPanel({
@@ -717,6 +740,8 @@ export function AnalysisPanel({
     _onKeyLevelsVisibilityChange,
     _trendlinesVisible = false,
     _onTrendlinesVisibilityChange,
+    actionPricesVisible = false,
+    onActionPricesVisibilityChange,
 }: AnalysisPanelProps) {
     const handleTogglePatternVisibility = (patternName: string): void => {
         onTogglePattern?.(patternName);
@@ -810,6 +835,12 @@ export function AnalysisPanel({
                     {analysis.actionRecommendation && (
                         <ActionRecommendationSection
                             rec={analysis.actionRecommendation}
+                            isChartVisible={actionPricesVisible}
+                            onToggleChart={() =>
+                                onActionPricesVisibilityChange?.(
+                                    !actionPricesVisible
+                                )
+                            }
                         />
                     )}
 

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -79,11 +79,12 @@ function ActionRecommendationSection({
                 <button
                     type="button"
                     onClick={onToggleChart}
-                    className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-xs transition-colors ${
+                    className={cn(
+                        'flex items-center gap-1 rounded px-1.5 py-0.5 text-xs transition-colors',
                         isChartVisible
                             ? 'text-primary-400 hover:text-primary-300'
                             : 'text-secondary-500 hover:text-secondary-400'
-                    }`}
+                    )}
                     aria-label={
                         isChartVisible
                             ? '차트 가격선 숨기기'
@@ -748,7 +749,7 @@ export function AnalysisPanel({
     _onKeyLevelsVisibilityChange,
     _trendlinesVisible = false,
     _onTrendlinesVisibilityChange,
-    actionPricesVisible = false,
+    actionPricesVisible = true,
     onActionPricesVisibilityChange,
 }: AnalysisPanelProps) {
     const handleTogglePatternVisibility = (patternName: string): void => {

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -41,7 +41,11 @@ function formatCooldown(ms: number): string {
     return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 }
 
-type ActionRecommendationTextKey = 'positionAnalysis' | 'entry' | 'exit' | 'riskReward';
+type ActionRecommendationTextKey =
+    | 'positionAnalysis'
+    | 'entry'
+    | 'exit'
+    | 'riskReward';
 
 interface ActionRecommendationField {
     label: string;
@@ -80,7 +84,11 @@ function ActionRecommendationSection({
                             ? 'text-primary-400 hover:text-primary-300'
                             : 'text-secondary-500 hover:text-secondary-400'
                     }`}
-                    aria-label={isChartVisible ? '차트 가격선 숨기기' : '차트 가격선 표시'}
+                    aria-label={
+                        isChartVisible
+                            ? '차트 가격선 숨기기'
+                            : '차트 가격선 표시'
+                    }
                 >
                     <EyeIcon isVisible={isChartVisible} />
                     차트

--- a/src/components/chart/StockChart.tsx
+++ b/src/components/chart/StockChart.tsx
@@ -94,7 +94,7 @@ export function StockChart({
     keyLevels: _keyLevels = EMPTY_KEY_LEVELS,
     keyLevelsVisible: _keyLevelsVisible = false,
     actionPrices,
-    actionPricesVisible = false,
+    actionPricesVisible = true,
     onPatternOverlayChange: _onPatternOverlayChange,
     onChartReady,
     onChartRemove,
@@ -329,8 +329,7 @@ export function StockChart({
     // });
 
     useActionRecommendationOverlay({
-        chartRef,
-        bars,
+        seriesRef,
         actionPrices,
         isVisible: actionPricesVisible,
         lineWidth: DEFAULT_LINE_WIDTH,

--- a/src/components/chart/StockChart.tsx
+++ b/src/components/chart/StockChart.tsx
@@ -18,6 +18,7 @@ import type {
     Timeframe,
     Trendline,
 } from '@/domain/types';
+import type { ValidatedActionPrices } from '@/domain/analysis/actionRecommendation';
 import { getTimeFormatter } from '@/domain/chart/timeFormat';
 import type { PaneIndices } from '@/components/chart/types';
 import { useMAOverlay } from '@/components/chart/hooks/useMAOverlay';
@@ -32,6 +33,7 @@ import { useCCIChart } from '@/components/chart/hooks/useCCIChart';
 import { useVolumeProfileOverlay } from '@/components/chart/hooks/useVolumeProfileOverlay';
 import { useIchimokuOverlay } from '@/components/chart/hooks/useIchimokuOverlay';
 import { useCandlePatternMarkers } from '@/components/chart/hooks/useCandlePatternMarkers';
+import { useActionRecommendationOverlay } from '@/components/chart/hooks/useActionRecommendationOverlay';
 import { usePaneLabels } from '@/components/chart/hooks/usePaneLabels';
 import { useOverlayLegend } from '@/components/chart/hooks/useOverlayLegend';
 import {
@@ -67,6 +69,8 @@ interface StockChartProps {
     trendlinesVisible?: boolean;
     keyLevels?: KeyLevels;
     keyLevelsVisible?: boolean;
+    actionPrices?: ValidatedActionPrices;
+    actionPricesVisible?: boolean;
     onPatternOverlayChange?: (
         visiblePatterns: Set<string>,
         togglePattern: (patternName: string) => void
@@ -89,6 +93,8 @@ export function StockChart({
     trendlinesVisible: _trendlinesVisible = false,
     keyLevels: _keyLevels = EMPTY_KEY_LEVELS,
     keyLevelsVisible: _keyLevelsVisible = false,
+    actionPrices,
+    actionPricesVisible = false,
     onPatternOverlayChange: _onPatternOverlayChange,
     onChartReady,
     onChartRemove,
@@ -321,6 +327,14 @@ export function StockChart({
     //     isVisible: keyLevelsVisible,
     //     lineWidth: DEFAULT_LINE_WIDTH,
     // });
+
+    useActionRecommendationOverlay({
+        chartRef,
+        bars,
+        actionPrices,
+        isVisible: actionPricesVisible,
+        lineWidth: DEFAULT_LINE_WIDTH,
+    });
 
     // 레이아웃 강제 갱신
     // indicator hook이 removeSeries로 마지막 series를 제거하면 LWC v5는 논리적

--- a/src/components/chart/StockChart.tsx
+++ b/src/components/chart/StockChart.tsx
@@ -18,7 +18,7 @@ import type {
     Timeframe,
     Trendline,
 } from '@/domain/types';
-import type { ValidatedActionPrices } from '@/domain/analysis/actionRecommendation';
+import type { ValidatedActionPrices } from '@/domain/types';
 import { getTimeFormatter } from '@/domain/chart/timeFormat';
 import type { PaneIndices } from '@/components/chart/types';
 import { useMAOverlay } from '@/components/chart/hooks/useMAOverlay';

--- a/src/components/chart/StockChart.tsx
+++ b/src/components/chart/StockChart.tsx
@@ -17,8 +17,8 @@ import type {
     PatternResult,
     Timeframe,
     Trendline,
+    ValidatedActionPrices,
 } from '@/domain/types';
-import type { ValidatedActionPrices } from '@/domain/types';
 import { getTimeFormatter } from '@/domain/chart/timeFormat';
 import type { PaneIndices } from '@/components/chart/types';
 import { useMAOverlay } from '@/components/chart/hooks/useMAOverlay';

--- a/src/components/chart/hooks/useActionRecommendationOverlay.ts
+++ b/src/components/chart/hooks/useActionRecommendationOverlay.ts
@@ -9,7 +9,7 @@ import type {
     UTCTimestamp,
 } from 'lightweight-charts';
 import { LineStyle } from 'lightweight-charts';
-import type { ValidatedActionPrices } from '@/domain/analysis/actionRecommendation';
+import type { ValidatedActionPrices } from '@/domain/types';
 import { CHART_COLORS } from '@/lib/chartColors';
 import { DEFAULT_LINE_WIDTH } from '@/components/chart/constants';
 
@@ -32,57 +32,47 @@ export function useActionRecommendationOverlay({
         const series = seriesRef.current;
 
         // 기존 가격선 제거
-        for (const pl of priceLinesRef.current) {
-            series?.removePriceLine(pl);
-        }
+        priceLinesRef.current.forEach(pl => series?.removePriceLine(pl));
         priceLinesRef.current = [];
 
         if (!series || !isVisible || !actionPrices) return;
 
-        const lines: IPriceLine[] = [];
+        const entryLines = actionPrices.entryPrices.map((price, idx) =>
+            series.createPriceLine({
+                price,
+                color: CHART_COLORS.actionEntry,
+                lineWidth,
+                lineStyle: LineStyle.Dashed,
+                axisLabelVisible: true,
+                title: `진입점 #${idx + 1}`,
+            })
+        );
 
-        // 진입점
-        actionPrices.entryPrices.forEach((price, idx) => {
-            lines.push(
-                series.createPriceLine({
-                    price,
-                    color: CHART_COLORS.actionEntry,
-                    lineWidth,
-                    lineStyle: LineStyle.Dashed,
-                    axisLabelVisible: true,
-                    title: `진입점 #${idx + 1}`,
-                })
-            );
-        });
+        const stopLossLine =
+            actionPrices.stopLoss !== undefined
+                ? [
+                      series.createPriceLine({
+                          price: actionPrices.stopLoss,
+                          color: CHART_COLORS.actionStopLoss,
+                          lineWidth,
+                          lineStyle: LineStyle.Dashed,
+                          axisLabelVisible: true,
+                          title: '손절점',
+                      }),
+                  ]
+                : [];
 
-        // 손절점
-        if (actionPrices.stopLoss !== undefined) {
-            lines.push(
-                series.createPriceLine({
-                    price: actionPrices.stopLoss,
-                    color: CHART_COLORS.actionStopLoss,
-                    lineWidth,
-                    lineStyle: LineStyle.Dashed,
-                    axisLabelVisible: true,
-                    title: '손절점',
-                })
-            );
-        }
+        const takeProfitLines = actionPrices.takeProfitPrices.map((price, idx) =>
+            series.createPriceLine({
+                price,
+                color: CHART_COLORS.actionTakeProfit,
+                lineWidth,
+                lineStyle: LineStyle.Dashed,
+                axisLabelVisible: true,
+                title: `청산점 #${idx + 1}`,
+            })
+        );
 
-        // 청산점
-        actionPrices.takeProfitPrices.forEach((price, idx) => {
-            lines.push(
-                series.createPriceLine({
-                    price,
-                    color: CHART_COLORS.actionTakeProfit,
-                    lineWidth,
-                    lineStyle: LineStyle.Dashed,
-                    axisLabelVisible: true,
-                    title: `청산점 #${idx + 1}`,
-                })
-            );
-        });
-
-        priceLinesRef.current = lines;
+        priceLinesRef.current = [...entryLines, ...stopLossLine, ...takeProfitLines];
     }, [actionPrices, isVisible, lineWidth]);
 }

--- a/src/components/chart/hooks/useActionRecommendationOverlay.ts
+++ b/src/components/chart/hooks/useActionRecommendationOverlay.ts
@@ -2,7 +2,12 @@
 
 import { useEffect, useRef } from 'react';
 import type { RefObject } from 'react';
-import type { IPriceLine, ISeriesApi, LineWidth, UTCTimestamp } from 'lightweight-charts';
+import type {
+    IPriceLine,
+    ISeriesApi,
+    LineWidth,
+    UTCTimestamp,
+} from 'lightweight-charts';
 import { LineStyle } from 'lightweight-charts';
 import type { ValidatedActionPrices } from '@/domain/analysis/actionRecommendation';
 import { CHART_COLORS } from '@/lib/chartColors';

--- a/src/components/chart/hooks/useActionRecommendationOverlay.ts
+++ b/src/components/chart/hooks/useActionRecommendationOverlay.ts
@@ -1,113 +1,83 @@
 'use client';
 
-import { useEffect, useEffectEvent, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import type { RefObject } from 'react';
-import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
-import type { Bar } from '@/domain/types';
+import type { IPriceLine, ISeriesApi, LineWidth, UTCTimestamp } from 'lightweight-charts';
+import { LineStyle } from 'lightweight-charts';
 import type { ValidatedActionPrices } from '@/domain/analysis/actionRecommendation';
 import { CHART_COLORS } from '@/lib/chartColors';
 import { DEFAULT_LINE_WIDTH } from '@/components/chart/constants';
-import {
-    buildLineData,
-    createLevelSeries,
-} from '@/components/chart/utils/keyLevelsUtils';
-
-interface LevelSeriesEntry {
-    series: ISeriesApi<'Line'>;
-    price: number;
-}
 
 interface UseActionRecommendationOverlayParams {
-    chartRef: RefObject<IChartApi | null>;
-    bars: Bar[];
+    seriesRef: RefObject<ISeriesApi<'Candlestick', UTCTimestamp> | null>;
     actionPrices: ValidatedActionPrices | undefined;
     isVisible: boolean;
     lineWidth?: LineWidth;
 }
 
 export function useActionRecommendationOverlay({
-    chartRef,
-    bars,
+    seriesRef,
     actionPrices,
     isVisible,
     lineWidth = DEFAULT_LINE_WIDTH,
 }: UseActionRecommendationOverlayParams): void {
-    const prevChartRef = useRef<IChartApi | null>(null);
-    const entriesRef = useRef<LevelSeriesEntry[]>([]);
+    const priceLinesRef = useRef<IPriceLine[]>([]);
 
-    const clearEntriesRef = useEffectEvent(() => {
-        entriesRef.current = [];
-    });
-
-    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
-        for (const { series } of entriesRef.current) {
-            chart.removeSeries(series);
-        }
-        entriesRef.current = [];
-    });
-
-    // 시리즈 lifecycle 관리 (생성/제거)
-    // bars는 의존하지 않음 — 데이터 세팅은 아래 effect가 단독 담당
     useEffect(() => {
-        const chart = chartRef.current;
+        const series = seriesRef.current;
 
-        if (prevChartRef.current !== chart) {
-            clearEntriesRef();
-            prevChartRef.current = chart;
+        // 기존 가격선 제거
+        for (const pl of priceLinesRef.current) {
+            series?.removePriceLine(pl);
+        }
+        priceLinesRef.current = [];
+
+        if (!series || !isVisible || !actionPrices) return;
+
+        const lines: IPriceLine[] = [];
+
+        // 진입점
+        actionPrices.entryPrices.forEach((price, idx) => {
+            lines.push(
+                series.createPriceLine({
+                    price,
+                    color: CHART_COLORS.actionEntry,
+                    lineWidth,
+                    lineStyle: LineStyle.Dashed,
+                    axisLabelVisible: true,
+                    title: `진입점 #${idx + 1}`,
+                })
+            );
+        });
+
+        // 손절점
+        if (actionPrices.stopLoss !== undefined) {
+            lines.push(
+                series.createPriceLine({
+                    price: actionPrices.stopLoss,
+                    color: CHART_COLORS.actionStopLoss,
+                    lineWidth,
+                    lineStyle: LineStyle.Dashed,
+                    axisLabelVisible: true,
+                    title: '손절점',
+                })
+            );
         }
 
-        if (!chart) return;
+        // 청산점
+        actionPrices.takeProfitPrices.forEach((price, idx) => {
+            lines.push(
+                series.createPriceLine({
+                    price,
+                    color: CHART_COLORS.actionTakeProfit,
+                    lineWidth,
+                    lineStyle: LineStyle.Dashed,
+                    axisLabelVisible: true,
+                    title: `청산점 #${idx + 1}`,
+                })
+            );
+        });
 
-        removeAllSeries(chart);
-
-        if (!isVisible || !actionPrices) return;
-
-        const entryEntries = actionPrices.entryPrices.map(price => ({
-            series: createLevelSeries(
-                chart,
-                CHART_COLORS.actionEntry,
-                lineWidth
-            ),
-            price,
-        }));
-
-        const stopLossEntries =
-            actionPrices.stopLoss !== undefined
-                ? [
-                      {
-                          series: createLevelSeries(
-                              chart,
-                              CHART_COLORS.actionStopLoss,
-                              lineWidth
-                          ),
-                          price: actionPrices.stopLoss,
-                      },
-                  ]
-                : [];
-
-        const takeProfitEntries = actionPrices.takeProfitPrices.map(price => ({
-            series: createLevelSeries(
-                chart,
-                CHART_COLORS.actionTakeProfit,
-                lineWidth
-            ),
-            price,
-        }));
-
-        entriesRef.current = [
-            ...entryEntries,
-            ...stopLossEntries,
-            ...takeProfitEntries,
-        ];
+        priceLinesRef.current = lines;
     }, [actionPrices, isVisible, lineWidth]);
-
-    // 데이터 동기화: 시리즈가 보이는 동안 bars/actionPrices 변경 시 업데이트
-    // isVisible이 true로 바뀔 때도 실행되어 새로 생성된 시리즈에 초기 데이터를 세팅함
-    useEffect(() => {
-        if (!isVisible) return;
-
-        for (const { series, price } of entriesRef.current) {
-            series.setData(buildLineData(bars, price));
-        }
-    }, [bars, actionPrices, isVisible]);
 }

--- a/src/components/chart/hooks/useActionRecommendationOverlay.ts
+++ b/src/components/chart/hooks/useActionRecommendationOverlay.ts
@@ -62,17 +62,22 @@ export function useActionRecommendationOverlay({
                   ]
                 : [];
 
-        const takeProfitLines = actionPrices.takeProfitPrices.map((price, idx) =>
-            series.createPriceLine({
-                price,
-                color: CHART_COLORS.actionTakeProfit,
-                lineWidth,
-                lineStyle: LineStyle.Dashed,
-                axisLabelVisible: true,
-                title: `청산점 #${idx + 1}`,
-            })
+        const takeProfitLines = actionPrices.takeProfitPrices.map(
+            (price, idx) =>
+                series.createPriceLine({
+                    price,
+                    color: CHART_COLORS.actionTakeProfit,
+                    lineWidth,
+                    lineStyle: LineStyle.Dashed,
+                    axisLabelVisible: true,
+                    title: `청산점 #${idx + 1}`,
+                })
         );
 
-        priceLinesRef.current = [...entryLines, ...stopLossLine, ...takeProfitLines];
+        priceLinesRef.current = [
+            ...entryLines,
+            ...stopLossLine,
+            ...takeProfitLines,
+        ];
     }, [actionPrices, isVisible, lineWidth]);
 }

--- a/src/components/chart/hooks/useActionRecommendationOverlay.ts
+++ b/src/components/chart/hooks/useActionRecommendationOverlay.ts
@@ -1,0 +1,113 @@
+'use client';
+
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { RefObject } from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import type { Bar } from '@/domain/types';
+import type { ValidatedActionPrices } from '@/domain/analysis/actionRecommendation';
+import { CHART_COLORS } from '@/lib/chartColors';
+import { DEFAULT_LINE_WIDTH } from '@/components/chart/constants';
+import {
+    buildLineData,
+    createLevelSeries,
+} from '@/components/chart/utils/keyLevelsUtils';
+
+interface LevelSeriesEntry {
+    series: ISeriesApi<'Line'>;
+    price: number;
+}
+
+interface UseActionRecommendationOverlayParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    actionPrices: ValidatedActionPrices | undefined;
+    isVisible: boolean;
+    lineWidth?: LineWidth;
+}
+
+export function useActionRecommendationOverlay({
+    chartRef,
+    bars,
+    actionPrices,
+    isVisible,
+    lineWidth = DEFAULT_LINE_WIDTH,
+}: UseActionRecommendationOverlayParams): void {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const entriesRef = useRef<LevelSeriesEntry[]>([]);
+
+    const clearEntriesRef = useEffectEvent(() => {
+        entriesRef.current = [];
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        for (const { series } of entriesRef.current) {
+            chart.removeSeries(series);
+        }
+        entriesRef.current = [];
+    });
+
+    // 시리즈 lifecycle 관리 (생성/제거)
+    // bars는 의존하지 않음 — 데이터 세팅은 아래 effect가 단독 담당
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearEntriesRef();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        removeAllSeries(chart);
+
+        if (!isVisible || !actionPrices) return;
+
+        const entryEntries = actionPrices.entryPrices.map(price => ({
+            series: createLevelSeries(
+                chart,
+                CHART_COLORS.actionEntry,
+                lineWidth
+            ),
+            price,
+        }));
+
+        const stopLossEntries =
+            actionPrices.stopLoss !== undefined
+                ? [
+                      {
+                          series: createLevelSeries(
+                              chart,
+                              CHART_COLORS.actionStopLoss,
+                              lineWidth
+                          ),
+                          price: actionPrices.stopLoss,
+                      },
+                  ]
+                : [];
+
+        const takeProfitEntries = actionPrices.takeProfitPrices.map(price => ({
+            series: createLevelSeries(
+                chart,
+                CHART_COLORS.actionTakeProfit,
+                lineWidth
+            ),
+            price,
+        }));
+
+        entriesRef.current = [
+            ...entryEntries,
+            ...stopLossEntries,
+            ...takeProfitEntries,
+        ];
+    }, [actionPrices, isVisible, lineWidth]);
+
+    // 데이터 동기화: 시리즈가 보이는 동안 bars/actionPrices 변경 시 업데이트
+    // isVisible이 true로 바뀔 때도 실행되어 새로 생성된 시리즈에 초기 데이터를 세팅함
+    useEffect(() => {
+        if (!isVisible) return;
+
+        for (const { series, price } of entriesRef.current) {
+            series.setData(buildLineData(bars, price));
+        }
+    }, [bars, actionPrices, isVisible]);
+}

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -118,7 +118,7 @@ export function ChartContent({
     );
     const [keyLevelsVisible, setKeyLevelsVisible] = useState(false);
     const [trendlinesVisible, setTrendlinesVisible] = useState(false);
-    const [actionPricesVisible, setActionPricesVisible] = useState(false);
+    const [actionPricesVisible, setActionPricesVisible] = useState(true);
 
     // 마무리 애니메이션이 모두 끝난 뒤에야 본문/배너가 사라지도록, isAnalyzing보다
     // 늦게 false로 떨어지는 displayAnalyzing 상태를 둔다. AnalysisPanel(본문)과

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useMemo, useRef } from 'react';
 import type React from 'react';
 import type { AnalysisResponse, Timeframe } from '@/domain/types';
 import { validateKeyLevels } from '@/domain/analysis/keyLevels';
+import { validateActionPrices } from '@/domain/analysis/actionRecommendation';
 import { cn } from '@/lib/cn';
 import { StockChart } from '@/components/chart/StockChart';
 import { VolumeChart } from '@/components/chart/VolumeChart';
@@ -117,6 +118,7 @@ export function ChartContent({
     );
     const [keyLevelsVisible, setKeyLevelsVisible] = useState(false);
     const [trendlinesVisible, setTrendlinesVisible] = useState(false);
+    const [actionPricesVisible, setActionPricesVisible] = useState(false);
 
     // 마무리 애니메이션이 모두 끝난 뒤에야 본문/배너가 사라지도록, isAnalyzing보다
     // 늦게 false로 떨어지는 displayAnalyzing 상태를 둔다. AnalysisPanel(본문)과
@@ -136,6 +138,11 @@ export function ChartContent({
     const validatedKeyLevels = useMemo(
         () => validateKeyLevels(analysis.keyLevels),
         [analysis.keyLevels]
+    );
+
+    const validatedActionPrices = useMemo(
+        () => validateActionPrices(analysis.actionRecommendation),
+        [analysis.actionRecommendation]
     );
 
     const handlePatternOverlayChange = useCallback(
@@ -168,6 +175,8 @@ export function ChartContent({
                         trendlinesVisible={trendlinesVisible}
                         keyLevels={validatedKeyLevels}
                         keyLevelsVisible={keyLevelsVisible}
+                        actionPrices={validatedActionPrices}
+                        actionPricesVisible={actionPricesVisible}
                         onPatternOverlayChange={handlePatternOverlayChange}
                         onChartReady={handleStockChartReady}
                         onChartRemove={handleStockChartRemove}
@@ -231,6 +240,8 @@ export function ChartContent({
                     _onKeyLevelsVisibilityChange={setKeyLevelsVisible}
                     _trendlinesVisible={trendlinesVisible}
                     _onTrendlinesVisibilityChange={setTrendlinesVisible}
+                    actionPricesVisible={actionPricesVisible}
+                    onActionPricesVisibilityChange={setActionPricesVisible}
                 />
             </aside>
 

--- a/src/domain/analysis/actionRecommendation.ts
+++ b/src/domain/analysis/actionRecommendation.ts
@@ -1,0 +1,30 @@
+import type { ActionRecommendation } from '@/domain/types';
+
+export interface ValidatedActionPrices {
+    entryPrices: number[];
+    stopLoss: number | undefined;
+    takeProfitPrices: number[];
+}
+
+export function validateActionPrices(
+    rec: ActionRecommendation | undefined
+): ValidatedActionPrices | undefined {
+    if (!rec) return undefined;
+
+    const entryPrices = (rec.entryPrices ?? []).filter(p => p > 0);
+    const stopLoss =
+        rec.stopLoss !== undefined && rec.stopLoss > 0
+            ? rec.stopLoss
+            : undefined;
+    const takeProfitPrices = (rec.takeProfitPrices ?? []).filter(p => p > 0);
+
+    if (
+        entryPrices.length === 0 &&
+        stopLoss === undefined &&
+        takeProfitPrices.length === 0
+    ) {
+        return undefined;
+    }
+
+    return { entryPrices, stopLoss, takeProfitPrices };
+}

--- a/src/domain/analysis/actionRecommendation.ts
+++ b/src/domain/analysis/actionRecommendation.ts
@@ -1,10 +1,4 @@
-import type { ActionRecommendation } from '@/domain/types';
-
-export interface ValidatedActionPrices {
-    entryPrices: number[];
-    stopLoss: number | undefined;
-    takeProfitPrices: number[];
-}
+import type { ActionRecommendation, ValidatedActionPrices } from '@/domain/types';
 
 export function validateActionPrices(
     rec: ActionRecommendation | undefined

--- a/src/domain/analysis/actionRecommendation.ts
+++ b/src/domain/analysis/actionRecommendation.ts
@@ -1,4 +1,7 @@
-import type { ActionRecommendation, ValidatedActionPrices } from '@/domain/types';
+import type {
+    ActionRecommendation,
+    ValidatedActionPrices,
+} from '@/domain/types';
 
 export function validateActionPrices(
     rec: ActionRecommendation | undefined

--- a/src/domain/analysis/prompt.ts
+++ b/src/domain/analysis/prompt.ts
@@ -291,7 +291,7 @@ const ANALYSIS_RESPONSE_SCHEMA: Record<keyof AnalysisResponse, string> = {
     trendlines:
         '[{ "direction": "ascending | descending", "start": { "time": 1700000000, "price": 150.00 }, "end": { "time": 1700100000, "price": 155.00 } }]',
     actionRecommendation:
-        '{ "positionAnalysis": "Current price position vs support/resistance analysis", "entry": "Entry strategy with specific price ranges", "exit": "Exit strategy with specific price ranges", "riskReward": "Risk-reward ratio analysis" }',
+        '{ "positionAnalysis": "Current price position vs support/resistance analysis", "entry": "Entry strategy with specific price ranges", "exit": "Exit strategy with specific price ranges", "riskReward": "Risk-reward ratio analysis", "entryPrices": [165.00, 167.00], "stopLoss": 160.00, "takeProfitPrices": [180.00, 195.00] }',
 };
 
 const buildSchemaBody = (): string => {
@@ -370,6 +370,10 @@ const ANALYSIS_GUIDELINES = [
     '- exit: Provide specific exit price ranges for both profit-taking and stop-loss, referencing the priceTargets and resistance levels above.',
     '- riskReward: Calculate the risk-reward ratio based on entry, stop-loss, and target prices. Express as a ratio (e.g., "stop-loss 3% vs target 9% → risk:reward = 1:3").',
     '- Write in accessible language that non-technical users can understand.',
+    '- entryPrices: Extract the numeric entry price(s) from your entry analysis. If a range, provide [low, high]. If a single price, provide [price]. Must match the prices mentioned in the entry text field exactly.',
+    '- stopLoss: Extract the stop-loss price from your exit analysis as a single number. Must match the stop-loss price mentioned in the exit text field.',
+    '- takeProfitPrices: Extract the take-profit target price(s) from your exit analysis. Sort ascending (lowest price first). Must match the target prices mentioned in the exit text field.',
+    '- entryPrices, stopLoss, takeProfitPrices must be numerically consistent with the text in entry/exit fields — they are the same prices in structured form for chart rendering.',
     '',
     '### Insufficient Data',
     '- If bar data is too short to reliably calculate an indicator or detect a pattern, state "데이터 부족" rather than guessing.',

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -230,6 +230,12 @@ export interface Trendline {
     end: TrendlinePoint;
 }
 
+export interface ValidatedActionPrices {
+    entryPrices: number[];
+    stopLoss: number | undefined;
+    takeProfitPrices: number[];
+}
+
 export interface ActionRecommendation {
     positionAnalysis: string;
     entry: string;

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -236,8 +236,8 @@ export interface ActionRecommendation {
     exit: string;
     riskReward: string;
     // 차트 오버레이용 구조화된 가격
-    entryPrices?: number[];      // 진입가 범위 [low, high] 또는 단일 [price]
-    stopLoss?: number;           // 손절가 (단일)
+    entryPrices?: number[]; // 진입가 범위 [low, high] 또는 단일 [price]
+    stopLoss?: number; // 손절가 (단일)
     takeProfitPrices?: number[]; // 목표가 (복수 가능, 오름차순)
 }
 

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -235,6 +235,10 @@ export interface ActionRecommendation {
     entry: string;
     exit: string;
     riskReward: string;
+    // 차트 오버레이용 구조화된 가격
+    entryPrices?: number[];      // 진입가 범위 [low, high] 또는 단일 [price]
+    stopLoss?: number;           // 손절가 (단일)
+    takeProfitPrices?: number[]; // 목표가 (복수 가능, 오름차순)
 }
 
 export interface AnalysisResponse {

--- a/src/lib/chartColors.ts
+++ b/src/lib/chartColors.ts
@@ -78,8 +78,8 @@ export const CHART_COLORS = {
     resistanceLine: '#ef5350',
 
     // Action Recommendation 가격선
-    actionEntry: '#60a5fa',      // 진입가 (파란)
-    actionStopLoss: '#f87171',   // 손절가 (밝은 빨강)
+    actionEntry: '#60a5fa', // 진입가 (파란)
+    actionStopLoss: '#f87171', // 손절가 (밝은 빨강)
     actionTakeProfit: '#4ade80', // 목표가 (밝은 초록)
 
     // Ichimoku Cloud

--- a/src/lib/chartColors.ts
+++ b/src/lib/chartColors.ts
@@ -78,8 +78,8 @@ export const CHART_COLORS = {
     resistanceLine: '#ef5350',
 
     // Action Recommendation 가격선
-    actionEntry: '#60a5fa',      // 진입가 (primary-400)
-    actionStopLoss: '#ef5350',   // 손절가 (bearish)
+    actionEntry: '#60a5fa', // 진입가 (primary-400)
+    actionStopLoss: '#ef5350', // 손절가 (bearish)
     actionTakeProfit: '#26a69a', // 목표가 (bullish)
 
     // Ichimoku Cloud

--- a/src/lib/chartColors.ts
+++ b/src/lib/chartColors.ts
@@ -78,9 +78,9 @@ export const CHART_COLORS = {
     resistanceLine: '#ef5350',
 
     // Action Recommendation 가격선
-    actionEntry: '#60a5fa', // 진입가 (파란)
-    actionStopLoss: '#f87171', // 손절가 (밝은 빨강)
-    actionTakeProfit: '#4ade80', // 목표가 (밝은 초록)
+    actionEntry: '#60a5fa',      // 진입가 (primary-400)
+    actionStopLoss: '#ef5350',   // 손절가 (bearish)
+    actionTakeProfit: '#26a69a', // 목표가 (bullish)
 
     // Ichimoku Cloud
     ichimokuTenkan: '#2962ff',

--- a/src/lib/chartColors.ts
+++ b/src/lib/chartColors.ts
@@ -77,6 +77,11 @@ export const CHART_COLORS = {
     supportLine: '#26a69a',
     resistanceLine: '#ef5350',
 
+    // Action Recommendation 가격선
+    actionEntry: '#60a5fa',      // 진입가 (파란)
+    actionStopLoss: '#f87171',   // 손절가 (밝은 빨강)
+    actionTakeProfit: '#4ade80', // 목표가 (밝은 초록)
+
     // Ichimoku Cloud
     ichimokuTenkan: '#2962ff',
     ichimokuKijun: '#e91e63',


### PR DESCRIPTION
## 관련 이슈

closes #229

## 구현 내용

ActionRecommendation 차트 가격선 오버레이 기능을 추가했습니다. 진입가, 손실율 가격선, 익절 가격선을 차트에 표시할 수 있습니다.

### 주요 변경 사항

**도메인 계층**
- `ActionRecommendation` 타입에 `entryPrices`, `stopLoss`, `takeProfitPrices` 필드 추가
- `validateActionPrices` 함수와 `ValidatedActionPrices` 인터페이스 구현 (`actionRecommendation.ts`)
- AI 프롬프트 스키마 업데이트 - 구조화된 가격 필드 요청

**UI/컴포넌트**
- `useActionRecommendationOverlay` 훅 추가 (useKeyLevelsOverlay 패턴 따름)
- `StockChart` props 확장 (`actionPrices`, `actionPricesVisible`)
- `ChartContent`에서 상태 관리 및 검증 로직 연결
- `AnalysisPanel`에 토글 버튼(눈 아이콘) 추가

**디자인 시스템**
- `chartColors.ts`에 `actionEntry`, `actionStopLoss`, `actionTakeProfit` 색상 추가

**테스트**
- `validateActionPrices` 유닛 테스트
- 프롬프트 스키마 필드 검증 테스트
- 차트 색상 어서션 테스트

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it

## 변경 파일 목록

[생성]
- src/domain/analysis/actionRecommendation.ts
- src/components/chart/hooks/useActionRecommendationOverlay.ts
- src/__tests__/domain/analysis/actionRecommendation.test.ts

[수정]
- src/domain/types.ts
- src/domain/analysis/prompt.ts
- src/lib/chartColors.ts
- src/components/chart/StockChart.tsx
- src/components/symbol-page/ChartContent.tsx
- src/components/analysis/AnalysisPanel.tsx
- src/__tests__/domain/analysis/prompt.test.ts
- src/__tests__/lib/chartColors.test.ts

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build