### PR TITLE
fix: 모바일 Bottom Sheet 컴포넌트 사라지는 문제

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,6 +18,14 @@ const nextConfig: NextConfig = {
         root: import.meta.dirname,
     },
 
+    // TODO: 임시 조치. submitAnalysisAction이 bars+indicators 전체를 payload로 보내 1MB 초과.
+    // 근본 해결은 Server Action 내부에서 서버가 직접 fetchBarsWithIndicators로 재구성하도록 리팩토링.
+    experimental: {
+        serverActions: {
+            bodySizeLimit: '5mb',
+        },
+    },
+
     headers: async () => [
         {
             source: '/(.*)',

--- a/src/__tests__/domain/analysis/confidence.test.ts
+++ b/src/__tests__/domain/analysis/confidence.test.ts
@@ -4,21 +4,20 @@ import {
 } from '@/domain/analysis/confidence';
 import type {
     PatternResult,
-    PatternSummary,
     RawAnalysisResponse,
     Skill,
     SkillChartDisplay,
-    StrategyResult,
 } from '@/domain/types';
+import type {
+    RawPatternSummary,
+    RawStrategyResult,
+} from '@/domain/analysis/normalize';
 import {
     HIGH_CONFIDENCE_WEIGHT,
     MEDIUM_CONFIDENCE_WEIGHT,
     MIN_CONFIDENCE_WEIGHT,
     UNMATCHED_SKILL_CONFIDENCE_WEIGHT,
 } from '@/domain/indicators/constants';
-
-type RawPatternSummary = Omit<PatternSummary, 'confidenceWeight' | 'id'>;
-type RawStrategyResult = Omit<StrategyResult, 'confidenceWeight' | 'id'>;
 
 const makeSkillChartDisplay = (
     overrides?: Partial<SkillChartDisplay>

--- a/src/__tests__/domain/analysis/confidence.test.ts
+++ b/src/__tests__/domain/analysis/confidence.test.ts
@@ -533,5 +533,80 @@ describe('confidence', () => {
                 );
             });
         });
+
+        describe('indicatorResults 정규화', () => {
+            it('유효한 indicatorResults 항목이 enriched 결과에 포함된다', () => {
+                const analysis = makeAnalysisResponse({
+                    indicatorResults: [
+                        {
+                            indicatorName: 'RSI',
+                            signals: [
+                                {
+                                    type: 'skill',
+                                    description: '과매수',
+                                    trend: 'bearish',
+                                    strength: 'strong',
+                                },
+                            ],
+                        },
+                    ],
+                });
+                const result = enrichAnalysisWithConfidence(analysis, []);
+                expect(result.indicatorResults).toHaveLength(1);
+                expect(result.indicatorResults[0].indicatorName).toBe('RSI');
+                expect(result.indicatorResults[0].signals[0].description).toBe(
+                    '과매수'
+                );
+            });
+
+            it('indicatorName이 없는 항목은 탈락시킨다', () => {
+                const analysis = makeAnalysisResponse({
+                    indicatorResults: [
+                        { signals: [] },
+                        { indicatorName: 'MACD', signals: [] },
+                    ],
+                });
+                const result = enrichAnalysisWithConfidence(analysis, []);
+                expect(result.indicatorResults).toHaveLength(1);
+                expect(result.indicatorResults[0].indicatorName).toBe('MACD');
+            });
+        });
+
+        describe('trendlines 정규화', () => {
+            it('유효한 trendline이 enriched 결과에 포함된다', () => {
+                const analysis = makeAnalysisResponse({
+                    trendlines: [
+                        {
+                            direction: 'ascending',
+                            start: { time: 1, price: 100 },
+                            end: { time: 2, price: 200 },
+                        },
+                    ],
+                });
+                const result = enrichAnalysisWithConfidence(analysis, []);
+                expect(result.trendlines).toHaveLength(1);
+                expect(result.trendlines[0].direction).toBe('ascending');
+            });
+
+            it('direction이 유효하지 않은 항목은 탈락시킨다', () => {
+                const analysis = makeAnalysisResponse({
+                    trendlines: [
+                        {
+                            direction: 'sideways',
+                            start: { time: 1, price: 100 },
+                            end: { time: 2, price: 200 },
+                        },
+                        {
+                            direction: 'descending',
+                            start: { time: 3, price: 300 },
+                            end: { time: 4, price: 250 },
+                        },
+                    ],
+                });
+                const result = enrichAnalysisWithConfidence(analysis, []);
+                expect(result.trendlines).toHaveLength(1);
+                expect(result.trendlines[0].direction).toBe('descending');
+            });
+        });
     }); // enrichAnalysisWithConfidence
 });

--- a/src/__tests__/domain/analysis/confidence.test.ts
+++ b/src/__tests__/domain/analysis/confidence.test.ts
@@ -2,14 +2,23 @@ import {
     enrichAnalysisWithConfidence,
     filterPatterns,
 } from '@/domain/analysis/confidence';
-import type { RawAnalysisResponse } from '@/domain/types';
+import type {
+    PatternResult,
+    PatternSummary,
+    RawAnalysisResponse,
+    Skill,
+    SkillChartDisplay,
+    StrategyResult,
+} from '@/domain/types';
 import {
     HIGH_CONFIDENCE_WEIGHT,
     MEDIUM_CONFIDENCE_WEIGHT,
     MIN_CONFIDENCE_WEIGHT,
     UNMATCHED_SKILL_CONFIDENCE_WEIGHT,
 } from '@/domain/indicators/constants';
