### PR TITLE
fix: Trend 데이터 누락 시 보조지표 화면 깨짐

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -101,6 +101,11 @@
 - Rule: CONVENTIONS.md Naming — underscore prefix reserved for intentionally-unused destructured parameters; consumed props must not have underscore
 - Context: ActionRecommendationField received _recommendedAction but used it in render; removed underscore to indicate the prop is actually consumed
 
+## [PR #301 | fix/295/trend-데이터-누락-시-보조지표-화면-깨짐 | 2026-04-14]
+- Violation: 동일 키를 공유하는 TREND_COLOR, TREND_BG_COLOR, TREND_LABEL 세 상수가 각각 별도 Record로 분산됨
+- Rule: MISTAKES.md Design #1 — 함께 업데이트되어야 하는 데이터는 단일 객체/상수에 위치해야 한다
+- Context: `trendUtils.ts`에서 세 상수를 단일 `TREND_DISPLAY_MAP: Record<Trend, TrendDisplay>`로 통합; VALID_TRENDS Set 제거 후 `!(trend in TREND_DISPLAY_MAP)` 체크로 대체
+
 ## [PR #229 Round 2 | feat/229/action-recommendation-chart-overlay | 2026-04-10]
 - Violation: StockChart prop default actionPricesVisible = false contradicted the parent ChartContent's intent (initialized to true). Default off-by-default is misleading when caller explicitly enables the feature.
 - Rule: FF.md Readability 1-C — Design intent must be exposed in code; default values must align with component usage context or caller must explicitly pass the value

