### PR TITLE
fix(mobile): 바텀시트 핸들 사라짐 버그 수정 및 네이티브 스와이프 UX 개선

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,26 @@
 # Fix Log
 
+## [PR #300 | fix/299/mobile-bottom-sheet-native-ux | 2026-04-14]
+- Violation: `useEffectEvent` 결과(`snapToPoint`)가 `useEffect` 의존성 배열에 포함됨
+- Rule: `react-hooks/exhaustive-deps` — `useEffectEvent` 반환 함수는 안정적 참조이므로 deps 배열에서 제거해야 함
+- Context: `MobileAnalysisSheet.tsx`의 `useEffect` deps에 `[isFullSnap, snapToPoint]`로 선언; `snapToPoint` 제거
+
+- Violation: `useEffect` cleanup에서 직접 조작한 DOM 스타일(`transform`, `transition`) 미초기화
+- Rule: React useEffect cleanup 원칙 — effect에서 직접 조작한 DOM 상태는 cleanup에서 원상복구해야 vaul 내부 스타일과 충돌 방지
+- Context: `MobileAnalysisSheet.tsx` cleanup에서 `drawerEl.style.transform = ''`, `drawerEl.style.transition = ''` 추가
+
+- Violation: 중첩 함수(`captureInitialTransform`)가 클로저로 외부 변수 캡처 — 모듈 레벨 순수 함수로 추출 필요
+- Rule: CONVENTIONS.md FP 규칙 — 외부 변수를 캡처하지 않는 중첩 함수는 모듈 레벨 순수 함수로 추출
+- Context: `captureInitialTransform`이 `drawerEl` 클로저를 캡처; `captureTransformY(el: HTMLDivElement)` 모듈 레벨 함수로 추출
+
+- Violation: null 가드 이전 변수 선언으로 `!` 단언 반복 사용
+- Rule: TypeScript narrowing — null 가드 이후 변수를 선언하면 `!` 없이 타입 안전하게 사용 가능
+- Context: `scrollEl`·`drawerEl` 선언이 `if (!contentRef.current || ...)` 가드보다 앞에 있어 `scrollEl!`, `drawerEl!` 반복; 가드 이후로 이동
+
+- Violation: `isDragging === true` 진입 후 `deltaY <= 0`일 때 `e.preventDefault()` 미호출로 브라우저 기본 스크롤 발생 가능
+- Rule: 터치 이벤트 UX — 드래그 제어 진입 후에는 모든 방향 이동에 대해 `preventDefault()`를 호출해야 함
+- Context: `onTouchMove`에서 `deltaY <= 0` early return이 `isDragging` 체크보다 앞에 있어 드래그 중 위로 되돌릴 때 스크롤 허용; 구조 재정렬 + `Math.max(0, deltaY)` 적용
+
 ## [PR #294 | feat/key-levels-clustering | 2026-04-13]
 - Violation: 가격 반올림 `100`이 매직 넘버로 사용됨
 - Rule: Domain Layer Checklist — No hardcoded literals → extract to constants

--- a/src/components/symbol-page/MobileAnalysisSheet.tsx
+++ b/src/components/symbol-page/MobileAnalysisSheet.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect, useEffectEvent } from 'react';
 import type { ReactNode } from 'react';
 import { Drawer } from 'vaul';
 import { cn } from '@/lib/cn';
@@ -16,6 +16,13 @@ export const MOBILE_SNAP_POINTS = [SNAP_PEEK, SNAP_HALF, SNAP_FULL] as const;
 // Vaul의 snapPoints prop은 readonly 배열을 허용하지 않아 mutable 사본을 사용한다
 const SNAP_POINTS_MUTABLE = [...MOBILE_SNAP_POINTS] as number[];
 