-import type { PatternResult, Skill, SkillChartDisplay } from '@/domain/types';
+
+type RawPatternSummary = Omit<PatternSummary, 'confidenceWeight' | 'id'>;
+type RawStrategyResult = Omit<StrategyResult, 'confidenceWeight' | 'id'>;
 
 const makeSkillChartDisplay = (
     overrides?: Partial<SkillChartDisplay>
@@ -31,8 +40,8 @@ const makeSkill = (overrides?: Partial<Skill>): Skill => ({
 });
 
 const makePatternSummary = (
-    overrides?: Partial<RawAnalysisResponse['patternSummaries'][number]>
-): RawAnalysisResponse['patternSummaries'][number] => ({
+    overrides?: Partial<RawPatternSummary>
+): RawPatternSummary => ({
     patternName: '테스트 패턴',
     skillName: '테스트 스킬',
     detected: true,
@@ -42,8 +51,8 @@ const makePatternSummary = (
 });
 
 const makeStrategyResult = (
-    overrides?: Partial<RawAnalysisResponse['strategyResults'][number]>
-): RawAnalysisResponse['strategyResults'][number] => ({
+    overrides?: Partial<RawStrategyResult>
+): RawStrategyResult => ({
     strategyName: '테스트 전략',
     trend: 'bullish',
     summary: '테스트 요약',

--- a/src/__tests__/domain/analysis/normalize.test.ts
+++ b/src/__tests__/domain/analysis/normalize.test.ts
@@ -418,9 +418,10 @@ describe('normalizeKeyPrice', () => {
 
 describe('normalizeTrendlinePoint', () => {
     it('유효한 객체를 반환한다', () => {
-        expect(
-            normalizeTrendlinePoint({ time: 100, price: 200 })
-        ).toEqual({ time: 100, price: 200 });
+        expect(normalizeTrendlinePoint({ time: 100, price: 200 })).toEqual({
+            time: 100,
+            price: 200,
+        });
     });
 
     it('time 또는 price가 숫자가 아니면 null을 반환한다', () => {
@@ -526,12 +527,8 @@ describe('normalizePatternSummary', () => {
     });
 
     it('patternName 또는 skillName이 없으면 null을 반환한다', () => {
-        expect(
-            normalizePatternSummary({ skillName: 'S' })
-        ).toBeNull();
-        expect(
-            normalizePatternSummary({ patternName: 'P' })
-        ).toBeNull();
+        expect(normalizePatternSummary({ skillName: 'S' })).toBeNull();
+        expect(normalizePatternSummary({ patternName: 'P' })).toBeNull();
     });
 
     it('객체가 아니면 null을 반환한다', () => {
@@ -581,9 +578,7 @@ describe('normalizeCandlePatternSummary', () => {
     });
 
     it('patternName이 없으면 null을 반환한다', () => {
-        expect(
-            normalizeCandlePatternSummary({ summary: 'x' })
-        ).toBeNull();
+        expect(normalizeCandlePatternSummary({ summary: 'x' })).toBeNull();
     });
 
     it('객체가 아니면 null을 반환한다', () => {
@@ -609,9 +604,7 @@ describe('normalizeTrendline', () => {
     });
 
     it('start 또는 end가 유효하지 않으면 null을 반환한다', () => {
-        expect(
-            normalizeTrendline({ ...validLine, start: null })
-        ).toBeNull();
+        expect(normalizeTrendline({ ...validLine, start: null })).toBeNull();
         expect(
             normalizeTrendline({ ...validLine, end: { time: 2 } })
         ).toBeNull();

--- a/src/__tests__/domain/analysis/normalize.test.ts
+++ b/src/__tests__/domain/analysis/normalize.test.ts
@@ -1,0 +1,711 @@
+import {
+    asArray,
+    asBoolean,
+    asEnum,
+    asNumber,
+    asObject,
+    asOptionalEnum,
+    asString,
+    normalizeActionRecommendation,
+    normalizeCandlePatternSummary,
+    normalizeIndicatorGuideResult,
+    normalizeKeyLevel,
+    normalizeKeyLevels,
+    normalizeKeyPrice,
+    normalizePatternLine,
+    normalizePatternSummary,
+    normalizePriceScenario,
+    normalizePriceTarget,
+    normalizePriceTargets,
+    normalizeRiskLevel,
+    normalizeSignal,
+    normalizeStrategyResult,
+    normalizeTimeRange,
+    normalizeTrend,
+    normalizeTrendline,
+    normalizeTrendlinePoint,
+} from '@/domain/analysis/normalize';
+
+describe('원시 값 헬퍼', () => {
+    describe('asString', () => {
+        it('문자열이면 그대로 반환한다', () => {
+            expect(asString('hello')).toBe('hello');
+        });
+
+        it('문자열이 아니면 기본값을 반환한다', () => {
+            expect(asString(123)).toBe('');
+            expect(asString({})).toBe('');
+            expect(asString(null)).toBe('');
+            expect(asString(undefined)).toBe('');
+        });
+
+        it('fallback 인자를 사용한다', () => {
+            expect(asString(null, 'fallback')).toBe('fallback');
+        });
+    });
+
+    describe('asNumber', () => {
+        it('유한한 숫자면 그대로 반환한다', () => {
+            expect(asNumber(42)).toBe(42);
+            expect(asNumber(0)).toBe(0);
+            expect(asNumber(-1.5)).toBe(-1.5);
+        });
+
+        it('숫자가 아니면 undefined를 반환한다', () => {
+            expect(asNumber('42')).toBeUndefined();
+            expect(asNumber(null)).toBeUndefined();
+            expect(asNumber({})).toBeUndefined();
+        });
+
+        it('NaN과 Infinity는 undefined로 처리한다', () => {
+            expect(asNumber(NaN)).toBeUndefined();
+            expect(asNumber(Infinity)).toBeUndefined();
+            expect(asNumber(-Infinity)).toBeUndefined();
+        });
+    });
+
+    describe('asBoolean', () => {
+        it('불리언이면 그대로 반환한다', () => {
+            expect(asBoolean(true)).toBe(true);
+            expect(asBoolean(false)).toBe(false);
+        });
+
+        it('불리언이 아니면 기본값을 반환한다', () => {
+            expect(asBoolean('true')).toBe(false);
+            expect(asBoolean(1)).toBe(false);
+            expect(asBoolean(null)).toBe(false);
+        });
+
+        it('fallback 인자를 사용한다', () => {
+            expect(asBoolean(null, true)).toBe(true);
+        });
+    });
+
+    describe('asEnum', () => {
+        const colors = ['red', 'green', 'blue'] as const;
+
+        it('유효한 값이면 그대로 반환한다', () => {
+            expect(asEnum('red', colors, 'green')).toBe('red');
+        });
+
+        it('유효하지 않으면 fallback을 반환한다', () => {
+            expect(asEnum('purple', colors, 'green')).toBe('green');
+            expect(asEnum(null, colors, 'green')).toBe('green');
+        });
+    });
+
+    describe('asOptionalEnum', () => {
+        const colors = ['red', 'green', 'blue'] as const;
+
+        it('유효한 값이면 그대로 반환한다', () => {
+            expect(asOptionalEnum('red', colors)).toBe('red');
+        });
+
+        it('유효하지 않으면 undefined를 반환한다', () => {
+            expect(asOptionalEnum('purple', colors)).toBeUndefined();
+            expect(asOptionalEnum(null, colors)).toBeUndefined();
+        });
+    });
+
+    describe('asObject', () => {
+        it('일반 객체는 그대로 반환한다', () => {
+            const obj = { foo: 'bar' };
+            expect(asObject(obj)).toBe(obj);
+        });
+
+        it('null은 null을 반환한다', () => {
+            expect(asObject(null)).toBeNull();
+        });
+
+        it('undefined는 null을 반환한다', () => {
+            expect(asObject(undefined)).toBeNull();
+        });
+
+        it('배열은 null을 반환한다', () => {
+            expect(asObject([])).toBeNull();
+            expect(asObject([1, 2])).toBeNull();
+        });
+
+        it('원시 값은 null을 반환한다', () => {
+            expect(asObject('string')).toBeNull();
+            expect(asObject(42)).toBeNull();
+            expect(asObject(true)).toBeNull();
+        });
+    });
+
+    describe('asArray', () => {
+        it('배열이면 그대로 반환한다', () => {
+            const arr = [1, 2, 3];
+            expect(asArray(arr)).toBe(arr);
+        });
+
+        it('배열이 아니면 빈 배열을 반환한다', () => {
+            expect(asArray(null)).toEqual([]);
+            expect(asArray({})).toEqual([]);
+            expect(asArray('not array')).toEqual([]);
+        });
+    });
+});
+
+describe('enum 래퍼', () => {
+    describe('normalizeTrend', () => {
+        it('유효한 Trend 값을 그대로 반환한다', () => {
+            expect(normalizeTrend('bullish')).toBe('bullish');
+            expect(normalizeTrend('bearish')).toBe('bearish');
+            expect(normalizeTrend('neutral')).toBe('neutral');
+        });
+
+        it('유효하지 않으면 neutral을 반환한다', () => {
+            expect(normalizeTrend('up')).toBe('neutral');
+            expect(normalizeTrend(null)).toBe('neutral');
+        });
+    });
+
+    describe('normalizeRiskLevel', () => {
+        it('유효한 RiskLevel을 그대로 반환한다', () => {
+            expect(normalizeRiskLevel('low')).toBe('low');
+            expect(normalizeRiskLevel('medium')).toBe('medium');
+            expect(normalizeRiskLevel('high')).toBe('high');
+        });
+
+        it('유효하지 않으면 medium을 반환한다', () => {
+            expect(normalizeRiskLevel('extreme')).toBe('medium');
+            expect(normalizeRiskLevel(undefined)).toBe('medium');
+        });
+    });
+});
+
+describe('normalizeKeyLevel', () => {
+    it('유효한 객체를 그대로 반환한다', () => {
+        expect(normalizeKeyLevel({ price: 100, reason: '지지' })).toEqual({
+            price: 100,
+            reason: '지지',
+        });
+    });
+
+    it('reason이 문자열이 아니면 빈 문자열로 대체한다', () => {
+        expect(normalizeKeyLevel({ price: 100, reason: null })).toEqual({
+            price: 100,
+            reason: '',
+        });
+    });
+
+    it('price가 숫자가 아니면 null을 반환한다', () => {
+        expect(normalizeKeyLevel({ price: '100', reason: 'x' })).toBeNull();
+        expect(normalizeKeyLevel({ reason: 'x' })).toBeNull();
+    });
+
+    it('객체가 아니면 null을 반환한다', () => {
+        expect(normalizeKeyLevel(null)).toBeNull();
+        expect(normalizeKeyLevel('foo')).toBeNull();
+    });
+});
+
+describe('normalizeKeyLevels', () => {
+    it('모든 필드를 정규화한다', () => {
+        const result = normalizeKeyLevels({
+            support: [{ price: 100, reason: 'S1' }],
+            resistance: [{ price: 200, reason: 'R1' }],
+            poc: { price: 150, reason: 'POC' },
+        });
+        expect(result.support).toEqual([{ price: 100, reason: 'S1' }]);
+        expect(result.resistance).toEqual([{ price: 200, reason: 'R1' }]);
+        expect(result.poc).toEqual({ price: 150, reason: 'POC' });
+    });
+
+    it('지원/저항 배열의 잘못된 항목은 탈락시킨다', () => {
+        const result = normalizeKeyLevels({
+            support: [
+                { price: 100, reason: 'S1' },
+                { reason: '가격없음' },
+                'invalid',
+            ],
+            resistance: [],
+        });
+        expect(result.support).toHaveLength(1);
+        expect(result.support[0].price).toBe(100);
+    });
+
+    it('객체가 아니면 빈 기본값을 반환한다', () => {
+        expect(normalizeKeyLevels(null)).toEqual({
+            support: [],
+            resistance: [],
+            poc: undefined,
+        });
+    });
+
+    it('poc가 잘못된 형식이면 undefined로 처리한다', () => {
+        const result = normalizeKeyLevels({
+            support: [],
+            resistance: [],
+            poc: { reason: 'no price' },
+        });
+        expect(result.poc).toBeUndefined();
+    });
+
+    it('배열 필드가 누락되면 빈 배열로 대체한다', () => {
+        const result = normalizeKeyLevels({});
+        expect(result.support).toEqual([]);
+        expect(result.resistance).toEqual([]);
+    });
+});
+
+describe('normalizePriceTarget', () => {
+    it('유효한 객체를 그대로 반환한다', () => {
+        expect(normalizePriceTarget({ price: 100, basis: '근거' })).toEqual({
+            price: 100,
+            basis: '근거',
+        });
+    });
+
+    it('basis가 문자열이 아니면 빈 문자열로 대체한다', () => {
+        expect(normalizePriceTarget({ price: 100, basis: 42 })).toEqual({
+            price: 100,
+            basis: '',
+        });
+    });
+
+    it('price가 숫자가 아니면 null을 반환한다', () => {
+        expect(normalizePriceTarget({ basis: 'x' })).toBeNull();
+    });
+
+    it('객체가 아니면 null을 반환한다', () => {
+        expect(normalizePriceTarget(null)).toBeNull();
+    });
+});
+
+describe('normalizePriceScenario', () => {
+    it('유효한 시나리오를 그대로 반환한다', () => {
+        expect(
+            normalizePriceScenario({
+                targets: [{ price: 100, basis: 'b1' }],
+                condition: '상승 시',
+            })
+        ).toEqual({
+            targets: [{ price: 100, basis: 'b1' }],
+            condition: '상승 시',
+        });
+    });
+
+    it('targets가 배열이 아니면 빈 배열을 사용한다', () => {
+        const result = normalizePriceScenario({
+            targets: 'not array',
+            condition: 'x',
+        });
+        expect(result?.targets).toEqual([]);
+    });
+
+    it('condition이 문자열이 아니면 빈 문자열로 대체한다', () => {
+        const result = normalizePriceScenario({
+            targets: [],
+            condition: null,
+        });
+        expect(result?.condition).toBe('');
+    });
+
+    it('객체가 아니면 null을 반환한다', () => {
+        expect(normalizePriceScenario(null)).toBeNull();
+    });
+});
+
+describe('normalizePriceTargets', () => {
+    it('bullish/bearish를 모두 정규화한다', () => {
+        const result = normalizePriceTargets({
+            bullish: { targets: [], condition: '상승' },
+            bearish: { targets: [], condition: '하락' },
+        });
+        expect(result.bullish?.condition).toBe('상승');
+        expect(result.bearish?.condition).toBe('하락');
+    });
+
+    it('객체가 아니면 기본값을 반환한다', () => {
+        expect(normalizePriceTargets(null)).toEqual({
+            bullish: null,
+            bearish: null,
+        });
+    });
+
+    it('bullish/bearish가 누락되면 null을 할당한다', () => {
+        const result = normalizePriceTargets({});
+        expect(result.bullish).toBeNull();
+        expect(result.bearish).toBeNull();
+    });
+});
+
+describe('normalizeSignal', () => {
+    it('유효한 시그널을 반환한다', () => {
+        expect(
+            normalizeSignal({
+                description: '강세',
+                trend: 'bullish',
+                strength: 'strong',
+            })
+        ).toEqual({
+            type: 'skill',
+            description: '강세',
+            trend: 'bullish',
+            strength: 'strong',
+        });
+    });
+
+    it('strength가 유효하지 않으면 undefined로 둔다', () => {
+        const result = normalizeSignal({
+            description: 'x',
+            trend: 'neutral',
+            strength: 'huge',
+        });
+        expect(result?.strength).toBeUndefined();
+    });
+
+    it('객체가 아니면 null을 반환한다', () => {
+        expect(normalizeSignal(null)).toBeNull();
+    });
+});
+
+describe('normalizeIndicatorGuideResult', () => {
+    it('유효한 결과를 반환한다', () => {
+        expect(
+            normalizeIndicatorGuideResult({
+                indicatorName: 'RSI',
+                signals: [{ description: '과매수', trend: 'bearish' }],
+            })
+        ).toEqual({
+            indicatorName: 'RSI',
+            signals: [
+                {
+                    type: 'skill',
+                    description: '과매수',
+                    trend: 'bearish',
+                    strength: undefined,
+                },
+            ],
+        });
+    });
+
+    it('indicatorName이 없으면 null을 반환한다', () => {
+        expect(normalizeIndicatorGuideResult({ signals: [] })).toBeNull();
+    });
+
+    it('signals의 잘못된 항목은 탈락시킨다', () => {
+        const result = normalizeIndicatorGuideResult({
+            indicatorName: 'MACD',
+            signals: ['invalid', { description: 'x', trend: 'bullish' }],
+        });
+        expect(result?.signals).toHaveLength(1);
+    });
+
+    it('객체가 아니면 null을 반환한다', () => {
+        expect(normalizeIndicatorGuideResult(null)).toBeNull();
+    });
+});
+
+describe('normalizeKeyPrice', () => {
+    it('유효한 객체를 반환한다', () => {
+        expect(normalizeKeyPrice({ label: '진입가', price: 100 })).toEqual({
+            label: '진입가',
+            price: 100,
+        });
+    });
+
+    it('price가 숫자가 아니면 null을 반환한다', () => {
+        expect(normalizeKeyPrice({ label: 'x' })).toBeNull();
+    });
+
+    it('객체가 아니면 null을 반환한다', () => {
+        expect(normalizeKeyPrice(null)).toBeNull();
+    });
+});
+
+describe('normalizeTrendlinePoint', () => {
+    it('유효한 객체를 반환한다', () => {
+        expect(
+            normalizeTrendlinePoint({ time: 100, price: 200 })
+        ).toEqual({ time: 100, price: 200 });
+    });
+
+    it('time 또는 price가 숫자가 아니면 null을 반환한다', () => {
+        expect(normalizeTrendlinePoint({ time: 'x', price: 200 })).toBeNull();
+        expect(normalizeTrendlinePoint({ time: 100, price: 'x' })).toBeNull();
+    });
+
+    it('객체가 아니면 null을 반환한다', () => {
+        expect(normalizeTrendlinePoint(null)).toBeNull();
+    });
+});
+
+describe('normalizePatternLine', () => {
+    it('유효한 라인을 반환한다', () => {
+        expect(
+            normalizePatternLine({
+                label: 'L1',
+                start: { time: 1, price: 10 },
+                end: { time: 2, price: 20 },
+            })
+        ).toEqual({
+            label: 'L1',
+            start: { time: 1, price: 10 },
+            end: { time: 2, price: 20 },
+        });
+    });
+
+    it('start 또는 end가 유효하지 않으면 null을 반환한다', () => {
+        expect(
+            normalizePatternLine({
+                label: 'x',
+                start: { time: 1 },
+                end: { time: 2, price: 20 },
+            })
+        ).toBeNull();
+    });
+
+    it('객체가 아니면 null을 반환한다', () => {
+        expect(normalizePatternLine(null)).toBeNull();
+    });
+});
+
+describe('normalizeTimeRange', () => {
+    it('유효한 범위를 반환한다', () => {
+        expect(normalizeTimeRange({ start: 1, end: 2 })).toEqual({
+            start: 1,
+            end: 2,
+        });
+    });
+
+    it('start 또는 end가 숫자가 아니면 undefined를 반환한다', () => {
+        expect(normalizeTimeRange({ start: 'x', end: 2 })).toBeUndefined();
+        expect(normalizeTimeRange({ start: 1 })).toBeUndefined();
+    });
+
+    it('객체가 아니면 undefined를 반환한다', () => {
+        expect(normalizeTimeRange(null)).toBeUndefined();
+    });
+});
+
+describe('normalizePatternSummary', () => {
+    it('유효한 요약을 반환한다', () => {
+        expect(
+            normalizePatternSummary({
+                patternName: 'Hammer',
+                skillName: '해머 스킬',
+                detected: true,
+                trend: 'bullish',
+                summary: '요약',
+            })
+        ).toEqual({
+            patternName: 'Hammer',
+            skillName: '해머 스킬',
+            detected: true,
+            trend: 'bullish',
+            summary: '요약',
+            keyPrices: undefined,
+            patternLines: undefined,
+            timeRange: undefined,
+        });
+    });
+
+    it('keyPrices와 patternLines를 정규화하여 포함한다', () => {
+        const result = normalizePatternSummary({
+            patternName: 'P',
+            skillName: 'S',
+            detected: true,
+            trend: 'bullish',
+            summary: 'x',
+            keyPrices: [{ label: 'x', price: 1 }, 'invalid'],
+            patternLines: [
+                {
+                    label: 'L',
+                    start: { time: 1, price: 1 },
+                    end: { time: 2, price: 2 },
+                },
+            ],
+            timeRange: { start: 1, end: 2 },
+        });
+        expect(result?.keyPrices).toHaveLength(1);
+        expect(result?.patternLines).toHaveLength(1);
+        expect(result?.timeRange).toEqual({ start: 1, end: 2 });
+    });
+
+    it('patternName 또는 skillName이 없으면 null을 반환한다', () => {
+        expect(
+            normalizePatternSummary({ skillName: 'S' })
+        ).toBeNull();
+        expect(
+            normalizePatternSummary({ patternName: 'P' })
+        ).toBeNull();
+    });
+
+    it('객체가 아니면 null을 반환한다', () => {
+        expect(normalizePatternSummary(null)).toBeNull();
+    });
+});
+
+describe('normalizeStrategyResult', () => {
+    it('유효한 결과를 반환한다', () => {
+        expect(
+            normalizeStrategyResult({
+                strategyName: '추세 추종',
+                trend: 'bullish',
+                summary: '요약',
+            })
+        ).toEqual({
+            strategyName: '추세 추종',
+            trend: 'bullish',
+            summary: '요약',
+        });
+    });
+
+    it('strategyName이 없으면 null을 반환한다', () => {
+        expect(normalizeStrategyResult({ summary: 'x' })).toBeNull();
+    });
+
+    it('객체가 아니면 null을 반환한다', () => {
+        expect(normalizeStrategyResult(null)).toBeNull();
+    });
+});
+
+describe('normalizeCandlePatternSummary', () => {
+    it('유효한 요약을 반환한다', () => {
+        expect(
+            normalizeCandlePatternSummary({
+                patternName: 'Doji',
+                detected: true,
+                trend: 'neutral',
+                summary: '도지',
+            })
+        ).toEqual({
+            patternName: 'Doji',
+            detected: true,
+            trend: 'neutral',
+            summary: '도지',
+        });
+    });
+
+    it('patternName이 없으면 null을 반환한다', () => {
+        expect(
+            normalizeCandlePatternSummary({ summary: 'x' })
+        ).toBeNull();
+    });
+
+    it('객체가 아니면 null을 반환한다', () => {
+        expect(normalizeCandlePatternSummary(null)).toBeNull();
+    });
+});
+
+describe('normalizeTrendline', () => {
+    const validLine = {
+        direction: 'ascending',
+        start: { time: 1, price: 10 },
+        end: { time: 2, price: 20 },
+    };
+
+    it('유효한 트렌드라인을 반환한다', () => {
+        expect(normalizeTrendline(validLine)).toEqual(validLine);
+    });
+
+    it('direction이 유효하지 않으면 null을 반환한다', () => {
+        expect(
+            normalizeTrendline({ ...validLine, direction: 'sideways' })
+        ).toBeNull();
+    });
+
+    it('start 또는 end가 유효하지 않으면 null을 반환한다', () => {
+        expect(
+            normalizeTrendline({ ...validLine, start: null })
+        ).toBeNull();
+        expect(
+            normalizeTrendline({ ...validLine, end: { time: 2 } })
+        ).toBeNull();
+    });
+
+    it('객체가 아니면 null을 반환한다', () => {
+        expect(normalizeTrendline(null)).toBeNull();
+    });
+});
+
+describe('normalizeActionRecommendation', () => {
+    it('텍스트 필드가 모두 문자열이면 전체를 반환한다', () => {
+        const result = normalizeActionRecommendation({
+            positionAnalysis: '중립 구간',
+            entry: '진입 전략',
+            exit: '청산 전략',
+            riskReward: '리스크',
+            entryRecommendation: 'wait',
+            entryPrices: [100, 105],
+            stopLoss: 95,
+            takeProfitPrices: [110, 120],
+        });
+        expect(result).toEqual({
+            positionAnalysis: '중립 구간',
+            entry: '진입 전략',
+            exit: '청산 전략',
+            riskReward: '리스크',
+            entryRecommendation: 'wait',
+            entryPrices: [100, 105],
+            stopLoss: 95,
+            takeProfitPrices: [110, 120],
+        });
+    });
+
+    it('텍스트 필드에 객체가 오면 빈 문자열로 대체한다', () => {
+        const result = normalizeActionRecommendation({
+            positionAnalysis: '정상',
+            entry: { takeProfitPrices: [110], stopLoss: 95 },
+            exit: '청산',
+            riskReward: '리스크',
+        });
+        expect(result?.entry).toBe('');
+        expect(result?.positionAnalysis).toBe('정상');
+    });
+
+    it('모든 텍스트 필드가 비면 undefined를 반환한다', () => {
+        expect(
+            normalizeActionRecommendation({
+                positionAnalysis: null,
+                entry: null,
+                exit: null,
+                riskReward: null,
+            })
+        ).toBeUndefined();
+    });
+
+    it('entryRecommendation이 유효하지 않으면 undefined로 둔다', () => {
+        const result = normalizeActionRecommendation({
+            entry: 'x',
+            entryRecommendation: 'confirm',
+        });
+        expect(result?.entryRecommendation).toBeUndefined();
+    });
+
+    it('entryPrices/takeProfitPrices 배열에서 숫자 아닌 항목을 걸러낸다', () => {
+        const result = normalizeActionRecommendation({
+            entry: 'x',
+            entryPrices: [100, '105', null],
+            takeProfitPrices: [110, NaN],
+        });
+        expect(result?.entryPrices).toEqual([100]);
+        expect(result?.takeProfitPrices).toEqual([110]);
+    });
+
+    it('entryPrices/takeProfitPrices가 배열이 아니면 undefined로 둔다', () => {
+        const result = normalizeActionRecommendation({
+            entry: 'x',
+            entryPrices: 'not array',
+            takeProfitPrices: null,
+        });
+        expect(result?.entryPrices).toBeUndefined();
+        expect(result?.takeProfitPrices).toBeUndefined();
+    });
+
+    it('stopLoss가 숫자가 아니면 undefined로 둔다', () => {
+        const result = normalizeActionRecommendation({
+            entry: 'x',
+            stopLoss: '95',
+        });
+        expect(result?.stopLoss).toBeUndefined();
+    });
+
+    it('객체가 아니면 undefined를 반환한다', () => {
+        expect(normalizeActionRecommendation(null)).toBeUndefined();
+        expect(normalizeActionRecommendation('string')).toBeUndefined();
+    });
+});

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -130,16 +130,20 @@ function ActionRecommendationSection({
                 </button>
             </div>
             <div className="flex flex-col gap-2">
-                {ACTION_RECOMMENDATION_FIELDS.map(({ label, key }) => (
-                    <div key={label} className="flex flex-col gap-0.5">
-                        <span className="text-secondary-400 text-xs font-medium">
-                            {label}
-                        </span>
-                        <p className="text-secondary-300 text-sm leading-relaxed whitespace-pre-line">
-                            {rec[key]}
-                        </p>
-                    </div>
-                ))}
+                {ACTION_RECOMMENDATION_FIELDS.map(({ label, key }) => {
+                    const value = rec[key];
+                    if (typeof value !== 'string' || value === '') return null;
+                    return (
+                        <div key={label} className="flex flex-col gap-0.5">
+                            <span className="text-secondary-400 text-xs font-medium">
+                                {label}
+                            </span>
+                            <p className="text-secondary-300 text-sm leading-relaxed whitespace-pre-line">
+                                {value}
+                            </p>
+                        </div>
+                    );
+                })}
             </div>
         </div>
     );

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -259,6 +259,8 @@ export function ChartContent({
     // analysisContent의 참조가 예상보다 안정적으로 유지되어 effect가 재실행되지 않는
     // 케이스가 관측되었다. timeframe을 deps에 넣어 타임프레임 전환 시 부모 시트
     // 콘텐츠 갱신이 확실히 일어나도록 한다.
+    // TODO(#319): MISTAKES.md Predictability 규칙 3 위반(body에서 사용하지 않는 dep)
+    //   임시 워크어라운드. 근본 해결은 analysisContent 메모이제이션 재구성으로 진행 예정.
     const notifyMobileContent = useEffectEvent(onMobileSheetContent);
     useEffect(() => {
         notifyMobileContent(analysisContent);

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -254,10 +254,15 @@ export function ChartContent({
 
     // MobileAnalysisSheet를 Suspense 경계 밖에서 렌더링하기 위해 콘텐츠를 상위로 전달한다.
     // Suspense 경계 내에서 직접 렌더링하면 타임프레임 전환 시 바텀시트가 사라진다.
+    //
+    // timeframe을 deps에 포함시키는 이유: React Compiler의 자동 메모이제이션 하에서
+    // analysisContent의 참조가 예상보다 안정적으로 유지되어 effect가 재실행되지 않는
+    // 케이스가 관측되었다. timeframe을 deps에 넣어 타임프레임 전환 시 부모 시트
+    // 콘텐츠 갱신이 확실히 일어나도록 한다.
     const notifyMobileContent = useEffectEvent(onMobileSheetContent);
     useEffect(() => {
         notifyMobileContent(analysisContent);
-    }, [analysisContent]);
+    }, [analysisContent, timeframe]);
 
     return (
         <div className="flex h-full w-full flex-col md:flex-row">

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { useState, useCallback, useMemo, useRef, useEffect, useEffectEvent } from 'react';
+import {
+    useState,
+    useCallback,
+    useMemo,
+    useRef,
+    useEffect,
+    useEffectEvent,
+} from 'react';
 import type React from 'react';
 import type { ReactNode } from 'react';
 import dynamic from 'next/dynamic';
@@ -100,7 +107,6 @@ export function ChartContent({
     initialAnalysisFailed,
     onMobileSheetContent,
 }: ChartContentProps) {
-
     const { bars, indicators } = useBars({ symbol, timeframe });
 
     const {

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useCallback, useMemo, useRef } from 'react';
+import { useState, useCallback, useMemo, useRef, useEffect, useEffectEvent } from 'react';
 import type React from 'react';
+import type { ReactNode } from 'react';
 import dynamic from 'next/dynamic';
 import type { AnalysisResponse, Timeframe } from '@/domain/types';
 import {
@@ -22,12 +23,7 @@ import {
 import { useChartSync } from '@/components/chart/hooks/useChartSync';
 import type { AnalysisStatus } from '@/components/symbol-page/utils/analysisStatus';
 import { getAnalysisStatus } from '@/components/symbol-page/utils/analysisStatus';
-import {
-    MobileAnalysisSheet,
-    SNAP_PEEK,
-    SNAP_HALF,
-    type SnapPoint,
-} from '@/components/symbol-page/MobileAnalysisSheet';
+import { SNAP_PEEK } from '@/components/symbol-page/MobileAnalysisSheet';
 import { useAnalysisProgress } from '@/components/symbol-page/hooks/useAnalysisProgress';
 
 const StockChart = dynamic(
@@ -92,6 +88,8 @@ interface ChartContentProps {
     initialAnalysis: AnalysisResponse;
     /** 서버에서 초기 AI 분석이 실패했는지 여부. true이면 마운트 시 자동으로 재분석을 실행한다. */
     initialAnalysisFailed: boolean;
+    /** 모바일 바텀시트에 렌더링할 콘텐츠가 변경될 때 호출된다. Suspense 경계 밖에서 시트를 유지하기 위해 상위로 끌어올린다. */
+    onMobileSheetContent: (content: ReactNode) => void;
 }
 
 export function ChartContent({
@@ -100,8 +98,8 @@ export function ChartContent({
     timeframeChangeCount,
     initialAnalysis,
     initialAnalysisFailed,
+    onMobileSheetContent,
 }: ChartContentProps) {
-    const [sheetSnap, setSheetSnap] = useState<SnapPoint>(SNAP_HALF);
 
     const { bars, indicators } = useBars({ symbol, timeframe });
 
@@ -248,6 +246,13 @@ export function ChartContent({
         ]
     );
 
+    // MobileAnalysisSheet를 Suspense 경계 밖에서 렌더링하기 위해 콘텐츠를 상위로 전달한다.
+    // Suspense 경계 내에서 직접 렌더링하면 타임프레임 전환 시 바텀시트가 사라진다.
+    const notifyMobileContent = useEffectEvent(onMobileSheetContent);
+    useEffect(() => {
+        notifyMobileContent(analysisContent);
+    }, [analysisContent]);
+
     return (
         <div className="flex h-full w-full flex-col md:flex-row">
             {/* 차트 영역 — 바텀시트는 fixed 오버레이. pb는 SNAP_PEEK 높이만큼 확보해 Peek 시 거래량 차트가 가려지지 않도록 한다 */}
@@ -320,14 +325,6 @@ export function ChartContent({
             >
                 {analysisContent}
             </aside>
-
-            {/* AI 분석 패널 — 모바일 바텀시트 (항상 렌더, Drawer.Content 내부 md:hidden으로 데스크톱에서 숨김) */}
-            <MobileAnalysisSheet
-                activeSnap={sheetSnap}
-                onActiveSnapChange={setSheetSnap}
-            >
-                {analysisContent}
-            </MobileAnalysisSheet>
 
             {/* 드래그 중 전체 화면 오버레이 — 텍스트 선택 방지 */}
             {isDragging && (

--- a/src/components/symbol-page/MobileAnalysisSheet.tsx
+++ b/src/components/symbol-page/MobileAnalysisSheet.tsx
@@ -93,7 +93,8 @@ export function MobileAnalysisSheet({
         // CSS transition을 직접 적용해 애니메이션을 처리한다.
         function snapBack(): void {
             drawerEl.style.transition = `transform 0.5s ${VAUL_EASING}`;
-            drawerEl.style.transform = `translateY(${initialTransformY}px)`;
+            // SNAP_FULL 위치는 항상 translateY(0)이므로 initialTransformY에 의존하지 않는다.
+            drawerEl.style.transform = 'translateY(0px)';
             drawerEl.addEventListener(
                 'transitionend',
                 () => {
@@ -111,9 +112,12 @@ export function MobileAnalysisSheet({
             startedAtTop = scrollEl.scrollTop <= 0;
             isDragging = false;
             if (startedAtTop) {
-                // onActiveSnapChange 호출 시 React가 vaul의 transform을 덮어쓰므로
-                // 이 값을 기준점으로 사용해 연속적인 애니메이션을 구성한다.
+                // 진행 중인 snapBack() 애니메이션을 즉시 중단해 initialTransformY와
+                // 실제 DOM 위치를 동기화한다. 이를 생략하면 애니메이션 중간값이
+                // 기준점으로 캡처되어 반복 스와이프 시 위치가 누적 drift된다.
                 initialTransformY = captureTransformY(drawerEl);
+                drawerEl.style.transition = 'none';
+                drawerEl.style.transform = `translateY(${initialTransformY}px)`;
             }
         }
 

--- a/src/components/symbol-page/SymbolPageClient.tsx
+++ b/src/components/symbol-page/SymbolPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useState } from 'react';
+import { Suspense, useState, useEffect } from 'react';
 import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -32,6 +32,7 @@ export function SymbolPageClient({
     initialAnalysisFailed,
     indicatorCount,
 }: SymbolPageClientProps) {
+    const [isMounted, setIsMounted] = useState(false);
     const [sheetSnap, setSheetSnap] = useState<SnapPoint>(SNAP_HALF);
     const [mobileSheetContent, setMobileSheetContent] =
         useState<ReactNode>(null);
@@ -46,6 +47,12 @@ export function SymbolPageClient({
 
     const ticker = symbol.toUpperCase();
     const hasCompanyName = !!assetInfo && assetInfo.name !== ticker;
+
+    // vaul이 클라이언트에서 aria-hidden을 DOM에 주입하므로 SSR에서는 렌더링을 생략한다.
+    // 서버와 클라이언트 간 Hydration mismatch를 방지하기 위해 마운트 후에만 시트를 표시한다.
+    useEffect(() => {
+        setIsMounted(true);
+    }, []);
 
     return (
         <SymbolPageProvider indicatorCount={indicatorCount}>
@@ -116,12 +123,14 @@ export function SymbolPageClient({
                     </ErrorBoundary>
                 </div>
                 {/* Suspense 경계 밖에 렌더링하여 타임프레임 전환 시 바텀시트가 사라지지 않도록 한다 */}
-                <MobileAnalysisSheet
-                    activeSnap={sheetSnap}
-                    onActiveSnapChange={setSheetSnap}
-                >
-                    {mobileSheetContent}
-                </MobileAnalysisSheet>
+                {isMounted && (
+                    <MobileAnalysisSheet
+                        activeSnap={sheetSnap}
+                        onActiveSnapChange={setSheetSnap}
+                    >
+                        {mobileSheetContent}
+                    </MobileAnalysisSheet>
+                )}
             </div>
         </SymbolPageProvider>
     );

--- a/src/components/symbol-page/SymbolPageClient.tsx
+++ b/src/components/symbol-page/SymbolPageClient.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { Suspense, useState, useEffect } from 'react';
+import { Suspense, useState } from 'react';
 import type { ReactNode } from 'react';
+import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { ErrorBoundary } from 'react-error-boundary';
 import type { AnalysisResponse } from '@/domain/types';
@@ -11,13 +12,24 @@ import { ChartErrorFallback } from '@/components/chart/ChartErrorFallback';
 import { TickerAutocomplete } from '@/components/search/TickerAutocomplete';
 import { ChartContent } from '@/components/symbol-page/ChartContent';
 import {
-    MobileAnalysisSheet,
     SNAP_HALF,
     type SnapPoint,
 } from '@/components/symbol-page/MobileAnalysisSheet';
 import { SymbolPageProvider } from '@/components/symbol-page/SymbolPageContext';
 import { useTimeframeChange } from '@/components/symbol-page/hooks/useTimeframeChange';
 import { useAssetInfo } from '@/components/symbol-page/hooks/useAssetInfo';
+
+// vaul은 내부 Radix DismissableLayer로 Drawer 외부 형제 요소에 aria-hidden을 주입한다.
+// 이 DOM 조작이 hydration 사이클과 겹치면 React가 mismatch를 감지하므로,
+// ssr: false로 모듈 로딩 경계까지 분리하여 hydration 완료 이후 비동기로 마운트한다.
+// 타입과 상수(SNAP_HALF, SnapPoint)는 정적 참조라 일반 import를 유지한다.
+const MobileAnalysisSheet = dynamic(
+    () =>
+        import('@/components/symbol-page/MobileAnalysisSheet').then(m => ({
+            default: m.MobileAnalysisSheet,
+        })),
+    { ssr: false }
+);
 
 interface SymbolPageClientProps {
     symbol: string;
@@ -32,7 +44,6 @@ export function SymbolPageClient({
     initialAnalysisFailed,
     indicatorCount,
 }: SymbolPageClientProps) {
-    const [isMounted, setIsMounted] = useState(false);
     const [sheetSnap, setSheetSnap] = useState<SnapPoint>(SNAP_HALF);
     const [mobileSheetContent, setMobileSheetContent] =
         useState<ReactNode>(null);
@@ -47,12 +58,6 @@ export function SymbolPageClient({
 
     const ticker = symbol.toUpperCase();
     const hasCompanyName = !!assetInfo && assetInfo.name !== ticker;
-
-    // vaul이 클라이언트에서 aria-hidden을 DOM에 주입하므로 SSR에서는 렌더링을 생략한다.
-    // 서버와 클라이언트 간 Hydration mismatch를 방지하기 위해 마운트 후에만 시트를 표시한다.
-    useEffect(() => {
-        setIsMounted(true);
-    }, []);
 
     return (
         <SymbolPageProvider indicatorCount={indicatorCount}>
@@ -123,14 +128,12 @@ export function SymbolPageClient({
                     </ErrorBoundary>
                 </div>
                 {/* Suspense 경계 밖에 렌더링하여 타임프레임 전환 시 바텀시트가 사라지지 않도록 한다 */}
-                {isMounted && (
-                    <MobileAnalysisSheet
-                        activeSnap={sheetSnap}
-                        onActiveSnapChange={setSheetSnap}
-                    >
-                        {mobileSheetContent}
-                    </MobileAnalysisSheet>
-                )}
+                <MobileAnalysisSheet
+                    activeSnap={sheetSnap}
+                    onActiveSnapChange={setSheetSnap}
+                >
+                    {mobileSheetContent}
+                </MobileAnalysisSheet>
             </div>
         </SymbolPageProvider>
     );

--- a/src/components/symbol-page/SymbolPageClient.tsx
+++ b/src/components/symbol-page/SymbolPageClient.tsx
@@ -33,7 +33,8 @@ export function SymbolPageClient({
     indicatorCount,
 }: SymbolPageClientProps) {
     const [sheetSnap, setSheetSnap] = useState<SnapPoint>(SNAP_HALF);
-    const [mobileSheetContent, setMobileSheetContent] = useState<ReactNode>(null);
+    const [mobileSheetContent, setMobileSheetContent] =
+        useState<ReactNode>(null);
     // Suspense로 인해 ChartContent가 remount될 때 타임프레임 변경 여부를 전달한다.
     // timeframe 변경 횟수를 카운트하여 ChartContent가 타임프레임 변경으로 인해
     // mount된 것인지 초기 mount인지를 구분한다.

--- a/src/components/symbol-page/SymbolPageClient.tsx
+++ b/src/components/symbol-page/SymbolPageClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Suspense } from 'react';
+import { Suspense, useState } from 'react';
+import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { ErrorBoundary } from 'react-error-boundary';
 import type { AnalysisResponse } from '@/domain/types';
@@ -9,6 +10,11 @@ import { ChartSkeleton } from '@/components/chart/ChartSkeleton';
 import { ChartErrorFallback } from '@/components/chart/ChartErrorFallback';
 import { TickerAutocomplete } from '@/components/search/TickerAutocomplete';
 import { ChartContent } from '@/components/symbol-page/ChartContent';
+import {
+    MobileAnalysisSheet,
+    SNAP_HALF,
+    type SnapPoint,
+} from '@/components/symbol-page/MobileAnalysisSheet';
 import { SymbolPageProvider } from '@/components/symbol-page/SymbolPageContext';
 import { useTimeframeChange } from '@/components/symbol-page/hooks/useTimeframeChange';
 import { useAssetInfo } from '@/components/symbol-page/hooks/useAssetInfo';
@@ -26,6 +32,8 @@ export function SymbolPageClient({
     initialAnalysisFailed,
     indicatorCount,
 }: SymbolPageClientProps) {
+    const [sheetSnap, setSheetSnap] = useState<SnapPoint>(SNAP_HALF);
+    const [mobileSheetContent, setMobileSheetContent] = useState<ReactNode>(null);
     // Suspense로 인해 ChartContent가 remount될 때 타임프레임 변경 여부를 전달한다.
     // timeframe 변경 횟수를 카운트하여 ChartContent가 타임프레임 변경으로 인해
     // mount된 것인지 초기 mount인지를 구분한다.
@@ -101,10 +109,18 @@ export function SymbolPageClient({
                                 timeframeChangeCount={timeframeChangeCount}
                                 initialAnalysis={initialAnalysis}
                                 initialAnalysisFailed={initialAnalysisFailed}
+                                onMobileSheetContent={setMobileSheetContent}
                             />
                         </Suspense>
                     </ErrorBoundary>
                 </div>
+                {/* Suspense 경계 밖에 렌더링하여 타임프레임 전환 시 바텀시트가 사라지지 않도록 한다 */}
+                <MobileAnalysisSheet
+                    activeSnap={sheetSnap}
+                    onActiveSnapChange={setSheetSnap}
+                >
+                    {mobileSheetContent}
+                </MobileAnalysisSheet>
             </div>
         </SymbolPageProvider>
     );

--- a/src/domain/analysis/confidence.ts
+++ b/src/domain/analysis/confidence.ts
@@ -87,9 +87,7 @@ export function enrichAnalysisWithConfidence(
     const indicatorResults = compact(
         asArray(raw.indicatorResults).map(normalizeIndicatorGuideResult)
     );
-    const trendlines = compact(
-        asArray(raw.trendlines).map(normalizeTrendline)
-    );
+    const trendlines = compact(asArray(raw.trendlines).map(normalizeTrendline));
 
     const patternSummaryIds = buildUniqueIds(patternSummaries, 'patternName');
     const candlePatternIds = buildUniqueIds(candlePatterns, 'patternName');

--- a/src/domain/analysis/confidence.ts
+++ b/src/domain/analysis/confidence.ts
@@ -13,6 +13,8 @@ import type {
 } from '@/domain/types';
 import {
     asArray,
+    asString,
+    compact,
     normalizeActionRecommendation,
     normalizeCandlePatternSummary,
     normalizeIndicatorGuideResult,
@@ -23,7 +25,6 @@ import {
     normalizeStrategyResult,
     normalizeTrend,
     normalizeTrendline,
-    asString,
 } from '@/domain/analysis/normalize';
 
 interface SkillLookup {
@@ -57,10 +58,6 @@ function buildUniqueIds<T, K extends keyof T>(items: T[], key: K): string[] {
         },
         { ids: [], counter: new Map() }
     ).ids;
-}
-
-function compact<T>(xs: (T | null)[]): T[] {
-    return xs.filter((x): x is T => x !== null);
 }
 
 export function filterPatterns(patterns: PatternResult[]): PatternResult[] {

--- a/src/domain/analysis/confidence.ts
+++ b/src/domain/analysis/confidence.ts
@@ -11,6 +11,20 @@ import type {
     Skill,
     StrategyResult,
 } from '@/domain/types';
+import {
+    asArray,
+    normalizeActionRecommendation,
+    normalizeCandlePatternSummary,
+    normalizeIndicatorGuideResult,
+    normalizeKeyLevels,
+    normalizePatternSummary,
+    normalizePriceTargets,
+    normalizeRiskLevel,
+    normalizeStrategyResult,
+    normalizeTrend,
+    normalizeTrendline,
+    asString,
+} from '@/domain/analysis/normalize';
 
 interface SkillLookup {
     byName: Map<string, Skill>;
@@ -45,6 +59,10 @@ function buildUniqueIds<T, K extends keyof T>(items: T[], key: K): string[] {
     ).ids;
 }
 
+function compact<T>(xs: (T | null)[]): T[] {
+    return xs.filter((x): x is T => x !== null);
+}
+
 export function filterPatterns(patterns: PatternResult[]): PatternResult[] {
     return patterns.filter(p => MIN_CONFIDENCE_WEIGHT <= p.confidenceWeight);
 }
@@ -55,10 +73,23 @@ export function enrichAnalysisWithConfidence(
 ): AnalysisResponse {
     const lookup = buildSkillLookup(skills);
 
-    // LLM이 필드를 누락하거나 null로 반환할 수 있으므로 기본값으로 정규화한다.
-    const patternSummaries = raw.patternSummaries ?? [];
-    const strategyResults = raw.strategyResults ?? [];
-    const candlePatterns = raw.candlePatterns ?? [];
+    // 모든 배열 필드를 타입 검증하며 정규화한다.
+    // 잘못된 항목(null 반환)은 탈락시킨다.
+    const patternSummaries = compact(
+        asArray(raw.patternSummaries).map(normalizePatternSummary)
+    );
+    const strategyResults = compact(
+        asArray(raw.strategyResults).map(normalizeStrategyResult)
+    );
+    const candlePatterns = compact(
+        asArray(raw.candlePatterns).map(normalizeCandlePatternSummary)
+    );
+    const indicatorResults = compact(
+        asArray(raw.indicatorResults).map(normalizeIndicatorGuideResult)
+    );
+    const trendlines = compact(
+        asArray(raw.trendlines).map(normalizeTrendline)
+    );
 
     const patternSummaryIds = buildUniqueIds(patternSummaries, 'patternName');
     const candlePatternIds = buildUniqueIds(candlePatterns, 'patternName');
@@ -82,21 +113,16 @@ export function enrichAnalysisWithConfidence(
     );
 
     return {
-        summary: raw.summary ?? '',
-        trend: raw.trend ?? 'neutral',
-        indicatorResults: raw.indicatorResults ?? [],
-        riskLevel: raw.riskLevel ?? 'medium',
-        keyLevels: {
-            support: raw.keyLevels?.support ?? [],
-            resistance: raw.keyLevels?.resistance ?? [],
-            poc: raw.keyLevels?.poc ?? undefined,
-        },
-        priceTargets: {
-            bullish: raw.priceTargets?.bullish ?? null,
-            bearish: raw.priceTargets?.bearish ?? null,
-        },
-        trendlines: raw.trendlines ?? [],
-        actionRecommendation: raw.actionRecommendation ?? undefined,
+        summary: asString(raw.summary),
+        trend: normalizeTrend(raw.trend),
+        indicatorResults,
+        riskLevel: normalizeRiskLevel(raw.riskLevel),
+        keyLevels: normalizeKeyLevels(raw.keyLevels),
+        priceTargets: normalizePriceTargets(raw.priceTargets),
+        trendlines,
+        actionRecommendation: normalizeActionRecommendation(
+            raw.actionRecommendation
+        ),
         patternSummaries: filterPatterns(enrichedPatterns),
         strategyResults: strategyResults.map(
             (

--- a/src/domain/analysis/normalize.ts
+++ b/src/domain/analysis/normalize.ts
@@ -69,6 +69,7 @@ export function asOptionalEnum<T extends string>(
 
 export function asObject(v: unknown): Record<string, unknown> | null {
     if (v === null || typeof v !== 'object' || Array.isArray(v)) return null;
+    // 바로 위 가드에서 null, 비객체, 배열을 모두 걸러내 Record 구조임을 확정했다.
     return v as Record<string, unknown>;
 }
 
@@ -76,7 +77,7 @@ export function asArray(v: unknown): unknown[] {
     return Array.isArray(v) ? v : [];
 }
 
-function compact<T>(xs: (T | null)[]): T[] {
+export function compact<T>(xs: (T | null)[]): T[] {
     return xs.filter((x): x is T => x !== null);
 }
 

--- a/src/domain/analysis/normalize.ts
+++ b/src/domain/analysis/normalize.ts
@@ -81,6 +81,11 @@ export function compact<T>(xs: (T | null)[]): T[] {
     return xs.filter((x): x is T => x !== null);
 }
 
+function normalizeNumberArray(v: unknown): number[] | undefined {
+    if (!Array.isArray(v)) return undefined;
+    return v.map(asNumber).filter((p): p is number => p !== undefined);
+}
+
 // --- enum 래퍼 ---
 
 export function normalizeTrend(v: unknown): Trend {
@@ -205,7 +210,7 @@ export function normalizeTimeRange(
     return { start, end };
 }
 
-type RawPatternSummary = Omit<PatternSummary, 'confidenceWeight' | 'id'>;
+export type RawPatternSummary = Omit<PatternSummary, 'confidenceWeight' | 'id'>;
 
 export function normalizePatternSummary(v: unknown): RawPatternSummary | null {
     const o = asObject(v);
@@ -233,7 +238,7 @@ export function normalizePatternSummary(v: unknown): RawPatternSummary | null {
     };
 }
 
-type RawStrategyResult = Omit<StrategyResult, 'confidenceWeight' | 'id'>;
+export type RawStrategyResult = Omit<StrategyResult, 'confidenceWeight' | 'id'>;
 
 export function normalizeStrategyResult(v: unknown): RawStrategyResult | null {
     const o = asObject(v);
@@ -289,18 +294,10 @@ export function normalizeActionRecommendation(
     const exit = asString(o.exit);
     const riskReward = asString(o.riskReward);
 
+    // LLM이 텍스트 설명 없이 숫자 필드만 반환하는 케이스는 프롬프트 구조상 발생하지
+    // 않으므로, 텍스트 4개 필드를 추천 존재 여부의 대표 신호로 사용한다.
+    // 모두 비어 있으면 숫자 필드가 있더라도 추천 자체가 없는 것으로 간주한다.
     if (!positionAnalysis && !entry && !exit && !riskReward) return undefined;
-
-    const entryPrices = Array.isArray(o.entryPrices)
-        ? o.entryPrices
-              .map(asNumber)
-              .filter((p): p is number => p !== undefined)
-        : undefined;
-    const takeProfitPrices = Array.isArray(o.takeProfitPrices)
-        ? o.takeProfitPrices
-              .map(asNumber)
-              .filter((p): p is number => p !== undefined)
-        : undefined;
 
     return {
         positionAnalysis,
@@ -311,8 +308,8 @@ export function normalizeActionRecommendation(
             o.entryRecommendation,
             VALID_ENTRY_RECOMMENDATIONS
         ),
-        entryPrices,
+        entryPrices: normalizeNumberArray(o.entryPrices),
         stopLoss: asNumber(o.stopLoss),
-        takeProfitPrices,
+        takeProfitPrices: normalizeNumberArray(o.takeProfitPrices),
     };
 }

--- a/src/domain/analysis/normalize.ts
+++ b/src/domain/analysis/normalize.ts
@@ -234,9 +234,7 @@ export function normalizePatternSummary(v: unknown): RawPatternSummary | null {
 
 type RawStrategyResult = Omit<StrategyResult, 'confidenceWeight' | 'id'>;
 
-export function normalizeStrategyResult(
-    v: unknown
-): RawStrategyResult | null {
+export function normalizeStrategyResult(v: unknown): RawStrategyResult | null {
     const o = asObject(v);
     if (!o) return null;
     const strategyName = asString(o.strategyName);

--- a/src/domain/analysis/normalize.ts
+++ b/src/domain/analysis/normalize.ts
@@ -1,0 +1,319 @@
+import type {
+    ActionRecommendation,
+    CandlePatternSummary,
+    EntryRecommendation,
+    IndicatorGuideResult,
+    KeyLevel,
+    KeyLevels,
+    KeyPrice,
+    PatternLine,
+    PatternSummary,
+    PriceScenario,
+    PriceTarget,
+    PriceTargets,
+    RiskLevel,
+    Signal,
+    SignalStrength,
+    StrategyResult,
+    Trend,
+    Trendline,
+    TrendlineDirection,
+    TrendlinePoint,
+} from '@/domain/types';
+
+const VALID_TRENDS: readonly Trend[] = ['bullish', 'bearish', 'neutral'];
+const VALID_RISK_LEVELS: readonly RiskLevel[] = ['low', 'medium', 'high'];
+const VALID_TRENDLINE_DIRECTIONS: readonly TrendlineDirection[] = [
+    'ascending',
+    'descending',
+];
+const VALID_SIGNAL_STRENGTHS: readonly SignalStrength[] = [
+    'strong',
+    'moderate',
+    'weak',
+];
+const VALID_ENTRY_RECOMMENDATIONS: readonly EntryRecommendation[] = [
+    'enter',
+    'wait',
+    'avoid',
+];
+
+// --- 원시 값 헬퍼 ---
+
+export function asString(v: unknown, fallback = ''): string {
+    return typeof v === 'string' ? v : fallback;
+}
+
+export function asNumber(v: unknown): number | undefined {
+    return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+}
+
+export function asBoolean(v: unknown, fallback = false): boolean {
+    return typeof v === 'boolean' ? v : fallback;
+}
+
+export function asEnum<T extends string>(
+    v: unknown,
+    valid: readonly T[],
+    fallback: T
+): T {
+    return valid.find(x => x === v) ?? fallback;
+}
+
+export function asOptionalEnum<T extends string>(
+    v: unknown,
+    valid: readonly T[]
+): T | undefined {
+    return valid.find(x => x === v);
+}
+
+export function asObject(v: unknown): Record<string, unknown> | null {
+    if (v === null || typeof v !== 'object' || Array.isArray(v)) return null;
+    return v as Record<string, unknown>;
+}
+
+export function asArray(v: unknown): unknown[] {
+    return Array.isArray(v) ? v : [];
+}
+
+function compact<T>(xs: (T | null)[]): T[] {
+    return xs.filter((x): x is T => x !== null);
+}
+
+// --- enum 래퍼 ---
+
+export function normalizeTrend(v: unknown): Trend {
+    return asEnum(v, VALID_TRENDS, 'neutral');
+}
+
+export function normalizeRiskLevel(v: unknown): RiskLevel {
+    return asEnum(v, VALID_RISK_LEVELS, 'medium');
+}
+
+// --- KeyLevel ---
+
+export function normalizeKeyLevel(v: unknown): KeyLevel | null {
+    const o = asObject(v);
+    if (!o) return null;
+    const price = asNumber(o.price);
+    if (price === undefined) return null;
+    return { price, reason: asString(o.reason) };
+}
+
+export function normalizeKeyLevels(v: unknown): KeyLevels {
+    const o = asObject(v);
+    if (!o) return { support: [], resistance: [], poc: undefined };
+    return {
+        support: compact(asArray(o.support).map(normalizeKeyLevel)),
+        resistance: compact(asArray(o.resistance).map(normalizeKeyLevel)),
+        poc: normalizeKeyLevel(o.poc) ?? undefined,
+    };
+}
+
+// --- PriceTargets ---
+
+export function normalizePriceTarget(v: unknown): PriceTarget | null {
+    const o = asObject(v);
+    if (!o) return null;
+    const price = asNumber(o.price);
+    if (price === undefined) return null;
+    return { price, basis: asString(o.basis) };
+}
+
+export function normalizePriceScenario(v: unknown): PriceScenario | null {
+    const o = asObject(v);
+    if (!o) return null;
+    return {
+        targets: compact(asArray(o.targets).map(normalizePriceTarget)),
+        condition: asString(o.condition),
+    };
+}
+
+export function normalizePriceTargets(v: unknown): PriceTargets {
+    const o = asObject(v);
+    if (!o) return { bullish: null, bearish: null };
+    return {
+        bullish: normalizePriceScenario(o.bullish),
+        bearish: normalizePriceScenario(o.bearish),
+    };
+}
+
+// --- Signals / IndicatorGuideResult ---
+
+export function normalizeSignal(v: unknown): Signal | null {
+    const o = asObject(v);
+    if (!o) return null;
+    // SignalType은 현재 'skill' 단일 값으로 고정
+    return {
+        type: 'skill',
+        description: asString(o.description),
+        trend: normalizeTrend(o.trend),
+        strength: asOptionalEnum(o.strength, VALID_SIGNAL_STRENGTHS),
+    };
+}
+
+export function normalizeIndicatorGuideResult(
+    v: unknown
+): IndicatorGuideResult | null {
+    const o = asObject(v);
+    if (!o) return null;
+    const indicatorName = asString(o.indicatorName);
+    if (!indicatorName) return null;
+    return {
+        indicatorName,
+        signals: compact(asArray(o.signals).map(normalizeSignal)),
+    };
+}
+
+// --- Pattern / Strategy / Candle ---
+
+export function normalizeKeyPrice(v: unknown): KeyPrice | null {
+    const o = asObject(v);
+    if (!o) return null;
+    const price = asNumber(o.price);
+    if (price === undefined) return null;
+    return { label: asString(o.label), price };
+}
+
+export function normalizeTrendlinePoint(v: unknown): TrendlinePoint | null {
+    const o = asObject(v);
+    if (!o) return null;
+    const time = asNumber(o.time);
+    const price = asNumber(o.price);
+    if (time === undefined || price === undefined) return null;
+    return { time, price };
+}
+
+export function normalizePatternLine(v: unknown): PatternLine | null {
+    const o = asObject(v);
+    if (!o) return null;
+    const start = normalizeTrendlinePoint(o.start);
+    const end = normalizeTrendlinePoint(o.end);
+    if (!start || !end) return null;
+    return { label: asString(o.label), start, end };
+}
+
+export function normalizeTimeRange(
+    v: unknown
+): { start: number; end: number } | undefined {
+    const o = asObject(v);
+    if (!o) return undefined;
+    const start = asNumber(o.start);
+    const end = asNumber(o.end);
+    if (start === undefined || end === undefined) return undefined;
+    return { start, end };
+}
+
+type RawPatternSummary = Omit<PatternSummary, 'confidenceWeight' | 'id'>;
+
+export function normalizePatternSummary(v: unknown): RawPatternSummary | null {
+    const o = asObject(v);
+    if (!o) return null;
+    const patternName = asString(o.patternName);
+    const skillName = asString(o.skillName);
+    if (!patternName || !skillName) return null;
+
+    const keyPricesArr = Array.isArray(o.keyPrices)
+        ? compact(o.keyPrices.map(normalizeKeyPrice))
+        : undefined;
+    const patternLinesArr = Array.isArray(o.patternLines)
+        ? compact(o.patternLines.map(normalizePatternLine))
+        : undefined;
+
+    return {
+        patternName,
+        skillName,
+        detected: asBoolean(o.detected),
+        trend: normalizeTrend(o.trend),
+        summary: asString(o.summary),
+        keyPrices: keyPricesArr,
+        patternLines: patternLinesArr,
+        timeRange: normalizeTimeRange(o.timeRange),
+    };
+}
+
+type RawStrategyResult = Omit<StrategyResult, 'confidenceWeight' | 'id'>;
+
+export function normalizeStrategyResult(
+    v: unknown
+): RawStrategyResult | null {
+    const o = asObject(v);
+    if (!o) return null;
+    const strategyName = asString(o.strategyName);
+    if (!strategyName) return null;
+    return {
+        strategyName,
+        trend: normalizeTrend(o.trend),
+        summary: asString(o.summary),
+    };
+}
+
+type RawCandlePatternSummary = Omit<CandlePatternSummary, 'id'>;
+
+export function normalizeCandlePatternSummary(
+    v: unknown
+): RawCandlePatternSummary | null {
+    const o = asObject(v);
+    if (!o) return null;
+    const patternName = asString(o.patternName);
+    if (!patternName) return null;
+    return {
+        patternName,
+        detected: asBoolean(o.detected),
+        trend: normalizeTrend(o.trend),
+        summary: asString(o.summary),
+    };
+}
+
+// --- Trendline ---
+
+export function normalizeTrendline(v: unknown): Trendline | null {
+    const o = asObject(v);
+    if (!o) return null;
+    const direction = asOptionalEnum(o.direction, VALID_TRENDLINE_DIRECTIONS);
+    const start = normalizeTrendlinePoint(o.start);
+    const end = normalizeTrendlinePoint(o.end);
+    if (!direction || !start || !end) return null;
+    return { direction, start, end };
+}
+
+// --- ActionRecommendation ---
+
+export function normalizeActionRecommendation(
+    raw: unknown
+): ActionRecommendation | undefined {
+    const o = asObject(raw);
+    if (!o) return undefined;
+
+    const positionAnalysis = asString(o.positionAnalysis);
+    const entry = asString(o.entry);
+    const exit = asString(o.exit);
+    const riskReward = asString(o.riskReward);
+
+    if (!positionAnalysis && !entry && !exit && !riskReward) return undefined;
+
+    const entryPrices = Array.isArray(o.entryPrices)
+        ? o.entryPrices
+              .map(asNumber)
+              .filter((p): p is number => p !== undefined)
+        : undefined;
+    const takeProfitPrices = Array.isArray(o.takeProfitPrices)
+        ? o.takeProfitPrices
+              .map(asNumber)
+              .filter((p): p is number => p !== undefined)
+        : undefined;
+
+    return {
+        positionAnalysis,
+        entry,
+        exit,
+        riskReward,
+        entryRecommendation: asOptionalEnum(
+            o.entryRecommendation,
+            VALID_ENTRY_RECOMMENDATIONS
+        ),
+        entryPrices,
+        stopLoss: asNumber(o.stopLoss),
+        takeProfitPrices,
+    };
+}

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -461,29 +461,23 @@ export interface AnalyzeVariables {
  * LLM이 반환하는 원시 분석 응답.
  *
  * 프롬프트에서는 모든 필드를 required로 요청하지만,
- * LLM 특성상 어떤 필드도 누락되거나 null로 반환될 수 있다.
- * {@link enrichAnalysisWithConfidence} 에서 누락 필드를 기본값으로
- * 정규화한 후 {@link AnalysisResponse} 로 변환된다.
+ * LLM 특성상 누락·null 반환뿐 아니라 잘못된 타입(예: string 필드에 객체)으로
+ * 반환되는 케이스까지 관측된다. 따라서 모든 필드를 unknown으로 받아
+ * {@link enrichAnalysisWithConfidence}에서 런타임 정규화한 뒤
+ * {@link AnalysisResponse}로 변환한다.
  */
 export interface RawAnalysisResponse {
-    summary?: string | null;
-    trend?: Trend | null;
-    indicatorResults?: IndicatorGuideResult[] | null;
-    riskLevel?: RiskLevel | null;
-    keyLevels?: {
-        support?: KeyLevel[] | null;
-        resistance?: KeyLevel[] | null;
-        poc?: KeyLevel | null;
-    } | null;
-    priceTargets?: {
-        bullish?: PriceScenario | null;
-        bearish?: PriceScenario | null;
-    } | null;
-    patternSummaries?: Omit<PatternSummary, 'confidenceWeight' | 'id'>[] | null;
-    strategyResults?: Omit<StrategyResult, 'confidenceWeight' | 'id'>[] | null;
-    candlePatterns?: Omit<CandlePatternSummary, 'id'>[] | null;
-    trendlines?: Trendline[] | null;
-    actionRecommendation?: ActionRecommendation | null;
+    summary?: unknown;
+    trend?: unknown;
+    indicatorResults?: unknown;
+    riskLevel?: unknown;
+    keyLevels?: unknown;
+    priceTargets?: unknown;
+    patternSummaries?: unknown;
+    strategyResults?: unknown;
+    candlePatterns?: unknown;
+    trendlines?: unknown;
+    actionRecommendation?: unknown;
 }
 
 // --- Job Result Types (submit + poll 패턴) ---


### PR DESCRIPTION
## 관련 이슈

closes #316

## 구현 내용

모바일 Bottom Sheet가 timeframe 전환 시 사라지는 문제를 해결하는 과정에서, 분석 파이프라인 전반의 안정성 이슈를 함께 정리했습니다.

### 1. 바텀시트 사라짐 근본 수정

- `ChartContent.tsx`의 `notifyMobileContent` useEffect deps에 `timeframe` 추가
- React Compiler 환경에서 `useMemo`된 `analysisContent`의 참조가 안정적으로 유지되어 effect가 재실행되지 않는 케이스 대응
- 원시값 `timeframe`을 deps에 포함시켜 타임프레임 전환 시 effect 재실행을 확실히 보장

### 2. Hydration mismatch 해결

- `MobileAnalysisSheet`를 `next/dynamic` + `{ ssr: false }`로 전환
- vaul 내부 Radix `DismissableLayer`가 Drawer 외부 형제 요소에 `aria-hidden`을 주입하는 과정과 hydration 사이클이 겹치는 문제를 원천 차단
- 기존 `isMounted` guard와 관련 useEffect 모두 제거 → 코드 단순화

### 3. LLM 응답 전면 정규화 (React child 에러 방지)

- `AnalysisPanel`이 `{rec[key]}`로 문자열을 `<p>` 자식으로 렌더하는데 LLM이 객체를 반환하면 `Objects are not valid as a React child` 에러로 분석 전체가 실패하던 문제 수정
- `src/domain/analysis/normalize.ts` 신규 추가 — 모든 `AnalysisResponse` 필드(summary, trend, riskLevel, keyLevels, priceTargets, indicatorResults, patternSummaries, strategyResults, candlePatterns, trendlines, actionRecommendation)에 대한 타입 검증 normalizer
- `RawAnalysisResponse`의 모든 필드를 `unknown`으로 변경 (LLM JSON 응답의 현실 반영)
- `enrichAnalysisWithConfidence`가 모든 필드를 normalizer로 처리, 필수 값 누락 항목은 탈락
- `AnalysisPanel.tsx` 렌더에 defensive check 추가 (이중 안전장치)

### 4. Server Action body size limit 임시 상향

- 분석 요청 payload가 1MB 기본 제한을 초과하여 413 에러 발생
- `experimental.serverActions.bodySizeLimit: '5mb'` 임시 적용
- 근본 해결(서버에서 bars/indicators 재구성)은 #318에서 진행 예정

## 변경 파일 목록

[신규]
- `src/domain/analysis/normalize.ts`

[수정]
- `next.config.ts`
- `src/components/symbol-page/ChartContent.tsx`
- `src/components/symbol-page/SymbolPageClient.tsx`
- `src/components/analysis/AnalysisPanel.tsx`
- `src/domain/analysis/confidence.ts`
- `src/domain/types.ts`
- `src/__tests__/domain/analysis/confidence.test.ts`

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style