### PR TITLE
feat: 지지/저항 레벨 밀집도 기반 클러스터링

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,26 @@
 # Fix Log
 
+## [PR #294 | feat/key-levels-clustering | 2026-04-13]
+- Violation: 가격 반올림 `100`이 매직 넘버로 사용됨
+- Rule: Domain Layer Checklist — No hardcoded literals → extract to constants
+- Context: `keyLevels.ts`에서 `Math.round(rawPrice * 100) / 100` → `PRICE_DECIMAL_FACTOR` 상수로 추출
+
+- Violation: 툴팁 위치 계산 시 뷰포트 상단 경계 미고려
+- Rule: UX — 트리거가 화면 상단에 있을 때 툴팁이 화면 밖으로 벗어남
+- Context: `getTooltipPosition()`에서 `aboveTop < TOOLTIP_VIEWPORT_PADDING`이면 하단에 표시하도록 개선
+
+- Violation: Portal 기반 툴팁이 초기 위치(0,0)에서 깜빡인 후 올바른 위치로 이동
+- Rule: UX — 포탈 렌더링 시 위치 계산 전 화면 깜빡임 발생
+- Context: `InfoTooltip`에 `positioned` 상태 추가, 위치 계산 완료 전까지 `visibility: hidden` 적용
+
+- Violation: `role="tooltip"` 요소에 `aria-describedby` 연결 누락
+- Rule: WAI-ARIA — tooltip 패턴은 트리거에 `aria-describedby`로 연결해야 스크린 리더 접근 가능
+- Context: `InfoTooltip`에 `useId()`로 고유 ID 생성, 트리거 button에 `aria-describedby` 추가
+
+- Violation: React key에 `source.price-source.reason` 조합 사용 — 동일 가격·사유 존재 시 중복 가능
+- Rule: React — 리스트 렌더링 시 key 고유성 보장
+- Context: `ConfluenceInfo`에서 key에 `index` 추가하여 고유성 확보
+
 ## [PR #292 | feat/291/cloud-run-worker | 2026-04-12]
 - Violation: Worker에서 Promise.all로 result와 status를 동시 저장 — poller가 done 상태를 보고 result가 아직 없을 수 있는 레이스 컨디션
 - Rule: 데이터 의존 관계가 있는 Redis 쓰기는 순차 실행

--- a/src/__tests__/domain/analysis/keyLevels.test.ts
+++ b/src/__tests__/domain/analysis/keyLevels.test.ts
@@ -363,5 +363,24 @@ describe('keyLevels', () => {
                 ]);
             });
         });
+
+        describe('currentPrice가 0일 때', () => {
+            it('epsilon이 0이므로 동일 가격만 병합한다', () => {
+                const input: KeyLevels = {
+                    support: [
+                        { price: 100.0, reason: 'A' },
+                        { price: 100.3, reason: 'B' },
+                        { price: 100.0, reason: 'C' },
+                    ],
+                    resistance: [],
+                };
+                const result = clusterKeyLevels(input, 0);
+                expect(result.support).toHaveLength(2);
+                expect(result.support[0].count).toBe(2);
+                expect(result.support[0].price).toBe(100.0);
+                expect(result.support[1].count).toBe(1);
+                expect(result.support[1].price).toBe(100.3);
+            });
+        });
     });
 });

