### PR TITLE
feat: Strategies 전략 스킬 추가 (Wyckoff, Divergence, Fibonacci, Breakout, Mean Reversion, Multi-Timeframe)

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -100,6 +100,15 @@
 - Rule: CONVENTIONS.md Naming — underscore prefix reserved for intentionally-unused destructured parameters; consumed props must not have underscore
 - Context: ActionRecommendationField received _recommendedAction but used it in render; removed underscore to indicate the prop is actually consumed
 
+## [PR #242 | feat/236/strategies-스킬-추가 | 2026-04-10]
+- Violation: 전략 스킬 frontmatter의 indicators 목록이 본문에서 참조하는 지표(ATR)를 누락
+- Rule: 스킬 문서 일관성 — indicators 목록은 본문에서 참조하는 모든 지표를 포함해야 함
+- Context: mean-reversion.md가 손절선 규칙에서 2 × ATR을 사용하지만 indicators에 atr 미포함
+
+- Violation: AI Analysis Instructions가 시스템이 실제로 제공하지 않는 데이터 범위(120봉, 다중 시간대)를 전제로 작성됨
+- Rule: AI 지침은 시스템의 실제 데이터 제공 범위와 일치해야 함
+- Context: wyckoff.md는 120봉 필요하나 RECENT_BARS_COUNT=30; multi-timeframe.md는 3-Tier 분석 전제하나 단일 타임프레임만 제공
+
 ## [PR #229 Round 2 | feat/229/action-recommendation-chart-overlay | 2026-04-10]
 - Violation: StockChart prop default actionPricesVisible = false contradicted the parent ChartContent's intent (initialized to true). Default off-by-default is misleading when caller explicitly enables the feature.
 - Rule: FF.md Readability 1-C — Design intent must be exposed in code; default values must align with component usage context or caller must explicitly pass the value

--- a/skills/strategies/breakout.md
+++ b/skills/strategies/breakout.md
@@ -1,0 +1,195 @@
+---
+name: 브레이크아웃 전략
+description: 주요 지지·저항선, 채널, 차트 패턴의 돌파를 감지하고 거래량·모멘텀 필터로 거짓 돌파를 걸러내어 진입하는 전략
+type: strategy
+category: neutral
+indicators: ['atr']
+confidence_weight: 0.7
+---
+
+## Overview
+
+The Breakout Strategy enters positions when price decisively penetrates a well-defined support or resistance boundary. Breakouts represent the market's resolution of a supply-demand equilibrium — when accumulated buying or selling pressure finally overwhelms the opposing side, price moves rapidly as orders are triggered.
+
+The primary challenge is distinguishing genuine breakouts from false breakouts (fakeouts), which occur 40-50% of the time. This strategy employs multiple confirmation filters — volume, closing price, multi-bar confirmation, and momentum alignment — to improve the success rate.
+
+The Turtle Trading system (Richard Dennis, 1983) is the most famous historical application of breakout trading, demonstrating that systematic breakout strategies can produce consistent returns over decades.
+
+---
+
+## Breakout Types
+
+### 1. Range Breakout
+
+Price has been confined within a horizontal consolidation range (defined by clear support and resistance). A breakout occurs when price closes beyond the range boundary.
+
+- **Upside breakout**: Close above resistance → long entry
+- **Downside breakout**: Close below support → short entry
+- The longer the range duration, the more significant the breakout (greater cause = greater effect)
+- Volume should increase substantially on the breakout bar
+
+### 2. Pattern Breakout
+
+A recognized chart pattern (triangle, flag, pennant, wedge, rectangle, head and shoulders) completes with a boundary violation.
+
+- **Continuation patterns** (flag, pennant, ascending triangle): breakout in the direction of the prior trend
+- **Reversal patterns** (head and shoulders, double top/bottom): breakout against the prior trend
+- Pattern-measured targets provide objective profit targets (e.g., head-and-shoulders target = head height projected from neckline)
+
+### 3. Moving Average Breakout
+
+Price breaks above or below a significant moving average (MA20, MA50, MA200) after an extended period on one side.
+
+- **MA200 breakout** is the most significant — often considered the dividing line between bull and bear markets
+- **MA50 breakout** signals intermediate-term trend changes
+- Requires price to remain above/below the MA for at least 2-3 closes to confirm
+
+### 4. Donchian Breakout (Turtle Trading)
+
+Price breaks above the highest high or below the lowest low of the past N bars.
+
+- **Classic Turtle system**: 20-bar Donchian channel breakout for entry, 10-bar for exit
+- Simple, objective, and fully systematic
+- Works best in trending markets; suffers in range-bound conditions
+- ATR-based position sizing controls risk per trade
+
+---
+
+## False Breakout Filters
+
+False breakouts are the primary risk. Apply these filters to reduce false signals:
+
+### Filter 1: Closing Price Confirmation
+
+- Only count a breakout when the **closing price** (not intraday price) is beyond the boundary
+- Intraday spikes that close back within the range are not breakouts
+- This single filter eliminates a large percentage of false signals
+
+### Filter 2: Volume Confirmation
+
+- Genuine breakouts are accompanied by a volume increase of **50% or more** above the recent average (20-bar volume average)
+- Volume should expand on the breakout bar and remain elevated for the next 2-3 bars
+- Breakouts on declining volume are highly suspect
+
+### Filter 3: Multi-Bar Confirmation (Conservative)
+
+- Require **2 consecutive closes** beyond the boundary
+- Reduces entry frequency but significantly improves win rate
+- Particularly useful for horizontal range breakouts
+
+### Filter 4: Momentum Alignment
+
+- RSI should not be in the extreme opposite zone (e.g., RSI > 70 for a downside breakout is contradictory)
+- MACD should be trending in the breakout direction
+- ADX rising above 25 confirms a trending environment favorable for breakouts
+
+### Filter 5: Retest Entry (Most Conservative)
+
+- Wait for price to break out, then pull back to retest the broken boundary (support becomes resistance, or resistance becomes support)
+- Enter on the retest if the boundary holds
+- Provides better risk/reward but may miss fast breakouts that never retest
+
+---
+
+## Entry Rules
+
+### Aggressive Entry
+
+1. Price closes beyond the breakout boundary
+2. Volume is 50%+ above the 20-bar average
+3. Enter at the close of the breakout bar or on the next open
+4. Stop loss: opposite side of the range, or 1.5 × ATR from entry
+
+### Standard Entry
+
+1. Price closes beyond the breakout boundary
+2. Volume confirms (50%+ above average)
+3. RSI/MACD align with breakout direction
+4. Wait for 2nd consecutive close beyond the boundary
+5. Enter at the close of the 2nd bar
+6. Stop loss: midpoint of the prior range, or 2 × ATR from entry
+
+### Conservative Entry (Retest)
+
+1. Price breaks out and closes beyond the boundary
+2. Price pulls back toward the broken boundary (retest)
+3. Price holds the boundary as new support/resistance (closes back in breakout direction)
+4. Enter on the hold confirmation
+5. Stop loss: below the retest low (long) or above the retest high (short), or 1.5 × ATR
+
+---
+
+## Exit Rules
+
+### Profit Targets
+
+- **Range breakout target**: range height projected from the breakout point
+- **Pattern breakout target**: pattern-specific measured move (e.g., triangle height, flag pole length)
+- **Donchian exit**: opposite channel boundary (20-bar high entry → exit at 10-bar low)
+- **ATR-based target**: 3-4 × ATR from entry for trending breakouts
+
+### Stop Loss
+
+- **Initial stop**: 1.5-2 × ATR below entry (long) or above entry (short)
+- **Alternative**: opposite side of the breakout range
+- **Trailing stop**: After 2 × ATR profit, trail stop at 2 × ATR behind highest close (long) or lowest close (short)
+
+### Position Management
+
+- Consider scaling in: 50% on initial breakout, 50% on successful retest
+- Scale out: 50% at 1:1 risk-reward, 50% at pattern target or 3 × ATR
+
+---
+
+## Confidence Weight Rationale
+
+confidence_weight: 0.70 — Breakout trading is one of the oldest and most systematically validated strategies, with decades of documented performance (Turtle Trading, channel breakout systems). The systematic nature allows clear rules and backtesting. However, the high false breakout rate (40-50% without filters) means filter application is critical and introduces discretion.
+
+Factors that increase confidence:
+- Volume expansion confirms the breakout (50%+ above average)
+- Breakout follows a long consolidation period (larger cause)
+- Multiple timeframes show aligned breakout direction
+- ADX > 25 confirms a trending environment
+- Pattern breakout with a clear measured target
+
+Factors that decrease confidence:
+- Breakout occurs on low or declining volume
+- Price has already tested the boundary multiple times with previous failed breakouts
+- Market is generally range-bound (ADX < 20)
+- Breakout occurs near major economic news or earnings (event-driven, not technical)
+- Very tight range with recent high volatility — choppy conditions
+
+---
+
+## Limitations and Caveats
+
+- **False breakout rate is high**: Without filters, 40-50% of breakouts fail. Even with filters, expect 25-35% false breakouts. This is the inherent cost of the strategy
+- **Late entry**: By definition, breakout trading buys after price has already moved. This means worse average entry prices compared to anticipatory strategies (like mean reversion)
+- **Chop markets**: Breakout strategies suffer significantly in range-bound, choppy markets. Frequent small losses accumulate. Use ADX or similar to filter environments
+- **Overnight gaps**: Breakouts that occur via overnight gaps may not be tradeable at the breakout price. Gap breakouts are valid but slippage can be significant
+- **Crowding**: Well-known breakout levels attract many traders, which can cause the breakout itself but also rapid reversals as early traders take quick profits
+
+---
+
+## AI Analysis Instructions
+
+Identify any potential breakout setups in the recent price data. Look for price approaching or recently violating key horizontal levels, chart pattern boundaries, or significant moving averages.
+
+Return the summary in **this exact structured format** (one `**label**: value` pair per line):
+
+```
+**브레이크아웃 유형**: [Range / Pattern / Moving Average / Donchian / 감지 없음]
+**돌파 레벨**: [돌파 또는 접근 중인 가격 수준, 예: "저항선 $175.50 (20일간 레인지 상단)"]
+**거래량 확인**: [거래량 상태, 예: "돌파 봉 거래량 20일 평균 대비 180% — 유효한 돌파 확인" / "거래량 미확인"]
+**필터 통과 여부**: [적용된 필터와 결과, 예: "종가 확인(통과) + 거래량(통과) + RSI 방향(통과) = 3/3 필터 충족"]
+**리테스트 상태**: [해당 시, 예: "돌파 후 리테스트 진행 중 — $175.50 지지 전환 테스트" / "리테스트 미발생"]
+**매매 신호**: [현재 신호, 예: "레인지 상단 돌파 확인 + 거래량 급증 — 매수 진입 적합" / "돌파 대기 중 — 아직 진입 시점 아님"]
+**상세 분석**: [돌파 맥락, 레인지/패턴 특성, 거짓 돌파 가능성, 목표가(패턴 측정치), 손절 레벨, 주의사항을 포함한 상세 분석 문단]
+```
+
+Additional output rules:
+- If price is **approaching** a key level but has not broken out, describe the setup and conditions needed for a valid breakout
+- If a **breakout has occurred**, evaluate all available filters (volume, closing price, momentum alignment) and state how many are satisfied
+- If a **false breakout** appears to have occurred (breakout followed by reversal back into range), identify it explicitly
+- If **no breakout setup** is visible, state "현재 명확한 브레이크아웃 셋업 미감지" and describe the current price structure
+- Set the `trend` field: `bullish` if upside breakout confirmed, `bearish` if downside breakout confirmed, `neutral` if approaching boundary or no breakout

