### PR TITLE
refactor: signals 필드 완전 제거 및 AI 프롬프트 엔지니어링 개선

### DIFF
--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -785,18 +785,7 @@ function buildAnalysisPrompt(
 type Trend = 'bullish' | 'bearish' | 'neutral';
 type RiskLevel = 'low' | 'medium' | 'high';
 type SignalStrength = 'strong' | 'moderate' | 'weak';
-type SignalType =
-    | 'rsi_overbought'
-    | 'rsi_oversold'
-    | 'macd_golden_cross'
-    | 'macd_dead_cross'
-    | 'bollinger_upper_breakout'
-    | 'bollinger_lower_breakout'
-    | 'bollinger_squeeze'
-    | 'dmi_bullish_trend'
-    | 'dmi_bearish_trend'
-    | 'pattern'
-    | 'skill';
+type SignalType = 'pattern' | 'skill';
 
 interface Signal {
     type: SignalType;
@@ -881,8 +870,7 @@ interface ActionRecommendation {
 interface AnalysisResponse {
     summary: string;
     trend: Trend;
-    signals: Signal[];              // 인디케이터 기반 신호 (skill 무관)
-    skillSignals: SkillSignal[];    // skill 기반 신호 (skill별로 그룹핑)
+    skillSignals: SkillSignal[];    // indicator_guide/skill 기반 신호 (skillName별 그룹핑)
     riskLevel: RiskLevel;
     keyLevels: KeyLevels;
     priceTargets: PriceTargets;     // 강세/약세 시나리오별 가격 목표

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -785,7 +785,7 @@ function buildAnalysisPrompt(
 type Trend = 'bullish' | 'bearish' | 'neutral';
 type RiskLevel = 'low' | 'medium' | 'high';
 type SignalStrength = 'strong' | 'moderate' | 'weak';
-type SignalType = 'pattern' | 'skill';
+type SignalType = 'skill';
 
 interface Signal {
     type: SignalType;
@@ -793,8 +793,8 @@ interface Signal {
     strength: SignalStrength;
 }
 
-interface SkillSignal {
-    skillName: string;
+interface IndicatorGuideResult {
+    indicatorName: string;     // indicator_guide skill 표시 이름 (예: 'RSI Signal Guide')
     signals: Signal[];
 }
 
@@ -851,13 +851,13 @@ interface CandlePatternSummary {
     summary: string;       // AI가 작성한 패턴별 요약
 }
 
-// skill별 분석 결과
-interface SkillResult {
-    id: string;            // 고유 ID (skillName_index 형식, React key용)
-    skillName: string;     // skill 표시 이름
-    trend: Trend;          // 해당 skill 분석이 시사하는 방향
-    summary: string;       // AI가 작성한 skill별 요약
-    confidenceWeight: number; // skill의 신뢰도 가중치 (0~1)
+// 전략 skill별 분석 결과 (type='strategy' skill)
+interface StrategyResult {
+    id: string;                 // 고유 ID (strategyName_index 형식, React key용)
+    strategyName: string;       // 전략 skill 표시 이름 (예: '엘리어트 파동')
+    trend: Trend;               // 해당 전략 분석이 시사하는 방향
+    summary: string;            // AI가 작성한 전략 요약 (markdown **label**: value 형식)
+    confidenceWeight: number;   // skill의 신뢰도 가중치 (0~1)
 }
 
 interface ActionRecommendation {
@@ -870,27 +870,32 @@ interface ActionRecommendation {
 interface AnalysisResponse {
     summary: string;
     trend: Trend;
-    skillSignals: SkillSignal[];    // indicator_guide/skill 기반 신호 (skillName별 그룹핑)
+    indicatorResults: IndicatorGuideResult[]; // indicator_guide skill 기반 신호 (indicatorName별 그룹핑) — "보조지표" 섹션에 렌더링
     riskLevel: RiskLevel;
     keyLevels: KeyLevels;
     priceTargets: PriceTargets;     // 강세/약세 시나리오별 가격 목표
-    patternSummaries: PatternSummary[]; // 감지된 패턴별 개별 요약 (type='pattern' skill)
-    skillResults: SkillResult[];        // skill별 분석 결과 (type!='pattern' skill)
-    candlePatterns: CandlePatternSummary[]; // 캔들 패턴 감지 결과
-    trendlines: Trendline[];           // AI가 감지한 추세선 목록 (0~3개)
+    patternSummaries: PatternSummary[];         // 차트 패턴 결과 (type='pattern' skill) — "차트 패턴" 섹션에 렌더링
+    strategyResults: StrategyResult[];          // 전략 skill 분석 결과 (type='strategy' skill) — "전략" 섹션에 렌더링
+    candlePatterns: CandlePatternSummary[];     // 캔들 패턴 감지 결과
+    trendlines: Trendline[];                    // AI가 감지한 추세선 목록 (0~3개)
     actionRecommendation?: ActionRecommendation; // 매매 전략 추천 (optional)
 }
 ```
 
-### signals vs skillSignals 구분 기준
+### 필드 ↔ UI 렌더링 매핑
 
 ```
-signals[]      → 인디케이터 수치 자체에서 도출되는 신호
-                 (RSI 과매수, MACD 크로스 등 skill 없이도 판단 가능한 것)
+indicatorResults[]  → AnalysisPanel "보조지표" 섹션
+                       indicator_guide skill의 시그널 결과
+                       indicatorName으로 그룹핑 (예: "RSI Signal Guide")
 
-skillSignals[] → skill 파일의 분석 기준을 적용해야만 도출되는 신호
-                 (RSI 다이버전스, 볼린저 스퀴즈 전략, 패턴 감지 등)
-                 skill 이름(skillName)으로 그룹핑
+strategyResults[]   → AnalysisPanel "전략" 섹션
+                       strategy skill의 분석 결과
+                       strategyName으로 식별 (예: "엘리어트 파동")
+
+patternSummaries[]  → AnalysisPanel "차트 패턴" 섹션
+                       pattern skill의 차트 패턴 감지 결과
+                       skillName으로 식별 (예: "Head and Shoulders")
 ```
 
 ---
@@ -1085,7 +1090,7 @@ skills/
 
 ```markdown
 ---
-name: string                  # skill 표시 이름 (SkillSignal.skillName에 사용)
+name: string                  # skill 표시 이름 (indicatorResults[].indicatorName, strategyResults[].strategyName, patternSummaries[].skillName 등 해당 카테고리별 식별자로 사용)
 description: string           # skill 설명
 type: pattern | indicator_guide | strategy | candlestick | support_resistance  # 선택
 category: string              # 선택. reversal_bullish | reversal_bearish | continuation_bullish | continuation_bearish | neutral

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -19,12 +19,6 @@
 - Rule: MISTAKES.md TypeScript #11 — 구현 변경 시 문서 동기화 필수
 - Context: PR #216에서 `src/infrastructure/ticker/`가 신규 추가됐으나 ARCHITECTURE.md 폴더 트리에 누락
 
-## [PR #216 Round 7 | feat/196/ticker-autocomplete | 2026-04-09]
-- Violation: `{isOpen && ...}` 블록 내부에서 `hasQuery`가 항상 `true`임에도 `&& hasQuery` 조건 유지 (dead code)
-- Rule: MISTAKES.md Coding Paradigm #4 — 결과를 변경하지 않는 조건(효과 없는 로직) 제거
-- Context: `isOpen = !isClosed && hasQuery`이므로 해당 블록 진입 시 `hasQuery`는 항상 true; `&& hasQuery` 제거
-
-
 
 ## [PR #216 Round 3 | feat/196/ticker-autocomplete | 2026-04-09]
 - Violation: 컴포넌트 교체 후 구 구현체 파일(`SymbolSearch.tsx`)이 삭제되지 않고 고아 파일로 남음

--- a/src/__tests__/domain/analysis/confidence.test.ts
+++ b/src/__tests__/domain/analysis/confidence.test.ts
@@ -68,7 +68,6 @@ const makeAnalysisResponse = (
 ): RawAnalysisResponse => ({
     summary: '테스트 종합 분석',
     trend: 'bullish',
-    signals: [],
     skillSignals: [],
     riskLevel: 'low',
     keyLevels: { support: [], resistance: [] },

--- a/src/__tests__/domain/analysis/confidence.test.ts
+++ b/src/__tests__/domain/analysis/confidence.test.ts
@@ -41,10 +41,10 @@ const makePatternSummary = (
     ...overrides,
 });
 
-const makeSkillResult = (
-    overrides?: Partial<RawAnalysisResponse['skillResults'][number]>
-): RawAnalysisResponse['skillResults'][number] => ({
-    skillName: '테스트 스킬',
+const makeStrategyResult = (
+    overrides?: Partial<RawAnalysisResponse['strategyResults'][number]>
+): RawAnalysisResponse['strategyResults'][number] => ({
+    strategyName: '테스트 전략',
     trend: 'bullish',
     summary: '테스트 요약',
     ...overrides,
@@ -68,7 +68,7 @@ const makeAnalysisResponse = (
 ): RawAnalysisResponse => ({
     summary: '테스트 종합 분석',
     trend: 'bullish',
-    skillSignals: [],
+    indicatorResults: [],
     riskLevel: 'low',
     keyLevels: { support: [], resistance: [] },
     priceTargets: {
@@ -76,7 +76,7 @@ const makeAnalysisResponse = (
         bearish: { targets: [], condition: '' },
     },
     patternSummaries: [],
-    skillResults: [],
+    strategyResults: [],
     candlePatterns: [],
     trendlines: [],
     ...overrides,
@@ -257,35 +257,35 @@ describe('confidence', () => {
             });
         });
 
-        describe('skillResults id 부여', () => {
-            it('단일 skillResult에 id가 부여된다', () => {
+        describe('strategyResults id 부여', () => {
+            it('단일 strategyResult에 id가 부여된다', () => {
                 const analysis = makeAnalysisResponse({
-                    skillResults: [
-                        makeSkillResult({ skillName: 'RSI 다이버전스' }),
+                    strategyResults: [
+                        makeStrategyResult({ strategyName: 'RSI 다이버전스' }),
                     ],
                 });
                 const result = enrichAnalysisWithConfidence(analysis, []);
-                expect(result.skillResults[0].id).toBe('RSI 다이버전스_0');
+                expect(result.strategyResults[0].id).toBe('RSI 다이버전스_0');
             });
 
-            it('동일한 skillName이 여러 개일 때 고유한 id를 부여한다', () => {
+            it('동일한 strategyName이 여러 개일 때 고유한 id를 부여한다', () => {
                 const analysis = makeAnalysisResponse({
-                    skillResults: [
-                        makeSkillResult({ skillName: 'RSI 다이버전스' }),
-                        makeSkillResult({ skillName: 'RSI 다이버전스' }),
+                    strategyResults: [
+                        makeStrategyResult({ strategyName: 'RSI 다이버전스' }),
+                        makeStrategyResult({ strategyName: 'RSI 다이버전스' }),
                     ],
                 });
                 const result = enrichAnalysisWithConfidence(analysis, []);
-                expect(result.skillResults[0].id).toBe('RSI 다이버전스_0');
-                expect(result.skillResults[1].id).toBe('RSI 다이버전스_1');
+                expect(result.strategyResults[0].id).toBe('RSI 다이버전스_0');
+                expect(result.strategyResults[1].id).toBe('RSI 다이버전스_1');
             });
         });
 
-        describe('skillResults confidenceWeight 채우기', () => {
-            it('skillResults에 skillName과 일치하는 skill의 confidenceWeight를 채운다', () => {
+        describe('strategyResults confidenceWeight 채우기', () => {
+            it('strategyResults에 strategyName과 일치하는 skill의 confidenceWeight를 채운다', () => {
                 const analysis = makeAnalysisResponse({
-                    skillResults: [
-                        makeSkillResult({ skillName: 'RSI 다이버전스' }),
+                    strategyResults: [
+                        makeStrategyResult({ strategyName: 'RSI 다이버전스' }),
                     ],
                 });
                 const skills = [
@@ -295,14 +295,16 @@ describe('confidence', () => {
                     }),
                 ];
                 const result = enrichAnalysisWithConfidence(analysis, skills);
-                expect(result.skillResults[0].confidenceWeight).toBe(
+                expect(result.strategyResults[0].confidenceWeight).toBe(
                     MEDIUM_CONFIDENCE_WEIGHT
                 );
             });
 
-            it('매칭되지 않는 skillName은 confidenceWeight를 0으로 채운다', () => {
+            it('매칭되지 않는 strategyName은 confidenceWeight를 0으로 채운다', () => {
                 const analysis = makeAnalysisResponse({
-                    skillResults: [makeSkillResult({ skillName: '없는스킬' })],
+                    strategyResults: [
+                        makeStrategyResult({ strategyName: '없는스킬' }),
+                    ],
                 });
                 const skills = [
                     makeSkill({
@@ -311,7 +313,7 @@ describe('confidence', () => {
                     }),
                 ];
                 const result = enrichAnalysisWithConfidence(analysis, skills);
-                expect(result.skillResults[0].confidenceWeight).toBe(
+                expect(result.strategyResults[0].confidenceWeight).toBe(
                     UNMATCHED_SKILL_CONFIDENCE_WEIGHT
                 );
             });
@@ -323,22 +325,22 @@ describe('confidence', () => {
                     patternSummaries: [
                         makePatternSummary({ skillName: '헤드앤숄더' }),
                     ],
-                    skillResults: [
-                        makeSkillResult({ skillName: 'RSI 다이버전스' }),
+                    strategyResults: [
+                        makeStrategyResult({ strategyName: 'RSI 다이버전스' }),
                     ],
                 });
                 const result = enrichAnalysisWithConfidence(analysis, []);
                 expect(result.patternSummaries).toHaveLength(0);
             });
 
-            it('skills가 빈 배열이면 skillResults의 confidenceWeight는 0이다', () => {
+            it('skills가 빈 배열이면 strategyResults의 confidenceWeight는 0이다', () => {
                 const analysis = makeAnalysisResponse({
-                    skillResults: [
-                        makeSkillResult({ skillName: 'RSI 다이버전스' }),
+                    strategyResults: [
+                        makeStrategyResult({ strategyName: 'RSI 다이버전스' }),
                     ],
                 });
                 const result = enrichAnalysisWithConfidence(analysis, []);
-                expect(result.skillResults[0].confidenceWeight).toBe(
+                expect(result.strategyResults[0].confidenceWeight).toBe(
                     UNMATCHED_SKILL_CONFIDENCE_WEIGHT
                 );
             });
@@ -500,7 +502,7 @@ describe('confidence', () => {
                 ).toBeUndefined();
             });
 
-            it('patternSummaries와 skillResults 외의 필드는 변경하지 않는다', () => {
+            it('patternSummaries와 strategyResults 외의 필드는 변경하지 않는다', () => {
                 const actionRecommendation = {
                     positionAnalysis: '원본 위치 분석',
                     entry: '원본 진입',

--- a/src/__tests__/domain/analysis/prompt.test.ts
+++ b/src/__tests__/domain/analysis/prompt.test.ts
@@ -1336,14 +1336,16 @@ describe('prompt', () => {
             expect(result).toContain('trend');
         });
 
-        it('signals 필드가 요청에 포함된다', () => {
+        it('signals 필드는 요청에 포함되지 않는다 (deprecated)', () => {
             const result = buildAnalysisPrompt(
                 TEST_SYMBOL,
                 [],
                 makeIndicators(),
                 []
             );
-            expect(result).toContain('signals');
+            // signals 필드가 스키마 top-level에 키로 존재하지 않아야 함
+            // (skillSignals 내부의 nested signals는 허용)
+            expect(result).not.toMatch(/^\s*"signals":/m);
         });
 
         it('skillSignals 필드가 요청에 포함된다', () => {
@@ -1956,7 +1958,7 @@ describe('prompt', () => {
     });
 
     describe('분석 요청 섹션 - Indicator Guide Writing Rules', () => {
-        it('indicator_guide skill이 있을 때 signals Writing Rules for Indicator Guides 섹션이 포함된다', () => {
+        it('indicator_guide skill이 있을 때 skillSignals Writing Rules for Indicator Guides 섹션이 포함된다', () => {
             const skill = makeSkill({
                 type: 'indicator_guide',
                 name: 'RSI Signal Guide',
@@ -1968,11 +1970,11 @@ describe('prompt', () => {
                 [skill]
             );
             expect(result).toContain(
-                'signals Writing Rules for Indicator Guides'
+                'skillSignals Writing Rules for Indicator Guides'
             );
         });
 
-        it('indicator_guide skill이 없을 때 signals Writing Rules for Indicator Guides 섹션이 포함되지 않는다', () => {
+        it('indicator_guide skill이 없을 때 skillSignals Writing Rules for Indicator Guides 섹션이 포함되지 않는다', () => {
             const result = buildAnalysisPrompt(
                 TEST_SYMBOL,
                 [],
@@ -1980,7 +1982,7 @@ describe('prompt', () => {
                 []
             );
             expect(result).not.toContain(
-                'signals Writing Rules for Indicator Guides'
+                'skillSignals Writing Rules for Indicator Guides'
             );
         });
 
@@ -2001,7 +2003,9 @@ describe('prompt', () => {
                 makeIndicators(),
                 skills
             );
-            expect(result).toContain('Indicator guide list to apply:');
+            expect(result).toContain(
+                'Indicator guide list (use these exact names for skillName):'
+            );
             expect(result).toContain('- RSI Signal Guide');
             expect(result).toContain('- MACD Signal Guide');
         });
@@ -2034,7 +2038,7 @@ describe('prompt', () => {
                 [skill]
             );
             expect(result).toContain(
-                'The description field must be written in Korean and include the indicator name and specific condition'
+                'The description field MUST be written in Korean and MUST include the indicator name and specific numeric condition'
             );
         });
 
@@ -2054,7 +2058,7 @@ describe('prompt', () => {
                 [indicatorGuideSkill, patternSkill]
             );
             const indicatorGuideIndex = result.indexOf(
-                'signals Writing Rules for Indicator Guides'
+                'skillSignals Writing Rules for Indicator Guides'
             );
             const patternWritingRulesIndex = result.indexOf(
                 'patternSummaries Writing Rules'
@@ -2075,9 +2079,55 @@ describe('prompt', () => {
                 [skill]
             );
             expect(result).not.toContain(
-                'signals Writing Rules for Indicator Guides'
+                'skillSignals Writing Rules for Indicator Guides'
             );
             expect(result).not.toContain('- Low Confidence Guide');
+        });
+
+        it('indicator_guide Writing Rules에 skillName 비어있음 금지를 명시한다', () => {
+            const skill = makeSkill({
+                type: 'indicator_guide',
+                name: 'RSI Signal Guide',
+            });
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                [skill]
+            );
+            expect(result).toContain('non-empty string');
+            expect(result).toContain('Never use an empty string');
+        });
+
+        it('indicator_guide Writing Rules에 다중 인디케이터 결합을 금지한다', () => {
+            const skill = makeSkill({
+                type: 'indicator_guide',
+                name: 'RSI Signal Guide',
+            });
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                [skill]
+            );
+            expect(result).toContain('EXACTLY ONE indicator guide');
+            expect(result).toContain('Never combine multiple indicators');
+        });
+
+        it('indicator_guide Writing Rules에 신호가 없으면 entry를 생성하지 않도록 지시한다', () => {
+            const skill = makeSkill({
+                type: 'indicator_guide',
+                name: 'RSI Signal Guide',
+            });
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                [skill]
+            );
+            expect(result).toContain(
+                'simply omit that guide from skillSignals'
+            );
         });
     });
 
@@ -2248,6 +2298,27 @@ describe('prompt', () => {
             expect(result).toContain('엘리어트 파동');
             expect(result).toContain('Active Skills');
             expect(result).toContain('Wyckoff Theory');
+        });
+
+        it('strategyInstruction에 trend 필드 필수 + neutral fallback을 명시한다', () => {
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                [strategySkill]
+            );
+            expect(result).toContain('NEVER omit this field');
+            expect(result).toContain('use "neutral"');
+        });
+
+        it('strategyInstruction에 REQUIRED FIELDS 지시가 포함된다', () => {
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                [strategySkill]
+            );
+            expect(result).toContain('REQUIRED FIELDS');
         });
     });
 
@@ -2571,6 +2642,42 @@ describe('prompt', () => {
             expect(result).toContain('Support/Resistance tool list to apply:');
             expect(result).toContain('- 피봇 포인트');
             expect(result).toContain('- 피보나치 확장');
+        });
+    });
+
+    describe('Critical Response Rules', () => {
+        it('분석 요청에 JSON 전용 출력 규칙이 포함된다', () => {
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                []
+            );
+            expect(result).toContain('Return ONLY a single valid JSON object');
+            expect(result).toContain(
+                'Do not wrap the JSON in markdown code fences'
+            );
+        });
+
+        it('분석 요청에 null 금지 + 빈 배열 사용 규칙이 포함된다', () => {
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                []
+            );
+            expect(result).toContain('return an empty array []');
+            expect(result).toContain('Never return null');
+        });
+
+        it('분석 요청에 Critical Response Rules 섹션이 포함된다', () => {
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                []
+            );
+            expect(result).toContain('Critical Response Rules (MUST follow)');
         });
     });
 });

--- a/src/__tests__/domain/analysis/prompt.test.ts
+++ b/src/__tests__/domain/analysis/prompt.test.ts
@@ -1344,18 +1344,18 @@ describe('prompt', () => {
                 []
             );
             // signals 필드가 스키마 top-level에 키로 존재하지 않아야 함
-            // (skillSignals 내부의 nested signals는 허용)
+            // (indicatorResults 내부의 nested signals는 허용)
             expect(result).not.toMatch(/^\s*"signals":/m);
         });
 
-        it('skillSignals 필드가 요청에 포함된다', () => {
+        it('indicatorResults 필드가 요청에 포함된다', () => {
             const result = buildAnalysisPrompt(
                 TEST_SYMBOL,
                 [],
                 makeIndicators(),
                 []
             );
-            expect(result).toContain('skillSignals');
+            expect(result).toContain('indicatorResults');
         });
 
         it('keyLevels 필드가 요청에 포함된다', () => {
@@ -1378,14 +1378,14 @@ describe('prompt', () => {
             expect(result).toContain('patternSummaries');
         });
 
-        it('skillResults 필드가 요청에 포함된다', () => {
+        it('strategyResults 필드가 요청에 포함된다', () => {
             const result = buildAnalysisPrompt(
                 TEST_SYMBOL,
                 [],
                 makeIndicators(),
                 []
             );
-            expect(result).toContain('skillResults');
+            expect(result).toContain('strategyResults');
         });
 
         it('riskLevel 필드가 요청에 포함된다', () => {
@@ -1958,7 +1958,7 @@ describe('prompt', () => {
     });
 
     describe('분석 요청 섹션 - Indicator Guide Writing Rules', () => {
-        it('indicator_guide skill이 있을 때 skillSignals Writing Rules for Indicator Guides 섹션이 포함된다', () => {
+        it('indicator_guide skill이 있을 때 indicatorResults Writing Rules for Indicator Guides 섹션이 포함된다', () => {
             const skill = makeSkill({
                 type: 'indicator_guide',
                 name: 'RSI Signal Guide',
@@ -1970,11 +1970,11 @@ describe('prompt', () => {
                 [skill]
             );
             expect(result).toContain(
-                'skillSignals Writing Rules for Indicator Guides'
+                'indicatorResults Writing Rules for Indicator Guides'
             );
         });
 
-        it('indicator_guide skill이 없을 때 skillSignals Writing Rules for Indicator Guides 섹션이 포함되지 않는다', () => {
+        it('indicator_guide skill이 없을 때 indicatorResults Writing Rules for Indicator Guides 섹션이 포함되지 않는다', () => {
             const result = buildAnalysisPrompt(
                 TEST_SYMBOL,
                 [],
@@ -1982,7 +1982,7 @@ describe('prompt', () => {
                 []
             );
             expect(result).not.toContain(
-                'skillSignals Writing Rules for Indicator Guides'
+                'indicatorResults Writing Rules for Indicator Guides'
             );
         });
 
@@ -2004,7 +2004,7 @@ describe('prompt', () => {
                 skills
             );
             expect(result).toContain(
-                'Indicator guide list (use these exact names for skillName):'
+                'Indicator guide list (use these exact names for indicatorName):'
             );
             expect(result).toContain('- RSI Signal Guide');
             expect(result).toContain('- MACD Signal Guide');
@@ -2058,7 +2058,7 @@ describe('prompt', () => {
                 [indicatorGuideSkill, patternSkill]
             );
             const indicatorGuideIndex = result.indexOf(
-                'skillSignals Writing Rules for Indicator Guides'
+                'indicatorResults Writing Rules for Indicator Guides'
             );
             const patternWritingRulesIndex = result.indexOf(
                 'patternSummaries Writing Rules'
@@ -2079,12 +2079,12 @@ describe('prompt', () => {
                 [skill]
             );
             expect(result).not.toContain(
-                'skillSignals Writing Rules for Indicator Guides'
+                'indicatorResults Writing Rules for Indicator Guides'
             );
             expect(result).not.toContain('- Low Confidence Guide');
         });
 
-        it('indicator_guide Writing Rules에 skillName 비어있음 금지를 명시한다', () => {
+        it('indicator_guide Writing Rules에 indicatorName 비어있음 금지를 명시한다', () => {
             const skill = makeSkill({
                 type: 'indicator_guide',
                 name: 'RSI Signal Guide',
@@ -2096,7 +2096,7 @@ describe('prompt', () => {
                 [skill]
             );
             expect(result).toContain('non-empty string');
-            expect(result).toContain('Never use an empty string');
+            expect(result).toContain('never use an empty string');
         });
 
         it('indicator_guide Writing Rules에 다중 인디케이터 결합을 금지한다', () => {
@@ -2126,8 +2126,96 @@ describe('prompt', () => {
                 [skill]
             );
             expect(result).toContain(
-                'simply omit that guide from skillSignals'
+                'simply omit that guide from indicatorResults'
             );
+        });
+    });
+
+    describe('분석 가이드라인 - Name Field Matching', () => {
+        let result: string;
+
+        beforeEach(() => {
+            result = buildAnalysisPrompt(TEST_SYMBOL, [], makeIndicators(), []);
+        });
+
+        it('공통 Name Field Matching 섹션이 포함된다', () => {
+            expect(result).toContain(
+                '### Name Field Matching (applies to all identifier fields)'
+            );
+        });
+
+        it('name 필드가 비어있으면 안 된다는 규칙이 명시된다', () => {
+            expect(result).toContain('non-empty string');
+            expect(result).toContain('EXACTLY matches');
+        });
+
+        it('verbatim copy 지시가 포함된다', () => {
+            expect(result).toContain('Copy each skill name verbatim');
+            expect(result).toContain(
+                'Do not translate, abbreviate, paraphrase'
+            );
+        });
+
+        it('적용 대상 필드가 명시된다 (patternSummaries.skillName, strategyResults.strategyName, indicatorResults.indicatorName)', () => {
+            expect(result).toContain('patternSummaries[].skillName');
+            expect(result).toContain('strategyResults[].strategyName');
+            expect(result).toContain('indicatorResults[].indicatorName');
+        });
+
+        it('skill이 없으면 entry를 omit하라는 지시가 포함된다', () => {
+            expect(result).toContain(
+                'omit the entry entirely rather than inventing a name'
+            );
+        });
+    });
+
+    describe('분석 요청 섹션 - patternSummaries trend 규칙', () => {
+        it('detected: false일 때도 trend 필수임을 명시한다', () => {
+            const skill = makeSkill({
+                type: 'pattern',
+                name: 'Head and Shoulders',
+            });
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                [skill]
+            );
+            expect(result).toContain(
+                'trend field is REQUIRED for every patternSummaries entry'
+            );
+            expect(result).toContain(
+                'including entries where detected is false'
+            );
+        });
+
+        it('not-detected 패턴의 고유 방향 예시가 포함된다', () => {
+            const skill = makeSkill({
+                type: 'pattern',
+                name: 'Head and Shoulders',
+            });
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                [skill]
+            );
+            expect(result).toContain('head-and-shoulders → bearish');
+            expect(result).toContain('inverse head-and-shoulders → bullish');
+        });
+
+        it('NEVER omit trend 지시가 포함된다', () => {
+            const skill = makeSkill({
+                type: 'pattern',
+                name: 'Head and Shoulders',
+            });
+            const result = buildAnalysisPrompt(
+                TEST_SYMBOL,
+                [],
+                makeIndicators(),
+                [skill]
+            );
+            expect(result).toContain('NEVER omit the trend field');
         });
     });
 
@@ -2232,7 +2320,7 @@ describe('prompt', () => {
             expect(result).not.toContain('Pattern Analysis');
         });
 
-        it('strategy skill에 대한 skillResults Writing Rules 지시사항이 생성된다', () => {
+        it('strategy skill에 대한 strategyResults Writing Rules 지시사항이 생성된다', () => {
             const result = buildAnalysisPrompt(
                 TEST_SYMBOL,
                 [],
@@ -2240,12 +2328,12 @@ describe('prompt', () => {
                 [strategySkill]
             );
             expect(result).toContain(
-                'skillResults Writing Rules for Strategy Skills'
+                'strategyResults Writing Rules for Strategy Skills'
             );
             expect(result).toContain('- 엘리어트 파동');
         });
 
-        it('strategy skill이 없으면 skillResults Writing Rules 지시사항이 포함되지 않는다', () => {
+        it('strategy skill이 없으면 strategyResults Writing Rules 지시사항이 포함되지 않는다', () => {
             const result = buildAnalysisPrompt(
                 TEST_SYMBOL,
                 [],
@@ -2253,7 +2341,7 @@ describe('prompt', () => {
                 []
             );
             expect(result).not.toContain(
-                'skillResults Writing Rules for Strategy Skills'
+                'strategyResults Writing Rules for Strategy Skills'
             );
         });
 

--- a/src/__tests__/infrastructure/ai/claude.test.ts
+++ b/src/__tests__/infrastructure/ai/claude.test.ts
@@ -11,7 +11,6 @@ describe('ClaudeProvider', () => {
     const mockAnalysisResponse: RawAnalysisResponse = {
         summary: 'Test summary',
         trend: 'bullish',
-        signals: [],
         skillSignals: [],
         riskLevel: 'low',
         keyLevels: {
@@ -92,12 +91,6 @@ describe('ClaudeProvider', () => {
             const result = await provider.analyze('test prompt');
 
             expect(['low', 'medium', 'high']).toContain(result.riskLevel);
-        });
-
-        it('signals는 배열을 반환한다', async () => {
-            const result = await provider.analyze('test prompt');
-
-            expect(Array.isArray(result.signals)).toBe(true);
         });
 
         it('skillSignals는 배열을 반환한다', async () => {

--- a/src/__tests__/infrastructure/ai/claude.test.ts
+++ b/src/__tests__/infrastructure/ai/claude.test.ts
@@ -11,7 +11,7 @@ describe('ClaudeProvider', () => {
     const mockAnalysisResponse: RawAnalysisResponse = {
         summary: 'Test summary',
         trend: 'bullish',
-        skillSignals: [],
+        indicatorResults: [],
         riskLevel: 'low',
         keyLevels: {
             support: [{ price: 100, reason: '이전 저점' }],
@@ -28,7 +28,7 @@ describe('ClaudeProvider', () => {
             },
         },
         patternSummaries: [],
-        skillResults: [],
+        strategyResults: [],
         candlePatterns: [],
         trendlines: [],
     };
@@ -93,10 +93,10 @@ describe('ClaudeProvider', () => {
             expect(['low', 'medium', 'high']).toContain(result.riskLevel);
         });
 
-        it('skillSignals는 배열을 반환한다', async () => {
+        it('indicatorResults는 배열을 반환한다', async () => {
             const result = await provider.analyze('test prompt');
 
-            expect(Array.isArray(result.skillSignals)).toBe(true);
+            expect(Array.isArray(result.indicatorResults)).toBe(true);
         });
 
         it('patternSummaries는 배열을 반환한다', async () => {
@@ -105,10 +105,10 @@ describe('ClaudeProvider', () => {
             expect(Array.isArray(result.patternSummaries)).toBe(true);
         });
 
-        it('skillResults는 배열을 반환한다', async () => {
+        it('strategyResults는 배열을 반환한다', async () => {
             const result = await provider.analyze('test prompt');
 
-            expect(Array.isArray(result.skillResults)).toBe(true);
+            expect(Array.isArray(result.strategyResults)).toBe(true);
         });
 
         it('candlePatterns는 배열을 반환한다', async () => {

--- a/src/__tests__/infrastructure/ai/gemini.test.ts
+++ b/src/__tests__/infrastructure/ai/gemini.test.ts
@@ -11,7 +11,6 @@ describe('GeminiProvider', () => {
     const mockAnalysisResponse: RawAnalysisResponse = {
         summary: 'Test summary',
         trend: 'bullish',
-        signals: [],
         skillSignals: [],
         riskLevel: 'low',
         keyLevels: {
@@ -94,12 +93,6 @@ describe('GeminiProvider', () => {
             const result = await provider.analyze('test prompt');
 
             expect(['low', 'medium', 'high']).toContain(result.riskLevel);
-        });
-
-        it('signals는 배열을 반환한다', async () => {
-            const result = await provider.analyze('test prompt');
-
-            expect(Array.isArray(result.signals)).toBe(true);
         });
 
         it('skillSignals는 배열을 반환한다', async () => {

--- a/src/__tests__/infrastructure/ai/gemini.test.ts
+++ b/src/__tests__/infrastructure/ai/gemini.test.ts
@@ -11,7 +11,7 @@ describe('GeminiProvider', () => {
     const mockAnalysisResponse: RawAnalysisResponse = {
         summary: 'Test summary',
         trend: 'bullish',
-        skillSignals: [],
+        indicatorResults: [],
         riskLevel: 'low',
         keyLevels: {
             support: [{ price: 100, reason: '이전 저점' }],
@@ -28,7 +28,7 @@ describe('GeminiProvider', () => {
             },
         },
         patternSummaries: [],
-        skillResults: [],
+        strategyResults: [],
         candlePatterns: [],
         trendlines: [],
     };
@@ -95,10 +95,10 @@ describe('GeminiProvider', () => {
             expect(['low', 'medium', 'high']).toContain(result.riskLevel);
         });
 
-        it('skillSignals는 배열을 반환한다', async () => {
+        it('indicatorResults는 배열을 반환한다', async () => {
             const result = await provider.analyze('test prompt');
 
-            expect(Array.isArray(result.skillSignals)).toBe(true);
+            expect(Array.isArray(result.indicatorResults)).toBe(true);
         });
 
         it('patternSummaries는 배열을 반환한다', async () => {
@@ -107,10 +107,10 @@ describe('GeminiProvider', () => {
             expect(Array.isArray(result.patternSummaries)).toBe(true);
         });
 
-        it('skillResults는 배열을 반환한다', async () => {
+        it('strategyResults는 배열을 반환한다', async () => {
             const result = await provider.analyze('test prompt');
 
-            expect(Array.isArray(result.skillResults)).toBe(true);
+            expect(Array.isArray(result.strategyResults)).toBe(true);
         });
 
         it('candlePatterns는 배열을 반환한다', async () => {

--- a/src/__tests__/infrastructure/market/analysisApi.test.ts
+++ b/src/__tests__/infrastructure/market/analysisApi.test.ts
@@ -68,7 +68,7 @@ const mockVariables: AnalyzeVariables = {
 const mockRawAnalysis: RawAnalysisResponse = {
     summary: '테스트 분석 요약',
     trend: 'bullish' as const,
-    skillSignals: [],
+    indicatorResults: [],
     riskLevel: 'low' as const,
     keyLevels: { support: [], resistance: [] },
     priceTargets: {
@@ -76,7 +76,7 @@ const mockRawAnalysis: RawAnalysisResponse = {
         bearish: { targets: [], condition: '' },
     },
     patternSummaries: [],
-    skillResults: [],
+    strategyResults: [],
     candlePatterns: [],
     trendlines: [],
 };

--- a/src/__tests__/infrastructure/market/analysisApi.test.ts
+++ b/src/__tests__/infrastructure/market/analysisApi.test.ts
@@ -68,7 +68,6 @@ const mockVariables: AnalyzeVariables = {
 const mockRawAnalysis: RawAnalysisResponse = {
     summary: '테스트 분석 요약',
     trend: 'bullish' as const,
-    signals: [],
     skillSignals: [],
     riskLevel: 'low' as const,
     keyLevels: { support: [], resistance: [] },

--- a/src/__tests__/infrastructure/market/analyzeAction.test.ts
+++ b/src/__tests__/infrastructure/market/analyzeAction.test.ts
@@ -74,7 +74,7 @@ const mockTimeframe: Timeframe = '1Day';
 const mockRawAnalysis: RawAnalysisResponse = {
     summary: '테스트 분석 요약',
     trend: 'bullish' as const,
-    skillSignals: [],
+    indicatorResults: [],
     riskLevel: 'low' as const,
     keyLevels: { support: [], resistance: [] },
     priceTargets: {
@@ -82,7 +82,7 @@ const mockRawAnalysis: RawAnalysisResponse = {
         bearish: { targets: [], condition: '' },
     },
     patternSummaries: [],
-    skillResults: [],
+    strategyResults: [],
     candlePatterns: [],
     trendlines: [],
 };
@@ -91,7 +91,7 @@ const mockResult: RunAnalysisResult = {
     ...mockRawAnalysis,
     skillsDegraded: false,
     patternSummaries: [],
-    skillResults: [],
+    strategyResults: [],
     candlePatterns: [],
 };
 

--- a/src/__tests__/infrastructure/market/analyzeAction.test.ts
+++ b/src/__tests__/infrastructure/market/analyzeAction.test.ts
@@ -74,7 +74,6 @@ const mockTimeframe: Timeframe = '1Day';
 const mockRawAnalysis: RawAnalysisResponse = {
     summary: '테스트 분석 요약',
     trend: 'bullish' as const,
-    signals: [],
     skillSignals: [],
     riskLevel: 'low' as const,
     keyLevels: { support: [], resistance: [] },

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -16,7 +16,6 @@ import { SymbolPageClient } from '@/components/symbol-page/SymbolPageClient';
 const FALLBACK_ANALYSIS: AnalysisResponse = {
     summary: 'AI 분석을 일시적으로 사용할 수 없습니다.',
     trend: 'neutral',
-    signals: [],
     skillSignals: [],
     riskLevel: 'medium',
     keyLevels: { support: [], resistance: [] },

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -16,7 +16,7 @@ import { SymbolPageClient } from '@/components/symbol-page/SymbolPageClient';
 const FALLBACK_ANALYSIS: AnalysisResponse = {
     summary: 'AI 분석을 일시적으로 사용할 수 없습니다.',
     trend: 'neutral',
-    skillSignals: [],
+    indicatorResults: [],
     riskLevel: 'medium',
     keyLevels: { support: [], resistance: [] },
     priceTargets: {
@@ -24,7 +24,7 @@ const FALLBACK_ANALYSIS: AnalysisResponse = {
         bearish: { targets: [], condition: '' },
     },
     patternSummaries: [],
-    skillResults: [],
+    strategyResults: [],
     candlePatterns: [],
     trendlines: [],
 };

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -14,7 +14,7 @@ import type {
     Signal,
     SignalStrength,
     SignalType,
-    SkillResult,
+    StrategyResult,
     Trend,
     Trendline,
     TrendlineDirection,
@@ -182,7 +182,6 @@ const SIGNAL_STRENGTH_LABEL: Record<SignalStrength, string> = {
 };
 
 const SIGNAL_TYPE_LABEL: Record<SignalType, string> = {
-    pattern: '패턴',
     skill: '스킬',
 };
 
@@ -559,18 +558,18 @@ function StructuredSkillSummary({ sections }: StructuredSkillSummaryProps) {
     );
 }
 
-interface SkillAccordionItemProps {
-    skill: SkillResult;
+interface StrategyAccordionItemProps {
+    strategy: StrategyResult;
 }
 
-function SkillAccordionItem({ skill }: SkillAccordionItemProps) {
+function StrategyAccordionItem({ strategy }: StrategyAccordionItemProps) {
     const [isOpen, setIsOpen] = useState(false);
 
     const handleToggleOpen = (): void => {
         setIsOpen(prev => !prev);
     };
 
-    const sections = parseStructuredSummary(skill.summary);
+    const sections = parseStructuredSummary(strategy.summary);
 
     return (
         <div className="border-secondary-700 overflow-hidden rounded-md border">
@@ -582,14 +581,14 @@ function SkillAccordionItem({ skill }: SkillAccordionItemProps) {
                     className="flex min-w-0 flex-1 items-center gap-2 px-3 py-2.5 text-left"
                 >
                     <span className="text-secondary-300 min-w-0 flex-1 truncate text-xs font-medium">
-                        {skill.skillName}
+                        {strategy.strategyName}
                     </span>
-                    <TrendBadge trend={skill.trend} />
+                    <TrendBadge trend={strategy.trend} />
                     <ChevronIcon isOpen={isOpen} />
                 </button>
                 <span className="shrink-0 pr-2">
                     <ConfidenceBadge
-                        confidenceWeight={skill.confidenceWeight}
+                        confidenceWeight={strategy.confidenceWeight}
                     />
                 </span>
             </div>
@@ -600,7 +599,7 @@ function SkillAccordionItem({ skill }: SkillAccordionItemProps) {
                         <StructuredSkillSummary sections={sections} />
                     ) : (
                         <p className="text-secondary-400 text-xs leading-relaxed">
-                            {skill.summary}
+                            {strategy.summary}
                         </p>
                     )}
                 </div>
@@ -789,25 +788,25 @@ export function AnalysisPanel({
         analysis.patternSummaries.map(p => p.skillName)
     );
 
-    const detectedSkillResults = analysis.skillResults.filter(
+    const detectedStrategyResults = analysis.strategyResults.filter(
         s =>
             s.confidenceWeight >= MIN_CONFIDENCE_WEIGHT &&
-            !patternSkillNames.has(s.skillName)
+            !patternSkillNames.has(s.strategyName)
     );
 
-    const detectedSkillNames = new Set(
-        detectedSkillResults.map(s => s.skillName)
+    const detectedStrategyNames = new Set(
+        detectedStrategyResults.map(s => s.strategyName)
     );
 
-    const detectedSkillSignals = analysis.skillSignals.filter(s =>
-        detectedSkillNames.has(s.skillName)
+    const strategyLinkedIndicatorResults = analysis.indicatorResults.filter(r =>
+        detectedStrategyNames.has(r.indicatorName)
     );
 
-    const indicatorSkillSignals = analysis.skillSignals.filter(
-        s =>
-            s.skillName !== '' &&
-            !patternSkillNames.has(s.skillName) &&
-            !detectedSkillNames.has(s.skillName)
+    const displayedIndicatorResults = analysis.indicatorResults.filter(
+        r =>
+            r.indicatorName !== '' &&
+            !patternSkillNames.has(r.indicatorName) &&
+            !detectedStrategyNames.has(r.indicatorName)
     );
 
     return (
@@ -843,8 +842,8 @@ export function AnalysisPanel({
                 </div>
             </div>
             <p className="text-secondary-500 font-mono text-xs">
-                {detectedPatterns.length + detectedSkillResults.length}개 스킬
-                감지 · {INDICATOR_KIND_COUNT}종 인디케이터 적용
+                {detectedPatterns.length + detectedStrategyResults.length}개
+                스킬 감지 · {INDICATOR_KIND_COUNT}종 인디케이터 적용
             </p>
 
             {/* 요약 — 분석 중에는 진행 인디케이터로 대체.
@@ -880,100 +879,6 @@ export function AnalysisPanel({
                                 )
                             }
                         />
-                    )}
-
-                    {/* 보조지표 시그널 */}
-                    {indicatorSkillSignals.length > 0 && (
-                        <div className="flex flex-col gap-2">
-                            <span className="text-secondary-500 text-xs font-semibold tracking-wide uppercase">
-                                보조지표
-                            </span>
-                            <div className="flex flex-col gap-1.5">
-                                {indicatorSkillSignals.map(skillSignal =>
-                                    skillSignal.signals.map((signal, index) => (
-                                        <SignalItem
-                                            key={`${skillSignal.skillName}-${signal.type}-${index}`}
-                                            signal={signal}
-                                            typeLabel={skillSignal.skillName}
-                                        />
-                                    ))
-                                )}
-                            </div>
-                        </div>
-                    )}
-
-                    {/* 스킬 시그널 (skillName별 그룹핑) — 감지된 스킬만 표시 */}
-                    {detectedSkillSignals.length > 0 && (
-                        <div className="flex flex-col gap-3">
-                            <span className="text-secondary-500 text-xs font-semibold tracking-wide uppercase">
-                                패턴 / 스킬
-                            </span>
-                            {detectedSkillSignals.map(skillSignal => (
-                                <div
-                                    key={skillSignal.skillName}
-                                    className="flex flex-col gap-1.5"
-                                >
-                                    <span className="text-secondary-400 text-xs font-medium">
-                                        {skillSignal.skillName}
-                                    </span>
-                                    {skillSignal.signals.map(
-                                        (signal, index) => (
-                                            <SignalItem
-                                                key={`${signal.type}-${index}`}
-                                                signal={signal}
-                                            />
-                                        )
-                                    )}
-                                </div>
-                            ))}
-                        </div>
-                    )}
-
-                    {/* 캔들 패턴 (아코디언) */}
-                    {/* 패턴 상세 (아코디언) — 감지된 패턴만 표시, 없으면 안내 메시지 */}
-                    <div className="flex flex-col gap-2">
-                        <span className="text-secondary-500 text-xs font-semibold tracking-wide uppercase">
-                            차트 패턴
-                        </span>
-                        {hasDetectedPatterns ? (
-                            <div className="flex flex-col gap-1.5">
-                                {detectedPatterns.map(pattern => (
-                                    <PatternAccordionItem
-                                        key={pattern.id}
-                                        pattern={pattern}
-                                        isVisible={
-                                            chartVisiblePatterns?.has(
-                                                pattern.patternName
-                                            ) ?? false
-                                        }
-                                        onToggleVisibility={
-                                            handleTogglePatternVisibility
-                                        }
-                                    />
-                                ))}
-                            </div>
-                        ) : (
-                            <p className="text-secondary-500 text-sm">
-                                감지된 패턴 없음
-                            </p>
-                        )}
-                    </div>
-
-                    {/* 스킬 상세 (아코디언) — 감지된 스킬만 표시 */}
-                    {detectedSkillResults.length > 0 && (
-                        <div className="flex flex-col gap-2">
-                            <span className="text-secondary-500 text-xs font-semibold tracking-wide uppercase">
-                                전략
-                            </span>
-                            <div className="flex flex-col gap-1.5">
-                                {detectedSkillResults.map(skill => (
-                                    <SkillAccordionItem
-                                        key={skill.id}
-                                        skill={skill}
-                                    />
-                                ))}
-                            </div>
-                        </div>
                     )}
 
                     {/* 지지/저항 레벨 */}
@@ -1127,6 +1032,107 @@ export function AnalysisPanel({
                                     scenario={analysis.priceTargets.bearish}
                                     colorClass="text-chart-bearish"
                                 />
+                            </div>
+                        </div>
+                    )}
+
+                    {/* 보조지표 */}
+                    {displayedIndicatorResults.length > 0 && (
+                        <div className="flex flex-col gap-2">
+                            <span className="text-secondary-500 text-xs font-semibold tracking-wide uppercase">
+                                보조지표
+                            </span>
+                            <div className="flex flex-col gap-1.5">
+                                {displayedIndicatorResults.map(
+                                    indicatorResult =>
+                                        indicatorResult.signals.map(
+                                            (signal, index) => (
+                                                <SignalItem
+                                                    key={`${indicatorResult.indicatorName}-${signal.type}-${index}`}
+                                                    signal={signal}
+                                                    typeLabel={
+                                                        indicatorResult.indicatorName
+                                                    }
+                                                />
+                                            )
+                                        )
+                                )}
+                            </div>
+                        </div>
+                    )}
+
+                    {/* 전략 연계 보조지표 (strategyResults 이름과 매칭되는 indicatorResults — 엣지 케이스) */}
+                    {strategyLinkedIndicatorResults.length > 0 && (
+                        <div className="flex flex-col gap-3">
+                            <span className="text-secondary-500 text-xs font-semibold tracking-wide uppercase">
+                                전략 연계 보조지표
+                            </span>
+                            {strategyLinkedIndicatorResults.map(
+                                indicatorResult => (
+                                    <div
+                                        key={indicatorResult.indicatorName}
+                                        className="flex flex-col gap-1.5"
+                                    >
+                                        <span className="text-secondary-400 text-xs font-medium">
+                                            {indicatorResult.indicatorName}
+                                        </span>
+                                        {indicatorResult.signals.map(
+                                            (signal, index) => (
+                                                <SignalItem
+                                                    key={`${signal.type}-${index}`}
+                                                    signal={signal}
+                                                />
+                                            )
+                                        )}
+                                    </div>
+                                )
+                            )}
+                        </div>
+                    )}
+
+                    {/* 캔들 패턴 (아코디언) */}
+                    {/* 패턴 상세 (아코디언) — 감지된 패턴만 표시, 없으면 안내 메시지 */}
+                    <div className="flex flex-col gap-2">
+                        <span className="text-secondary-500 text-xs font-semibold tracking-wide uppercase">
+                            차트 패턴
+                        </span>
+                        {hasDetectedPatterns ? (
+                            <div className="flex flex-col gap-1.5">
+                                {detectedPatterns.map(pattern => (
+                                    <PatternAccordionItem
+                                        key={pattern.id}
+                                        pattern={pattern}
+                                        isVisible={
+                                            chartVisiblePatterns?.has(
+                                                pattern.patternName
+                                            ) ?? false
+                                        }
+                                        onToggleVisibility={
+                                            handleTogglePatternVisibility
+                                        }
+                                    />
+                                ))}
+                            </div>
+                        ) : (
+                            <p className="text-secondary-500 text-sm">
+                                감지된 패턴 없음
+                            </p>
+                        )}
+                    </div>
+
+                    {/* 전략 상세 (아코디언) — 감지된 전략만 표시 */}
+                    {detectedStrategyResults.length > 0 && (
+                        <div className="flex flex-col gap-2">
+                            <span className="text-secondary-500 text-xs font-semibold tracking-wide uppercase">
+                                전략
+                            </span>
+                            <div className="flex flex-col gap-1.5">
+                                {detectedStrategyResults.map(strategy => (
+                                    <StrategyAccordionItem
+                                        key={strategy.id}
+                                        strategy={strategy}
+                                    />
+                                ))}
                             </div>
                         </div>
                     )}

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -203,7 +203,7 @@ function SignalItem({ signal, typeLabel }: SignalItemProps) {
             </span>
             <div className="min-w-0 flex-1">
                 <span className="text-secondary-300 block text-xs font-medium">
-                    {typeLabel || SIGNAL_TYPE_LABEL[signal.type]}
+                    {typeLabel ?? SIGNAL_TYPE_LABEL[signal.type]}
                 </span>
                 <span className="text-secondary-400 block text-xs">
                     {signal.description}
@@ -794,19 +794,8 @@ export function AnalysisPanel({
             !patternSkillNames.has(s.strategyName)
     );
 
-    const detectedStrategyNames = new Set(
-        detectedStrategyResults.map(s => s.strategyName)
-    );
-
-    const strategyLinkedIndicatorResults = analysis.indicatorResults.filter(r =>
-        detectedStrategyNames.has(r.indicatorName)
-    );
-
     const displayedIndicatorResults = analysis.indicatorResults.filter(
-        r =>
-            r.indicatorName !== '' &&
-            !patternSkillNames.has(r.indicatorName) &&
-            !detectedStrategyNames.has(r.indicatorName)
+        r => r.indicatorName !== '' && !patternSkillNames.has(r.indicatorName)
     );
 
     return (
@@ -1058,35 +1047,6 @@ export function AnalysisPanel({
                                         )
                                 )}
                             </div>
-                        </div>
-                    )}
-
-                    {/* 전략 연계 보조지표 (strategyResults 이름과 매칭되는 indicatorResults — 엣지 케이스) */}
-                    {strategyLinkedIndicatorResults.length > 0 && (
-                        <div className="flex flex-col gap-3">
-                            <span className="text-secondary-500 text-xs font-semibold tracking-wide uppercase">
-                                전략 연계 보조지표
-                            </span>
-                            {strategyLinkedIndicatorResults.map(
-                                indicatorResult => (
-                                    <div
-                                        key={indicatorResult.indicatorName}
-                                        className="flex flex-col gap-1.5"
-                                    >
-                                        <span className="text-secondary-400 text-xs font-medium">
-                                            {indicatorResult.indicatorName}
-                                        </span>
-                                        {indicatorResult.signals.map(
-                                            (signal, index) => (
-                                                <SignalItem
-                                                    key={`${signal.type}-${index}`}
-                                                    signal={signal}
-                                                />
-                                            )
-                                        )}
-                                    </div>
-                                )
-                            )}
                         </div>
                     )}
 

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -182,15 +182,6 @@ const SIGNAL_STRENGTH_LABEL: Record<SignalStrength, string> = {
 };
 
 const SIGNAL_TYPE_LABEL: Record<SignalType, string> = {
-    rsi_overbought: 'RSI 과매수',
-    rsi_oversold: 'RSI 과매도',
-    macd_golden_cross: 'MACD 골든 크로스',
-    macd_dead_cross: 'MACD 데드 크로스',
-    bollinger_upper_breakout: '볼린저 상단 돌파',
-    bollinger_lower_breakout: '볼린저 하단 이탈',
-    bollinger_squeeze: '볼린저 스퀴즈',
-    dmi_bullish_trend: 'DMI 상승 추세',
-    dmi_bearish_trend: 'DMI 하락 추세',
     pattern: '패턴',
     skill: '스킬',
 };
@@ -213,7 +204,7 @@ function SignalItem({ signal, typeLabel }: SignalItemProps) {
             </span>
             <div className="min-w-0 flex-1">
                 <span className="text-secondary-300 block text-xs font-medium">
-                    {typeLabel ?? SIGNAL_TYPE_LABEL[signal.type]}
+                    {typeLabel || SIGNAL_TYPE_LABEL[signal.type]}
                 </span>
                 <span className="text-secondary-400 block text-xs">
                     {signal.description}
@@ -814,6 +805,7 @@ export function AnalysisPanel({
 
     const indicatorSkillSignals = analysis.skillSignals.filter(
         s =>
+            s.skillName !== '' &&
             !patternSkillNames.has(s.skillName) &&
             !detectedSkillNames.has(s.skillName)
     );
@@ -890,22 +882,13 @@ export function AnalysisPanel({
                         />
                     )}
 
-                    {/* 인디케이터 시그널 */}
-                    {(analysis.signals.some(s => s.type !== 'skill') ||
-                        indicatorSkillSignals.length > 0) && (
+                    {/* 보조지표 시그널 */}
+                    {indicatorSkillSignals.length > 0 && (
                         <div className="flex flex-col gap-2">
                             <span className="text-secondary-500 text-xs font-semibold tracking-wide uppercase">
                                 보조지표
                             </span>
                             <div className="flex flex-col gap-1.5">
-                                {analysis.signals
-                                    .filter(s => s.type !== 'skill')
-                                    .map((signal, index) => (
-                                        <SignalItem
-                                            key={`${signal.type}-${index}`}
-                                            signal={signal}
-                                        />
-                                    ))}
                                 {indicatorSkillSignals.map(skillSignal =>
                                     skillSignal.signals.map((signal, index) => (
                                         <SignalItem

--- a/src/domain/analysis/confidence.ts
+++ b/src/domain/analysis/confidence.ts
@@ -9,7 +9,7 @@ import type {
     PatternSummary,
     RawAnalysisResponse,
     Skill,
-    SkillResult,
+    StrategyResult,
 } from '@/domain/types';
 
 interface SkillLookup {
@@ -62,7 +62,10 @@ export function enrichAnalysisWithConfidence(
         analysis.candlePatterns,
         'patternName'
     );
-    const skillResultIds = buildUniqueIds(analysis.skillResults, 'skillName');
+    const strategyResultIds = buildUniqueIds(
+        analysis.strategyResults,
+        'strategyName'
+    );
 
     const enrichedPatterns: PatternResult[] = analysis.patternSummaries.map(
         (
@@ -84,15 +87,15 @@ export function enrichAnalysisWithConfidence(
     return {
         ...analysis,
         patternSummaries: filterPatterns(enrichedPatterns),
-        skillResults: analysis.skillResults.map(
+        strategyResults: analysis.strategyResults.map(
             (
-                r: Omit<SkillResult, 'confidenceWeight' | 'id'>,
+                r: Omit<StrategyResult, 'confidenceWeight' | 'id'>,
                 index: number
-            ): SkillResult => ({
+            ): StrategyResult => ({
                 ...r,
-                id: skillResultIds[index],
+                id: strategyResultIds[index],
                 confidenceWeight:
-                    findSkill(lookup, r.skillName)?.confidenceWeight ??
+                    findSkill(lookup, r.strategyName)?.confidenceWeight ??
                     UNMATCHED_SKILL_CONFIDENCE_WEIGHT,
             })
         ),

--- a/src/domain/analysis/prompt.ts
+++ b/src/domain/analysis/prompt.ts
@@ -304,9 +304,8 @@ const ANALYSIS_RESPONSE_SCHEMA: Record<keyof AnalysisResponse, string> = {
     summary:
         '"A comprehensive, accessible summary that synthesizes ALL findings (indicators, patterns, volume profile, skills, strategies) into plain language a non-technical user can understand. Instead of stating raw indicator values, explain their practical meaning (e.g., instead of RSI is overbought at 75, say the stock has risen quickly and may be due for a pause). Answer: What is happening with this stock and what does it mean for the investor? Use \\n to separate each topic."',
     trend: '"bullish | bearish | neutral"',
-    signals:
-        '[{ "type": "...", "description": "...", "strength": "strong | moderate | weak" }]',
-    skillSignals: '[{ "skillName": "...", "signals": [...] }]',
+    skillSignals:
+        '[{ "skillName": "RSI Signal Guide", "signals": [{ "type": "skill", "description": "RSI 72.5 — 과매수 임계선에 근접, 단기 조정 가능", "strength": "strong | moderate | weak" }] }]',
     riskLevel: '"low | medium | high"',
     keyLevels:
         '{ "support": [{ "price": 150.00, "reason": "..." }], "resistance": [{ "price": 160.00, "reason": "..." }], "poc": { "price": 155.00, "reason": "..." } }',
@@ -316,7 +315,7 @@ const ANALYSIS_RESPONSE_SCHEMA: Record<keyof AnalysisResponse, string> = {
         // Only chart patterns defined in skills/*.md. Candle patterns go in candlePatterns.
         '[{ "patternName": "...", "skillName": "...", "detected": true, "trend": "bullish | bearish | neutral", "summary": "...", "keyPrices": [{ "label": "넥라인", "price": 150.00 }], "patternLines": [{ "label": "상단 추세선", "start": { "time": 1700000000, "price": 155.00 }, "end": { "time": 1700100000, "price": 152.00 } }, { "label": "하단 추세선", "start": { "time": 1700000000, "price": 148.00 }, "end": { "time": 1700100000, "price": 146.00 } }], "timeRange": { "start": 1700000000, "end": 1700100000 } }]',
     skillResults:
-        '[{ "skillName": "...", "trend": "bullish | bearish | neutral", "summary": "..." }]',
+        '[{ "skillName": "...", "trend": "bullish | bearish | neutral (REQUIRED — never omit)", "summary": "..." }]',
     candlePatterns:
         // Only candle patterns detected from bar data. Skills patterns go in patternSummaries.
         '[{ "patternName": "three_outside_down", "detected": true, "trend": "bearish", "summary": "..." }]',
@@ -355,7 +354,7 @@ const ANALYSIS_GUIDELINES = [
     '### Ichimoku Cloud Interpretation',
     '- Price above the cloud (Kumo): bullish trend; price below: bearish trend; price inside: neutral/consolidation',
     '- Tenkan-sen crossing above Kijun-sen is a bullish signal (TK cross); crossing below is bearish',
-    '- Chikou Span above price from 26 periods ago confirms bullish momentum; below confirms bearish',
+    `- Chikou Span above price from ${ICHIMOKU_BASE_PERIOD} periods ago confirms bullish momentum; below confirms bearish`,
     '- Thick cloud ahead indicates strong support/resistance; thin cloud suggests a potential breakout zone',
     '',
     '### Price Target Calculation',
@@ -461,6 +460,17 @@ const ANALYSIS_GUIDELINES = [
 const RESPONSE_LANGUAGE_INSTRUCTION =
     'IMPORTANT: All text field values in the JSON response (summary, description, reason, basis, condition, positionAnalysis, entry, exit, riskReward, etc.) must be written in Korean (한국어). Do not use English for any response content. Use formal/polite speech level (존댓말, e.g. "~입니다", "~습니다"). For the summary field, use \\n to separate each topic or sentence into its own line — do not write the summary as a single long paragraph. Other text fields (description, reason, basis, condition, positionAnalysis, entry, exit, riskReward, etc.) should also use \\n for line breaks where it improves readability.';
 
+const CRITICAL_RESPONSE_RULES = [
+    '',
+    '### Critical Response Rules (MUST follow)',
+    '- Return ONLY a single valid JSON object. Do not include any prose, explanation, or commentary before or after the JSON.',
+    '- Do not wrap the JSON in markdown code fences (no ```json ... ```). Output the raw JSON object directly.',
+    '- The JSON must exactly match the schema structure shown below. Do not add extra fields, rename fields, or omit required fields.',
+    '- For array fields that have no results, return an empty array []. Never return null or omit the field.',
+    '- All numeric price values must be plain numbers (e.g., 150.25), not strings.',
+    '- All Unix timestamp values must be integers copied verbatim from the [ts:<number>] markers in the bar data.',
+].join('\n');
+
 const buildAnalysisRequest = (
     patternSkills: Skill[],
     strategySkills: Skill[],
@@ -502,7 +512,10 @@ const buildAnalysisRequest = (
                   '- For each strategy skill listed below, include exactly one entry in skillResults.',
                   "- Follow the summary format specified in each strategy skill's ## AI Analysis Instructions section.",
                   '- The summary field must use the structured markdown format with **label**: value lines.',
-                  "- Set the trend field based on each skill's own analysis instructions (bullish/bearish/neutral).",
+                  '- REQUIRED FIELDS (never omit any):',
+                  '  1. skillName: exactly match one strategy skill name from the list below.',
+                  '  2. trend: one of "bullish", "bearish", "neutral". Set based on the skill\'s own analysis instructions. NEVER omit this field — if the analysis is inconclusive, use "neutral".',
+                  "  3. summary: non-empty Korean markdown text following the skill's format.",
                   '',
                   'Strategy skill list to analyze:',
                   ...strategySkills.map(s => `- ${s.name}`),
@@ -513,22 +526,25 @@ const buildAnalysisRequest = (
         indicatorGuideSkills.length > 0
             ? [
                   '',
-                  '### signals Writing Rules for Indicator Guides',
+                  '### skillSignals Writing Rules for Indicator Guides',
                   '- Use the Indicator Signal Guides above to interpret the current indicator values in ## Indicator Values.',
                   '- For each indicator guide, evaluate whether the current values meet any signal condition described in its Signal Interpretation section.',
-                  '- When a signal condition is met, include a corresponding entry in the signals array.',
-                  '- Do NOT add entries to the signals array for indicator guide results. Instead, add them to the skillSignals array.',
-                  '- For each indicator guide that produces a signal, add one entry to skillSignals: { "skillName": "<exact skill name>", "signals": [{ "type": "skill", "description": "...", "strength": "..." }] }.',
-                  '- The skillName field in the skillSignals entry MUST exactly match the skill name from the list below.',
-                  '- The description field must be written in Korean and include the indicator name and specific condition (e.g., "Stochastic %K 82 — 과매수 구간 진입, ADX 18로 레인지 환경에서 신뢰도 높음").',
-                  '- Signal strength guidelines:',
-                  '  - strong: value is in an extreme zone (e.g., RSI > 80 or < 20, Stochastic > 90 or < 10, CCI > +200 or < -200) OR multiple indicators confirm the same direction',
-                  '  - moderate: value is in a standard threshold zone (e.g., RSI 70–80, Stochastic 80–90, CCI ±100–200) with single-indicator confirmation',
-                  '  - weak: value is approaching a threshold but not yet crossed, or the signal conflicts with the prevailing trend',
-                  '- When the Key Combinations section of a guide identifies a multi-indicator confluence that is currently active, increase the signal strength by one level and note the confluence in the description.',
+                  '- For every detected signal, add one entry to the skillSignals array in the following exact format:',
+                  '    { "skillName": "<exact skill name from the list below>", "signals": [{ "type": "skill", "description": "<Korean explanation>", "strength": "strong | moderate | weak" }] }',
+                  '- CRITICAL RULES (never violate):',
+                  '  1. skillName MUST be a non-empty string that exactly matches one skill name from the list below. Never use an empty string, a translated name, or a generic label.',
+                  '  2. Each skillSignals entry corresponds to EXACTLY ONE indicator guide. Never combine multiple indicators (e.g., "MACD and Bollinger") into one entry. Create separate entries for separate indicators.',
+                  '  3. The type field of each signal entry MUST be "skill". Never use any other value.',
+                  '  4. The description field MUST be written in Korean and MUST include the indicator name and specific numeric condition (e.g., "RSI 72.5 — 과매수 임계선에 근접, 단기 조정 가능").',
+                  '- Signal strength calibration:',
+                  '  - strong: value is in an extreme zone (e.g., RSI > 80 or < 20, Stochastic > 90 or < 10, CCI > +200 or < -200) OR multiple indicators confirm the same direction with high confluence',
+                  '  - moderate: value is in a standard overbought/oversold zone (e.g., RSI 70–80, Stochastic 80–90, CCI ±100–200) with single-indicator confirmation',
+                  '  - weak: value is approaching a threshold but has not yet crossed, or the signal conflicts with the prevailing trend',
+                  '- When the Key Combinations section of a guide identifies a multi-indicator confluence that is currently active, increase the strength by one level AND note the confluence in the description field.',
                   "- Respect each guide's Caveats section: do not generate a signal if the caveats indicate it would be unreliable in the current market context (e.g., Stochastic overbought in a strong uptrend with ADX > 25 should not automatically produce a bearish signal).",
+                  '- If no signal conditions are met for a given indicator guide, simply omit that guide from skillSignals. Do not create placeholder or empty entries.',
                   '',
-                  'Indicator guide list to apply:',
+                  'Indicator guide list (use these exact names for skillName):',
                   ...indicatorGuideSkills.map(s => `- ${s.name}`),
               ].join('\n')
             : '';
@@ -569,6 +585,7 @@ const buildAnalysisRequest = (
 
     return [
         '## Analysis Request',
+        CRITICAL_RESPONSE_RULES,
         RESPONSE_LANGUAGE_INSTRUCTION,
         'Based on the data above, perform technical analysis and respond in the following JSON format:',
         buildSchemaBody(),

--- a/src/domain/analysis/prompt.ts
+++ b/src/domain/analysis/prompt.ts
@@ -304,8 +304,8 @@ const ANALYSIS_RESPONSE_SCHEMA: Record<keyof AnalysisResponse, string> = {
     summary:
         '"A comprehensive, accessible summary that synthesizes ALL findings (indicators, patterns, volume profile, skills, strategies) into plain language a non-technical user can understand. Instead of stating raw indicator values, explain their practical meaning (e.g., instead of RSI is overbought at 75, say the stock has risen quickly and may be due for a pause). Answer: What is happening with this stock and what does it mean for the investor? Use \\n to separate each topic."',
     trend: '"bullish | bearish | neutral"',
-    skillSignals:
-        '[{ "skillName": "RSI Signal Guide", "signals": [{ "type": "skill", "description": "RSI 72.5 — 과매수 임계선에 근접, 단기 조정 가능", "strength": "strong | moderate | weak" }] }]',
+    indicatorResults:
+        '[{ "indicatorName": "RSI Signal Guide", "signals": [{ "type": "skill", "description": "RSI 72.5 — 과매수 임계선에 근접, 단기 조정 가능", "strength": "strong | moderate | weak" }] }]',
     riskLevel: '"low | medium | high"',
     keyLevels:
         '{ "support": [{ "price": 150.00, "reason": "..." }], "resistance": [{ "price": 160.00, "reason": "..." }], "poc": { "price": 155.00, "reason": "..." } }',
@@ -314,8 +314,8 @@ const ANALYSIS_RESPONSE_SCHEMA: Record<keyof AnalysisResponse, string> = {
     patternSummaries:
         // Only chart patterns defined in skills/*.md. Candle patterns go in candlePatterns.
         '[{ "patternName": "...", "skillName": "...", "detected": true, "trend": "bullish | bearish | neutral", "summary": "...", "keyPrices": [{ "label": "넥라인", "price": 150.00 }], "patternLines": [{ "label": "상단 추세선", "start": { "time": 1700000000, "price": 155.00 }, "end": { "time": 1700100000, "price": 152.00 } }, { "label": "하단 추세선", "start": { "time": 1700000000, "price": 148.00 }, "end": { "time": 1700100000, "price": 146.00 } }], "timeRange": { "start": 1700000000, "end": 1700100000 } }]',
-    skillResults:
-        '[{ "skillName": "...", "trend": "bullish | bearish | neutral (REQUIRED — never omit)", "summary": "..." }]',
+    strategyResults:
+        '[{ "strategyName": "...", "trend": "bullish | bearish | neutral (REQUIRED — never omit)", "summary": "..." }]',
     candlePatterns:
         // Only candle patterns detected from bar data. Skills patterns go in patternSummaries.
         '[{ "patternName": "three_outside_down", "detected": true, "trend": "bearish", "summary": "..." }]',
@@ -334,6 +334,12 @@ const buildSchemaBody = (): string => {
 
 const ANALYSIS_GUIDELINES = [
     '## Analysis Guidelines',
+    '',
+    '### Name Field Matching (applies to all identifier fields)',
+    '- Every name-identifier field in the response — patternSummaries[].skillName, strategyResults[].strategyName, and indicatorResults[].indicatorName — MUST be a non-empty string that EXACTLY matches one of the skill names from the lists provided in the Writing Rules sections below.',
+    '- Copy each skill name verbatim. Do not translate, abbreviate, paraphrase, reorder, or modify the casing.',
+    '- Never use an empty string "" or a generic label (e.g., "indicator", "strategy", "pattern") for any name-identifier field.',
+    '- If no skill from the provided list is applicable to a given finding, omit the entry entirely rather than inventing a name.',
     '',
     '### Candle Patterns vs Chart Patterns',
     '- candlePatterns: Only include candle patterns (single/multi candle) detected from bar data. Chart patterns defined in skills/*.md go in patternSummaries.',
@@ -488,7 +494,8 @@ const buildAnalysisRequest = (
                   '- Patterns that are not detected must still be included with detected: false.',
                   '- **Do not include any patterns not listed below in patternSummaries.**',
                   '- **Do not include candle patterns (single/multi candle) in patternSummaries.** Candle patterns belong only in candlePatterns.',
-                  '- The "skillName" field in each patternSummaries entry MUST exactly match one of the skill names listed below. Copy the name verbatim — do not translate, abbreviate, or modify it.',
+                  '- skillName: follow the Name Field Matching rule in ## Analysis Guidelines. It MUST exactly match one of the pattern skill names from the list below.',
+                  '- The trend field is REQUIRED for every patternSummaries entry, including entries where detected is false. For not-detected patterns, use the pattern\'s inherent directional bias (e.g., head-and-shoulders → bearish, inverse head-and-shoulders → bullish, ascending wedge → bearish, descending wedge → bullish, double top → bearish, double bottom → bullish). Use "neutral" only when the pattern has no inherent bias. NEVER omit the trend field.',
                   '',
                   '### patternLines Writing Rules',
                   '- patternLines is an optional field. Include it only when detected: true and the pattern has diagonal trendlines (e.g., wedge upper/lower trendlines, neckline).',
@@ -508,12 +515,12 @@ const buildAnalysisRequest = (
         strategySkills.length > 0
             ? [
                   '',
-                  '### skillResults Writing Rules for Strategy Skills',
-                  '- For each strategy skill listed below, include exactly one entry in skillResults.',
+                  '### strategyResults Writing Rules for Strategy Skills',
+                  '- For each strategy skill listed below, include exactly one entry in strategyResults.',
                   "- Follow the summary format specified in each strategy skill's ## AI Analysis Instructions section.",
                   '- The summary field must use the structured markdown format with **label**: value lines.',
                   '- REQUIRED FIELDS (never omit any):',
-                  '  1. skillName: exactly match one strategy skill name from the list below.',
+                  '  1. strategyName: follow the Name Field Matching rule in ## Analysis Guidelines. It MUST exactly match one strategy skill name from the list below.',
                   '  2. trend: one of "bullish", "bearish", "neutral". Set based on the skill\'s own analysis instructions. NEVER omit this field — if the analysis is inconclusive, use "neutral".',
                   "  3. summary: non-empty Korean markdown text following the skill's format.",
                   '',
@@ -526,14 +533,14 @@ const buildAnalysisRequest = (
         indicatorGuideSkills.length > 0
             ? [
                   '',
-                  '### skillSignals Writing Rules for Indicator Guides',
+                  '### indicatorResults Writing Rules for Indicator Guides',
                   '- Use the Indicator Signal Guides above to interpret the current indicator values in ## Indicator Values.',
                   '- For each indicator guide, evaluate whether the current values meet any signal condition described in its Signal Interpretation section.',
-                  '- For every detected signal, add one entry to the skillSignals array in the following exact format:',
-                  '    { "skillName": "<exact skill name from the list below>", "signals": [{ "type": "skill", "description": "<Korean explanation>", "strength": "strong | moderate | weak" }] }',
+                  '- For every detected signal, add one entry to the indicatorResults array in the following exact format:',
+                  '    { "indicatorName": "<exact skill name from the list below>", "signals": [{ "type": "skill", "description": "<Korean explanation>", "strength": "strong | moderate | weak" }] }',
                   '- CRITICAL RULES (never violate):',
-                  '  1. skillName MUST be a non-empty string that exactly matches one skill name from the list below. Never use an empty string, a translated name, or a generic label.',
-                  '  2. Each skillSignals entry corresponds to EXACTLY ONE indicator guide. Never combine multiple indicators (e.g., "MACD and Bollinger") into one entry. Create separate entries for separate indicators.',
+                  '  1. indicatorName: follow the Name Field Matching rule in ## Analysis Guidelines. It MUST be a non-empty string — never use an empty string, a translated name, or a generic label.',
+                  '  2. Each indicatorResults entry corresponds to EXACTLY ONE indicator guide. Never combine multiple indicators (e.g., "MACD and Bollinger") into one entry. Create separate entries for separate indicators.',
                   '  3. The type field of each signal entry MUST be "skill". Never use any other value.',
                   '  4. The description field MUST be written in Korean and MUST include the indicator name and specific numeric condition (e.g., "RSI 72.5 — 과매수 임계선에 근접, 단기 조정 가능").',
                   '- Signal strength calibration:',
@@ -542,9 +549,9 @@ const buildAnalysisRequest = (
                   '  - weak: value is approaching a threshold but has not yet crossed, or the signal conflicts with the prevailing trend',
                   '- When the Key Combinations section of a guide identifies a multi-indicator confluence that is currently active, increase the strength by one level AND note the confluence in the description field.',
                   "- Respect each guide's Caveats section: do not generate a signal if the caveats indicate it would be unreliable in the current market context (e.g., Stochastic overbought in a strong uptrend with ADX > 25 should not automatically produce a bearish signal).",
-                  '- If no signal conditions are met for a given indicator guide, simply omit that guide from skillSignals. Do not create placeholder or empty entries.',
+                  '- If no signal conditions are met for a given indicator guide, simply omit that guide from indicatorResults. Do not create placeholder or empty entries.',
                   '',
-                  'Indicator guide list (use these exact names for skillName):',
+                  'Indicator guide list (use these exact names for indicatorName):',
                   ...indicatorGuideSkills.map(s => `- ${s.name}`),
               ].join('\n')
             : '';

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -157,7 +157,7 @@ export type SkillShowcaseItem = Pick<
     'name' | 'description' | 'type' | 'confidenceWeight'
 >;
 
-export type SignalType = 'pattern' | 'skill';
+export type SignalType = 'skill';
 
 export type SignalStrength = 'strong' | 'moderate' | 'weak';
 
@@ -171,8 +171,8 @@ export interface Signal {
     strength: SignalStrength;
 }
 
-export interface SkillSignal {
-    skillName: string;
+export interface IndicatorGuideResult {
+    indicatorName: string;
     signals: Signal[];
 }
 
@@ -230,9 +230,9 @@ export interface PatternResult extends PatternSummary {
     renderConfig?: SkillChartDisplay;
 }
 
-export interface SkillResult {
+export interface StrategyResult {
     id: string;
-    skillName: string;
+    strategyName: string;
     trend: Trend;
     summary: string;
     confidenceWeight: number;
@@ -282,12 +282,12 @@ export interface ActionRecommendation {
 export interface AnalysisResponse {
     summary: string;
     trend: Trend;
-    skillSignals: SkillSignal[];
+    indicatorResults: IndicatorGuideResult[];
     riskLevel: RiskLevel;
     keyLevels: KeyLevels;
     priceTargets: PriceTargets;
     patternSummaries: PatternResult[];
-    skillResults: SkillResult[];
+    strategyResults: StrategyResult[];
     candlePatterns: CandlePatternSummary[];
     trendlines: Trendline[];
     actionRecommendation?: ActionRecommendation;
@@ -327,9 +327,9 @@ export interface AnalyzeVariables {
 
 export type RawAnalysisResponse = Omit<
     AnalysisResponse,
-    'patternSummaries' | 'skillResults' | 'candlePatterns'
+    'patternSummaries' | 'strategyResults' | 'candlePatterns'
 > & {
     patternSummaries: Omit<PatternSummary, 'confidenceWeight' | 'id'>[];
-    skillResults: Omit<SkillResult, 'confidenceWeight' | 'id'>[];
+    strategyResults: Omit<StrategyResult, 'confidenceWeight' | 'id'>[];
     candlePatterns: Omit<CandlePatternSummary, 'id'>[];
 };

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -157,18 +157,7 @@ export type SkillShowcaseItem = Pick<
     'name' | 'description' | 'type' | 'confidenceWeight'
 >;
 
-export type SignalType =
-    | 'rsi_overbought'
-    | 'rsi_oversold'
-    | 'macd_golden_cross'
-    | 'macd_dead_cross'
-    | 'bollinger_upper_breakout'
-    | 'bollinger_lower_breakout'
-    | 'bollinger_squeeze'
-    | 'dmi_bullish_trend'
-    | 'dmi_bearish_trend'
-    | 'pattern'
-    | 'skill';
+export type SignalType = 'pattern' | 'skill';
 
 export type SignalStrength = 'strong' | 'moderate' | 'weak';
 
@@ -293,7 +282,6 @@ export interface ActionRecommendation {
 export interface AnalysisResponse {
     summary: string;
     trend: Trend;
-    signals: Signal[];
     skillSignals: SkillSignal[];
     riskLevel: RiskLevel;
     keyLevels: KeyLevels;


### PR DESCRIPTION
## 관련 이슈

closes #246

## 구현 내용

### 타입 시스템 정리 (src/domain/types.ts)
- `SignalType`을 `'pattern' | 'skill'`로 축소 (9개 레거시 지표 타입 제거)
- `AnalysisResponse.signals` 필드 완전 제거

### AI 프롬프트 엔지니어링 (src/domain/analysis/prompt.ts)
- `ANALYSIS_RESPONSE_SCHEMA`에서 `signals` 제거
- `indicatorGuideInstruction` 개선: 모순된 "add to signals array" 라인 제거, CRITICAL RULES 섹션 추가
- `strategyInstruction` 강화: REQUIRED FIELDS 섹션 추가, trend 필드 필수화
- `CRITICAL_RESPONSE_RULES` 신규 상수: JSON-only 출력, markdown 코드 펜스 금지, 빈 배열 강제, 정확한 timestamp 복사
- Ichimoku "26 periods" hardcoding 제거 및 상수화

### UI 정리 (src/components/analysis/AnalysisPanel.tsx)
- `SIGNAL_TYPE_LABEL` 축소 (narrowed SignalType에 맞춤)
- Empty string bug fix: `??` → `||` in `SignalItem` typeLabel
- `indicatorSkillSignals` 필터에 `s.skillName !== ''` 방어 가드 추가
- `analysis.signals` 렌더링 경로 완전 제거

### 기타 변경사항
- 폴백 업데이트: `FALLBACK_ANALYSIS.signals` 제거
- 5개 mock 파일 업데이트: `signals: []` 제거, signals 검증 제거
- 8개 신규 테스트 추가 (prompt.test.ts): skillName 필수, 다중 지표 금지, 스키마 동기화 검증 등
- docs/DOMAIN.md 동기화

## 검증

- yarn lint: 0 errors (사전 미사용 변수 경고 제외)
- yarn lint:style: clean
- yarn test: 1072/1072 passing (prompt.test.ts 포함 신규 8개 테스트)
- yarn build: success

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 테스트 구조: describe → describe(context) → it

## 변경 파일 목록

[수정]
- docs/DOMAIN.md
- src/domain/types.ts
- src/domain/analysis/prompt.ts
- src/components/analysis/AnalysisPanel.tsx
- src/app/[symbol]/page.tsx
- src/__tests__/domain/analysis/confidence.test.ts
- src/__tests__/domain/analysis/prompt.test.ts
- src/__tests__/infrastructure/ai/claude.test.ts
- src/__tests__/infrastructure/ai/gemini.test.ts
- src/__tests__/infrastructure/market/analysisApi.test.ts
- src/__tests__/infrastructure/market/analyzeAction.test.ts

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build