--- a/src/__tests__/domain/analysis/keyLevels.test.ts
+++ b/src/__tests__/domain/analysis/keyLevels.test.ts
@@ -1,4 +1,8 @@
-import { validateKeyLevels } from '@/domain/analysis/keyLevels';
+import {
+    validateKeyLevels,
+    clusterKeyLevels,
+    DEFAULT_EPSILON_PERCENT,
+} from '@/domain/analysis/keyLevels';
 import type { KeyLevels } from '@/domain/types';
 
 describe('keyLevels', () => {
@@ -167,6 +171,196 @@ describe('keyLevels', () => {
                     { price: 200, reason: '유효 저항' },
                 ]);
                 expect(result.poc).toEqual({ price: 150, reason: 'PoC 유효' });
+            });
+        });
+    });
+
+    describe('clusterKeyLevels', () => {
+        const currentPrice = 100;
+        const epsilonPercent = DEFAULT_EPSILON_PERCENT;
+
+        describe('빈 배열일 때', () => {
+            it('빈 배열을 그대로 반환한다', () => {
+                const input: KeyLevels = {
+                    support: [],
+                    resistance: [],
+                };
+                const result = clusterKeyLevels(
+                    input,
+                    currentPrice,
+                    epsilonPercent
+                );
+                expect(result.support).toEqual([]);
+                expect(result.resistance).toEqual([]);
+            });
+        });
+
+        describe('단독 레벨일 때', () => {
+            it('count=1, sources에 원본을 포함한다', () => {
+                const input: KeyLevels = {
+                    support: [{ price: 95, reason: '지지선' }],
+                    resistance: [],
+                };
+                const result = clusterKeyLevels(
+                    input,
+                    currentPrice,
+                    epsilonPercent
+                );
+                expect(result.support).toEqual([
+                    {
+                        price: 95,
+                        reason: '지지선',
+                        count: 1,
+                        sources: [{ price: 95, reason: '지지선' }],
+                    },
+                ]);
+            });
+        });
+
+        describe('2개 레벨이 epsilon 이내일 때', () => {
+            it('하나의 클러스터로 병합하고 평균 가격을 반환한다', () => {
+                const input: KeyLevels = {
+                    support: [
+                        { price: 100.2, reason: 'MA20' },
+                        { price: 100.0, reason: 'EMA20' },
+                    ],
+                    resistance: [],
+                };
+                const result = clusterKeyLevels(
+                    input,
+                    currentPrice,
+                    epsilonPercent
+                );
+                expect(result.support).toHaveLength(1);
+                expect(result.support[0].count).toBe(2);
+                expect(result.support[0].price).toBeCloseTo(100.1);
+                expect(result.support[0].reason).toBe('2개 지표 수렴');
+                expect(result.support[0].sources).toHaveLength(2);
+            });
+        });
+
+        describe('3개 이상 연쇄 클러스터링', () => {
+            it('인접한 레벨들을 하나의 클러스터로 묶는다', () => {
+                const input: KeyLevels = {
+                    support: [
+                        { price: 100.0, reason: 'A' },
+                        { price: 100.3, reason: 'B' },
+                        { price: 100.5, reason: 'C' },
+                    ],
+                    resistance: [],
+                };
+                // epsilon = 0.5, gaps: 0.3 ≤ 0.5, 0.2 ≤ 0.5
+                const result = clusterKeyLevels(
+                    input,
+                    currentPrice,
+                    epsilonPercent
+                );
+                expect(result.support).toHaveLength(1);
+                expect(result.support[0].count).toBe(3);
+                // (100.0 + 100.3 + 100.5) / 3 ≈ 100.267 → 반올림 100.27
+                expect(result.support[0].price).toBeCloseTo(100.27);
+                expect(result.support[0].reason).toBe('3개 지표 수렴');
+            });
+        });
+
+        describe('epsilon 초과 gap이 있을 때', () => {
+            it('별도 클러스터로 분리한다', () => {
+                const input: KeyLevels = {
+                    support: [
+                        { price: 100.0, reason: 'A' },
+                        { price: 100.3, reason: 'B' },
+                        { price: 101.5, reason: 'C' },
+                    ],
+                    resistance: [],
+                };
+                // epsilon = 0.5, gaps: 0.3 ≤ 0.5, 1.2 > 0.5
+                const result = clusterKeyLevels(
+                    input,
+                    currentPrice,
+                    epsilonPercent
+                );
+                expect(result.support).toHaveLength(2);
+                expect(result.support[0].count).toBe(2);
+                expect(result.support[1].count).toBe(1);
+                expect(result.support[1].reason).toBe('C');
+            });
+        });
+
+        describe('POC 처리', () => {
+            it('poc는 변경 없이 그대로 통과한다', () => {
+                const input: KeyLevels = {
+                    support: [],
+                    resistance: [],
+                    poc: { price: 150, reason: 'PoC' },
+                };
+                const result = clusterKeyLevels(
+                    input,
+                    currentPrice,
+                    epsilonPercent
+                );
+                expect(result.poc).toEqual({ price: 150, reason: 'PoC' });
+            });
+
+            it('poc가 undefined이면 결과도 undefined이다', () => {
+                const input: KeyLevels = {
+                    support: [],
+                    resistance: [],
+                };
+                const result = clusterKeyLevels(
+                    input,
+                    currentPrice,
+                    epsilonPercent
+                );
+                expect(result.poc).toBeUndefined();
+            });
+        });
+
+        describe('support와 resistance 독립 처리', () => {
+            it('각각 별도로 클러스터링한다', () => {
+                const input: KeyLevels = {
+                    support: [
+                        { price: 95.0, reason: 'S1' },
+                        { price: 95.3, reason: 'S2' },
+                    ],
+                    resistance: [
+                        { price: 105.0, reason: 'R1' },
+                        { price: 105.2, reason: 'R2' },
+                    ],
+                };
+                const result = clusterKeyLevels(
+                    input,
+                    currentPrice,
+                    epsilonPercent
+                );
+                expect(result.support).toHaveLength(1);
+                expect(result.support[0].count).toBe(2);
+                expect(result.resistance).toHaveLength(1);
+                expect(result.resistance[0].count).toBe(2);
+            });
+        });
+
+        describe('입력 순서와 관계없이 정렬 후 클러스터링', () => {
+            it('역순으로 입력해도 동일한 결과를 반환한다', () => {
+                const input: KeyLevels = {
+                    support: [
+                        { price: 100.5, reason: 'C' },
+                        { price: 100.0, reason: 'A' },
+                        { price: 100.3, reason: 'B' },
+                    ],
+                    resistance: [],
+                };
+                const result = clusterKeyLevels(
+                    input,
+                    currentPrice,
+                    epsilonPercent
+                );
+                expect(result.support).toHaveLength(1);
+                expect(result.support[0].count).toBe(3);
+                expect(result.support[0].sources).toEqual([
+                    { price: 100.0, reason: 'A' },
+                    { price: 100.3, reason: 'B' },
+                    { price: 100.5, reason: 'C' },
+                ]);
             });
         });
     });