--- a/skills/strategies/divergence.md
+++ b/skills/strategies/divergence.md
@@ -1,0 +1,182 @@
+---
+name: 다이버전스 전략
+description: 가격과 오실레이터(RSI, MACD, Stochastic)의 방향 불일치를 통해 추세 반전 또는 추세 지속을 예측하는 전략
+type: strategy
+category: neutral
+indicators: ['rsi', 'macd', 'stochastic']
+confidence_weight: 0.7
+---
+
+## Overview
+
+Divergence Trading identifies discrepancies between price action and oscillator readings to anticipate trend reversals or confirm trend continuations. When price makes a new high or low but the corresponding oscillator fails to confirm, the underlying momentum has shifted — signaling a potential change in direction.
+
+This strategy leverages oscillators already available in the system (RSI, MACD, Stochastic) without requiring additional indicators, maximizing the value of existing data.
+
+---
+
+## Divergence Types
+
+### Regular Divergence (Trend Reversal Signals)
+
+Regular divergences signal that the current trend is losing momentum and a reversal is likely.
+
+| Type | Price Action | Oscillator Action | Signal | Reliability |
+|---|---|---|---|---|
+| Regular Bullish | Lower Low | Higher Low | Downtrend weakening → potential reversal to upside | High when at support |
+| Regular Bearish | Higher High | Lower High | Uptrend weakening → potential reversal to downside | High when at resistance |
+
+### Hidden Divergence (Trend Continuation Signals)
+
+Hidden divergences confirm that the current trend remains intact despite a temporary pullback.
+
+| Type | Price Action | Oscillator Action | Signal | Reliability |
+|---|---|---|---|---|
+| Hidden Bullish | Higher Low | Lower Low | Pullback within uptrend → continuation upward | High in strong uptrends |
+| Hidden Bearish | Lower High | Higher High | Bounce within downtrend → continuation downward | High in strong downtrends |
+
+### Key Distinction
+
+- **Regular divergence** = momentum is failing to confirm the new extreme → potential reversal
+- **Hidden divergence** = price is holding the trend while the oscillator overshoots → trend continuation
+
+---
+
+## Oscillator-Specific Guidelines
+
+### RSI Divergence
+
+- Most effective when RSI is in extreme zones (below 30 or above 70)
+- Regular Bullish: price makes lower low while RSI makes higher low, especially if RSI was below 30 and is recovering
+- Regular Bearish: price makes higher high while RSI makes lower high, especially if RSI was above 70 and is declining
+- Hidden divergences are valid when RSI is in the neutral zone (40-60) during a strong trend
+
+### MACD Divergence
+
+- Use the MACD histogram for divergence detection (more sensitive than the MACD line)
+- Regular Bullish: price makes lower low while MACD histogram makes shallower negative bar
+- Regular Bearish: price makes higher high while MACD histogram makes shorter positive bar
+- MACD signal line crossover after divergence adds confirmation
+- MACD divergences tend to precede larger moves than RSI divergences
+
+### Stochastic Divergence
+
+- Best used in ranging or moderately trending markets
+- Most effective when %K is in extreme zones (below 20 or above 80)
+- %K/%D crossover after divergence provides entry timing
+- Less reliable in strong trending markets where Stochastic can remain overbought/oversold for extended periods
+
+### Multi-Oscillator Confirmation
+
+When two or more oscillators show the same divergence simultaneously, signal reliability increases significantly:
+
+| Combination | Estimated Win Rate | Notes |
+|---|---|---|
+| RSI + MACD | ~73% | Highest reliability — momentum + trend confirmation |
+| RSI + Stochastic | ~65% | Good for ranging markets |
+| MACD + Stochastic | ~62% | Momentum focus |
+| All three | ~78% | Rare but most reliable |
+
+---
+
+## Entry Rules
+
+### Regular Bullish Divergence Entry
+
+1. **Identify divergence**: Price makes lower low while oscillator makes higher low
+2. **Wait for confirmation**: Oscillator exits oversold zone (RSI crosses above 30, Stochastic %K crosses above 20, or MACD histogram turns positive)
+3. **Double confirmation (optional)**: Price bounces from a known support level
+4. **Entry trigger**: Enter long when the confirmation candle closes
+5. **Stop loss**: Below the most recent swing low (the lower low in the divergence)
+6. **Target**: Previous swing high or resistance level; alternatively, 1:2 risk-reward ratio
+
+### Regular Bearish Divergence Entry
+
+1. **Identify divergence**: Price makes higher high while oscillator makes lower high
+2. **Wait for confirmation**: Oscillator exits overbought zone (RSI crosses below 70, Stochastic %K crosses below 80, or MACD histogram turns negative)
+3. **Double confirmation (optional)**: Price rejects from a known resistance level
+4. **Entry trigger**: Enter short when the confirmation candle closes
+5. **Stop loss**: Above the most recent swing high (the higher high in the divergence)
+6. **Target**: Previous swing low or support level; alternatively, 1:2 risk-reward ratio
+
+### Hidden Bullish Divergence Entry
+
+1. **Prerequisite**: Confirmed uptrend (higher highs, higher lows, price above key moving averages)
+2. **Identify divergence**: Price makes higher low while oscillator makes lower low
+3. **Entry trigger**: Enter long when oscillator begins recovering from the lower low
+4. **Stop loss**: Below the higher low in the divergence
+5. **Target**: Retest of the most recent high or next resistance
+
+### Hidden Bearish Divergence Entry
+
+1. **Prerequisite**: Confirmed downtrend (lower highs, lower lows, price below key moving averages)
+2. **Identify divergence**: Price makes lower high while oscillator makes higher high
+3. **Entry trigger**: Enter short when oscillator begins declining from the higher high
+4. **Stop loss**: Above the lower high in the divergence
+5. **Target**: Retest of the most recent low or next support
+
+---
+
+## Exit Rules
+
+- **Primary exit**: Target price reached (support/resistance level or risk-reward ratio target)
+- **Trailing stop**: Move stop to breakeven after 1:1 risk-reward is reached, then trail behind swing points
+- **Invalidation exit**: Close position if a new divergence forms in the opposite direction
+- **Time-based exit**: If price fails to move in the expected direction within 10-15 bars after entry, consider closing for a small loss or breakeven
+
+---
+
+## Confidence Weight Rationale
+
+confidence_weight: 0.70 — Divergence is a well-documented, statistically validated phenomenon across markets. Multi-oscillator confirmation substantially improves reliability. However, divergences can persist for extended periods before resolving (especially in strong trends), and entry timing requires additional confirmation.
+
+Factors that increase confidence:
+- Multiple oscillators show the same divergence simultaneously
+- Divergence occurs at a known support/resistance level
+- Volume confirms the divergence (decreasing volume on the price extreme)
+- Divergence appears on a higher timeframe (daily or weekly)
+
+Factors that decrease confidence:
+- Only one oscillator shows divergence
+- Strong trending market (regular divergences can persist through multiple swings)
+- No clear support/resistance confluence
+- Divergence on very low timeframes (1-minute, 5-minute) — higher noise ratio
+
+---
+
+## Limitations and Caveats
+
+- **Never trade divergence alone**: Divergence is a warning signal, not an entry signal by itself. Always require confirmation (oscillator exit from extreme zone, candlestick pattern, or support/resistance test)
+- **Strong trend danger**: In a powerful trend, regular divergence can appear at multiple consecutive swings before the trend actually reverses. This leads to premature entries and repeated stop-outs. Check the higher timeframe trend direction first
+- **Hidden divergence misconception**: Hidden divergence confirms trend continuation — it is NOT a reversal signal. Do not confuse hidden bullish (continuation) with regular bullish (reversal)
+- **Timeframe consistency**: The divergence and the entry confirmation should be observed on the same timeframe. Do not mix timeframes (e.g., divergence on daily, entry on 5-minute)
+- **Oscillator recalculation**: Oscillator values change with each new bar. A divergence visible on incomplete bars may disappear when the bar closes. Always confirm on closed bars
+
+---
+
+## AI Analysis Instructions
+
+Scan the most recent price data and available oscillator values (RSI, MACD histogram, Stochastic %K) for divergence patterns. Check both the most recent swing and the prior swing for comparison.
+
+For each divergence detected:
+1. Identify the type (Regular Bullish, Regular Bearish, Hidden Bullish, Hidden Bearish)
+2. Specify which oscillator(s) show the divergence
+3. Assess whether confirmation conditions have been met
+
+Return the summary in **this exact structured format** (one `**label**: value` pair per line):
+
+```
+**감지된 다이버전스**: [Regular Bullish / Regular Bearish / Hidden Bullish / Hidden Bearish / 감지 없음]
+**관련 오실레이터**: [다이버전스를 보이는 오실레이터 목록, 예: "RSI + MACD 동시 다이버전스"]
+**가격 패턴**: [다이버전스 구성 설명, 예: "가격 Lower Low($142→$138) + RSI Higher Low(28→32)"]
+**확인 상태**: [확인 완료 / 확인 대기 중 / 미확인, 예: "RSI 30선 상향 돌파 확인 — 진입 조건 충족"]
+**매매 신호**: [구체적 진입 신호, 예: "Regular Bullish 확인 — RSI+MACD 동시 다이버전스로 높은 신뢰도 매수 신호" / "명확한 다이버전스 신호 없음"]
+**상세 분석**: [다이버전스 맥락, 지지/저항 수렴 여부, 멀티 오실레이터 일치 여부, 주의사항을 포함한 상세 분석 문단]
+```
+
+Additional output rules:
+- If **multiple oscillators** show the same divergence, explicitly note this as higher confidence
+- If divergence is detected but **confirmation is pending**, state the specific condition needed (e.g., "RSI가 30선을 상향 돌파하면 확인 완료")
+- If **hidden divergence** is detected, emphasize that it is a continuation signal, not a reversal
+- If no divergence is found, state "현재 가격-오실레이터 간 다이버전스 미감지" and briefly describe the current momentum alignment
+- Set the `trend` field: `bullish` if regular bullish or hidden bullish divergence confirmed, `bearish` if regular bearish or hidden bearish divergence confirmed, `neutral` if no divergence or unconfirmed

