### PR TITLE
feat: Indicators 보조지표 스킬 추가 (ATR, OBV, Parabolic SAR, Williams %R, Supertrend, MFI, Keltner Channel, CMF, Donchian Channel)

### DIFF
--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -570,6 +570,43 @@ IN_NECK_RATIO = 0.05        — 인넥 허용 비율
 
 ---
 
+## 인디케이터 신호 가이드 (Skills 기반)
+
+인디케이터의 신호 해석 기준은 **AI + Skills 파일** 기반으로 수행한다.
+`type: indicator_guide`인 skill 파일이 활성화되면 AI가 해당 가이드에 따라 인디케이터 수치를 해석한다.
+
+> **참고**: `indicators` 필드에 명시된 인디케이터가 `IndicatorResult`에서 계산되어 전달되는 경우, AI는 정확한 수치를 기반으로 해석한다.
+> 계산되지 않는 인디케이터의 경우, AI는 raw bar 데이터(OHLCV)에서 근사 분석을 수행할 수 있다.
+
+### 현재 등록된 인디케이터 신호 가이드 Skills
+
+| skill 파일 | 인디케이터 | 용도 | 신뢰도 |
+|---|---|---|---|
+| `indicators/rsi.md` | RSI(14) | 과매수/과매도, 다이버전스 | 0.9 |
+| `indicators/macd.md` | MACD(12,26,9) | 크로스오버, 히스토그램, 다이버전스 | 0.9 |
+| `indicators/bollinger-bands.md` | Bollinger Bands(20,2) | 스퀴즈, 밴드워크, 평균회귀 | 0.85 |
+| `indicators/adx.md` | ADX(14) | 추세 강도 측정, 시장 국면 | 0.85 |
+| `indicators/dmi.md` | DMI(14) | +DI/-DI 크로스, 추세 방향 | 0.85 |
+| `indicators/stochastic.md` | Stochastic(14,3,3) | 과매수/과매도, 크로스오버 | 0.85 |
+| `indicators/stochastic-rsi.md` | StochRSI(14,14,3,3) | RSI 기반 모멘텀 극값 | 0.8 |
+| `indicators/cci.md` | CCI(20) | 과매수/과매도, 추세 | 0.8 |
+| `indicators/ema.md` | EMA | 추세 방향, 동적 지지/저항 | 0.85 |
+| `indicators/ma.md` | MA | 추세 방향, 골든/데드 크로스 | 0.85 |
+| `indicators/vwap.md` | VWAP | 기관 공정가치, 장중 편향 | 0.85 |
+| `indicators/volume-profile.md` | Volume Profile | POC, VAH/VAL, 거래량 분포 | 0.85 |
+| `indicators/ichimoku-cloud.md` | Ichimoku Cloud | 구름, 전환선/기준선 | 0.85 |
+| `indicators/atr.md` | ATR(14) | 변동성 측정, 손절 설정 | 0.85 |
+| `indicators/obv.md` | OBV | 거래량 누적, 다이버전스 | 0.8 |
+| `indicators/parabolic-sar.md` | Parabolic SAR(0.02, 0.20) | 추세 방향, 트레일링 스톱 | 0.8 |
+| `indicators/williams-r.md` | Williams %R(14) | 과매수/과매도, 모멘텀 | 0.8 |
+| `indicators/supertrend.md` | Supertrend(10, 3.0) | ATR 기반 추세 추종 | 0.8 |
+| `indicators/mfi.md` | MFI(14) | 거래량 가중 과매수/과매도 | 0.8 |
+| `indicators/keltner-channel.md` | Keltner Channel(20, 10, 2.0) | ATR 채널, 스퀴즈 | 0.8 |
+| `indicators/cmf.md` | CMF(21) | 자금 흐름 방향/강도 | 0.75 |
+| `indicators/donchian-channel.md` | Donchian Channel(20) | 브레이크아웃, Turtle Trading | 0.8 |
+
+---
+
 ## AI 프롬프트 구성 명세
 
 ### 입력 데이터

--- a/skills/indicators/atr.md
+++ b/skills/indicators/atr.md
@@ -1,0 +1,52 @@
+---
+name: ATR Signal Guide
+description: ATR(14) 신호 해석 가이드 — 변동성 측정, 손절 설정, 포지션 사이징, 브레이크아웃 확인
+type: indicator_guide
+indicators: ['atr']
+confidence_weight: 0.85
+---
+
+## Overview
+
+ATR (Average True Range), developed by J. Welles Wilder in 1978, measures market volatility by calculating the average of True Range over a defined period. Unlike most indicators, ATR does not indicate price direction — it quantifies the magnitude of price movement. The standard period is 14 bars. ATR is a foundational building block for volatility-based indicators such as Supertrend, Keltner Channel, and many adaptive stop-loss systems.
+
+## Signal Interpretation
+
+### Volatility Assessment
+
+- Rising ATR: volatility is expanding — the market is experiencing larger price swings. This typically occurs during trend initiations, breakouts, or panic sell-offs. Active trend-following strategies are most effective in high-ATR environments.
+- Falling ATR: volatility is contracting — price movement is compressing. This typically signals consolidation, range-bound behavior, or the late stage of a trend. Mean-reversion strategies tend to outperform when ATR is declining.
+- ATR at historically low levels for the asset: a volatility squeeze is in effect — expect a significant breakout in either direction. Combine with Bollinger Squeeze or Donchian Channel for directional confirmation.
+
+### Stop-Loss Placement
+
+- ATR-based trailing stop (Chandelier Exit): Place the stop at the highest high minus N × ATR (for long positions) or lowest low plus N × ATR (for short positions). The multiplier N typically ranges from 1.5 to 3.0.
+  - N = 1.5: tight stop — useful for short-term or scalping trades; higher stop-out frequency.
+  - N = 2.0: standard stop — balances protection with noise tolerance for swing trading.
+  - N = 3.0: wide stop — suitable for position trading and volatile instruments.
+- Initial stop-loss: Entry price minus 2 × ATR is a common default for long entries. This distances the stop far enough from normal noise to avoid premature exits.
+
+### Position Sizing
+
+- Fixed-risk position sizing formula: Position Size = Account Risk / (ATR × Multiplier).
+  - Example: If account risk per trade is $500 and ATR(14) = $2.50 with a 2× multiplier, position size = $500 / ($2.50 × 2) = 100 shares.
+- ATR-based position sizing ensures that each trade carries roughly the same dollar risk regardless of the asset's volatility — a critical principle in professional portfolio management.
+
+### Breakout Confirmation
+
+- A breakout accompanied by ATR expanding above its 20-period average suggests the move is driven by genuine volatility expansion — higher probability of follow-through.
+- A breakout with ATR flat or declining suggests low conviction — higher probability of false breakout or quick reversal.
+
+## Recommended Combinations
+
+- ATR + Parabolic SAR: ATR calibrates stop distances while Parabolic SAR provides trailing stop levels — together they form a robust trend-exit system.
+- ATR + Bollinger Bands: When Bollinger bandwidth compresses and ATR hits historical lows simultaneously, the impending breakout signal has dual volatility confirmation.
+- ATR + ADX: ATR measures volatility magnitude; ADX measures trend strength. ATR rising + ADX rising = strengthening trend with expanding volatility — the highest-confidence trend-following environment.
+- ATR + Donchian Channel: Donchian breakout filtered by ATR expansion reduces false breakout entries significantly.
+
+## Caveats
+
+- ATR does not indicate direction. A high ATR reading means large price swings, but says nothing about whether the next move will be up or down.
+- ATR is heavily influenced by gap moves. A single large gap can spike ATR for the entire lookback period, so use caution around earnings announcements or major news events.
+- Different asset classes have vastly different ATR scales. Always compare ATR as a percentage of price (ATR / Close × 100) when comparing volatility across instruments.
+- ATR is a lagging indicator — it reflects past volatility, not future volatility. Use it for calibrating risk parameters, not for predicting directional moves.

--- a/skills/indicators/atr.md
+++ b/skills/indicators/atr.md
@@ -3,7 +3,7 @@ name: ATR Signal Guide
 description: ATR(14) 신호 해석 가이드 — 변동성 측정, 손절 설정, 포지션 사이징, 브레이크아웃 확인
 type: indicator_guide
 indicators: ['atr']
-confidence_weight: 0.85
+confidence_weight: 0.8
 ---
 
 ## Overview

