### PR TITLE
feat: block invalid ticker cache and notFound routing

### DIFF
--- a/src/__tests__/domain/ticker.test.ts
+++ b/src/__tests__/domain/ticker.test.ts
@@ -1,4 +1,8 @@
-import { isKoreanInput, deduplicateResults, isValidTickerFormat } from '@/domain/ticker';
+import {
+    isKoreanInput,
+    deduplicateResults,
+    isValidTickerFormat,
+} from '@/domain/ticker';
 import type { TickerSearchResult } from '@/domain/types';
 
 const makeResult = (symbol: string): TickerSearchResult => ({

--- a/src/__tests__/domain/ticker.test.ts
+++ b/src/__tests__/domain/ticker.test.ts
@@ -1,4 +1,4 @@
-import { isKoreanInput, deduplicateResults } from '@/domain/ticker';
+import { isKoreanInput, deduplicateResults, isValidTickerFormat } from '@/domain/ticker';
 import type { TickerSearchResult } from '@/domain/types';
 
 const makeResult = (symbol: string): TickerSearchResult => ({
@@ -42,6 +42,80 @@ describe('isKoreanInput', () => {
     describe('빈 문자열일 때', () => {
         it('false를 반환한다', () => {
             expect(isKoreanInput('')).toBe(false);
+        });
+    });
+});
+
+describe('isValidTickerFormat', () => {
+    describe('표준 미국 주식 티커일 때', () => {
+        it('단일 알파벳 티커를 허용한다', () => {
+            expect(isValidTickerFormat('A')).toBe(true);
+        });
+
+        it('4자리 티커를 허용한다', () => {
+            expect(isValidTickerFormat('AAPL')).toBe(true);
+        });
+
+        it('5자리 티커를 허용한다', () => {
+            expect(isValidTickerFormat('GOOGL')).toBe(true);
+        });
+    });
+
+    describe('클래스 주식 티커(점 포함)일 때', () => {
+        it('BRK.A 형식을 허용한다', () => {
+            expect(isValidTickerFormat('BRK.A')).toBe(true);
+        });
+
+        it('BRK.B 형식을 허용한다', () => {
+            expect(isValidTickerFormat('BRK.B')).toBe(true);
+        });
+    });
+
+    describe('파일 확장자 형식일 때', () => {
+        it('FAVICON.ICO를 거부한다', () => {
+            expect(isValidTickerFormat('FAVICON.ICO')).toBe(false);
+        });
+
+        it('INDEX.PHP를 거부한다', () => {
+            expect(isValidTickerFormat('INDEX.PHP')).toBe(false);
+        });
+
+        it('XMLRPC.PHP를 거부한다', () => {
+            expect(isValidTickerFormat('XMLRPC.PHP')).toBe(false);
+        });
+
+        it('MANIFEST.WEBMANIFEST를 거부한다', () => {
+            expect(isValidTickerFormat('MANIFEST.WEBMANIFEST')).toBe(false);
+        });
+    });
+
+    describe('하이픈이 포함된 경로 형식일 때', () => {
+        it('WP-LOGIN.PHP를 거부한다', () => {
+            expect(isValidTickerFormat('WP-LOGIN.PHP')).toBe(false);
+        });
+    });
+
+    describe('숫자가 포함된 형식일 때', () => {
+        it('INVALIDTICKER123을 거부한다', () => {
+            expect(isValidTickerFormat('INVALIDTICKER123')).toBe(false);
+        });
+    });
+
+    describe('6자 이상 알파벳 형식일 때', () => {
+        it('6자리 티커를 거부한다', () => {
+            expect(isValidTickerFormat('TOOLNG')).toBe(false);
+        });
+    });
+
+    describe('빈 문자열일 때', () => {
+        it('false를 반환한다', () => {
+            expect(isValidTickerFormat('')).toBe(false);
+        });
+    });
+
+    describe('소문자가 포함될 때', () => {
+        it('소문자 티커를 거부한다', () => {
+            expect(isValidTickerFormat('aapl')).toBe(false);
         });
     });
 });

--- a/src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts
+++ b/src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts
@@ -98,9 +98,10 @@ describe('getAssetInfoAction', () => {
             mockGetKoreanNames.mockResolvedValueOnce({ AAPL: '애플' });
 
             const result = await getAssetInfoAction('AAPL');
-            expect(result.symbol).toBe('AAPL');
-            expect(result.name).toBe('AAPL Inc');
-            expect(result.koreanName).toBe('애플');
+            expect(result).not.toBeNull();
+            expect(result!.symbol).toBe('AAPL');
+            expect(result!.name).toBe('AAPL Inc');
+            expect(result!.koreanName).toBe('애플');
         });
 
         it('한국어명이 없으면 koreanName 없이 반환한다', async () => {
@@ -108,8 +109,9 @@ describe('getAssetInfoAction', () => {
             mockGetKoreanNames.mockResolvedValueOnce({});
 
             const result = await getAssetInfoAction('IONQ');
-            expect(result.symbol).toBe('IONQ');
-            expect(result.koreanName).toBeUndefined();
+            expect(result).not.toBeNull();
+            expect(result!.symbol).toBe('IONQ');
+            expect(result!.koreanName).toBeUndefined();
         });
 
         it('한국어명이 없으면 translateAndCache를 waitUntil로 등록한다', async () => {
@@ -138,7 +140,8 @@ describe('getAssetInfoAction', () => {
             mockGetKoreanNames.mockResolvedValueOnce({});
 
             const result = await getAssetInfoAction('aapl');
-            expect(result.symbol).toBe('AAPL');
+            expect(result).not.toBeNull();
+            expect(result!.symbol).toBe('AAPL');
             expect(mockSearchBySymbol).toHaveBeenCalledWith('AAPL');
         });
     });
@@ -150,24 +153,45 @@ describe('getAssetInfoAction', () => {
             mockGetKoreanNames.mockResolvedValueOnce({});
 
             const result = await getAssetInfoAction('AAPL');
-            expect(result.name).toBe('AAPL.A Inc');
+            expect(result).not.toBeNull();
+            expect(result!.name).toBe('AAPL.A Inc');
         });
     });
 
-    describe('FMP 결과가 없을 때', () => {
-        it('symbol을 name 폴백으로 사용한다', async () => {
+    describe('형식이 유효하지 않은 티커일 때', () => {
+        it('FMP를 호출하지 않고 null을 반환한다', async () => {
+            const result = await getAssetInfoAction('FAVICON.ICO');
+            expect(result).toBeNull();
+            expect(mockSearchBySymbol).not.toHaveBeenCalled();
+        });
+
+        it('캐시를 생성하지 않는다', async () => {
+            await getAssetInfoAction('WP-LOGIN.PHP');
+            await new Promise(resolve => setTimeout(resolve, 0));
+            expect(mockCacheSet).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('형식은 유효하지만 FMP 결과가 없을 때', () => {
+        it('null을 반환한다', async () => {
             mockSearchBySymbol.mockResolvedValueOnce([]);
 
-            const result = await getAssetInfoAction('UNKNOWN');
-            expect(result.symbol).toBe('UNKNOWN');
-            expect(result.name).toBe('UNKNOWN');
-            expect(result.koreanName).toBeUndefined();
+            const result = await getAssetInfoAction('LAES');
+            expect(result).toBeNull();
+        });
+
+        it('캐시를 생성하지 않는다', async () => {
+            mockSearchBySymbol.mockResolvedValueOnce([]);
+
+            await getAssetInfoAction('LAES');
+            await new Promise(resolve => setTimeout(resolve, 0));
+            expect(mockCacheSet).not.toHaveBeenCalled();
         });
 
         it('translateAndCache를 호출하지 않는다', async () => {
             mockSearchBySymbol.mockResolvedValueOnce([]);
 
-            await getAssetInfoAction('UNKNOWN');
+            await getAssetInfoAction('LAES');
             await new Promise(resolve => setTimeout(resolve, 0));
             expect(mockTranslateCompanyNames).not.toHaveBeenCalled();
         });
@@ -180,8 +204,9 @@ describe('getAssetInfoAction', () => {
             mockGetKoreanNames.mockResolvedValueOnce({ AAPL: '애플' });
 
             const result = await getAssetInfoAction('AAPL');
-            expect(result.symbol).toBe('AAPL');
-            expect(result.koreanName).toBe('애플');
+            expect(result).not.toBeNull();
+            expect(result!.symbol).toBe('AAPL');
+            expect(result!.koreanName).toBe('애플');
         });
     });
 
@@ -192,7 +217,8 @@ describe('getAssetInfoAction', () => {
             mockGetKoreanNames.mockResolvedValueOnce({});
 
             const result = await getAssetInfoAction('AAPL');
-            expect(result.symbol).toBe('AAPL');
+            expect(result).not.toBeNull();
+            expect(result!.symbol).toBe('AAPL');
             expect(mockSearchBySymbol).toHaveBeenCalled();
         });
     });
@@ -205,7 +231,8 @@ describe('getAssetInfoAction', () => {
 
             const result = await getAssetInfoAction('AAPL');
             await new Promise(resolve => setTimeout(resolve, 0));
-            expect(result.symbol).toBe('AAPL');
+            expect(result).not.toBeNull();
+            expect(result!.symbol).toBe('AAPL');
         });
     });
 
@@ -219,7 +246,8 @@ describe('getAssetInfoAction', () => {
 
             const result = await getAssetInfoAction('IONQ');
             await new Promise(resolve => setTimeout(resolve, 0));
-            expect(result.symbol).toBe('IONQ');
+            expect(result).not.toBeNull();
+            expect(result!.symbol).toBe('IONQ');
         });
     });
 

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import {
     QueryClient,
     dehydrate,
@@ -51,6 +52,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const { symbol } = await params;
     const ticker = symbol.toUpperCase();
     const assetInfo = await getAssetInfoAction(ticker);
+    if (!assetInfo) return notFound();
 
     const displayName = buildDisplayName(assetInfo, ticker);
     const title = `${displayName} 기술적 분석`;
@@ -89,6 +91,7 @@ export default async function SymbolPage({ params }: Props) {
     const { symbol } = await params;
     const ticker = symbol.toUpperCase();
     const assetInfo = await getAssetInfoAction(ticker);
+    if (!assetInfo) return notFound();
 
     const displayName = buildDisplayName(assetInfo, ticker);
 

--- a/src/components/symbol-page/hooks/useAssetInfo.ts
+++ b/src/components/symbol-page/hooks/useAssetInfo.ts
@@ -11,5 +11,5 @@ export function useAssetInfo(symbol: string): AssetInfo | undefined {
         queryFn: () => getAssetInfoAction(symbol),
         staleTime: QUERY_STALE_TIME_MS,
     });
-    return data;
+    return data ?? undefined;
 }

--- a/src/domain/ticker.ts
+++ b/src/domain/ticker.ts
@@ -2,6 +2,13 @@ import type { TickerSearchResult } from '@/domain/types';
 
 const KOREAN_UNICODE_REGEX = /[\u3131-\u3163\uac00-\ud7a3]/;
 
+// 미국 주식 티커 형식: 1–5 대문자, 또는 BRK.A 형식(점 + 1–2 대문자)
+const TICKER_FORMAT_REGEX = /^(?:[A-Z]{1,5}|[A-Z]{1,4}\.[A-Z]{1,2})$/;
+
+export function isValidTickerFormat(ticker: string): boolean {
+    return TICKER_FORMAT_REGEX.test(ticker);
+}
+
 export function isKoreanInput(query: string): boolean {
     return KOREAN_UNICODE_REGEX.test(query);
 }

--- a/src/infrastructure/ticker/getAssetInfoAction.ts
+++ b/src/infrastructure/ticker/getAssetInfoAction.ts
@@ -16,6 +16,7 @@ import {
     setKoreanTickers,
 } from '@/infrastructure/ticker/koreanNameStore';
 import { translateCompanyNames } from '@/infrastructure/ticker/koreanTranslator';
+import { isValidTickerFormat } from '@/domain/ticker';
 import type { AssetInfo, KoreanTickerEntry } from '@/domain/types';
 
 async function translateAndCache(
@@ -51,59 +52,69 @@ async function translateAndCache(
     }
 }
 
-const resolveAssetInfo = cache(async (symbol: string): Promise<AssetInfo> => {
-    const upper = symbol.toUpperCase();
-    const cacheProvider = createCacheProvider();
-    const cacheKey = buildAssetInfoCacheKey(upper);
+const resolveAssetInfo = cache(
+    async (symbol: string): Promise<AssetInfo | null> => {
+        const upper = symbol.toUpperCase();
 
-    if (cacheProvider) {
-        try {
-            const cached = await cacheProvider.get<AssetInfo>(cacheKey);
-            if (cached) return cached;
-        } catch (error) {
-            console.error('Asset info cache get failed:', error);
+        if (!isValidTickerFormat(upper)) return null;
+
+        const cacheProvider = createCacheProvider();
+        const cacheKey = buildAssetInfoCacheKey(upper);
+
+        if (cacheProvider) {
+            try {
+                const cached = await cacheProvider.get<AssetInfo>(cacheKey);
+                if (cached) return cached;
+            } catch (error) {
+                console.error('Asset info cache get failed:', error);
+            }
         }
-    }
 
-    const fmpResults = await searchBySymbol(upper);
-    const usResults = filterUsExchanges(fmpResults);
-    const match = usResults.find(r => r.symbol === upper) ?? usResults[0];
+        const fmpResults = await searchBySymbol(upper);
+        const usResults = filterUsExchanges(fmpResults);
+        const match = usResults.find(r => r.symbol === upper) ?? usResults[0];
 
-    const name = match?.name ?? upper;
-    const exchange = match?.exchange ?? '';
-    const exchangeFullName = match?.exchangeFullName ?? '';
+        if (!match) return null;
 
-    const koreanNames = await getKoreanNames([upper]);
-    const koreanName = koreanNames[upper];
+        const { name, exchange, exchangeFullName } = match;
 
-    const info: AssetInfo = {
-        symbol: upper,
-        name,
-        ...(koreanName && { koreanName }),
-    };
+        const koreanNames = await getKoreanNames([upper]);
+        const koreanName = koreanNames[upper];
 
-    if (!koreanName && match) {
-        waitUntil(
-            translateAndCache(upper, name, exchange, exchangeFullName).catch(
-                error =>
-                    console.error('Asset info translateAndCache failed:', error)
-            )
-        );
-    }
+        const info: AssetInfo = {
+            symbol: upper,
+            name,
+            ...(koreanName && { koreanName }),
+        };
 
-    if (cacheProvider) {
-        waitUntil(
-            cacheProvider
-                .set(cacheKey, info, ASSET_INFO_CACHE_TTL)
-                .catch(error =>
-                    console.error('Asset info cache set failed:', error)
+        if (!koreanName) {
+            waitUntil(
+                translateAndCache(upper, name, exchange, exchangeFullName).catch(
+                    error =>
+                        console.error(
+                            'Asset info translateAndCache failed:',
+                            error
+                        )
                 )
-        );
+            );
+        }
+
+        if (cacheProvider) {
+            waitUntil(
+                cacheProvider
+                    .set(cacheKey, info, ASSET_INFO_CACHE_TTL)
+                    .catch(error =>
+                        console.error('Asset info cache set failed:', error)
+                    )
+            );
+        }
+
+        return info;
     }
+);
 
-    return info;
-});
-
-export async function getAssetInfoAction(symbol: string): Promise<AssetInfo> {
+export async function getAssetInfoAction(
+    symbol: string
+): Promise<AssetInfo | null> {
     return resolveAssetInfo(symbol.toUpperCase());
 }

--- a/src/infrastructure/ticker/getAssetInfoAction.ts
+++ b/src/infrastructure/ticker/getAssetInfoAction.ts
@@ -89,12 +89,13 @@ const resolveAssetInfo = cache(
 
         if (!koreanName) {
             waitUntil(
-                translateAndCache(upper, name, exchange, exchangeFullName).catch(
-                    error =>
-                        console.error(
-                            'Asset info translateAndCache failed:',
-                            error
-                        )
+                translateAndCache(
+                    upper,
+                    name,
+                    exchange,
+                    exchangeFullName
+                ).catch(error =>
+                    console.error('Asset info translateAndCache failed:', error)
                 )
             );
         }


### PR DESCRIPTION
## 관련 이슈

방어 로직 구현 (별도 이슈 없음)

## 구현 내용

Bot 요청으로 인한 Redis 캐시 오염 방지:

### 1단계: 포맷 검증 (domain)
- `isValidTickerFormat()`: 1-5글자 대문자 또는 BRK.A 형식만 허용
- 유효하지 않은 포맷은 즉시 거부 (API 호출 없음, 캐싱 없음)
- FAVICON.ICO, WP-LOGIN.PHP 같은 봇 요청 방어

### 2단계: 존재 여부 확인 (infrastructure)
- FMP에 없는 (유효 포맷이지만 실제로 없는) 티커는 null 반환
- null인 경우 캐싱하지 않음
- 실제로 존재하는 경우만 캐싱

### 3단계: 라우팅 (app/page)
- `getAssetInfoAction` 반환값이 null이면 `notFound()` 호출
- 메타데이터 생성 시에도 동일하게 적용

### 4단계: 훅 호환성 (components)
- 액션이 null을 반환하므로 훅이 `undefined`를 반환하도록 조정

### 테스트 커버리지
- `isValidTickerFormat`: 8개 describe 블록
- 포맷 검증, 존재 여부 확인, null 캐싱 방지 등 모두 테스트
- 전체 43개 테스트 통과

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it

## 변경 파일 목록

[수정]
- src/domain/ticker.ts
- src/infrastructure/ticker/getAssetInfoAction.ts
- src/app/[symbol]/page.tsx
- src/components/symbol-page/hooks/useAssetInfo.ts
- src/__tests__/domain/ticker.test.ts
- src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build