--- a/skills/strategies/fibonacci.md
+++ b/skills/strategies/fibonacci.md
@@ -1,0 +1,216 @@
+---
+name: 피보나치 전략
+description: 피보나치 되돌림/확장 비율을 활용하여 지지·저항 레벨과 목표가를 산출하고, 패턴·지표와 결합하여 매매 시점을 판별하는 전략
+type: strategy
+category: neutral
+indicators: []
+confidence_weight: 0.65
+---
+
+## Overview
+
+The Fibonacci Strategy uses ratios derived from the Fibonacci sequence (0, 1, 1, 2, 3, 5, 8, 13, 21, ...) to identify potential support/resistance levels and price targets. The key ratios — 23.6%, 38.2%, 50%, 61.8%, and 78.6% — are applied to price swings to project where pullbacks may find support and where trend extensions may reach.
+
+The 61.8% ratio (the Golden Ratio, approximately 1.618) is the mathematical foundation: each Fibonacci number divided by the next approaches 0.618. The other ratios derive from relationships between numbers at various positions in the sequence.
+
+While the mathematical basis of Fibonacci levels has limited independent predictive power in academic literature, their widespread use among traders worldwide creates a self-fulfilling prophecy effect — enough market participants watch the same levels that price frequently reacts at those points.
+
+---
+
+## Fibonacci Ratios
+
+| Ratio | Source | Common Name | Significance |
+|---|---|---|---|
+| 0.236 (23.6%) | n / n+3 position | Shallow retracement | Minor support in strong trends |
+| 0.382 (38.2%) | n / n+2 position | Moderate retracement | Key support — healthy pullback |
+| 0.500 (50.0%) | Not a Fibonacci ratio | Midpoint | Practically significant despite non-Fibonacci origin |
+| 0.618 (61.8%) | n / n+1 position (Golden Ratio) | Deep retracement | Most important level — make-or-break for trend |
+| 0.786 (78.6%) | Square root of 0.618 | Very deep retracement | Last defense before full retracement |
+| 1.272 (127.2%) | Square root of 1.618 | Extension | First extension target |
+| 1.618 (161.8%) | Golden Ratio | Extension | Primary extension target |
+| 2.000 (200.0%) | 2x | Extension | Round-number extension target |
+| 2.618 (261.8%) | 1.618² | Extension | Extended move target |
+
+---
+
+## Fibonacci Retracement
+
+Fibonacci Retracement measures how far price pulls back from a completed swing before resuming the trend.
+
+### Application in an Uptrend
+
+1. Identify a completed upswing: Swing Low (start) → Swing High (end)
+2. Draw retracement levels from Swing Low (0%) to Swing High (100%)
+3. Retracement levels act as **support**: 23.6%, 38.2%, 50%, 61.8%, 78.6%
+4. As price pulls back, watch for bounces at these levels
+
+### Application in a Downtrend
+
+1. Identify a completed downswing: Swing High (start) → Swing Low (end)
+2. Draw retracement levels from Swing High (0%) to Swing Low (100%)
+3. Retracement levels act as **resistance**: 23.6%, 38.2%, 50%, 61.8%, 78.6%
+4. As price bounces, watch for rejection at these levels
+
+### Retracement Depth Interpretation
+
+| Depth | Interpretation |
+|---|---|
+| 23.6-38.2% | Shallow — very strong trend, minor pause |
+| 38.2-50.0% | Moderate — healthy pullback within a normal trend |
+| 50.0-61.8% | Deep — trend intact but momentum weakening |
+| 61.8-78.6% | Very deep — trend integrity questionable |
+| Beyond 78.6% | Near-full retracement — trend likely broken |
+
+---
+
+## Fibonacci Extension
+
+Fibonacci Extension projects potential price targets beyond the original swing by applying Fibonacci ratios.
+
+### Three-Point Extension
+
+1. Identify three points: Swing Low (A) → Swing High (B) → Retracement Low (C)
+2. Extension levels project from point C using the A-B distance:
+   - 127.2% extension: C + (B − A) × 1.272
+   - 161.8% extension: C + (B − A) × 1.618
+   - 200.0% extension: C + (B − A) × 2.000
+   - 261.8% extension: C + (B − A) × 2.618
+3. These levels serve as **profit targets** for positions entered at or near point C
+
+### Target Priority
+
+- **Conservative target**: 127.2% extension
+- **Primary target**: 161.8% extension (most commonly reached)
+- **Aggressive target**: 200% or 261.8% extension (strong trends only)
+
+---
+
+## Fibonacci Cluster
+
+A Fibonacci Cluster forms when retracement or extension levels from multiple independent swings converge at the same price zone. Clusters create particularly strong support/resistance areas.
+
+**Construction**:
+1. Draw Fibonacci retracements from the 2-3 most recent significant swings
+2. Identify zones where levels from different swings align within 0.5-1% of each other
+3. More overlapping levels = stronger cluster = higher probability of price reaction
+
+**Significance ranking**:
+- 2 levels converging: notable zone
+- 3+ levels converging: high-probability support/resistance
+- Cluster aligned with horizontal support/resistance or moving average: highest probability
+
+---
+
+## Elliott Wave Integration
+
+Fibonacci ratios have specific expected relationships with Elliott Wave positions:
+
+| Wave | Expected Fibonacci Relationship |
+|---|---|
+| Wave 2 | Retraces 50-61.8% of Wave 1 (deep retracement common) |
+| Wave 3 | Extends 161.8% of Wave 1 (measured from Wave 2 end) |
+| Wave 4 | Retraces 23.6-38.2% of Wave 3 (shallow retracement common) |
+| Wave 5 | Equals Wave 1, or extends 61.8-100% of Waves 1-3 combined |
+| Wave A | Often equals Wave 5, or retraces 38.2-61.8% of the impulse |
+| Wave C | Often equals Wave A, or extends 127.2-161.8% of Wave A |
+
+When Elliott Wave analysis and Fibonacci levels agree, confidence in both increases substantially.
+
+---
+
+## Entry Rules
+
+### Retracement Buy (Uptrend)
+
+1. **Prerequisite**: Confirmed uptrend with a clear completed upswing
+2. **Identify levels**: Draw retracement from the most recent swing low to swing high
+3. **Wait for price**: Price pulls back to 38.2%, 50%, or 61.8% level
+4. **Confirmation required**: At least one of:
+   - Bullish candlestick pattern at the Fibonacci level (hammer, engulfing, morning star)
+   - RSI divergence at the level
+   - Volume decrease during pullback, increase on bounce
+   - Level coincides with horizontal support or moving average
+5. **Entry**: On confirmation candle close
+6. **Stop loss**: Below the next deeper Fibonacci level (e.g., enter at 38.2%, stop below 50%)
+7. **Target**: Retest of the swing high, or Fibonacci extension levels
+
+### Retracement Sell (Downtrend)
+
+1. **Prerequisite**: Confirmed downtrend with a clear completed downswing
+2. **Identify levels**: Draw retracement from the most recent swing high to swing low
+3. **Wait for price**: Price bounces to 38.2%, 50%, or 61.8% level
+4. **Confirmation required**: At least one of the confirmation signals listed above (bearish equivalents)
+5. **Entry**: On confirmation candle close
+6. **Stop loss**: Above the next shallower Fibonacci level
+7. **Target**: Retest of the swing low, or Fibonacci extension levels
+
+### Extension Target Setting
+
+1. After entering at a retracement level, set targets at extension levels
+2. **Partial exit strategy**:
+   - Close 50% at 127.2% extension
+   - Close 30% at 161.8% extension
+   - Trail remaining 20% with stop at 127.2%
+
+---
+
+## Exit Rules
+
+- **Primary exit**: Price reaches the Fibonacci extension target
+- **Invalidation**: Price breaks through the 78.6% retracement level (trend likely broken — exit long positions)
+- **Cluster exit**: If price reaches a Fibonacci cluster from the opposite direction, expect strong resistance — consider taking profit
+- **Trailing**: Move stop to breakeven when price reaches the 0% level (original swing high/low), then trail using Fibonacci levels of the new swing
+
+---
+
+## Confidence Weight Rationale
+
+confidence_weight: 0.65 — Fibonacci levels have strong practical utility due to widespread adoption, but independent predictive power is academically weak. The self-fulfilling prophecy effect is real but not guaranteed. Fibonacci levels work best as a confluence tool — combining with other analysis rather than used in isolation.
+
+Factors that increase confidence:
+- Fibonacci level aligns with horizontal support/resistance
+- Fibonacci cluster (multiple swings converge at the same level)
+- Candlestick pattern confirms at the Fibonacci level
+- Elliott Wave position matches expected Fibonacci relationship
+- Level aligns with a key moving average (MA20, MA50, MA200)
+
+Factors that decrease confidence:
+- Fibonacci level used in isolation without any confluence
+- No clear swing structure to anchor the Fibonacci drawing
+- Choppy, trendless market with no defined swings
+- Multiple close retracement levels (38.2% and 50% within 1%) — ambiguous zone
+
+---
+
+## Limitations and Caveats
+
+- **Not a standalone tool**: Academic research consistently shows Fibonacci levels alone do not outperform random support/resistance levels. Their value comes from confluence with other analysis methods
+- **Subjective swing selection**: Different traders may select different swing points, producing different levels. Use the most visually obvious, significant swings
+- **Self-fulfilling prophecy**: The primary driver of Fibonacci effectiveness is that many traders watch these levels simultaneously. This means the effect can weaken in markets with fewer technical traders
+- **Over-application**: Drawing Fibonacci on every minor swing produces too many levels, making the analysis meaningless. Apply only to significant, clearly defined swings
+- **The 50% level is not Fibonacci**: Despite being universally included in Fibonacci tools, 50% is a simple midpoint. It works well practically, but attributing it to Fibonacci mathematics is incorrect
+
+---
+
+## AI Analysis Instructions
+
+Identify the most significant recent swing(s) in the price data and calculate Fibonacci retracement levels. If price has already begun retracing, identify which level is currently in play.
+
+Return the summary in **this exact structured format** (one `**label**: value` pair per line):
+
+```
+**스윙 구간**: [피보나치 적용 구간, 예: "스윙 저점 $138 → 스윙 고점 $175 (상승 스윙)"]
+**주요 되돌림 레벨**: [계산된 레벨, 예: "38.2%=$160.87, 50%=$156.50, 61.8%=$152.13"]
+**현재 가격 위치**: [가격이 어느 레벨 근처에 있는지, 예: "50% 레벨($156.50) 근처에서 지지 테스트 중"]
+**클러스터 존**: [감지된 피보나치 클러스터, 예: "$155-157 구간에 2개 스윙의 38.2%와 61.8%가 수렴" / "클러스터 미감지"]
+**확장 목표가**: [해당 시 확장 레벨, 예: "127.2%=$185.10, 161.8%=$197.83"]
+**매매 신호**: [현재 신호, 예: "61.8% 레벨에서 망치형 캔들 확인 — 반등 매수 적합" / "명확한 피보나치 신호 없음"]
+**상세 분석**: [스윙 구조, 되돌림 깊이 해석, 지지·저항 수렴 여부, 엘리어트 파동과의 관계(해당 시), 주의사항을 포함한 상세 분석 문단]
+```
+
+Additional output rules:
+- Calculate retracement levels based on the most significant recent swing (use the largest, clearest swing visible in the data)
+- If price is currently **at or near** a Fibonacci level (within 1%), describe the price reaction at that level
+- If a **Fibonacci cluster** is identified (levels from multiple swings converging), highlight it as a high-probability zone
+- If price has broken below 78.6% retracement, note that the trend is likely invalidated
+- Set the `trend` field: `bullish` if price is bouncing from a retracement level in an uptrend, `bearish` if price is rejecting from a retracement level in a downtrend, `neutral` if price is between levels or no clear trend

--- a/skills/strategies/mean-reversion.md
+++ b/skills/strategies/mean-reversion.md
@@ -1,0 +1,181 @@
+---
+name: 평균 회귀 전략
+description: 가격이 이동평균 또는 통계적 평균에서 과도하게 이탈한 후 평균으로 회귀하는 경향을 이용하여 역추세 진입 시점을 판별하는 전략
+type: strategy
+category: neutral
+indicators: ['rsi', 'bollinger']
+confidence_weight: 0.7
+---
+
+## Overview
+
+The Mean Reversion Strategy is based on the statistical tendency of prices to return to their mean (average) after deviating significantly. When price moves too far from its average — measured by standard deviations, oscillator extremes, or band violations — the probability of a reversal back toward the mean increases.
+
+This is one of the most academically validated strategies in quantitative finance, with documented effectiveness across equities, commodities, and forex markets, particularly in range-bound environments (win rate 60-70% in sideways markets).
+
+The strategy works best when the market is **not trending strongly** (ADX < 25). In trending markets, mean reversion signals produce losing trades (catching falling knives or shorting into strength).
+
+---
+
+## Core Principle
+
+Price oscillates around a moving average or equilibrium level. Extreme deviations from this level are unsustainable and tend to correct:
+
+- **Oversold (extreme below mean)**: Price has fallen too far, too fast → high probability of bounce back toward mean
+- **Overbought (extreme above mean)**: Price has risen too far, too fast → high probability of pullback toward mean
+
+The "mean" can be defined as:
+1. A moving average (MA20, MA50)
+2. The middle Bollinger Band (MA20)
+3. VWAP (Volume Weighted Average Price)
+4. A statistical mean over a defined lookback period
+
+---
+
+## Signal Indicators
+
+### Bollinger Bands
+
+The primary mean reversion tool. Bollinger Bands (20-period MA ± 2 standard deviations) contain approximately 95% of price action.
+
+| Condition | Signal | Interpretation |
+|---|---|---|
+| Price touches/penetrates lower band | Oversold | Buy signal — price at statistical extreme below mean |
+| Price touches/penetrates upper band | Overbought | Sell signal — price at statistical extreme above mean |
+| Price at middle band (MA20) | Mean | Target — expected reversion destination |
+| Band width contracting (squeeze) | Low volatility | Caution — breakout likely, mean reversion may fail |
+| Band width expanding | High volatility | Extreme moves may continue before reverting |
+
+**Bollinger Band %B**:
+- %B = (Price − Lower Band) / (Upper Band − Lower Band)
+- %B < 0: Price below lower band (extreme oversold)
+- %B > 1: Price above upper band (extreme overbought)
+- %B = 0.5: Price at middle band (mean)
+
+### RSI (Relative Strength Index)
+
+| Condition | Signal | Action |
+|---|---|---|
+| RSI < 30 | Oversold | Buy signal — selling momentum exhausted |
+| RSI < 20 | Extremely oversold | Strong buy signal — extreme deviation |
+| RSI > 70 | Overbought | Sell signal — buying momentum exhausted |
+| RSI > 80 | Extremely overbought | Strong sell signal — extreme deviation |
+| RSI crossing 50 from below | Bullish mean cross | Mean confirmed — upward reversion in progress |
+| RSI crossing 50 from above | Bearish mean cross | Mean confirmed — downward reversion in progress |
+
+### Moving Average Deviation
+
+When price deviates more than 2 standard deviations from a key moving average, mean reversion probability increases:
+
+- Distance from MA = (Current Price − MA) / MA × 100
+- Deviation > +10% from MA → overbought
+- Deviation < −10% from MA → oversold
+- Adjust thresholds based on the asset's historical volatility
+
+---
+
+## Entry Rules
+
+### Mean Reversion Buy (Oversold)
+
+**Standard Entry**:
+1. **Environment check**: ADX < 25 (non-trending or weakly trending market)
+2. **Primary signal**: Price touches or penetrates the lower Bollinger Band
+3. **Confirmation**: RSI < 30 simultaneously (dual-indicator oversold)
+4. **Entry trigger**: Enter long when a bullish reversal candle forms (hammer, bullish engulfing, or any candle that closes in the upper half of its range)
+5. **Stop loss**: Below the lowest point of the oversold move, or 2 × ATR below entry
+6. **Target**: Middle Bollinger Band (MA20) for primary target; upper Bollinger Band for aggressive target
+
+**High-Confidence Entry** (3 conditions simultaneously):
+1. Price below lower Bollinger Band (%B < 0)
+2. RSI < 30
+3. Price at or near a known support level (horizontal support, prior swing low, or Fibonacci level)
+→ This triple confluence produces the highest win rate for mean reversion entries
+
+### Mean Reversion Sell (Overbought)
+
+**Standard Entry**:
+1. **Environment check**: ADX < 25
+2. **Primary signal**: Price touches or penetrates the upper Bollinger Band
+3. **Confirmation**: RSI > 70 simultaneously
+4. **Entry trigger**: Enter short when a bearish reversal candle forms (shooting star, bearish engulfing, or any candle that closes in the lower half of its range)
+5. **Stop loss**: Above the highest point of the overbought move, or 2 × ATR above entry
+6. **Target**: Middle Bollinger Band (MA20) for primary target; lower Bollinger Band for aggressive target
+
+---
+
+## Exit Rules
+
+- **Primary target**: Middle Bollinger Band (MA20) — this is the "mean" in mean reversion
+- **Extended target**: Opposite Bollinger Band — only when initial move back to mean shows strong momentum
+- **Stop loss**: 2 × ATR beyond the extreme point of the deviation
+- **Time-based exit**: If price fails to begin reverting within 5-7 bars, the oversold/overbought condition may be part of a trend rather than a deviation — close position
+- **Invalidation**: If RSI reaches even more extreme levels (e.g., entered at RSI 28, RSI drops to 15) without price stabilizing, the setup may be failing — tighten stop or exit
+
+---
+
+## Environment Filter: ADX
+
+The ADX (Average Directional Index) is critical for filtering mean reversion signals:
+
+| ADX Value | Market Environment | Mean Reversion Suitability |
+|---|---|---|
+| < 15 | No trend, very low volatility | Good — but small moves, tight targets |
+| 15-25 | Weak trend or range-bound | Best environment for mean reversion |
+| 25-35 | Moderate trend developing | Caution — mean reversion works but with higher risk |
+| > 35 | Strong trend | Avoid mean reversion — use trend-following instead |
+| > 50 | Extreme trend | Do not use mean reversion — high risk of continued deviation |
+
+---
+
+## Confidence Weight Rationale
+
+confidence_weight: 0.70 — Mean reversion is one of the most academically documented market phenomena, with robust statistical evidence across asset classes. The strategy has a clear mathematical foundation (deviation from mean) and well-defined entry/exit criteria. However, the critical dependency on market environment (ranging vs. trending) and the risk of catching falling knives in trending markets limit the weight.
+
+Factors that increase confidence:
+- ADX < 25 confirms non-trending environment
+- Multiple indicators simultaneously confirm oversold/overbought (Bollinger + RSI)
+- Price is at a known support/resistance level (triple confluence)
+- Volume decreases during the extreme move (exhaustion)
+- Higher timeframe shows no clear trend (sideways)
+
+Factors that decrease confidence:
+- ADX > 30 (trending market — mean reversion is counter-trend)
+- Only one indicator shows oversold/overbought (single signal)
+- Fundamental catalyst driving the move (earnings, news) — may not revert
+- Price has been trending strongly on the higher timeframe
+- Bollinger Bands expanding rapidly (increasing volatility)
+
+---
+
+## Limitations and Caveats
+
+- **Catching falling knives**: The most dangerous failure mode. In a strong downtrend, price can remain "oversold" for days or weeks, producing repeated losing buy signals. Always check the higher timeframe trend and ADX before entering
+- **Not for trending markets**: Mean reversion is fundamentally a range-bound strategy. Applying it in trending markets leads to systematic losses. The ADX filter is not optional — it is essential
+- **News-driven moves**: Fundamental catalysts (earnings surprises, regulatory changes, macro events) can cause permanent price shifts, not temporary deviations. Mean reversion does not apply to fundamental re-pricing
+- **Band expansion trap**: When Bollinger Bands are expanding (increasing volatility), touching the lower band may be the start of a larger move, not an extreme. Look for band contraction or stabilization before entering
+- **Asymmetric risk**: Mean reversion targets (back to the mean) are typically smaller than potential losses (deviation continues). Strict stop losses and position sizing are essential to survive the losing trades
+
+---
+
+## AI Analysis Instructions
+
+Evaluate the current price relative to its statistical mean using Bollinger Bands and RSI. Determine whether the market environment is suitable for mean reversion (ADX assessment).
+
+Return the summary in **this exact structured format** (one `**label**: value` pair per line):
+
+```
+**시장 환경**: [ADX 기반 판단, 예: "ADX 18 — 비추세 환경으로 평균 회귀 전략 적합" / "ADX 38 — 강한 추세로 평균 회귀 부적합"]
+**볼린저 밴드 위치**: [현재 가격의 밴드 내 위치, 예: "하단 밴드 터치 (%B = -0.05) — 극단적 과매도"]
+**RSI 상태**: [RSI 값과 해석, 예: "RSI 25 — 과매도 구간, 매수 신호 활성"]
+**이평선 이격도**: [MA 대비 가격 이격, 예: "MA20 대비 -8.2% 이격 — 과매도 영역 근접"]
+**매매 신호**: [종합 판단, 예: "볼린저 하단 터치 + RSI 28 = 이중 과매도 확인 — 반등 매수 적합" / "과매수/과매도 조건 미충족"]
+**상세 분석**: [시장 환경 적합성, 복합 지표 분석, 지지·저항 수렴 여부, 평균 회귀 목표가(중심 밴드), 리스크, 주의사항을 포함한 상세 분석 문단]
+```
+
+Additional output rules:
+- If **ADX > 30**, explicitly warn that mean reversion signals are unreliable in the current trending environment
+- If **Bollinger + RSI** both confirm oversold/overbought simultaneously, flag as high-confidence signal
+- If price is at a **known support/resistance level** while oversold/overbought, flag as triple confluence (highest confidence)
+- If neither oversold nor overbought conditions exist, state "현재 과매수/과매도 조건 미충족 — 평균 회귀 신호 없음"
+- Set the `trend` field: `bullish` if oversold conditions confirmed in non-trending market, `bearish` if overbought conditions confirmed in non-trending market, `neutral` if no mean reversion signal or trending environment

