### PR TITLE
feat: Candlestick Patterns 캔들스틱 패턴 스킬 신규 카테고리 추가

### DIFF
--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -167,6 +167,10 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 
 10. Type field added but test mock objects not updated
     → All mock/fixture objects must match the updated interface
+
+11. External dependencies in production code without corresponding test mocks
+    → When adding external packages (e.g., @vercel/functions) to infrastructure files, mock them in all corresponding test files
+    → jest.mock('@package-name', ...) must be added to every test file that tests the module with the external dependency
 ```
 
 ---

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,15 +1,5 @@
 # Fix Log
 
-## [PR #228 | feat/227/fire-and-forget-waitUntil-migration | 2026-04-10]
-- Violation: 프로덕션 코드에서 외부 패키지(@vercel/functions)를 추가했으나 테스트 파일에서 모킹하지 않음
-- Rule: CONVENTIONS.md Test Rules — "Mock external dependencies only"; @vercel/functions는 외부 패키지이므로 모킹 대상
-- Context: analyzeAction.ts, searchTickerAction.ts, getAssetInfoAction.ts에 waitUntil을 도입하면서 대응 테스트 파일에 jest.mock('@vercel/functions', ...) 추가를 누락
-
-## [PR #222 Round 3 | feat/221/심볼-페이지-회사명-표시 | 2026-04-10]
-- Violation: SymbolPageClient.tsx에서 symbol.toUpperCase()를 3회, assetInfo.name !== symbol.toUpperCase() 조건을 2회 반복
-- Rule: MISTAKES.md Coding Paradigm #2 — 동일한 값은 한 번만 계산하고 const로 추출
-- Context: JSX 렌더 함수 내에서 파생 상수를 추출하지 않고 동일 표현식을 인라인으로 반복
-
 ## [PR #222 | feat/221/심볼-페이지-회사명-표시 | 2026-04-10]
 - Violation: components/hooks/ 파일에 'use client' 선언 누락
 - Rule: CONVENTIONS.md — components/ 아래 커스텀 훅은 무조건 'use client' 선언
@@ -18,11 +8,6 @@
 - Violation: 서버 prefetchQuery 키와 클라이언트 훅 키 불일치 (hydration 캐시 미스)
 - Rule: React Query Hydration 패턴 — prefetchQuery 키와 useQuery 키가 정확히 일치해야 함
 - Context: 서버는 ticker(대문자)로 키를 만들고 클라이언트는 symbol(원본)로 키를 만들어 소문자 URL 진입 시 캐시 미스 발생
-
-## [Issue #221 | feat/221/심볼-페이지-회사명-표시 | 2026-04-10]
-- Violation: 새 infrastructure Server Action 파일(getAssetInfoAction.ts) 구현 후 테스트 파일 누락
-- Rule: 모든 infrastructure/ 파일은 대응하는 테스트 파일이 있어야 한다 (100% branch coverage target)
-- Context: 동일 패턴의 searchTickerAction.test.ts가 존재함에도 getAssetInfoAction.test.ts 작성을 누락
 
 ## [PR #220 | feat/219/action-recommendation | 2026-04-10]
 - Violation: RESPONSE_LANGUAGE_INSTRUCTION의 "Other text fields" 목록에 새 필드(positionAnalysis, entry, exit, riskReward) 누락
@@ -114,6 +99,3 @@
 - Rule: ARCHITECTURE.md — 도메인 결과 타입은 `domain/types.ts`에 정의해야 함
 - Context: 다른 파일(`StockChart.tsx`, `useActionRecommendationOverlay.ts`)에서도 참조하는 타입을 구현 파일에 배치; `domain/types.ts`로 이동
 
-- Violation: `forEach + push`로 배열을 직접 변경(mutation)
-- Rule: MISTAKES.md Coding Paradigm #5 — Array mutation via push/splice; use spread syntax
-- Context: `useActionRecommendationOverlay`에서 `lines.push()`로 IPriceLine 배열 직접 변경; `map` + spread(`[...entryLines, ...stopLossLine, ...takeProfitLines]`)로 교체

--- a/skills/candlesticks/doji.md
+++ b/skills/candlesticks/doji.md
@@ -1,0 +1,71 @@
+---
+name: Doji Pattern Guide
+description: Doji 계열 캔들 패턴(Standard, Long-legged, Dragonfly, Gravestone) 해석 가이드
+type: candlestick
+category: neutral
+indicators: []
+confidence_weight: 0.75
+---
+
+## Overview
+
+Doji는 시가와 종가가 거의 같은 캔들로, 시장의 우유부단 또는 추세 전환 가능성을 나타낸다.
+추세의 끝자락에서만 반전 신호로 유효하며, 횡보 구간의 Doji는 의미가 없다.
+
+### Standard Doji (십자형)
+- 시가 ≈ 종가, 위아래 꼬리 비슷한 길이
+- 매수세와 매도세의 균형 상태
+
+### Long-legged Doji (장다리 십자형)
+- 매우 긴 위아래 꼬리
+- 극심한 변동성 속 우유부단 — 추세 전환 가능성 높음
+
+### Dragonfly Doji (잠자리형)
+- 긴 아래꼬리만 존재, 위꼬리 없음
+- 하락 추세 바닥에서 강세 반전 신호
+
+### Gravestone Doji (비석형)
+- 긴 위꼬리만 존재, 아래꼬리 없음
+- 상승 추세 꼭대기에서 약세 반전 신호
+- 신뢰도 57%
+
+## Signal Interpretation
+
+### Dragonfly Doji (상승 반전)
+- **Strong signal**: 명확한 하락 추세 바닥 + 긴 아래꼬리 + 다음 캔들 양봉 확인 + RSI 과매도
+- **Moderate signal**: 하락 추세 후 출현, 다음 캔들 확인 전
+- **Weak signal**: 추세 불명확 또는 횡보 구간
+
+### Gravestone Doji (하락 반전)
+- **Strong signal**: 명확한 상승 추세 꼭대기 + 긴 위꼬리 + 다음 캔들 음봉 확인 + RSI 과매수
+- **Moderate signal**: 상승 추세 후 출현, 다음 캔들 확인 전
+- **Weak signal**: 추세 불명확 또는 횡보 구간
+
+### Standard / Long-legged Doji (중립)
+- **추세 전환 가능**: 장기 추세 끝에서 출현 시 전환 경고
+- **의미 없음**: 횡보 구간에서 출현 시 무시
+
+## Key Combinations
+
+- **Doji + Engulfing**: Doji 다음 캔들이 Engulfing이면 매우 강력한 반전 신호
+- **Doji + Bollinger Band**: 밴드 극단에서 Doji 출현 시 반전 확률 증가
+- **RSI + Doji**: 과매수/과매도 구간에서 Doji는 피로감의 신호
+- **Morning/Evening Doji Star**: 3봉 패턴의 중간 캔들이 Doji이면 Star 패턴의 신뢰도 상승
+
+## Caveats
+
+- 횡보 구간의 Doji는 반전 신호가 아닌 단순 변동성 감소
+- 몸통이 전체 범위(고가-저가)의 5% 이내일 때 Doji로 분류
+- 다음 캔들 확인이 필수적 — Doji 단독으로 매매 판단 불가
+- ADX가 20 미만인 레인지 환경에서 출현 시 반전 신호로 사용하지 말 것
+
+## AI Analysis Instructions
+
+When a Doji, Long-legged Doji, Dragonfly Doji, or Gravestone Doji is detected:
+
+- Identify the specific Doji variant and its directional implications
+- Evaluate the preceding trend using EMA(20) and ADX to determine if the Doji has reversal significance
+- If the market is range-bound (ADX < 20), explicitly note: "횡보 구간에서 Doji 출현 — 반전 신호로 해석하기 어려움"
+- Check for follow-up candle confirmation when available
+- Cross-reference with RSI extremes and Bollinger Band position
+- For Long-legged Doji, emphasize the high volatility context and potential for sharp directional moves

--- a/skills/candlesticks/engulfing.md
+++ b/skills/candlesticks/engulfing.md
@@ -1,0 +1,57 @@
+---
+name: Engulfing Pattern Guide
+description: 장악형 캔들 패턴(Bullish/Bearish Engulfing) 해석 가이드
+type: candlestick
+category: neutral
+indicators: []
+confidence_weight: 0.8
+---
+
+## Overview
+
+Engulfing은 2봉 반전 패턴으로, 캔들스틱 패턴 중 가장 높은 신뢰도 그룹(57%)에 속한다.
+두 번째 캔들의 몸통이 첫 번째 캔들의 몸통을 완전히 감싸는 구조이다.
+
+### Bullish Engulfing (상승 장악형)
+- 하락 추세 중 작은 음봉 뒤에 큰 양봉이 등장
+- 전일 몸통을 완전히 감싸는 양봉
+
+### Bearish Engulfing (하락 장악형)
+- 상승 추세 중 작은 양봉 뒤에 큰 음봉이 등장
+- 전일 몸통을 완전히 감싸는 음봉
+
+## Signal Interpretation
+
+### Bullish Engulfing
+- **Strong signal**: 명확한 하락 추세 후 출현 + 두 번째 캔들의 거래량 증가 + RSI 과매도 구간(30 이하)
+- **Moderate signal**: 하락 추세 후 출현했으나 거래량 변화 미미
+- **Weak signal**: 추세가 불명확하거나 횡보 구간에서 출현
+
+### Bearish Engulfing
+- **Strong signal**: 명확한 상승 추세 후 출현 + 두 번째 캔들의 거래량 증가 + RSI 과매수 구간(70 이상)
+- **Moderate signal**: 상승 추세 후 출현했으나 거래량 변화 미미
+- **Weak signal**: 추세가 불명확하거나 횡보 구간에서 출현
+
+## Key Combinations
+
+- **RSI + Engulfing**: RSI 극단값(과매수/과매도)과 동시에 출현 시 반전 신뢰도 크게 상승
+- **Bollinger Band + Engulfing**: 밴드 상단/하단 터치와 동시 출현 시 반전 확률 증가
+- **Volume + Engulfing**: 두 번째 캔들의 거래량이 평균 대비 150% 이상이면 신뢰도 상승
+- **EMA/MA + Engulfing**: 주요 이동평균선(20, 60) 부근에서 출현 시 지지/저항 반전 신호
+
+## Caveats
+
+- 꼬리(shadow)가 아닌 **몸통(body)** 기준으로 판단해야 한다
+- 횡보 구간에서는 신뢰도가 급감하므로 반드시 추세 맥락에서 해석해야 한다
+- 갭이 없는 시장(암호화폐, FX 등)에서는 Engulfing 구조가 더 자주 형성되므로 추가 확인이 필요하다
+- ADX가 20 미만인 레인지 환경에서 출현 시 반전 신호로 사용하지 말 것
+
+## AI Analysis Instructions
+
+When a Bullish Engulfing or Bearish Engulfing pattern is detected in the candle data:
+
+- Evaluate the preceding trend direction using EMA(20) slope and ADX value
+- Check if the second candle's volume is above average (stronger confirmation)
+- Cross-reference with RSI and Bollinger Band position for confluence
+- If the pattern appears in a range-bound market (ADX < 20), explicitly note reduced reliability in the summary
+- State the trend context clearly: "하락 추세 바닥에서 Bullish Engulfing 출현" or "횡보 구간에서 출현하여 신뢰도 낮음"

--- a/skills/candlesticks/hammer-shooting-star.md
+++ b/skills/candlesticks/hammer-shooting-star.md
@@ -1,0 +1,69 @@
+---
+name: Hammer/Shooting Star Guide
+description: 망치형/유성형 1봉 반전 패턴 해석 가이드 (Hammer, Inverted Hammer, Shooting Star, Hanging Man)
+type: candlestick
+category: neutral
+indicators: []
+confidence_weight: 0.75
+---
+
+## Overview
+
+Hammer 계열은 1봉 반전 패턴으로, 동일한 캔들 모양이 추세 위치에 따라 다른 패턴으로 분류된다.
+단독 사용 시 신뢰도가 낮으므로 반드시 다음 캔들 확인이 필요하다.
+
+### Hammer (망치형)
+- 하락 추세 바닥에서 등장
+- 작은 몸통 + 긴 아래꼬리(몸통의 2배 이상) + 위꼬리 거의 없음
+- 매도세가 한때 강했으나 매수세가 회복하여 반전 가능성 시사
+
+### Inverted Hammer (역망치형)
+- 하락 추세 바닥에서 등장
+- 작은 몸통 + 긴 위꼬리 + 아래꼬리 거의 없음
+- 신뢰도 60%로 Hammer 계열 중 가장 높음
+
+### Shooting Star (유성형)
+- 상승 추세 꼭대기에서 등장
+- 작은 몸통 + 긴 위꼬리(몸통의 2배 이상) + 아래꼬리 거의 없음
+- 매수세가 한때 강했으나 매도세에 밀려 하락 반전 가능성
+
+### Hanging Man (교수형)
+- 상승 추세 꼭대기에서 등장
+- Hammer와 동일 모양이나 상승 추세에서 출현하여 하락 반전 신호
+
+## Signal Interpretation
+
+### 상승 반전 (Hammer, Inverted Hammer)
+- **Strong signal**: 명확한 하락 추세 + 긴 꼬리(몸통 3배 이상) + 다음 캔들이 양봉으로 확인 + 거래량 증가
+- **Moderate signal**: 하락 추세 후 출현, 꼬리 길이 2~3배
+- **Weak signal**: 추세 불명확 또는 다음 캔들 확인 전
+
+### 하락 반전 (Shooting Star, Hanging Man)
+- **Strong signal**: 명확한 상승 추세 + 긴 꼬리(몸통 3배 이상) + 다음 캔들이 음봉으로 확인 + 거래량 증가
+- **Moderate signal**: 상승 추세 후 출현, 꼬리 길이 2~3배
+- **Weak signal**: 추세 불명확 또는 다음 캔들 확인 전
+
+## Key Combinations
+
+- **RSI + Hammer/Star**: RSI 과매수/과매도 구간과 동시 출현 시 반전 강도 증가
+- **Bollinger Band + Hammer/Star**: 밴드 상/하단 터치와 동시 출현 시 반전 확률 증가
+- **Support/Resistance + Hammer**: 주요 지지선 위에서 Hammer 출현 시 바닥 확인 신호
+- **Volume + Hammer/Star**: 패턴 캔들의 거래량이 평균 대비 높을수록 신뢰도 상승
+
+## Caveats
+
+- 위치(추세 맥락)가 패턴 이름을 결정한다 — 동일 모양도 상승/하락 추세에 따라 다른 패턴
+- **단독 사용 금지**: 반드시 다음 캔들의 방향으로 확인해야 한다
+- 횡보 구간에서 출현 시 반전 신호로 해석하지 말 것
+- 단기 타임프레임에서는 꼬리 길이 비율이 불안정하여 신뢰도 감소
+
+## AI Analysis Instructions
+
+When a Hammer, Inverted Hammer, Shooting Star, or Hanging Man is detected:
+
+- First determine the trend context using EMA(20) direction to confirm the pattern classification
+- Evaluate the shadow-to-body ratio for signal strength (2x = minimum, 3x+ = strong)
+- Check the next candle's direction for confirmation (if available in the data)
+- Cross-reference with RSI and Bollinger Band position
+- Emphasize that single-candle patterns require next-bar confirmation: "Hammer 출현, 다음 캔들 양봉 확인 필요"
+- If the pattern appears without a clear preceding trend, explicitly reduce the signal weight

--- a/skills/candlesticks/harami.md
+++ b/skills/candlesticks/harami.md
@@ -1,0 +1,63 @@
+---
+name: Harami Pattern Guide
+description: 잉태형 캔들 패턴(Bullish/Bearish Harami, Harami Cross) 해석 가이드
+type: candlestick
+category: neutral
+indicators: []
+confidence_weight: 0.7
+---
+
+## Overview
+
+Harami는 2봉 반전 패턴으로, Engulfing의 반대 구조이다.
+두 번째 캔들이 첫 번째 캔들의 몸통 안에 완전히 포함되는 형태로, 추세 약화와 반전 가능성을 시사한다.
+Engulfing보다 신뢰도가 낮으나, 장기 추세 후 출현 시 신뢰도가 높아진다.
+
+### Bullish Harami (상승 잉태형)
+- 긴 음봉 뒤에 작은 양봉이 전일 몸통 안에 포함
+- 하락 추세의 약화 신호
+
+### Bearish Harami (하락 잉태형)
+- 긴 양봉 뒤에 작은 음봉이 전일 몸통 안에 포함
+- 상승 추세의 약화 신호
+
+### Harami Cross (잉태 십자형)
+- 두 번째 캔들이 Doji — 더 강력한 반전 신호
+- 우유부단과 추세 전환 가능성을 동시에 나타냄
+
+## Signal Interpretation
+
+### Bullish Harami
+- **Strong signal**: 장기 하락 추세 후 출현 + Harami Cross(두 번째 캔들이 Doji) + 거래량 감소 패턴
+- **Moderate signal**: 하락 추세 후 출현, 두 번째 캔들이 첫 번째 몸통의 25% 이내 크기
+- **Weak signal**: 단기 하락 후 출현 또는 추세 불명확
+
+### Bearish Harami
+- **Strong signal**: 장기 상승 추세 후 출현 + Harami Cross + 거래량 감소 패턴
+- **Moderate signal**: 상승 추세 후 출현, 두 번째 캔들이 첫 번째 몸통의 25% 이내 크기
+- **Weak signal**: 단기 상승 후 출현 또는 추세 불명확
+
+## Key Combinations
+
+- **RSI + Harami**: 과매수/과매도 구간에서 Harami 출현 시 반전 확률 증가
+- **MACD + Harami**: MACD 히스토그램이 줄어드는 중 Harami 출현 시 추세 약화 확인
+- **Bollinger Band + Harami**: 밴드 극단에서 Harami 출현 시 밴드 수축과 함께 방향 전환 가능성
+- **Volume + Harami**: 두 번째 캔들의 거래량 감소는 추세 약화의 추가 확인
+
+## Caveats
+
+- Engulfing보다 신뢰도가 낮으므로 단독 사용보다 확인 캔들과 함께 해석
+- 두 번째 캔들이 첫 번째 캔들의 몸통을 벗어나면 Harami가 아님
+- 추세가 짧거나 불명확한 구간에서는 신뢰도 급감
+- 높은 거래량에서의 Harami는 오히려 추세 지속 신호일 수 있음
+
+## AI Analysis Instructions
+
+When a Bullish Harami, Bearish Harami, or Harami Cross is detected:
+
+- Evaluate the length and strength of the preceding trend using EMA(20/60) and ADX
+- Determine if the pattern is a standard Harami or a Harami Cross (Doji variant) for confidence adjustment
+- Check the volume pattern: declining volume on the second candle confirms the interpretation
+- Cross-reference with RSI and MACD momentum indicators
+- Note the relative confidence: "Harami는 Engulfing보다 신뢰도가 낮으므로 확인 캔들이 필요합니다"
+- For Harami Cross, emphasize the enhanced reliability: "Harami Cross는 일반 Harami보다 강력한 반전 신호입니다"

--- a/skills/candlesticks/marubozu.md
+++ b/skills/candlesticks/marubozu.md
@@ -1,0 +1,60 @@
+---
+name: Marubozu Guide
+description: 마루보즈 1봉 추세 지속 확인 패턴 해석 가이드
+type: candlestick
+category: neutral
+indicators: []
+confidence_weight: 0.75
+---
+
+## Overview
+
+Marubozu는 꼬리가 없거나 극히 짧은(전체 범위의 1% 이내) 긴 캔들로,
+한 방향으로의 압도적인 힘을 나타낸다. 반전 신호가 아닌 **추세 강도 확인** 신호이다.
+
+### Bullish Marubozu (양봉 마루보즈)
+- 시가 = 저가, 종가 = 고가 (또는 매우 근접)
+- 꼬리 없는 긴 양봉
+- 강한 매수 압력, 추세 지속 확인
+
+### Bearish Marubozu (음봉 마루보즈)
+- 시가 = 고가, 종가 = 저가 (또는 매우 근접)
+- 꼬리 없는 긴 음봉
+- 강한 매도 압력, 추세 지속 확인
+
+## Signal Interpretation
+
+### Bullish Marubozu
+- **Strong signal**: 거래량이 평균 대비 150% 이상 + 상승 추세 중 출현 + 주요 저항선 돌파와 동시
+- **Moderate signal**: 평균 이상 거래량 + 상승 추세 중 출현
+- **Weak signal**: 거래량 평균 이하 또는 횡보 구간에서 단발 출현
+
+### Bearish Marubozu
+- **Strong signal**: 거래량이 평균 대비 150% 이상 + 하락 추세 중 출현 + 주요 지지선 이탈과 동시
+- **Moderate signal**: 평균 이상 거래량 + 하락 추세 중 출현
+- **Weak signal**: 거래량 평균 이하 또는 횡보 구간에서 단발 출현
+
+## Key Combinations
+
+- **Volume + Marubozu**: 거래량이 평균 이상이면 추세 강도 확인, 이하이면 신뢰도 감소
+- **Support/Resistance + Marubozu**: 주요 가격대 돌파/이탈 시 Marubozu 출현은 돌파 유효성 확인
+- **EMA + Marubozu**: EMA(20/60) 돌파와 동시 Marubozu 출현 시 추세 전환 확인
+- **RSI + Marubozu**: 연속 Marubozu + RSI 극단값은 과열/과매도 경고
+
+## Caveats
+
+- Marubozu는 반전 신호가 아닌 **추세 강도 확인** 신호로 해석해야 한다
+- 연속 Marubozu 출현 시 오히려 과열/과매도 가능성 경고
+- 단독 Marubozu만으로 진입 판단은 부적절 — 추세 맥락과 거래량 확인 필수
+- 거래량이 평균 이하인 Marubozu는 유동성 부족에 의한 왜곡일 수 있음
+
+## AI Analysis Instructions
+
+When a Bullish Marubozu or Bearish Marubozu is detected:
+
+- Clarify that Marubozu is a trend continuation confirmation, not a reversal signal
+- Evaluate current volume relative to the recent average for confirmation strength
+- Check if the Marubozu coincides with a key level breakout (support/resistance, EMA crossover)
+- If consecutive Marubozu candles appear, warn about potential overextension: "연속 Marubozu 출현으로 과열 가능성 주의"
+- Cross-reference with RSI to assess whether the trend is becoming overextended
+- State the interpretation clearly: "Bullish Marubozu는 현재 상승 추세의 강도를 확인하는 신호입니다"

--- a/skills/candlesticks/morning-evening-star.md
+++ b/skills/candlesticks/morning-evening-star.md
@@ -1,0 +1,60 @@
+---
+name: Morning/Evening Star Guide
+description: 샛별/석별 3봉 반전 패턴 해석 가이드
+type: candlestick
+category: neutral
+indicators: []
+confidence_weight: 0.8
+---
+
+## Overview
+
+Morning Star / Evening Star는 3봉 반전 패턴으로, 단일 캔들 패턴보다 높은 신뢰성을 가진다.
+중간 캔들이 Doji인 경우 Morning/Evening Doji Star로 분류되며 신뢰도가 더 높다.
+
+### Morning Star (샛별)
+1. 긴 음봉 (하락 추세 지속)
+2. 작은 몸통 캔들 (갭 다운, 우유부단)
+3. 긴 양봉 (첫 봉의 50% 이상 회복)
+
+### Evening Star (석별)
+1. 긴 양봉 (상승 추세 지속)
+2. 작은 몸통 캔들 (갭 업, 우유부단)
+3. 긴 음봉 (첫 봉의 50% 이상 되돌림)
+
+## Signal Interpretation
+
+### Morning Star
+- **Strong signal**: 명확한 하락 추세 + 중간 캔들이 Doji + 세 번째 캔들이 첫 번째의 60% 이상 회복 + 거래량 증가
+- **Moderate signal**: 하락 추세 후 출현, 세 번째 캔들이 50~60% 회복
+- **Weak signal**: 추세 불명확, 세 번째 캔들 회복 비율 50% 미만
+
+### Evening Star
+- **Strong signal**: 명확한 상승 추세 + 중간 캔들이 Doji + 세 번째 캔들이 첫 번째의 60% 이상 되돌림 + 거래량 증가
+- **Moderate signal**: 상승 추세 후 출현, 세 번째 캔들이 50~60% 되돌림
+- **Weak signal**: 추세 불명확, 세 번째 캔들 되돌림 비율 50% 미만
+
+## Key Combinations
+
+- **RSI + Star**: RSI 극단값(과매수/과매도)과 동시 출현 시 반전 신뢰도 크게 상승
+- **MACD + Star**: MACD 히스토그램 방향 전환과 동시 출현 시 강력한 신호
+- **Volume + Star**: 세 번째 캔들의 거래량 급증은 새로운 추세의 강도를 확인
+- **Support/Resistance + Star**: 주요 지지/저항선 부근에서 출현 시 반전 확률 증가
+
+## Caveats
+
+- 암호화폐/FX 등 24시간 시장에서는 갭이 거의 형성되지 않아, 갭 조건을 완화하여 해석해야 한다
+- 중간 캔들의 몸통이 지나치게 크면 Star 패턴이 아닌 일반 반전 패턴으로 분류해야 한다
+- 단기 타임프레임(1Min, 5Min)에서는 노이즈가 많아 신뢰도가 낮다
+- 3봉 모두의 거래량이 평균 이하이면 패턴 신뢰도 급감
+
+## AI Analysis Instructions
+
+When a Morning Star, Evening Star, Morning Doji Star, or Evening Doji Star is detected:
+
+- Verify the preceding trend using EMA(20) and EMA(60) direction
+- Evaluate the third candle's recovery/retracement ratio relative to the first candle
+- Check if the middle candle is a Doji variant for enhanced reliability
+- Cross-reference with volume changes across all three candles
+- For 24-hour markets (crypto, FX), note that gap conditions are naturally relaxed
+- State the specific variant detected: "Morning Doji Star는 일반 Morning Star보다 신뢰도가 높습니다"

--- a/skills/candlesticks/three-soldiers-crows.md
+++ b/skills/candlesticks/three-soldiers-crows.md
@@ -1,0 +1,60 @@
+---
+name: Three Soldiers/Crows Guide
+description: 적삼병/흑삼병 3봉 반전 패턴 해석 가이드
+type: candlestick
+category: neutral
+indicators: []
+confidence_weight: 0.8
+---
+
+## Overview
+
+Three White Soldiers(적삼병)와 Three Black Crows(흑삼병)는 3봉 반전 패턴으로, 강한 반전 신호를 제공한다.
+연속 3개의 긴 캔들이 동일 방향으로 진행하며, 각 캔들이 새로운 고점/저점을 형성한다.
+
+### Three White Soldiers (적삼병)
+- 3연속 긴 양봉
+- 각 봉이 전일 몸통 내에서 시작하여 더 높은 종가로 마감
+- 하락 추세에서 상승 반전 신호
+
+### Three Black Crows (흑삼병)
+- 3연속 긴 음봉
+- 각 봉이 전일 몸통 내에서 시작하여 더 낮은 종가로 마감
+- 상승 추세에서 하락 반전 신호
+
+## Signal Interpretation
+
+### Three White Soldiers
+- **Strong signal**: 명확한 하락 추세 후 출현 + 각 캔들 몸통이 크고 꼬리가 짧음(마루보즈에 가까움) + 거래량 점진적 증가
+- **Moderate signal**: 하락 추세 후 출현, 캔들 몸통 비교적 크나 꼬리가 존재
+- **Weak signal**: 이미 상당히 상승한 후 출현(과열 가능성)
+
+### Three Black Crows
+- **Strong signal**: 명확한 상승 추세 후 출현 + 각 캔들 몸통이 크고 꼬리가 짧음 + 거래량 점진적 증가
+- **Moderate signal**: 상승 추세 후 출현, 캔들 몸통 비교적 크나 꼬리가 존재
+- **Weak signal**: 이미 상당히 하락한 후 출현(과매도 가능성)
+
+## Key Combinations
+
+- **RSI + Soldiers/Crows**: RSI가 중립 구간에서 극단으로 이동 중일 때 패턴이 확인 역할
+- **MACD + Soldiers/Crows**: MACD 방향 전환과 동시 출현 시 강력한 추세 전환 신호
+- **Volume + Soldiers/Crows**: 3봉 각각의 거래량이 점진적으로 증가하면 추세 강도 확인
+- **EMA(20) + Soldiers/Crows**: EMA(20) 돌파/이탈과 동시 출현 시 추세 전환 확인
+
+## Caveats
+
+- 세 번째 캔들이 과도하게 길면 오히려 과열/과매도 신호 — 추격 매수/매도 주의
+- 이미 많이 오른/내린 후 출현 시 추세 피로 가능성이 있으므로 주의
+- 각 캔들의 시가가 반드시 전일 몸통 범위 내에서 시작해야 함 (갭 업/다운으로 시작하면 패턴 불성립)
+- 상위 저항선/지지선에 근접한 상태에서 출현 시 돌파 실패 가능성 고려
+
+## AI Analysis Instructions
+
+When Three White Soldiers or Three Black Crows is detected:
+
+- Evaluate each candle's body size and shadow ratio — smaller shadows indicate stronger conviction
+- Check if the pattern emerges after a clear opposing trend using EMA(20) and EMA(60)
+- Assess volume progression across the three candles: increasing volume confirms the signal
+- If the third candle is exceptionally long relative to the first two, warn about potential overextension: "세 번째 캔들이 과도하게 길어 과열 가능성 주의"
+- Cross-reference with nearby resistance/support levels to evaluate continuation potential
+- State the pattern strength based on body-to-shadow ratios of all three candles

--- a/src/__tests__/domain/analysis/prompt.test.ts
+++ b/src/__tests__/domain/analysis/prompt.test.ts
@@ -1973,4 +1973,196 @@ describe('prompt', () => {
             expect(result).toContain('Wyckoff Theory');
         });
     });
+
+    describe('Skills 섹션 - type이 candlestick인 skill일 때', () => {
+        it('Candlestick Pattern Guides 섹션에 포함된다', () => {
+            const skill = makeSkill({
+                type: 'candlestick',
+                name: 'Engulfing Pattern Guide',
+            });
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                [skill]
+            );
+            expect(result).toContain('Candlestick Pattern Guides');
+            expect(result).toContain('Engulfing Pattern Guide');
+        });
+
+        it('패턴 분석 섹션에는 포함되지 않는다', () => {
+            const skill = makeSkill({
+                type: 'candlestick',
+                name: 'Engulfing Pattern Guide',
+            });
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                [skill]
+            );
+            expect(result).not.toContain('Pattern Analysis');
+        });
+
+        it('활성화된 Skills 섹션에는 포함되지 않는다', () => {
+            const skill = makeSkill({
+                type: 'candlestick',
+                name: 'Engulfing Pattern Guide',
+            });
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                [skill]
+            );
+            expect(result).not.toContain('Active Skills');
+        });
+
+        it('candlestick skill이 없을 때 Candlestick Pattern Guides 섹션이 포함되지 않는다', () => {
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                []
+            );
+            expect(result).not.toContain('Candlestick Pattern Guides');
+        });
+
+        it('여러 candlestick skill이 모두 Candlestick Pattern Guides 섹션에 포함된다', () => {
+            const skills = [
+                makeSkill({
+                    type: 'candlestick',
+                    name: 'Engulfing Pattern Guide',
+                }),
+                makeSkill({
+                    type: 'candlestick',
+                    name: 'Doji Pattern Guide',
+                }),
+            ];
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                skills
+            );
+            expect(result).toContain('Candlestick Pattern Guides');
+            expect(result).toContain('Engulfing Pattern Guide');
+            expect(result).toContain('Doji Pattern Guide');
+        });
+
+        it('candlestick, pattern, indicator_guide, strategy, regular skill이 각각 해당 섹션에 포함된다', () => {
+            const candlestickSkill = makeSkill({
+                type: 'candlestick',
+                name: 'Engulfing Pattern Guide',
+            });
+            const patternSkill = makeSkill({
+                type: 'pattern',
+                name: 'Head and Shoulders',
+            });
+            const indicatorGuideSkill = makeSkill({
+                type: 'indicator_guide',
+                name: 'RSI Signal Guide',
+            });
+            const strategySkill = makeSkill({
+                type: 'strategy',
+                name: '엘리어트 파동',
+            });
+            const regularSkill = makeSkill({
+                type: undefined,
+                name: 'Wyckoff Theory',
+            });
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                [
+                    candlestickSkill,
+                    patternSkill,
+                    indicatorGuideSkill,
+                    strategySkill,
+                    regularSkill,
+                ]
+            );
+            expect(result).toContain('Candlestick Pattern Guides');
+            expect(result).toContain('Engulfing Pattern Guide');
+            expect(result).toContain('Pattern Analysis');
+            expect(result).toContain('Head and Shoulders');
+            expect(result).toContain('Indicator Signal Guides');
+            expect(result).toContain('RSI Signal Guide');
+            expect(result).toContain('Strategy Analysis');
+            expect(result).toContain('엘리어트 파동');
+            expect(result).toContain('Active Skills');
+            expect(result).toContain('Wyckoff Theory');
+        });
+
+        it('confidenceWeight가 0.5 미만인 candlestick skill은 포함되지 않는다', () => {
+            const skill = makeSkill({
+                type: 'candlestick',
+                name: 'Low Confidence Guide',
+                confidenceWeight: TEST_BELOW_MIN_CONFIDENCE,
+            });
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                [skill]
+            );
+            expect(result).not.toContain('Low Confidence Guide');
+            expect(result).not.toContain('Candlestick Pattern Guides');
+        });
+    });
+
+    describe('분석 요청 섹션 - Candlestick Writing Rules', () => {
+        it('candlestick skill이 있을 때 candlePatterns Writing Rules 섹션이 포함된다', () => {
+            const skill = makeSkill({
+                type: 'candlestick',
+                name: 'Engulfing Pattern Guide',
+            });
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                [skill]
+            );
+            expect(result).toContain(
+                'candlePatterns Writing Rules for Candlestick Skills'
+            );
+        });
+
+        it('candlestick skill이 없을 때 candlePatterns Writing Rules 섹션이 포함되지 않는다', () => {
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                []
+            );
+            expect(result).not.toContain(
+                'candlePatterns Writing Rules for Candlestick Skills'
+            );
+        });
+
+        it('candlestick skill 이름 목록이 분석 요청에 포함된다', () => {
+            const skills = [
+                makeSkill({
+                    type: 'candlestick',
+                    name: 'Engulfing Pattern Guide',
+                }),
+                makeSkill({
+                    type: 'candlestick',
+                    name: 'Doji Pattern Guide',
+                }),
+            ];
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                skills
+            );
+            expect(result).toContain(
+                'Candlestick pattern guide list to apply:'
+            );
+            expect(result).toContain('- Engulfing Pattern Guide');
+            expect(result).toContain('- Doji Pattern Guide');
+        });
+    });
 });

--- a/src/__tests__/infrastructure/skills/loader.test.ts
+++ b/src/__tests__/infrastructure/skills/loader.test.ts
@@ -557,6 +557,83 @@ Three absolute rules govern all Elliott Wave counts.`;
         });
     });
 