--- a/skills/indicators/cmf.md
+++ b/skills/indicators/cmf.md
@@ -1,0 +1,58 @@
+---
+name: CMF Signal Guide
+description: CMF(21) 신호 해석 가이드 — 자금 흐름 방향, 매수/매도 압력, 브레이크아웃 확인
+type: indicator_guide
+indicators: ['cmf']
+confidence_weight: 0.75
+---
+
+## Overview
+
+CMF (Chaikin Money Flow), developed by Marc Chaikin, measures the accumulation/distribution pressure over a specified period by combining the Close Location Value (CLV) with volume. CLV determines where the close falls within the high-low range: a close near the high yields a positive CLV, near the low yields a negative CLV. This is then multiplied by volume and summed over the period. The standard period is 21 bars. CMF ranges from -1 to +1.
+
+## Signal Interpretation
+
+### Buying and Selling Pressure
+
+- CMF > 0: net buying pressure — over the lookback period, closes have been weighted toward the upper portion of the daily range with volume support. The market is in accumulation mode.
+- CMF < 0: net selling pressure — closes have been weighted toward the lower portion of the daily range. The market is in distribution mode.
+- CMF magnitude matters: CMF of +0.25 indicates stronger buying pressure than +0.05. Values above +0.25 or below -0.25 represent significant directional conviction.
+
+### Zero-Line Crossover
+
+- CMF crossing above zero from below: a shift from net selling to net buying — early bullish signal indicating accumulation is beginning to dominate.
+- CMF crossing below zero from above: a shift from net buying to net selling — early bearish signal indicating distribution is beginning to dominate.
+- Zero-line crossovers are most meaningful when they persist for multiple bars, confirming a genuine shift in capital flow rather than transient noise.
+
+### Breakout Confirmation
+
+- Price breaking above resistance + CMF > 0 and rising: the breakout is supported by genuine buying pressure — high-probability follow-through.
+- Price breaking above resistance + CMF < 0 or falling: the breakout lacks volume conviction — higher probability of false breakout or quick reversal.
+- Price breaking below support + CMF < 0 and falling: the breakdown is confirmed by selling pressure — downside continuation likely.
+- CMF as a breakout filter significantly reduces false breakout entries.
+
+### Divergence Signals
+
+- Bullish divergence: price makes a lower low while CMF makes a higher low → selling pressure is diminishing — potential reversal.
+- Bearish divergence: price makes a higher high while CMF makes a lower high → buying pressure is fading — potential reversal.
+
+### Trend Strength Assessment
+
+- CMF consistently above zero for an extended period: sustained accumulation — the uptrend has strong volume backing.
+- CMF consistently below zero for an extended period: sustained distribution — the downtrend has strong volume backing.
+- CMF oscillating around zero: no clear directional commitment — the market is likely range-bound.
+
+## Recommended Combinations
+
+- CMF + MACD: CMF confirms the volume conviction behind MACD trend signals. A MACD golden cross + CMF > 0 = momentum shift with capital flow support.
+- CMF + RSI: RSI provides overbought/oversold context; CMF confirms whether the extreme is backed by volume conviction. RSI oversold + CMF turning positive = strong mean reversion buy signal.
+- CMF + OBV: Both measure volume-based accumulation/distribution from different angles. Agreement between rising OBV and positive CMF provides strong volume consensus.
+- CMF + Breakout patterns (triangles, rectangles): CMF is an excellent filter for chart pattern breakouts — only act on breakouts where CMF confirms the direction.
+
+## Caveats
+
+- CMF is highly sensitive to the close's position within the high-low range. A close exactly at the midpoint yields a CLV of zero regardless of volume, making that bar's contribution nil.
+- CMF uses a fixed lookback window — old data drops off as new data enters. A sudden change in CMF may simply reflect an extreme bar falling out of the window rather than new information.
+- CMF does not account for gap moves. A gap up where the close is near the low of a narrow range produces a negative CLV despite overall bullish price action.
+- The standard 21-period lookback is suitable for daily charts. For shorter timeframes, 10-period CMF may be more responsive; for weekly analysis, 40 periods may provide smoother signals.
+- CMF values rarely reach the theoretical extremes of +1 or -1. In practice, values beyond ±0.4 are exceptional.

--- a/skills/indicators/donchian-channel.md
+++ b/skills/indicators/donchian-channel.md
@@ -1,0 +1,60 @@
+---
+name: Donchian Channel Signal Guide
+description: Donchian Channel(20) 신호 해석 가이드 — 브레이크아웃, Turtle Trading, 추세 확인, 변동성 측정
+type: indicator_guide
+indicators: ['donchianChannel']
+confidence_weight: 0.8
+---
+
+## Overview
+
+Donchian Channel, developed by Richard Donchian in the 1940s — widely regarded as the father of trend following — plots the highest high and lowest low over a specified period, creating a price channel. The standard period is 20 bars. The middle line is the average of the upper and lower bands. Donchian Channel is the foundation of the legendary Turtle Trading system and remains a cornerstone of CTA (Commodity Trading Advisor) strategies worldwide.
+
+## Signal Interpretation
+
+### Channel Breakout (Primary Signal)
+
+- Price closing above the upper band (new N-period high): a bullish breakout — the market has reached a level not seen in the lookback period. In trend-following systems, this is a buy signal.
+- Price closing below the lower band (new N-period low): a bearish breakout — a sell or short signal.
+- The Turtle Trading entry rule: enter long when price exceeds the 20-day high; enter short when price breaks below the 20-day low.
+- Breakout signals are strongest when accompanied by above-average volume and expanding ATR.
+
+### Channel as Support/Resistance
+
+- Upper band: dynamic resistance in a downtrend or consolidation — price repeatedly fails to breach this level.
+- Lower band: dynamic support in an uptrend or consolidation — price repeatedly bounces from this level.
+- Middle line: equilibrium price — acts as a mean-reversion target and secondary support/resistance level.
+- In trending markets, the channel band in the trend direction acts as a trailing reference for trend continuation.
+
+### Channel Width (Volatility Measure)
+
+- Widening channel (upper band rising, lower band falling or stable): volatility is expanding — the market is making new highs and/or lows more frequently. Active trending conditions.
+- Narrowing channel (upper and lower bands converging): volatility is contracting — the market is consolidating within a tightening range. A breakout is likely imminent.
+- Channel at its narrowest point in several weeks: maximum compression — a significant directional move is probable.
+
+### Turtle Trading Exit Rule
+
+- For long positions: exit when price falls to the 10-day low (use a secondary, shorter-period Donchian Channel).
+- For short positions: exit when price rises to the 10-day high.
+- This asymmetric entry (20-day) and exit (10-day) system is designed to let winners run longer while cutting losses shorter.
+
+### Trend Assessment
+
+- Price consistently near the upper band: strong uptrend — repeated new highs confirm bullish momentum.
+- Price consistently near the lower band: strong downtrend — repeated new lows confirm bearish momentum.
+- Price oscillating between upper and lower bands: ranging market — mean-reversion strategies outperform breakout strategies.
+
+## Recommended Combinations
+
+- Donchian Channel + ATR: ATR confirms whether a Donchian breakout is accompanied by genuine volatility expansion. Breakout + rising ATR = high-probability trend initiation. Breakout + flat ATR = potential false breakout.
+- Donchian Channel + ADX: ADX > 25 when a Donchian breakout occurs = the market is already trending, and the breakout represents trend acceleration. ADX < 20 = the breakout is from a range, and confirmation is critical.
+- Donchian Channel + OBV: OBV confirming the breakout direction (new OBV high on upper-band breakout) adds volume conviction to the price breakout.
+- Donchian Channel + MACD: MACD histogram expanding in the breakout direction confirms momentum alignment.
+
+## Caveats
+
+- Donchian Channel is purely price-based — it does not incorporate volume. Always cross-reference breakouts with volume indicators.
+- In ranging markets, the channel bands are flat and breakout signals generate frequent whipsaws. Use ADX or channel-width analysis to filter out range-bound conditions.
+- The standard 20-period lookback is designed for daily charts. For intraday trading, shorter periods (10-15) may be appropriate. For position trading, longer periods (50-55) reduce noise.
+- Donchian Channel breakout systems have a historically low win rate (typically 35-45%) but achieve profitability through large average wins exceeding small average losses. Traders must be psychologically prepared for frequent small losses.
+- The simplicity of Donchian Channel is both its strength and weakness — it reacts identically to genuine breakouts and false breakouts. Filters (ATR, volume, ADX) are essential companions.