--- a/skills/strategies/mean-reversion.md
+++ b/skills/strategies/mean-reversion.md
@@ -3,7 +3,7 @@ name: 평균 회귀 전략
 description: 가격이 이동평균 또는 통계적 평균에서 과도하게 이탈한 후 평균으로 회귀하는 경향을 이용하여 역추세 진입 시점을 판별하는 전략
 type: strategy
 category: neutral
-indicators: ['rsi', 'bollinger']
+indicators: ['rsi', 'bollinger', 'atr']
 confidence_weight: 0.7
 ---
 

--- a/skills/strategies/multi-timeframe.md
+++ b/skills/strategies/multi-timeframe.md
@@ -1,0 +1,211 @@
+---
+name: 다중 시간대 분석
+description: 상위 시간대에서 추세 방향을 확인하고 하위 시간대에서 최적의 진입 타이밍을 잡는 체계적 분석 프레임워크
+type: strategy
+category: neutral
+indicators: ['ma', 'rsi', 'macd']
+confidence_weight: 0.75
+---
+
+## Overview
+
+Multi-Timeframe Analysis (MTA) is a systematic framework used by professional traders to align trade direction with the dominant trend while optimizing entry timing on lower timeframes. The core principle is simple: **trade in the direction of the higher timeframe trend, enter on the lower timeframe signal**.
+
+This approach dramatically reduces false signals by filtering out trades that conflict with the dominant trend. A buy signal on a 1-hour chart that contradicts a clear downtrend on the daily chart is far more likely to fail than one that aligns with a daily uptrend.
+
+MTA is not a standalone trading system — it is a **meta-strategy** that enhances the accuracy of all other strategies (breakout, divergence, mean reversion, etc.) by adding a directional filter.
+
+---
+
+## Three-Tier Timeframe Structure
+
+Analysis proceeds from the highest timeframe to the lowest, with each tier serving a distinct purpose:
+
+| Tier | Purpose | Typical Timeframes | What to Analyze |
+|---|---|---|---|
+| Higher TF (Direction) | Determine the dominant trend direction | Weekly / Daily | Trend direction, major support/resistance, market phase |
+| Middle TF (Strategy) | Identify trading setups and patterns | Daily / 4-Hour | Chart patterns, indicator setups, key levels, entry zones |
+| Lower TF (Timing) | Pinpoint precise entry and exit | 1-Hour / 15-Min | Entry triggers, candlestick patterns, micro-level support/resistance |
+
+### Timeframe Combinations
+
+| Trading Style | Higher TF | Middle TF | Lower TF |
+|---|---|---|---|
+| Position | Monthly | Weekly | Daily |
+| Swing | Weekly | Daily | 4-Hour |
+| Short-term | Daily | 4-Hour | 1-Hour |
+| Intraday | 4-Hour | 1-Hour | 15-Min |
+
+**Rule**: Each tier should be approximately 4-6× the period of the next lower tier. Using timeframes too close together (e.g., 15-min and 30-min) provides redundant information; too far apart (e.g., monthly and 5-min) creates unactionable gaps.
+
+---
+
+## Core Rules
+
+### Rule 1: Trade Only in the Higher TF Direction
+
+- If the Higher TF shows an uptrend → only take long positions on the Middle and Lower TFs
+- If the Higher TF shows a downtrend → only take short positions on the Middle and Lower TFs
+- If the Higher TF is range-bound → both directions are acceptable, but with reduced position size
+
+**Never take a counter-trend trade against the Higher TF direction.** This single rule eliminates the majority of losing trades.
+
+### Rule 2: Higher TF Support/Resistance Takes Priority
+
+- A resistance level on the daily chart outweighs a buy signal on the 1-hour chart
+- A support level on the weekly chart outweighs a sell signal on the 4-hour chart
+- Always check if the Middle/Lower TF trade would run into a Higher TF level before entering
+
+### Rule 3: Minimum Two-Tier Agreement
+
+- Enter only when at least 2 of 3 timeframes agree on direction
+- Ideal entry: all 3 tiers align (trend, setup, and timing all bullish or all bearish)
+- Never enter when only 1 tier supports the trade
+
+### Rule 4: Higher TF Overrides Lower TF Extremes
+
+- If the Higher TF shows an overbought condition (RSI > 70), ignore bullish signals on the Lower TF
+- If the Higher TF shows an oversold condition (RSI < 30), ignore bearish signals on the Lower TF
+- Higher TF extreme readings suggest the current trend phase is nearing exhaustion
+
+---
+
+## Analysis Procedure
+
+### Step 1: Higher TF — Establish Direction
+
+Analyze the Higher TF to determine the dominant trend:
+
+1. **Trend identification**: Is price making higher highs and higher lows (uptrend), lower highs and lower lows (downtrend), or neither (range)?
+2. **Moving average position**: Is price above or below MA50 and MA200?
+3. **Key levels**: Identify the nearest major support and resistance levels
+4. **Momentum**: Is RSI trending above 50 (bullish) or below 50 (bearish)?
+
+**Output**: A directional bias — LONG ONLY, SHORT ONLY, or NEUTRAL (range-bound)
+
+### Step 2: Middle TF — Identify Setup
+
+With the directional bias established, analyze the Middle TF for trading setups:
+
+1. **Setup identification**: Look for chart patterns, indicator setups, or price action that aligns with the Higher TF direction
+2. **Entry zone**: Identify the price zone where a trade would offer good risk/reward (support for longs, resistance for shorts)
+3. **Indicator alignment**: Confirm MACD, RSI, and other indicators support the direction
+4. **Invalidation level**: Define the price level that would negate the setup
+
+**Output**: A specific trade setup or "no setup available"
+
+### Step 3: Lower TF — Time the Entry
+
+With a valid setup identified on the Middle TF, use the Lower TF for precise entry timing:
+
+1. **Entry trigger**: Look for a specific candlestick pattern, indicator crossover, or micro-level breakout that confirms the Middle TF setup
+2. **Stop loss placement**: Place the stop below the Lower TF swing low (long) or above the Lower TF swing high (short)
+3. **Position sizing**: Calculate position size based on the stop loss distance and risk per trade
+4. **Execution**: Enter when the trigger fires; do not chase if missed
+
+**Output**: A precise entry price, stop loss, and position size
+
+---
+
+## Alignment Scoring
+
+Rate the multi-timeframe alignment to determine position sizing:
+
+| Alignment | Description | Position Size |
+|---|---|---|
+| Strong (3/3) | All three timeframes agree on direction | Full position (100%) |
+| Moderate (2/3) | Higher and Middle TFs agree; Lower TF neutral or not yet triggered | Reduced position (50-75%) |
+| Weak (1/3) | Only one timeframe supports the trade | No entry — wait for better alignment |
+| Conflicting | Higher TF contradicts Lower TF direction | No entry — signal is likely a false signal |
+
+---
+
+## Common Patterns by Alignment
+
+### Trend Continuation (Highest Probability)
+
+- **Higher TF**: Clear uptrend (above MA50, MA200, higher highs/lows)
+- **Middle TF**: Pullback to support (Fibonacci retracement, MA20, trendline)
+- **Lower TF**: Bullish reversal candle or indicator crossover at support
+- → Enter long at the Lower TF trigger, targeting the Middle TF resistance
+
+### Trend Reversal (Requires More Confirmation)
+
+- **Higher TF**: Shows signs of exhaustion (RSI divergence, climactic volume)
+- **Middle TF**: Bearish pattern forming (head and shoulders, double top)
+- **Lower TF**: Breakdown below pattern boundary with volume
+- → Enter short at the Lower TF confirmation, but with reduced size due to counter-Higher-TF risk
+
+### Range-Bound Entry
+
+- **Higher TF**: No clear trend; price oscillating between defined support and resistance
+- **Middle TF**: Mean reversion setup (Bollinger Band extreme, RSI extreme)
+- **Lower TF**: Reversal candle at the range boundary
+- → Enter in the direction of mean reversion, targeting the opposite range boundary
+
+---
+
+## Indicator Usage Across Timeframes
+
+| Indicator | Higher TF Usage | Middle TF Usage | Lower TF Usage |
+|---|---|---|---|
+| Moving Averages | Trend direction (above/below MA50, MA200) | Dynamic support/resistance (MA20, MA50) | Entry trigger (MA5 crossover) |
+| RSI | Trend strength (above/below 50) | Overbought/oversold zones | Divergence detection, timing |
+| MACD | Trend direction (above/below zero line) | Signal crossovers, histogram direction | Momentum confirmation |
+| Bollinger Bands | Trend channel identification | Entry zones (band touches) | Timing (squeeze breakout) |
+| Volume | Trend health (expanding/contracting) | Setup confirmation | Entry bar volume confirmation |
+
+---
+
+## Confidence Weight Rationale
+
+confidence_weight: 0.75 — Multi-Timeframe Analysis is the most universal professional framework. It does not predict direction itself but dramatically improves the accuracy of any directional strategy by adding a structural filter. The framework is systematic, objective, and well-validated across decades of professional use.
+
+Factors that increase confidence:
+- All three timeframes align in the same direction (3/3 agreement)
+- Higher TF trend is well-established (not early-stage or late-stage)
+- Middle TF setup has clear pattern structure with defined invalidation
+- Lower TF entry trigger fires with volume confirmation
+
+Factors that decrease confidence:
+- Higher TF is range-bound (no clear directional bias)
+- Middle and Lower TFs conflict with each other
+- Higher TF shows late-stage trend exhaustion (extended RSI, climactic volume)
+- Only one timeframe available for analysis (single-timeframe data)
+
+---
+
+## Limitations and Caveats
+
+- **Analysis paralysis**: Waiting for perfect 3/3 alignment across all timeframes can mean missing many valid trades. Perfect alignment is rare — 2/3 is often sufficient
+- **Timeframe conflicts are common**: It is normal for timeframes to disagree. This is information, not a problem. When they conflict, the Higher TF takes precedence
+- **Data requirements**: Multi-timeframe analysis requires sufficient historical data across all timeframes. Limited data on higher timeframes (e.g., only 30 weekly bars) may produce unreliable trend readings
+- **Speed of analysis**: In fast-moving markets, completing a full three-tier analysis before the Lower TF trigger passes can be challenging. Preparation (pre-identifying Higher and Middle TF levels) helps
+- **Not a prediction tool**: MTA aligns your trades with the dominant trend — it does not predict reversals or new trends. All three timeframes can agree and the trade can still lose if an unexpected catalyst appears
+
+---
+
+## AI Analysis Instructions
+
+Analyze the available price data across the timeframes provided. Determine the trend on the highest available timeframe, identify setups on the middle timeframe, and note any entry triggers on the lowest timeframe.
+
+If only one timeframe of data is available, analyze that timeframe's trend, support/resistance, and momentum, then recommend what to look for on higher and lower timeframes for confirmation.
+
+Return the summary in **this exact structured format** (one `**label**: value` pair per line):
+
+```
+**상위 시간대 추세**: [추세 방향, 예: "일봉 기준 상승 추세 — 가격 MA50/MA200 상방, Higher High/Higher Low 패턴"]
+**중간 시간대 셋업**: [감지된 셋업, 예: "4시간봉 MA20 지지 테스트 중 — 풀백 매수 셋업 형성"]
+**하위 시간대 타이밍**: [진입 트리거, 예: "1시간봉 RSI 30선 상향 돌파 + 망치형 캔들 — 진입 트리거 발생"]
+**시간대 정렬도**: [정렬 점수, 예: "3/3 강한 정렬 — 전 시간대 상승 방향 일치" / "2/3 보통 — 상위·중간 상승, 하위 미확인"]
+**방향성 판단**: [종합 방향, 예: "LONG ONLY — 상위 시간대 상승 추세 확인. 하위 시간대에서 매수 진입만 허용"]
+**매매 신호**: [현재 실행 가능한 신호, 예: "상위 상승 + 중간 풀백 지지 + 하위 반전 확인 = 매수 진입 적합" / "시간대 충돌로 진입 보류"]
+**상세 분석**: [각 시간대별 분석 요약, 정렬 상태, 주요 지지·저항, 진입·손절·목표가, 주의사항을 포함한 상세 분석 문단]
+```
+
+Additional output rules:
+- If **only one timeframe** is available, state what you can conclude from it and what additional timeframes would provide
+- If **Higher TF conflicts** with the Middle/Lower TF trade direction, explicitly warn against counter-trend entry
+- If **all three timeframes align**, flag as a high-confidence setup
+- If the Higher TF shows **late-stage exhaustion** (extreme RSI, multiple divergences), warn even if direction aligns
+- Set the `trend` field: `bullish` if Higher TF uptrend confirmed and at least 2/3 tiers agree, `bearish` if Higher TF downtrend confirmed and at least 2/3 tiers agree, `neutral` if Higher TF range-bound or timeframes conflict

--- a/skills/strategies/multi-timeframe.md
+++ b/skills/strategies/multi-timeframe.md
@@ -187,9 +187,14 @@ Factors that decrease confidence:
 
 ## AI Analysis Instructions
 
-Analyze the available price data across the timeframes provided. Determine the trend on the highest available timeframe, identify setups on the middle timeframe, and note any entry triggers on the lowest timeframe.
+**Current system limitation**: The system currently provides data for a single timeframe per analysis request. Multi-timeframe data is not yet available simultaneously. When only one timeframe is provided, use the following approach:
 
-If only one timeframe of data is available, analyze that timeframe's trend, support/resistance, and momentum, then recommend what to look for on higher and lower timeframes for confirmation.
+1. Treat the provided timeframe as the **Middle TF (Strategy)** tier
+2. Infer the **Higher TF (Direction)** trend from longer-period indicators (MA50, MA200, long-term context data) and the overall price structure visible in the available bars
+3. Note what **Lower TF (Timing)** confirmation would be needed — recommend the user check a lower timeframe for precise entry triggers
+4. Assess alignment based on what can be determined: indicator trends, moving average positions, and support/resistance levels within the available data
+
+If multiple timeframes of data are available in the future, perform the full three-tier analysis as described above.
 
 Return the summary in **this exact structured format** (one `**label**: value` pair per line):
 