+    describe('candlestick 타입 파싱', () => {
+        const CANDLESTICK_SKILL_MD = `---
+name: Engulfing Pattern Guide
+description: 장악형 캔들 패턴 해석 가이드
+type: candlestick
+category: neutral
+indicators: []
+confidence_weight: 0.8
+---
+
+## Overview
+
+Engulfing은 2봉 반전 패턴이다.`;
+
+        it('type이 candlestick이면 candlestick으로 파싱한다', async () => {
+            mockReaddir.mockResolvedValue([fileDirent('engulfing.md')]);
+            mockReadFile.mockResolvedValue(CANDLESTICK_SKILL_MD);
+
+            const skills = await loader.loadSkills();
+
+            expect(skills[0].type).toBe('candlestick');
+        });
+
+        it('candlestick type의 name, description, indicators를 올바르게 파싱한다', async () => {
+            mockReaddir.mockResolvedValue([fileDirent('engulfing.md')]);
+            mockReadFile.mockResolvedValue(CANDLESTICK_SKILL_MD);
+
+            const skills = await loader.loadSkills();
+
+            expect(skills[0].name).toBe('Engulfing Pattern Guide');
+            expect(skills[0].description).toBe('장악형 캔들 패턴 해석 가이드');
+            expect(skills[0].indicators).toEqual([]);
+        });
+
+        it('candlestick type의 confidenceWeight를 올바르게 파싱한다', async () => {
+            mockReaddir.mockResolvedValue([fileDirent('engulfing.md')]);
+            mockReadFile.mockResolvedValue(CANDLESTICK_SKILL_MD);
+
+            const skills = await loader.loadSkills();
+
+            expect(skills[0].confidenceWeight).toBe(0.8);
+        });
+
+        it('candlestick type의 content를 올바르게 파싱한다', async () => {
+            mockReaddir.mockResolvedValue([fileDirent('engulfing.md')]);
+            mockReadFile.mockResolvedValue(CANDLESTICK_SKILL_MD);
+
+            const skills = await loader.loadSkills();
+
+            expect(skills[0].content).toContain('Overview');
+        });
+
+        it('candlesticks 하위 디렉토리의 candlestick 스킬을 재귀적으로 읽는다', async () => {
+            const SKILLS_DIR = path.join(process.cwd(), 'skills');
+            const CANDLESTICKS_DIR = path.join(SKILLS_DIR, 'candlesticks');
+            const candlestickFile = path.join(CANDLESTICKS_DIR, 'engulfing.md');
+
+            mockReaddir.mockImplementation((dir: string) => {
+                if (dir === SKILLS_DIR)
+                    return Promise.resolve([dirDirent('candlesticks')]);
+                if (dir === CANDLESTICKS_DIR)
+                    return Promise.resolve([fileDirent('engulfing.md')]);
+                return Promise.resolve([]);
+            });
+            mockReadFile.mockImplementation((p: string) => {
+                if (p === candlestickFile)
+                    return Promise.resolve(CANDLESTICK_SKILL_MD);
+                return Promise.resolve('');
+            });
+
+            const skills = await loader.loadSkills();
+
+            expect(skills).toHaveLength(1);
+            expect(skills[0].type).toBe('candlestick');
+        });
+    });
+
     describe('readdir 에러', () => {
         it('readdir가 실패하면 에러를 전파한다', async () => {
             mockReaddir.mockRejectedValue(

--- a/src/components/home/SkillsShowcase.tsx
+++ b/src/components/home/SkillsShowcase.tsx
@@ -17,6 +17,7 @@ const TABS: TabConfig[] = [
     { value: 'indicator_guide', label: '보조지표' },
     { value: 'pattern', label: '차트 패턴' },
     { value: 'strategy', label: '전략' },
+    { value: 'candlestick', label: '캔들 패턴' },
 ];
 
 interface TypeBadgeConfig {
@@ -39,6 +40,11 @@ const TYPE_BADGE: Record<SkillType, TypeBadgeConfig> = {
         label: '전략',
         className:
             'bg-ui-warning/10 text-ui-warning border border-ui-warning/30',
+    },
+    candlestick: {
+        label: '캔들',
+        className:
+            'bg-chart-bullish/10 text-chart-bullish border border-chart-bullish/30',
     },
 };
 

--- a/src/components/home/StatsBar.tsx
+++ b/src/components/home/StatsBar.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react';
+
 import type { SkillShowcaseItem } from '@/domain/types';
 
 interface StatsBarProps {
@@ -42,17 +44,25 @@ export function StatsBar({ skills }: StatsBarProps) {
             }
         );
 
+    const stats = [
+        { value: skills.length, label: '개 분석 스킬' },
+        { value: indicatorCount, label: '종 보조지표' },
+        { value: patternCount, label: '개 차트 패턴' },
+        { value: strategyCount, label: '개 전략 분석' },
+        { value: candlestickCount, label: '개 캔들 패턴' },
+    ];
+
     return (
         <div className="text-secondary-500 mt-6 flex flex-wrap items-center justify-center gap-x-2 font-mono text-xs lg:justify-start">
-            <span>{skills.length}개 분석 스킬</span>
-            <span className="text-secondary-700">·</span>
-            <span>{indicatorCount}종 보조지표</span>
-            <span className="text-secondary-700">·</span>
-            <span>{patternCount}개 차트 패턴</span>
-            <span className="text-secondary-700">·</span>
-            <span>{strategyCount}개 전략 분석</span>
-            <span className="text-secondary-700">·</span>
-            <span>{candlestickCount}개 캔들 패턴</span>
+            {stats.map((stat, i) => (
+                <Fragment key={stat.label}>
+                    {i > 0 && <span className="text-secondary-700">·</span>}
+                    <span>
+                        {stat.value}
+                        {stat.label}
+                    </span>
+                </Fragment>
+            ))}
         </div>
     );
 }

--- a/src/components/home/StatsBar.tsx
+++ b/src/components/home/StatsBar.tsx
@@ -5,19 +5,42 @@ interface StatsBarProps {
 }
 
 export function StatsBar({ skills }: StatsBarProps) {
-    const { indicatorCount, patternCount, strategyCount } = skills.reduce(
-        (counts, skill) => {
-            if (skill.type === 'indicator_guide') {
-                counts.indicatorCount++;
-            } else if (skill.type === 'pattern') {
-                counts.patternCount++;
-            } else if (skill.type === 'strategy') {
-                counts.strategyCount++;
+    const { indicatorCount, patternCount, strategyCount, candlestickCount } =
+        skills.reduce(
+            (counts, skill) => {
+                if (skill.type === 'indicator_guide') {
+                    return {
+                        ...counts,
+                        indicatorCount: counts.indicatorCount + 1,
+                    };
+                }
+                if (skill.type === 'pattern') {
+                    return {
+                        ...counts,
+                        patternCount: counts.patternCount + 1,
+                    };
+                }
+                if (skill.type === 'strategy') {
+                    return {
+                        ...counts,
+                        strategyCount: counts.strategyCount + 1,
+                    };
+                }
+                if (skill.type === 'candlestick') {
+                    return {
+                        ...counts,
+                        candlestickCount: counts.candlestickCount + 1,
+                    };
+                }
+                return counts;
+            },
+            {
+                indicatorCount: 0,
+                patternCount: 0,
+                strategyCount: 0,
+                candlestickCount: 0,
             }
-            return counts;
-        },
-        { indicatorCount: 0, patternCount: 0, strategyCount: 0 }
-    );
+        );
 
     return (
         <div className="text-secondary-500 mt-6 flex flex-wrap items-center justify-center gap-x-2 font-mono text-xs lg:justify-start">
@@ -28,6 +51,8 @@ export function StatsBar({ skills }: StatsBarProps) {
             <span>{patternCount}개 차트 패턴</span>
             <span className="text-secondary-700">·</span>
             <span>{strategyCount}개 전략 분석</span>
+            <span className="text-secondary-700">·</span>
+            <span>{candlestickCount}개 캔들 패턴</span>
         </div>
     );
 }

--- a/src/domain/analysis/prompt.ts
+++ b/src/domain/analysis/prompt.ts
@@ -386,7 +386,8 @@ const RESPONSE_LANGUAGE_INSTRUCTION =
 const buildAnalysisRequest = (
     patternSkills: Skill[],
     strategySkills: Skill[],
-    indicatorGuideSkills: Skill[]
+    indicatorGuideSkills: Skill[],
+    candlestickSkills: Skill[]
 ): string => {
     const patternListInstruction =
         patternSkills.length > 0
@@ -451,6 +452,22 @@ const buildAnalysisRequest = (
               ].join('\n')
             : '';
 
+    const candlestickInstruction =
+        candlestickSkills.length > 0
+            ? [
+                  '',
+                  '### candlePatterns Writing Rules for Candlestick Skills',
+                  '- Use the Candlestick Pattern Guides above to interpret the candle patterns detected in ## Detected Candle Patterns.',
+                  '- For each detected candle pattern, evaluate the trend context, confirmation signals, and statistical reliability as described in the matching guide.',
+                  '- When a pattern matches a guide, enrich the candlePatterns entry with the guide insights: trend context validity, volume confirmation, and recommended indicator cross-checks.',
+                  '- The summary field of each candlePatterns entry must include the guide-informed interpretation, not just pattern name repetition.',
+                  '- If a detected pattern appears in a sideways/range-bound market context and the guide warns about reduced reliability, note this explicitly in the summary.',
+                  '',
+                  'Candlestick pattern guide list to apply:',
+                  ...candlestickSkills.map(s => `- ${s.name}`),
+              ].join('\n')
+            : '';
+
     return [
         '## Analysis Request',
         RESPONSE_LANGUAGE_INSTRUCTION,
@@ -459,6 +476,7 @@ const buildAnalysisRequest = (
         indicatorGuideInstruction,
         patternListInstruction,
         strategyInstruction,
+        candlestickInstruction,
     ]
         .filter(s => s !== '')
         .join('\n');
@@ -479,11 +497,15 @@ export function buildAnalysisPrompt(
     const indicatorGuideSkills = activeSkills.filter(
         s => s.type === 'indicator_guide'
     );
+    const candlestickSkills = activeSkills.filter(
+        s => s.type === 'candlestick'
+    );
     const regularSkills = activeSkills.filter(
         s =>
             s.type !== 'pattern' &&
             s.type !== 'strategy' &&
-            s.type !== 'indicator_guide'
+            s.type !== 'indicator_guide' &&
+            s.type !== 'candlestick'
     );
 
     const sections = [
@@ -504,6 +526,11 @@ export function buildAnalysisPrompt(
                   `## Pattern Analysis\n${patternSkills.map(buildSkillBlock).join('\n\n')}`,
               ]
             : []),
+        ...(candlestickSkills.length > 0
+            ? [
+                  `## Candlestick Pattern Guides\n${candlestickSkills.map(buildSkillBlock).join('\n\n')}`,
+              ]
+            : []),
         ...(strategySkills.length > 0
             ? [
                   `## Strategy Analysis\n${strategySkills.map(buildSkillBlock).join('\n\n')}`,
@@ -518,7 +545,8 @@ export function buildAnalysisPrompt(
         buildAnalysisRequest(
             patternSkills,
             strategySkills,
-            indicatorGuideSkills
+            indicatorGuideSkills,
+            candlestickSkills
         ),
     ];
 

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -98,7 +98,11 @@ export interface SkillDisplay {
     chart: SkillChartDisplay;
 }
 
-export type SkillType = 'pattern' | 'indicator_guide' | 'strategy';
+export type SkillType =
+    | 'pattern'
+    | 'indicator_guide'
+    | 'strategy'
+    | 'candlestick';
 
 export interface Skill {
     name: string;

--- a/src/infrastructure/skills/loader.ts
+++ b/src/infrastructure/skills/loader.ts
@@ -158,6 +158,7 @@ const SKILL_TYPES: readonly SkillType[] = [
     'pattern',
     'indicator_guide',
     'strategy',
+    'candlestick',
 ];
 
 const isSkillType = (value: unknown): value is SkillType =>


### PR DESCRIPTION
## 관련 이슈

closes #237

## 구현 내용

- 캔들스틱 패턴 스킬 신규 카테고리 `skills/candlesticks/` 추가
- 7개 캔들스틱 패턴 스킬 파일 생성:
  - Doji (도지)
  - Engulfing (엥걸핑)
  - Hammer & Shooting Star (망치와 유성)
  - Harami (하라미)
  - Marubozu (마루보즈)
  - Morning Star & Evening Star (샛별과 저녁별)
  - Three Soldiers & Three Crows (세 병사와 세 까마귀)
- `infrastructure/skills/loader.ts`: 캔들스틱 카테고리 로딩 기능 추가
- `domain/types.ts`: `SkillCategory` 타입에 `'candlesticks'` 추가
- `domain/analysis/prompt.ts`: 프롬프트 엔지니어링에 캔들스틱 패턴 시스템 메시지 추가
- `components/home/SkillsShowcase.tsx`: 캔들스틱 섹션 표시 추가
- `components/home/StatsBar.tsx`: 캔들스틱 스킬 통계 표시 추가
- 테스트 케이스 추가: `prompt.test.ts`, `loader.test.ts`

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it

## 변경 파일 목록

[생성]
- `skills/candlesticks/doji.md`
- `skills/candlesticks/engulfing.md`
- `skills/candlesticks/hammer-shooting-star.md`
- `skills/candlesticks/harami.md`
- `skills/candlesticks/marubozu.md`
- `skills/candlesticks/morning-evening-star.md`
- `skills/candlesticks/three-soldiers-crows.md`

[수정]
- `src/domain/types.ts`
- `src/domain/analysis/prompt.ts`
- `src/infrastructure/skills/loader.ts`
- `src/components/home/SkillsShowcase.tsx`
- `src/components/home/StatsBar.tsx`
- `src/__tests__/domain/analysis/prompt.test.ts`
- `src/__tests__/infrastructure/skills/loader.test.ts`
- `docs/MISTAKES.md`
- `docs/__agents_only__/fix-log.md`

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build