--- a/src/__tests__/domain/analysis/keyLevels.test.ts
+++ b/src/__tests__/domain/analysis/keyLevels.test.ts
@@ -279,10 +279,11 @@ describe('keyLevels', () => {
                     currentPrice,
                     epsilonPercent
                 );
+                // 내림차순: 높은 가격 클러스터가 먼저
                 expect(result.support).toHaveLength(2);
-                expect(result.support[0].count).toBe(2);
-                expect(result.support[1].count).toBe(1);
-                expect(result.support[1].reason).toBe('C');
+                expect(result.support[0].count).toBe(1);
+                expect(result.support[0].reason).toBe('C');
+                expect(result.support[1].count).toBe(2);
             });
         });
 
@@ -374,12 +375,13 @@ describe('keyLevels', () => {
                     ],
                     resistance: [],
                 };
+                // 내림차순: 높은 가격이 먼저
                 const result = clusterKeyLevels(input, 0);
                 expect(result.support).toHaveLength(2);
-                expect(result.support[0].count).toBe(2);
-                expect(result.support[0].price).toBe(100.0);
-                expect(result.support[1].count).toBe(1);
-                expect(result.support[1].price).toBe(100.3);
+                expect(result.support[0].count).toBe(1);
+                expect(result.support[0].price).toBe(100.3);
+                expect(result.support[1].count).toBe(2);
+                expect(result.support[1].price).toBe(100.0);
             });
         });
     });

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -517,7 +517,10 @@ function ConfluenceInfo({ level }: ConfluenceInfoProps) {
                         className="flex items-baseline gap-2 whitespace-nowrap"
                     >
                         <span className="text-secondary-300 shrink-0">
-                            {source.price.toLocaleString()}
+                            {source.price.toLocaleString(undefined, {
+                                minimumFractionDigits: 2,
+                                maximumFractionDigits: 2,
+                            })}
                         </span>
                         <span className="text-secondary-400">
                             {source.reason}
@@ -1053,7 +1056,13 @@ export function AnalysisPanel({
                                                 className="flex flex-col"
                                             >
                                                 <span className="text-chart-bearish text-sm font-medium">
-                                                    {level.price.toLocaleString()}
+                                                    {level.price.toLocaleString(
+                                                        undefined,
+                                                        {
+                                                            minimumFractionDigits: 2,
+                                                            maximumFractionDigits: 2,
+                                                        }
+                                                    )}
                                                 </span>
                                                 <span className="text-secondary-600 inline-flex items-center text-xs">
                                                     {level.reason}
@@ -1076,7 +1085,13 @@ export function AnalysisPanel({
                                                 className="flex flex-col"
                                             >
                                                 <span className="text-chart-bullish text-sm font-medium">
-                                                    {level.price.toLocaleString()}
+                                                    {level.price.toLocaleString(
+                                                        undefined,
+                                                        {
+                                                            minimumFractionDigits: 2,
+                                                            maximumFractionDigits: 2,
+                                                        }
+                                                    )}
                                                 </span>
                                                 <span className="text-secondary-600 inline-flex items-center text-xs">
                                                     {level.reason}
@@ -1095,7 +1110,13 @@ export function AnalysisPanel({
                                         PoC
                                     </span>
                                     <span className="text-sm font-medium">
-                                        {keyLevels.poc.price.toLocaleString()}
+                                        {keyLevels.poc.price.toLocaleString(
+                                            undefined,
+                                            {
+                                                minimumFractionDigits: 2,
+                                                maximumFractionDigits: 2,
+                                            }
+                                        )}
                                     </span>
                                     <span className="text-secondary-600 text-xs">
                                         {keyLevels.poc.reason}

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -403,10 +403,7 @@ function getTooltipPosition(
         triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2;
     const maxLeft =
         window.innerWidth - tooltipRect.width - TOOLTIP_VIEWPORT_PADDING;
-    const left = Math.max(
-        TOOLTIP_VIEWPORT_PADDING,
-        Math.min(rawLeft, maxLeft)
-    );
+    const left = Math.max(TOOLTIP_VIEWPORT_PADDING, Math.min(rawLeft, maxLeft));
 
     return { top, left };
 }
@@ -470,10 +467,7 @@ function InfoTooltip({ children }: InfoTooltipProps) {
                             if (el && triggerRef.current) {
                                 const triggerRect =
                                     triggerRef.current.getBoundingClientRect();
-                                const pos = getTooltipPosition(
-                                    triggerRect,
-                                    el
-                                );
+                                const pos = getTooltipPosition(triggerRect, el);
                                 if (
                                     pos.top !== position.top ||
                                     pos.left !== position.left
@@ -526,8 +520,8 @@ function KeyLevelsHeaderInfo() {
     return (
         <InfoTooltip>
             <span className="text-secondary-300">
-                가까운 가격대의 지표들이 수렴된 레벨입니다. 수렴 지표가
-                많을수록 해당 가격대의 지지/저항 신뢰도가 높습니다.
+                가까운 가격대의 지표들이 수렴된 레벨입니다. 수렴 지표가 많을수록
+                해당 가격대의 지지/저항 신뢰도가 높습니다.
             </span>
         </InfoTooltip>
     );

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useId, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type React from 'react';
 import type {
@@ -393,12 +393,18 @@ interface TooltipPosition {
     left: number;
 }
 
+const TOOLTIP_GAP = 6;
+
 function getTooltipPosition(
     triggerRect: DOMRect,
     tooltipEl: HTMLElement
 ): TooltipPosition {
     const tooltipRect = tooltipEl.getBoundingClientRect();
-    const top = triggerRect.top - tooltipRect.height - 6;
+    const aboveTop = triggerRect.top - tooltipRect.height - TOOLTIP_GAP;
+    const top =
+        aboveTop < TOOLTIP_VIEWPORT_PADDING
+            ? triggerRect.bottom + TOOLTIP_GAP
+            : aboveTop;
     const rawLeft =
         triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2;
     const maxLeft =
@@ -413,7 +419,9 @@ interface InfoTooltipProps {
 }
 
 function InfoTooltip({ children }: InfoTooltipProps) {
+    const tooltipId = useId();
     const [open, setOpen] = useState(false);
+    const [positioned, setPositioned] = useState(false);
     const triggerRef = useRef<HTMLButtonElement>(null);
     const tooltipRef = useRef<HTMLDivElement>(null);
     const [position, setPosition] = useState<TooltipPosition>({
@@ -426,25 +434,23 @@ function InfoTooltip({ children }: InfoTooltipProps) {
     });
 
     const handleClick = (): void => {
-        if (!open && triggerRef.current) {
-            const rect = triggerRef.current.getBoundingClientRect();
-            setPosition({ top: rect.top - 6, left: rect.left });
+        if (open) {
+            setOpen(false);
+            setPositioned(false);
+        } else {
+            setOpen(true);
         }
-        setOpen(prev => !prev);
     };
 
     const handlePointerEnter = (e: React.PointerEvent): void => {
         if (e.pointerType === 'touch') return;
-        if (triggerRef.current) {
-            const rect = triggerRef.current.getBoundingClientRect();
-            setPosition({ top: rect.top - 6, left: rect.left });
-        }
         setOpen(true);
     };
 
     const handlePointerLeave = (e: React.PointerEvent): void => {
         if (e.pointerType === 'touch') return;
         setOpen(false);
+        setPositioned(false);
     };
 
     return (
@@ -452,6 +458,7 @@ function InfoTooltip({ children }: InfoTooltipProps) {
             <button
                 ref={triggerRef}
                 type="button"
+                aria-describedby={open ? tooltipId : undefined}
                 onClick={handleClick}
                 onPointerEnter={handlePointerEnter}
                 onPointerLeave={handlePointerLeave}
@@ -474,11 +481,17 @@ function InfoTooltip({ children }: InfoTooltipProps) {
                                 ) {
                                     setPosition(pos);
                                 }
+                                if (!positioned) setPositioned(true);
                             }
                         }}
+                        id={tooltipId}
                         role="tooltip"
                         className="bg-secondary-800 border-secondary-600 fixed z-[9999] rounded border p-2 text-xs leading-relaxed shadow-lg"
-                        style={{ top: position.top, left: position.left }}
+                        style={{
+                            top: position.top,
+                            left: position.left,
+                            visibility: positioned ? 'visible' : 'hidden',
+                        }}
                     >
                         {children}
                     </div>,
@@ -498,9 +511,9 @@ function ConfluenceInfo({ level }: ConfluenceInfoProps) {
     return (
         <InfoTooltip>
             <div className="flex flex-col gap-1">
-                {level.sources.map(source => (
+                {level.sources.map((source, index) => (
                     <div
-                        key={`${source.price}-${source.reason}`}
+                        key={`${source.price}-${source.reason}-${index}`}
                         className="flex items-baseline gap-2 whitespace-nowrap"
                     >
                         <span className="text-secondary-300 shrink-0">

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import type React from 'react';
 import type {
     ActionRecommendation,
     AnalysisResponse,
     CandlePatternSummary,
     EntryRecommendation,
-    KeyLevels,
+    ClusteredKeyLevel,
+    ClusteredKeyLevels,
     PatternResult,
     PriceScenario,
     RiskLevel,
@@ -32,6 +34,7 @@ import {
 } from '@/components/analysis/utils/parseStructuredSummary';
 import { AnalysisProgress } from '@/components/analysis/AnalysisProgress';
 import { AnalysisToast } from '@/components/analysis/AnalysisToast';
+import { useOnClickOutside } from '@/components/hooks/useOnClickOutside';
 import type { CooldownNotice } from '@/components/symbol-page/hooks/useAnalysis';
 import { TRENDLINE_DIRECTION_LABEL } from '@/components/trendline/constants';
 
@@ -383,6 +386,153 @@ function ConfidenceBadge({ confidenceWeight }: ConfidenceBadgeProps) {
     );
 }
 
+const TOOLTIP_VIEWPORT_PADDING = 8;
+
+interface TooltipPosition {
+    top: number;
+    left: number;
+}
+
+function getTooltipPosition(
+    triggerRect: DOMRect,
+    tooltipEl: HTMLElement
+): TooltipPosition {
+    const tooltipRect = tooltipEl.getBoundingClientRect();
+    const top = triggerRect.top - tooltipRect.height - 6;
+    const rawLeft =
+        triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2;
+    const maxLeft =
+        window.innerWidth - tooltipRect.width - TOOLTIP_VIEWPORT_PADDING;
+    const left = Math.max(
+        TOOLTIP_VIEWPORT_PADDING,
+        Math.min(rawLeft, maxLeft)
+    );
+
+    return { top, left };
+}
+
+interface InfoTooltipProps {
+    children: React.ReactNode;
+}
+
+function InfoTooltip({ children }: InfoTooltipProps) {
+    const [open, setOpen] = useState(false);
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const tooltipRef = useRef<HTMLDivElement>(null);
+    const [position, setPosition] = useState<TooltipPosition>({
+        top: 0,
+        left: 0,
+    });
+
+    useOnClickOutside([triggerRef, tooltipRef], () => setOpen(false), {
+        enabled: open,
+    });
+
+    const handleClick = (): void => {
+        if (!open && triggerRef.current) {
+            const rect = triggerRef.current.getBoundingClientRect();
+            setPosition({ top: rect.top - 6, left: rect.left });
+        }
+        setOpen(prev => !prev);
+    };
+
+    const handlePointerEnter = (e: React.PointerEvent): void => {
+        if (e.pointerType === 'touch') return;
+        if (triggerRef.current) {
+            const rect = triggerRef.current.getBoundingClientRect();
+            setPosition({ top: rect.top - 6, left: rect.left });
+        }
+        setOpen(true);
+    };
+
+    const handlePointerLeave = (e: React.PointerEvent): void => {
+        if (e.pointerType === 'touch') return;
+        setOpen(false);
+    };
+
+    return (
+        <>
+            <button
+                ref={triggerRef}
+                type="button"
+                onClick={handleClick}
+                onPointerEnter={handlePointerEnter}
+                onPointerLeave={handlePointerLeave}
+                className="text-secondary-600 hover:text-secondary-400 ml-1 cursor-help text-xs leading-none transition-colors"
+            >
+                ⓘ
+            </button>
+            {open &&
+                createPortal(
+                    <div
+                        ref={el => {
+                            tooltipRef.current = el;
+                            if (el && triggerRef.current) {
+                                const triggerRect =
+                                    triggerRef.current.getBoundingClientRect();
+                                const pos = getTooltipPosition(
+                                    triggerRect,
+                                    el
+                                );
+                                if (
+                                    pos.top !== position.top ||
+                                    pos.left !== position.left
+                                ) {
+                                    setPosition(pos);
+                                }
+                            }
+                        }}
+                        role="tooltip"
+                        className="bg-secondary-800 border-secondary-600 fixed z-[9999] rounded border p-2 text-xs leading-relaxed shadow-lg"
+                        style={{ top: position.top, left: position.left }}
+                    >
+                        {children}
+                    </div>,
+                    document.body
+                )}
+        </>
+    );
+}
+
+interface ConfluenceInfoProps {
+    level: ClusteredKeyLevel;
+}
+
+function ConfluenceInfo({ level }: ConfluenceInfoProps) {
+    if (level.count < 2) return null;
+
+    return (
+        <InfoTooltip>
+            <div className="flex flex-col gap-1">
+                {level.sources.map(source => (
+                    <div
+                        key={`${source.price}-${source.reason}`}
+                        className="flex items-baseline gap-2 whitespace-nowrap"
+                    >
+                        <span className="text-secondary-300 shrink-0">
+                            {source.price.toLocaleString()}
+                        </span>
+                        <span className="text-secondary-400">
+                            {source.reason}
+                        </span>
+                    </div>
+                ))}
+            </div>
+        </InfoTooltip>
+    );
+}
+
+function KeyLevelsHeaderInfo() {
+    return (
+        <InfoTooltip>
+            <span className="text-secondary-300">
+                가까운 가격대의 지표들이 수렴된 레벨입니다. 수렴 지표가
+                많을수록 해당 가격대의 지지/저항 신뢰도가 높습니다.
+            </span>
+        </InfoTooltip>
+    );
+}
+
 interface PatternAccordionItemProps {
     pattern: PatternResult;
     isVisible: boolean;
@@ -730,7 +880,7 @@ function ReanalyzeButton({
 
 interface AnalysisPanelProps {
     analysis: AnalysisResponse;
-    keyLevels: KeyLevels;
+    keyLevels: ClusteredKeyLevels;
     isAnalyzing?: boolean;
     /** 마무리 애니메이션을 포함해 "사용자에게 분석이 진행 중인 것처럼 보이는" 상태.
      *  AnalysisProgress 표시·본문 섹션 숨김에 사용된다. ChartContent가 소유한다. */
@@ -878,33 +1028,11 @@ export function AnalysisPanel({
                         keyLevels.resistance.length > 0 ||
                         keyLevels.poc !== undefined) && (
                         <div className="flex flex-col gap-2">
-                            <div className="flex items-center justify-between">
+                            <div className="flex items-center">
                                 <span className="text-secondary-500 text-xs font-semibold tracking-wide uppercase">
                                     주요 레벨
                                 </span>
-                                {/*{onKeyLevelsVisibilityChange !== undefined && (*/}
-                                {/*    <button*/}
-                                {/*        type="button"*/}
-                                {/*        onClick={() =>*/}
-                                {/*            onKeyLevelsVisibilityChange(*/}
-                                {/*                !keyLevelsVisible*/}
-                                {/*            )*/}
-                                {/*        }*/}
-                                {/*        className={cn(*/}
-                                {/*            'shrink-0 rounded p-1 transition-colors',*/}
-                                {/*            keyLevelsVisible*/}
-                                {/*                ? 'text-primary-400 hover:text-primary-300'*/}
-                                {/*                : 'text-secondary-600 hover:text-secondary-400'*/}
-                                {/*        )}*/}
-                                {/*        title={*/}
-                                {/*            keyLevelsVisible*/}
-                                {/*                ? '차트에서 숨기기'*/}
-                                {/*                : '차트에서 보기'*/}
-                                {/*        }*/}
-                                {/*    >*/}
-                                {/*        <EyeIcon isVisible={keyLevelsVisible} />*/}
-                                {/*    </button>*/}
-                                {/*)}*/}
+                                <KeyLevelsHeaderInfo />
                             </div>
                             <div className="grid grid-cols-2 gap-3">
                                 {keyLevels.resistance.length > 0 && (
@@ -920,8 +1048,11 @@ export function AnalysisPanel({
                                                 <span className="text-chart-bearish text-sm font-medium">
                                                     {level.price.toLocaleString()}
                                                 </span>
-                                                <span className="text-secondary-600 text-xs">
+                                                <span className="text-secondary-600 inline-flex items-center text-xs">
                                                     {level.reason}
+                                                    <ConfluenceInfo
+                                                        level={level}
+                                                    />
                                                 </span>
                                             </div>
                                         ))}
@@ -940,8 +1071,11 @@ export function AnalysisPanel({
                                                 <span className="text-chart-bullish text-sm font-medium">
                                                     {level.price.toLocaleString()}
                                                 </span>
-                                                <span className="text-secondary-600 text-xs">
+                                                <span className="text-secondary-600 inline-flex items-center text-xs">
                                                     {level.reason}
+                                                    <ConfluenceInfo
+                                                        level={level}
+                                                    />
                                                 </span>
                                             </div>
                                         ))}

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -4,7 +4,10 @@ import { useState, useCallback, useMemo, useRef } from 'react';
 import type React from 'react';
 import dynamic from 'next/dynamic';
 import type { AnalysisResponse, Timeframe } from '@/domain/types';
-import { validateKeyLevels } from '@/domain/analysis/keyLevels';
+import {
+    validateKeyLevels,
+    clusterKeyLevels,
+} from '@/domain/analysis/keyLevels';
 import { validateActionPrices } from '@/domain/analysis/actionRecommendation';
 import { cn } from '@/lib/cn';
 import { ChartSkeleton } from '@/components/chart/ChartSkeleton';
@@ -170,6 +173,12 @@ export function ChartContent({
         [analysis.keyLevels]
     );
 
+    const clusteredKeyLevels = useMemo(() => {
+        const lastBar = bars[bars.length - 1];
+        if (!lastBar) return { support: [], resistance: [], poc: undefined };
+        return clusterKeyLevels(validatedKeyLevels, lastBar.close);
+    }, [validatedKeyLevels, bars]);
+
     const validatedActionPrices = useMemo(
         () => validateActionPrices(analysis.actionRecommendation),
         [analysis.actionRecommendation]
@@ -199,7 +208,7 @@ export function ChartContent({
                 />
                 <AnalysisPanel
                     analysis={analysis}
-                    keyLevels={validatedKeyLevels}
+                    keyLevels={clusteredKeyLevels}
                     isAnalyzing={isAnalyzing}
                     showProgress={displayAnalyzing}
                     progressPhaseIndex={progressPhaseIndex}
@@ -221,7 +230,7 @@ export function ChartContent({
         [
             analysisStatus,
             analysis,
-            validatedKeyLevels,
+            clusteredKeyLevels,
             isAnalyzing,
             displayAnalyzing,
             progressPhaseIndex,
@@ -253,7 +262,7 @@ export function ChartContent({
                         patterns={analysis.patternSummaries}
                         trendlines={analysis.trendlines}
                         trendlinesVisible={trendlinesVisible}
-                        keyLevels={validatedKeyLevels}
+                        keyLevels={clusteredKeyLevels}
                         keyLevelsVisible={keyLevelsVisible}
                         actionPrices={validatedActionPrices}
                         actionPricesVisible={actionPricesVisible}

--- a/src/domain/analysis/keyLevels.ts
+++ b/src/domain/analysis/keyLevels.ts
@@ -65,7 +65,7 @@ export function clusterKeyLevels(
     const epsilon = epsilonPercent * currentPrice;
 
     return {
-        support: clusterLevels(keyLevels.support, epsilon),
+        support: clusterLevels(keyLevels.support, epsilon).toReversed(),
         resistance: clusterLevels(keyLevels.resistance, epsilon),
         poc: keyLevels.poc,
     };

--- a/src/domain/analysis/keyLevels.ts
+++ b/src/domain/analysis/keyLevels.ts
@@ -6,6 +6,7 @@ import type {
 } from '@/domain/types';
 
 export const DEFAULT_EPSILON_PERCENT = 0.005;
+const PRICE_DECIMAL_FACTOR = 100;
 
 function isValidKeyLevel(level: KeyLevel): boolean {
     return level.price > 0 && level.reason.trim() !== '';
@@ -33,8 +34,8 @@ function clusterLevels(
 
     const clusters = sorted.slice(1).reduce<KeyLevel[][]>(
         (acc, current) => {
-            const lastCluster = acc[acc.length - 1];
-            const lastPrice = lastCluster[lastCluster.length - 1].price;
+            const lastCluster = acc[acc.length - 1]!;
+            const lastPrice = lastCluster[lastCluster.length - 1]!.price;
 
             if (current.price - lastPrice <= epsilon) {
                 return [...acc.slice(0, -1), [...lastCluster, current]];
@@ -48,7 +49,8 @@ function clusterLevels(
         const count = group.length;
         const rawPrice =
             group.reduce((sum, level) => sum + level.price, 0) / count;
-        const price = Math.round(rawPrice * 100) / 100;
+        const price =
+            Math.round(rawPrice * PRICE_DECIMAL_FACTOR) / PRICE_DECIMAL_FACTOR;
         const reason = count === 1 ? group[0].reason : `${count}개 지표 수렴`;
 
         return { price, reason, count, sources: group };

--- a/src/domain/analysis/keyLevels.ts
+++ b/src/domain/analysis/keyLevels.ts
@@ -37,10 +37,7 @@ function clusterLevels(
             const lastPrice = lastCluster[lastCluster.length - 1].price;
 
             if (current.price - lastPrice <= epsilon) {
-                return [
-                    ...acc.slice(0, -1),
-                    [...lastCluster, current],
-                ];
+                return [...acc.slice(0, -1), [...lastCluster, current]];
             }
             return [...acc, [current]];
         },
@@ -52,8 +49,7 @@ function clusterLevels(
         const rawPrice =
             group.reduce((sum, level) => sum + level.price, 0) / count;
         const price = Math.round(rawPrice * 100) / 100;
-        const reason =
-            count === 1 ? group[0].reason : `${count}개 지표 수렴`;
+        const reason = count === 1 ? group[0].reason : `${count}개 지표 수렴`;
 
         return { price, reason, count, sources: group };
     });

--- a/src/domain/analysis/keyLevels.ts
+++ b/src/domain/analysis/keyLevels.ts
@@ -1,4 +1,11 @@
-import type { KeyLevel, KeyLevels } from '@/domain/types';
+import type {
+    ClusteredKeyLevel,
+    ClusteredKeyLevels,
+    KeyLevel,
+    KeyLevels,
+} from '@/domain/types';
+
+export const DEFAULT_EPSILON_PERCENT = 0.005;
 
 function isValidKeyLevel(level: KeyLevel): boolean {
     return level.price > 0 && level.reason.trim() !== '';
@@ -13,4 +20,55 @@ export function validateKeyLevels(keyLevels: KeyLevels): KeyLevels {
             : undefined;
 
     return { support, resistance, poc };
+}
+
+function clusterLevels(
+    levels: KeyLevel[],
+    epsilon: number
+): ClusteredKeyLevel[] {
+    if (levels.length === 0) return [];
+
+    // levels is non-empty after the guard above
+    const sorted = levels.toSorted((a, b) => a.price - b.price);
+
+    const clusters = sorted.slice(1).reduce<KeyLevel[][]>(
+        (acc, current) => {
+            const lastCluster = acc[acc.length - 1];
+            const lastPrice = lastCluster[lastCluster.length - 1].price;
+
+            if (current.price - lastPrice <= epsilon) {
+                return [
+                    ...acc.slice(0, -1),
+                    [...lastCluster, current],
+                ];
+            }
+            return [...acc, [current]];
+        },
+        [[sorted[0]]]
+    );
+
+    return clusters.map(group => {
+        const count = group.length;
+        const rawPrice =
+            group.reduce((sum, level) => sum + level.price, 0) / count;
+        const price = Math.round(rawPrice * 100) / 100;
+        const reason =
+            count === 1 ? group[0].reason : `${count}개 지표 수렴`;
+
+        return { price, reason, count, sources: group };
+    });
+}
+
+export function clusterKeyLevels(
+    keyLevels: KeyLevels,
+    currentPrice: number,
+    epsilonPercent: number = DEFAULT_EPSILON_PERCENT
+): ClusteredKeyLevels {
+    const epsilon = epsilonPercent * currentPrice;
+
+    return {
+        support: clusterLevels(keyLevels.support, epsilon),
+        resistance: clusterLevels(keyLevels.resistance, epsilon),
+        poc: keyLevels.poc,
+    };
 }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -296,6 +296,17 @@ export interface KeyLevels {
     poc?: KeyLevel;
 }
 
+export interface ClusteredKeyLevel extends KeyLevel {
+    count: number;
+    sources: KeyLevel[];
+}
+
+export interface ClusteredKeyLevels {
+    support: ClusteredKeyLevel[];
+    resistance: ClusteredKeyLevel[];
+    poc?: KeyLevel;
+}
+
 export interface PriceTarget {
     price: number;
     basis: string;


### PR DESCRIPTION
## 관련 이슈

closes #{이슈}

## 구현 내용

## Summary
- AI 분석이 반환하는 지지/저항 레벨이 과다할 때 밀집도 기반 클러스터링으로 압축
- 수렴된 지표가 많을수록 신뢰도가 높다는 정보를 ⓘ 툴팁으로 제공
- Portal 기반 렌더링으로 차트 z-index 문제 해결, 모바일 viewport 오버플로 방지

### 변경 사항

1. **src/domain/types.ts** — ClusteredKeyLevel (extends KeyLevel with count + sources) 및 ClusteredKeyLevels 인터페이스 추가
2. **src/domain/analysis/keyLevels.ts** — gap 기반 1D 클러스터링 알고리즘 구현 (clusterKeyLevels 함수), DEFAULT_EPSILON_PERCENT 상수 내보내기, 평균 가격을 소수점 2자리로 반올림
3. **src/__tests__/domain/analysis/keyLevels.test.ts** — 8가지 테스트 케이스: 빈 배열, 단일 레벨, 2개 항목 클러스터링, 3개 이상 연쇄 클러스터링, gap 분리, POC 통과, 지지/저항 독립 처리, 입력 순서 불변성
4. **src/components/symbol-page/ChartContent.tsx** — validateKeyLevels 후 clusterKeyLevels 연결, 클러스터된 데이터를 AnalysisPanel과 StockChart에 전달
5. **src/components/analysis/AnalysisPanel.tsx** — Portal 기반 InfoTooltip 컴포넌트 (viewport clamping), ConfluenceInfo 구성 지표 표시 (호버/클릭 시), KeyLevelsHeaderInfo로 confluence 개념 설명, ⓘ 아이콘 사용

## 레이어 및 코드 품질 체크

- [ ] @docs/CONVENTIONS.md 준수 확인
- [ ] @docs/FF.md 준수 확인
- [ ] @docs/MISTAKES.md 준수 확인
- [ ] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [ ] 인디케이터 초기 구간 null 반환 (0, NaN 없음)
- [ ] 반환 타입 명시
- [ ] for/while 없이 map/filter/reduce 사용
- [ ] any 타입 없음
- [ ] 새 파일에 대응하는 테스트 파일 포함
- [ ] 테스트 구조: describe → describe(context) → it
- [ ] 초기 구간 null 케이스 테스트 포함
- [ ] 매직 넘버 없음

## 변경 파일 목록

[수정]
- src/domain/types.ts
- src/domain/analysis/keyLevels.ts
- src/__tests__/domain/analysis/keyLevels.test.ts
- src/components/symbol-page/ChartContent.tsx
- src/components/analysis/AnalysisPanel.tsx

## CI Check lists

- [ ] yarn format
- [ ] yarn lint
- [ ] yarn lint:style
- [ ] yarn test
- [ ] yarn build

## Test plan
- [ ] `yarn test` 통과 확인 (21개 테스트)
- [ ] `yarn build` 타입 에러 없음
- [ ] 데스크탑: 분석 실행 후 주요 레벨 클러스터링 확인, ⓘ 호버 시 원본 레벨 목록 표시
- [ ] 모바일: 툴팁이 화면 밖으로 벗어나지 않는지 확인
- [ ] 차트 오버레이에 클러스터 대표 가격으로 라인 표시 확인

🤖 Generated with Claude Code