--- a/src/__tests__/components/analysis/utils/trendUtils.test.ts
+++ b/src/__tests__/components/analysis/utils/trendUtils.test.ts
@@ -10,11 +10,14 @@ describe('resolveTrendDisplay', () => {
             ['bullish', TREND_LABEL.bullish],
             ['bearish', TREND_LABEL.bearish],
             ['neutral', TREND_LABEL.neutral],
-        ])('%s → label이 %s인 TrendDisplay를 반환한다', (trend, expectedLabel) => {
-            const result = resolveTrendDisplay(trend);
-            expect(result).not.toBeNull();
-            expect(result!.label).toBe(expectedLabel);
-        });
+        ])(
+            '%s → label이 %s인 TrendDisplay를 반환한다',
+            (trend, expectedLabel) => {
+                const result = resolveTrendDisplay(trend);
+                expect(result).not.toBeNull();
+                expect(result!.label).toBe(expectedLabel);
+            }
+        );
 
         it('bullish → color에 chart-bullish 클래스를 포함한다', () => {
             const result = resolveTrendDisplay('bullish');

--- a/src/__tests__/components/analysis/utils/trendUtils.test.ts
+++ b/src/__tests__/components/analysis/utils/trendUtils.test.ts
@@ -1,15 +1,12 @@
-import {
-    resolveTrendDisplay,
-    TREND_LABEL,
-} from '@/components/analysis/utils/trendUtils';
+import { resolveTrendDisplay } from '@/components/analysis/utils/trendUtils';
 import type { Trend } from '@/domain/types';
 
 describe('resolveTrendDisplay', () => {
     describe('유효한 Trend 값일 때', () => {
         it.each<[Trend, string]>([
-            ['bullish', TREND_LABEL.bullish],
-            ['bearish', TREND_LABEL.bearish],
-            ['neutral', TREND_LABEL.neutral],
+            ['bullish', '강세'],
+            ['bearish', '약세'],
+            ['neutral', '보합'],
         ])(
             '%s → label이 %s인 TrendDisplay를 반환한다',
             (trend, expectedLabel) => {

--- a/src/__tests__/components/analysis/utils/trendUtils.test.ts
+++ b/src/__tests__/components/analysis/utils/trendUtils.test.ts
@@ -1,0 +1,49 @@
+import {
+    resolveTrendDisplay,
+    TREND_LABEL,
+} from '@/components/analysis/utils/trendUtils';
+import type { Trend } from '@/domain/types';
+
+describe('resolveTrendDisplay', () => {
+    describe('유효한 Trend 값일 때', () => {
+        it.each<[Trend, string]>([
+            ['bullish', TREND_LABEL.bullish],
+            ['bearish', TREND_LABEL.bearish],
+            ['neutral', TREND_LABEL.neutral],
+        ])('%s → label이 %s인 TrendDisplay를 반환한다', (trend, expectedLabel) => {
+            const result = resolveTrendDisplay(trend);
+            expect(result).not.toBeNull();
+            expect(result!.label).toBe(expectedLabel);
+        });
+
+        it('bullish → color에 chart-bullish 클래스를 포함한다', () => {
+            const result = resolveTrendDisplay('bullish');
+            expect(result!.color).toContain('chart-bullish');
+        });
+
+        it('bearish → color에 chart-bearish 클래스를 포함한다', () => {
+            const result = resolveTrendDisplay('bearish');
+            expect(result!.color).toContain('chart-bearish');
+        });
+
+        it('neutral → bgColor에 secondary 클래스를 포함한다', () => {
+            const result = resolveTrendDisplay('neutral');
+            expect(result!.bgColor).toContain('secondary');
+        });
+    });
+
+    describe('Trend 데이터가 누락된 경우', () => {
+        it('null을 받으면 null을 반환한다', () => {
+            expect(resolveTrendDisplay(null)).toBeNull();
+        });
+
+        it('undefined을 받으면 null을 반환한다', () => {
+            expect(resolveTrendDisplay(undefined)).toBeNull();
+        });
+
+        it('알 수 없는 문자열을 받으면 null을 반환한다', () => {
+            // AI 응답이 예상과 다른 값을 내려보내는 경우를 방어한다
+            expect(resolveTrendDisplay('unknown' as Trend)).toBeNull();
+        });
+    });
+});

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -32,6 +32,7 @@ import {
     parseStructuredSummary,
     type SkillSummarySection,
 } from '@/components/analysis/utils/parseStructuredSummary';
+import { resolveTrendDisplay } from '@/components/analysis/utils/trendUtils';
 import { AnalysisProgress } from '@/components/analysis/AnalysisProgress';
 import { AnalysisToast } from '@/components/analysis/AnalysisToast';
 import { useOnClickOutside } from '@/components/hooks/useOnClickOutside';
@@ -142,23 +143,6 @@ function ActionRecommendationSection({
     );
 }
 
-const TREND_COLOR: Record<Trend, string> = {
-    bullish: 'text-chart-bullish',
-    bearish: 'text-chart-bearish',
-    neutral: 'text-secondary-400',
-};
-
-const TREND_BG_COLOR: Record<Trend, string> = {
-    bullish: 'bg-chart-bullish/10 border-chart-bullish/30',
-    bearish: 'bg-chart-bearish/10 border-chart-bearish/30',
-    neutral: 'bg-secondary-700/30 border-secondary-600/30',
-};
-
-const TREND_LABEL: Record<Trend, string> = {
-    bullish: '강세',
-    bearish: '약세',
-    neutral: '보합',
-};
 
 const RISK_LEVEL_COLOR: Record<RiskLevel, string> = {
     low: 'text-chart-bullish',
@@ -218,19 +202,22 @@ function SignalItem({ signal, typeLabel }: SignalItemProps) {
 }
 
 interface TrendBadgeProps {
-    trend: Trend;
+    trend: Trend | null | undefined;
 }
 
 function TrendBadge({ trend }: TrendBadgeProps) {
+    const display = resolveTrendDisplay(trend);
+    if (display === null) return null;
+
     return (
         <span
             className={cn(
                 'rounded border px-2 py-0.5 text-xs font-bold',
-                TREND_COLOR[trend],
-                TREND_BG_COLOR[trend]
+                display.color,
+                display.bgColor
             )}
         >
-            {TREND_LABEL[trend]}
+            {display.label}
         </span>
     );
 }

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -143,7 +143,6 @@ function ActionRecommendationSection({
     );
 }
 
-
 const RISK_LEVEL_COLOR: Record<RiskLevel, string> = {
     low: 'text-chart-bullish',
     medium: 'text-ui-warning',

--- a/src/components/analysis/utils/trendUtils.ts
+++ b/src/components/analysis/utils/trendUtils.ts
@@ -1,0 +1,43 @@
+import type { Trend } from '@/domain/types';
+
+const TREND_COLOR: Record<Trend, string> = {
+    bullish: 'text-chart-bullish',
+    bearish: 'text-chart-bearish',
+    neutral: 'text-secondary-400',
+};
+
+const TREND_BG_COLOR: Record<Trend, string> = {
+    bullish: 'bg-chart-bullish/10 border-chart-bullish/30',
+    bearish: 'bg-chart-bearish/10 border-chart-bearish/30',
+    neutral: 'bg-secondary-700/30 border-secondary-600/30',
+};
+
+export const TREND_LABEL: Record<Trend, string> = {
+    bullish: '강세',
+    bearish: '약세',
+    neutral: '보합',
+};
+
+const VALID_TRENDS = new Set<string>(['bullish', 'bearish', 'neutral']);
+
+export interface TrendDisplay {
+    label: string;
+    color: string;
+    bgColor: string;
+}
+
+/**
+ * trend 값이 유효한 Trend 리터럴이면 표시 정보를 반환한다.
+ * null · undefined · 알 수 없는 값이 들어오면 null을 반환해 렌더링을 건너뛴다.
+ * AI 응답에서 trend 필드가 누락되거나 예상치 못한 값이 오는 경우를 방어한다.
+ */
+export function resolveTrendDisplay(
+    trend: Trend | null | undefined
+): TrendDisplay | null {
+    if (trend == null || !VALID_TRENDS.has(trend)) return null;
+    return {
+        label: TREND_LABEL[trend],
+        color: TREND_COLOR[trend],
+        bgColor: TREND_BG_COLOR[trend],
+    };
+}

--- a/src/components/analysis/utils/trendUtils.ts
+++ b/src/components/analysis/utils/trendUtils.ts
@@ -1,30 +1,28 @@
 import type { Trend } from '@/domain/types';
 
-const TREND_COLOR: Record<Trend, string> = {
-    bullish: 'text-chart-bullish',
-    bearish: 'text-chart-bearish',
-    neutral: 'text-secondary-400',
-};
-
-const TREND_BG_COLOR: Record<Trend, string> = {
-    bullish: 'bg-chart-bullish/10 border-chart-bullish/30',
-    bearish: 'bg-chart-bearish/10 border-chart-bearish/30',
-    neutral: 'bg-secondary-700/30 border-secondary-600/30',
-};
-
-export const TREND_LABEL: Record<Trend, string> = {
-    bullish: '강세',
-    bearish: '약세',
-    neutral: '보합',
-};
-
-const VALID_TRENDS = new Set<string>(['bullish', 'bearish', 'neutral']);
-
 export interface TrendDisplay {
     label: string;
     color: string;
     bgColor: string;
 }
+
+const TREND_DISPLAY_MAP: Record<Trend, TrendDisplay> = {
+    bullish: {
+        label: '강세',
+        color: 'text-chart-bullish',
+        bgColor: 'bg-chart-bullish/10 border-chart-bullish/30',
+    },
+    bearish: {
+        label: '약세',
+        color: 'text-chart-bearish',
+        bgColor: 'bg-chart-bearish/10 border-chart-bearish/30',
+    },
+    neutral: {
+        label: '보합',
+        color: 'text-secondary-400',
+        bgColor: 'bg-secondary-700/30 border-secondary-600/30',
+    },
+};
 
 /**
  * trend 값이 유효한 Trend 리터럴이면 표시 정보를 반환한다.
@@ -34,10 +32,6 @@ export interface TrendDisplay {
 export function resolveTrendDisplay(
     trend: Trend | null | undefined
 ): TrendDisplay | null {
-    if (trend == null || !VALID_TRENDS.has(trend)) return null;
-    return {
-        label: TREND_LABEL[trend],
-        color: TREND_COLOR[trend],
-        bgColor: TREND_BG_COLOR[trend],
-    };
+    if (trend == null || !(trend in TREND_DISPLAY_MAP)) return null;
+    return TREND_DISPLAY_MAP[trend];
 }


### PR DESCRIPTION
## 관련 이슈

closes #295

## 구현 내용

- `src/components/analysis/utils/trendUtils.ts` (신규): TrendDisplay를 안전하게 해석하는 순수 유틸리티 함수로, null/undefined trend 값 처리
- `src/components/analysis/AnalysisPanel.tsx` (수정): TrendBadge가 Trend|null|undefined를 받아들이고, trend 데이터 없을 때 아무것도 렌더링하지 않도록 변경
- `src/__tests__/components/analysis/utils/trendUtils.test.ts` (신규): 유효한 값과 누락 데이터 케이스를 커버하는 테스트

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 인디케이터 초기 구간 null 반환 (0, NaN 없음)
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it
- [x] 초기 구간 null 케이스 테스트 포함
- [x] 매직 넘버 없음

## 변경 파일 목록

[생성]
- src/components/analysis/utils/trendUtils.ts
- src/__tests__/components/analysis/utils/trendUtils.test.ts

[수정]
- src/components/analysis/AnalysisPanel.tsx

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build