### PR TITLE
feat: 타임프레임 변경 시 진행 중인 분석 취소

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -130,6 +130,15 @@
 - Rule: FF.md Readability 1-C — Design intent must be exposed in code; default values must align with component usage context or caller must explicitly pass the value
 - Context: ChartContent initializes actionPricesVisible={true}, but StockChart defaulted to false when prop was optional, creating contradiction between declaration and runtime behavior. Fixed by changing StockChart default to true to expose the actual design intent.
 
+## [PR #313 | feat/312/타임프레임-변경-시-분석-작업-취소 | 2026-04-15]
+- Violation: cancelAnalysisJobAction.ts의 fetch 호출에 타임아웃 미설정 — 네트워크 지연 시 Server Action이 무기한 대기 가능
+- Rule: CONVENTIONS.md — fire-and-forget fetch 요청에는 타임아웃을 설정해 클라이언트 흐름이 블로킹되지 않도록 해야 함
+- Context: `/cancel` 엔드포인트 호출에 AbortSignal.timeout(5000) 추가
+
+- Violation: useAnalysis.ts 카운트다운 effect에서 cooldownStartValueRef + Date.now() 기반 수동 계산 사용
+- Rule: Coding Paradigm — 함수형 상태 업데이트(prev => ...)를 사용하면 외부 ref 없이 동일 효과를 더 단순하게 달성할 수 있음
+- Context: setReanalyzeCooldownMs(prev => Math.max(0, prev - 1000))로 단순화; cooldownStartValueRef 제거
+
 ## [Issue #312 | feat/312/타임프레임-변경-시-분석-작업-취소 | 2026-04-15]
 - Violation: worker/src/index.ts — key construction logic and full key list duplicated from queue.ts without documentation
 - Rule: FF.md Cohesion 3-B — shared Redis key schema must be documented when module boundary prevents import

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -130,5 +130,22 @@
 - Rule: FF.md Readability 1-C — Design intent must be exposed in code; default values must align with component usage context or caller must explicitly pass the value
 - Context: ChartContent initializes actionPricesVisible={true}, but StockChart defaulted to false when prop was optional, creating contradiction between declaration and runtime behavior. Fixed by changing StockChart default to true to expose the actual design intent.
 
+## [Issue #312 | feat/312/타임프레임-변경-시-분석-작업-취소 | 2026-04-15]
+- Violation: worker/src/index.ts — key construction logic and full key list duplicated from queue.ts without documentation
+- Rule: FF.md Cohesion 3-B — shared Redis key schema must be documented when module boundary prevents import
+- Context: Worker process cannot import queue.ts directly due to environment constraints; key construction duplicated; added JSDoc documenting the schema origin
+
+- Violation: worker/src/index.ts — JOB_TTL_SECONDS = 3600 hardcoded without comment linking to the shared constant in queue.ts
+- Rule: CONVENTIONS.md — shared constants must be explicitly referenced or extracted to infrastructure/config
+- Context: Queue service defines JOB_TTL_SECONDS = 3600; hardcoded in worker without link to source; added comment documenting sync requirement
+
+- Violation: useAnalysis.ts — eslint-disable-next-line react-hooks/exhaustive-deps used to suppress deps warning
+- Rule: CONVENTIONS.md react-hooks/exhaustive-deps — must restructure to fix the actual issue, not suppress the lint rule
+- Context: Mutation deps warning caused by unstable callback; fixed by restructuring with isCountdownActive boolean and cooldownStartValueRef to break the closure chain
+
+- Violation: cancelAnalysisJobAction.ts — Server Action passthrough with no error handling
+- Rule: CONVENTIONS.md — fire-and-forget actions should swallow errors and log a warning instead of throwing to caller
+- Context: Action called without try-catch; caller receives uncaught error; added try-catch to swallow and log, matching notification-action pattern
+
 
 

--- a/src/__tests__/infrastructure/jobs/queue.test.ts
+++ b/src/__tests__/infrastructure/jobs/queue.test.ts
@@ -6,6 +6,8 @@ import {
     getJobResult,
     getJobError,
     getJobMeta,
+    cancelJob,
+    isJobCancelled,
     cleanupJob,
 } from '@/infrastructure/jobs/queue';
 import { createJobRedis } from '@/infrastructure/jobs/redis';