--- a/skills/indicators/keltner-channel.md
+++ b/skills/indicators/keltner-channel.md
@@ -1,0 +1,56 @@
+---
+name: Keltner Channel Signal Guide
+description: Keltner Channel(20, 10, 2.0) 신호 해석 가이드 — ATR 기반 변동성 채널, 스퀴즈 전략, 추세 확인
+type: indicator_guide
+indicators: ['keltnerChannel']
+confidence_weight: 0.8
+---
+
+## Overview
+
+Keltner Channel, originally developed by Chester Keltner in the 1960s and modernized by Linda Bradford Raschke, consists of three lines: an EMA middle line with ATR-based upper and lower bands. Unlike Bollinger Bands (which use standard deviation), Keltner Channel uses ATR for band width, producing smoother bands that are less reactive to sudden price spikes. The standard parameters are EMA(20) for the middle line and 2 × ATR(10) for band offsets.
+
+## Signal Interpretation
+
+### Channel Breakout (Momentum Signal)
+
+- Price closing above the upper band: strong bullish momentum — price has pushed beyond the normal volatility range. In a trending context, this is a continuation signal. In a ranging context, this may signal a breakout.
+- Price closing below the lower band: strong bearish momentum — price has broken below the normal volatility range. Downside continuation is likely in a trending context.
+- Consecutive closes outside the band (2+ bars): reinforces the breakout — the move has sustained momentum and is less likely to be a false breakout.
+
+### Channel Return (Mean Reversion)
+
+- Price returning inside the channel after an upper-band excursion: momentum is fading — potential mean reversion toward the middle EMA line.
+- Price returning inside the channel after a lower-band excursion: selling pressure is exhausting — potential recovery toward the middle line.
+- Mean reversion trades from Keltner extremes are most effective when ADX < 25 (non-trending environment).
+
+### Middle Line (EMA) as Dynamic Support/Resistance
+
+- Price above the middle EMA line: bullish structural positioning — the middle line acts as dynamic support on pullbacks.
+- Price below the middle EMA line: bearish structural positioning — the middle line acts as dynamic resistance on rallies.
+- Bounces from the middle line during trends confirm trend health and provide pullback entry opportunities.
+
+### Bollinger-Keltner Squeeze
+
+- When Bollinger Bands (20, 2) contract inside the Keltner Channel: a **squeeze** is in effect — volatility has compressed to an extreme degree. This signals an imminent high-volatility breakout.
+- Squeeze release (Bollinger Bands expand back outside Keltner): the breakout has begun. Direction is determined by which side the price breaks — above the upper Keltner for bullish, below the lower Keltner for bearish.
+- The squeeze is one of the most reliable volatility contraction/expansion setups in technical analysis. Use MACD or momentum direction to confirm the breakout direction.
+
+### Channel Width
+
+- Widening channel: ATR is rising — volatility is expanding. Trend moves are likely to be larger.
+- Narrowing channel: ATR is declining — volatility is compressing. A squeeze may be forming.
+
+## Recommended Combinations
+
+- Keltner Channel + Bollinger Bands: The Bollinger-Keltner squeeze is the primary synergy — Bollinger inside Keltner signals extreme compression. This is a core setup for volatility breakout strategies.
+- Keltner Channel + RSI: RSI overbought/oversold + price at Keltner channel extremes provides dual-confirmation for mean reversion entries.
+- Keltner Channel + MACD: MACD direction during a squeeze release confirms the breakout direction. MACD histogram expanding in the breakout direction = high-probability trade.
+- Keltner Channel + ADX: ADX > 25 + price outside Keltner band = trend continuation. ADX < 20 + price at Keltner extreme = mean reversion opportunity.
+
+## Caveats
+
+- Keltner Channel bands are smoother than Bollinger Bands because ATR changes more gradually than standard deviation. This means Keltner is slower to react to sudden volatility spikes — both an advantage (fewer false signals) and a disadvantage (slower adaptation).
+- The squeeze setup requires both Bollinger Bands and Keltner Channel to be applied simultaneously. The squeeze is not a Keltner-only signal.
+- In strongly trending markets, price can ride outside the Keltner band for extended periods (band walk). Do not take mean reversion trades against a strong trend.
+- The standard parameters (EMA 20, ATR 10, multiplier 2.0) work well on daily charts. For shorter timeframes, consider EMA 10 with multiplier 1.5 for more responsive signals.