--- a/skills/strategies/wyckoff.md
+++ b/skills/strategies/wyckoff.md
@@ -1,0 +1,186 @@
+---
+name: 와이코프 방법론
+description: 수요와 공급의 법칙에 기반하여 축적-마크업-분배-마크다운 4단계 시장 사이클을 분석하고, 스마트머니의 행동을 추적하여 최적의 매매 시점을 판별하는 전략
+type: strategy
+category: neutral
+indicators: []
+confidence_weight: 0.65
+---
+
+## Overview
+
+The Wyckoff Method, developed by Richard Wyckoff in the 1930s, analyzes markets through the lens of supply and demand dynamics and the behavior of the "Composite Man" — an abstraction representing institutional (smart money) activity. The method identifies four recurring market phases: Accumulation, Markup, Distribution, and Markdown. By tracking volume-price relationships and structural patterns within each phase, traders can align their positions with institutional activity rather than against it.
+
+Three fundamental laws govern the Wyckoff framework:
+
+1. **Law of Supply and Demand**: Price moves up when demand exceeds supply, and down when supply exceeds demand. Price equilibrium produces consolidation.
+2. **Law of Effort vs. Result**: Volume (effort) should confirm price movement (result). Divergence between effort and result signals potential trend change.
+3. **Law of Cause and Effect**: A trading range (cause) produces a subsequent trend (effect). The width and duration of the range indicate the magnitude of the resulting trend.
+
+---
+
+## The Composite Man
+
+Assume a single entity — the Composite Man — controls market activity. His behavior follows a repeating pattern:
+
+1. **Accumulates** shares at low prices during a trading range (Accumulation)
+2. **Marks up** the price by driving demand (Markup)
+3. **Distributes** shares at high prices during a new trading range (Distribution)
+4. **Marks down** the price by withdrawing support (Markdown)
+
+The trader's objective is to identify which phase the Composite Man is currently executing and align accordingly.
+
+---
+
+## Four Market Phases
+
+### Phase 1: Accumulation
+
+Smart money quietly buys at depressed prices. Price moves sideways with volume patterns revealing institutional activity.
+
+**Sub-phases**:
+
+| Sub-phase | Key Events | Description |
+|---|---|---|
+| Phase A | PS → SC → AR → ST | Stopping of the prior downtrend. Preliminary Support (PS) slows decline, Selling Climax (SC) marks capitulation with extreme volume, Automatic Rally (AR) establishes upper range boundary, Secondary Test (ST) retests SC area on decreased volume |
+| Phase B | ST in Phase B, Tests | Building a cause. Wide-range price swings within AR-SC boundaries. Volume tests of supply and demand |
+| Phase C | Spring / LPS | The critical test. **Spring** — a brief dip below SC support that traps sellers, then rapidly reverses. This is the highest-probability buy signal. Last Point of Support (LPS) confirms successful Spring test |
+| Phase D | SOS, LPS, Backup | Markup begins. Sign of Strength (SOS) — price rises on expanding volume, clearly breaking above the range. Last Point of Support (LPS) in Phase D is the final pullback before sustained markup |
+| Phase E | Exit range | Price exits the trading range and enters sustained markup |
+
+**Key volume signatures in Accumulation**:
+- SC: extreme volume spike, wide-range bar closing well off lows
+- ST: reduced volume relative to SC (diminished selling pressure)
+- Spring: volume spike on the break below support, then immediate reversal
+- SOS: increasing volume on upward moves, decreasing volume on pullbacks
+
+### Phase 2: Markup
+
+Price trends upward with higher highs and higher lows. Demand consistently exceeds supply. Pullbacks are shallow and brief. Volume expands on advances and contracts on corrections.
+
+### Phase 3: Distribution
+
+Smart money sells holdings to the public at elevated prices. Price moves sideways with volume patterns revealing institutional selling.
+
+Distribution is the structural mirror of Accumulation:
+
+| Accumulation Event | Distribution Equivalent |
+|---|---|
+| Selling Climax (SC) | Buying Climax (BC) |
+| Automatic Rally (AR) | Automatic Reaction (AR) |
+| Spring (below support) | Upthrust After Distribution (UTAD) — a brief push above resistance that traps buyers, then reverses sharply. Primary sell signal |
+| Sign of Strength (SOS) | Sign of Weakness (SOW) — price drops on expanding volume |
+| Last Point of Support (LPS) | Last Point of Supply (LPSY) — final rally attempt fails on weak volume |
+
+### Phase 4: Markdown
+
+Price trends downward with lower highs and lower lows. Supply consistently exceeds demand. Bounces are shallow and brief. Volume may expand on declines.
+
+---
+
+## Key Wyckoff Events
+
+| Event | Phase | Description | Volume Signature |
+|---|---|---|---|
+| PS (Preliminary Support) | Accumulation A | First significant buying after prolonged decline | Moderate increase |
+| SC (Selling Climax) | Accumulation A | Capitulation — extreme panic selling | Extreme spike |
+| AR (Automatic Rally) | Accumulation A | Sharp bounce after SC, establishes upper boundary | Moderate |
+| ST (Secondary Test) | Accumulation A/B | Retests SC area to confirm demand absorption | Lower than SC |
+| Spring | Accumulation C | False breakdown below SC support — primary buy signal | Spike then reversal |
+| SOS (Sign of Strength) | Accumulation D | Breakout above AR on expanding volume | Strong increase |
+| BC (Buying Climax) | Distribution A | Peak euphoria — extreme buying | Extreme spike |
+| UTAD (Upthrust After Distribution) | Distribution C | False breakout above BC resistance — primary sell signal | Spike then reversal |
+| SOW (Sign of Weakness) | Distribution D | Breakdown below AR on expanding volume | Strong increase |
+
+---
+
+## Entry and Exit Rules
+
+### Long Entry (Accumulation)
+
+1. **Primary signal**: Spring confirmed — price dips below support, volume spikes, then reverses back above support within 1-3 bars
+2. **Confirmation**: SOS follows the Spring — price breaks above the trading range on increasing volume
+3. **Conservative entry**: LPS in Phase D — pullback after SOS holds above the middle of the trading range
+4. **Stop loss**: Below the Spring low (or below SC low for wider stop)
+
+### Short Entry (Distribution)
+
+1. **Primary signal**: UTAD confirmed — price pushes above resistance, volume spikes, then reverses back below resistance within 1-3 bars
+2. **Confirmation**: SOW follows the UTAD — price breaks below the trading range on increasing volume
+3. **Conservative entry**: LPSY in Phase D — rally after SOW fails to reach the middle of the trading range
+4. **Stop loss**: Above the UTAD high (or above BC high for wider stop)
+
+### Exit Rules
+
+- **Long exit**: Signs of Distribution emerging — BC pattern, widening volume on declines within a range
+- **Short exit**: Signs of Accumulation emerging — SC pattern, declining volume on drops within a range
+- **Trailing stop**: Move stop to the most recent LPS (long) or LPSY (short) as the trend progresses
+
+---
+
+## Effort vs. Result Analysis
+
+Volume-price divergence is central to Wyckoff analysis:
+
+| Volume (Effort) | Price (Result) | Interpretation |
+|---|---|---|
+| High volume | Large price move in same direction | Harmony — trend likely continues |
+| High volume | Small price move or no progress | Divergence — opposition is absorbing. Possible reversal |
+| Low volume | Price holds or rises in uptrend | Supply dried up — bullish continuation likely |
+| Low volume | Price holds or drops in downtrend | Demand dried up — bearish continuation likely |
+
+---
+
+## Confidence Weight Rationale
+
+confidence_weight: 0.65 — Wyckoff analysis requires significant interpretive judgment. Phase identification, especially real-time distinction between Accumulation Phase B and continued range-bound trading, is inherently subjective. The method's strength lies in its comprehensive framework rather than precise entry/exit signals. Combined with other strategies (especially volume-based indicators), reliability increases substantially.
+
+Factors that increase confidence:
+- Volume patterns clearly confirm phase identification (SC/BC with extreme volume)
+- Spring or UTAD events produce immediate, decisive reversals
+- Multiple Wyckoff events align in sequence (ST → Spring → SOS progression)
+- Price-volume harmony on trend moves after exiting the trading range
+
+Factors that decrease confidence:
+- Trading range lacks clear SC/BC event (gradual rather than climactic)
+- Multiple Springs or UTADs without follow-through (whipsaw conditions)
+- Low overall volume makes effort-result analysis unreliable
+- Range duration is too short to establish meaningful cause
+
+---
+
+## Limitations and Caveats
+
+- Real-time phase identification is the primary challenge — in hindsight, phases are clear; in real-time, Phase B can persist far longer than expected
+- Springs and UTADs can fail — not every false breakout leads to reversal. Confirmation via SOS/SOW is essential
+- The method was developed for individual stocks and is most effective where institutional volume patterns are visible. Highly liquid index ETFs may show less distinct Wyckoff patterns
+- Modern algorithmic trading can create synthetic volume patterns that mimic Wyckoff events
+- Must be combined with other analysis methods (indicators, trend analysis) for confirmation
+
+---
+
+## AI Analysis Instructions
+
+Use the **last 120 bars maximum** for analysis. Focus on identifying the most recent phase and any active Wyckoff events.
+
+Analyze the price-volume relationship to determine the current Wyckoff phase. Pay special attention to:
+- Volume behavior at range boundaries (support/resistance tests)
+- Whether effort (volume) matches result (price movement)
+- The presence of climactic events (SC, BC, Spring, UTAD)
+
+Return the summary in **this exact structured format** (one `**label**: value` pair per line):
+
+```
+**현재 시장 단계**: [축적(Accumulation) / 마크업(Markup) / 분배(Distribution) / 마크다운(Markdown) / 판별 불가]
+**세부 단계**: [해당 시 Phase A~E 명시, 예: "축적 Phase C — Spring 테스트 진행 중"]
+**핵심 이벤트**: [감지된 와이코프 이벤트, 예: "SC($120, 거래량 급증) → AR($145) → ST($125, 감소된 거래량) → Spring 대기 중"]
+**노력 대비 결과**: [현재 거래량-가격 관계 분석, 예: "고거래량 + 소폭 하락 = 매집 흡수 진행 중 (조화/괴리 판단)"]
+**매매 신호**: [현재 활성화된 신호, 예: "Spring 확인 — 매수 진입 적합" / "UTAD 확인 — 매도 진입 적합" / "명확한 신호 없음"]
+**상세 분석**: [전체적인 시장 구조, 거래 범위 특성, Composite Man의 행동 추정, 주의사항을 포함한 상세 분석 문단]
+```
+
+Additional output rules:
+- If the market is in a **trading range** (Accumulation or Distribution), identify sub-phase (A through E) and describe expected next events
+- If the market is in a **trending phase** (Markup or Markdown), assess trend health via volume-price harmony
+- If no clear Wyckoff structure is identifiable, state "와이코프 구조 불명확 — 횡보 구간 또는 데이터 부족" and explain why
+- Set the `trend` field: `bullish` if in Accumulation Phase C-E or Markup, `bearish` if in Distribution Phase C-E or Markdown, `neutral` if in early Accumulation/Distribution (Phase A-B) or unclear