@@ -65,6 +67,16 @@ describe('jobs/queue 모듈은', () => {
         it('getJobMeta는 null을 반환한다', async () => {
             const result = await getJobMeta('job-1');
             expect(result).toBeNull();
+        });
+
+        it('cancelJob은 아무 작업도 하지 않는다', async () => {
+            await cancelJob('job-1');
+            expect(mockSet).not.toHaveBeenCalled();
+        });
+
+        it('isJobCancelled는 false를 반환한다', async () => {
+            const result = await isJobCancelled('job-1');
+            expect(result).toBe(false);
         });
 
         it('cleanupJob은 아무 작업도 하지 않는다', async () => {
@@ -142,8 +154,35 @@ describe('jobs/queue 모듈은', () => {
             expect(result).toBeNull();
         });
 
-        it('cleanupJob은 4개의 키를 모두 삭제한다', async () => {
-            mockDel.mockResolvedValueOnce(4);
+        it('cancelJob은 cancelled 키를 TTL과 함께 저장한다', async () => {
+            mockSet.mockResolvedValueOnce('OK');
+
+            await cancelJob('job-9');
+
+            expect(mockSet).toHaveBeenCalledWith('job:job-9:cancelled', '1', {
+                ex: 3600,
+            });
+        });
+
+        it('isJobCancelled는 cancelled 키가 "1"이면 true를 반환한다', async () => {
+            mockGet.mockResolvedValueOnce('1');
+
+            const result = await isJobCancelled('job-10');
+
+            expect(mockGet).toHaveBeenCalledWith('job:job-10:cancelled');
+            expect(result).toBe(true);
+        });
+
+        it('isJobCancelled는 cancelled 키가 없으면 false를 반환한다', async () => {
+            mockGet.mockResolvedValueOnce(null);
+
+            const result = await isJobCancelled('job-11');
+
+            expect(result).toBe(false);
+        });
+
+        it('cleanupJob은 5개의 키를 모두 삭제한다', async () => {
+            mockDel.mockResolvedValueOnce(5);
 
             await cleanupJob('job-8');
 
@@ -151,7 +190,8 @@ describe('jobs/queue 모듈은', () => {
                 'job:job-8:status',
                 'job:job-8:result',
                 'job:job-8:error',
-                'job:job-8:meta'
+                'job:job-8:meta',
+                'job:job-8:cancelled'
             );
         });
     });

--- a/src/__tests__/infrastructure/market/cancelAnalysisJobAction.test.ts
+++ b/src/__tests__/infrastructure/market/cancelAnalysisJobAction.test.ts
@@ -81,6 +81,7 @@ describe('cancelAnalysisJobAction', () => {
                         'X-Worker-Secret': 'test-secret',
                     }),
                     body: JSON.stringify({ jobId: 'job-xyz' }),
+                    signal: expect.any(AbortSignal),
                 })
             );
         });

