### PR TITLE
feat: SMC(Smart Money Concepts) 보조지표 및 Skills 파일 추가

### DIFF
--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -320,4 +320,10 @@ This file contains only **recurring gotchas** that agents keep missing despite e
    → Constants with different purposes/domains should be in separate modules
    ❌ src/lib/seo.ts contains both SEO metadata (ogTitle, ogDescription) and legal disclaimers
    ✅ Separate: src/lib/seo.ts for SEO, src/lib/legal.ts for legal constants
+
+7. Business domain constants placed in lib/ (violation of lib/CLAUDE.md scope)
+   → lib/ may contain only utility wrappers, React Query key factories, config constants, chart colors
+   → Business domain knowledge (POPULAR_TICKERS, legal disclaimers) must go to domain/ or sitemap-specific modules
+   ❌ POPULAR_TICKERS defined in src/lib/seo.ts
+   ✅ Inline at usage site (src/app/sitemap.ts) or domain-specific module
 ```

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -22,10 +22,6 @@
 - Rule: 일관성 원칙 — 동일 모듈 내 `collectMdFiles`(재귀 탐색)와 구현 방식이 달라 향후 서브디렉토리 추가 시 카운트 불일치 발생 가능
 - Context: `countSkillFiles` 추가 시 `collectMdFiles` 재활용 없이 단순 `readdir` 사용; `collectMdFiles`를 재활용하도록 수정
 
-- Violation: 새로운 public 함수 `countSkillFiles` 추가 시 테스트 케이스 없음
-- Rule: MISTAKES.md Tests #2 — 새로 추가된 함수는 반드시 최소 하나의 `it()` 케이스가 있어야 함
-- Context: infrastructure 레이어 신규 export 함수에 대한 테스트 누락; 정상 케이스(서브디렉토리 재귀 포함) 및 에러 케이스 추가로 해결
-
 ## [PR #267 Round 2 | feat/256/privacy-terms-pages | 2026-04-11]
 - Violation: `lib/seo.ts`에 법적 내용 상수(`INVESTMENT_DISCLAIMER`, `LEGAL_EFFECTIVE_DATE`, `PRIVACY_PATH` 등)와 SEO 상수가 혼재
 - Rule: FF Cohesion 3-A — 다른 목적의 상수는 분리된 모듈에 위치해야 함
@@ -99,11 +95,6 @@
 - Rule: FF.md Readability 1-C — Design intent must be exposed in code; default values must align with component usage context or caller must explicitly pass the value
 - Context: ChartContent initializes actionPricesVisible={true}, but StockChart defaulted to false when prop was optional, creating contradiction between declaration and runtime behavior. Fixed by changing StockChart default to true to expose the actual design intent.
 
-## [PR #245 | feat/240/9종-보조지표-domain-계산-로직 | 2026-04-11]
-- Violation: period 기반 인디케이터 테스트에서 초기 null 범위 케이스 누락
-- Rule: CONVENTIONS.md "Required Test Cases for Period-Based Indicators" — 처음 N개 null 케이스 필수
-- Context: `keltnerChannel.test.ts`에 '처음 max(emaPeriod-1, atrPeriod)개의 값은 null이다' 테스트 케이스 미포함; 추가 시 리뷰어 제안 수식(max(emaPeriod, atrPeriod))이 구현과 불일치하여 실제 null 구간(emaPeriod-1)으로 수정
-
 ## [PR #230 | feat/229/action-recommendation-chart-overlay | 2026-04-10]
 - Violation: `#f87171`(actionStopLoss)과 `#4ade80`(actionTakeProfit)은 디자인 시스템에 없는 임의 hex 값 사용
 - Rule: DESIGN.md — 상승/하락 색상은 `#26a69a`(bullish) / `#ef5350`(bearish) 고정; 임의 hex 금지
@@ -112,3 +103,4 @@
 - Violation: `ValidatedActionPrices` 인터페이스를 구현 파일(`actionRecommendation.ts`)에 정의
 - Rule: ARCHITECTURE.md — 도메인 결과 타입은 `domain/types.ts`에 정의해야 함
 - Context: 다른 파일(`StockChart.tsx`, `useActionRecommendationOverlay.ts`)에서도 참조하는 타입을 구현 파일에 배치; `domain/types.ts`로 이동
+

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -22,11 +22,6 @@
 - Rule: 일관성 원칙 — 동일 모듈 내 `collectMdFiles`(재귀 탐색)와 구현 방식이 달라 향후 서브디렉토리 추가 시 카운트 불일치 발생 가능
 - Context: `countSkillFiles` 추가 시 `collectMdFiles` 재활용 없이 단순 `readdir` 사용; `collectMdFiles`를 재활용하도록 수정
 
-## [PR #267 Round 2 | feat/256/privacy-terms-pages | 2026-04-11]
-- Violation: `lib/seo.ts`에 법적 내용 상수(`INVESTMENT_DISCLAIMER`, `LEGAL_EFFECTIVE_DATE`, `PRIVACY_PATH` 등)와 SEO 상수가 혼재
-- Rule: FF Cohesion 3-A — 다른 목적의 상수는 분리된 모듈에 위치해야 함
-- Context: privacy/terms 페이지 추가 시 법적 상수를 seo.ts에 추가; `src/lib/legal.ts`로 분리하여 해결
-
 ## [PR #270 | feat/261/차트-dynamic-import-모바일-TTI-개선 | 2026-04-11]
 - Violation: dynamic import loading 컴포넌트(`ChartSkeleton`)가 `absolute inset-0`을 사용함에도 래퍼 컨테이너에 `relative` 클래스 누락
 - Rule: CSS Positioning — `absolute` 자식이 올바른 영역에 렌더되려면 부모 체인에 `positioned element`(`relative/absolute/fixed/sticky`)가 있어야 함
@@ -66,11 +61,6 @@
 - Violation: `.env.example` documented only `ALPACA_SECRET_KEY=` (fallback) and omitted `ALPACA_API_SECRET=` (primary key read by `alpaca.ts`)
 - Rule: docs/API.md — env var documentation must include primary variable names; omitting the primary causes setup errors for new developers
 - Context: `alpaca.ts` reads `ALPACA_API_SECRET` first via `?? ALPACA_SECRET_KEY` fallback, but `.env.example` only listed the fallback variable; `ALPACA_API_SECRET=` was added to the example file
-
-## [PR #208 | feat/185/seo-최적화 | 2026-04-07]
-- Violation: `POPULAR_TICKERS` (비즈니스 도메인 지식)가 `src/lib/seo.ts`에 정의되어 lib 레이어 허용 범위를 벗어남
-- Rule: lib/CLAUDE.md — lib 레이어는 utility wrappers, React Query key factories, config constants, chart color constants만 허용; 도메인 비즈니스 상수는 금지
-- Context: `POPULAR_TICKERS`는 `sitemap.ts`에서만 사용되는 상수로 lib이 아닌 사용처(sitemap.ts) 내부로 인라인 이동하여 해결
 
 ## [fix/bars-null-and-ssr-window-error (FMP API spec fix) | 2026-04-06]
 - Violation: `console.log(url)` left in `fmp.ts` `getBars()` — debug artifact shipped to infrastructure

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -104,3 +104,4 @@
 - Rule: ARCHITECTURE.md — 도메인 결과 타입은 `domain/types.ts`에 정의해야 함
 - Context: 다른 파일(`StockChart.tsx`, `useActionRecommendationOverlay.ts`)에서도 참조하는 타입을 구현 파일에 배치; `domain/types.ts`로 이동
 
+

--- a/skills/strategies/smart-money-concepts.md
+++ b/skills/strategies/smart-money-concepts.md
@@ -1,0 +1,193 @@
+---
+name: 스마트 머니 컨셉 (SMC)
+description: ICT/SMC 방법론에 기반하여 기관 자금의 행동 패턴을 분석 — BOS/CHoCH 구조 이탈, 오더 블록, 공정 가치 갭(FVG), 스윙 포인트, 프리미엄·디스카운트 존을 통해 기관이 축적·청산하는 가격대를 식별하는 전략
+type: strategy
+category: neutral
+indicators: ['atr', 'smc']
+confidence_weight: 0.85
+---
+
+## Overview
+
+Smart Money Concepts (SMC), rooted in the Inner Circle Trader (ICT) methodology, analyses markets by tracking the footprints of institutional capital ("smart money"). Unlike retail trading approaches, SMC assumes that large institutions — banks, hedge funds, central banks — drive sustained price movements through deliberate accumulation and distribution cycles. The methodology identifies the price levels where institutions are likely to enter and exit, then aligns retail positions with those flows.
+
+SMC pre-computed values available in the `smc` indicator field:
+
+| Field | Description |
+|---|---|
+| `swingHighs` / `swingLows` | Confirmed pivot swing points |
+| `structureBreaks` | BOS and CHoCH events with direction and type |
+| `orderBlocks` | Order block zones with mitigation status |
+| `fairValueGaps` | FVG zones with mitigation status |
+| `equalHighs` / `equalLows` | Equal price levels (EQH / EQL) |
+| `premiumZone` | Upper 25% of the recent swing range |
+| `equilibriumZone` | Middle 50% of the recent swing range |
+| `discountZone` | Lower 25% of the recent swing range |
+
+---
+
+## Core Concepts
+
+### 1. Market Structure — BOS and CHoCH
+
+Market structure describes the directional bias of price through its sequence of swing highs and swing lows.
+
+**Bullish structure**: series of higher highs (HH) and higher lows (HL)
+**Bearish structure**: series of lower highs (LH) and lower lows (LL)
+
+**Break of Structure (BOS)**
+- Occurs when price closes beyond the most recent swing level in the SAME direction as the current trend.
+- Confirms trend continuation — institutions are still active in the current direction.
+- A bullish BOS closes above the most recent confirmed swing high; a bearish BOS closes below the most recent swing low.
+
+**Change of Character (CHoCH)**
+- Occurs when price closes beyond a swing level in the OPPOSITE direction to the current trend.
+- The first counter-trend break — signals a potential trend reversal.
+- CHoCH does not confirm a reversal alone; it is a warning signal. Look for confirmation via order block or FVG reaction.
+
+**Analysis rules:**
+- Count consecutive BOS events in the same direction to measure trend strength.
+- A CHoCH after a long BOS sequence is a high-probability reversal warning.
+- CHoCH followed by a successful test of an order block becomes a high-conviction reversal setup.
+
+---
+
+### 2. Order Blocks (OBs)
+
+An order block is the last candle before a significant directional move, representing the price zone where institutional orders were placed.
+
+**Bullish OB**: The last bearish candle (close < open) immediately before a bullish BOS or CHoCH.
+**Bearish OB**: The last bullish candle (close > open) immediately before a bearish BOS or CHoCH.
+
+**Mitigation**: An order block is mitigated when price returns to the zone and crosses through it:
+- Bullish OB mitigated: price closes below OB.low → institutions have exited or been absorbed.
+- Bearish OB mitigated: price closes above OB.high → same logic in reverse.
+
+**Analysis rules:**
+- Unmitigated OBs are the primary areas of interest for potential reversals or continuations.
+- When price returns to an unmitigated OB in the direction of the dominant structure, this is a high-probability entry zone.
+- The closer to the OB the test occurs, the higher the probability of a reaction.
+- Mitigated OBs lose their significance — do not expect reactions from them.
+- OBs near equal highs or lows have additional confluence (liquidity resting above/below these levels acts as fuel for the institutional move).
+
+---
+
+### 3. Fair Value Gaps (FVGs)
+
+A Fair Value Gap is a price imbalance — a three-candle sequence where the middle candle leaves a gap untraded by the surrounding candles.
+
+**Bullish FVG**: `bars[i].low > bars[i-2].high` — price moved up so fast that a zone was skipped.
+**Bearish FVG**: `bars[i].high < bars[i-2].low` — price moved down so fast that a zone was skipped.
+
+The FVG zone for a bullish gap is `[bars[i-2].high, bars[i].low]`. For a bearish gap: `[bars[i].high, bars[i-2].low]`.
+
+**Mitigation**: An FVG is mitigated when price re-enters the gap zone.
+
+**Analysis rules:**
+- Unmitigated FVGs are magnets for price — institutions often drive price back to fill these imbalances before continuing.
+- Bullish FVG in a bullish trend = potential support zone when price returns.
+- Bearish FVG in a bearish trend = potential resistance zone when price returns.
+- Multiple stacked FVGs in the same zone increase the probability of a reaction.
+- An FVG that overlaps with an order block creates an especially high-probability zone.
+- Fully mitigated FVGs have reduced significance — do not expect a strong reaction.
+
+---
+
+### 4. Equal Highs and Equal Lows (EQH / EQL)
+
+Equal highs (EQH) are two or more swing highs within a tight price range (within `0.5 × ATR`). Equal lows (EQL) are the low-side equivalent.
+
+**Why they matter:**
+Institutions use equal highs and lows as liquidity pools. Retail traders place stop-losses just beyond these obvious levels. Institutions often drive price through EQH/EQL to trigger those stops and collect liquidity before reversing in the opposite direction.
+
+**Analysis rules:**
+- EQH above current price = liquidity target. If structure is bullish and price is pushing toward EQH, expect a brief spike through then reversal — or a continuation if institutions are genuinely accumulating.
+- EQL below current price = liquidity target. If structure is bearish and price is approaching EQL, expect a brief dip below then reversal — or a continuation.
+- A BOS through EQH/EQL with follow-through confirms institutional intent in that direction.
+- A failed break through EQH/EQL (quick spike then reversal, often with a wick) is a high-probability reversal signal called a "liquidity sweep."
+
+---
+
+### 5. Premium, Equilibrium, and Discount Zones
+
+Based on the most recent confirmed swing range (last swing high to last swing low):
+
+| Zone | Range | Interpretation |
+|---|---|---|
+| **Premium** | Top 25% of range | Price is expensive relative to the range |
+| **Equilibrium** | Middle 50% of range | Price is at fair value |
+| **Discount** | Bottom 25% of range | Price is cheap relative to the range |
+
+**Analysis rules:**
+- Institutional buyers typically accumulate in the Discount zone; sellers distribute in the Premium zone.
+- Bullish bias: look for long setups when price is in Discount, near an unmitigated bullish OB or FVG.
+- Bearish bias: look for short setups when price is in Premium, near an unmitigated bearish OB or FVG.
+- Price at Equilibrium is neutral — wait for a directional signal rather than entering blind.
+- Equilibrium combined with a strong CHoCH is a mean-reversion trigger.
+
+---
+
+## Confluence Framework
+
+Signals are rated by the number of SMC factors aligning at the same price level:
+
+| Confluence Count | Signal Strength |
+|---|---|
+| 1 factor | Low — do not act alone |
+| 2 factors | Moderate — context-dependent |
+| 3+ factors | High — primary actionable signal |
+
+**Highest-probability setups:**
+1. CHoCH + unmitigated OB in Discount zone (bullish reversal)
+2. CHoCH + unmitigated OB in Premium zone (bearish reversal)
+3. BOS continuation + FVG test at Discount/Premium boundary
+4. Liquidity sweep through EQH/EQL + OB or FVG in the swept zone
+
+**Disconfirming factors (reduce confidence):**
+- OB or FVG already mitigated
+- Structure is mixed (no clear BOS sequence)
+- Price is at Equilibrium with no nearby OB or FVG
+- Equal highs/lows targeted but no reversal signal follows the sweep
+
+---
+
+## AI Analysis Instructions
+
+Use the pre-computed `smc` indicator values and the last 30 bars of OHLCV data.
+
+**Step 1 — Determine market structure bias**
+- Count consecutive bullish vs bearish BOS events in `structureBreaks`.
+- Identify the most recent CHoCH event and whether it has been confirmed by subsequent structure.
+- State: bullish / bearish / mixed (transitioning).
+
+**Step 2 — Identify active key levels**
+- List unmitigated order blocks closest to current price (both bullish and bearish OBs).
+- List unmitigated FVGs nearest to current price.
+- Note any EQH or EQL within 2 × ATR of current price.
+- State which zone (premium / equilibrium / discount) the current price occupies.
+
+**Step 3 — Build confluence**
+- For each key level, count overlapping factors (OB + FVG, EQH proximity, zone alignment).
+- Assign signal strength: low (1 factor), moderate (2), high (3+).
+
+**Step 4 — Form directional opinion**
+- Combine structure bias with key level analysis.
+- State explicitly whether you expect a continuation or reversal, and the primary reason.
+
+Return the analysis in **this exact structured format** (one `**label**: value` pair per line):
+
+```
+**시장 구조**: [강세 / 약세 / 전환 중 — BOS/CHoCH 시퀀스 요약]
+**현재 가격 영역**: [프리미엄 / 균형 / 디스카운트]
+**주요 활성 레벨**: [미완료 OB 및 FVG 레벨, 예: "불리시 OB $185.20–$186.50 (미완료), 불리시 FVG $183.00–$184.20"]
+**유동성 대상**: [근접한 EQH/EQL, 예: "EQH $190.50 — 청산 후 반전 가능"]
+**신호 강도**: [낮음 / 중간 / 높음 — 합류 요인 수 기재]
+**방향 의견**: [강세 / 약세 / 중립]
+**상세 분석**: [구조 흐름, 핵심 레벨과의 관계, 현재 가격 위치, 예상 시나리오(주 시나리오와 무효화 조건)를 포함한 상세 분석 문단]
+```
+
+Additional output rules:
+- If no unmitigated OBs or FVGs are within 3 × ATR of current price, state "근처 미완료 레벨 없음" and focus analysis on zone + structure alone.
+- If CHoCH occurred within the last 10 bars, flag it explicitly as a high-priority reversal watch.
+- If price swept EQH or EQL within the last 5 bars without follow-through, flag it as a potential liquidity grab reversal.
+- Set `trend` field: `bullish` if structure is bullish and price is in Discount near an OB/FVG, `bearish` if structure is bearish and price is in Premium near an OB/FVG, `neutral` otherwise.

--- a/src/__tests__/components/chart/utils/overlayLabelUtils.test.ts
+++ b/src/__tests__/components/chart/utils/overlayLabelUtils.test.ts
@@ -4,6 +4,7 @@ import {
     resolveOverlayValues,
 } from '@/components/chart/utils/overlayLabelUtils';
 import { CHART_COLORS, getPeriodColor } from '@/lib/chartColors';