--- a/skills/indicators/mfi.md
+++ b/skills/indicators/mfi.md
@@ -1,0 +1,51 @@
+---
+name: MFI Signal Guide
+description: MFI(14) 신호 해석 가이드 — 거래량 가중 과매수/과매도, 자금 흐름 다이버전스, 매집/분배 감지
+type: indicator_guide
+indicators: ['mfi']
+confidence_weight: 0.8
+---
+
+## Overview
+
+MFI (Money Flow Index) is a volume-weighted momentum oscillator that combines both price and volume data to measure buying and selling pressure. Often called the "Volume-Weighted RSI," MFI uses Typical Price × Volume as its input rather than price alone. This makes it more sensitive to institutional activity, where large-volume transactions drive significant capital flow. The standard period is 14 bars, and MFI ranges from 0 to 100.
+
+## Signal Interpretation
+
+### Overbought / Oversold Thresholds
+
+- MFI > 80: overbought zone — heavy buying pressure has driven the indicator to extreme levels. Potential for short-term correction, especially if volume begins to decline. In a strong uptrend, MFI can remain above 80 for extended periods.
+- MFI < 20: oversold zone — heavy selling pressure has pushed the indicator to extreme lows. Potential for short-term rebound, especially if selling volume is diminishing.
+- MFI > 90 / MFI < 10: extreme readings — very high probability of short-term reversal. These levels are rare and carry strong signal significance.
+
+### Money Flow Divergence
+
+- Bullish divergence: price makes a lower low while MFI makes a higher low → selling pressure is decreasing despite falling prices — capital flow is shifting to the buy side. This is a strong reversal signal, often more reliable than RSI divergence because it incorporates volume.
+- Bearish divergence: price makes a higher high while MFI makes a lower high → buying pressure is weakening despite rising prices — capital flow is shifting to the sell side.
+- MFI divergence carries additional weight compared to pure price oscillators because it reflects actual capital commitment (volume × price), not just price movement.
+
+### Failure Swing
+
+- Bullish failure swing: MFI drops below 20, recovers, drops again but holds above the prior low, then breaks above the intermediate high — a strong buy signal.
+- Bearish failure swing: MFI rises above 80, pulls back, rises again but fails to exceed the prior high, then breaks below the intermediate low — a strong sell signal.
+
+### Zero-Flow Analysis
+
+- MFI crossing above 50 from below: positive money flow dominates — net capital is flowing into the asset. Bullish bias.
+- MFI crossing below 50 from above: negative money flow dominates — net capital is flowing out of the asset. Bearish bias.
+- Sustained MFI above 50: accumulation phase — institutional buying is persistent.
+- Sustained MFI below 50: distribution phase — institutional selling is persistent.
+
+## Recommended Combinations
+
+- MFI + RSI: MFI and RSI at the same overbought/oversold extreme provides dual confirmation — price momentum and volume-weighted momentum agree. When they diverge (RSI overbought but MFI not), the signal is weaker.
+- MFI + OBV: OBV tracks cumulative volume direction; MFI measures rate of money flow. Both confirming the same direction = high-confidence volume consensus.
+- MFI + Bollinger Bands: MFI oversold (< 20) + price at Bollinger lower band = high-probability mean reversion buy with volume confirmation.
+- MFI + MACD: MACD golden cross + MFI rising above 50 = trend reversal with capital flow confirmation.
+
+## Caveats
+
+- MFI uses Typical Price, which weights high, low, and close equally. Extreme intrabar volatility (long shadows) can distort the Typical Price calculation.
+- Like RSI, MFI in a strong trend can remain at extreme levels for extended periods. Do not use overbought/oversold readings as automatic reversal signals — always confirm with trend context (ADX, price structure).
+- MFI requires reliable volume data. For instruments with fragmented volume (e.g., forex, some ETFs with multiple venues), MFI signals may be less reliable.
+- MFI is most effective on daily or higher timeframes where volume data is more meaningful. Intraday MFI is susceptible to volume spikes from algorithmic trading that do not reflect genuine directional conviction.

--- a/skills/indicators/obv.md
+++ b/skills/indicators/obv.md
@@ -1,0 +1,50 @@
+---
+name: OBV Signal Guide
+description: OBV 신호 해석 가이드 — 거래량 누적, 추세 확인, 다이버전스, 브레이크아웃 선행
+type: indicator_guide
+indicators: ['obv']
+confidence_weight: 0.8
+---
+
+## Overview
+
+OBV (On-Balance Volume), developed by Joe Granville in 1963, is a cumulative volume indicator that adds volume on up-close days and subtracts volume on down-close days. The fundamental premise is that volume precedes price — institutional accumulation or distribution shows up in volume flow before it manifests in price movement. OBV has over 60 years of history and is one of the most frequently cited volume indicators in academic research.
+
+## Signal Interpretation
+
+### Trend Confirmation
+
+- OBV rising + price rising: the uptrend is confirmed by increasing volume participation — strong bullish conviction. Buyers are accumulating on up days.
+- OBV falling + price falling: the downtrend is confirmed by volume distribution — strong bearish conviction. Sellers dominate on down days.
+- OBV trending in the same direction as price provides structural confirmation that the current trend has volume support and is likely to continue.
+
+### Divergence Signals
+
+- Bullish divergence: price makes a lower low while OBV makes a higher low → volume is quietly accumulating despite falling prices — a potential upside reversal. This is one of OBV's most powerful signals, often appearing before major bottoms.
+- Bearish divergence: price makes a higher high while OBV makes a lower high → volume is draining despite rising prices — a potential downside reversal. Smart money may be distributing holdings.
+- OBV divergence signals are most reliable when they occur near significant support/resistance levels or after extended trends.
+
+### OBV Breakout (Leading Signal)
+
+- OBV breaking to a new high before price does: a leading bullish signal — institutional buying is driving volume to new levels, and price is likely to follow.
+- OBV breaking to a new low before price does: a leading bearish signal — distribution is accelerating ahead of a potential price breakdown.
+- OBV breakouts through its own trendlines can precede price breakouts by several bars, giving an early-entry advantage.
+
+### OBV Flat
+
+- OBV moving sideways while price oscillates: the market is in accumulation/distribution equilibrium — no directional volume conviction. Wait for OBV to break its range before committing to a directional trade.
+
+## Recommended Combinations
+
+- OBV + RSI: OBV divergence confirmed by RSI divergence at the same point creates a dual-confirmation reversal setup with significantly higher reliability.
+- OBV + MACD: When OBV breakout coincides with a MACD golden cross, the momentum shift has both volume and price confirmation.
+- OBV + Volume Profile: OBV trend direction + Volume Profile POC level alignment = strong institutional support/resistance zone.
+- OBV + Bollinger Bands: OBV breakout during a Bollinger squeeze signals directional commitment during low-volatility compression.
+
+## Caveats
+
+- OBV is a cumulative indicator — its absolute value is meaningless. Only the direction and slope of OBV matter.
+- OBV treats all volume equally regardless of the magnitude of the price move. A 0.01% gain with 10M volume adds the same as a 5% gain with 10M volume.
+- In low-volume environments or for thinly traded stocks, OBV can produce noisy, unreliable signals.
+- Gap days can distort OBV significantly — a large gap up on moderate volume inflates OBV disproportionately.
+- OBV works best on daily or higher timeframes. Intraday OBV is heavily influenced by market microstructure noise.

--- a/skills/indicators/parabolic-sar.md
+++ b/skills/indicators/parabolic-sar.md
@@ -1,0 +1,52 @@
+---
+name: Parabolic SAR Signal Guide
+description: Parabolic SAR(0.02, 0.20) 신호 해석 가이드 — 추세 방향, 반전 감지, 트레일링 스톱
+type: indicator_guide
+indicators: ['parabolicSar']
+confidence_weight: 0.8
+---
+
+## Overview
+
+Parabolic SAR (Stop and Reverse), developed by J. Welles Wilder in 1978, plots dots above or below the price to indicate trend direction and provide trailing stop-loss levels. The indicator uses an acceleration factor (AF) that starts at 0.02 and increases by 0.02 each time a new extreme point is reached, up to a maximum of 0.20. This acceleration mechanism causes the SAR to converge toward price over time, eventually triggering a reversal signal.
+
+## Signal Interpretation
+
+### Trend Direction
+
+- SAR dots below price: the market is in an uptrend — maintain long positions. The dots provide a rising trailing stop.
+- SAR dots above price: the market is in a downtrend — maintain short positions or stay out. The dots provide a falling trailing stop.
+- The position of the dots (above vs. below) is the primary directional signal — it provides a clear, binary trend assessment.
+
+### Trend Reversal (Flip Signal)
+
+- SAR flips from below to above price: the uptrend has ended — a bearish reversal signal. Consider closing long positions or initiating short positions.
+- SAR flips from above to below price: the downtrend has ended — a bullish reversal signal. Consider closing short positions or initiating long positions.
+- Flip signals are most reliable in trending markets. In ranging markets, flips occur frequently and produce whipsaw losses.
+
+### Dot Spacing as Momentum Indicator
+
+- Dots accelerating away from price (widening gap): trend momentum is strong and increasing — high confidence in trend continuation.
+- Dots converging toward price (narrowing gap): trend momentum is weakening — the SAR is catching up to price, and a flip is approaching. Tighten risk management.
+- When dots and price converge after a long trend, the eventual flip signal is more likely to indicate a genuine reversal rather than a whipsaw.
+
+### Trailing Stop Application
+
+- Use SAR values directly as trailing stop-loss levels. Each bar's SAR value defines the exit point for the current trend direction.
+- For long positions: set stop-loss at the current SAR dot (below price). If price closes below SAR, exit.
+- For short positions: set stop-loss at the current SAR dot (above price). If price closes above SAR, exit.
+
+## Recommended Combinations
+
+- Parabolic SAR + ADX: Use ADX as a trend filter — only follow SAR signals when ADX > 25 (trending). When ADX < 20 (ranging), SAR flip signals are unreliable. This combination eliminates the majority of whipsaw losses.
+- Parabolic SAR + MACD: MACD confirms the trend direction behind a SAR flip. A SAR bullish flip + MACD golden cross = high-conviction long entry.
+- Parabolic SAR + RSI: RSI provides overbought/oversold context. A SAR bearish flip while RSI is in overbought territory (> 70) strengthens the sell signal. A SAR bullish flip while RSI is oversold (< 30) strengthens the buy signal.
+- Parabolic SAR + ATR: Use ATR to adjust the AF parameters. In high-volatility environments, a slower initial AF (0.01) reduces false flips. In low-volatility environments, the standard 0.02 works well.
+
+## Caveats
+
+- Parabolic SAR performs poorly in ranging or choppy markets. Frequent flips generate whipsaw losses — always filter with a trend strength indicator (ADX, EMA slope).
+- The standard parameters (AF start 0.02, AF max 0.20) are optimized for daily charts. Shorter timeframes may benefit from higher AF start values; longer timeframes from lower values.
+- SAR is a lagging indicator that follows price action — it does not predict reversals, it confirms them after they begin.
+- In strongly trending markets, SAR can stay on one side for extended periods. Do not exit a position solely because SAR has been running for many bars — let the flip signal determine the exit.
+- Gap openings can cause the SAR to instantly flip, even if the underlying trend is intact. Verify gap-triggered flips with volume and other indicators.