--- a/skills/strategies/wyckoff.md
+++ b/skills/strategies/wyckoff.md
@@ -4,7 +4,7 @@ description: 수요와 공급의 법칙에 기반하여 축적-마크업-분배-
 type: strategy
 category: neutral
 indicators: []
-confidence_weight: 0.65
+confidence_weight: 0.0
 ---
 
 ## Overview
@@ -133,7 +133,7 @@ Volume-price divergence is central to Wyckoff analysis:
 
 ## Confidence Weight Rationale
 
-confidence_weight: 0.65 — Wyckoff analysis requires significant interpretive judgment. Phase identification, especially real-time distinction between Accumulation Phase B and continued range-bound trading, is inherently subjective. The method's strength lies in its comprehensive framework rather than precise entry/exit signals. Combined with other strategies (especially volume-based indicators), reliability increases substantially.
+confidence_weight: 0.00 (disabled) — Wyckoff analysis requires 60-120 bars of detailed OHLCV data for reliable phase identification, but the system currently provides ~30 bars. Disabled until extended bar data is available. Original weight was 0.65, reflecting that Wyckoff analysis requires significant interpretive judgment. Phase identification, especially real-time distinction between Accumulation Phase B and continued range-bound trading, is inherently subjective. The method's strength lies in its comprehensive framework rather than precise entry/exit signals. Combined with other strategies (especially volume-based indicators), reliability increases substantially.
 
 Factors that increase confidence:
 - Volume patterns clearly confirm phase identification (SC/BC with extreme volume)
@@ -160,6 +160,8 @@ Factors that decrease confidence:
 ---
 
 ## AI Analysis Instructions
+
+**This strategy is currently disabled** (confidence_weight set to 0.0) because Wyckoff analysis requires a minimum of 60-120 bars of detailed OHLCV data to identify accumulation/distribution phases and key events (SC, AR, ST, Spring, UTAD). The system currently provides ~30 bars of detailed data, which is insufficient for reliable phase identification. Re-enable this strategy when the system can provide extended bar data without exceeding prompt length limits.
 
 Use the **last 120 bars maximum** for analysis. Focus on identifying the most recent phase and any active Wyckoff events.
 


### PR DESCRIPTION
## 관련 이슈

closes #236

## 구현 내용

6개의 새로운 전략 스킬 마크다운 파일을 skills/strategies/ 디렉토리에 추가:
- **wyckoff.md** - Wyckoff Method 분석 (축적/상승/분배/하락 단계)
- **divergence.md** - Divergence Trading (가격 vs 오실레이터 다이버전스를 통한 반전/지속 신호)
- **fibonacci.md** - Fibonacci Strategy (되돌림/확장 레벨을 통한 지지/저항 및 목표가)
- **breakout.md** - Breakout Strategy (범위/패턴/MA/Donchian 브레이크아웃, 거짓 신호 필터)
- **mean-reversion.md** - Mean Reversion Strategy (Bollinger/RSI를 활용한 과매도/과매수 평균 회귀)
- **multi-timeframe.md** - Multi-Timeframe Analysis (3-계층 시간대 프레임워크를 통한 방향성 정렬)

FileSkillsLoader가 skills/ 디렉토리의 새로운 .md 파일을 자동으로 감지하므로 코드 변경 없이 콘텐츠만 추가.

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] 콘텐츠 전용 추가 (코드 변경 없음)

## 변경 파일 목록

[생성]
- skills/strategies/wyckoff.md
- skills/strategies/divergence.md
- skills/strategies/fibonacci.md
- skills/strategies/breakout.md
- skills/strategies/mean-reversion.md
- skills/strategies/multi-timeframe.md

[수정] 없음

## CI Check lists

- [x] yarn format (콘텐츠 파일이므로 불필요)
- [x] yarn lint (콘텐츠 파일이므로 불필요)
- [x] yarn lint:style (콘텐츠 파일이므로 불필요)
- [x] yarn test (콘텐츠 파일이므로 불필요)
- [x] yarn build (콘텐츠 파일이므로 성공)