### PR TITLE
perf: 차트 라이브러리 dynamic import로 모바일 TTI 개선

### DIFF
--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -226,6 +226,18 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 
 ---
 
+## Documentation Sync
+
+```
+1. Skill document metadata and body content out of sync
+   → Frontmatter indicators list must include all indicators referenced in the document body
+   → AI instructions must reflect the system's actual capabilities, not idealized requirements
+   ❌ mean-reversion.md body uses 2×ATR but frontmatter indicators omits atr
+   ✅ Frontmatter includes all body references; update AI instructions to match actual RECENT_BARS_COUNT=30
+```
+
+---
+
 ## Pure Function Contracts
 
 ```
@@ -286,4 +298,9 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 5. Domain logic conditions differ between server and client
    → When the same business rule applies in both layers, ensure identical conditions on both sides
    → Example: if client uses `name !== ticker` guard, server `buildDisplayName` must use the same guard
+
+6. Unrelated data mixed in a single constant
+   → Constants with different purposes/domains should be in separate modules
+   ❌ src/lib/seo.ts contains both SEO metadata (ogTitle, ogDescription) and legal disclaimers
+   ✅ Separate: src/lib/seo.ts for SEO, src/lib/legal.ts for legal constants
 ```

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,10 @@
 # Fix Log
 
+## [PR #270 | feat/261/차트-dynamic-import-모바일-TTI-개선 | 2026-04-11]
+- Violation: dynamic import loading 컴포넌트(`ChartSkeleton`)가 `absolute inset-0`을 사용함에도 래퍼 컨테이너에 `relative` 클래스 누락
+- Rule: CSS Positioning — `absolute` 자식이 올바른 영역에 렌더되려면 부모 체인에 `positioned element`(`relative/absolute/fixed/sticky`)가 있어야 함
+- Context: StockChart 컨테이너(`<div className="relative flex-3">`)는 기존에 `relative`가 있었으나, VolumeChart 컨테이너는 정적 import에서 로딩 상태가 없어 `relative`가 없었음; dynamic import 전환으로 loading prop이 생기면서 문제가 드러남
+
 ## [PR #267 Round 2 | feat/256/privacy-terms-pages | 2026-04-11]
 - Violation: `Footer.tsx`의 `<div role="note">`에 accessible name(`aria-label`) 누락
 - Rule: WAI-ARIA — role="note" 요소에 aria-label로 accessible name을 제공해야 함

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,10 +1,6 @@
 # Fix Log
 
 ## [PR #267 Round 2 | feat/256/privacy-terms-pages | 2026-04-11]
-- Violation: `lib/seo.ts`에 법적 내용 상수(`INVESTMENT_DISCLAIMER`, `LEGAL_EFFECTIVE_DATE`, `PRIVACY_PATH` 등)와 SEO 상수가 혼재
-- Rule: FF Cohesion 3-A — 다른 목적의 상수는 분리된 모듈에 위치해야 함
-- Context: privacy/terms 페이지 추가 시 법적 상수를 seo.ts에 추가; `src/lib/legal.ts`로 분리하여 해결
-
 - Violation: `Footer.tsx`의 `<div role="note">`에 accessible name(`aria-label`) 누락
 - Rule: WAI-ARIA — role="note" 요소에 aria-label로 accessible name을 제공해야 함
 - Context: privacy/page.tsx와 terms/page.tsx의 동일 요소에는 aria-label이 있으나 Footer.tsx에만 누락됨
@@ -77,15 +73,6 @@
 - Violation: Component props with leading underscore used in component body (e.g., _recommendedAction used as recommendedAction)
 - Rule: CONVENTIONS.md Naming — underscore prefix reserved for intentionally-unused destructured parameters; consumed props must not have underscore
 - Context: ActionRecommendationField received _recommendedAction but used it in render; removed underscore to indicate the prop is actually consumed
-
-## [PR #242 | feat/236/strategies-스킬-추가 | 2026-04-10]
-- Violation: 전략 스킬 frontmatter의 indicators 목록이 본문에서 참조하는 지표(ATR)를 누락
-- Rule: 스킬 문서 일관성 — indicators 목록은 본문에서 참조하는 모든 지표를 포함해야 함
-- Context: mean-reversion.md가 손절선 규칙에서 2 × ATR을 사용하지만 indicators에 atr 미포함
-
-- Violation: AI Analysis Instructions가 시스템이 실제로 제공하지 않는 데이터 범위(120봉, 다중 시간대)를 전제로 작성됨
-- Rule: AI 지침은 시스템의 실제 데이터 제공 범위와 일치해야 함
-- Context: wyckoff.md는 120봉 필요하나 RECENT_BARS_COUNT=30; multi-timeframe.md는 3-Tier 분석 전제하나 단일 타임프레임만 제공
 
 ## [PR #229 Round 2 | feat/229/action-recommendation-chart-overlay | 2026-04-10]
 - Violation: StockChart prop default actionPricesVisible = false contradicted the parent ChartContent's intent (initialized to true). Default off-by-default is misleading when caller explicitly enables the feature.

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -2,12 +2,12 @@
 
 import { useState, useCallback, useMemo, useRef } from 'react';
 import type React from 'react';
+import dynamic from 'next/dynamic';
 import type { AnalysisResponse, Timeframe } from '@/domain/types';
 import { validateKeyLevels } from '@/domain/analysis/keyLevels';
 import { validateActionPrices } from '@/domain/analysis/actionRecommendation';
 import { cn } from '@/lib/cn';
-import { StockChart } from '@/components/chart/StockChart';
-import { VolumeChart } from '@/components/chart/VolumeChart';
+import { ChartSkeleton } from '@/components/chart/ChartSkeleton';
 import { AnalysisPanel } from '@/components/analysis/AnalysisPanel';
 import { useBars } from '@/components/symbol-page/hooks/useBars';
 import { useAnalysis } from '@/components/symbol-page/hooks/useAnalysis';
@@ -25,6 +25,16 @@ import {
     SNAP_HALF,
     type SnapPoint,
 } from '@/components/symbol-page/MobileAnalysisSheet';
+
+const StockChart = dynamic(
+    () => import('@/components/chart/StockChart').then(mod => mod.StockChart),
+    { ssr: false, loading: () => <ChartSkeleton /> }
+);
+
+const VolumeChart = dynamic(
+    () => import('@/components/chart/VolumeChart').then(mod => mod.VolumeChart),
+    { ssr: false, loading: () => <ChartSkeleton /> }
+);
 
 function AnalyzingBanner() {
     return (

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -231,7 +231,7 @@ export function ChartContent({
                 </div>
 
                 {/* 거래량 차트 */}
-                <div className="border-secondary-700 flex-1 border-t">
+                <div className="border-secondary-700 relative flex-1 border-t">
                     <VolumeChart
                         bars={bars}
                         onChartReady={handleVolumeChartReady}


### PR DESCRIPTION
## 관련 이슈

closes #261

## 구현 내용

Next.js `dynamic()` API를 사용해 StockChart와 VolumeChart를 동적으로 로드합니다.
- `ssr: false` 설정으로 SSR 비활성화 (lightweight-charts는 브라우저 API 필요)
- `loading` prop으로 로딩 중 ChartSkeleton 표시
- 초기 번들에서 lightweight-charts 제외 → 모바일 TTI 개선 (현재 7.1s)

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] 외부 라이브러리 추가 없음
- [x] 타입 안전성 확인

## 변경 파일 목록

[수정]
- `src/components/symbol-page/ChartContent.tsx`: dynamic import 적용

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn build