### PR TITLE
feat: Squeeze Momentum 인디케이터 추가

### DIFF
--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -75,6 +75,8 @@ export interface IndicatorResult {
     cmf: (number | null)[];
     donchianChannel: DonchianChannelResult[];
     buySellVolume: BuySellVolumeResult[];
+    smc: SMCResult;
+    squeezeMomentum: SqueezeMomentumResult[];
 }
 
 export interface MACDResult {
@@ -154,6 +156,16 @@ export const EMA_SUPPORT_RESISTANCE_LONG_INDEX = 3;  // 60기간 EMA
 export const VP_DEFAULT_ROW_SIZE = 24;
 export const VP_VALUE_AREA_PERCENTAGE = 0.7;
 export const VP_MIN_BARS = 30;
+
+export const SQUEEZE_MOMENTUM_BB_LENGTH = 20;
+export const SQUEEZE_MOMENTUM_KC_LENGTH = 20;
+export const SQUEEZE_MOMENTUM_KC_MULT = 1.5;
+
+export const SMC_SWING_PERIOD = 5;
+export const SMC_EQUAL_LEVEL_ATR_MULTIPLIER = 0.5;
+export const SMC_ATR_PERIOD = 14;
+export const SMC_PREMIUM_RATIO = 0.75;
+export const SMC_DISCOUNT_RATIO = 0.25;
 ```
 
 ---
@@ -567,6 +579,112 @@ null 없음 (첫 봉부터 값 존재)
 초기 null 없음 (모든 봉에 값 반환)
 ```
 
+### SMC (Smart Money Concepts)
+
+```
+참고: ICT (Inner Circle Trader) / Smart Money Concepts 방법론
+원본 TradingView 인디케이터: "Smart Money Concepts [LuxAlgo]" by LuxAlgo
+독립적인 TypeScript 재구현 — PineScript 소스 코드의 직접 포팅 아님
+
+파라미터: swingPeriod=5, atrPeriod=14, equalLevelAtrMult=0.5,
+          premiumRatio=0.75, discountRatio=0.25
+
+반환 타입: SMCResult (단일 객체, 배열 아님)
+
+구성 요소 및 알고리즘:
+
+1. Swing Points (스윙 고점/저점)
+   - 인덱스 i가 스윙 고점: bars[i-period..i+period] 범위에서 high 최댓값
+   - 인덱스 i가 스윙 저점: bars[i-period..i+period] 범위에서 low 최솟값
+   - 양 끝에서 period개 봉은 미확정 → 제외
+   - 결과: swingHighs[], swingLows[] (각각 { index, price, type })
+
+2. Fair Value Gap (공정가치 갭, FVG)
+   - 상승 FVG (bar i): bars[i].low > bars[i-2].high
+     → 갭 구간: [bars[i-2].high, bars[i].low]
+   - 하락 FVG (bar i): bars[i].high < bars[i-2].low
+     → 갭 구간: [bars[i].high, bars[i-2].low]
+   - 완화(mitigation): 이후 봉이 갭 구간을 재진입하면 isMitigated=true
+   - 결과: fairValueGaps[] (각각 { index, high, low, type, isMitigated })
+
+3. Structure Breaks (구조 이탈: BOS / CHoCH)
+   상태머신 방식으로 스윙 레벨 돌파를 추적:
+   - BOS (Break of Structure): 현재 추세 방향의 스윙 레벨 돌파 (추세 지속)
+   - CHoCH (Change of Character): 현재 추세 반대 방향 스윙 레벨 돌파 (추세 전환 가능)
+   - 판단 기준: close 가격이 활성 스윙 레벨을 돌파하면 기록
+   - 결과: structureBreaks[] (각각 { index, price, type, breakType })
+
+4. Order Blocks (주문 블록)
+   - 각 구조 이탈(structureBreak)에 대해:
+     - 상승 이탈: 이탈 직전 마지막 하락 봉 (close < open)
+     - 하락 이탈: 이탈 직전 마지막 상승 봉 (close > open)
+   - 완화(mitigation):
+     - 상승 OB: 이후 봉의 low가 OB.low 하회
+     - 하락 OB: 이후 봉의 high가 OB.high 상회
+   - 결과: orderBlocks[] (각각 { startIndex, high, low, type, isMitigated })
+
+5. Equal Highs / Equal Lows (EQH / EQL)
+   - 두 스윙 고점의 가격 차이 ≤ ATR × equalLevelAtrMult(0.5) → Equal High
+   - 두 스윙 저점의 가격 차이 ≤ ATR × equalLevelAtrMult(0.5) → Equal Low
+   - 가격: 두 피벗의 중간값
+   - 결과: equalHighs[], equalLows[] (각각 { price, firstIndex, secondIndex, type })
+
+6. Premium / Equilibrium / Discount Zones
+   - 가장 최근 스윙 고점과 저점으로 범위 산출
+   - Premium zone:     [rangeTop, rangeBottom + 0.75 × range]  (상단 25%)
+   - Equilibrium zone: [rangeBottom + 0.75 × range, rangeBottom + 0.25 × range]  (중간 50%)
+   - Discount zone:    [rangeBottom + 0.25 × range, rangeBottom]  (하단 25%)
+   - 결과: premiumZone, equilibriumZone, discountZone (각각 { high, low, type } | null)
+
+의존성: calculateATR (swingPeriod × 2 + 1 미만 봉은 빈 결과 반환)
+```
+
+### Squeeze Momentum Indicator
+
+```
+원작자: LazyBear (PineScript "Squeeze Momentum Indicator [LazyBear]")
+출처: https://kr.tradingview.com/script/nqQ1DT5a-Squeeze-Momentum-Indicator-LazyBear/
+독립적인 TypeScript 재구현 — PineScript 소스 코드의 직접 포팅 아님
+
+파라미터: bbLength=20, kcLength=20, kcMult=1.5
+          (주의: BB 표준편차에도 kcMult=1.5 적용 — 원본 스크립트 동일)
+
+반환 타입: SqueezeMomentumResult[]
+
+알고리즘:
+
+1. Bollinger Bands
+   basis = SMA(close, bbLength=20)
+   dev   = kcMult(1.5) × stdDev(close, bbLength)
+   upperBB = basis + dev
+   lowerBB = basis - dev
+
+2. Keltner Channel
+   ma      = SMA(close, kcLength=20)
+   rangema = SMA(trueRange, kcLength)
+   upperKC = ma + rangema × kcMult(1.5)
+   lowerKC = ma - rangema × kcMult(1.5)
+
+3. Squeeze 상태 (세 상태는 상호 배타적)
+   sqzOn  = lowerBB > lowerKC AND upperBB < upperKC  (BB가 KC 안에 압축)
+   sqzOff = lowerBB < lowerKC AND upperBB > upperKC  (BB가 KC 밖으로 팽창)
+   noSqz  = NOT sqzOn AND NOT sqzOff                 (전환 중간 상태)
+
+4. 모멘텀 값 (val)
+   delta[i] = close[i] - avg(avg(highest(high, kcLength), lowest(low, kcLength)), SMA(close, kcLength))
+   val = linreg(delta_window[i-kcLength+1 .. i], kcLength)
+
+   val > 0: 상승 모멘텀, val < 0: 하락 모멘텀
+   val 부호 전환: 모멘텀 방향 반전 신호
+
+5. increasing
+   val > prevVal: true (모멘텀 강화)
+   val < prevVal: false (모멘텀 약화)
+   첫 번째 유효 val: null
+
+초기 max(bbLength, kcLength) - 1개 구간 = null
+```
+
 ### calculateIndicators 통합 함수
 
 ```typescript
@@ -576,6 +694,8 @@ function calculateIndicators(bars: Bar[]): IndicatorResult {
     // MA_DEFAULT_PERIODS, EMA_DEFAULT_PERIODS 상수를 사용해
     // 각 기간별로 계산 후 Record<number, (number | null)[]> 형태로 반환
     // volumeProfile: calculateVolumeProfile(bars) — bars < VP_MIN_BARS면 null
+    // smc: calculateSmc(bars) — 단일 SMCResult 객체 (배열 아님)
+    // squeezeMomentum: calculateSqueezeMomentum(bars) — SqueezeMomentumResult[]
 }
 ```
 
@@ -762,6 +882,33 @@ IN_NECK_RATIO = 0.05        — 인넥 허용 비율
 | `indicators/cmf.md` | CMF(21) | 자금 흐름 방향/강도 | 0.75 |
 | `indicators/donchian-channel.md` | Donchian Channel(20) | 브레이크아웃, Turtle Trading | 0.8 |
 | `indicators/buy-sell-volume.md` | Buy/Sell Volume | 캔들 내 매수/매도 압력 분해 | 0.75 |
+| `indicators/squeeze-momentum.md` | Squeeze Momentum(BB:20,KC:20,mult:1.5) | BB/KC 스퀴즈 감지, 모멘텀 방향 | 0.8 |
+| `indicators/smart-money-concepts.md` | 스마트 머니 컨셉 (SMC) | 0.85 |
+
+> **SMC**는 `smc` 필드(`IndicatorResult.smc`)를 참조한다.
+> `indicators: ['atr', 'smc']`로 선언되어 있으며, AI는 Swing Points, Order Blocks, FVG,
+> Structure Breaks, Premium/Discount Zone 데이터를 직접 해석한다.
+
+---
+
+## 전략 Skills (Strategy Skills)
+
+투자 전략 분석은 **AI + Skills 파일** 기반으로 수행한다.
+`type: strategy`인 skill 파일이 활성화되면 AI가 해당 전략 기준에 따라 차트를 해석한다.
+
+### 현재 등록된 전략 Skills
+
+| skill 파일 | 전략 | 신뢰도 |
+|---|---|---|
+| `strategies/ma-cycle.md` | 이동평균선 대순환 분석 | 0.8 |
+| `strategies/macd-cycle.md` | MACD 대순환 분석 | 0.75 |
+| `strategies/multi-timeframe.md` | 다중 시간대 분석 | 0.75 |
+| `strategies/breakout.md` | 브레이크아웃 전략 | 0.7 |
+| `strategies/divergence.md` | 다이버전스 전략 | 0.7 |
+| `strategies/mean-reversion.md` | 평균 회귀 전략 | 0.7 |
+| `strategies/elliott-wave.md` | 엘리어트 파동 | 0.7 |
+| `strategies/fibonacci.md` | 피보나치 전략 | 0.65 |
+| `strategies/wyckoff.md` | 와이코프 방법론 | 0.0 (비활성) |
 
 ---
 
@@ -1232,16 +1379,17 @@ infrastructure/ai/claude.ts
 ### indicators 필드와 계산 흐름의 관계
 
 skill의 `indicators` 필드는 **해당 skill이 분석에 필요로 하는 인디케이터 목록**이다.
-app 레이어는 활성화된 모든 skill의 `indicators`를 합산해
-불필요한 인디케이터를 계산하지 않도록 최적화할 수 있다.
+현재 이 필드는 파싱 후 `Skill.indicators: string[]`에 저장되지만,
+프롬프트 빌드 로직(`buildAnalysisPrompt`)에서 직접 소비되지는 않는다.
+인디케이터 값은 `IndicatorResult` 전체가 프롬프트에 포함되어 AI가 참조한다.
 
 ```typescript
-// 예시
+// 예시 (향후 최적화 용도)
 const activeSkills = allSkills.filter(s => s.confidenceWeight >= 0.5);
 const requiredIndicators = new Set(activeSkills.flatMap(s => s.indicators));
 
 // requiredIndicators에 없는 인디케이터는 계산 생략 가능
-// (현재는 전체 계산 후 전달하는 단순 구현도 허용)
+// (현재는 전체 계산 후 전달하는 단순 구현)
 ```
 
 ### 패턴 skill 예시

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -670,17 +670,17 @@ null 없음 (첫 봉부터 값 존재)
    sqzOff = lowerBB < lowerKC AND upperBB > upperKC  (BB가 KC 밖으로 팽창)
    noSqz  = NOT sqzOn AND NOT sqzOff                 (전환 중간 상태)
 
-4. 모멘텀 값 (val)
+4. 모멘텀 값 (momentum)
    delta[i] = close[i] - avg(avg(highest(high, kcLength), lowest(low, kcLength)), SMA(close, kcLength))
-   val = linreg(delta_window[i-kcLength+1 .. i], kcLength)
+   momentum = linreg(delta_window[i-kcLength+1 .. i], kcLength)
 
-   val > 0: 상승 모멘텀, val < 0: 하락 모멘텀
-   val 부호 전환: 모멘텀 방향 반전 신호
+   momentum > 0: 상승 모멘텀, momentum < 0: 하락 모멘텀
+   momentum 부호 전환: 모멘텀 방향 반전 신호
 
 5. increasing
-   val > prevVal: true (모멘텀 강화)
-   val < prevVal: false (모멘텀 약화)
-   첫 번째 유효 val: null
+   momentum > prevMomentum: true (모멘텀 강화)
+   momentum < prevMomentum: false (모멘텀 약화)
+   첫 번째 유효 momentum: null
 
 초기 max(bbLength, kcLength) - 1개 구간 = null
 ```

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -883,7 +883,7 @@ IN_NECK_RATIO = 0.05        — 인넥 허용 비율
 | `indicators/donchian-channel.md` | Donchian Channel(20) | 브레이크아웃, Turtle Trading | 0.8 |
 | `indicators/buy-sell-volume.md` | Buy/Sell Volume | 캔들 내 매수/매도 압력 분해 | 0.75 |
 | `indicators/squeeze-momentum.md` | Squeeze Momentum(BB:20,KC:20,mult:1.5) | BB/KC 스퀴즈 감지, 모멘텀 방향 | 0.8 |
-| `indicators/smart-money-concepts.md` | 스마트 머니 컨셉 (SMC) | 0.85 |
+| `indicators/smart-money-concepts.md` | 스마트 머니 컨셉 (SMC) | BOS/CHoCH 구조, 오더 블록, FVG, 프리미엄·디스카운트 존 해석 | 0.85 |
 
 > **SMC**는 `smc` 필드(`IndicatorResult.smc`)를 참조한다.
 > `indicators: ['atr', 'smc']`로 선언되어 있으며, AI는 Swing Points, Order Blocks, FVG,

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,12 +1,22 @@
 # Fix Log
 
-## [PR #274 | feat/273/buy-sell-volume-인디케이터 | 2026-04-11]
-- Violation: IndicatorResult에 buySellVolume 필드 추가 시 prompt.test.ts makeIndicators 팩토리와 constants.test.ts에 대응 케이스 미추가
-- Rule: MISTAKES.md Tests #10 — "Type field added but test mock objects not updated"; Tests #2 — "New field/indicator without corresponding test cases"
-- Context: buySellVolume을 IndicatorResult에 추가하면서 기존 테스트 픽스처(makeIndicators)와 EMPTY_INDICATOR_RESULT 검증 테스트를 함께 업데이트하지 않아 TS 컴파일 에러 및 assertion 실패 발생
-- Violation: formatVolumeSection → formatBuySellVolumeSection 교체 후 prompt.test.ts의 거래량 섹션 assertion이 구버전 출력 텍스트 기준으로 남음
-- Rule: MISTAKES.md Tests #1 — "Not updating tests when return type changes"
-- Context: 'bar average', 'Current volume', '% of average' assertion이 새 출력('Current bar:', 'cumulative', 'Buy ratio:')으로 업데이트되지 않아 런타임 실패
+## [PR #278 | feat/squeeze-momentum-indicator | 2026-04-12]
+- Violation: 계산 정확도 테스트 누락 — period-based 인디케이터임에도 val 부호(양수/음수)만 검증하고 수동 계산 레퍼런스 값과의 일치 여부(toBeCloseTo) 테스트 없음
+- Rule: CONVENTIONS.md — Period-Based Indicator 필수 테스트 케이스 표: "첫 번째 값이 명세와 일치한다"
+- Context: squeezeMomentum.test.ts에서 상승/하락 부호 검증만 작성하고 PineScript 원본 알고리즘 기준 수동 계산값(9.5)과 toBeCloseTo 검증 누락
+
+- Violation: 워밍업 기간 상수가 실제 첫 번째 유효 출력 인덱스를 과소평가 — 중첩 윈도우 의존성을 고려하지 않음
+- Rule: MISTAKES.md Tests #4 — 경계 상수는 소스에서 임포트해야 하며, 수동 계산 시 알고리즘 전체 의존성 체인을 반영해야 함
+- Context: MIN_BARS = max(bbLength, kcLength) = 20으로 정의했으나, delta 윈도우가 kcLength 길이의 delta 배열을 필요로 하고 각 delta 값은 kcLength 바가 필요하여 실제 워밍업은 2*kcLength-1 = 39바
+
+- Violation: .map() 외부 변수(let prevVal)로 상태를 누적하여 함수형 패러다임 위반
+- Rule: CONVENTIONS.md Coding Paradigm — "순수 함수 선호; 외부 상태 변이 금지"; 이전 계산에 의존하는 상태 기반 로직은 reduce 또는 두 패스 구조로 구현해야 함
+- Context: calculateSqueezeMomentum의 bars.map() 내부에서 let prevVal = null 외부 변수를 직접 수정하여 increasing 필드를 계산; 두 패스(intermediate 계산 + increasing 추가)로 분리하여 해결
+
+- Violation: 루프마다 전체 배열 슬라이싱(O(n²)) — sma/stdDev는 내부에서 slice(-period)를 수행하므로 전체 배열 전달 불필요
+- Rule: CONVENTIONS.md Performance — 불필요한 배열 복사를 피하고 필요한 윈도우만 전달
+- Context: closes.slice(0, i+1) 전달 대신 closes.slice(Math.max(0, i-maxPeriod+1), i+1)로 좁혀 O(n²) → O(n) 개선
+
 
 ## [PR #272 Round 2 | refactor/271/skill-counts-build-time-derivation | 2026-04-11]
 - Violation: `indicatorCount` prop이 `SymbolPageClient` → `ChartContent` → `AnalysisPanel`로 드릴링됨 (두 중간 컴포넌트 모두 미사용)

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,10 @@
 # Fix Log
 
+## [PR #278 Round 2 | feat/squeeze-momentum-indicator | 2026-04-12]
+- Violation: `utils.ts`에서 `const window = values.slice(-period)` — 브라우저 전역 `window` 객체 섀도잉
+- Rule: CONVENTIONS.md ESLint no-shadow — `window`, `document`, `location` 등 전역 이름 사용 금지
+- Context: `stdDev`와 `linreg` 두 함수 모두 지역 변수명으로 `window`를 사용; `vals`로 변경
+
 ## [PR #278 | feat/squeeze-momentum-indicator | 2026-04-12]
 - Violation: 계산 정확도 테스트 누락 — period-based 인디케이터임에도 val 부호(양수/음수)만 검증하고 수동 계산 레퍼런스 값과의 일치 여부(toBeCloseTo) 테스트 없음
 - Rule: CONVENTIONS.md — Period-Based Indicator 필수 테스트 케이스 표: "첫 번째 값이 명세와 일치한다"

--- a/skills/indicators/smart-money-concepts.md
+++ b/skills/indicators/smart-money-concepts.md
@@ -1,7 +1,7 @@
 ---
 name: 스마트 머니 컨셉 (SMC)
-description: ICT/SMC 방법론에 기반하여 기관 자금의 행동 패턴을 분석 — BOS/CHoCH 구조 이탈, 오더 블록, 공정 가치 갭(FVG), 스윙 포인트, 프리미엄·디스카운트 존을 통해 기관이 축적·청산하는 가격대를 식별하는 전략
-type: strategy
+description: ICT/SMC 방법론에 기반하여 기관 자금의 행동 패턴을 분석 — BOS/CHoCH 구조 이탈, 오더 블록, 공정 가치 갭(FVG), 스윙 포인트, 프리미엄·디스카운트 존을 통해 기관이 축적·청산하는 가격대를 식별하는 보조지표
+type: indicator_guide
 category: neutral
 indicators: ['atr', 'smc']
 confidence_weight: 0.85

--- a/skills/indicators/squeeze-momentum.md
+++ b/skills/indicators/squeeze-momentum.md
@@ -1,0 +1,63 @@
+---
+name: 스퀴즈 모멘텀 신호 가이드
+description: Squeeze Momentum Indicator(BB:20, KC:20, mult:1.5) 신호 해석 가이드 — 변동성 압축 감지, 모멘텀 방향, 돌파 시점 식별
+type: indicator_guide
+indicators: ['squeezeMomentum']
+confidence_weight: 0.8
+---
+
+## Overview
+
+The Squeeze Momentum Indicator, originally developed by LazyBear (PineScript: https://www.tradingview.com/v/4IneGo8h/), combines Bollinger Bands (BB) and Keltner Channel (KC) to detect periods of volatility compression ("squeeze") and measures the momentum of the subsequent release. The core insight is that when BB contracts inside KC, price is coiling — energy is building for a high-probability breakout. The linear regression momentum value reveals the directional bias of that energy.
+
+**Parameters used:** BB length = 20, KC length = 20, KC multiplier = 1.5 (applied to both BB deviation and KC ATR offset).
+
+## Signal Interpretation
+
+### Squeeze State
+
+- **Squeeze ON (`sqzOn = true`)**: Bollinger Bands are entirely inside the Keltner Channel — volatility has compressed to an extreme. This is the setup phase. The longer the squeeze persists, the more energy is coiled and the more powerful the eventual breakout.
+- **Squeeze OFF (`sqzOff = true`)**: Bollinger Bands have expanded back outside the Keltner Channel — the squeeze has been released. This is the trigger phase. Price is beginning to move with expanded volatility.
+- **No Squeeze (`noSqz = true`)**: Neither condition is met — a transitional state, less actionable on its own.
+
+### Momentum Value (val)
+
+The momentum value is derived from a linear regression of `close − avg(avg(highest_high, lowest_low), sma_close)` over 20 bars. It measures the directional momentum within the squeeze context:
+
+- **val > 0 and rising (`increasing = true`)**: Bullish momentum is strengthening — price is trending upward with increasing force.
+- **val > 0 and falling (`increasing = false`)**: Bullish momentum is weakening — the upward move may be losing steam.
+- **val < 0 and falling (`increasing = false`)**: Bearish momentum is strengthening — price is trending downward with increasing force.
+- **val < 0 and rising (`increasing = true`)**: Bearish momentum is weakening — the downward move may be bottoming out.
+- **val crossing zero (sign change)**: Momentum direction reversal — one of the most significant signals. A cross from negative to positive is a bullish reversal; positive to negative is a bearish reversal.
+
+### Combined Squeeze + Momentum Signals
+
+- **sqzOff + val > 0 + rising**: Highest-probability bullish breakout — squeeze just released with strong upward momentum. Classic buy setup.
+- **sqzOff + val < 0 + falling**: Highest-probability bearish breakdown — squeeze just released with strong downward momentum. Classic short setup.
+- **sqzOn + val rising (positive)**: Bullish energy accumulating within the squeeze — anticipate upside breakout.
+- **sqzOn + val falling (negative)**: Bearish energy accumulating within the squeeze — anticipate downside breakdown.
+- **sqzOff + val direction change**: Squeeze released but momentum is already reversing — potential false breakout or early exhaustion.
+
+## Directional Bias Assessment
+
+When the squeeze fires (`sqzOff` transitions from false to true), evaluate momentum direction at the moment of release:
+
+1. If `val > 0` at release: bullish breakout expected — price likely to continue higher.
+2. If `val < 0` at release: bearish breakdown expected — price likely to continue lower.
+3. The `increasing` field provides a real-time momentum acceleration signal — rising absolute value means the move is gaining strength, falling absolute value means it is decelerating.
+
+## Recommended Combinations
+
+- **Squeeze Momentum + MACD**: MACD histogram direction at the moment of squeeze release confirms the breakout direction. Both aligned = very high-probability setup.
+- **Squeeze Momentum + RSI**: RSI above 50 with sqzOff + val > 0 reinforces bullish breakout. RSI below 50 with sqzOff + val < 0 reinforces bearish breakdown.
+- **Squeeze Momentum + Volume Analysis**: Buy volume surge during squeeze release (sqzOff) dramatically increases breakout reliability.
+- **Squeeze Momentum + Keltner Channel**: The squeeze is defined by BB/KC relationship, so reviewing the Keltner Channel width provides additional context on whether the squeeze is tightening or loosening.
+- **Squeeze Momentum + Supertrend**: Supertrend direction alignment with squeeze release momentum provides a strong trend-following entry confirmation.
+
+## Caveats
+
+- The squeeze can persist for many bars — a long squeeze is not a fading signal. In fact, prolonged squeezes (10+ bars) historically produce larger moves upon release.
+- In choppy, low-volatility markets, the squeeze may cycle on and off frequently without producing meaningful moves. Confirm with ADX (ADX > 20 indicates sufficient trend strength).
+- The momentum value from linear regression is a smooth, lagging measure. It will not capture sharp intraday reversals — it reflects the underlying directional bias over the window period.
+- Do not use val zero-crossings in isolation on very short timeframes — noise can cause frequent crossings without sustained directional moves. Require the cross to hold for at least 1-2 bars.
+- This indicator is best applied on daily and hourly charts. On minute charts, reduce the KC/BB lengths to 10-14 for more responsive signals.

--- a/skills/indicators/squeeze-momentum.md
+++ b/skills/indicators/squeeze-momentum.md
@@ -20,36 +20,36 @@ The Squeeze Momentum Indicator, originally developed by LazyBear (PineScript: ht
 - **Squeeze OFF (`sqzOff = true`)**: Bollinger Bands have expanded back outside the Keltner Channel — the squeeze has been released. This is the trigger phase. Price is beginning to move with expanded volatility.
 - **No Squeeze (`noSqz = true`)**: Neither condition is met — a transitional state, less actionable on its own.
 
-### Momentum Value (val)
+### Momentum Value (momentum)
 
 The momentum value is derived from a linear regression of `close − avg(avg(highest_high, lowest_low), sma_close)` over 20 bars. It measures the directional momentum within the squeeze context:
 
-- **val > 0 and rising (`increasing = true`)**: Bullish momentum is strengthening — price is trending upward with increasing force.
-- **val > 0 and falling (`increasing = false`)**: Bullish momentum is weakening — the upward move may be losing steam.
-- **val < 0 and falling (`increasing = false`)**: Bearish momentum is strengthening — price is trending downward with increasing force.
-- **val < 0 and rising (`increasing = true`)**: Bearish momentum is weakening — the downward move may be bottoming out.
-- **val crossing zero (sign change)**: Momentum direction reversal — one of the most significant signals. A cross from negative to positive is a bullish reversal; positive to negative is a bearish reversal.
+- **momentum > 0 and rising (`increasing = true`)**: Bullish momentum is strengthening — price is trending upward with increasing force.
+- **momentum > 0 and falling (`increasing = false`)**: Bullish momentum is weakening — the upward move may be losing steam.
+- **momentum < 0 and falling (`increasing = false`)**: Bearish momentum is strengthening — price is trending downward with increasing force.
+- **momentum < 0 and rising (`increasing = true`)**: Bearish momentum is weakening — the downward move may be bottoming out.
+- **momentum crossing zero (sign change)**: Momentum direction reversal — one of the most significant signals. A cross from negative to positive is a bullish reversal; positive to negative is a bearish reversal.
 
 ### Combined Squeeze + Momentum Signals
 
-- **sqzOff + val > 0 + rising**: Highest-probability bullish breakout — squeeze just released with strong upward momentum. Classic buy setup.
-- **sqzOff + val < 0 + falling**: Highest-probability bearish breakdown — squeeze just released with strong downward momentum. Classic short setup.
-- **sqzOn + val rising (positive)**: Bullish energy accumulating within the squeeze — anticipate upside breakout.
-- **sqzOn + val falling (negative)**: Bearish energy accumulating within the squeeze — anticipate downside breakdown.
-- **sqzOff + val direction change**: Squeeze released but momentum is already reversing — potential false breakout or early exhaustion.
+- **sqzOff + momentum > 0 + rising**: Highest-probability bullish breakout — squeeze just released with strong upward momentum. Classic buy setup.
+- **sqzOff + momentum < 0 + falling**: Highest-probability bearish breakdown — squeeze just released with strong downward momentum. Classic short setup.
+- **sqzOn + momentum rising (positive)**: Bullish energy accumulating within the squeeze — anticipate upside breakout.
+- **sqzOn + momentum falling (negative)**: Bearish energy accumulating within the squeeze — anticipate downside breakdown.
+- **sqzOff + momentum direction change**: Squeeze released but momentum is already reversing — potential false breakout or early exhaustion.
 
 ## Directional Bias Assessment
 
 When the squeeze fires (`sqzOff` transitions from false to true), evaluate momentum direction at the moment of release:
 
-1. If `val > 0` at release: bullish breakout expected — price likely to continue higher.
-2. If `val < 0` at release: bearish breakdown expected — price likely to continue lower.
+1. If `momentum > 0` at release: bullish breakout expected — price likely to continue higher.
+2. If `momentum < 0` at release: bearish breakdown expected — price likely to continue lower.
 3. The `increasing` field provides a real-time momentum acceleration signal — rising absolute value means the move is gaining strength, falling absolute value means it is decelerating.
 
 ## Recommended Combinations
 
 - **Squeeze Momentum + MACD**: MACD histogram direction at the moment of squeeze release confirms the breakout direction. Both aligned = very high-probability setup.
-- **Squeeze Momentum + RSI**: RSI above 50 with sqzOff + val > 0 reinforces bullish breakout. RSI below 50 with sqzOff + val < 0 reinforces bearish breakdown.
+- **Squeeze Momentum + RSI**: RSI above 50 with sqzOff + momentum > 0 reinforces bullish breakout. RSI below 50 with sqzOff + momentum < 0 reinforces bearish breakdown.
 - **Squeeze Momentum + Volume Analysis**: Buy volume surge during squeeze release (sqzOff) dramatically increases breakout reliability.
 - **Squeeze Momentum + Keltner Channel**: The squeeze is defined by BB/KC relationship, so reviewing the Keltner Channel width provides additional context on whether the squeeze is tightening or loosening.
 - **Squeeze Momentum + Supertrend**: Supertrend direction alignment with squeeze release momentum provides a strong trend-following entry confirmation.
@@ -59,5 +59,5 @@ When the squeeze fires (`sqzOff` transitions from false to true), evaluate momen
 - The squeeze can persist for many bars — a long squeeze is not a fading signal. In fact, prolonged squeezes (10+ bars) historically produce larger moves upon release.
 - In choppy, low-volatility markets, the squeeze may cycle on and off frequently without producing meaningful moves. Confirm with ADX (ADX > 20 indicates sufficient trend strength).
 - The momentum value from linear regression is a smooth, lagging measure. It will not capture sharp intraday reversals — it reflects the underlying directional bias over the window period.
-- Do not use val zero-crossings in isolation on very short timeframes — noise can cause frequent crossings without sustained directional moves. Require the cross to hold for at least 1-2 bars.
+- Do not use momentum zero-crossings in isolation on very short timeframes — noise can cause frequent crossings without sustained directional moves. Require the cross to hold for at least 1-2 bars.
 - This indicator is best applied on daily and hourly charts. On minute charts, reduce the KC/BB lengths to 10-14 for more responsive signals.

--- a/src/__tests__/domain/analysis/prompt.test.ts
+++ b/src/__tests__/domain/analysis/prompt.test.ts
@@ -138,6 +138,7 @@ const makeIndicators = (
     cmf: [],
     donchianChannel: [],
     buySellVolume: [],
+    squeezeMomentum: [],
     ...overrides,
     smc: overrides?.smc ?? EMPTY_SMC_RESULT,
 });

--- a/src/__tests__/domain/indicators/squeezeMomentum.test.ts
+++ b/src/__tests__/domain/indicators/squeezeMomentum.test.ts
@@ -1,0 +1,203 @@
+import { calculateSqueezeMomentum } from '@/domain/indicators/squeezeMomentum';
+import {
+    SQUEEZE_MOMENTUM_BB_LENGTH,
+    SQUEEZE_MOMENTUM_KC_LENGTH,
+    SQUEEZE_MOMENTUM_KC_MULT,
+} from '@/domain/indicators/constants';
+import type { Bar, SqueezeMomentumResult } from '@/domain/types';
+
+function makeBars(
+    values: { high: number; low: number; close: number }[]
+): Bar[] {
+    return values.map((v, i) => ({
+        time: i,
+        open: v.close,
+        high: v.high,
+        low: v.low,
+        close: v.close,
+        volume: 1000,
+    }));
+}
+
+function makeUniformBars(count: number, price = 100): Bar[] {
+    return makeBars(
+        Array.from({ length: count }, () => ({
+            high: price + 5,
+            low: price - 5,
+            close: price,
+        }))
+    );
+}
+
+const MIN_BARS = Math.max(SQUEEZE_MOMENTUM_BB_LENGTH, SQUEEZE_MOMENTUM_KC_LENGTH);
+
+describe('calculateSqueezeMomentum', () => {
+    describe('입력 배열이 비어있을 때', () => {
+        it('빈 배열을 반환한다', () => {
+            expect(calculateSqueezeMomentum([])).toEqual([]);
+        });
+    });
+
+    describe('입력 배열 길이가 period 미만일 때', () => {
+        it('전부 null인 결과 배열을 반환한다', () => {
+            const bars = makeUniformBars(MIN_BARS - 1);
+            const result = calculateSqueezeMomentum(bars);
+            expect(result).toHaveLength(bars.length);
+            expect(result.every(r => r.val === null)).toBe(true);
+        });
+    });
+
+    describe('입력 배열 길이가 충분할 때', () => {
+        it('입력과 동일한 길이의 배열을 반환한다', () => {
+            const bars = makeUniformBars(50);
+            expect(calculateSqueezeMomentum(bars)).toHaveLength(50);
+        });
+
+        it('처음 period-1개의 val은 null이다', () => {
+            const bars = makeUniformBars(50);
+            const result = calculateSqueezeMomentum(bars);
+            expect(
+                result.slice(0, MIN_BARS - 1).every(r => r.val === null)
+            ).toBe(true);
+        });
+
+        it('충분한 데이터 이후 val은 number다', () => {
+            const bars = makeUniformBars(50);
+            const result = calculateSqueezeMomentum(bars);
+            const valid = result.filter(r => r.val !== null);
+            expect(valid.length).toBeGreaterThan(0);
+            valid.forEach(r => {
+                expect(typeof r.val).toBe('number');
+            });
+        });
+
+        it('기본값이 올바르다', () => {
+            const bars = makeUniformBars(50);
+            expect(calculateSqueezeMomentum(bars)).toEqual(
+                calculateSqueezeMomentum(
+                    bars,
+                    SQUEEZE_MOMENTUM_BB_LENGTH,
+                    SQUEEZE_MOMENTUM_KC_LENGTH,
+                    SQUEEZE_MOMENTUM_KC_MULT
+                )
+            );
+        });
+    });
+
+    describe('균일 가격 데이터일 때', () => {
+        it('val이 0에 수렴한다 (모멘텀 없음)', () => {
+            const bars = makeUniformBars(60);
+            const result = calculateSqueezeMomentum(bars);
+            result
+                .filter(r => r.val !== null)
+                .forEach(r => {
+                    expect(r.val as number).toBeCloseTo(0, 5);
+                });
+        });
+
+        it('균일 가격에서 sqzOn/sqzOff/noSqz 중 하나만 true다', () => {
+            const bars = makeUniformBars(60);
+            const result = calculateSqueezeMomentum(bars);
+            result
+                .filter(r => r.sqzOn !== null)
+                .forEach(r => {
+                    const trueCount = [r.sqzOn, r.sqzOff, r.noSqz].filter(
+                        Boolean
+                    ).length;
+                    expect(trueCount).toBe(1);
+                });
+        });
+
+        it('stdDev≈0인 균일 가격에서 sqzOn이 true다 (BB가 KC 안에 압축됨)', () => {
+            // Uniform close → stdDev ≈ 0 → BB width ≈ 0 (very narrow)
+            // True range = high-low = 10 → KC width = 1.5*10 = 15 (wide)
+            // BB is entirely inside KC → sqzOn must be true
+            const bars = makeUniformBars(60);
+            const valid = calculateSqueezeMomentum(bars).filter(
+                r => r.sqzOn !== null
+            );
+            expect(valid.length).toBeGreaterThan(0);
+            valid.forEach(r => {
+                expect(r.sqzOn).toBe(true);
+            });
+        });
+    });
+
+    describe('상승 추세 데이터일 때', () => {
+        it('val이 양수가 된다 (상승 모멘텀)', () => {
+            const bars = makeBars(
+                Array.from({ length: 60 }, (_, i) => ({
+                    high: 100 + i + 5,
+                    low: 100 + i - 5,
+                    close: 100 + i,
+                }))
+            );
+            const result = calculateSqueezeMomentum(bars);
+            const valid = result.filter(r => r.val !== null);
+            const lastVal = valid[valid.length - 1].val as number;
+            expect(lastVal).toBeGreaterThan(0);
+        });
+    });
+
+    describe('하락 추세 데이터일 때', () => {
+        it('val이 음수가 된다 (하락 모멘텀)', () => {
+            const bars = makeBars(
+                Array.from({ length: 60 }, (_, i) => ({
+                    high: 200 - i + 5,
+                    low: 200 - i - 5,
+                    close: 200 - i,
+                }))
+            );
+            const result = calculateSqueezeMomentum(bars);
+            const valid = result.filter(r => r.val !== null);
+            const lastVal = valid[valid.length - 1].val as number;
+            expect(lastVal).toBeLessThan(0);
+        });
+    });
+
+    describe('increasing 필드', () => {
+        it('첫 번째 유효한 val은 increasing이 null이다', () => {
+            const bars = makeUniformBars(50);
+            const result = calculateSqueezeMomentum(bars);
+            const firstValid = result.find(r => r.val !== null);
+            expect(firstValid?.increasing).toBeNull();
+        });
+
+        it('두 번째 이후 유효 val은 increasing이 boolean이다', () => {
+            const bars = makeBars(
+                Array.from({ length: 60 }, (_, i) => ({
+                    high: 100 + i + 5,
+                    low: 100 + i - 5,
+                    close: 100 + i,
+                }))
+            );
+            const result = calculateSqueezeMomentum(bars);
+            const valid = result.filter(r => r.val !== null);
+            // Skip the first valid entry (increasing === null)
+            valid.slice(1).forEach(r => {
+                expect(typeof r.increasing).toBe('boolean');
+            });
+        });
+    });
+
+    describe('sqzOn / sqzOff / noSqz 상호 배타성', () => {
+        it('유효한 결과에서 세 상태 중 정확히 하나만 true다', () => {
+            const bars = makeBars(
+                Array.from({ length: 60 }, (_, i) => ({
+                    high: 100 + Math.sin(i) * 10,
+                    low: 100 + Math.sin(i) * 10 - 10,
+                    close: 100 + Math.sin(i) * 5,
+                }))
+            );
+            const result = calculateSqueezeMomentum(bars);
+            result
+                .filter(r => r.sqzOn !== null)
+                .forEach((r: SqueezeMomentumResult) => {
+                    const count = [r.sqzOn, r.sqzOff, r.noSqz].filter(
+                        Boolean
+                    ).length;
+                    expect(count).toBe(1);
+                });
+        });
+    });
+});

--- a/src/__tests__/domain/indicators/squeezeMomentum.test.ts
+++ b/src/__tests__/domain/indicators/squeezeMomentum.test.ts
@@ -64,7 +64,9 @@ describe('calculateSqueezeMomentum', () => {
                     .slice(0, SQUEEZE_MOMENTUM_MIN_BARS - 1)
                     .every(r => r.momentum === null)
             ).toBe(true);
-            expect(result[SQUEEZE_MOMENTUM_MIN_BARS - 1].momentum).not.toBeNull();
+            expect(
+                result[SQUEEZE_MOMENTUM_MIN_BARS - 1].momentum
+            ).not.toBeNull();
         });
 
         it('충분한 데이터 이후 val은 number다', () => {

--- a/src/__tests__/domain/indicators/squeezeMomentum.test.ts
+++ b/src/__tests__/domain/indicators/squeezeMomentum.test.ts
@@ -29,7 +29,10 @@ function makeUniformBars(count: number, price = 100): Bar[] {
     );
 }
 
-const MIN_BARS = Math.max(SQUEEZE_MOMENTUM_BB_LENGTH, SQUEEZE_MOMENTUM_KC_LENGTH);
+const MIN_BARS = Math.max(
+    SQUEEZE_MOMENTUM_BB_LENGTH,
+    SQUEEZE_MOMENTUM_KC_LENGTH
+);
 
 describe('calculateSqueezeMomentum', () => {
     describe('입력 배열이 비어있을 때', () => {

--- a/src/__tests__/domain/indicators/squeezeMomentum.test.ts
+++ b/src/__tests__/domain/indicators/squeezeMomentum.test.ts
@@ -3,6 +3,7 @@ import {
     SQUEEZE_MOMENTUM_BB_LENGTH,
     SQUEEZE_MOMENTUM_KC_LENGTH,
     SQUEEZE_MOMENTUM_KC_MULT,
+    SQUEEZE_MOMENTUM_MIN_BARS,
 } from '@/domain/indicators/constants';
 import type { Bar, SqueezeMomentumResult } from '@/domain/types';
 
@@ -35,10 +36,6 @@ const MIN_BARS = Math.max(
     SQUEEZE_MOMENTUM_KC_LENGTH
 );
 
-// Actual warmup: delta window needs kcLength bars that each need kcLength bars,
-// so the first valid val appears at index 2*kcLength - 2.
-const ACTUAL_WARMUP = 2 * SQUEEZE_MOMENTUM_KC_LENGTH - 1;
-
 describe('calculateSqueezeMomentum', () => {
     describe('입력 배열이 비어있을 때', () => {
         it('빈 배열을 반환한다', () => {
@@ -62,12 +59,14 @@ describe('calculateSqueezeMomentum', () => {
         });
 
         it('첫 번째 유효한 val은 실제 워밍업 기간 이후에 나타난다', () => {
-            const bars = makeUniformBars(ACTUAL_WARMUP + 10);
+            const bars = makeUniformBars(SQUEEZE_MOMENTUM_MIN_BARS + 10);
             const result = calculateSqueezeMomentum(bars);
             expect(
-                result.slice(0, ACTUAL_WARMUP - 1).every(r => r.val === null)
+                result
+                    .slice(0, SQUEEZE_MOMENTUM_MIN_BARS - 1)
+                    .every(r => r.val === null)
             ).toBe(true);
-            expect(result[ACTUAL_WARMUP - 1].val).not.toBeNull();
+            expect(result[SQUEEZE_MOMENTUM_MIN_BARS - 1].val).not.toBeNull();
         });
 
         it('충분한 데이터 이후 val은 number다', () => {

--- a/src/__tests__/domain/indicators/squeezeMomentum.test.ts
+++ b/src/__tests__/domain/indicators/squeezeMomentum.test.ts
@@ -31,10 +31,8 @@ function makeUniformBars(count: number, price = 100): Bar[] {
 }
 
 // Minimum bars for any non-null output in BB/KC (inner indicators warmup)
-const MIN_BARS = Math.max(
-    SQUEEZE_MOMENTUM_BB_LENGTH,
-    SQUEEZE_MOMENTUM_KC_LENGTH
-);
+// BB_LENGTH === KC_LENGTH === 20, so either constant is equivalent here
+const MIN_BARS = SQUEEZE_MOMENTUM_BB_LENGTH;
 
 describe('calculateSqueezeMomentum', () => {
     describe('입력 배열이 비어있을 때', () => {
@@ -48,7 +46,7 @@ describe('calculateSqueezeMomentum', () => {
             const bars = makeUniformBars(MIN_BARS - 1);
             const result = calculateSqueezeMomentum(bars);
             expect(result).toHaveLength(bars.length);
-            expect(result.every(r => r.val === null)).toBe(true);
+            expect(result.every(r => r.momentum === null)).toBe(true);
         });
     });
 
@@ -64,18 +62,18 @@ describe('calculateSqueezeMomentum', () => {
             expect(
                 result
                     .slice(0, SQUEEZE_MOMENTUM_MIN_BARS - 1)
-                    .every(r => r.val === null)
+                    .every(r => r.momentum === null)
             ).toBe(true);
-            expect(result[SQUEEZE_MOMENTUM_MIN_BARS - 1].val).not.toBeNull();
+            expect(result[SQUEEZE_MOMENTUM_MIN_BARS - 1].momentum).not.toBeNull();
         });
 
         it('충분한 데이터 이후 val은 number다', () => {
             const bars = makeUniformBars(50);
             const result = calculateSqueezeMomentum(bars);
-            const valid = result.filter(r => r.val !== null);
+            const valid = result.filter(r => r.momentum !== null);
             expect(valid.length).toBeGreaterThan(0);
             valid.forEach(r => {
-                expect(typeof r.val).toBe('number');
+                expect(typeof r.momentum).toBe('number');
             });
         });
 
@@ -97,9 +95,9 @@ describe('calculateSqueezeMomentum', () => {
             const bars = makeUniformBars(60);
             const result = calculateSqueezeMomentum(bars);
             result
-                .filter(r => r.val !== null)
+                .filter(r => r.momentum !== null)
                 .forEach(r => {
-                    expect(r.val as number).toBeCloseTo(0, 5);
+                    expect(r.momentum as number).toBeCloseTo(0, 5);
                 });
         });
 
@@ -148,8 +146,8 @@ describe('calculateSqueezeMomentum', () => {
                 }))
             );
             const result = calculateSqueezeMomentum(bars);
-            const firstValid = result.find(r => r.val !== null);
-            expect(firstValid?.val).toBeCloseTo(9.5, 4);
+            const firstValid = result.find(r => r.momentum !== null);
+            expect(firstValid?.momentum).toBeCloseTo(9.5, 4);
         });
     });
 
@@ -163,8 +161,8 @@ describe('calculateSqueezeMomentum', () => {
                 }))
             );
             const result = calculateSqueezeMomentum(bars);
-            const valid = result.filter(r => r.val !== null);
-            const lastVal = valid[valid.length - 1].val!;
+            const valid = result.filter(r => r.momentum !== null);
+            const lastVal = valid[valid.length - 1].momentum!;
             expect(lastVal).toBeGreaterThan(0);
         });
     });
@@ -179,8 +177,8 @@ describe('calculateSqueezeMomentum', () => {
                 }))
             );
             const result = calculateSqueezeMomentum(bars);
-            const valid = result.filter(r => r.val !== null);
-            const lastVal = valid[valid.length - 1].val!;
+            const valid = result.filter(r => r.momentum !== null);
+            const lastVal = valid[valid.length - 1].momentum!;
             expect(lastVal).toBeLessThan(0);
         });
     });
@@ -189,7 +187,7 @@ describe('calculateSqueezeMomentum', () => {
         it('첫 번째 유효한 val은 increasing이 null이다', () => {
             const bars = makeUniformBars(50);
             const result = calculateSqueezeMomentum(bars);
-            const firstValid = result.find(r => r.val !== null);
+            const firstValid = result.find(r => r.momentum !== null);
             expect(firstValid?.increasing).toBeNull();
         });
 
@@ -202,7 +200,7 @@ describe('calculateSqueezeMomentum', () => {
                 }))
             );
             const result = calculateSqueezeMomentum(bars);
-            const valid = result.filter(r => r.val !== null);
+            const valid = result.filter(r => r.momentum !== null);
             // Skip the first valid entry (increasing === null)
             valid.slice(1).forEach(r => {
                 expect(typeof r.increasing).toBe('boolean');

--- a/src/__tests__/domain/indicators/squeezeMomentum.test.ts
+++ b/src/__tests__/domain/indicators/squeezeMomentum.test.ts
@@ -29,10 +29,15 @@ function makeUniformBars(count: number, price = 100): Bar[] {
     );
 }
 
+// Minimum bars for any non-null output in BB/KC (inner indicators warmup)
 const MIN_BARS = Math.max(
     SQUEEZE_MOMENTUM_BB_LENGTH,
     SQUEEZE_MOMENTUM_KC_LENGTH
 );
+
+// Actual warmup: delta window needs kcLength bars that each need kcLength bars,
+// so the first valid val appears at index 2*kcLength - 2.
+const ACTUAL_WARMUP = 2 * SQUEEZE_MOMENTUM_KC_LENGTH - 1;
 
 describe('calculateSqueezeMomentum', () => {
     describe('입력 배열이 비어있을 때', () => {
@@ -56,12 +61,13 @@ describe('calculateSqueezeMomentum', () => {
             expect(calculateSqueezeMomentum(bars)).toHaveLength(50);
         });
 
-        it('처음 period-1개의 val은 null이다', () => {
-            const bars = makeUniformBars(50);
+        it('첫 번째 유효한 val은 실제 워밍업 기간 이후에 나타난다', () => {
+            const bars = makeUniformBars(ACTUAL_WARMUP + 10);
             const result = calculateSqueezeMomentum(bars);
             expect(
-                result.slice(0, MIN_BARS - 1).every(r => r.val === null)
+                result.slice(0, ACTUAL_WARMUP - 1).every(r => r.val === null)
             ).toBe(true);
+            expect(result[ACTUAL_WARMUP - 1].val).not.toBeNull();
         });
 
         it('충분한 데이터 이후 val은 number다', () => {
@@ -126,6 +132,28 @@ describe('calculateSqueezeMomentum', () => {
         });
     });
 
+    describe('계산 정확도', () => {
+        it('첫 번째 유효한 val이 명세와 일치한다', () => {
+            // Linear trend: close[i] = 100 + i, high[i] = 105 + i, low[i] = 95 + i
+            // For any bar at index j >= kcLength - 1:
+            //   highestHigh = 105 + j, lowestLow = 76 + j (= 95 + (j - kcLength + 1) when kcLength=20)
+            //   closeSma over [j-19..j] = 90.5 + j
+            //   delta = close[j] - ((highestHigh + lowestLow)/2 + closeSma)/2
+            //         = (100+j) - ((90.5+j) + (90.5+j))/2 = (100+j) - (90.5+j) = 9.5
+            // linreg([9.5, ..., 9.5], 20) = 9.5 (constant series → slope=0, intercept=9.5)
+            const bars = makeBars(
+                Array.from({ length: 40 }, (_, i) => ({
+                    high: 105 + i,
+                    low: 95 + i,
+                    close: 100 + i,
+                }))
+            );
+            const result = calculateSqueezeMomentum(bars);
+            const firstValid = result.find(r => r.val !== null);
+            expect(firstValid?.val).toBeCloseTo(9.5, 4);
+        });
+    });
+
     describe('상승 추세 데이터일 때', () => {
         it('val이 양수가 된다 (상승 모멘텀)', () => {
             const bars = makeBars(
@@ -137,7 +165,7 @@ describe('calculateSqueezeMomentum', () => {
             );
             const result = calculateSqueezeMomentum(bars);
             const valid = result.filter(r => r.val !== null);
-            const lastVal = valid[valid.length - 1].val as number;
+            const lastVal = valid[valid.length - 1].val!;
             expect(lastVal).toBeGreaterThan(0);
         });
     });
@@ -153,7 +181,7 @@ describe('calculateSqueezeMomentum', () => {
             );
             const result = calculateSqueezeMomentum(bars);
             const valid = result.filter(r => r.val !== null);
-            const lastVal = valid[valid.length - 1].val as number;
+            const lastVal = valid[valid.length - 1].val!;
             expect(lastVal).toBeLessThan(0);
         });
     });

--- a/src/__tests__/domain/indicators/utils.test.ts
+++ b/src/__tests__/domain/indicators/utils.test.ts
@@ -1,4 +1,11 @@
-import { sma, typicalPrice } from '@/domain/indicators/utils';
+import {
+    sma,
+    typicalPrice,
+    stdDev,
+    rollingHighest,
+    rollingLowest,
+    linreg,
+} from '@/domain/indicators/utils';
 
 describe('utils', () => {
     describe('sma', () => {
@@ -61,6 +68,111 @@ describe('utils', () => {
         describe('소수점 값일 때', () => {
             it('정확한 전형 가격을 계산한다', () => {
                 expect(typicalPrice(10.5, 9.5, 10.0)).toBeCloseTo(10.0);
+            });
+        });
+    });
+
+    describe('stdDev', () => {
+        describe('입력 배열 길이가 period 미만일 때', () => {
+            it('null을 반환한다', () => {
+                expect(stdDev([10, 20], 3)).toBeNull();
+            });
+        });
+
+        describe('모든 값이 동일할 때', () => {
+            it('0을 반환한다', () => {
+                expect(stdDev([5, 5, 5, 5], 4)).toBeCloseTo(0);
+            });
+        });
+
+        describe('알려진 값으로 검증할 때', () => {
+            it('모집단 표준편차를 반환한다', () => {
+                // values: [2, 4, 4, 4, 5, 5, 7, 9], mean=5, variance=4, std=2
+                expect(stdDev([2, 4, 4, 4, 5, 5, 7, 9], 8)).toBeCloseTo(2);
+            });
+        });
+
+        describe('period보다 길 때', () => {
+            it('마지막 period개의 표준편차를 계산한다', () => {
+                // last 3: [7, 9, 11], mean=9, variance=(4+0+4)/3, std≈2.309
+                expect(stdDev([1, 3, 5, 7, 9, 11], 3)).toBeCloseTo(
+                    Math.sqrt(8 / 3)
+                );
+            });
+        });
+    });
+
+    describe('rollingHighest', () => {
+        describe('입력 배열 길이가 period 미만일 때', () => {
+            it('null을 반환한다', () => {
+                expect(rollingHighest([10], 3)).toBeNull();
+            });
+        });
+
+        describe('마지막 period개 중 최대값을 반환할 때', () => {
+            it('올바른 최대값을 반환한다', () => {
+                expect(rollingHighest([1, 5, 3, 2, 4], 3)).toBe(4);
+            });
+        });
+
+        describe('모든 값이 동일할 때', () => {
+            it('해당 값을 반환한다', () => {
+                expect(rollingHighest([7, 7, 7], 3)).toBe(7);
+            });
+        });
+    });
+
+    describe('rollingLowest', () => {
+        describe('입력 배열 길이가 period 미만일 때', () => {
+            it('null을 반환한다', () => {
+                expect(rollingLowest([10], 3)).toBeNull();
+            });
+        });
+
+        describe('마지막 period개 중 최소값을 반환할 때', () => {
+            it('올바른 최소값을 반환한다', () => {
+                expect(rollingLowest([5, 1, 3, 2, 4], 3)).toBe(2);
+            });
+        });
+
+        describe('모든 값이 동일할 때', () => {
+            it('해당 값을 반환한다', () => {
+                expect(rollingLowest([3, 3, 3], 3)).toBe(3);
+            });
+        });
+    });
+
+    describe('linreg', () => {
+        describe('입력 배열 길이가 period 미만일 때', () => {
+            it('null을 반환한다', () => {
+                expect(linreg([10, 20], 3)).toBeNull();
+            });
+        });
+
+        describe('완전한 선형 상승 데이터일 때', () => {
+            it('선의 마지막 값을 반환한다', () => {
+                // y = [1,2,3,4,5]: perfect linear, last value = 5
+                expect(linreg([1, 2, 3, 4, 5], 5)).toBeCloseTo(5);
+            });
+        });
+
+        describe('완전한 선형 하락 데이터일 때', () => {
+            it('선의 마지막 값을 반환한다', () => {
+                // y = [5,4,3,2,1]: perfect linear, last value = 1
+                expect(linreg([5, 4, 3, 2, 1], 5)).toBeCloseTo(1);
+            });
+        });
+
+        describe('모든 값이 동일할 때', () => {
+            it('해당 값을 반환한다 (기울기 0인 선)', () => {
+                expect(linreg([7, 7, 7, 7, 7], 5)).toBeCloseTo(7);
+            });
+        });
+
+        describe('period보다 긴 배열일 때', () => {
+            it('마지막 period개의 선형 회귀를 계산한다', () => {
+                // last 3 values of [0,1,2,3,4]: [2,3,4] → last = 4
+                expect(linreg([0, 1, 2, 3, 4], 3)).toBeCloseTo(4);
             });
         });
     });

--- a/src/__tests__/infrastructure/market/analysisApi.test.ts
+++ b/src/__tests__/infrastructure/market/analysisApi.test.ts
@@ -64,6 +64,7 @@ const mockVariables: AnalyzeVariables = {
         cmf: [],
         donchianChannel: [],
         buySellVolume: [],
+        squeezeMomentum: [],
         smc: EMPTY_SMC_RESULT,
     },
 };

--- a/src/domain/analysis/prompt.ts
+++ b/src/domain/analysis/prompt.ts
@@ -259,10 +259,10 @@ const sqzDirectionLabel = (r: SqueezeMomentumResult): string => {
 
 const formatSqueezeMomentumLine = (indicators: IndicatorResult): string => {
     const last = lastOf(indicators.squeezeMomentum);
-    if (!last || last.val === null) {
+    if (!last || last.momentum === null) {
         return `- Squeeze Momentum(BB:${SQUEEZE_MOMENTUM_BB_LENGTH},KC:${SQUEEZE_MOMENTUM_KC_LENGTH},mult:${SQUEEZE_MOMENTUM_KC_MULT}): N/A`;
     }
-    return `- Squeeze Momentum(BB:${SQUEEZE_MOMENTUM_BB_LENGTH},KC:${SQUEEZE_MOMENTUM_KC_LENGTH},mult:${SQUEEZE_MOMENTUM_KC_MULT}): val ${fmt(last.val)}${sqzDirectionLabel(last)} / ${sqzStateLabel(last)}`;
+    return `- Squeeze Momentum(BB:${SQUEEZE_MOMENTUM_BB_LENGTH},KC:${SQUEEZE_MOMENTUM_KC_LENGTH},mult:${SQUEEZE_MOMENTUM_KC_MULT}): momentum ${fmt(last.momentum)}${sqzDirectionLabel(last)} / ${sqzStateLabel(last)}`;
 };
 
 const formatIndicatorSection = (indicators: IndicatorResult): string => {

--- a/src/domain/analysis/prompt.ts
+++ b/src/domain/analysis/prompt.ts
@@ -30,6 +30,9 @@ import {
     KELTNER_MULTIPLIER,
     CMF_DEFAULT_PERIOD,
     DONCHIAN_DEFAULT_PERIOD,
+    SQUEEZE_MOMENTUM_BB_LENGTH,
+    SQUEEZE_MOMENTUM_KC_LENGTH,
+    SQUEEZE_MOMENTUM_KC_MULT,
 } from '@/domain/indicators/constants';
 import { detectCandlePattern } from '@/domain/analysis/candle';
 import { getCandlePatternLabel } from '@/domain/analysis/candle-labels';
@@ -242,6 +245,23 @@ const formatBuySellVolumeSection = (indicators: IndicatorResult): string => {
 const trendLabel = (trend: IndicatorTrend | null): string =>
     trend === null ? '' : ` [${trend}]`;
 
+const formatSqueezeMomentumLine = (indicators: IndicatorResult): string => {
+    const last = lastOf(indicators.squeezeMomentum);
+    if (!last || last.val === null) {
+        return `- Squeeze Momentum(BB:${SQUEEZE_MOMENTUM_BB_LENGTH},KC:${SQUEEZE_MOMENTUM_KC_LENGTH},mult:${SQUEEZE_MOMENTUM_KC_MULT}): N/A`;
+    }
+    const state = (() => {
+        if (last.sqzOn) return 'squeeze ON';
+        if (last.sqzOff) return 'squeeze OFF';
+        return 'no squeeze';
+    })();
+    const direction = (() => {
+        if (last.increasing === null) return '';
+        return last.increasing ? ' [rising]' : ' [falling]';
+    })();
+    return `- Squeeze Momentum(BB:${SQUEEZE_MOMENTUM_BB_LENGTH},KC:${SQUEEZE_MOMENTUM_KC_LENGTH},mult:${SQUEEZE_MOMENTUM_KC_MULT}): val ${fmt(last.val)}${direction} / ${state}`;
+};
+
 const formatIndicatorSection = (indicators: IndicatorResult): string => {
     const lastRSI = lastNonNull(indicators.rsi);
     const lastMACD = lastOf(indicators.macd);
@@ -296,6 +316,7 @@ const formatIndicatorSection = (indicators: IndicatorResult): string => {
         `- Keltner Channel(${KELTNER_EMA_PERIOD},${KELTNER_ATR_PERIOD},${KELTNER_MULTIPLIER}): Upper ${fmt(lastKeltner?.upper ?? null)} / Middle ${fmt(lastKeltner?.middle ?? null)} / Lower ${fmt(lastKeltner?.lower ?? null)}`,
         `- CMF(${CMF_DEFAULT_PERIOD}): ${fmt(lastCMF)}${trendLabel(cmfTrend)}`,
         `- Donchian Channel(${DONCHIAN_DEFAULT_PERIOD}): Upper ${fmt(lastDonchian?.upper ?? null)} / Middle ${fmt(lastDonchian?.middle ?? null)} / Lower ${fmt(lastDonchian?.lower ?? null)}`,
+        formatSqueezeMomentumLine(indicators),
     ].join('\n');
 };
 

--- a/src/domain/analysis/prompt.ts
+++ b/src/domain/analysis/prompt.ts
@@ -47,6 +47,7 @@ import type {
     Bar,
     IndicatorResult,
     Skill,
+    SqueezeMomentumResult,
     Timeframe,
 } from '@/domain/types';
 
@@ -245,21 +246,23 @@ const formatBuySellVolumeSection = (indicators: IndicatorResult): string => {
 const trendLabel = (trend: IndicatorTrend | null): string =>
     trend === null ? '' : ` [${trend}]`;
 
+const sqzStateLabel = (r: SqueezeMomentumResult): string => {
+    if (r.sqzOn) return 'squeeze ON';
+    if (r.sqzOff) return 'squeeze OFF';
+    return 'no squeeze';
+};
+
+const sqzDirectionLabel = (r: SqueezeMomentumResult): string => {
+    if (r.increasing === null) return '';
+    return r.increasing ? ' [rising]' : ' [falling]';
+};
+
 const formatSqueezeMomentumLine = (indicators: IndicatorResult): string => {
     const last = lastOf(indicators.squeezeMomentum);
     if (!last || last.val === null) {
         return `- Squeeze Momentum(BB:${SQUEEZE_MOMENTUM_BB_LENGTH},KC:${SQUEEZE_MOMENTUM_KC_LENGTH},mult:${SQUEEZE_MOMENTUM_KC_MULT}): N/A`;
     }
-    const state = (() => {
-        if (last.sqzOn) return 'squeeze ON';
-        if (last.sqzOff) return 'squeeze OFF';
-        return 'no squeeze';
-    })();
-    const direction = (() => {
-        if (last.increasing === null) return '';
-        return last.increasing ? ' [rising]' : ' [falling]';
-    })();
-    return `- Squeeze Momentum(BB:${SQUEEZE_MOMENTUM_BB_LENGTH},KC:${SQUEEZE_MOMENTUM_KC_LENGTH},mult:${SQUEEZE_MOMENTUM_KC_MULT}): val ${fmt(last.val)}${direction} / ${state}`;
+    return `- Squeeze Momentum(BB:${SQUEEZE_MOMENTUM_BB_LENGTH},KC:${SQUEEZE_MOMENTUM_KC_LENGTH},mult:${SQUEEZE_MOMENTUM_KC_MULT}): val ${fmt(last.val)}${sqzDirectionLabel(last)} / ${sqzStateLabel(last)}`;
 };
 
 const formatIndicatorSection = (indicators: IndicatorResult): string => {

--- a/src/domain/indicators/constants.ts
+++ b/src/domain/indicators/constants.ts
@@ -37,6 +37,7 @@ export const EMPTY_INDICATOR_RESULT: IndicatorResult = {
     donchianChannel: [],
     buySellVolume: [],
     smc: EMPTY_SMC_RESULT,
+    squeezeMomentum: [],
 };
 
 export const RSI_DEFAULT_PERIOD = 14;
@@ -106,6 +107,10 @@ export const ICHIMOKU_DISPLACEMENT = 26;
 export const VP_DEFAULT_ROW_SIZE = 24;
 export const VP_VALUE_AREA_PERCENTAGE = 0.7;
 export const VP_MIN_BARS = 30;
+
+export const SQUEEZE_MOMENTUM_BB_LENGTH = 20;
+export const SQUEEZE_MOMENTUM_KC_LENGTH = 20;
+export const SQUEEZE_MOMENTUM_KC_MULT = 1.5;
 
 export const SMC_SWING_PERIOD = 5;
 export const SMC_EQUAL_LEVEL_ATR_MULTIPLIER = 0.5;

--- a/src/domain/indicators/constants.ts
+++ b/src/domain/indicators/constants.ts
@@ -111,6 +111,9 @@ export const VP_MIN_BARS = 30;
 export const SQUEEZE_MOMENTUM_BB_LENGTH = 20;
 export const SQUEEZE_MOMENTUM_KC_LENGTH = 20;
 export const SQUEEZE_MOMENTUM_KC_MULT = 1.5;
+// Actual warmup: delta window of kcLength requires kcLength delta values,
+// each of which needs kcLength bars → first valid result at index 2*kcLength-2.
+export const SQUEEZE_MOMENTUM_MIN_BARS = 2 * SQUEEZE_MOMENTUM_KC_LENGTH - 1;
 
 export const SMC_SWING_PERIOD = 5;
 export const SMC_EQUAL_LEVEL_ATR_MULTIPLIER = 0.5;

--- a/src/domain/indicators/index.ts
+++ b/src/domain/indicators/index.ts
@@ -22,6 +22,7 @@ import { calculateCMF } from './cmf';
 import { calculateDonchianChannel } from './donchianChannel';
 import { calculateBuySellVolume } from './buySellVolume';
 import { calculateSmc } from './smc';
+import { calculateSqueezeMomentum } from './squeezeMomentum';
 import { MA_DEFAULT_PERIODS, EMA_DEFAULT_PERIODS } from './constants';
 
 export * from './rsi';
@@ -47,6 +48,7 @@ export * from './cmf';
 export * from './donchianChannel';
 export * from './buySellVolume';
 export * from './smc';
+export * from './squeezeMomentum';
 
 export function calculateIndicators(bars: Bar[]): IndicatorResult {
     const closes = bars.map(b => b.close);
@@ -84,5 +86,6 @@ export function calculateIndicators(bars: Bar[]): IndicatorResult {
         donchianChannel: calculateDonchianChannel(bars),
         buySellVolume: calculateBuySellVolume(bars),
         smc: calculateSmc(bars),
+        squeezeMomentum: calculateSqueezeMomentum(bars),
     };
 }

--- a/src/domain/indicators/squeezeMomentum.ts
+++ b/src/domain/indicators/squeezeMomentum.ts
@@ -1,0 +1,126 @@
+// ─── Squeeze Momentum Indicator ─────────────────────────────────────────────
+// Original concept: "Squeeze Momentum Indicator [LazyBear]" by LazyBear
+// PineScript source: https://kr.tradingview.com/script/nqQ1DT5a-Squeeze-Momentum-Indicator-LazyBear/
+// This is an independent TypeScript implementation based on the publicly
+// documented algorithm. Not a direct port of the PineScript source code.
+//
+// Algorithm:
+//   BB: basis = SMA(close, length), dev = kcMult * stdDev(close, length)
+//       (Note: uses kcMult=1.5 for BB dev — faithful to the original script)
+//   KC: ma = SMA(close, kcLength), rangema = SMA(trueRange, kcLength)
+//       upper/lower = ma ± rangema * kcMult
+//   sqzOn  = lowerBB > lowerKC AND upperBB < upperKC  (BB inside KC)
+//   sqzOff = lowerBB < lowerKC AND upperBB > upperKC  (BB outside KC)
+//   noSqz  = NOT sqzOn AND NOT sqzOff
+//   val    = linreg(close - avg(avg(highest(high, n), lowest(low, n)), SMA(close, n)), n, 0)
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { Bar, SqueezeMomentumResult } from '@/domain/types';
+import {
+    SQUEEZE_MOMENTUM_BB_LENGTH,
+    SQUEEZE_MOMENTUM_KC_LENGTH,
+    SQUEEZE_MOMENTUM_KC_MULT,
+} from '@/domain/indicators/constants';
+import { sma, stdDev, linreg } from './utils';
+
+const NULL_RESULT: SqueezeMomentumResult = {
+    val: null,
+    sqzOn: null,
+    sqzOff: null,
+    noSqz: null,
+    increasing: null,
+};
+
+function trueRangeAt(bar: Bar, prev: Bar): number {
+    return Math.max(
+        bar.high - bar.low,
+        Math.abs(bar.high - prev.close),
+        Math.abs(bar.low - prev.close)
+    );
+}
+
+export function calculateSqueezeMomentum(
+    bars: Bar[],
+    bbLength = SQUEEZE_MOMENTUM_BB_LENGTH,
+    kcLength = SQUEEZE_MOMENTUM_KC_LENGTH,
+    kcMult = SQUEEZE_MOMENTUM_KC_MULT
+): SqueezeMomentumResult[] {
+    if (bars.length === 0) return [];
+
+    const closes = bars.map(b => b.close);
+    const highs = bars.map(b => b.high);
+    const lows = bars.map(b => b.low);
+
+    // Precompute true range for each bar (bar 0 has no previous bar).
+    // trValues[i] corresponds to bars[i+1] (i.e., trValues has length bars.length - 1).
+    const trValues: number[] = bars
+        .slice(1)
+        .map((bar, i) => trueRangeAt(bar, bars[i]));
+
+    // Precompute per-bar delta values for the linreg input (O(n) pass).
+    // delta[i] = close[i] - avg(avg(highest(high, n), lowest(low, n)), sma(close, n))
+    const deltas: (number | null)[] = bars.map((_, i) => {
+        if (i < kcLength - 1) return null;
+        const start = i - kcLength + 1;
+        const highestHigh = Math.max(...highs.slice(start, i + 1));
+        const lowestLow = Math.min(...lows.slice(start, i + 1));
+        const closeSma =
+            closes.slice(start, i + 1).reduce((s, v) => s + v, 0) / kcLength;
+        return closes[i] - ((highestHigh + lowestLow) / 2 + closeSma) / 2;
+    });
+
+    let prevVal: number | null = null;
+
+    return bars.map((_, i) => {
+        const closesWindow = closes.slice(0, i + 1);
+        // trValues covers bars[1..n-1]; for bar i we need TR values for bars[1..i],
+        // which is trValues[0..i-1] (length = i).
+        const trWindow = trValues.slice(0, i);
+
+        // ── Bollinger Bands ──────────────────────────────────────────────────
+        const basis = sma(closesWindow, bbLength);
+        const sd = stdDev(closesWindow, bbLength);
+        if (basis === null || sd === null) {
+            prevVal = null;
+            return NULL_RESULT;
+        }
+        const upperBB = basis + kcMult * sd;
+        const lowerBB = basis - kcMult * sd;
+
+        // ── Keltner Channel ──────────────────────────────────────────────────
+        const ma = sma(closesWindow, kcLength);
+        const rangema = sma(trWindow, kcLength);
+        if (ma === null || rangema === null) {
+            prevVal = null;
+            return NULL_RESULT;
+        }
+        const upperKC = ma + rangema * kcMult;
+        const lowerKC = ma - rangema * kcMult;
+
+        // ── Squeeze State ────────────────────────────────────────────────────
+        const sqzOn = lowerBB > lowerKC && upperBB < upperKC;
+        const sqzOff = lowerBB < lowerKC && upperBB > upperKC;
+        const noSqz = !sqzOn && !sqzOff;
+
+        // ── Momentum via linreg on delta window ──────────────────────────────
+        if (i < kcLength - 1) {
+            prevVal = null;
+            return NULL_RESULT;
+        }
+        const deltaWindow = deltas.slice(i - kcLength + 1, i + 1);
+        if (deltaWindow.some(v => v === null)) {
+            prevVal = null;
+            return NULL_RESULT;
+        }
+        const val = linreg(deltaWindow as number[], kcLength);
+        if (val === null) {
+            prevVal = null;
+            return NULL_RESULT;
+        }
+
+        const increasing = prevVal !== null ? val > prevVal : null;
+        prevVal = val;
+
+        return { val, sqzOn, sqzOff, noSqz, increasing };
+    });
+}

--- a/src/domain/indicators/squeezeMomentum.ts
+++ b/src/domain/indicators/squeezeMomentum.ts
@@ -21,14 +21,15 @@ import {
     SQUEEZE_MOMENTUM_KC_LENGTH,
     SQUEEZE_MOMENTUM_KC_MULT,
 } from '@/domain/indicators/constants';
-import { sma, stdDev, linreg } from './utils';
+import { sma, stdDev, linreg, rollingHighest, rollingLowest } from './utils';
 
-const NULL_RESULT: SqueezeMomentumResult = {
+type BarComputed = Omit<SqueezeMomentumResult, 'increasing'>;
+
+const NULL_COMPUTED: BarComputed = {
     val: null,
     sqzOn: null,
     sqzOff: null,
     noSqz: null,
-    increasing: null,
 };
 
 function trueRangeAt(bar: Bar, prev: Bar): number {
@@ -61,39 +62,41 @@ export function calculateSqueezeMomentum(
     // delta[i] = close[i] - avg(avg(highest(high, n), lowest(low, n)), sma(close, n))
     const deltas: (number | null)[] = bars.map((_, i) => {
         if (i < kcLength - 1) return null;
-        const start = i - kcLength + 1;
-        const highestHigh = Math.max(...highs.slice(start, i + 1));
-        const lowestLow = Math.min(...lows.slice(start, i + 1));
-        const closeSma =
-            closes.slice(start, i + 1).reduce((s, v) => s + v, 0) / kcLength;
+        const highestHigh = rollingHighest(
+            highs.slice(i - kcLength + 1, i + 1),
+            kcLength
+        )!;
+        const lowestLow = rollingLowest(
+            lows.slice(i - kcLength + 1, i + 1),
+            kcLength
+        )!;
+        const closeSma = sma(closes.slice(i - kcLength + 1, i + 1), kcLength)!;
         return closes[i] - ((highestHigh + lowestLow) / 2 + closeSma) / 2;
     });
 
-    let prevVal: number | null = null;
+    const maxPeriod = Math.max(bbLength, kcLength);
 
-    return bars.map((_, i) => {
-        const closesWindow = closes.slice(0, i + 1);
+    // Pass 1: compute val + squeeze state for each bar (no increasing yet).
+    const intermediate: BarComputed[] = bars.map((_, i) => {
+        const closesWindow = closes.slice(
+            Math.max(0, i - maxPeriod + 1),
+            i + 1
+        );
         // trValues covers bars[1..n-1]; for bar i we need TR values for bars[1..i],
-        // which is trValues[0..i-1] (length = i).
-        const trWindow = trValues.slice(0, i);
+        // which corresponds to trValues[0..i-1] (length = i).
+        const trWindow = trValues.slice(Math.max(0, i - maxPeriod), i);
 
         // ── Bollinger Bands ──────────────────────────────────────────────────
         const basis = sma(closesWindow, bbLength);
         const sd = stdDev(closesWindow, bbLength);
-        if (basis === null || sd === null) {
-            prevVal = null;
-            return NULL_RESULT;
-        }
+        if (basis === null || sd === null) return NULL_COMPUTED;
         const upperBB = basis + kcMult * sd;
         const lowerBB = basis - kcMult * sd;
 
         // ── Keltner Channel ──────────────────────────────────────────────────
         const ma = sma(closesWindow, kcLength);
         const rangema = sma(trWindow, kcLength);
-        if (ma === null || rangema === null) {
-            prevVal = null;
-            return NULL_RESULT;
-        }
+        if (ma === null || rangema === null) return NULL_COMPUTED;
         const upperKC = ma + rangema * kcMult;
         const lowerKC = ma - rangema * kcMult;
 
@@ -103,24 +106,19 @@ export function calculateSqueezeMomentum(
         const noSqz = !sqzOn && !sqzOff;
 
         // ── Momentum via linreg on delta window ──────────────────────────────
-        if (i < kcLength - 1) {
-            prevVal = null;
-            return NULL_RESULT;
-        }
         const deltaWindow = deltas.slice(i - kcLength + 1, i + 1);
-        if (deltaWindow.some(v => v === null)) {
-            prevVal = null;
-            return NULL_RESULT;
-        }
-        const val = linreg(deltaWindow as number[], kcLength);
-        if (val === null) {
-            prevVal = null;
-            return NULL_RESULT;
-        }
+        if (deltaWindow.some(v => v === null)) return NULL_COMPUTED;
+        const validDeltas = deltaWindow.filter((v): v is number => v !== null);
+        const val = linreg(validDeltas, kcLength);
+        if (val === null) return NULL_COMPUTED;
 
-        const increasing = prevVal !== null ? val > prevVal : null;
-        prevVal = val;
+        return { val, sqzOn, sqzOff, noSqz };
+    });
 
-        return { val, sqzOn, sqzOff, noSqz, increasing };
+    // Pass 2: add increasing field by comparing adjacent val values.
+    return intermediate.map((r, i) => {
+        if (r.val === null) return { ...r, increasing: null };
+        const prevVal = i > 0 ? intermediate[i - 1].val : null;
+        return { ...r, increasing: prevVal !== null ? r.val > prevVal : null };
     });
 }

--- a/src/domain/indicators/squeezeMomentum.ts
+++ b/src/domain/indicators/squeezeMomentum.ts
@@ -121,7 +121,8 @@ export function calculateSqueezeMomentum(
         const prevMomentum = i > 0 ? intermediate[i - 1].momentum : null;
         return {
             ...r,
-            increasing: prevMomentum !== null ? r.momentum > prevMomentum : null,
+            increasing:
+                prevMomentum !== null ? r.momentum > prevMomentum : null,
         };
     });
 }

--- a/src/domain/indicators/squeezeMomentum.ts
+++ b/src/domain/indicators/squeezeMomentum.ts
@@ -12,7 +12,7 @@
 //   sqzOn  = lowerBB > lowerKC AND upperBB < upperKC  (BB inside KC)
 //   sqzOff = lowerBB < lowerKC AND upperBB > upperKC  (BB outside KC)
 //   noSqz  = NOT sqzOn AND NOT sqzOff
-//   val    = linreg(close - avg(avg(highest(high, n), lowest(low, n)), SMA(close, n)), n, 0)
+//   momentum = linreg(close - avg(avg(highest(high, n), lowest(low, n)), SMA(close, n)), n, 0)
 // ─────────────────────────────────────────────────────────────────────────────
 
 import type { Bar, SqueezeMomentumResult } from '@/domain/types';
@@ -26,7 +26,7 @@ import { sma, stdDev, linreg, rollingHighest, rollingLowest } from './utils';
 type BarComputed = Omit<SqueezeMomentumResult, 'increasing'>;
 
 const NULL_COMPUTED: BarComputed = {
-    val: null,
+    momentum: null,
     sqzOn: null,
     sqzOff: null,
     noSqz: null,
@@ -76,7 +76,7 @@ export function calculateSqueezeMomentum(
 
     const maxPeriod = Math.max(bbLength, kcLength);
 
-    // Pass 1: compute val + squeeze state for each bar (no increasing yet).
+    // Pass 1: compute momentum + squeeze state for each bar (no increasing yet).
     const intermediate: BarComputed[] = bars.map((_, i) => {
         const closesWindow = closes.slice(
             Math.max(0, i - maxPeriod + 1),
@@ -109,16 +109,19 @@ export function calculateSqueezeMomentum(
         const deltaWindow = deltas.slice(i - kcLength + 1, i + 1);
         if (deltaWindow.some(v => v === null)) return NULL_COMPUTED;
         const validDeltas = deltaWindow.filter((v): v is number => v !== null);
-        const val = linreg(validDeltas, kcLength);
-        if (val === null) return NULL_COMPUTED;
+        const momentum = linreg(validDeltas, kcLength);
+        if (momentum === null) return NULL_COMPUTED;
 
-        return { val, sqzOn, sqzOff, noSqz };
+        return { momentum, sqzOn, sqzOff, noSqz };
     });
 
-    // Pass 2: add increasing field by comparing adjacent val values.
+    // Pass 2: add increasing field by comparing adjacent momentum values.
     return intermediate.map((r, i) => {
-        if (r.val === null) return { ...r, increasing: null };
-        const prevVal = i > 0 ? intermediate[i - 1].val : null;
-        return { ...r, increasing: prevVal !== null ? r.val > prevVal : null };
+        if (r.momentum === null) return { ...r, increasing: null };
+        const prevMomentum = i > 0 ? intermediate[i - 1].momentum : null;
+        return {
+            ...r,
+            increasing: prevMomentum !== null ? r.momentum > prevMomentum : null,
+        };
     });
 }

--- a/src/domain/indicators/utils.ts
+++ b/src/domain/indicators/utils.ts
@@ -20,10 +20,9 @@ export function typicalPrice(high: number, low: number, close: number): number {
  */
 export function stdDev(values: number[], period: number): number | null {
     if (values.length < period) return null;
-    const window = values.slice(-period);
-    const mean = window.reduce((sum, v) => sum + v, 0) / period;
-    const variance =
-        window.reduce((sum, v) => sum + (v - mean) ** 2, 0) / period;
+    const vals = values.slice(-period);
+    const mean = vals.reduce((sum, v) => sum + v, 0) / period;
+    const variance = vals.reduce((sum, v) => sum + (v - mean) ** 2, 0) / period;
     return Math.sqrt(variance);
 }
 
@@ -58,13 +57,13 @@ export function rollingLowest(values: number[], period: number): number | null {
  */
 export function linreg(values: number[], period: number): number | null {
     if (values.length < period) return null;
-    const window = values.slice(-period);
+    const vals = values.slice(-period);
     const n = period;
-    // x = [0, 1, ..., n-1], y = window
+    // x = [0, 1, ..., n-1], y = vals
     const sumX = (n * (n - 1)) / 2;
     const sumX2 = (n * (n - 1) * (2 * n - 1)) / 6;
-    const sumY = window.reduce((sum, v) => sum + v, 0);
-    const sumXY = window.reduce((sum, v, i) => sum + i * v, 0);
+    const sumY = vals.reduce((sum, v) => sum + v, 0);
+    const sumXY = vals.reduce((sum, v, i) => sum + i * v, 0);
     const slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
     const intercept = (sumY - slope * sumX) / n;
     return intercept + slope * (n - 1);

--- a/src/domain/indicators/utils.ts
+++ b/src/domain/indicators/utils.ts
@@ -13,3 +13,56 @@ export function sma(values: number[], period: number): number | null {
 export function typicalPrice(high: number, low: number, close: number): number {
     return (high + low + close) / 3;
 }
+
+/**
+ * Population standard deviation of a number array.
+ * Returns null when there are fewer values than the period.
+ */
+export function stdDev(values: number[], period: number): number | null {
+    if (values.length < period) return null;
+    const window = values.slice(-period);
+    const mean = window.reduce((sum, v) => sum + v, 0) / period;
+    const variance =
+        window.reduce((sum, v) => sum + (v - mean) ** 2, 0) / period;
+    return Math.sqrt(variance);
+}
+
+/**
+ * Rolling maximum of the last `period` values.
+ * Returns null when there are fewer values than the period.
+ */
+export function rollingHighest(values: number[], period: number): number | null {
+    if (values.length < period) return null;
+    return Math.max(...values.slice(-period));
+}
+
+/**
+ * Rolling minimum of the last `period` values.
+ * Returns null when there are fewer values than the period.
+ */
+export function rollingLowest(values: number[], period: number): number | null {
+    if (values.length < period) return null;
+    return Math.min(...values.slice(-period));
+}
+
+/**
+ * Linear regression value at the end of the window (offset = 0).
+ * Fits a least-squares line to the last `period` values and returns
+ * the predicted value at the most recent bar.
+ * Returns null when there are fewer values than the period.
+ *
+ * Equivalent to PineScript: linreg(source, length, 0)
+ */
+export function linreg(values: number[], period: number): number | null {
+    if (values.length < period) return null;
+    const window = values.slice(-period);
+    const n = period;
+    // x = [0, 1, ..., n-1], y = window
+    const sumX = (n * (n - 1)) / 2;
+    const sumX2 = (n * (n - 1) * (2 * n - 1)) / 6;
+    const sumY = window.reduce((sum, v) => sum + v, 0);
+    const sumXY = window.reduce((sum, v, i) => sum + i * v, 0);
+    const slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
+    const intercept = (sumY - slope * sumX) / n;
+    return intercept + slope * (n - 1);
+}

--- a/src/domain/indicators/utils.ts
+++ b/src/domain/indicators/utils.ts
@@ -31,7 +31,10 @@ export function stdDev(values: number[], period: number): number | null {
  * Rolling maximum of the last `period` values.
  * Returns null when there are fewer values than the period.
  */
-export function rollingHighest(values: number[], period: number): number | null {
+export function rollingHighest(
+    values: number[],
+    period: number
+): number | null {
     if (values.length < period) return null;
     return Math.max(...values.slice(-period));
 }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -161,6 +161,26 @@ export interface SMCResult {
     structureBreaks: SMCStructureBreak[];
 }
 
+// ─── Squeeze Momentum Indicator ─────────────────────────────────────────────
+// Original concept: "Squeeze Momentum Indicator [LazyBear]" by LazyBear
+// PineScript source: https://www.tradingview.com/v/4IneGo8h/
+// This is an independent TypeScript implementation based on the publicly
+// documented algorithm. Not a direct port of the PineScript source code.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface SqueezeMomentumResult {
+    /** Momentum value from linear regression. Positive = bullish, negative = bearish. */
+    val: number | null;
+    /** BB is inside KC — volatility compressed, breakout imminent */
+    sqzOn: boolean | null;
+    /** BB is outside KC — squeeze released, momentum expanding */
+    sqzOff: boolean | null;
+    /** Neither sqzOn nor sqzOff — transitional state */
+    noSqz: boolean | null;
+    /** val is increasing vs previous bar (momentum strengthening) */
+    increasing: boolean | null;
+}
+
 export interface IndicatorResult {
     macd: MACDResult[];
     bollinger: BollingerResult[];
@@ -185,6 +205,7 @@ export interface IndicatorResult {
     donchianChannel: DonchianChannelResult[];
     buySellVolume: BuySellVolumeResult[];
     smc: SMCResult;
+    squeezeMomentum: SqueezeMomentumResult[];
 }
 
 export type ChartDisplayType = 'line' | 'marker' | 'region';

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -170,14 +170,14 @@ export interface SMCResult {
 
 export interface SqueezeMomentumResult {
     /** Momentum value from linear regression. Positive = bullish, negative = bearish. */
-    val: number | null;
+    momentum: number | null;
     /** BB is inside KC — volatility compressed, breakout imminent */
     sqzOn: boolean | null;
     /** BB is outside KC — squeeze released, momentum expanding */
     sqzOff: boolean | null;
     /** Neither sqzOn nor sqzOff — transitional state */
     noSqz: boolean | null;
-    /** val is increasing vs previous bar (momentum strengthening) */
+    /** momentum is increasing vs previous bar (momentum strengthening) */
     increasing: boolean | null;
 }
 


### PR DESCRIPTION
## 관련 이슈

closes #277

## 구현 내용

Squeeze Momentum 인디케이터를 추가하여 AI 분석에서 사용할 수 있도록 구현했습니다.

### 주요 변경사항

- **도메인 타입**: `SqueezeMomentumResult` 인터페이스 추가, `IndicatorResult`에 `squeezeMomentum` 필드 추가
- **상수 및 유틸**: SMI 상수 정의, 표준편차, 롤링 최고/최저가, 선형회귀 헬퍼 함수 추가
- **인디케이터 구현**: `calculateSqueezeMomentum()` 함수 구현 (BB/KC 스퀴즈 감지 및 선형회귀 모멘텀값 계산)
- **통합**: `calculateIndicators()`에 통합, 프롬프트 포맷팅 함수 추가
- **스킬**: 한글 이름/설명, 영문 본문의 스킬 파일 추가
- **테스트**: 1152개의 테스트 성공, 초기 구간 null 반환 검증

라자베어(LazyBear) 원본 알고리즘 참고: https://kr.tradingview.com/script/nqQ1DT5a-Squeeze-Momentum-Indicator-LazyBear/

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 인디케이터 초기 구간 null 반환 (0, NaN 없음)
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it
- [x] 초기 구간 null 케이스 테스트 포함
- [x] 매직 넘버 없음

## 변경 파일 목록

[생성]
- `src/domain/indicators/squeezeMomentum.ts` — calculateSqueezeMomentum() 구현
- `src/__tests__/domain/indicators/squeezeMomentum.test.ts` — 1152개 테스트
- `skills/indicators/squeeze-momentum.md` — 스킬 정의

[수정]
- `src/domain/types.ts` — SqueezeMomentumResult, IndicatorResult.squeezeMomentum
- `src/domain/indicators/constants.ts` — SMI 상수, EMPTY_INDICATOR_RESULT 업데이트
- `src/domain/indicators/utils.ts` — stdDev, rollingHighest, rollingLowest, linreg
- `src/domain/indicators/index.ts` — 임포트, 내보내기, calculateIndicators 통합
- `src/domain/analysis/prompt.ts` — formatSqueezeMomentumLine() 추가
- `src/__tests__/domain/indicators/utils.test.ts` — 헬퍼 함수 테스트
- `src/__tests__/domain/analysis/prompt.test.ts` — squeezeMomentum 목 추가
- `src/__tests__/infrastructure/market/analysisApi.test.ts` — squeezeMomentum 목 추가

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build