+// vaul 드로어 애니메이션과 동일한 easing 곡선
+const VAUL_EASING = 'cubic-bezier(0.32, 0.72, 0, 1)';
+// 드래그 시 손가락 속도 대비 시트 이동 비율 (러버밴드 효과)
+const DRAG_RESISTANCE = 0.6;
+// 드래그로 간주하기 위한 최소 이동량(px)
+const DRAG_THRESHOLD_PX = 8;
+
 interface MobileAnalysisSheetProps {
     activeSnap: SnapPoint;
     onActiveSnapChange: (snap: SnapPoint) => void;
@@ -28,51 +35,148 @@ export function MobileAnalysisSheet({
     children,
 }: MobileAnalysisSheetProps) {
     // Vaul이 최소 스냅 아래 드래그 시 내부적으로 닫으려 할 수 있다. open 상태를
-    // 직접 제어해 즉시 재오픈함으로써 시트가 화면에서 사라지지 않도록 한다.
+    // 직접 제어해 즉시 재오픈하고, activeSnap도 SNAP_PEEK로 초기화해
+    // 시트와 핸들이 화면에서 사라지지 않도록 한다.
     const [isOpen, setIsOpen] = useState(true);
-    const handleOpenChange = useCallback((open: boolean) => {
-        if (!open) setIsOpen(true);
-    }, []);
-
-    const isFullSnap = activeSnap === SNAP_FULL;
 
     // FULL 스냅 + scrollTop === 0에서 아래로 스와이프 시 시트를 축소하는 제스처.
     // vaul의 shouldDrag는 isDraggingInDirection 체크에서 아래 방향 드래그를
     // 무조건 차단하므로, 별도 터치 핸들러로 스냅 포인트를 직접 전환한다.
+    // touchmove에서 Drawer.Content의 transform을 직접 조작하여
+    // 손가락을 따라오는 실시간 피드백을 제공한다.
     const contentRef = useRef<HTMLDivElement>(null);
+    const drawerContentRef = useRef<HTMLDivElement>(null);
+
+    const isFullSnap = activeSnap === SNAP_FULL;
+
+    const handleOpenChange = useCallback(
+        (open: boolean) => {
+            if (!open) {
+                onActiveSnapChange(SNAP_PEEK);
+                setIsOpen(true);
+            }
+        },
+        [onActiveSnapChange],
+    );
+
+    // useEffectEvent로 래핑하여 부모가 메모이제이션 없이 콜백을 전달해도
+    // effect가 재마운트되지 않도록 안정적인 참조를 보장한다.
+    const snapToPoint = useEffectEvent((snap: SnapPoint) => {
+        onActiveSnapChange(snap);
+    });
 
     useEffect(() => {
-        const el = contentRef.current;
-        if (!el || !isFullSnap) return;
+        const scrollEl = contentRef.current;
+        const drawerEl = drawerContentRef.current!;
+        if (!contentRef.current || !drawerContentRef.current || !isFullSnap)
+            return;
 
         let startY = 0;
         let startedAtTop = false;
+        let isDragging = false;
+        let initialTransformY = 0;
+
+        // vaul이 현재 적용한 translateY 값(px)을 computed style에서 읽는다.
+        // onActiveSnapChange 호출 시 React가 vaul의 transform을 덮어쓰므로
+        // 이 값을 기준점으로 사용해 연속적인 애니메이션을 구성한다.
+        function captureInitialTransform(): number {
+            const matrix = new DOMMatrix(
+                window.getComputedStyle(drawerEl).transform,
+            );
+            return matrix.m42;
+        }
+
+        // 드래그를 중단하고 vaul의 FULL 스냅 위치로 부드럽게 복귀한다.
+        // activeSnap이 이미 SNAP_FULL이면 React가 리렌더를 건너뛰므로
+        // CSS transition을 직접 적용해 애니메이션을 처리한다.
+        function snapBack(): void {
+            drawerEl.style.transition = `transform 0.5s ${VAUL_EASING}`;
+            drawerEl.style.transform = `translateY(${initialTransformY}px)`;
+            drawerEl.addEventListener(
+                'transitionend',
+                () => {
+                    // 새로운 드래그가 시작된 경우 transition 초기화를 건너뛴다
+                    if (!isDragging) {
+                        drawerEl.style.transition = '';
+                    }
+                },
+                { once: true },
+            );
+        }
 
         function onTouchStart(e: TouchEvent): void {
             startY = e.touches[0].clientY;
-            startedAtTop = el!.scrollTop <= 0;
-        }
-
-        function onTouchEnd(e: TouchEvent): void {
-            if (!startedAtTop) return;
-            const deltaY = e.changedTouches[0].clientY - startY;
-            if (deltaY <= 0) return;
-
-            const vh = window.innerHeight;
-            if (deltaY > vh * 0.5) {
-                onActiveSnapChange(SNAP_PEEK);
-            } else if (deltaY > vh * 0.15) {
-                onActiveSnapChange(SNAP_HALF);
+            startedAtTop = scrollEl!.scrollTop <= 0;
+            isDragging = false;
+            if (startedAtTop) {
+                initialTransformY = captureInitialTransform();
             }
         }
 
-        el.addEventListener('touchstart', onTouchStart, { passive: true });
-        el.addEventListener('touchend', onTouchEnd, { passive: true });
+        function onTouchMove(e: TouchEvent): void {
+            if (!startedAtTop) return;
+            const deltaY = e.touches[0].clientY - startY;
+            if (deltaY <= 0) return;
+
+            if (!isDragging && deltaY > DRAG_THRESHOLD_PX) {
+                isDragging = true;
+            }
+            if (!isDragging) return;
+
+            // 콘텐츠 스크롤을 차단하고 시트 드래그로 처리한다
+            e.preventDefault();
+
+            drawerEl.style.transition = 'none';
+            drawerEl.style.transform = `translateY(${initialTransformY + deltaY * DRAG_RESISTANCE}px)`;
+        }
+
+        function onTouchEnd(e: TouchEvent): void {
+            if (!startedAtTop || !isDragging) return;
+            isDragging = false;
+
+            const deltaY = e.changedTouches[0].clientY - startY;
+            const vh = window.innerHeight;
+
+            if (deltaY > vh * 0.45) {
+                // 충분히 드래그: PEEK로 스냅
+                // snapToPoint → React 리렌더 → vaul이 현재 transform 위치에서
+                // 새 스냅 위치까지 CSS transition으로 애니메이션
+                snapToPoint(SNAP_PEEK);
+            } else if (deltaY > vh * 0.12) {
+                // 중간 드래그: HALF로 스냅
+                snapToPoint(SNAP_HALF);
+            } else {
+                // 드래그 부족: FULL로 복귀
+                snapBack();
+            }
+        }
+
+        function onTouchCancel(): void {
+            if (isDragging) {
+                isDragging = false;
+                snapBack();
+            }
+        }
+
+        scrollEl!.addEventListener('touchstart', onTouchStart, {
+            passive: true,
+        });
+        // passive: false — isDragging 진입 후 e.preventDefault()를 호출하기 위해 필요
+        scrollEl!.addEventListener('touchmove', onTouchMove, {
+            passive: false,
+        });
+        scrollEl!.addEventListener('touchend', onTouchEnd, { passive: true });
+        scrollEl!.addEventListener('touchcancel', onTouchCancel, {
+            passive: true,
+        });
+
         return () => {
-            el.removeEventListener('touchstart', onTouchStart);
-            el.removeEventListener('touchend', onTouchEnd);
+            scrollEl!.removeEventListener('touchstart', onTouchStart);
+            scrollEl!.removeEventListener('touchmove', onTouchMove);
+            scrollEl!.removeEventListener('touchend', onTouchEnd);
+            scrollEl!.removeEventListener('touchcancel', onTouchCancel);
         };
-    }, [isFullSnap, onActiveSnapChange]);
+    }, [isFullSnap, snapToPoint]);
 
     return (
         <Drawer.Root
@@ -88,6 +192,7 @@ export function MobileAnalysisSheet({
         >
             <Drawer.Portal>
                 <Drawer.Content
+                    ref={drawerContentRef}
                     className="bg-secondary-900 border-secondary-700 fixed inset-x-0 bottom-0 z-40 flex max-h-[97svh] flex-col overflow-hidden overscroll-contain rounded-t-2xl border-t pb-[env(safe-area-inset-bottom)] shadow-[0_-8px_24px_-8px_rgba(0,0,0,0.6)] md:hidden"
                     aria-live="polite"
                 >
@@ -105,7 +210,7 @@ export function MobileAnalysisSheet({
                         ref={contentRef}
                         className={cn(
                             'min-h-0 flex-1 px-4 pt-3 pb-[calc(env(safe-area-inset-bottom,0px)+1rem)]',
-                            isFullSnap ? 'overflow-y-auto' : 'overflow-hidden'
+                            isFullSnap ? 'overflow-y-auto' : 'overflow-hidden',
                         )}
                     >
                         {children}

--- a/src/components/symbol-page/MobileAnalysisSheet.tsx
+++ b/src/components/symbol-page/MobileAnalysisSheet.tsx
@@ -24,6 +24,11 @@ const SNAP_POINTS_MUTABLE = [...MOBILE_SNAP_POINTS] as number[];
 
 // vaul 드로어 애니메이션과 동일한 easing 곡선
 const VAUL_EASING = 'cubic-bezier(0.32, 0.72, 0, 1)';
+
+// vaul이 현재 적용한 translateY 값(px)을 computed style에서 읽는다.
+function captureTransformY(el: HTMLDivElement): number {
+    return new DOMMatrix(window.getComputedStyle(el).transform).m42;
+}
 // 드래그 시 손가락 속도 대비 시트 이동 비율 (러버밴드 효과)
 const DRAG_RESISTANCE = 0.6;
 // 드래그로 간주하기 위한 최소 이동량(px)
@@ -72,25 +77,16 @@ export function MobileAnalysisSheet({
     });
 
     useEffect(() => {
-        const scrollEl = contentRef.current;
-        const drawerEl = drawerContentRef.current!;
         if (!contentRef.current || !drawerContentRef.current || !isFullSnap)
             return;
+
+        const scrollEl = contentRef.current;
+        const drawerEl = drawerContentRef.current;
 
         let startY = 0;
         let startedAtTop = false;
         let isDragging = false;
         let initialTransformY = 0;
-
-        // vaul이 현재 적용한 translateY 값(px)을 computed style에서 읽는다.
-        // onActiveSnapChange 호출 시 React가 vaul의 transform을 덮어쓰므로
-        // 이 값을 기준점으로 사용해 연속적인 애니메이션을 구성한다.
-        function captureInitialTransform(): number {
-            const matrix = new DOMMatrix(
-                window.getComputedStyle(drawerEl).transform
-            );
-            return matrix.m42;
-        }
 
         // 드래그를 중단하고 vaul의 FULL 스냅 위치로 부드럽게 복귀한다.
         // activeSnap이 이미 SNAP_FULL이면 React가 리렌더를 건너뛰므로
@@ -112,28 +108,35 @@ export function MobileAnalysisSheet({
 
         function onTouchStart(e: TouchEvent): void {
             startY = e.touches[0].clientY;
-            startedAtTop = scrollEl!.scrollTop <= 0;
+            startedAtTop = scrollEl.scrollTop <= 0;
             isDragging = false;
             if (startedAtTop) {
-                initialTransformY = captureInitialTransform();
+                // onActiveSnapChange 호출 시 React가 vaul의 transform을 덮어쓰므로
+                // 이 값을 기준점으로 사용해 연속적인 애니메이션을 구성한다.
+                initialTransformY = captureTransformY(drawerEl);
             }
         }
 
         function onTouchMove(e: TouchEvent): void {
             if (!startedAtTop) return;
             const deltaY = e.touches[0].clientY - startY;
-            if (deltaY <= 0) return;
 
-            if (!isDragging && deltaY > DRAG_THRESHOLD_PX) {
-                isDragging = true;
+            if (!isDragging) {
+                if (deltaY <= 0) return;
+                if (deltaY > DRAG_THRESHOLD_PX) {
+                    isDragging = true;
+                } else {
+                    return;
+                }
             }
-            if (!isDragging) return;
 
-            // 콘텐츠 스크롤을 차단하고 시트 드래그로 처리한다
+            // 드래그 진입 후 모든 방향의 터치 이동을 제어하고 기본 스크롤을 차단한다.
+            // passive: false로 등록되어 있어 호출 가능하다.
             e.preventDefault();
 
             drawerEl.style.transition = 'none';
-            drawerEl.style.transform = `translateY(${initialTransformY + deltaY * DRAG_RESISTANCE}px)`;
+            // 위로 드래그해도 시트가 시작 위치 위로 올라가지 않도록 0으로 제한한다.
+            drawerEl.style.transform = `translateY(${initialTransformY + Math.max(0, deltaY) * DRAG_RESISTANCE}px)`;
         }
 
         function onTouchEnd(e: TouchEvent): void {
@@ -164,25 +167,28 @@ export function MobileAnalysisSheet({
             }
         }
 
-        scrollEl!.addEventListener('touchstart', onTouchStart, {
+        scrollEl.addEventListener('touchstart', onTouchStart, {
             passive: true,
         });
         // passive: false — isDragging 진입 후 e.preventDefault()를 호출하기 위해 필요
-        scrollEl!.addEventListener('touchmove', onTouchMove, {
+        scrollEl.addEventListener('touchmove', onTouchMove, {
             passive: false,
         });
-        scrollEl!.addEventListener('touchend', onTouchEnd, { passive: true });
-        scrollEl!.addEventListener('touchcancel', onTouchCancel, {
+        scrollEl.addEventListener('touchend', onTouchEnd, { passive: true });
+        scrollEl.addEventListener('touchcancel', onTouchCancel, {
             passive: true,
         });
 
         return () => {
-            scrollEl!.removeEventListener('touchstart', onTouchStart);
-            scrollEl!.removeEventListener('touchmove', onTouchMove);
-            scrollEl!.removeEventListener('touchend', onTouchEnd);
-            scrollEl!.removeEventListener('touchcancel', onTouchCancel);
+            scrollEl.removeEventListener('touchstart', onTouchStart);
+            scrollEl.removeEventListener('touchmove', onTouchMove);
+            scrollEl.removeEventListener('touchend', onTouchEnd);
+            scrollEl.removeEventListener('touchcancel', onTouchCancel);
+            // 직접 조작한 스타일을 초기화하여 vaul의 내부 스타일과 충돌을 방지한다.
+            drawerEl.style.transform = '';
+            drawerEl.style.transition = '';
         };
-    }, [isFullSnap, snapToPoint]);
+    }, [isFullSnap]);
 
     return (
         <Drawer.Root

--- a/src/components/symbol-page/MobileAnalysisSheet.tsx
+++ b/src/components/symbol-page/MobileAnalysisSheet.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { useState, useCallback, useRef, useEffect, useEffectEvent } from 'react';
+import {
+    useState,
+    useCallback,
+    useRef,
+    useEffect,
+    useEffectEvent,
+} from 'react';
 import type { ReactNode } from 'react';
 import { Drawer } from 'vaul';
 import { cn } from '@/lib/cn';
@@ -56,7 +62,7 @@ export function MobileAnalysisSheet({
                 setIsOpen(true);
             }
         },
-        [onActiveSnapChange],
+        [onActiveSnapChange]
     );
 
     // useEffectEvent로 래핑하여 부모가 메모이제이션 없이 콜백을 전달해도
@@ -81,7 +87,7 @@ export function MobileAnalysisSheet({
         // 이 값을 기준점으로 사용해 연속적인 애니메이션을 구성한다.
         function captureInitialTransform(): number {
             const matrix = new DOMMatrix(
-                window.getComputedStyle(drawerEl).transform,
+                window.getComputedStyle(drawerEl).transform
             );
             return matrix.m42;
         }
@@ -100,7 +106,7 @@ export function MobileAnalysisSheet({
                         drawerEl.style.transition = '';
                     }
                 },
-                { once: true },
+                { once: true }
             );
         }
 
@@ -210,7 +216,7 @@ export function MobileAnalysisSheet({
                         ref={contentRef}
                         className={cn(
                             'min-h-0 flex-1 px-4 pt-3 pb-[calc(env(safe-area-inset-bottom,0px)+1rem)]',
-                            isFullSnap ? 'overflow-y-auto' : 'overflow-hidden',
+                            isFullSnap ? 'overflow-y-auto' : 'overflow-hidden'
                         )}
                     >
                         {children}


### PR DESCRIPTION
## 관련 이슈

Closes #299

## 구현 내용

두 가지 UX 버그를 모바일 바텀시트 컴포넌트(`MobileAnalysisSheet`)에서 수정했습니다.

### 1. 핸들 사라짐 버그 (중요)

사용자가 시트를 `SNAP_PEEK` 아래로 드래그하면 vaul이 `onOpenChange(false)`를 발생시킵니다. 기존 핸들러는 `setIsOpen(true)`만 호출했으나 `activeSnap`을 리셋하지 않아서 시트가 시각적으로 사라지고 핸들이 접근 불가능해졌습니다.

**수정**: `handleOpenChange`에서 `setIsOpen(true)` 전에 `onActiveSnapChange(SNAP_PEEK)`를 호출하여 snap 상태를 리셋합니다.

### 2. 리얼타임 드래그 피드백 부족 (UX)

FULL snap에서 콘텐츠 영역 swipe 핸들러는 `touchend`에서만 실행되었고 제스처 중 시각적 피드백이 없었습니다(시트가 손가락을 따라가지 않음).

**수정**: 완전한 제스처 시스템 구현:
- `touchstart`: vaul의 현재 `translateY`를 `DOMMatrix`로 캡처
- `touchmove`: 실시간 transform을 저항감 있게 적용(`passive: false`로 `preventDefault` 가능)
- `touchend`: 드래그 거리에 따라 PEEK/HALF로 snap 또는 CSS transition으로 FULL로 애니메이션(`snapBack()`)
- `touchcancel`: `snapBack()`으로 위치 복구
- `onActiveSnapChange`를 `useEffectEvent`로 래핑(`snapToPoint`)해 부모의 non-memoized callback 변경 시 effect 재마운트 방지

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] 컴포넌트 레이어 import 규칙 준수
- [x] 타입 명시
- [x] any 타입 없음

## 변경 파일 목록

[수정]
- `src/components/symbol-page/MobileAnalysisSheet.tsx`

## CI Check lists

- [ ] yarn format
- [ ] yarn lint
- [ ] yarn lint:style
- [ ] yarn test
- [ ] yarn build