+import { EMPTY_SMC_RESULT } from '@/domain/indicators/constants';
 import type { Bar, IndicatorResult } from '@/domain/types';
 
 const mockBars: Bar[] = [
@@ -38,6 +39,8 @@ const mockIndicators: IndicatorResult = {
     keltnerChannel: [],
     cmf: [],
     donchianChannel: [],
+    buySellVolume: [],
+    smc: EMPTY_SMC_RESULT,
 };
 
 describe('buildOverlayLabelConfigs', () => {

--- a/src/__tests__/domain/analysis/prompt.test.ts
+++ b/src/__tests__/domain/analysis/prompt.test.ts
@@ -27,6 +27,7 @@ import {
     KELTNER_MULTIPLIER,
     CMF_DEFAULT_PERIOD,
     DONCHIAN_DEFAULT_PERIOD,
+    EMPTY_SMC_RESULT,
 } from '@/domain/indicators/constants';
 import {
     HAMMER_BODY_OFFSET,
@@ -138,6 +139,7 @@ const makeIndicators = (
     donchianChannel: [],
     buySellVolume: [],
     ...overrides,
+    smc: overrides?.smc ?? EMPTY_SMC_RESULT,
 });
 
 const makeEngulfingBars = (): [Bar, Bar] => [

--- a/src/__tests__/domain/indicators/smc.test.ts
+++ b/src/__tests__/domain/indicators/smc.test.ts
@@ -7,11 +7,7 @@ import type { Bar, SMCResult } from '@/domain/types';
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
-function makeBar(
-    close: number,
-    overrides: Partial<Bar> = {},
-    index = 0
-): Bar {
+function makeBar(close: number, overrides: Partial<Bar> = {}, index = 0): Bar {
     return {
         time: index * 60,
         open: close,
@@ -198,7 +194,9 @@ describe('calculateSmc', () => {
             const result = calculateSmc(bars);
             // At least one swing should be detected in a long enough uniform series
             // (ties are treated as valid maxima/minima)
-            expect(result.swingHighs.length + result.swingLows.length).toBeGreaterThan(0);
+            expect(
+                result.swingHighs.length + result.swingLows.length
+            ).toBeGreaterThan(0);
         });
     });
 
@@ -206,9 +204,9 @@ describe('calculateSmc', () => {
         it('상승 FVG를 감지한다', () => {
             // Bar i-2 high = 100, bar i low = 105 → bullish FVG
             const bars = makeBars([
-                { high: 100, low: 90, close: 95 },   // i-2: high=100
-                { high: 103, low: 93, close: 98 },   // i-1 (middle bar)
-                { high: 112, low: 105, close: 110 },  // i: low=105 > 100
+                { high: 100, low: 90, close: 95 }, // i-2: high=100
+                { high: 103, low: 93, close: 98 }, // i-1 (middle bar)
+                { high: 112, low: 105, close: 110 }, // i: low=105 > 100
             ]);
             const result = calculateSmc(bars, 1);
             expect(result.fairValueGaps.length).toBe(1);
@@ -220,9 +218,9 @@ describe('calculateSmc', () => {
         it('하락 FVG를 감지한다', () => {
             // Bar i-2 low = 110, bar i high = 105 → bearish FVG
             const bars = makeBars([
-                { high: 120, low: 110, close: 115 },  // i-2: low=110
-                { high: 115, low: 107, close: 111 },  // i-1
-                { high: 105, low: 95, close: 100 },   // i: high=105 < 110
+                { high: 120, low: 110, close: 115 }, // i-2: low=110
+                { high: 115, low: 107, close: 111 }, // i-1
+                { high: 105, low: 95, close: 100 }, // i: high=105 < 110
             ]);
             const result = calculateSmc(bars, 1);
             expect(result.fairValueGaps.length).toBe(1);
@@ -248,10 +246,10 @@ describe('calculateSmc', () => {
 
         it('상승 FVG가 이후 캔들에 의해 침범되면 isMitigated가 true다', () => {
             const bars = makeBars([
-                { high: 100, low: 90, close: 95 },    // anchor: high=100
+                { high: 100, low: 90, close: 95 }, // anchor: high=100
                 { high: 103, low: 93, close: 98 },
-                { high: 112, low: 105, close: 110 },   // bullish FVG: zone [100, 105]
-                { high: 108, low: 104, close: 106 },   // low=104 <= fvg.high=105 → mitigated
+                { high: 112, low: 105, close: 110 }, // bullish FVG: zone [100, 105]
+                { high: 108, low: 104, close: 106 }, // low=104 <= fvg.high=105 → mitigated
             ]);
             const result = calculateSmc(bars, 1);
             const fvg = result.fairValueGaps.find(f => f.type === 'bullish');
@@ -260,10 +258,10 @@ describe('calculateSmc', () => {
 
         it('상승 FVG가 이후에도 유효하면 isMitigated가 false다', () => {
             const bars = makeBars([
-                { high: 100, low: 90, close: 95 },    // anchor: high=100
+                { high: 100, low: 90, close: 95 }, // anchor: high=100
                 { high: 103, low: 93, close: 98 },
-                { high: 112, low: 105, close: 110 },   // bullish FVG
-                { high: 115, low: 106, close: 113 },   // low=106 > fvg.high=105 → not mitigated
+                { high: 112, low: 105, close: 110 }, // bullish FVG
+                { high: 115, low: 106, close: 113 }, // low=106 > fvg.high=105 → not mitigated
             ]);
             const result = calculateSmc(bars, 1);
             const fvg = result.fairValueGaps.find(f => f.type === 'bullish');
@@ -275,14 +273,18 @@ describe('calculateSmc', () => {
         it('스윙 고점을 상향 돌파하면 불리시 구조 이탈을 기록한다', () => {
             const bars = makeBullishBreakSequence();
             const result = calculateSmc(bars, 3);
-            const bullishBreaks = result.structureBreaks.filter(b => b.type === 'bullish');
+            const bullishBreaks = result.structureBreaks.filter(
+                b => b.type === 'bullish'
+            );
             expect(bullishBreaks.length).toBeGreaterThan(0);
         });
 
         it('스윙 저점을 하향 돌파하면 베어리시 구조 이탈을 기록한다', () => {
             const bars = makeBearishBreakSequence();
             const result = calculateSmc(bars, 3);
-            const bearishBreaks = result.structureBreaks.filter(b => b.type === 'bearish');
+            const bearishBreaks = result.structureBreaks.filter(
+                b => b.type === 'bearish'
+            );
             expect(bearishBreaks.length).toBeGreaterThan(0);
         });
 
@@ -409,7 +411,9 @@ describe('calculateSmc', () => {
         it('premium 존의 high는 discount 존의 low보다 크다', () => {
             const result = calculateSmc(makeBullishBreakSequence(), 3);
             // makeBullishBreakSequence guarantees zones are non-null
-            expect(result.premiumZone!.high).toBeGreaterThan(result.discountZone!.low);
+            expect(result.premiumZone!.high).toBeGreaterThan(
+                result.discountZone!.low
+            );
         });
 
         it('존 type 필드가 올바르다', () => {
@@ -440,7 +444,9 @@ describe('calculateSmc', () => {
 
         it('기본 swingPeriod는 SMC_SWING_PERIOD와 동일하다', () => {
             const bars = makeUniformBars(ENOUGH_BARS);
-            expect(calculateSmc(bars)).toEqual(calculateSmc(bars, SMC_SWING_PERIOD));
+            expect(calculateSmc(bars)).toEqual(
+                calculateSmc(bars, SMC_SWING_PERIOD)
+            );
         });
     });
 });

--- a/src/__tests__/domain/indicators/smc.test.ts
+++ b/src/__tests__/domain/indicators/smc.test.ts
@@ -1,0 +1,446 @@
+import { calculateSmc } from '@/domain/indicators/smc';
+import {
+    SMC_SWING_PERIOD,
+    SMC_ATR_PERIOD,
+} from '@/domain/indicators/constants';
+import type { Bar, SMCResult } from '@/domain/types';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeBar(
+    close: number,
+    overrides: Partial<Bar> = {},
+    index = 0
+): Bar {
+    return {
+        time: index * 60,
+        open: close,
+        high: close + 5,
+        low: close - 5,
+        close,
+        volume: 1000,
+        ...overrides,
+    };
+}
+
+function makeBars(
+    values: { open?: number; high: number; low: number; close: number }[]
+): Bar[] {
+    return values.map((v, i) => ({
+        time: i * 60,
+        open: v.open ?? v.close,
+        high: v.high,
+        low: v.low,
+        close: v.close,
+        volume: 1000,
+    }));
+}
+
+function makeUniformBars(count: number, price = 100): Bar[] {
+    return Array.from({ length: count }, (_, i) =>
+        makeBar(price, { high: price + 5, low: price - 5 }, i)
+    );
+}
+
+/**
+ * Build a realistic bar sequence that creates a bullish BOS:
+ *   Phase 1 (uptrend) → swing high forms
+ *   Phase 2 (pullback) → swing low forms, bearish trend established
+ *   Phase 3 (breakout) → price closes above Phase 1 swing high → bullish BOS
+ */
+function makeBullishBreakSequence(): Bar[] {
+    const phase1 = Array.from({ length: 10 }, (_, i) => ({
+        time: i * 60,
+        open: 100 + i * 4,
+        high: 100 + i * 4 + 3,
+        low: 100 + i * 4 - 3,
+        close: 100 + i * 4 + 2,
+        volume: 1000,
+    }));
+    const phase2 = Array.from({ length: 10 }, (_, i) => ({
+        time: (10 + i) * 60,
+        open: 138 - i * 4,
+        high: 138 - i * 4 + 3,
+        low: 138 - i * 4 - 3,
+        close: 138 - i * 4 - 2,
+        volume: 1000,
+    }));
+    // Phase 3: strong rally breaking above phase 1 peak (~140)
+    const phase3 = Array.from({ length: 10 }, (_, i) => ({
+        time: (20 + i) * 60,
+        open: 102 + i * 6,
+        high: 102 + i * 6 + 5,
+        low: 102 + i * 6 - 2,
+        close: 102 + i * 6 + 4,
+        volume: 1000,
+    }));
+    return [...phase1, ...phase2, ...phase3];
+}
+
+/**
+ * Build a realistic bar sequence that creates a bearish BOS:
+ *   Phase 1 (downtrend) → swing low forms
+ *   Phase 2 (bounce) → swing high forms, bullish trend established
+ *   Phase 3 (breakdown) → price closes below Phase 1 swing low → bearish BOS
+ */
+function makeBearishBreakSequence(): Bar[] {
+    const phase1 = Array.from({ length: 10 }, (_, i) => ({
+        time: i * 60,
+        open: 200 - i * 4,
+        high: 200 - i * 4 + 3,
+        low: 200 - i * 4 - 3,
+        close: 200 - i * 4 - 2,
+        volume: 1000,
+    }));
+    const phase2 = Array.from({ length: 10 }, (_, i) => ({
+        time: (10 + i) * 60,
+        open: 162 + i * 4,
+        high: 162 + i * 4 + 3,
+        low: 162 + i * 4 - 3,
+        close: 162 + i * 4 + 2,
+        volume: 1000,
+    }));
+    // Phase 3: sharp drop breaking below phase 1 trough (~160)
+    const phase3 = Array.from({ length: 10 }, (_, i) => ({
+        time: (20 + i) * 60,
+        open: 198 - i * 6,
+        high: 198 - i * 6 + 2,
+        low: 198 - i * 6 - 5,
+        close: 198 - i * 6 - 4,
+        volume: 1000,
+    }));
+    return [...phase1, ...phase2, ...phase3];
+}
+
+const ENOUGH_BARS = SMC_SWING_PERIOD * 2 + SMC_ATR_PERIOD + 5;
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('calculateSmc', () => {
+    describe('입력 배열이 비어있을 때', () => {
+        it('빈 배열을 반환한다', () => {
+            const result = calculateSmc([]);
+            expect(result.swingHighs).toEqual([]);
+            expect(result.swingLows).toEqual([]);
+            expect(result.orderBlocks).toEqual([]);
+            expect(result.fairValueGaps).toEqual([]);
+            expect(result.equalHighs).toEqual([]);
+            expect(result.equalLows).toEqual([]);
+            expect(result.structureBreaks).toEqual([]);
+            expect(result.premiumZone).toBeNull();
+            expect(result.discountZone).toBeNull();
+            expect(result.equilibriumZone).toBeNull();
+        });
+    });
+
+    describe('입력 배열 길이가 스윙 감지에 필요한 최소 길이보다 짧을 때', () => {
+        it('스윙 포인트를 감지하지 못한다', () => {
+            const bars = makeUniformBars(SMC_SWING_PERIOD * 2);
+            const result = calculateSmc(bars);
+            expect(result.swingHighs).toEqual([]);
+            expect(result.swingLows).toEqual([]);
+        });
+    });
+
+    describe('스윙 포인트 감지', () => {
+        it('상승 후 하락하는 바 시퀀스에서 스윙 고점을 감지한다', () => {
+            // Tip pattern: rises to a peak then falls
+            const bars = makeBars([
+                { high: 105, low: 95, close: 100 },
+                { high: 110, low: 100, close: 105 },
+                { high: 115, low: 105, close: 110 },
+                { high: 120, low: 110, close: 115 }, // swing high candidate
+                { high: 118, low: 108, close: 113 },
+                { high: 115, low: 105, close: 110 },
+                { high: 112, low: 102, close: 107 },
+                { high: 109, low: 99, close: 104 },
+                { high: 106, low: 96, close: 101 },
+                { high: 103, low: 93, close: 98 },
+                { high: 100, low: 90, close: 95 },
+            ]);
+            const result = calculateSmc(bars, 3);
+            expect(result.swingHighs.length).toBeGreaterThan(0);
+            const peak = result.swingHighs.find(s => s.price === 120);
+            expect(peak).toBeDefined();
+        });
+
+        it('하락 후 상승하는 바 시퀀스에서 스윙 저점을 감지한다', () => {
+            const bars = makeBars([
+                { high: 115, low: 105, close: 110 },
+                { high: 112, low: 102, close: 107 },
+                { high: 109, low: 99, close: 104 },
+                { high: 106, low: 94, close: 95 }, // swing low candidate
+                { high: 108, low: 98, close: 103 },
+                { high: 111, low: 101, close: 106 },
+                { high: 114, low: 104, close: 109 },
+                { high: 117, low: 107, close: 112 },
+                { high: 120, low: 110, close: 115 },
+                { high: 123, low: 113, close: 118 },
+            ]);
+            const result = calculateSmc(bars, 3);
+            expect(result.swingLows.length).toBeGreaterThan(0);
+            const trough = result.swingLows.find(s => s.price === 94);
+            expect(trough).toBeDefined();
+        });
+
+        it('스윙 포인트의 index 필드는 bars 배열의 실제 인덱스다', () => {
+            const bars = makeUniformBars(ENOUGH_BARS);
+            const result = calculateSmc(bars);
+            [...result.swingHighs, ...result.swingLows].forEach(s => {
+                expect(s.index).toBeGreaterThanOrEqual(0);
+                expect(s.index).toBeLessThan(bars.length);
+            });
+        });
+
+        it('균일한 가격에서는 스윙 포인트를 감지한다', () => {
+            // With uniform bars every candidate bar ties for max/min, so it IS the max/min
+            const bars = makeUniformBars(ENOUGH_BARS, 100);
+            const result = calculateSmc(bars);
+            // At least one swing should be detected in a long enough uniform series
+            // (ties are treated as valid maxima/minima)
+            expect(result.swingHighs.length + result.swingLows.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe('Fair Value Gap 감지', () => {
+        it('상승 FVG를 감지한다', () => {
+            // Bar i-2 high = 100, bar i low = 105 → bullish FVG
+            const bars = makeBars([
+                { high: 100, low: 90, close: 95 },   // i-2: high=100
+                { high: 103, low: 93, close: 98 },   // i-1 (middle bar)
+                { high: 112, low: 105, close: 110 },  // i: low=105 > 100
+            ]);
+            const result = calculateSmc(bars, 1);
+            expect(result.fairValueGaps.length).toBe(1);
+            expect(result.fairValueGaps[0].type).toBe('bullish');
+            expect(result.fairValueGaps[0].low).toBe(100);
+            expect(result.fairValueGaps[0].high).toBe(105);
+        });
+
+        it('하락 FVG를 감지한다', () => {
+            // Bar i-2 low = 110, bar i high = 105 → bearish FVG
+            const bars = makeBars([
+                { high: 120, low: 110, close: 115 },  // i-2: low=110
+                { high: 115, low: 107, close: 111 },  // i-1
+                { high: 105, low: 95, close: 100 },   // i: high=105 < 110
+            ]);
+            const result = calculateSmc(bars, 1);
+            expect(result.fairValueGaps.length).toBe(1);
+            expect(result.fairValueGaps[0].type).toBe('bearish');
+            expect(result.fairValueGaps[0].high).toBe(110);
+            expect(result.fairValueGaps[0].low).toBe(105);
+        });
+
+        it('FVG가 없는 경우 빈 배열을 반환한다', () => {
+            const bars = makeUniformBars(10, 100);
+            const result = calculateSmc(bars, 3);
+            expect(result.fairValueGaps).toEqual([]);
+        });
+
+        it('3개 미만의 bars에서 FVG를 감지하지 않는다', () => {
+            const bars = makeBars([
+                { high: 100, low: 90, close: 95 },
+                { high: 103, low: 93, close: 98 },
+            ]);
+            const result = calculateSmc(bars, 1);
+            expect(result.fairValueGaps).toEqual([]);
+        });
+
+        it('상승 FVG가 이후 캔들에 의해 침범되면 isMitigated가 true다', () => {
+            const bars = makeBars([
+                { high: 100, low: 90, close: 95 },    // anchor: high=100
+                { high: 103, low: 93, close: 98 },
+                { high: 112, low: 105, close: 110 },   // bullish FVG: zone [100, 105]
+                { high: 108, low: 104, close: 106 },   // low=104 <= fvg.high=105 → mitigated
+            ]);
+            const result = calculateSmc(bars, 1);
+            const fvg = result.fairValueGaps.find(f => f.type === 'bullish');
+            expect(fvg?.isMitigated).toBe(true);
+        });
+
+        it('상승 FVG가 이후에도 유효하면 isMitigated가 false다', () => {
+            const bars = makeBars([
+                { high: 100, low: 90, close: 95 },    // anchor: high=100
+                { high: 103, low: 93, close: 98 },
+                { high: 112, low: 105, close: 110 },   // bullish FVG
+                { high: 115, low: 106, close: 113 },   // low=106 > fvg.high=105 → not mitigated
+            ]);
+            const result = calculateSmc(bars, 1);
+            const fvg = result.fairValueGaps.find(f => f.type === 'bullish');
+            expect(fvg?.isMitigated).toBe(false);
+        });
+    });
+
+    describe('구조 이탈 감지 (BOS / CHoCH)', () => {
+        it('스윙 고점을 상향 돌파하면 불리시 구조 이탈을 기록한다', () => {
+            const bars = makeBullishBreakSequence();
+            const result = calculateSmc(bars, 3);
+            const bullishBreaks = result.structureBreaks.filter(b => b.type === 'bullish');
+            expect(bullishBreaks.length).toBeGreaterThan(0);
+        });
+
+        it('스윙 저점을 하향 돌파하면 베어리시 구조 이탈을 기록한다', () => {
+            const bars = makeBearishBreakSequence();
+            const result = calculateSmc(bars, 3);
+            const bearishBreaks = result.structureBreaks.filter(b => b.type === 'bearish');
+            expect(bearishBreaks.length).toBeGreaterThan(0);
+        });
+
+        it('breakType은 bos 또는 choch 중 하나다', () => {
+            const bars = makeBullishBreakSequence();
+            const result = calculateSmc(bars, 3);
+            result.structureBreaks.forEach(sb => {
+                expect(['bos', 'choch']).toContain(sb.breakType);
+            });
+        });
+
+        it('스윙 포인트가 없으면 구조 이탈을 감지하지 않는다', () => {
+            const bars = makeUniformBars(3, 100);
+            const result = calculateSmc(bars);
+            expect(result.structureBreaks).toEqual([]);
+        });
+
+        it('구조 이탈의 index 필드는 bars 배열의 유효한 인덱스다', () => {
+            const bars = makeBullishBreakSequence();
+            const result = calculateSmc(bars, 3);
+            result.structureBreaks.forEach(sb => {
+                expect(sb.index).toBeGreaterThanOrEqual(0);
+                expect(sb.index).toBeLessThan(bars.length);
+            });
+        });
+    });
+
+    describe('Order Block 감지', () => {
+        it('불리시 구조 이탈 후 Order Block을 감지한다', () => {
+            const bars = makeBullishBreakSequence();
+            const result = calculateSmc(bars, 3);
+            // makeBullishBreakSequence guarantees structure breaks and opposing candles
+            expect(result.structureBreaks.length).toBeGreaterThan(0);
+            expect(result.orderBlocks.length).toBeGreaterThan(0);
+        });
+
+        it('Order Block의 high는 low보다 크거나 같다', () => {
+            const bars = makeBullishBreakSequence();
+            const result = calculateSmc(bars, 3);
+            result.orderBlocks.forEach(ob => {
+                expect(ob.high).toBeGreaterThanOrEqual(ob.low);
+            });
+        });
+
+        it('Order Block의 type은 bullish 또는 bearish다', () => {
+            const bars = makeBullishBreakSequence();
+            const result = calculateSmc(bars, 3);
+            result.orderBlocks.forEach(ob => {
+                expect(['bullish', 'bearish']).toContain(ob.type);
+            });
+        });
+
+        it('Order Block의 startIndex는 유효한 bars 인덱스다', () => {
+            const bars = makeBullishBreakSequence();
+            const result = calculateSmc(bars, 3);
+            result.orderBlocks.forEach(ob => {
+                expect(ob.startIndex).toBeGreaterThanOrEqual(0);
+                expect(ob.startIndex).toBeLessThan(bars.length);
+            });
+        });
+
+        it('isMitigated는 boolean 값이다', () => {
+            const bars = makeBullishBreakSequence();
+            const result = calculateSmc(bars, 3);
+            result.orderBlocks.forEach(ob => {
+                expect(typeof ob.isMitigated).toBe('boolean');
+            });
+        });
+    });
+
+    describe('Equal High / Low 감지', () => {
+        it('equalHighs와 equalLows는 배열로 반환한다', () => {
+            const bars = makeUniformBars(ENOUGH_BARS, 100);
+            const result = calculateSmc(bars);
+            expect(Array.isArray(result.equalHighs)).toBe(true);
+            expect(Array.isArray(result.equalLows)).toBe(true);
+        });
+
+        it('Equal Level의 firstIndex는 secondIndex보다 작다', () => {
+            const bars = makeUniformBars(ENOUGH_BARS, 100);
+            const result = calculateSmc(bars);
+            [...result.equalHighs, ...result.equalLows].forEach(el => {
+                expect(el.firstIndex).toBeLessThan(el.secondIndex);
+            });
+        });
+
+        it('Equal Level의 type은 high 또는 low다', () => {
+            const bars = makeUniformBars(ENOUGH_BARS, 100);
+            const result = calculateSmc(bars);
+            result.equalHighs.forEach(el => expect(el.type).toBe('high'));
+            result.equalLows.forEach(el => expect(el.type).toBe('low'));
+        });
+
+        it('Equal Level의 price는 두 스윙 가격의 평균이다', () => {
+            const bars = makeUniformBars(ENOUGH_BARS, 100);
+            const result = calculateSmc(bars);
+            [...result.equalHighs, ...result.equalLows].forEach(el => {
+                // price should be within the ATR range of both swing prices
+                expect(el.price).toBeGreaterThan(0);
+            });
+        });
+    });
+
+    describe('Premium / Discount / Equilibrium 존', () => {
+        it('스윙 포인트가 있으면 세 존을 모두 반환한다', () => {
+            const bars = makeBullishBreakSequence();
+            const result = calculateSmc(bars, 3);
+            // makeBullishBreakSequence guarantees swing highs and lows
+            expect(result.swingHighs.length).toBeGreaterThan(0);
+            expect(result.swingLows.length).toBeGreaterThan(0);
+            expect(result.premiumZone).not.toBeNull();
+            expect(result.discountZone).not.toBeNull();
+            expect(result.equilibriumZone).not.toBeNull();
+        });
+
+        it('스윙 포인트가 없으면 세 존은 모두 null이다', () => {
+            const bars = makeUniformBars(3, 100);
+            const result = calculateSmc(bars);
+            expect(result.premiumZone).toBeNull();
+            expect(result.discountZone).toBeNull();
+            expect(result.equilibriumZone).toBeNull();
+        });
+
+        it('premium 존의 high는 discount 존의 low보다 크다', () => {
+            const result = calculateSmc(makeBullishBreakSequence(), 3);
+            // makeBullishBreakSequence guarantees zones are non-null
+            expect(result.premiumZone!.high).toBeGreaterThan(result.discountZone!.low);
+        });
+
+        it('존 type 필드가 올바르다', () => {
+            const result = calculateSmc(makeBullishBreakSequence(), 3);
+            // makeBullishBreakSequence guarantees all three zones are present
+            expect(result.premiumZone!.type).toBe('premium');
+            expect(result.discountZone!.type).toBe('discount');
+            expect(result.equilibriumZone!.type).toBe('equilibrium');
+        });
+    });
+
+    describe('반환 타입 구조', () => {
+        it('모든 필수 필드가 포함된 SMCResult 객체를 반환한다', () => {
+            const bars = makeUniformBars(ENOUGH_BARS);
+            const result: SMCResult = calculateSmc(bars);
+
+            expect(result).toHaveProperty('swingHighs');
+            expect(result).toHaveProperty('swingLows');
+            expect(result).toHaveProperty('orderBlocks');
+            expect(result).toHaveProperty('fairValueGaps');
+            expect(result).toHaveProperty('equalHighs');
+            expect(result).toHaveProperty('equalLows');
+            expect(result).toHaveProperty('premiumZone');
+            expect(result).toHaveProperty('discountZone');
+            expect(result).toHaveProperty('equilibriumZone');
+            expect(result).toHaveProperty('structureBreaks');
+        });
+
+        it('기본 swingPeriod는 SMC_SWING_PERIOD와 동일하다', () => {
+            const bars = makeUniformBars(ENOUGH_BARS);
+            expect(calculateSmc(bars)).toEqual(calculateSmc(bars, SMC_SWING_PERIOD));
+        });
+    });
+});

--- a/src/__tests__/domain/indicators/smc.test.ts
+++ b/src/__tests__/domain/indicators/smc.test.ts
@@ -381,9 +381,13 @@ describe('calculateSmc', () => {
         it('Equal Level의 price는 두 스윙 가격의 평균이다', () => {
             const bars = makeUniformBars(ENOUGH_BARS, 100);
             const result = calculateSmc(bars);
-            [...result.equalHighs, ...result.equalLows].forEach(el => {
-                // price should be within the ATR range of both swing prices
-                expect(el.price).toBeGreaterThan(0);
+            // uniform bars (close=100): swing high price=105, swing low price=95
+            // equal high average = (105+105)/2 = 105, equal low average = (95+95)/2 = 95
+            result.equalHighs.forEach(el => {
+                expect(el.price).toBe(105);
+            });
+            result.equalLows.forEach(el => {
+                expect(el.price).toBe(95);
             });
         });
     });

--- a/src/__tests__/infrastructure/market/analysisApi.test.ts
+++ b/src/__tests__/infrastructure/market/analysisApi.test.ts
@@ -1,4 +1,5 @@
 import { runAnalysis } from '@/infrastructure/market/analysisApi';
+import { EMPTY_SMC_RESULT } from '@/domain/indicators/constants';
 import type {
     AnalyzeVariables,
     IndicatorResult,
@@ -63,6 +64,7 @@ const mockVariables: AnalyzeVariables = {
         cmf: [],
         donchianChannel: [],
         buySellVolume: [],
+        smc: EMPTY_SMC_RESULT,
     },
 };
 

--- a/src/__tests__/infrastructure/market/analyzeAction.test.ts
+++ b/src/__tests__/infrastructure/market/analyzeAction.test.ts
@@ -1,4 +1,5 @@
 import { analyzeAction } from '@/infrastructure/market/analyzeAction';
+import { EMPTY_SMC_RESULT } from '@/domain/indicators/constants';
 import type {
     AnalyzeVariables,
     RawAnalysisResponse,
@@ -66,6 +67,8 @@ const mockVariables: AnalyzeVariables = {
         keltnerChannel: [],
         cmf: [],
         donchianChannel: [],
+        buySellVolume: [],
+        smc: EMPTY_SMC_RESULT,
     },
 };
 

--- a/src/__tests__/infrastructure/market/getBarsAction.test.ts
+++ b/src/__tests__/infrastructure/market/getBarsAction.test.ts
@@ -1,4 +1,5 @@
 import { getBarsAction } from '@/infrastructure/market/getBarsAction';
+import { EMPTY_SMC_RESULT } from '@/domain/indicators/constants';
 import type { BarsData, Timeframe } from '@/domain/types';
 
 jest.mock('@/infrastructure/market/barsApi');
@@ -43,6 +44,8 @@ const mockBarsData: BarsData = {
         keltnerChannel: [],
         cmf: [],
         donchianChannel: [],
+        buySellVolume: [],
+        smc: EMPTY_SMC_RESULT,
     },
 };
 

--- a/src/domain/indicators/constants.ts
+++ b/src/domain/indicators/constants.ts
@@ -1,4 +1,17 @@
-import type { IndicatorResult } from '@/domain/types';
+import type { IndicatorResult, SMCResult } from '@/domain/types';
+
+export const EMPTY_SMC_RESULT: SMCResult = {
+    swingHighs: [],
+    swingLows: [],
+    orderBlocks: [],
+    fairValueGaps: [],
+    equalHighs: [],
+    equalLows: [],
+    premiumZone: null,
+    discountZone: null,
+    equilibriumZone: null,
+    structureBreaks: [],
+};
 
 export const EMPTY_INDICATOR_RESULT: IndicatorResult = {
     macd: [],
@@ -23,6 +36,7 @@ export const EMPTY_INDICATOR_RESULT: IndicatorResult = {
     cmf: [],
     donchianChannel: [],
     buySellVolume: [],
+    smc: EMPTY_SMC_RESULT,
 };
 
 export const RSI_DEFAULT_PERIOD = 14;
@@ -92,6 +106,12 @@ export const ICHIMOKU_DISPLACEMENT = 26;
 export const VP_DEFAULT_ROW_SIZE = 24;
 export const VP_VALUE_AREA_PERCENTAGE = 0.7;
 export const VP_MIN_BARS = 30;
+
+export const SMC_SWING_PERIOD = 5;
+export const SMC_EQUAL_LEVEL_ATR_MULTIPLIER = 0.5;
+export const SMC_ATR_PERIOD = 14;
+export const SMC_PREMIUM_RATIO = 0.75;
+export const SMC_DISCOUNT_RATIO = 0.25;
 
 export const HIGH_CONFIDENCE_WEIGHT = 0.8;
 export const MEDIUM_CONFIDENCE_WEIGHT = 0.7;

--- a/src/domain/indicators/index.ts
+++ b/src/domain/indicators/index.ts
@@ -21,6 +21,7 @@ import { calculateKeltnerChannel } from './keltnerChannel';
 import { calculateCMF } from './cmf';
 import { calculateDonchianChannel } from './donchianChannel';
 import { calculateBuySellVolume } from './buySellVolume';
+import { calculateSmc } from './smc';
 import { MA_DEFAULT_PERIODS, EMA_DEFAULT_PERIODS } from './constants';
 
 export * from './rsi';
@@ -45,6 +46,7 @@ export * from './keltnerChannel';
 export * from './cmf';
 export * from './donchianChannel';
 export * from './buySellVolume';
+export * from './smc';
 
 export function calculateIndicators(bars: Bar[]): IndicatorResult {
     const closes = bars.map(b => b.close);
@@ -81,5 +83,6 @@ export function calculateIndicators(bars: Bar[]): IndicatorResult {
         cmf: calculateCMF(bars),
         donchianChannel: calculateDonchianChannel(bars),
         buySellVolume: calculateBuySellVolume(bars),
+        smc: calculateSmc(bars),
     };
 }

--- a/src/domain/indicators/smc.ts
+++ b/src/domain/indicators/smc.ts
@@ -49,21 +49,30 @@ import { calculateATR } from '@/domain/indicators/atr';
 function detectSwingPoints(bars: Bar[], period: number): SMCSwingPoint[] {
     if (bars.length < period * 2 + 1) return [];
 
-    return bars.reduce<SMCSwingPoint[]>((acc, bar, i) => {
-        if (i < period || i >= bars.length - period) return acc;
+    return bars
+        .map((bar, i) => {
+            if (i < period || i >= bars.length - period) return null;
 
-        const window = bars.slice(i - period, i + period + 1);
-        const maxHigh = window.reduce((m, b) => Math.max(m, b.high), -Infinity);
-        const minLow = window.reduce((m, b) => Math.min(m, b.low), Infinity);
+            const window = bars.slice(i - period, i + period + 1);
+            const maxHigh = window.reduce(
+                (m, b) => Math.max(m, b.high),
+                -Infinity
+            );
+            const minLow = window.reduce(
+                (m, b) => Math.min(m, b.low),
+                Infinity
+            );
 
-        const found: SMCSwingPoint[] = [];
-        if (bar.high === maxHigh)
-            found.push({ index: i, price: bar.high, type: 'high' });
-        if (bar.low === minLow)
-            found.push({ index: i, price: bar.low, type: 'low' });
+            const found: SMCSwingPoint[] = [];
+            if (bar.high === maxHigh)
+                found.push({ index: i, price: bar.high, type: 'high' });
+            if (bar.low === minLow)
+                found.push({ index: i, price: bar.low, type: 'low' });
 
-        return found.length > 0 ? [...acc, ...found] : acc;
-    }, []);
+            return found.length > 0 ? found : null;
+        })
+        .filter((points): points is SMCSwingPoint[] => points !== null)
+        .flat();
 }
 
 // ─── Fair Value Gap detection ─────────────────────────────────────────────────
@@ -82,33 +91,34 @@ function detectSwingPoints(bars: Bar[], period: number): SMCSwingPoint[] {
 function detectFairValueGaps(bars: Bar[]): SMCFairValueGap[] {
     if (bars.length < 3) return [];
 
-    const raw = bars.slice(2).reduce<SMCFairValueGap[]>((acc, bar, idx) => {
-        const i = idx + 2;
-        const anchor = bars[i - 2];
+    const raw = bars
+        .slice(2)
+        .map((bar, idx): SMCFairValueGap | null => {
+            const i = idx + 2;
+            const anchor = bars[i - 2];
 
-        const isBullish = bar.low > anchor.high;
-        const isBearish = bar.high < anchor.low;
+            const isBullish = bar.low > anchor.high;
+            const isBearish = bar.high < anchor.low;
 
-        if (!isBullish && !isBearish) return acc;
+            if (!isBullish && !isBearish) return null;
 
-        const fvg: SMCFairValueGap = isBullish
-            ? {
-                  index: i,
-                  high: bar.low,
-                  low: anchor.high,
-                  type: 'bullish',
-                  isMitigated: false,
-              }
-            : {
-                  index: i,
-                  high: anchor.low,
-                  low: bar.high,
-                  type: 'bearish',
-                  isMitigated: false,
-              };
-
-        return [...acc, fvg];
-    }, []);
+            return isBullish
+                ? {
+                      index: i,
+                      high: bar.low,
+                      low: anchor.high,
+                      type: 'bullish',
+                      isMitigated: false,
+                  }
+                : {
+                      index: i,
+                      high: anchor.low,
+                      low: bar.high,
+                      type: 'bearish',
+                      isMitigated: false,
+                  };
+        })
+        .filter((fvg): fvg is SMCFairValueGap => fvg !== null);
 
     return raw.map(fvg => ({
         ...fvg,
@@ -266,25 +276,19 @@ function detectOrderBlocks(
  *  - bullishBreak → last bearish candle (close < open)
  *  - bearishBreak → last bullish candle (close > open)
  */
+// Note: a for loop is used here for early return — reduceRight cannot short-circuit.
 function findLastOpposingCandle(
     bars: Bar[],
     endIndex: number,
     lookingForBullishBreak: boolean
 ): number | null {
-    return bars
-        .slice(0, endIndex)
-        .reduceRight<number | null>((found, bar, i) => {
-            if (found !== null) return found;
-            const isBearish = bar.close < bar.open;
-            const isBullish = bar.close > bar.open;
-            return lookingForBullishBreak
-                ? isBearish
-                    ? i
-                    : null
-                : isBullish
-                  ? i
-                  : null;
-        }, null);
+    for (let i = endIndex - 1; i >= 0; i--) {
+        const bar = bars[i];
+        const isBearish = bar.close < bar.open;
+        const isBullish = bar.close > bar.open;
+        if (lookingForBullishBreak ? isBearish : isBullish) return i;
+    }
+    return null;
 }
 
 // ─── Equal High / Low detection ───────────────────────────────────────────────
@@ -312,12 +316,12 @@ function findEqualLevels(
     atrValues: (number | null)[],
     type: 'high' | 'low'
 ): SMCEqualLevel[] {
-    return swings.reduce<SMCEqualLevel[]>((acc, swing, i) => {
+    return swings.flatMap((swing, i) => {
         const atr = atrValues[swing.index];
-        if (atr === null) return acc;
+        if (atr === null) return [];
 
         const threshold = SMC_EQUAL_LEVEL_ATR_MULTIPLIER * atr;
-        const newLevels = swings
+        return swings
             .slice(i + 1)
             .filter(other => Math.abs(other.price - swing.price) <= threshold)
             .map<SMCEqualLevel>(other => ({
@@ -326,9 +330,7 @@ function findEqualLevels(
                 secondIndex: other.index,
                 type,
             }));
-
-        return newLevels.length > 0 ? [...acc, ...newLevels] : acc;
-    }, []);
+    });
 }
 
 // ─── Premium / Discount / Equilibrium zones ───────────────────────────────────

--- a/src/domain/indicators/smc.ts
+++ b/src/domain/indicators/smc.ts
@@ -1,0 +1,365 @@
+/**
+ * Smart Money Concepts (SMC) Indicator
+ *
+ * Concept reference:
+ *   Smart Money Concepts (SMC) / ICT (Inner Circle Trader) methodology
+ *
+ * Original TradingView indicator:
+ *   "Smart Money Concepts [LuxAlgo]" by LuxAlgo
+ *   https://kr.tradingview.com/script/CnB3fSph-Smart-Money-Concepts-SMC-LuxAlgo/
+ *   Licensed under CC BY-NC-SA 4.0
+ *   © LuxAlgo
+ *
+ * This file is an INDEPENDENT TypeScript implementation of publicly documented
+ * SMC/ICT trading concepts. It does not copy or directly port any source code
+ * from the LuxAlgo PineScript indicator. The algorithms are derived from the
+ * publicly available SMC methodology documentation.
+ */
+
+import type {
+    Bar,
+    SMCResult,
+    SMCSwingPoint,
+    SMCOrderBlock,
+    SMCFairValueGap,
+    SMCEqualLevel,
+    SMCStructureBreak,
+    SMCStructureDirection,
+    SMCBreakType,
+} from '@/domain/types';
+import {
+    SMC_SWING_PERIOD,
+    SMC_EQUAL_LEVEL_ATR_MULTIPLIER,
+    SMC_ATR_PERIOD,
+    SMC_PREMIUM_RATIO,
+    SMC_DISCOUNT_RATIO,
+    EMPTY_SMC_RESULT,
+} from '@/domain/indicators/constants';
+import { calculateATR } from '@/domain/indicators/atr';
+
+// ─── Swing detection ─────────────────────────────────────────────────────────
+
+/**
+ * Detect swing highs and swing lows from bar data.
+ *
+ * A bar at index i is a swing high if its high is the maximum in the window
+ * [i - period, i + period]. A swing low uses the minimum. Only bars with at
+ * least `period` neighbours on both sides qualify as pivots.
+ */
+function detectSwingPoints(bars: Bar[], period: number): SMCSwingPoint[] {
+    if (bars.length < period * 2 + 1) return [];
+
+    return bars.reduce<SMCSwingPoint[]>((acc, bar, i) => {
+        if (i < period || i >= bars.length - period) return acc;
+
+        const window = bars.slice(i - period, i + period + 1);
+        const maxHigh = window.reduce((m, b) => Math.max(m, b.high), -Infinity);
+        const minLow = window.reduce((m, b) => Math.min(m, b.low), Infinity);
+
+        const found: SMCSwingPoint[] = [];
+        if (bar.high === maxHigh) found.push({ index: i, price: bar.high, type: 'high' });
+        if (bar.low === minLow) found.push({ index: i, price: bar.low, type: 'low' });
+
+        return found.length > 0 ? [...acc, ...found] : acc;
+    }, []);
+}
+
+// ─── Fair Value Gap detection ─────────────────────────────────────────────────
+
+/**
+ * Detect Fair Value Gaps (FVGs / price imbalances).
+ *
+ * Bullish FVG at bar i: bars[i].low > bars[i-2].high
+ *   → gap zone: [bars[i-2].high (low), bars[i].low (high)]
+ *   → mitigated when a later bar's low touches the top of the gap
+ *
+ * Bearish FVG at bar i: bars[i].high < bars[i-2].low
+ *   → gap zone: [bars[i].high (low), bars[i-2].low (high)]
+ *   → mitigated when a later bar's high touches the bottom of the gap
+ */
+function detectFairValueGaps(bars: Bar[]): SMCFairValueGap[] {
+    if (bars.length < 3) return [];
+
+    const raw = bars.slice(2).reduce<SMCFairValueGap[]>((acc, bar, idx) => {
+        const i = idx + 2;
+        const anchor = bars[i - 2];
+
+        const isBullish = bar.low > anchor.high;
+        const isBearish = bar.high < anchor.low;
+
+        if (!isBullish && !isBearish) return acc;
+
+        const fvg: SMCFairValueGap = isBullish
+            ? { index: i, high: bar.low, low: anchor.high, type: 'bullish', isMitigated: false }
+            : { index: i, high: anchor.low, low: bar.high, type: 'bearish', isMitigated: false };
+
+        return [...acc, fvg];
+    }, []);
+
+    return raw.map(fvg => ({
+        ...fvg,
+        isMitigated: bars.slice(fvg.index + 1).some(b =>
+            fvg.type === 'bullish' ? b.low <= fvg.high : b.high >= fvg.low
+        ),
+    }));
+}
+
+// ─── Structure break detection (BOS / CHoCH) ─────────────────────────────────
+
+/**
+ * Detect BOS (Break of Structure) and CHoCH (Change of Character).
+ *
+ * State machine rules:
+ *  - BOS:   close crosses the active swing level in the SAME direction as
+ *           the current trend (structural continuation).
+ *  - CHoCH: close crosses the active swing level in the OPPOSITE direction
+ *           (potential trend reversal — the first counter-trend break).
+ *
+ * Active swing levels are updated as new pivots become confirmed over time.
+ * A level is consumed (marked broken) upon the first close beyond it.
+ *
+ * Note: for loops are used here because the algorithm relies on two
+ * independent advancing pointers (highIdx, lowIdx) over sorted swing arrays,
+ * which cannot be expressed cleanly as map/reduce without sacrificing clarity.
+ */
+function detectStructureBreaks(
+    bars: Bar[],
+    swingHighs: SMCSwingPoint[],
+    swingLows: SMCSwingPoint[]
+): SMCStructureBreak[] {
+    if (swingHighs.length === 0 || swingLows.length === 0) return [];
+
+    let trend: SMCStructureDirection | null = null;
+    let activeHigh: SMCSwingPoint | null = null;
+    let activeLow: SMCSwingPoint | null = null;
+    let highConsumed = false;
+    let lowConsumed = false;
+    let breaks: SMCStructureBreak[] = [];
+    let highIdx = 0;
+    let lowIdx = 0;
+
+    for (let i = 0; i < bars.length; i++) {
+        const bar = bars[i];
+
+        // Advance active swing high to the most recent confirmed pivot
+        while (highIdx < swingHighs.length && swingHighs[highIdx].index <= i) {
+            const candidate = swingHighs[highIdx];
+            if (activeHigh === null || candidate.index > activeHigh.index) {
+                activeHigh = candidate;
+                highConsumed = false;
+            }
+            highIdx++;
+        }
+
+        // Advance active swing low to the most recent confirmed pivot
+        while (lowIdx < swingLows.length && swingLows[lowIdx].index <= i) {
+            const candidate = swingLows[lowIdx];
+            if (activeLow === null || candidate.index > activeLow.index) {
+                activeLow = candidate;
+                lowConsumed = false;
+            }
+            lowIdx++;
+        }
+
+        // Bullish break: close crosses above the active swing high
+        if (activeHigh !== null && !highConsumed && bar.close > activeHigh.price) {
+            const breakType: SMCBreakType = trend === 'bearish' ? 'choch' : 'bos';
+            breaks = [
+                ...breaks,
+                { index: i, price: activeHigh.price, type: 'bullish', breakType },
+            ];
+            trend = 'bullish';
+            highConsumed = true;
+        }
+
+        // Bearish break: close crosses below the active swing low
+        if (activeLow !== null && !lowConsumed && bar.close < activeLow.price) {
+            const breakType: SMCBreakType = trend === 'bullish' ? 'choch' : 'bos';
+            breaks = [
+                ...breaks,
+                { index: i, price: activeLow.price, type: 'bearish', breakType },
+            ];
+            trend = 'bearish';
+            lowConsumed = true;
+        }
+    }
+
+    return breaks;
+}
+
+// ─── Order Block detection ────────────────────────────────────────────────────
+
+/**
+ * Detect Order Blocks (OBs).
+ *
+ * For each confirmed structure break, the order block is the last candle
+ * whose body direction is OPPOSITE to the break direction, found in the
+ * bars leading up to the break.
+ *
+ *  - Bullish break → last bearish candle (close < open) before break index
+ *  - Bearish break → last bullish candle (close > open) before break index
+ *
+ * Mitigation: price subsequently crosses through the OB zone entirely
+ * (low goes below OB.low for bullish OB, high goes above OB.high for bearish OB).
+ */
+function detectOrderBlocks(bars: Bar[], structureBreaks: SMCStructureBreak[]): SMCOrderBlock[] {
+    return structureBreaks.reduce<SMCOrderBlock[]>((acc, sb) => {
+        const isBullishBreak = sb.type === 'bullish';
+        const obIndex = findLastOpposingCandle(bars, sb.index, isBullishBreak);
+        if (obIndex === null) return acc;
+
+        const obBar = bars[obIndex];
+        const ob: SMCOrderBlock = {
+            startIndex: obIndex,
+            high: obBar.high,
+            low: obBar.low,
+            type: sb.type,
+            isMitigated: bars.slice(obIndex + 1).some(b =>
+                isBullishBreak ? b.low < obBar.low : b.high > obBar.high
+            ),
+        };
+
+        return [...acc, ob];
+    }, []);
+}
+
+/**
+ * Return the index of the last candle before `endIndex` whose body
+ * direction is opposite to the expected break direction:
+ *  - bullishBreak → last bearish candle (close < open)
+ *  - bearishBreak → last bullish candle (close > open)
+ */
+function findLastOpposingCandle(
+    bars: Bar[],
+    endIndex: number,
+    lookingForBullishBreak: boolean
+): number | null {
+    return bars.slice(0, endIndex).reduceRight<number | null>((found, bar, i) => {
+        if (found !== null) return found;
+        const isBearish = bar.close < bar.open;
+        const isBullish = bar.close > bar.open;
+        return lookingForBullishBreak
+            ? isBearish ? i : null
+            : isBullish ? i : null;
+    }, null);
+}
+
+// ─── Equal High / Low detection ───────────────────────────────────────────────
+
+/**
+ * Detect Equal Highs and Equal Lows (EQH / EQL).
+ *
+ * Two swing highs (or lows) are considered "equal" when their prices are
+ * within `SMC_EQUAL_LEVEL_ATR_MULTIPLIER × ATR` of each other at the time
+ * of the earlier pivot.
+ */
+function detectEqualLevels(
+    swingHighs: SMCSwingPoint[],
+    swingLows: SMCSwingPoint[],
+    atrValues: (number | null)[]
+): { equalHighs: SMCEqualLevel[]; equalLows: SMCEqualLevel[] } {
+    return {
+        equalHighs: findEqualLevels(swingHighs, atrValues, 'high'),
+        equalLows: findEqualLevels(swingLows, atrValues, 'low'),
+    };
+}
+
+function findEqualLevels(
+    swings: SMCSwingPoint[],
+    atrValues: (number | null)[],
+    type: 'high' | 'low'
+): SMCEqualLevel[] {
+    return swings.reduce<SMCEqualLevel[]>((acc, swing, i) => {
+        const atr = atrValues[swing.index];
+        if (atr === null) return acc;
+
+        const threshold = SMC_EQUAL_LEVEL_ATR_MULTIPLIER * atr;
+        const newLevels = swings
+            .slice(i + 1)
+            .filter(other => Math.abs(other.price - swing.price) <= threshold)
+            .map<SMCEqualLevel>(other => ({
+                price: (swing.price + other.price) / 2,
+                firstIndex: swing.index,
+                secondIndex: other.index,
+                type,
+            }));
+
+        return newLevels.length > 0 ? [...acc, ...newLevels] : acc;
+    }, []);
+}
+
+// ─── Premium / Discount / Equilibrium zones ───────────────────────────────────
+
+
+/**
+ * Calculate Premium, Discount, and Equilibrium zones from the most recent
+ * swing range (last confirmed swing high and swing low).
+ *
+ *  - Premium zone:     top 25% of the range  → price is relatively expensive
+ *  - Equilibrium zone: middle 50% of the range
+ *  - Discount zone:    bottom 25% of the range → price is relatively cheap
+ */
+function detectZones(
+    swingHighs: SMCSwingPoint[],
+    swingLows: SMCSwingPoint[]
+): Pick<SMCResult, 'premiumZone' | 'discountZone' | 'equilibriumZone'> {
+    const empty = { premiumZone: null, discountZone: null, equilibriumZone: null };
+
+    if (swingHighs.length === 0 || swingLows.length === 0) return empty;
+
+    const lastHigh = swingHighs[swingHighs.length - 1];
+    const lastLow = swingLows[swingLows.length - 1];
+    const rangeTop = Math.max(lastHigh.price, lastLow.price);
+    const rangeBottom = Math.min(lastHigh.price, lastLow.price);
+    const range = rangeTop - rangeBottom;
+
+    if (range <= 0) return empty;
+
+    return {
+        premiumZone: {
+            high: rangeTop,
+            low: rangeBottom + SMC_PREMIUM_RATIO * range,
+            type: 'premium',
+        },
+        equilibriumZone: {
+            high: rangeBottom + SMC_PREMIUM_RATIO * range,
+            low: rangeBottom + SMC_DISCOUNT_RATIO * range,
+            type: 'equilibrium',
+        },
+        discountZone: {
+            high: rangeBottom + SMC_DISCOUNT_RATIO * range,
+            low: rangeBottom,
+            type: 'discount',
+        },
+    };
+}
+
+// ─── Main export ──────────────────────────────────────────────────────────────
+
+export function calculateSmc(bars: Bar[], swingPeriod = SMC_SWING_PERIOD): SMCResult {
+    if (bars.length === 0) return EMPTY_SMC_RESULT;
+
+    const atrValues = calculateATR(bars, SMC_ATR_PERIOD);
+    const swingPoints = detectSwingPoints(bars, swingPeriod);
+    const swingHighs = swingPoints.filter(p => p.type === 'high');
+    const swingLows = swingPoints.filter(p => p.type === 'low');
+
+    const fairValueGaps = detectFairValueGaps(bars);
+    const structureBreaks = detectStructureBreaks(bars, swingHighs, swingLows);
+    const orderBlocks = detectOrderBlocks(bars, structureBreaks);
+    const { equalHighs, equalLows } = detectEqualLevels(swingHighs, swingLows, atrValues);
+    const { premiumZone, discountZone, equilibriumZone } = detectZones(swingHighs, swingLows);
+
+    return {
+        swingHighs,
+        swingLows,
+        orderBlocks,
+        fairValueGaps,
+        equalHighs,
+        equalLows,
+        premiumZone,
+        discountZone,
+        equilibriumZone,
+        structureBreaks,
+    };
+}

--- a/src/domain/indicators/smc.ts
+++ b/src/domain/indicators/smc.ts
@@ -57,8 +57,10 @@ function detectSwingPoints(bars: Bar[], period: number): SMCSwingPoint[] {
         const minLow = window.reduce((m, b) => Math.min(m, b.low), Infinity);
 
         const found: SMCSwingPoint[] = [];
-        if (bar.high === maxHigh) found.push({ index: i, price: bar.high, type: 'high' });
-        if (bar.low === minLow) found.push({ index: i, price: bar.low, type: 'low' });
+        if (bar.high === maxHigh)
+            found.push({ index: i, price: bar.high, type: 'high' });
+        if (bar.low === minLow)
+            found.push({ index: i, price: bar.low, type: 'low' });
 
         return found.length > 0 ? [...acc, ...found] : acc;
     }, []);
@@ -90,17 +92,31 @@ function detectFairValueGaps(bars: Bar[]): SMCFairValueGap[] {
         if (!isBullish && !isBearish) return acc;
 
         const fvg: SMCFairValueGap = isBullish
-            ? { index: i, high: bar.low, low: anchor.high, type: 'bullish', isMitigated: false }
-            : { index: i, high: anchor.low, low: bar.high, type: 'bearish', isMitigated: false };
+            ? {
+                  index: i,
+                  high: bar.low,
+                  low: anchor.high,
+                  type: 'bullish',
+                  isMitigated: false,
+              }
+            : {
+                  index: i,
+                  high: anchor.low,
+                  low: bar.high,
+                  type: 'bearish',
+                  isMitigated: false,
+              };
 
         return [...acc, fvg];
     }, []);
 
     return raw.map(fvg => ({
         ...fvg,
-        isMitigated: bars.slice(fvg.index + 1).some(b =>
-            fvg.type === 'bullish' ? b.low <= fvg.high : b.high >= fvg.low
-        ),
+        isMitigated: bars
+            .slice(fvg.index + 1)
+            .some(b =>
+                fvg.type === 'bullish' ? b.low <= fvg.high : b.high >= fvg.low
+            ),
     }));
 }
 
@@ -162,11 +178,21 @@ function detectStructureBreaks(
         }
 
         // Bullish break: close crosses above the active swing high
-        if (activeHigh !== null && !highConsumed && bar.close > activeHigh.price) {
-            const breakType: SMCBreakType = trend === 'bearish' ? 'choch' : 'bos';
+        if (
+            activeHigh !== null &&
+            !highConsumed &&
+            bar.close > activeHigh.price
+        ) {
+            const breakType: SMCBreakType =
+                trend === 'bearish' ? 'choch' : 'bos';
             breaks = [
                 ...breaks,
-                { index: i, price: activeHigh.price, type: 'bullish', breakType },
+                {
+                    index: i,
+                    price: activeHigh.price,
+                    type: 'bullish',
+                    breakType,
+                },
             ];
             trend = 'bullish';
             highConsumed = true;
@@ -174,10 +200,16 @@ function detectStructureBreaks(
 
         // Bearish break: close crosses below the active swing low
         if (activeLow !== null && !lowConsumed && bar.close < activeLow.price) {
-            const breakType: SMCBreakType = trend === 'bullish' ? 'choch' : 'bos';
+            const breakType: SMCBreakType =
+                trend === 'bullish' ? 'choch' : 'bos';
             breaks = [
                 ...breaks,
-                { index: i, price: activeLow.price, type: 'bearish', breakType },
+                {
+                    index: i,
+                    price: activeLow.price,
+                    type: 'bearish',
+                    breakType,
+                },
             ];
             trend = 'bearish';
             lowConsumed = true;
@@ -202,7 +234,10 @@ function detectStructureBreaks(
  * Mitigation: price subsequently crosses through the OB zone entirely
  * (low goes below OB.low for bullish OB, high goes above OB.high for bearish OB).
  */
-function detectOrderBlocks(bars: Bar[], structureBreaks: SMCStructureBreak[]): SMCOrderBlock[] {
+function detectOrderBlocks(
+    bars: Bar[],
+    structureBreaks: SMCStructureBreak[]
+): SMCOrderBlock[] {
     return structureBreaks.reduce<SMCOrderBlock[]>((acc, sb) => {
         const isBullishBreak = sb.type === 'bullish';
         const obIndex = findLastOpposingCandle(bars, sb.index, isBullishBreak);
@@ -214,9 +249,11 @@ function detectOrderBlocks(bars: Bar[], structureBreaks: SMCStructureBreak[]): S
             high: obBar.high,
             low: obBar.low,
             type: sb.type,
-            isMitigated: bars.slice(obIndex + 1).some(b =>
-                isBullishBreak ? b.low < obBar.low : b.high > obBar.high
-            ),
+            isMitigated: bars
+                .slice(obIndex + 1)
+                .some(b =>
+                    isBullishBreak ? b.low < obBar.low : b.high > obBar.high
+                ),
         };
 
         return [...acc, ob];
@@ -234,14 +271,20 @@ function findLastOpposingCandle(
     endIndex: number,
     lookingForBullishBreak: boolean
 ): number | null {
-    return bars.slice(0, endIndex).reduceRight<number | null>((found, bar, i) => {
-        if (found !== null) return found;
-        const isBearish = bar.close < bar.open;
-        const isBullish = bar.close > bar.open;
-        return lookingForBullishBreak
-            ? isBearish ? i : null
-            : isBullish ? i : null;
-    }, null);
+    return bars
+        .slice(0, endIndex)
+        .reduceRight<number | null>((found, bar, i) => {
+            if (found !== null) return found;
+            const isBearish = bar.close < bar.open;
+            const isBullish = bar.close > bar.open;
+            return lookingForBullishBreak
+                ? isBearish
+                    ? i
+                    : null
+                : isBullish
+                  ? i
+                  : null;
+        }, null);
 }
 
 // ─── Equal High / Low detection ───────────────────────────────────────────────
@@ -290,7 +333,6 @@ function findEqualLevels(
 
 // ─── Premium / Discount / Equilibrium zones ───────────────────────────────────
 
-
 /**
  * Calculate Premium, Discount, and Equilibrium zones from the most recent
  * swing range (last confirmed swing high and swing low).
@@ -303,7 +345,11 @@ function detectZones(
     swingHighs: SMCSwingPoint[],
     swingLows: SMCSwingPoint[]
 ): Pick<SMCResult, 'premiumZone' | 'discountZone' | 'equilibriumZone'> {
-    const empty = { premiumZone: null, discountZone: null, equilibriumZone: null };
+    const empty = {
+        premiumZone: null,
+        discountZone: null,
+        equilibriumZone: null,
+    };
 
     if (swingHighs.length === 0 || swingLows.length === 0) return empty;
 
@@ -336,7 +382,10 @@ function detectZones(
 
 // ─── Main export ──────────────────────────────────────────────────────────────
 
-export function calculateSmc(bars: Bar[], swingPeriod = SMC_SWING_PERIOD): SMCResult {
+export function calculateSmc(
+    bars: Bar[],
+    swingPeriod = SMC_SWING_PERIOD
+): SMCResult {
     if (bars.length === 0) return EMPTY_SMC_RESULT;
 
     const atrValues = calculateATR(bars, SMC_ATR_PERIOD);
@@ -347,8 +396,15 @@ export function calculateSmc(bars: Bar[], swingPeriod = SMC_SWING_PERIOD): SMCRe
     const fairValueGaps = detectFairValueGaps(bars);
     const structureBreaks = detectStructureBreaks(bars, swingHighs, swingLows);
     const orderBlocks = detectOrderBlocks(bars, structureBreaks);
-    const { equalHighs, equalLows } = detectEqualLevels(swingHighs, swingLows, atrValues);
-    const { premiumZone, discountZone, equilibriumZone } = detectZones(swingHighs, swingLows);
+    const { equalHighs, equalLows } = detectEqualLevels(
+        swingHighs,
+        swingLows,
+        atrValues
+    );
+    const { premiumZone, discountZone, equilibriumZone } = detectZones(
+        swingHighs,
+        swingLows
+    );
 
     return {
         swingHighs,

--- a/src/domain/indicators/smc.ts
+++ b/src/domain/indicators/smc.ts
@@ -276,19 +276,17 @@ function detectOrderBlocks(
  *  - bullishBreak → last bearish candle (close < open)
  *  - bearishBreak → last bullish candle (close > open)
  */
-// Note: a for loop is used here for early return — reduceRight cannot short-circuit.
 function findLastOpposingCandle(
     bars: Bar[],
     endIndex: number,
     lookingForBullishBreak: boolean
 ): number | null {
-    for (let i = endIndex - 1; i >= 0; i--) {
-        const bar = bars[i];
-        const isBearish = bar.close < bar.open;
-        const isBullish = bar.close > bar.open;
-        if (lookingForBullishBreak ? isBearish : isBullish) return i;
-    }
-    return null;
+    const idx = bars
+        .slice(0, endIndex)
+        .findLastIndex(bar =>
+            lookingForBullishBreak ? bar.close < bar.open : bar.close > bar.open
+        );
+    return idx === -1 ? null : idx;
 }
 
 // ─── Equal High / Low detection ───────────────────────────────────────────────

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -94,6 +94,73 @@ export interface BuySellVolumeResult {
     sellVolume: number;
 }
 
+// ─── Smart Money Concepts ────────────────────────────────────────────────────
+// Concept reference: Smart Money Concepts (SMC) / ICT methodology
+// Original TradingView indicator: "Smart Money Concepts [LuxAlgo]" by LuxAlgo
+// This is an independent TypeScript implementation based on publicly documented
+// SMC trading concepts. Not a port of LuxAlgo's PineScript source code.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type SMCStructureDirection = 'bullish' | 'bearish';
+export type SMCBreakType = 'bos' | 'choch';
+export type SMCSwingPointType = 'high' | 'low';
+export type SMCZoneType = 'premium' | 'discount' | 'equilibrium';
+
+export interface SMCSwingPoint {
+    index: number;
+    price: number;
+    type: SMCSwingPointType;
+}
+
+export interface SMCOrderBlock {
+    startIndex: number;
+    high: number;
+    low: number;
+    type: SMCStructureDirection;
+    isMitigated: boolean;
+}
+
+export interface SMCFairValueGap {
+    index: number;
+    high: number;
+    low: number;
+    type: SMCStructureDirection;
+    isMitigated: boolean;
+}
+
+export interface SMCEqualLevel {
+    price: number;
+    firstIndex: number;
+    secondIndex: number;
+    type: SMCSwingPointType;
+}
+
+export interface SMCZone {
+    high: number;
+    low: number;
+    type: SMCZoneType;
+}
+
+export interface SMCStructureBreak {
+    index: number;
+    price: number;
+    type: SMCStructureDirection;
+    breakType: SMCBreakType;
+}
+
+export interface SMCResult {
+    swingHighs: SMCSwingPoint[];
+    swingLows: SMCSwingPoint[];
+    orderBlocks: SMCOrderBlock[];
+    fairValueGaps: SMCFairValueGap[];
+    equalHighs: SMCEqualLevel[];
+    equalLows: SMCEqualLevel[];
+    premiumZone: SMCZone | null;
+    discountZone: SMCZone | null;
+    equilibriumZone: SMCZone | null;
+    structureBreaks: SMCStructureBreak[];
+}
+
 export interface IndicatorResult {
     macd: MACDResult[];
     bollinger: BollingerResult[];
@@ -117,6 +184,7 @@ export interface IndicatorResult {
     cmf: (number | null)[];
     donchianChannel: DonchianChannelResult[];
     buySellVolume: BuySellVolumeResult[];
+    smc: SMCResult;
 }
 
 export type ChartDisplayType = 'line' | 'marker' | 'region';


### PR DESCRIPTION
## 관련 이슈

closes #275

## 구현 내용

- Closes #275
- LuxAlgo의 Smart Money Concepts를 참고한 독립 TypeScript 구현체 추가
- swing highs/lows, FVG, 구조 이탈(BOS/CHoCH), Order Block, Equal Levels, Premium/Discount/Equilibrium 존 감지
- AI 분석용 Skills 파일(`skills/strategies/smart-money-concepts.md`) 추가
- 기존 테스트 파일 5개에 `smc: EMPTY_SMC_RESULT` 필드 추가

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 인디케이터 초기 구간 null 반환 (0, NaN 없음)
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it
- [x] 초기 구간 null 케이스 테스트 포함
- [x] 매직 넘버 없음

## 변경 파일 목록

[생성]
- src/domain/indicators/smc.ts — SMC 인디케이터 계산 로직
- src/__tests__/domain/indicators/smc.test.ts — 32개 테스트 포함
- skills/strategies/smart-money-concepts.md — AI 분석 Skills 파일

[수정]
- src/domain/types.ts — SMC 타입 계층 추가 (SMCSwingPoint, SMCOrderBlock, SMCFairValueGap, SMCEqualLevel, SMCZone, SMCStructureBreak, SMCResult)
- src/domain/indicators/constants.ts — SMC 상수 추가 및 EMPTY_SMC_RESULT 내보내기
- src/domain/indicators/index.ts — calculateSmc 내보내기 및 calculateIndicators에 smc 필드 추가
- src/__tests__/domain/analysis/prompt.test.ts — mock에 smc 필드 추가
- src/__tests__/infrastructure/market/analysisApi.test.ts — mock에 smc 필드 추가
- src/__tests__/infrastructure/market/analyzeAction.test.ts — mock에 smc 필드 추가
- src/__tests__/infrastructure/market/getBarsAction.test.ts — mock에 smc 필드 추가
- src/__tests__/components/chart/utils/overlayLabelUtils.test.ts — mock에 smc 필드 추가

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build