--- a/src/__tests__/infrastructure/market/cancelAnalysisJobAction.test.ts
+++ b/src/__tests__/infrastructure/market/cancelAnalysisJobAction.test.ts
@@ -1,0 +1,43 @@
+jest.mock('@/infrastructure/jobs/queue');
+
+import { cancelAnalysisJobAction } from '@/infrastructure/market/cancelAnalysisJobAction';
+import { cancelJob } from '@/infrastructure/jobs/queue';
+
+const mockCancelJob = cancelJob as jest.MockedFunction<typeof cancelJob>;
+
+describe('cancelAnalysisJobAction', () => {
+    beforeEach(() => {
+        mockCancelJob.mockReset();
+        jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('cancelJob에 jobId를 전달한다', async () => {
+        mockCancelJob.mockResolvedValueOnce(undefined);
+
+        await cancelAnalysisJobAction('job-abc');
+
+        expect(mockCancelJob).toHaveBeenCalledWith('job-abc');
+    });
+
+    it('cancelJob이 실패해도 에러를 전파하지 않는다 (fire-and-forget)', async () => {
+        mockCancelJob.mockRejectedValueOnce(new Error('Redis error'));
+
+        await expect(cancelAnalysisJobAction('job-fail')).resolves.toBeUndefined();
+    });
+
+    it('cancelJob이 실패하면 경고 로그를 남긴다', async () => {
+        mockCancelJob.mockRejectedValueOnce(new Error('Redis error'));
+
+        await cancelAnalysisJobAction('job-fail');
+
+        expect(console.warn).toHaveBeenCalledWith(
+            '[cancelAnalysisJobAction] Failed to signal cancellation:',
+            'job-fail',
+            expect.any(Error)
+        );
+    });
+});

--- a/src/__tests__/infrastructure/market/cancelAnalysisJobAction.test.ts
+++ b/src/__tests__/infrastructure/market/cancelAnalysisJobAction.test.ts
@@ -5,7 +5,10 @@ import { cancelJob } from '@/infrastructure/jobs/queue';
 
 const mockCancelJob = cancelJob as jest.MockedFunction<typeof cancelJob>;
 
-const mockFetch = jest.fn<Promise<Response>, [RequestInfo | URL, RequestInit?]>();
+const mockFetch = jest.fn<
+    Promise<Response>,
+    [RequestInfo | URL, RequestInit?]
+>();
 
 describe('cancelAnalysisJobAction', () => {
     const originalFetch = global.fetch;
@@ -57,7 +60,9 @@ describe('cancelAnalysisJobAction', () => {
             process.env.WORKER_URL = 'https://worker.test';
             process.env.WORKER_SECRET = 'test-secret';
             mockCancelJob.mockResolvedValue(undefined);
-            mockFetch.mockResolvedValue(new Response(JSON.stringify({ status: 'ok' })));
+            mockFetch.mockResolvedValue(
+                new Response(JSON.stringify({ status: 'ok' }))
+            );
         });
 
         afterEach(() => {

--- a/src/__tests__/infrastructure/market/cancelAnalysisJobAction.test.ts
+++ b/src/__tests__/infrastructure/market/cancelAnalysisJobAction.test.ts
@@ -5,13 +5,22 @@ import { cancelJob } from '@/infrastructure/jobs/queue';
 
 const mockCancelJob = cancelJob as jest.MockedFunction<typeof cancelJob>;
 
+const mockFetch = jest.fn<Promise<Response>, [RequestInfo | URL, RequestInit?]>();
+
 describe('cancelAnalysisJobAction', () => {
+    const originalFetch = global.fetch;
+
     beforeEach(() => {
         mockCancelJob.mockReset();
+        mockFetch.mockReset();
+        global.fetch = mockFetch;
         jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     });
 
     afterEach(() => {
+        global.fetch = originalFetch;
+        delete process.env.WORKER_URL;
+        delete process.env.WORKER_SECRET;
         jest.restoreAllMocks();
     });
 
@@ -26,7 +35,9 @@ describe('cancelAnalysisJobAction', () => {
     it('cancelJob이 실패해도 에러를 전파하지 않는다 (fire-and-forget)', async () => {
         mockCancelJob.mockRejectedValueOnce(new Error('Redis error'));
 
-        await expect(cancelAnalysisJobAction('job-fail')).resolves.toBeUndefined();
+        await expect(
+            cancelAnalysisJobAction('job-fail')
+        ).resolves.toBeUndefined();
     });
 
     it('cancelJob이 실패하면 경고 로그를 남긴다', async () => {
@@ -39,5 +50,84 @@ describe('cancelAnalysisJobAction', () => {
             'job-fail',
             expect.any(Error)
         );
+    });
+
+    describe('WORKER_URL/WORKER_SECRET 설정 시', () => {
+        beforeEach(() => {
+            process.env.WORKER_URL = 'https://worker.test';
+            process.env.WORKER_SECRET = 'test-secret';
+            mockCancelJob.mockResolvedValue(undefined);
+            mockFetch.mockResolvedValue(new Response(JSON.stringify({ status: 'ok' })));
+        });
+
+        afterEach(() => {
+            delete process.env.WORKER_URL;
+            delete process.env.WORKER_SECRET;
+        });
+
+        it('워커 /cancel 엔드포인트에 POST 요청을 보낸다', async () => {
+            await cancelAnalysisJobAction('job-xyz');
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                'https://worker.test/cancel',
+                expect.objectContaining({
+                    method: 'POST',
+                    headers: expect.objectContaining({
+                        'X-Worker-Secret': 'test-secret',
+                    }),
+                    body: JSON.stringify({ jobId: 'job-xyz' }),
+                })
+            );
+        });
+
+        it('fetch 실패해도 에러를 전파하지 않는다', async () => {
+            mockFetch.mockRejectedValueOnce(new Error('network error'));
+
+            await expect(
+                cancelAnalysisJobAction('job-net-fail')
+            ).resolves.toBeUndefined();
+        });
+
+        it('fetch 실패 시 경고 로그를 남긴다', async () => {
+            mockFetch.mockRejectedValueOnce(new Error('network error'));
+
+            await cancelAnalysisJobAction('job-net-fail');
+
+            expect(console.warn).toHaveBeenCalledWith(
+                '[cancelAnalysisJobAction] Failed to signal cancellation:',
+                'job-net-fail',
+                expect.any(Error)
+            );
+        });
+    });
+
+    describe('WORKER_URL/WORKER_SECRET 미설정 시', () => {
+        it('fetch를 호출하지 않는다', async () => {
+            mockCancelJob.mockResolvedValueOnce(undefined);
+
+            await cancelAnalysisJobAction('job-no-worker');
+
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it('WORKER_URL만 설정된 경우 fetch를 호출하지 않는다', async () => {
+            process.env.WORKER_URL = 'https://worker.test';
+            mockCancelJob.mockResolvedValueOnce(undefined);
+
+            await cancelAnalysisJobAction('job-partial');
+
+            expect(mockFetch).not.toHaveBeenCalled();
+            delete process.env.WORKER_URL;
+        });
+
+        it('WORKER_SECRET만 설정된 경우 fetch를 호출하지 않는다', async () => {
+            process.env.WORKER_SECRET = 'test-secret';
+            mockCancelJob.mockResolvedValueOnce(undefined);
+
+            await cancelAnalysisJobAction('job-partial');
+
+            expect(mockFetch).not.toHaveBeenCalled();
+            delete process.env.WORKER_SECRET;
+        });
     });
 });

--- a/src/components/symbol-page/hooks/useAnalysis.ts
+++ b/src/components/symbol-page/hooks/useAnalysis.ts
@@ -112,9 +112,6 @@ export function useAnalysis({
     const initialAnalysisFailedRef = useRef(initialAnalysisFailed);
     // polling 완료 시 force 경로 쿨다운 처리를 위해 마지막 요청의 force 여부를 추적
     const lastForceRef = useRef(false);
-    // 쿨다운 카운트다운 시작 시점의 초기 값. isCountdownActive가 true로 전환될 때 캡처한다.
-    const cooldownStartValueRef = useRef(0);
-
     // 3. useMutation
     const {
         data: submitData,
@@ -302,20 +299,13 @@ export function useAnalysis({
     // isCountdownActive(0 → 양수 전환)가 true가 될 때만 인터벌을 시작해 중복 시작을 방지한다.
     useEffect(() => {
         if (!isCountdownActive) return;
-        cooldownStartValueRef.current = reanalyzeCooldownMs;
-        const startedAt = Date.now();
         const intervalId = window.setInterval(() => {
-            const remaining = Math.max(
-                0,
-                cooldownStartValueRef.current - (Date.now() - startedAt)
-            );
-            setReanalyzeCooldownMs(remaining);
-            if (remaining <= 0) window.clearInterval(intervalId);
+            setReanalyzeCooldownMs(prev => Math.max(0, prev - 1000));
         }, 1000);
         return () => {
             window.clearInterval(intervalId);
         };
-    }, [isCountdownActive]); // eslint: setReanalyzeCooldownMs is a stable setter; cooldownStartValueRef is a ref
+    }, [isCountdownActive]);
 
     // 마운트 시점 및 심볼/타임프레임 변경 시 서버에서 쿨다운 진실값을 동기화한다.
     useEffect(() => {

--- a/src/components/symbol-page/hooks/useAnalysis.ts
+++ b/src/components/symbol-page/hooks/useAnalysis.ts
@@ -19,6 +19,7 @@ import type {
 import { MS_PER_MINUTE } from '@/domain/constants/time';
 import { submitAnalysisAction } from '@/infrastructure/market/submitAnalysisAction';
 import { pollAnalysisAction } from '@/infrastructure/market/pollAnalysisAction';
+import { cancelAnalysisJobAction } from '@/infrastructure/market/cancelAnalysisJobAction';
 import {
     tryAcquireReanalyzeCooldown,
     releaseReanalyzeCooldown,
@@ -104,11 +105,15 @@ export function useAnalysis({
     const latestRef = useRef<AnalyzeVariables>({ symbol, bars, indicators });
     const latestTimeframeRef = useRef<Timeframe>(timeframe);
     const prevTimeframeChangeCountRef = useRef(0);
+    // 현재 진행 중인 워커 job ID. 타임프레임 변경 시 취소 신호 전달에 사용.
+    const currentJobIdRef = useRef<string | null>(null);
     // 초기 마운트 시 서버 분석 실패 여부를 캡처한다.
     // 이후 렌더링에서 이 값이 변경되더라도 마운트 시 한 번만 사용된다.
     const initialAnalysisFailedRef = useRef(initialAnalysisFailed);
     // polling 완료 시 force 경로 쿨다운 처리를 위해 마지막 요청의 force 여부를 추적
     const lastForceRef = useRef(false);
+    // 쿨다운 카운트다운 시작 시점의 초기 값. isCountdownActive가 true로 전환될 때 캡처한다.
+    const cooldownStartValueRef = useRef(0);
 
     // 3. useMutation
     const {
@@ -127,12 +132,14 @@ export function useAnalysis({
         },
         onSuccess: (data, variables) => {
             if (data.status === 'cached') {
+                currentJobIdRef.current = null;
                 setAnalysisResult(data.result);
                 // 캐시 히트 = 분석 완료 → force 경로만 쿨다운 시작
                 if (variables.force) {
                     setReanalyzeCooldownMs(REANALYZE_COOLDOWN_MS);
                 }
             } else if (data.status === 'submitted') {
+                currentJobIdRef.current = data.jobId;
                 setIsPolling(true);
                 // submitted 단계에서는 쿨다운을 시작하지 않는다.
                 // polling 완료(done) 시에만 쿨다운을 시작한다.
@@ -152,6 +159,8 @@ export function useAnalysis({
     const analysis = analysisResult ?? initialAnalysis;
     const isAnalyzing = isSubmitting || isPolling;
     const analysisError = submitError?.message ?? pollError ?? null;
+    // 쿨다운 카운트다운이 활성화된 상태. effect deps에 사용해 불필요한 재시작을 방지한다.
+    const isCountdownActive = reanalyzeCooldownMs > 0;
 
     // 5. Handlers
     // latestRef 패턴을 사용하므로 symbol·bars·indicators를 deps에서 제외하고 안정적인 함수 참조를 유지한다.
@@ -211,6 +220,7 @@ export function useAnalysis({
                     if (cancelled) break;
 
                     if (result.status === 'done') {
+                        currentJobIdRef.current = null;
                         setAnalysisResult(result.result);
                         if (lastForceRef.current) {
                             setReanalyzeCooldownMs(REANALYZE_COOLDOWN_MS);
@@ -219,6 +229,7 @@ export function useAnalysis({
                         return;
                     }
                     if (result.status === 'error') {
+                        currentJobIdRef.current = null;
                         // worker/src/retry.ts AI_SERVER_UNSTABLE_CODE 센티넬과 동기화 필요
                         const errorMessage =
                             result.error === 'AI_SERVER_UNSTABLE'
@@ -238,6 +249,7 @@ export function useAnalysis({
                     // 'processing' → 다음 poll 계속
                 } catch {
                     if (cancelled) break;
+                    currentJobIdRef.current = null;
                     setPollError('분석 결과 조회에 실패했습니다.');
                     if (lastForceRef.current) {
                         void releaseReanalyzeCooldown(
@@ -265,12 +277,20 @@ export function useAnalysis({
         mutate({ ...latestRef.current, force: false });
     }, [mutate]);
 
-    // 타임프레임 변경 시 이전 mutation 상태를 초기화하고 새 분석을 자동 실행한다.
+    // 타임프레임 변경 시 진행 중인 워커 작업을 취소하고, 이전 mutation 상태를 초기화한 뒤 새 분석을 자동 실행한다.
     useEffect(() => {
         if (timeframeChangeCount === prevTimeframeChangeCountRef.current) {
             return;
         }
         prevTimeframeChangeCountRef.current = timeframeChangeCount;
+
+        // 진행 중인 워커 작업에 취소 신호를 보낸다. reset() 호출 이전에 jobId를 캡처해야 한다.
+        const jobId = currentJobIdRef.current;
+        if (jobId) {
+            void cancelAnalysisJobAction(jobId);
+            currentJobIdRef.current = null;
+        }
+
         reset();
         setPollError(null);
         setAnalysisResult(null);
@@ -279,14 +299,15 @@ export function useAnalysis({
     }, [timeframeChangeCount, reset, mutate]);
 
     // 쿨다운이 활성화된 동안 1초마다 로컬에서 카운트다운한다.
+    // isCountdownActive(0 → 양수 전환)가 true가 될 때만 인터벌을 시작해 중복 시작을 방지한다.
     useEffect(() => {
-        if (reanalyzeCooldownMs <= 0) return;
+        if (!isCountdownActive) return;
+        cooldownStartValueRef.current = reanalyzeCooldownMs;
         const startedAt = Date.now();
-        const startValue = reanalyzeCooldownMs;
         const intervalId = window.setInterval(() => {
             const remaining = Math.max(
                 0,
-                startValue - (Date.now() - startedAt)
+                cooldownStartValueRef.current - (Date.now() - startedAt)
             );
             setReanalyzeCooldownMs(remaining);
             if (remaining <= 0) window.clearInterval(intervalId);
@@ -294,8 +315,7 @@ export function useAnalysis({
         return () => {
             window.clearInterval(intervalId);
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [reanalyzeCooldownMs === 0]);
+    }, [isCountdownActive]); // eslint: setReanalyzeCooldownMs is a stable setter; cooldownStartValueRef is a ref
 
     // 마운트 시점 및 심볼/타임프레임 변경 시 서버에서 쿨다운 진실값을 동기화한다.
     useEffect(() => {

--- a/src/infrastructure/jobs/queue.ts
+++ b/src/infrastructure/jobs/queue.ts
@@ -23,6 +23,10 @@ function metaKey(jobId: string): string {
     return `job:${jobId}:meta`;
 }
 
+function cancelledKey(jobId: string): string {
+    return `job:${jobId}:cancelled`;
+}
+
 // Upstash REST client는 값을 자동으로 직렬화/역직렬화한다.
 // set(key, object) → JSON 문자열로 저장, get(key) → 파싱된 객체로 반환.
 // 따라서 JSON.stringify/JSON.parse를 수동으로 호출하지 않는다.
@@ -59,6 +63,19 @@ export async function getJobMeta(jobId: string): Promise<JobMeta | null> {
     return redis.get<JobMeta>(metaKey(jobId));
 }
 
+export async function cancelJob(jobId: string): Promise<void> {
+    const redis = createJobRedis();
+    if (!redis) return;
+    await redis.set(cancelledKey(jobId), '1', { ex: JOB_TTL_SECONDS });
+}
+
+export async function isJobCancelled(jobId: string): Promise<boolean> {
+    const redis = createJobRedis();
+    if (!redis) return false;
+    const val = await redis.get<string>(cancelledKey(jobId));
+    return val === '1';
+}
+
 export async function cleanupJob(jobId: string): Promise<void> {
     const redis = createJobRedis();
     if (!redis) return;
@@ -66,6 +83,7 @@ export async function cleanupJob(jobId: string): Promise<void> {
         statusKey(jobId),
         resultKey(jobId),
         errorKey(jobId),
-        metaKey(jobId)
+        metaKey(jobId),
+        cancelledKey(jobId)
     );
 }

--- a/src/infrastructure/market/cancelAnalysisJobAction.ts
+++ b/src/infrastructure/market/cancelAnalysisJobAction.ts
@@ -3,11 +3,35 @@
 import { cancelJob } from '@/infrastructure/jobs/queue';
 
 export async function cancelAnalysisJobAction(jobId: string): Promise<void> {
-    try {
-        await cancelJob(jobId);
-    } catch (error) {
-        // 취소는 fire-and-forget — Redis 장애 시 클라이언트 흐름을 막지 않는다.
-        // 워커 작업은 TTL 만료 후 자연 정리된다.
-        console.warn('[cancelAnalysisJobAction] Failed to signal cancellation:', jobId, error);
+    const workerUrl = process.env.WORKER_URL;
+    const workerSecret = process.env.WORKER_SECRET;
+
+    const tasks: Promise<unknown>[] = [cancelJob(jobId)];
+
+    // 워커가 설정된 경우 /cancel 엔드포인트에도 신호를 보내 진행 중인 AI 호출을 즉시 중단한다.
+    if (workerUrl && workerSecret) {
+        tasks.push(
+            fetch(`${workerUrl}/cancel`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Worker-Secret': workerSecret,
+                },
+                body: JSON.stringify({ jobId }),
+            })
+        );
+    }
+
+    // 취소는 fire-and-forget — Redis 장애나 워커 에러 시 클라이언트 흐름을 막지 않는다.
+    // 워커 작업은 TTL 만료 후 자연 정리된다.
+    const results = await Promise.allSettled(tasks);
+    for (const result of results) {
+        if (result.status === 'rejected') {
+            console.warn(
+                '[cancelAnalysisJobAction] Failed to signal cancellation:',
+                jobId,
+                result.reason
+            );
+        }
     }
 }

--- a/src/infrastructure/market/cancelAnalysisJobAction.ts
+++ b/src/infrastructure/market/cancelAnalysisJobAction.ts
@@ -1,0 +1,13 @@
+'use server';
+
+import { cancelJob } from '@/infrastructure/jobs/queue';
+
+export async function cancelAnalysisJobAction(jobId: string): Promise<void> {
+    try {
+        await cancelJob(jobId);
+    } catch (error) {
+        // 취소는 fire-and-forget — Redis 장애 시 클라이언트 흐름을 막지 않는다.
+        // 워커 작업은 TTL 만료 후 자연 정리된다.
+        console.warn('[cancelAnalysisJobAction] Failed to signal cancellation:', jobId, error);
+    }
+}

--- a/src/infrastructure/market/cancelAnalysisJobAction.ts
+++ b/src/infrastructure/market/cancelAnalysisJobAction.ts
@@ -9,6 +9,7 @@ export async function cancelAnalysisJobAction(jobId: string): Promise<void> {
     const tasks: Promise<unknown>[] = [cancelJob(jobId)];
 
     // 워커가 설정된 경우 /cancel 엔드포인트에도 신호를 보내 진행 중인 AI 호출을 즉시 중단한다.
+    // AbortSignal.timeout으로 5초 제한 — 취소 요청이 클라이언트 흐름을 오래 잡지 않도록 한다.
     if (workerUrl && workerSecret) {
         tasks.push(
             fetch(`${workerUrl}/cancel`, {
@@ -18,20 +19,21 @@ export async function cancelAnalysisJobAction(jobId: string): Promise<void> {
                     'X-Worker-Secret': workerSecret,
                 },
                 body: JSON.stringify({ jobId }),
+                signal: AbortSignal.timeout(5000),
             })
         );
     }
 
     // 취소는 fire-and-forget — Redis 장애나 워커 에러 시 클라이언트 흐름을 막지 않는다.
-    // 워커 작업은 TTL 만료 후 자연 정리된다.
+    // HTTP 4xx/5xx도 무시한다 — 워커 작업은 TTL 만료 후 자연 정리된다.
     const results = await Promise.allSettled(tasks);
-    for (const result of results) {
-        if (result.status === 'rejected') {
+    results
+        .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+        .forEach(r =>
             console.warn(
                 '[cancelAnalysisJobAction] Failed to signal cancellation:',
                 jobId,
-                result.reason
-            );
-        }
-    }
+                r.reason
+            )
+        );
 }

--- a/worker/src/claude.ts
+++ b/worker/src/claude.ts
@@ -4,16 +4,22 @@ import { AI_SYSTEM_PROMPT } from './ai-system-prompt.js';
 
 const client = new Anthropic({ apiKey: config.claude.apiKey });
 
-export async function callClaude(prompt: string): Promise<string> {
+export async function callClaude(
+    prompt: string,
+    signal?: AbortSignal
+): Promise<string> {
     const start = Date.now();
-    const message = await client.messages.create({
-        model: config.claude.model,
-        max_tokens: config.claude.maxTokens,
-        temperature: 0,
-        top_p: 0.95,
-        system: AI_SYSTEM_PROMPT,
-        messages: [{ role: 'user', content: prompt }],
-    });
+    const message = await client.messages.create(
+        {
+            model: config.claude.model,
+            max_tokens: config.claude.maxTokens,
+            temperature: 0,
+            top_p: 0.95,
+            system: AI_SYSTEM_PROMPT,
+            messages: [{ role: 'user', content: prompt }],
+        },
+        { signal }
+    );
 
     const elapsed = Date.now() - start;
     console.log(`[Claude] Response time: ${elapsed}ms`);

--- a/worker/src/gemini.ts
+++ b/worker/src/gemini.ts
@@ -26,6 +26,7 @@ export interface GeminiCallOptions {
     thinking?: boolean;
     apiKey?: string;
     thinkingBudget?: number;
+    signal?: AbortSignal;
 }
 
 export async function callGemini(
@@ -37,6 +38,10 @@ export async function callGemini(
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), GEMINI_TIMEOUT_MS);
+    // 외부 취소 신호를 타임아웃 컨트롤러에 전파 — abort 시 Gemini HTTP 요청을 즉시 중단한다.
+    // propagateAbort는 finally에서 제거해 신호가 발생하지 않은 경우의 리스너 누수를 방지한다.
+    const propagateAbort = () => controller.abort();
+    options.signal?.addEventListener('abort', propagateAbort, { once: true });
 
     const start = Date.now();
     try {
@@ -119,5 +124,6 @@ export async function callGemini(
         return text;
     } finally {
         clearTimeout(timeoutId);
+        options.signal?.removeEventListener('abort', propagateAbort);
     }
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,5 +1,5 @@
 import { constants } from 'node:http2';
-import express from 'express';
+import express, { type Request, type Response } from 'express';
 import { Redis } from '@upstash/redis';
 import { config } from './config.js';
 import { callGemini, MAX_TOKENS_CODE } from './gemini.js';
@@ -17,6 +17,9 @@ const JOB_TTL_SECONDS = 3600;
 const AI_RETRY_MAX_ATTEMPTS = 5;
 const AI_RETRY_MAX_ATTEMPTS_FREE = 3;
 const AI_RETRY_DELAY_MS = 5000;
+
+// 진행 중인 job의 AbortController를 보관 — /cancel 엔드포인트 수신 시 즉시 abort 가능
+const activeJobs = new Map<string, AbortController>();
 
 function isMaxTokensError(error: unknown): boolean {
     return (
@@ -50,7 +53,8 @@ function getThinkingBudgetSequence(initial: number): number[] {
  */
 async function callGeminiReducingBudget(
     prompt: string,
-    apiKey: string
+    apiKey: string,
+    signal?: AbortSignal
 ): Promise<string> {
     const budgets = getThinkingBudgetSequence(config.gemini.thinkingBudget);
 
@@ -61,6 +65,7 @@ async function callGeminiReducingBudget(
                 model: config.gemini.model,
                 thinking: budget > 0,
                 thinkingBudget: budget,
+                signal,
             });
         } catch (error) {
             if (isMaxTokensError(error)) {
@@ -91,9 +96,10 @@ async function callGeminiReducingBudget(
 async function callGeminiWithFallback(
     prompt: string,
     apiKey: string,
-    maxAttempts: number = AI_RETRY_MAX_ATTEMPTS
+    maxAttempts: number = AI_RETRY_MAX_ATTEMPTS,
+    signal?: AbortSignal
 ): Promise<string> {
-    return withRetry(() => callGeminiReducingBudget(prompt, apiKey), {
+    return withRetry(() => callGeminiReducingBudget(prompt, apiKey, signal), {
         maxAttempts,
         baseDelayMs: AI_RETRY_DELAY_MS,
     });
@@ -106,9 +112,9 @@ async function callGeminiWithFallback(
     // }
 }
 
-async function callAI(prompt: string): Promise<string> {
+async function callAI(prompt: string, signal?: AbortSignal): Promise<string> {
     if (config.aiProvider === 'claude') {
-        return callClaude(prompt);
+        return callClaude(prompt, signal);
     }
 
     const { freeApiKey, apiKey } = config.gemini;
@@ -118,7 +124,8 @@ async function callAI(prompt: string): Promise<string> {
             return await callGeminiWithFallback(
                 prompt,
                 freeApiKey,
-                AI_RETRY_MAX_ATTEMPTS_FREE
+                AI_RETRY_MAX_ATTEMPTS_FREE,
+                signal
             );
         } catch {
             console.warn(
@@ -127,7 +134,7 @@ async function callAI(prompt: string): Promise<string> {
         }
     }
 
-    return callGeminiWithFallback(prompt, apiKey);
+    return callGeminiWithFallback(prompt, apiKey, AI_RETRY_MAX_ATTEMPTS, signal);
 }
 
 const app = express();
@@ -143,11 +150,37 @@ interface AnalyzeRequest {
     prompt: string;
 }
 
-app.get('/health', (_req, res) => {
+app.get('/health', (_req: Request, res: Response) => {
     res.json({ status: 'ok' });
 });
 
-app.post('/analyze', (req, res) => {
+app.post('/cancel', (req: Request, res: Response) => {
+    if (req.headers['x-worker-secret'] !== config.workerSecret) {
+        res.status(HTTP_STATUS_UNAUTHORIZED).json({ error: 'Unauthorized' });
+        return;
+    }
+
+    // express req.body는 any 타입; 실제 필드는 아래 if문에서 검증
+    const { jobId } = req.body as { jobId?: string };
+    if (!jobId) {
+        res.status(HTTP_STATUS_BAD_REQUEST).json({ error: 'jobId is required' });
+        return;
+    }
+
+    const controller = activeJobs.get(jobId);
+    if (controller && !controller.signal.aborted) {
+        controller.abort();
+        console.log(`[Worker] Job ${jobId} aborted via /cancel`);
+    } else {
+        console.log(
+            `[Worker] Job ${jobId} not found or already aborted (completed or different instance)`
+        );
+    }
+
+    res.json({ status: 'ok', jobId });
+});
+
+app.post('/analyze', (req: Request, res: Response) => {
     if (req.headers['x-worker-secret'] !== config.workerSecret) {
         res.status(HTTP_STATUS_UNAUTHORIZED).json({ error: 'Unauthorized' });
         return;
@@ -167,9 +200,12 @@ app.post('/analyze', (req, res) => {
         `[Worker] Job received: ${jobId} (prompt: ${(prompt.length / 1024).toFixed(1)}KB)`
     );
 
+    const controller = new AbortController();
+    activeJobs.set(jobId, controller);
+
     // Cloud Run은 요청 처리 중에만 CPU를 할당하므로,
-    // 응답을 보내지 않고 Gemini 완료까지 요청을 열어둔다.
-    void processJob(jobId, prompt)
+    // 응답을 보내지 않고 AI 완료까지 요청을 열어둔다.
+    void processJob(jobId, prompt, controller)
         .then(() => {
             res.json({ status: 'done', jobId });
         })
@@ -179,6 +215,9 @@ app.post('/analyze', (req, res) => {
                 status: 'error',
                 jobId,
             });
+        })
+        .finally(() => {
+            activeJobs.delete(jobId);
         });
 });
 
@@ -199,9 +238,13 @@ async function cleanupCancelledJob(jobId: string): Promise<void> {
     );
 }
 
-async function processJob(jobId: string, prompt: string): Promise<void> {
+async function processJob(
+    jobId: string,
+    prompt: string,
+    controller: AbortController
+): Promise<void> {
     // AI 호출 전 취소 여부 확인 (제출과 처리 사이에 취소됐을 수 있음)
-    if (await isCancelled(jobId)) {
+    if (controller.signal.aborted || (await isCancelled(jobId))) {
         console.log(`[Worker] Job ${jobId} cancelled before processing`);
         await cleanupCancelledJob(jobId);
         return;
@@ -212,14 +255,14 @@ async function processJob(jobId: string, prompt: string): Promise<void> {
     });
 
     try {
-        const result = await callAI(prompt);
+        const result = await callAI(prompt, controller.signal);
 
         if (!result || result.trim() === '') {
             throw new Error('AI returned an empty response');
         }
 
         // AI 완료 후 취소 여부 재확인 — 처리 중 타임프레임이 변경됐을 수 있음
-        if (await isCancelled(jobId)) {
+        if (controller.signal.aborted || (await isCancelled(jobId))) {
             console.log(`[Worker] Job ${jobId} cancelled after AI completion`);
             await cleanupCancelledJob(jobId);
             return;
@@ -236,6 +279,13 @@ async function processJob(jobId: string, prompt: string): Promise<void> {
 
         console.log(`[Worker] Job ${jobId} completed`);
     } catch (error) {
+        // AbortError는 취소 요청에 의한 것 — error로 기록하지 않고 cleanup한다.
+        if (controller.signal.aborted) {
+            console.log(`[Worker] Job ${jobId} aborted during AI call`);
+            await cleanupCancelledJob(jobId);
+            return;
+        }
+
         const message =
             error instanceof Error ? error.message : 'Unknown error';
         console.error(`[Worker] Job ${jobId} failed:`, message);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -12,6 +12,7 @@ const {
     HTTP_STATUS_INTERNAL_SERVER_ERROR,
 } = constants;
 
+// Must match JOB_TTL_SECONDS in src/infrastructure/jobs/queue.ts (cannot import across module boundary).
 const JOB_TTL_SECONDS = 3600;
 const AI_RETRY_MAX_ATTEMPTS = 5;
 const AI_RETRY_MAX_ATTEMPTS_FREE = 3;
@@ -181,7 +182,31 @@ app.post('/analyze', (req, res) => {
         });
 });
 
+// Key helpers mirror src/infrastructure/jobs/queue.ts (cannot import across module boundary).
+// When adding or renaming keys in queue.ts, update cleanupCancelledJob() here in sync.
+async function isCancelled(jobId: string): Promise<boolean> {
+    const val = await redis.get<string>(`job:${jobId}:cancelled`);
+    return val === '1';
+}
+
+async function cleanupCancelledJob(jobId: string): Promise<void> {
+    await redis.del(
+        `job:${jobId}:status`,
+        `job:${jobId}:result`,
+        `job:${jobId}:error`,
+        `job:${jobId}:meta`,
+        `job:${jobId}:cancelled`
+    );
+}
+
 async function processJob(jobId: string, prompt: string): Promise<void> {
+    // AI 호출 전 취소 여부 확인 (제출과 처리 사이에 취소됐을 수 있음)
+    if (await isCancelled(jobId)) {
+        console.log(`[Worker] Job ${jobId} cancelled before processing`);
+        await cleanupCancelledJob(jobId);
+        return;
+    }
+
     await redis.set(`job:${jobId}:status`, 'processing', {
         ex: JOB_TTL_SECONDS,
     });
@@ -191,6 +216,13 @@ async function processJob(jobId: string, prompt: string): Promise<void> {
 
         if (!result || result.trim() === '') {
             throw new Error('AI returned an empty response');
+        }
+
+        // AI 완료 후 취소 여부 재확인 — 처리 중 타임프레임이 변경됐을 수 있음
+        if (await isCancelled(jobId)) {
+            console.log(`[Worker] Job ${jobId} cancelled after AI completion`);
+            await cleanupCancelledJob(jobId);
+            return;
         }
 
         // result를 먼저 저장한 후 status를 업데이트한다.

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -134,7 +134,12 @@ async function callAI(prompt: string, signal?: AbortSignal): Promise<string> {
         }
     }
 
-    return callGeminiWithFallback(prompt, apiKey, AI_RETRY_MAX_ATTEMPTS, signal);
+    return callGeminiWithFallback(
+        prompt,
+        apiKey,
+        AI_RETRY_MAX_ATTEMPTS,
+        signal
+    );
 }
 
 const app = express();
@@ -163,7 +168,9 @@ app.post('/cancel', (req: Request, res: Response) => {
     // express req.body는 any 타입; 실제 필드는 아래 if문에서 검증
     const { jobId } = req.body as { jobId?: string };
     if (!jobId) {
-        res.status(HTTP_STATUS_BAD_REQUEST).json({ error: 'jobId is required' });
+        res.status(HTTP_STATUS_BAD_REQUEST).json({
+            error: 'jobId is required',
+        });
         return;
     }
 


### PR DESCRIPTION
## 관련 이슈

closes #312

## 구현 내용

AbortController를 사용하여 AI 호출 중간 취소 기능을 구현했습니다.

### worker/src/index.ts
- `activeJobs: Map<string, AbortController>` 추가: 진행 중인 작업 추적
- `POST /cancel` 엔드포인트 추가: jobId로 컨트롤러 조회 후 abort 처리
- `processJob(jobId, prompt, controller)`: `controller.signal`을 `callAI`에 전달, `signal.aborted` 감지 시 `cleanupCancelledJob` 호출
- `POST /analyze` 핸들러: AbortController 생성 및 activeJobs에 저장, `.finally()`에서 제거
- 미사용 코드 제거: `CANCEL_POLL_INTERVAL_MS`, `sleep()`
- Express 핸들러 params 타입 오류 수정 (Request, Response import)

### worker/src/gemini.ts
- `signal?: AbortSignal` 추가: GeminiCallOptions에 선택사항으로 추가
- 외부 signal을 내부 AbortController에 전파 (propagateAbort 리스너)
- finally 블록에서 리스너 제거하여 메모리 누수 방지

### worker/src/claude.ts
- `signal?: AbortSignal` 파라미터 추가, Anthropic SDK 옵션으로 전달

### src/infrastructure/market/cancelAnalysisJobAction.ts
- Redis (`cancelJob`)와 Worker (`POST /cancel`)에 동시 취소 요청 (Promise.allSettled)
- WORKER_URL / WORKER_SECRET 환경변수 읽기, 누락 시 fetch 스킵

### src/__tests__/infrastructure/market/cancelAnalysisJobAction.test.ts
- Worker fetch 호출 검증: URL, 헤더, body 정확성
- fetch 실패 시 에러 무시 테스트
- 환경변수 누락 (전체/부분) 시 fetch 미호출 테스트
- 중첩 describe의 afterEach 추가하여 테스트 격리 개선

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 인디케이터 초기 구간 null 반환 (0, NaN 없음)
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it
- [x] 초기 구간 null 케이스 테스트 포함
- [x] 매직 넘버 없음

## 변경 파일 목록

[수정]
- worker/src/index.ts
- worker/src/gemini.ts
- worker/src/claude.ts
- src/infrastructure/market/cancelAnalysisJobAction.ts
- src/__tests__/infrastructure/market/cancelAnalysisJobAction.test.ts
- src/components/symbol-page/hooks/useAnalysis.ts
- src/infrastructure/jobs/queue.ts
- src/__tests__/infrastructure/jobs/queue.test.ts
- docs/__agents_only__/fix-log.md

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build