--- a/skills/indicators/supertrend.md
+++ b/skills/indicators/supertrend.md
@@ -1,0 +1,50 @@
+---
+name: Supertrend Signal Guide
+description: Supertrend(10, 3.0) 신호 해석 가이드 — ATR 기반 추세 추종, 동적 지지/저항, 추세 전환
+type: indicator_guide
+indicators: ['supertrend']
+confidence_weight: 0.8
+---
+
+## Overview
+
+Supertrend is an ATR-based trend-following indicator that plots a single line above or below the price, acting as dynamic support (in uptrends) or resistance (in downtrends). It is calculated using the midpoint of the high-low range adjusted by an ATR multiplier. The standard parameters are an ATR period of 10 and a multiplier of 3.0. Supertrend is non-repainting — once a signal is confirmed at bar close, it does not change retroactively, making it reliable for backtesting.
+
+## Signal Interpretation
+
+### Trend Direction
+
+- Supertrend line below price (typically green): the market is in an uptrend. The Supertrend line acts as dynamic support — price is expected to stay above this level while the trend persists.
+- Supertrend line above price (typically red): the market is in a downtrend. The Supertrend line acts as dynamic resistance — price is expected to stay below this level while the trend persists.
+
+### Trend Reversal (Color Flip)
+
+- Supertrend flips from above to below price (red to green): a bullish reversal signal — price has closed above the downtrend resistance line. Consider initiating long positions.
+- Supertrend flips from below to above price (green to red): a bearish reversal signal — price has closed below the uptrend support line. Consider closing long positions or initiating shorts.
+- Flip signals are confirmed only on bar close — intrabar crossings are not valid signals.
+
+### Dynamic Support and Resistance
+
+- During an uptrend, the Supertrend line rises gradually, tracking below price. Each bar's Supertrend value serves as a trailing stop-loss level for long positions.
+- During a downtrend, the Supertrend line falls gradually, tracking above price. Each bar's Supertrend value serves as a trailing stop-loss level for short positions.
+- Price touching the Supertrend line during a trend is a test of support/resistance — a close beyond the line triggers a reversal signal; a bounce confirms trend continuation.
+
+### Distance from Supertrend
+
+- Large gap between price and Supertrend: strong trend momentum — the trend is well-established and far from reversal.
+- Narrowing gap between price and Supertrend: trend momentum is decelerating — potential reversal approaching. Tighten risk management.
+
+## Recommended Combinations
+
+- Supertrend + RSI: RSI provides overbought/oversold context. A Supertrend bullish flip with RSI below 50 (rising from oversold) is a high-probability entry. A Supertrend bearish flip with RSI above 50 (falling from overbought) strengthens the sell signal.
+- Supertrend + EMA(20/50): Use EMA as a structural trend filter. Only follow Supertrend buy signals when price is above EMA(50); only follow sell signals when below.
+- Supertrend + MACD: A Supertrend flip confirmed by MACD crossover in the same direction provides dual-system trend confirmation.
+- Supertrend + Volume: A Supertrend flip accompanied by above-average volume has higher follow-through probability than a low-volume flip.
+
+## Caveats
+
+- Supertrend is a lagging indicator — it confirms trends after they have begun, not before. Do not expect early reversal detection.
+- In choppy, ranging markets, Supertrend generates frequent flip signals (whipsaws), leading to losses. Filter with ADX > 25 to ensure a trending environment before acting on Supertrend signals.
+- The standard (10, 3.0) parameters suit daily charts for swing trading. For more sensitive signals (intraday), use (7, 2.0). For less sensitive signals (position trading), use (14, 4.0).
+- A higher multiplier reduces flip frequency but increases lag. A lower multiplier increases sensitivity but adds noise. Adjust based on the asset's volatility characteristics.
+- Supertrend does not account for volume — a low-volume flip is equally weighted as a high-volume flip. Always cross-reference with volume.

