### PR TITLE
fix: FMP daily bar 날짜 오류 및 당일 실시간 quote 추가 (#306, #307)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -256,6 +256,42 @@ interface FmpDailyBar {
 
 ---
 
+### 3. Quote (당일 실시간 시세)
+
+```
+GET /stable/quote?symbol={symbol}&apikey={key}
+```
+
+당일 거래 중 실시간 시세를 조회. EOD 엔드포인트가 당일 데이터를 포함하지 않는 장중에 호출하여 일봉 데이터에 append한다.
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|----------|------|------|------|
+| symbol | string | ✅ | 종목 심볼 |
+| apikey | string | ✅ | FMP API 키 |
+
+**Response**
+
+```typescript
+interface FmpQuote {
+    price: number;    // 현재가 (당일 bar의 close로 사용)
+    open: number;     // 당일 시가
+    dayHigh: number;  // 당일 고가
+    dayLow: number;   // 당일 저가
+    volume: number;   // 당일 거래량
+    timestamp: number; // Unix timestamp (초 단위)
+}
+
+// 응답: FmpQuote[] (배열 형태, 단일 심볼이므로 [0]만 사용)
+```
+
+**주의사항**
+- 장 마감 후 EOD 엔드포인트가 업데이트되면 당일 데이터가 중복될 수 있으므로, 마지막 EOD 봉의 time과 비교하여 중복 시 append 생략
+- 실패(non-ok, 빈 배열, 네트워크 오류) 시 EOD 데이터만으로 graceful degradation
+
+---
+
 ## Market Data Provider 선택
 
 ```bash

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -46,10 +46,6 @@
 - Context: `onTouchMove`에서 `deltaY <= 0` early return이 `isDragging` 체크보다 앞에 있어 드래그 중 위로 되돌릴 때 스크롤 허용; 구조 재정렬 + `Math.max(0, deltaY)` 적용
 
 ## [PR #294 | feat/key-levels-clustering | 2026-04-13]
-- Violation: 가격 반올림 `100`이 매직 넘버로 사용됨
-- Rule: Domain Layer Checklist — No hardcoded literals → extract to constants
-- Context: `keyLevels.ts`에서 `Math.round(rawPrice * 100) / 100` → `PRICE_DECIMAL_FACTOR` 상수로 추출
-
 - Violation: React key에 `source.price-source.reason` 조합 사용 — 동일 가격·사유 존재 시 중복 가능
 - Rule: React — 리스트 렌더링 시 key 고유성 보장
 - Context: `ConfluenceInfo`에서 key에 `index` 추가하여 고유성 확보
@@ -128,5 +124,6 @@
 - Violation: StockChart prop default actionPricesVisible = false contradicted the parent ChartContent's intent (initialized to true). Default off-by-default is misleading when caller explicitly enables the feature.
 - Rule: FF.md Readability 1-C — Design intent must be exposed in code; default values must align with component usage context or caller must explicitly pass the value
 - Context: ChartContent initializes actionPricesVisible={true}, but StockChart defaulted to false when prop was optional, creating contradiction between declaration and runtime behavior. Fixed by changing StockChart default to true to expose the actual design intent.
+
 
 

--- a/src/__tests__/infrastructure/market/fmp.test.ts
+++ b/src/__tests__/infrastructure/market/fmp.test.ts
@@ -18,6 +18,19 @@ const mockFmpDailyBar = {
     volume: 1000000,
 };
 
+// 당일 quote 모의 데이터 (timestamp는 2024-01-16 15:00 UTC → 날짜 2024-01-16)
+const mockFmpQuote = {
+    price: 110,
+    open: 105,
+    dayHigh: 115,
+    dayLow: 104,
+    volume: 2000000,
+    timestamp: Math.floor(new Date('2024-01-16T15:00:00Z').getTime() / 1000),
+};
+
+// 대부분의 테스트에서 quote fetch가 결과에 영향을 주지 않도록 빈 응답을 반환하는 mock
+const emptyQuoteMock = { ok: true, json: async () => [] };
+
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
@@ -254,6 +267,7 @@ describe('FmpProvider', () => {
                     ok: true,
                     json: async () => [],
                 });
+                mockFetch.mockResolvedValueOnce(emptyQuoteMock);
 
                 const provider = new FmpProvider();
                 await provider.getBars({
@@ -273,6 +287,7 @@ describe('FmpProvider', () => {
                     ok: true,
                     json: async () => [mockFmpDailyBar],
                 });
+                mockFetch.mockResolvedValueOnce(emptyQuoteMock);
 
                 const provider = new FmpProvider();
                 const bars = await provider.getBars({
@@ -282,7 +297,10 @@ describe('FmpProvider', () => {
 
                 expect(bars).toHaveLength(1);
                 expect(bars[0]).toEqual({
-                    time: Math.floor(new Date('2024-01-15').getTime() / 1000),
+                    // 'T00:00:00'을 붙여 local time midnight으로 파싱 (timezone 버그 수정)
+                    time: Math.floor(
+                        new Date('2024-01-15T00:00:00').getTime() / 1000
+                    ),
                     open: 100,
                     high: 105,
                     low: 99,
@@ -301,6 +319,7 @@ describe('FmpProvider', () => {
                     ok: true,
                     json: async () => newestFirst,
                 });
+                mockFetch.mockResolvedValueOnce(emptyQuoteMock);
 
                 const provider = new FmpProvider();
                 const bars = await provider.getBars({
@@ -313,7 +332,7 @@ describe('FmpProvider', () => {
                 expect(bars[2].close).toBe(103);
             });
 
-            it('before 파라미터가 있으면 to 쿼리 파라미터로 전달한다', async () => {
+            it('before 파라미터가 있으면 to 쿼리 파라미터로 전달하고 quote를 호출하지 않는다', async () => {
                 mockFetch.mockResolvedValueOnce({
                     ok: true,
                     json: async () => [],
@@ -326,6 +345,8 @@ describe('FmpProvider', () => {
                     before: '2024-01-15T00:00:00Z',
                 });
 
+                // before가 있으면 quote fetch를 건너뛰므로 fetch는 1번만 호출된다
+                expect(mockFetch).toHaveBeenCalledTimes(1);
                 const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
                 expect(new URL(url).searchParams.get('to')).toBe('2024-01-15');
             });
@@ -335,6 +356,7 @@ describe('FmpProvider', () => {
                     ok: true,
                     json: async () => [],
                 });
+                mockFetch.mockResolvedValueOnce(emptyQuoteMock);
 
                 const provider = new FmpProvider();
                 await provider.getBars({
@@ -355,6 +377,8 @@ describe('FmpProvider', () => {
                     status: 403,
                     statusText: 'Forbidden',
                 });
+                // Promise.all로 EOD와 quote를 동시에 요청하므로 quote mock도 필요
+                mockFetch.mockResolvedValueOnce(emptyQuoteMock);
 
                 const provider = new FmpProvider();
                 await expect(
@@ -367,6 +391,7 @@ describe('FmpProvider', () => {
                     ok: true,
                     json: async () => ({ error: 'Invalid ticker' }),
                 });
+                mockFetch.mockResolvedValueOnce(emptyQuoteMock);
 
                 const provider = new FmpProvider();
                 const bars = await provider.getBars({
@@ -382,6 +407,7 @@ describe('FmpProvider', () => {
                     ok: true,
                     json: async () => [],
                 });
+                mockFetch.mockResolvedValueOnce(emptyQuoteMock);
 
                 const provider = new FmpProvider();
                 const bars = await provider.getBars({
@@ -390,6 +416,181 @@ describe('FmpProvider', () => {
                 });
 
                 expect(bars).toEqual([]);
+            });
+
+            describe('당일 quote 추가', () => {
+                it('마지막 EOD 봉 이후 날짜의 quote를 마지막 봉으로 추가한다', async () => {
+                    mockFetch.mockResolvedValueOnce({
+                        ok: true,
+                        json: async () => [mockFmpDailyBar], // 마지막: 2024-01-15
+                    });
+                    mockFetch.mockResolvedValueOnce({
+                        ok: true,
+                        json: async () => [mockFmpQuote], // 당일: 2024-01-16
+                    });
+
+                    const provider = new FmpProvider();
+                    const bars = await provider.getBars({
+                        symbol: 'AAPL',
+                        timeframe: '1Day',
+                    });
+
+                    expect(bars).toHaveLength(2);
+                    expect(bars[1]).toEqual({
+                        time: Math.floor(
+                            new Date('2024-01-16T00:00:00').getTime() / 1000
+                        ),
+                        open: mockFmpQuote.open,
+                        high: mockFmpQuote.dayHigh,
+                        low: mockFmpQuote.dayLow,
+                        close: mockFmpQuote.price,
+                        volume: mockFmpQuote.volume,
+                    });
+                });
+
+                it('quote 날짜가 마지막 EOD 봉과 같으면 추가하지 않는다', async () => {
+                    // 장 마감 후 EOD가 업데이트된 경우
+                    const sameDayQuote = {
+                        ...mockFmpQuote,
+                        timestamp: Math.floor(
+                            new Date('2024-01-15T20:00:00Z').getTime() / 1000
+                        ), // 2024-01-15
+                    };
+                    mockFetch.mockResolvedValueOnce({
+                        ok: true,
+                        json: async () => [mockFmpDailyBar], // 마지막: 2024-01-15
+                    });
+                    mockFetch.mockResolvedValueOnce({
+                        ok: true,
+                        json: async () => [sameDayQuote], // 당일도 2024-01-15
+                    });
+
+                    const provider = new FmpProvider();
+                    const bars = await provider.getBars({
+                        symbol: 'AAPL',
+                        timeframe: '1Day',
+                    });
+
+                    expect(bars).toHaveLength(1);
+                });
+
+                it('quote API가 ok가 아닌 응답을 반환해도 EOD 데이터를 반환한다', async () => {
+                    mockFetch.mockResolvedValueOnce({
+                        ok: true,
+                        json: async () => [mockFmpDailyBar],
+                    });
+                    mockFetch.mockResolvedValueOnce({
+                        ok: false,
+                        status: 429,
+                        statusText: 'Too Many Requests',
+                    });
+
+                    const provider = new FmpProvider();
+                    const bars = await provider.getBars({
+                        symbol: 'AAPL',
+                        timeframe: '1Day',
+                    });
+
+                    expect(bars).toHaveLength(1);
+                    expect(bars[0].close).toBe(103);
+                });
+
+                it('quote API가 배열이 아닌 응답을 반환해도 EOD 데이터를 반환한다', async () => {
+                    mockFetch.mockResolvedValueOnce({
+                        ok: true,
+                        json: async () => [mockFmpDailyBar],
+                    });
+                    mockFetch.mockResolvedValueOnce({
+                        ok: true,
+                        json: async () => ({ error: 'Not found' }),
+                    });
+
+                    const provider = new FmpProvider();
+                    const bars = await provider.getBars({
+                        symbol: 'AAPL',
+                        timeframe: '1Day',
+                    });
+
+                    expect(bars).toHaveLength(1);
+                });
+
+                it('quote API가 빈 배열을 반환해도 EOD 데이터를 반환한다', async () => {
+                    mockFetch.mockResolvedValueOnce({
+                        ok: true,
+                        json: async () => [mockFmpDailyBar],
+                    });
+                    mockFetch.mockResolvedValueOnce(emptyQuoteMock);
+
+                    const provider = new FmpProvider();
+                    const bars = await provider.getBars({
+                        symbol: 'AAPL',
+                        timeframe: '1Day',
+                    });
+
+                    expect(bars).toHaveLength(1);
+                });
+
+                it('quote fetch가 예외를 던져도 EOD 데이터를 반환한다', async () => {
+                    mockFetch.mockResolvedValueOnce({
+                        ok: true,
+                        json: async () => [mockFmpDailyBar],
+                    });
+                    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+                    const provider = new FmpProvider();
+                    const bars = await provider.getBars({
+                        symbol: 'AAPL',
+                        timeframe: '1Day',
+                    });
+
+                    expect(bars).toHaveLength(1);
+                });
+
+                it('EOD 데이터가 없고 quote가 유효하면 quote 봉만 반환한다', async () => {
+                    mockFetch.mockResolvedValueOnce({
+                        ok: true,
+                        json: async () => [],
+                    });
+                    mockFetch.mockResolvedValueOnce({
+                        ok: true,
+                        json: async () => [mockFmpQuote],
+                    });
+
+                    const provider = new FmpProvider();
+                    const bars = await provider.getBars({
+                        symbol: 'AAPL',
+                        timeframe: '1Day',
+                    });
+
+                    expect(bars).toHaveLength(1);
+                    expect(bars[0].close).toBe(mockFmpQuote.price);
+                });
+
+                it('quote URL에 symbol과 apikey를 포함한다', async () => {
+                    mockFetch.mockResolvedValueOnce({
+                        ok: true,
+                        json: async () => [],
+                    });
+                    mockFetch.mockResolvedValueOnce(emptyQuoteMock);
+
+                    const provider = new FmpProvider();
+                    await provider.getBars({
+                        symbol: 'TSLA',
+                        timeframe: '1Day',
+                    });
+
+                    const [quoteUrl] = mockFetch.mock.calls[1] as [
+                        string,
+                        RequestInit,
+                    ];
+                    expect(quoteUrl).toContain(
+                        'financialmodelingprep.com/stable/quote'
+                    );
+                    expect(new URL(quoteUrl).searchParams.get('symbol')).toBe(
+                        'TSLA'
+                    );
+                    expect(quoteUrl).toContain('apikey=test-fmp-key');
+                });
             });
         });
     });

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -283,6 +283,11 @@ export function ChartContent({
                         onChartRemove={handleVolumeChartRemove}
                     />
                 </div>
+
+                {/* 데이터 지연 안내 */}
+                <p className="text-secondary-500 px-2 py-1 text-right text-[10px]">
+                    시세 데이터는 최대 15분 지연됩니다
+                </p>
             </div>
 
             {/* 드래그 핸들 — flex 형제로 배치 (데스크톱 전용) */}

--- a/src/infrastructure/market/fmp.ts
+++ b/src/infrastructure/market/fmp.ts
@@ -32,6 +32,15 @@ interface FmpDailyBar {
     volume: number;
 }
 
+interface FmpQuote {
+    price: number; // 현재가 (당일 bar의 close로 사용)
+    open: number;
+    dayHigh: number;
+    dayLow: number;
+    volume: number;
+    timestamp: number; // Unix timestamp (초 단위)
+}
+
 function toFmpBar(raw: FmpBar): Bar {
     return {
         time: Math.floor(new Date(raw.date + ' UTC').getTime() / 1000),
@@ -45,7 +54,10 @@ function toFmpBar(raw: FmpBar): Bar {
 
 function toFmpDailyBar(raw: FmpDailyBar): Bar {
     return {
-        time: Math.floor(new Date(raw.date).getTime() / 1000),
+        // 'T00:00:00'을 붙여 local time midnight으로 파싱한다.
+        // date-only ISO 문자열(예: "2026-04-14")은 UTC midnight으로 파싱되어
+        // US Eastern(UTC-4) 등의 타임존에서 하루 앞 날짜로 표시되는 버그가 있다.
+        time: Math.floor(new Date(raw.date + 'T00:00:00').getTime() / 1000),
         open: raw.open,
         high: raw.high,
         low: raw.low,
@@ -108,6 +120,11 @@ export class FmpProvider implements MarketDataProvider {
         return `${FMP_BASE_URL}/historical-price-eod/full?${params}`;
     }
 
+    private buildQuoteUrl(symbol: string): string {
+        const params = new URLSearchParams({ apikey: this.apiKey, symbol });
+        return `${FMP_BASE_URL}/quote?${params}`;
+    }
+
     // FMP API는 limit 파라미터를 지원하지 않습니다.
     // from 파라미터는 from 쿼리로, before 파라미터는 to 쿼리로 변환합니다.
     // Daily(1Day) 타임프레임은 /stable/historical-price-eod/full 엔드포인트를 사용합니다.
@@ -164,24 +181,79 @@ export class FmpProvider implements MarketDataProvider {
         fromDate: string | undefined,
         endDate: string | undefined
     ): Promise<Bar[]> {
-        const url = this.buildDailyUrl(symbol, fromDate, endDate);
+        const eodUrl = this.buildDailyUrl(symbol, fromDate, endDate);
 
-        console.log(url);
-        const res = await fetch(url, {
-            next: { revalidate: 60 },
-        });
+        // endDate가 지정된 경우 과거 데이터 조회이므로 당일 quote를 추가하지 않는다.
+        const [eodRes, todayBar] = await Promise.all([
+            fetch(eodUrl, { next: { revalidate: 60 } }),
+            endDate === undefined
+                ? this.fetchTodayQuoteBar(symbol)
+                : Promise.resolve(null),
+        ]);
 
-        if (!res.ok) {
-            throw new Error(`FMP API error: ${res.status} ${res.statusText}`);
+        if (!eodRes.ok) {
+            throw new Error(`FMP API error: ${eodRes.status} ${eodRes.statusText}`);
         }
 
         // res.json() returns unknown; asserting shape against FMP API contract
-        const raw = (await res.json()) as FmpDailyBar[];
+        const raw = (await eodRes.json()) as FmpDailyBar[];
 
         if (!Array.isArray(raw)) {
             return [];
         }
 
-        return raw.map(r => toFmpDailyBar(r)).toReversed();
+        const eodBars = raw.map(r => toFmpDailyBar(r)).toReversed();
+
+        if (todayBar === null) return eodBars;
+
+        // 마지막 EOD 봉이 당일 quote 봉과 같거나 이후이면 장 마감 후 EOD에 이미 포함된 것
+        const lastBar = eodBars.at(-1);
+        if (lastBar !== undefined && lastBar.time >= todayBar.time) {
+            return eodBars;
+        }
+
+        return [...eodBars, todayBar];
+    }
+
+    /**
+     * 당일 실시간 quote를 Bar 형태로 반환한다.
+     * 실패 시 null을 반환하여 EOD 데이터만으로 graceful degradation한다.
+     * (EOD 조회 실패와 달리 전체 요청을 실패시키지 않는 의도적 비대칭 처리)
+     */
+    private async fetchTodayQuoteBar(symbol: string): Promise<Bar | null> {
+        const url = this.buildQuoteUrl(symbol);
+        try {
+            const res = await fetch(url, { next: { revalidate: 60 } });
+            if (!res.ok) return null;
+
+            // res.json() returns unknown; FMP quote API response shape guaranteed by provider contract
+            const raw = (await res.json()) as FmpQuote[];
+            if (!Array.isArray(raw) || raw.length === 0) return null;
+
+            const quote = raw[0]!;
+            const d = new Date(quote.timestamp * 1000);
+            const dateStr = [
+                d.getUTCFullYear(),
+                String(d.getUTCMonth() + 1).padStart(2, '0'),
+                String(d.getUTCDate()).padStart(2, '0'),
+            ].join('-');
+
+            return {
+                time: Math.floor(
+                    new Date(dateStr + 'T00:00:00').getTime() / 1000
+                ),
+                open: quote.open,
+                high: quote.dayHigh,
+                low: quote.dayLow,
+                close: quote.price,
+                volume: quote.volume,
+            };
+        } catch (error) {
+            console.warn(
+                '[FmpProvider] Failed to fetch today quote, using EOD data only:',
+                error
+            );
+            return null;
+        }
     }
 }

--- a/src/infrastructure/market/fmp.ts
+++ b/src/infrastructure/market/fmp.ts
@@ -6,6 +6,7 @@ import type {
 } from './types';
 
 const FMP_BASE_URL = 'https://financialmodelingprep.com/stable';
+const FMP_REVALIDATE_SECONDS = 60;
 
 const FMP_INTRADAY_TIMEFRAME_MAP: Record<Exclude<Timeframe, '1Day'>, string> = {
     '1Min': '1min',
@@ -121,7 +122,8 @@ export class FmpProvider implements MarketDataProvider {
     }
 
     private buildQuoteUrl(symbol: string): string {
-        const params = new URLSearchParams({ apikey: this.apiKey, symbol });
+        const params = new URLSearchParams({ apikey: this.apiKey });
+        params.set('symbol', symbol);
         return `${FMP_BASE_URL}/quote?${params}`;
     }
 
@@ -159,7 +161,7 @@ export class FmpProvider implements MarketDataProvider {
         );
 
         const res = await fetch(url, {
-            next: { revalidate: 60 },
+            next: { revalidate: FMP_REVALIDATE_SECONDS },
         });
 
         if (!res.ok) {
@@ -185,7 +187,7 @@ export class FmpProvider implements MarketDataProvider {
 
         // endDate가 지정된 경우 과거 데이터 조회이므로 당일 quote를 추가하지 않는다.
         const [eodRes, todayBar] = await Promise.all([
-            fetch(eodUrl, { next: { revalidate: 60 } }),
+            fetch(eodUrl, { next: { revalidate: FMP_REVALIDATE_SECONDS } }),
             endDate === undefined
                 ? this.fetchTodayQuoteBar(symbol)
                 : Promise.resolve(null),
@@ -197,7 +199,7 @@ export class FmpProvider implements MarketDataProvider {
             );
         }
 
-        // res.json() returns unknown; asserting shape against FMP API contract
+        // eodRes.json() returns unknown; asserting shape against FMP API contract
         const raw = (await eodRes.json()) as FmpDailyBar[];
 
         if (!Array.isArray(raw)) {
@@ -220,12 +222,22 @@ export class FmpProvider implements MarketDataProvider {
     /**
      * 당일 실시간 quote를 Bar 형태로 반환한다.
      * 실패 시 null을 반환하여 EOD 데이터만으로 graceful degradation한다.
-     * (EOD 조회 실패와 달리 전체 요청을 실패시키지 않는 의도적 비대칭 처리)
+     *
+     * EOD 조회 실패(throw)와 달리 quote 실패는 전체 요청을 실패시키지 않는 의도적 비대칭 처리다.
+     * quote는 당일 봉 보강용 부가 데이터이므로 실패해도 차트 렌더링에 치명적이지 않다.
+     * 반면 EOD 데이터는 차트의 핵심이므로 실패 시 즉시 throw한다.
+     *
+     * 주의: timestamp에서 UTC 날짜를 추출하므로 정규장 시간(9:30 AM – 4:00 PM ET) 내에서만
+     * ET 거래일과 날짜가 일치한다. 애프터마켓(예: 8:00 PM ET = 익일 01:00 UTC)의 경우
+     * UTC 날짜가 ET 거래일보다 하루 앞설 수 있으나, FMP /stable/quote는 정규장 기준
+     * 당일 데이터를 반환하므로 현재 구현 범위에서는 문제없다.
      */
     private async fetchTodayQuoteBar(symbol: string): Promise<Bar | null> {
         const url = this.buildQuoteUrl(symbol);
         try {
-            const res = await fetch(url, { next: { revalidate: 60 } });
+            const res = await fetch(url, {
+                next: { revalidate: FMP_REVALIDATE_SECONDS },
+            });
             if (!res.ok) return null;
 
             // res.json() returns unknown; FMP quote API response shape guaranteed by provider contract
@@ -234,11 +246,7 @@ export class FmpProvider implements MarketDataProvider {
 
             const quote = raw[0]!;
             const d = new Date(quote.timestamp * 1000);
-            const dateStr = [
-                d.getUTCFullYear(),
-                String(d.getUTCMonth() + 1).padStart(2, '0'),
-                String(d.getUTCDate()).padStart(2, '0'),
-            ].join('-');
+            const dateStr = d.toISOString().split('T')[0]!;
 
             return {
                 time: Math.floor(

--- a/src/infrastructure/market/fmp.ts
+++ b/src/infrastructure/market/fmp.ts
@@ -192,7 +192,9 @@ export class FmpProvider implements MarketDataProvider {
         ]);
 
         if (!eodRes.ok) {
-            throw new Error(`FMP API error: ${eodRes.status} ${eodRes.statusText}`);
+            throw new Error(
+                `FMP API error: ${eodRes.status} ${eodRes.statusText}`
+            );
         }
 
         // res.json() returns unknown; asserting shape against FMP API contract


### PR DESCRIPTION
## 관련 이슈

Closes #306
Closes #307

## 구현 내용

### 이슈 설명
- **#306**: FMP daily bar 조회 시 timezone 오류로 인해 잘못된 날짜의 데이터 반환
- **#307**: 당일 실시간 quote 데이터 미제공 (어제 종가 기반)

### 해결 방법

1. **Daily bar 날짜 오류 수정** (src/infrastructure/market/fmp.ts)
   - FMP API는 UTC 기반 데이터 반환
   - 로컬 timezone 기준 자정(T00:00:00) 이후 데이터를 당일로 처리
   - Date 객체 + 'T00:00:00' 형식으로 조회하여 timezone 일관성 확보

2. **당일 실시간 quote 추가**
   - FmpQuote 인터페이스 추가 (symbol, price, changesPercentage, change)
   - fetchTodayQuoteBar() 함수 구현 (최신 quote 데이터 조회)
   - getDailyBars()에서 오늘 데이터 조회 시 quote 병렬 조회

3. **테스트 강화** (src/__tests__/infrastructure/market/fmp.test.ts)
   - 29개 테스트 케이스 (7개 신규 추가)
   - 오늘 quote 동작 검증: 정상 조회, 에러 처리, 데이터 병합

4. **문서 업데이트** (docs/API.md)
   - FMP Quote 엔드포인트 명세 추가

## 변경 파일 목록

[수정]
- src/infrastructure/market/fmp.ts
- src/__tests__/infrastructure/market/fmp.test.ts
- docs/API.md

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] 외부 라이브러리 import 확인
- [x] 반환 타입 명시
- [x] any 타입 없음
- [x] 테스트 구조: describe → describe(context) → it
- [x] 매직 넘버 없음

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build