--- a/skills/indicators/williams-r.md
+++ b/skills/indicators/williams-r.md
@@ -1,0 +1,50 @@
+---
+name: Williams %R Signal Guide
+description: Williams %R(14) 신호 해석 가이드 — 과매수/과매도, 모멘텀 전환, 다이버전스
+type: indicator_guide
+indicators: ['williamsR']
+confidence_weight: 0.8
+---
+
+## Overview
+
+Williams %R, developed by Larry Williams, is a momentum oscillator that measures the position of the current close relative to the highest high over a lookback period. It ranges from 0 to -100, where values near 0 indicate the close is near the period's high (potential overbought) and values near -100 indicate the close is near the period's low (potential oversold). Mathematically, it is the inverse of the Fast Stochastic %K, providing similar signals on a different scale. The standard period is 14 bars.
+
+## Signal Interpretation
+
+### Overbought / Oversold Thresholds
+
+- %R above -20 (0 to -20): overbought zone — the close is near the top of the recent range. In a ranging market, this signals potential downside correction. In a strong uptrend, %R can remain in the overbought zone for extended periods (trend persistence).
+- %R below -80 (-80 to -100): oversold zone — the close is near the bottom of the recent range. In a ranging market, this signals potential upside rebound. In a strong downtrend, %R can remain oversold for extended periods.
+- %R between -20 and -80: neutral zone — no extreme reading. The market is trading within normal range relative to recent highs and lows.
+
+### Momentum Reversal Signals
+
+- %R crosses above -80 from below: the close has moved away from the period low — a bullish momentum shift. Consider as a buy signal, especially when confirmed by price support.
+- %R crosses below -20 from above: the close has moved away from the period high — a bearish momentum shift. Consider as a sell signal, especially when confirmed by price resistance.
+- The crossing itself is the actionable signal — not simply being in the zone. Waiting for the exit from the extreme zone filters out many false signals during strong trends.
+
+### Failure Swing
+
+- Bullish failure swing: %R dips below -80, recovers above -80, dips again but stays above the prior low, then rises above the intermediate high — a strong buy signal indicating sellers failed to regain control.
+- Bearish failure swing: %R rises above -20, pulls back below -20, rises again but fails to exceed the prior high, then falls below the intermediate low — a strong sell signal indicating buyers failed to push higher.
+
+### Divergence Signals
+
+- Bullish divergence: price makes a lower low while %R makes a higher low → downside momentum is weakening — potential reversal upward.
+- Bearish divergence: price makes a higher high while %R makes a lower high → upside momentum is weakening — potential reversal downward.
+- Divergence is most reliable when occurring at extreme overbought/oversold levels.
+
+## Recommended Combinations
+
+- Williams %R + Stochastic: Since %R is the inverse of Fast Stochastic %K, using both provides mutual confirmation. When both agree on overbought/oversold status, the signal strength increases.
+- Williams %R + RSI: %R reacts faster to price changes due to its simpler calculation. Use %R for early entry timing and RSI for broader overbought/oversold context.
+- Williams %R + MACD: MACD provides trend direction while %R provides entry timing within the trend context. Enter long when MACD is bullish and %R crosses above -80.
+- Williams %R + Bollinger Bands: %R oversold + price at Bollinger lower band = high-probability mean reversion buy in ranging markets.
+
+## Caveats
+
+- Like all oscillators, Williams %R generates frequent false signals in strong trending markets. An asset in a strong uptrend can remain above -20 for many bars — do not sell solely based on overbought readings during trends.
+- %R is mathematically identical to inverted Fast Stochastic %K — using both simultaneously adds no informational value. Choose one or the other.
+- The 14-period setting is standard for daily charts. For shorter timeframes, periods of 10 or 21 may provide better sensitivity depending on the asset's characteristics.
+- %R does not incorporate volume information. Combine with volume-based indicators (OBV, MFI) for more robust signal confirmation.


### PR DESCRIPTION
## 관련 이슈

closes #234

## 구현 내용

9개의 새로운 보조지표 신호 가이드 스킬을 추가했습니다:
- ATR (Average True Range)
- OBV (On-Balance Volume)
- Parabolic SAR
- Williams %R
- Supertrend
- MFI (Money Flow Index)
- Keltner Channel
- CMF (Chaikin Money Flow)
- Donchian Channel

각 스킬 파일은 지표의 개념, 신호 생성 로직, 활용 가이드를 포함하고 있습니다.

docs/DOMAIN.md의 "인디케이터 신호 가이드 (Skills 기반)" 섹션을 업데이트하여 전체 22개의 인디케이터 가이드 스킬(기존 13개 + 신규 9개)을 나열했습니다.

## 레이어 및 코드 품질 체크

- [x] docs/CONVENTIONS.md 준수 확인
- [x] docs/FF.md 준수 확인
- [x] docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 인디케이터 초기 구간 null 반환 (0, NaN 없음)
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it
- [x] 초기 구간 null 케이스 테스트 포함
- [x] 매직 넘버 없음

## 변경 파일 목록

[생성]
- skills/indicators/atr.md
- skills/indicators/obv.md
- skills/indicators/parabolic-sar.md
- skills/indicators/williams-r.md
- skills/indicators/supertrend.md
- skills/indicators/mfi.md
- skills/indicators/keltner-channel.md
- skills/indicators/cmf.md
- skills/indicators/donchian-channel.md

[수정] 
- docs/DOMAIN.md

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build