### PR TITLE
feat: AssetInfo.fmpSymbol로 지수 심볼 bars 조회 구현

### DIFF
--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -83,6 +83,27 @@ This file contains only **recurring gotchas** that agents keep missing despite e
     ✅ worker/src/index.ts: // Matches JOB_TTL_SECONDS in queue.ts; update both if changed
              const JOB_TTL_SECONDS = 3600;
     → Redis key schemas duplicated across files must include a JSDoc block documenting the schema origin and dependency chain
+
+16. Custom hooks declared after derived variables in component/hook code
+    → All hook calls must be declared before derived variables (const x = ...), handlers, or effects
+    ❌ const timeframe = computeTimeframe(); useQuery(...)
+    ✅ useQuery(...); const timeframe = computeTimeframe();
+    → Ordering: useState/useRef → useQuery/useMutation → derived variables → handlers → useEffect
+
+17. Non-hook utility functions defined inside hook files
+    → Pure utilities like sleep() belong in utils/ subfolders, not inside hook files
+    ❌ useAnalysis.ts: const sleep = (ms) => new Promise(...)
+    ✅ symbol-page/utils/sleep.ts
+
+18. Inline styles in JSX when Tailwind classes are available
+    → Always use Tailwind; never inline style={{ ... }} for layout or styling
+    ❌ <ins style={{ display: 'block' }} />
+    ✅ <ins className="block" />
+
+19. Nested functions without explicit parameters extracted to module level
+    → When extracting a function from a parent function scope, make all parent variables explicit parameters
+    ❌ function searchAction() { function toResult(x) { ... parent var ... } }
+    ✅ function toResult(x, parentVar) { ... }; function searchAction() { toResult(..., parentVar); }
 ```
 
 ---

--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -242,6 +242,12 @@ This file contains only **recurring gotchas** that agents keep missing despite e
     → Expected values from module exports must also be imported, not hardcoded
     ❌ expect(label).toBe('STRONG'); // STRONG_LABEL imported from same module as function
     ✅ import { SIGNAL_STRENGTH_LABEL } from '@/utils'; expect(label).toBe(SIGNAL_STRENGTH_LABEL.strong);
+
+14. Time-dependent functions in tests must be explicitly mocked
+    → Functions using Date.now(), new Date() must be mocked in test files
+    → Hard-coded expected values (e.g., TTL seconds) without mocking time sources cause flaky tests
+    ❌ analyzeAction test: expect(ttl).toBe(86400); without mocking new Date()
+    ✅ jest.mock('@/infrastructure/cache/config', ...); mock Date to fixed timestamp before assertions
 ```
 
 ---
@@ -340,20 +346,44 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 
 ---
 
-## Pure Function Contracts
+## Infrastructure Functions
 
 ```
-1. Utility functions must guard all valid input ranges explicitly
-   → Pure functions must handle edge cases so callers cannot receive invalid results
-   → Include guards for both lower bounds (null, negative) and upper bounds (array length, max values)
-   ❌ function resolveBarIndex(index) { if (index < 0) return 0; return index; }  // missing upper bound
-   ✅ function resolveBarIndex(index) { if (index < 0) return 0; if (index >= length) return length - 1; return index; }
+1. Conditional logic branches must all update shared data consistently
+   → Background jobs and retry paths must produce same data shape as main path
+   → When caching results, all code paths must store the same fields
+   ❌ Main path: cache.set(symbol, { symbol, name, koreanName, fmpSymbol })
+      Background job: cache.set(symbol, { symbol, name, koreanName })  // fmpSymbol missing
+   ✅ Both paths: cache.set(symbol, { symbol, name, koreanName, fmpSymbol })
 
-2. External dependencies must fail gracefully consistently across the module
-   → All calls to the same external service should use identical error handling patterns
-   → If one call uses try-catch, all calls to that service should be wrapped identically
-   ❌ cache.get(key)  // no try-catch, but cache.set(key, val) has try-catch
-   ✅ const value = await cache.get(key).catch(error => { console.error(...); return null; });
+2. Infrastructure functions must have 100% branch coverage
+   → All if/else, optional chaining (?.), nullish coalescing (??) paths tested
+   → Test edge cases like subsecond boundaries, zero values, Math.max guard behavior
+   ❌ Math.max(1, Math.floor(diffMs / 1000)) guard that converts 0→1 untested
+   ✅ Add test case: diffMs = 500ms covers the Math.max(1, 0) = 1 path
+
+3. No debug artifacts (console.log) in infrastructure files
+   → Infrastructure functions are utilities; logging belongs in higher layers
+   ❌ getBars() { console.log(...timing...); return bars; }
+   ✅ Remove logging; expose metrics via return type if needed
+```
+
+---
+
+## Fire-and-Forget Operations
+
+```
+1. Fire-and-forget fetch requests must have timeouts
+   → fetch() without timeout can block indefinitely on network delay
+   → Apply AbortSignal.timeout(ms) to prevent client-side blocking
+   ❌ fetch('/cancel', { method: 'POST' })  // no timeout
+   ✅ fetch('/cancel', { method: 'POST', signal: AbortSignal.timeout(5000) })
+
+2. Fire-and-forget Server Actions must swallow errors
+   → Error propagation from background actions blocks the caller
+   → Wrap in try-catch, log warning, and return normally
+   ❌ async function cancelAction() { await fetch('/cancel'); }  // throws to caller if fetch fails
+   ✅ async function cancelAction() { try { await fetch(...); } catch (e) { console.warn('Background action failed', e); } }
 ```
 
 ---

--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -40,6 +40,17 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 6. Repeating identical filtering/calculation logic across multiple useEffect/useMemo blocks
    → Extract to useMemo (hooks) or const (regular code)
 
+6.5. State/function/documentation divergence — parts of the system not synchronized when requirements change
+   → When reset() is called, all related state (useState + useMutation) must be reset together
+   → When function implementation changes, all related functions in the same module must use consistent approach
+   → When prompt/instruction fields are updated, all field lists and documentation must stay synchronized
+   ❌ reset() clears useMutation data but leaves separate useState stale
+   ❌ collectMdFiles uses recursion but countSkillFiles uses non-recursive readdir
+   ❌ Prompt field added to first list but omitted from second list in same instruction block
+   ✅ reset() clears both useMutation and all related useState state together
+   ✅ countSkillFiles reuses collectMdFiles for consistency
+   ✅ All field lists synchronized when new fields are added
+
 7. Repeating identical className ternary 3+ times
    → Extract to a helper function
 

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,13 +1,5 @@
 # Fix Log
 
-## [PR #326 | feat/325/지수-심볼-지원 | 2026-04-17]
-- Violation: `useAssetInfo(symbol)` (`useQuery`)가 파생 변수 `timeframe` 이후에 선언됨
-- Rule: CONVENTIONS.md — Custom Hook 선언 순서: useState → useRef → useQuery/useMutation → 파생 변수 → 핸들러 → useEffect
-- Context: `useTimeframeChange.ts`에서 `const timeframe = ...` (파생 변수) 뒤에 `useAssetInfo` 호출이 위치
-
-- Violation: `toIndexResult` 인라인 함수가 `searchTickerAction` 함수 내부에 정의됨
-- Rule: CONVENTIONS.md — 중첩 함수는 명시적 파라미터와 함께 모듈 레벨로 추출
-- Context: `searchTickerAction` 함수 내에 `toIndexResult` 화살표 함수를 인라인으로 정의했으나 모듈 레벨 `toIndexTickerResult`로 추출해야 함
 
 ## [PR #315 Round 3 | feat/314/애드센스-배너-광고-구현 | 2026-04-16]
 - Violation: layout.tsx에서 `<Script strategy="lazyOnload">`를 `<head>` 내부에 배치
@@ -32,10 +24,6 @@
 - Rule: Design — 동적 텍스트 콘텐츠에 `whitespace-nowrap` 사용 금지; 자연스러운 줄바꿈 허용
 - Context: 긴 한국어 안내 메시지가 작은 화면에서 컨테이너를 넘어 레이아웃 깨짐 유발 가능; 클래스 제거
 
-## [Issue #314 | feat/314/애드센스-배너-광고-구현 | 2026-04-15]
-- Violation: AdBanner.tsx의 `<ins>` 엘리먼트에 `style={{ display: 'block' }}` 인라인 스타일 사용
-- Rule: CONVENTIONS.md — No inline styles → Tailwind only; `block` 클래스를 사용해야 함
-- Context: AdSense `<ins>` 태그에 `display: block`을 적용하기 위해 인라인 스타일을 사용했으나, Tailwind의 `block` 클래스로 대체 가능
 
 ## [PR #304 | feat/296/캐시-만료-KST-17시-자동-초기화 | 2026-04-14]
 - Violation: `computeEffectiveTtl`이 `new Date()`에 의존함에도 `analyzeAction.test.ts`, `pollAnalysisAction.test.ts`에서 mock 없이 하드코딩 TTL 단언 — 시간대에 따라 flaky 테스트 발생
@@ -69,9 +57,6 @@
 - Rule: 상태 일관성 — reset() 호출 시 관련 useState도 함께 초기화해야 함
 - Context: `useAnalysis.ts`에서 reset()은 useMutation data만 초기화하고, 별도 useState인 analysisResult는 그대로 유지
 
-- Violation: sleep 유틸리티 함수가 hooks/ 파일 내 직접 정의
-- Rule: CONVENTIONS.md — 비훅 순수 유틸리티 함수는 utils/ 서브폴더에 분리
-- Context: `useAnalysis.ts`에서 `sleep` 함수를 인라인 정의; `symbol-page/utils/sleep.ts`로 분리
 
 ## [PR #272 Round 2 | refactor/271/skill-counts-build-time-derivation | 2026-04-11]
 - Violation: `indicatorCount` prop이 `SymbolPageClient` → `ChartContent` → `AnalysisPanel`로 드릴링됨 (두 중간 컴포넌트 모두 미사용)

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -145,3 +145,12 @@
 
 
 
+
+## [Issue #325 | feat/325/지수-심볼-지원 | 2026-04-17]
+- Violation: Infrastructure 함수(FmpProvider.getBars)에 `console.log` 디버그 로그 잔류
+- Rule: Infrastructure Layer Checklist — No console.log or debug artifacts
+- Context: `fmp.ts`의 기존 `getBars` 메서드에 남아있던 타이밍 로그를 제거하지 않고 유지한 채 PR 제출
+
+- Violation: findIndexMatch 반환 타입을 `ReturnType<typeof filterIndexResults>[number] | undefined`로 표현
+- Rule: TypeScript — 재사용 가능하거나 의미를 전달해야 하는 반환 타입은 구조적 유틸리티 타입 대신 명시적 named type으로 표현
+- Context: `filterIndexResults`가 `FmpSearchResult[]`를 반환하므로 해당 표현식은 `FmpSearchResult | undefined`와 동일; 명시적 타입 사용이 더 가독성 높음

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -53,11 +53,6 @@
 - Rule: 데이터 의존 관계가 있는 Redis 쓰기는 순차 실행
 - Context: `worker/src/index.ts`에서 `Promise.all([set result, set status])` → `await set result; await set status`로 순차 실행
 
-- Violation: 타임프레임 변경 시 analysisResult(useState)를 null로 초기화하지 않아 이전 결과가 남음
-- Rule: 상태 일관성 — reset() 호출 시 관련 useState도 함께 초기화해야 함
-- Context: `useAnalysis.ts`에서 reset()은 useMutation data만 초기화하고, 별도 useState인 analysisResult는 그대로 유지
-
-
 ## [PR #272 Round 2 | refactor/271/skill-counts-build-time-derivation | 2026-04-11]
 - Violation: `indicatorCount` prop이 `SymbolPageClient` → `ChartContent` → `AnalysisPanel`로 드릴링됨 (두 중간 컴포넌트 모두 미사용)
 - Rule: FF Coupling 4-D — 중간 컴포넌트가 직접 사용하지 않는 prop을 아래로 전달하는 것은 Props Drilling 위반
@@ -66,11 +61,6 @@
 - Violation: `countSkillFiles`에 캐싱 없음 — 페이지 요청마다 skills/ 디렉토리를 다시 스캔
 - Rule: App CLAUDE.md — "infrastructure 함수에는 `'use cache'` 디렉티브로 명시적 캐싱 적용"
 - Context: `'use cache'` 디렉티브 적용; `cacheComponents: true` 활성화 필요
-
-## [PR #272 | refactor/271/skill-counts-build-time-derivation | 2026-04-11]
-- Violation: `countMdFiles`가 `readdir`를 1레벨만 호출하여 비재귀적으로 구현됨
-- Rule: 일관성 원칙 — 동일 모듈 내 `collectMdFiles`(재귀 탐색)와 구현 방식이 달라 향후 서브디렉토리 추가 시 카운트 불일치 발생 가능
-- Context: `countSkillFiles` 추가 시 `collectMdFiles` 재활용 없이 단순 `readdir` 사용; `collectMdFiles`를 재활용하도록 수정
 
 ## [PR #270 | feat/261/차트-dynamic-import-모바일-TTI-개선 | 2026-04-11]
 - Violation: dynamic import loading 컴포넌트(`ChartSkeleton`)가 `absolute inset-0`을 사용함에도 래퍼 컨테이너에 `relative` 클래스 누락
@@ -81,11 +71,6 @@
 - Violation: 서버 prefetchQuery 키와 클라이언트 훅 키 불일치 (hydration 캐시 미스)
 - Rule: React Query Hydration 패턴 — prefetchQuery 키와 useQuery 키가 정확히 일치해야 함
 - Context: 서버는 ticker(대문자)로 키를 만들고 클라이언트는 symbol(원본)로 키를 만들어 소문자 URL 진입 시 캐시 미스 발생
-
-## [PR #220 | feat/219/action-recommendation | 2026-04-10]
-- Violation: RESPONSE_LANGUAGE_INSTRUCTION의 "Other text fields" 목록에 새 필드(positionAnalysis, entry, exit, riskReward) 누락
-- Rule: Prompt 일관성 — 한국어 작성 지시와 줄바꿈 지시 목록이 동기화되어야 함
-- Context: actionRecommendation 필드 추가 시 첫 번째 필드 목록에만 추가하고 두 번째 목록은 누락
 
 ## [PR #216 Round 3 | feat/196/ticker-autocomplete | 2026-04-09]
 - Violation: 컴포넌트 교체 후 구 구현체 파일(`SymbolSearch.tsx`)이 삭제되지 않고 고아 파일로 남음

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,14 @@
 # Fix Log
 
+## [PR #326 | feat/325/지수-심볼-지원 | 2026-04-17]
+- Violation: `useAssetInfo(symbol)` (`useQuery`)가 파생 변수 `timeframe` 이후에 선언됨
+- Rule: CONVENTIONS.md — Custom Hook 선언 순서: useState → useRef → useQuery/useMutation → 파생 변수 → 핸들러 → useEffect
+- Context: `useTimeframeChange.ts`에서 `const timeframe = ...` (파생 변수) 뒤에 `useAssetInfo` 호출이 위치
+
+- Violation: `toIndexResult` 인라인 함수가 `searchTickerAction` 함수 내부에 정의됨
+- Rule: CONVENTIONS.md — 중첩 함수는 명시적 파라미터와 함께 모듈 레벨로 추출
+- Context: `searchTickerAction` 함수 내에 `toIndexResult` 화살표 함수를 인라인으로 정의했으나 모듈 레벨 `toIndexTickerResult`로 추출해야 함
+
 ## [PR #315 Round 3 | feat/314/애드센스-배너-광고-구현 | 2026-04-16]
 - Violation: layout.tsx에서 `<Script strategy="lazyOnload">`를 `<head>` 내부에 배치
 - Rule: Next.js Best Practices — `next/script`는 `<body>` 영역에 배치해야 함; `lazyOnload`는 브라우저 유휴 시점 실행이므로 `<head>` 배치가 의미상 부적절
@@ -27,11 +36,6 @@
 - Violation: AdBanner.tsx의 `<ins>` 엘리먼트에 `style={{ display: 'block' }}` 인라인 스타일 사용
 - Rule: CONVENTIONS.md — No inline styles → Tailwind only; `block` 클래스를 사용해야 함
 - Context: AdSense `<ins>` 태그에 `display: block`을 적용하기 위해 인라인 스타일을 사용했으나, Tailwind의 `block` 클래스로 대체 가능
-
-## [PR #304 Round 2 | feat/296/캐시-만료-KST-17시-자동-초기화 | 2026-04-14]
-- Violation: `computeSecondsUntilKst17`에서 `0 < diffMs < 1000ms` 경계(서브초 구간)에서 `Math.max(1, 0) = 1` 반환 경로에 대한 테스트 누락
-- Rule: Infrastructure Layer Checklist — 100% branch coverage for infrastructure (all ?., ??, if/else paths)
-- Context: `Math.max(1, Math.floor(diffMs / MS_PER_SECOND))`의 `Math.max`가 0을 1로 올리는 경로가 테스트되지 않았음; `diffMs = 500ms`인 케이스 추가로 해결
 
 ## [PR #304 | feat/296/캐시-만료-KST-17시-자동-초기화 | 2026-04-14]
 - Violation: `computeEffectiveTtl`이 `new Date()`에 의존함에도 `analyzeAction.test.ts`, `pollAnalysisAction.test.ts`에서 mock 없이 하드코딩 TTL 단언 — 시간대에 따라 flaky 테스트 발생
@@ -129,27 +133,10 @@
 - Violation: computeFromDay 반환값이 YYYY-MM-DD 형식 — Alpaca API가 RFC3339 형식 요구
 - Rule: Provider pair symmetric rule — Alpaca start 파라미터는 RFC3339 형식 필요
 - Context: barsApi.ts의 computeFromDay가 substring(0, 10)만 반환; T00:00:00Z 추가로 RFC3339 호환성 확보 (FMP는 fromDate.substring(0,10)으로 처리하므로 영향 없음)
-
 ## [PR #313 | feat/312/타임프레임-변경-시-분석-작업-취소 | 2026-04-15]
-- Violation: cancelAnalysisJobAction.ts의 fetch 호출에 타임아웃 미설정 — 네트워크 지연 시 Server Action이 무기한 대기 가능
-- Rule: CONVENTIONS.md — fire-and-forget fetch 요청에는 타임아웃을 설정해 클라이언트 흐름이 블로킹되지 않도록 해야 함
-- Context: `/cancel` 엔드포인트 호출에 AbortSignal.timeout(5000) 추가
-
 - Violation: useAnalysis.ts — eslint-disable-next-line react-hooks/exhaustive-deps used to suppress deps warning
 - Rule: CONVENTIONS.md react-hooks/exhaustive-deps — must restructure to fix the actual issue, not suppress the lint rule
 - Context: Mutation deps warning caused by unstable callback; fixed by restructuring with isCountdownActive boolean and cooldownStartValueRef to break the closure chain
-
-- Violation: cancelAnalysisJobAction.ts — Server Action passthrough with no error handling
-- Rule: CONVENTIONS.md — fire-and-forget actions should swallow errors and log a warning instead of throwing to caller
-- Context: Action called without try-catch; caller receives uncaught error; added try-catch to swallow and log, matching notification-action pattern
-
-
-
-
-## [Issue #325 | feat/325/지수-심볼-지원 | 2026-04-17]
-- Violation: Infrastructure 함수(FmpProvider.getBars)에 `console.log` 디버그 로그 잔류
-- Rule: Infrastructure Layer Checklist — No console.log or debug artifacts
-- Context: `fmp.ts`의 기존 `getBars` 메서드에 남아있던 타이밍 로그를 제거하지 않고 유지한 채 PR 제출
 
 - Violation: findIndexMatch 반환 타입을 `ReturnType<typeof filterIndexResults>[number] | undefined`로 표현
 - Rule: TypeScript — 재사용 가능하거나 의미를 전달해야 하는 반환 타입은 구조적 유틸리티 타입 대신 명시적 named type으로 표현

--- a/src/__tests__/infrastructure/market/barsApi.test.ts
+++ b/src/__tests__/infrastructure/market/barsApi.test.ts
@@ -206,6 +206,27 @@ describe('fetchBarsWithIndicators 함수는', () => {
             );
             expect(mockCacheLife).toHaveBeenCalledWith('minutes');
         });
+
+        it('fmpSymbol이 주어지면 getBars에 fmpSymbol을 전달한다', async () => {
+            mockGetBars.mockResolvedValueOnce([]);
+
+            await fetchBarsWithIndicators('SPX', DEFAULT_TIMEFRAME, '^SPX');
+
+            expect(mockGetBars).toHaveBeenCalledWith(
+                expect.objectContaining({ symbol: '^SPX' })
+            );
+        });
+
+        it('fmpSymbol이 주어지면 cacheTag에 fmpSymbol을 사용한다', async () => {
+            mockGetBars.mockResolvedValueOnce([]);
+            const mockCacheTag = cacheTag as jest.Mock;
+
+            await fetchBarsWithIndicators('SPX', DEFAULT_TIMEFRAME, '^SPX');
+
+            expect(mockCacheTag).toHaveBeenCalledWith(
+                `bars:^SPX:${DEFAULT_TIMEFRAME}`
+            );
+        });
     });
 
     describe('getBars가 에러를 던질 때', () => {

--- a/src/__tests__/infrastructure/market/fmp.test.ts
+++ b/src/__tests__/infrastructure/market/fmp.test.ts
@@ -287,6 +287,58 @@ describe('FmpProvider', () => {
             });
         });
 
+        describe('지수 심볼 (^ 접두사 포함)일 때', () => {
+            it('intraday 요청 시 ^ 접두사가 포함된 심볼을 그대로 FMP URL에 사용한다', async () => {
+                mockFetch.mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => [],
+                });
+
+                const provider = new FmpProvider();
+                await provider.getBars({ symbol: '^SPX', timeframe: '5Min' });
+
+                const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+                expect(new URL(url).searchParams.get('symbol')).toBe('^SPX');
+            });
+
+            it('daily 요청 시 EOD URL과 quote URL 모두 ^ 접두사 심볼을 그대로 사용한다', async () => {
+                mockFetch.mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => [],
+                });
+                mockFetch.mockResolvedValueOnce(emptyQuoteMock);
+
+                const provider = new FmpProvider();
+                await provider.getBars({ symbol: '^VIX', timeframe: '1Day' });
+
+                const [eodUrl] = mockFetch.mock.calls[0] as [
+                    string,
+                    RequestInit,
+                ];
+                const [quoteUrl] = mockFetch.mock.calls[1] as [
+                    string,
+                    RequestInit,
+                ];
+                expect(new URL(eodUrl).searchParams.get('symbol')).toBe('^VIX');
+                expect(new URL(quoteUrl).searchParams.get('symbol')).toBe(
+                    '^VIX'
+                );
+            });
+
+            it('일반 주식 심볼은 ^ 접두사 없이 그대로 사용한다', async () => {
+                mockFetch.mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => [],
+                });
+
+                const provider = new FmpProvider();
+                await provider.getBars({ symbol: 'AAPL', timeframe: '5Min' });
+
+                const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+                expect(new URL(url).searchParams.get('symbol')).toBe('AAPL');
+            });
+        });
+
         describe('daily 타임프레임 (1Day)', () => {
             it('historical-price-eod/full 엔드포인트로 요청한다', async () => {
                 mockFetch.mockResolvedValueOnce({

--- a/src/__tests__/infrastructure/market/getBarsAction.test.ts
+++ b/src/__tests__/infrastructure/market/getBarsAction.test.ts
@@ -62,7 +62,8 @@ describe('getBarsAction 함수는', () => {
 
             expect(mockFetchBarsWithIndicators).toHaveBeenCalledWith(
                 'AAPL',
-                '1Day'
+                '1Day',
+                undefined
             );
             expect(result).toBe(mockBarsData);
         });
@@ -74,7 +75,20 @@ describe('getBarsAction 함수는', () => {
 
             expect(mockFetchBarsWithIndicators).toHaveBeenCalledWith(
                 'TSLA',
-                '5Min'
+                '5Min',
+                undefined
+            );
+        });
+
+        it('fmpSymbol이 주어지면 fetchBarsWithIndicators에 그대로 전달한다', async () => {
+            mockFetchBarsWithIndicators.mockResolvedValueOnce(mockBarsData);
+
+            await getBarsAction('SPX', '1Day', '^SPX');
+
+            expect(mockFetchBarsWithIndicators).toHaveBeenCalledWith(
+                'SPX',
+                '1Day',
+                '^SPX'
             );
         });
     });

--- a/src/__tests__/infrastructure/ticker/fmpTickerApi.test.ts
+++ b/src/__tests__/infrastructure/ticker/fmpTickerApi.test.ts
@@ -2,6 +2,8 @@ import {
     searchBySymbol,
     searchByName,
     filterUsExchanges,
+    filterIndexResults,
+    toDisplaySymbol,
     toTickerSearchResult,
 } from '@/infrastructure/ticker/fmpTickerApi';
 import type { FmpSearchResult } from '@/infrastructure/ticker/types';
@@ -49,6 +51,68 @@ describe('filterUsExchanges', () => {
     describe('빈 배열일 때', () => {
         it('빈 배열을 반환한다', () => {
             expect(filterUsExchanges([])).toEqual([]);
+        });
+    });
+});
+
+describe('filterIndexResults', () => {
+    describe('^ 접두사를 가진 심볼만 포함할 때', () => {
+        it('모든 결과를 반환한다', () => {
+            const results = [
+                makeFmpResult({ symbol: '^SPX' }),
+                makeFmpResult({ symbol: '^DJI' }),
+            ];
+            expect(filterIndexResults(results)).toHaveLength(2);
+        });
+    });
+
+    describe('일반 주식 심볼이 혼합될 때', () => {
+        it('^ 접두사 심볼만 반환한다', () => {
+            const results = [
+                makeFmpResult({ symbol: '^SPX' }),
+                makeFmpResult({ symbol: 'AAPL' }),
+                makeFmpResult({ symbol: '^VIX' }),
+            ];
+            const filtered = filterIndexResults(results);
+            expect(filtered).toHaveLength(2);
+            expect(filtered.map(r => r.symbol)).toEqual(['^SPX', '^VIX']);
+        });
+    });
+
+    describe('빈 배열일 때', () => {
+        it('빈 배열을 반환한다', () => {
+            expect(filterIndexResults([])).toEqual([]);
+        });
+    });
+
+    describe('^ 접두사가 없는 결과만 있을 때', () => {
+        it('빈 배열을 반환한다', () => {
+            const results = [makeFmpResult({ symbol: 'AAPL' })];
+            expect(filterIndexResults(results)).toEqual([]);
+        });
+    });
+});
+
+describe('toDisplaySymbol', () => {
+    describe('^ 접두사가 있을 때', () => {
+        it('^SPX를 SPX로 변환한다', () => {
+            expect(toDisplaySymbol('^SPX')).toBe('SPX');
+        });
+
+        it('^DJI를 DJI로 변환한다', () => {
+            expect(toDisplaySymbol('^DJI')).toBe('DJI');
+        });
+    });
+
+    describe('^ 접두사가 없을 때', () => {
+        it('심볼을 그대로 반환한다', () => {
+            expect(toDisplaySymbol('AAPL')).toBe('AAPL');
+        });
+    });
+
+    describe('빈 문자열일 때', () => {
+        it('빈 문자열을 반환한다', () => {
+            expect(toDisplaySymbol('')).toBe('');
         });
     });
 });

--- a/src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts
+++ b/src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts
@@ -220,6 +220,18 @@ describe('getAssetInfoAction', () => {
             const result = await getAssetInfoAction('SPX');
             expect(result).toBeNull();
         });
+
+        it('정확한 심볼 매치 없을 때 첫 번째 결과로 폴백한다', async () => {
+            mockFilterUsExchanges.mockReturnValueOnce([]);
+            mockSearchBySymbol
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce([makeFmpResult('^SPXW')]);
+            mockGetKoreanNames.mockResolvedValueOnce({});
+
+            const result = await getAssetInfoAction('SPX');
+            expect(result).not.toBeNull();
+            expect(result!.fmpSymbol).toBe('^SPXW');
+        });
     });
 
     describe('일반 주식 심볼일 때', () => {

--- a/src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts
+++ b/src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts
@@ -343,6 +343,27 @@ describe('getAssetInfoAction', () => {
             );
         });
 
+        it('지수 심볼 번역 완료 후 캐시에 fmpSymbol을 포함하여 갱신한다', async () => {
+            mockFilterUsExchanges.mockReturnValueOnce([]);
+            mockSearchBySymbol
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce([makeFmpResult('^SPX')]);
+            mockGetKoreanNames.mockResolvedValueOnce({});
+            mockTranslateCompanyNames.mockResolvedValue({ SPX: 'S&P 500' });
+
+            await getAssetInfoAction('SPX');
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(mockCacheSet).toHaveBeenCalledWith(
+                expect.stringContaining('SPX'),
+                expect.objectContaining({
+                    fmpSymbol: '^SPX',
+                    koreanName: 'S&P 500',
+                }),
+                expect.any(Number)
+            );
+        });
+
         it('번역 결과가 비어있으면 setKoreanTickers를 호출하지 않는다', async () => {
             mockSearchBySymbol.mockResolvedValueOnce([makeFmpResult('IONQ')]);
             mockGetKoreanNames.mockResolvedValueOnce({});

--- a/src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts
+++ b/src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts
@@ -21,6 +21,7 @@ jest.mock('@/infrastructure/cache/redis', () => ({
 jest.mock('@/infrastructure/ticker/fmpTickerApi', () => ({
     searchBySymbol: jest.fn(),
     filterUsExchanges: jest.fn((results: unknown[]) => results),
+    filterIndexResults: jest.fn((results: unknown[]) => results),
 }));
 
 jest.mock('@/infrastructure/ticker/koreanNameStore', () => ({
@@ -37,6 +38,7 @@ import { createCacheProvider } from '@/infrastructure/cache/redis';
 import {
     searchBySymbol,
     filterUsExchanges,
+    filterIndexResults,
 } from '@/infrastructure/ticker/fmpTickerApi';
 import {
     getKoreanNames,
@@ -47,6 +49,7 @@ import { translateCompanyNames } from '@/infrastructure/ticker/koreanTranslator'
 const mockCreateCacheProvider = createCacheProvider as jest.Mock;
 const mockSearchBySymbol = searchBySymbol as jest.Mock;
 const mockFilterUsExchanges = filterUsExchanges as jest.Mock;
+const mockFilterIndexResults = filterIndexResults as jest.Mock;
 const mockGetKoreanNames = getKoreanNames as jest.Mock;
 const mockSetKoreanTickers = setKoreanTickers as jest.Mock;
 const mockTranslateCompanyNames = translateCompanyNames as jest.Mock;
@@ -67,6 +70,9 @@ describe('getAssetInfoAction', () => {
             delete: mockCacheDelete,
         });
         mockFilterUsExchanges.mockImplementation(
+            (results: unknown[]) => results
+        );
+        mockFilterIndexResults.mockImplementation(
             (results: unknown[]) => results
         );
         mockSearchBySymbol.mockResolvedValue([]);
@@ -169,6 +175,60 @@ describe('getAssetInfoAction', () => {
             await getAssetInfoAction('WP-LOGIN.PHP');
             await new Promise(resolve => setTimeout(resolve, 0));
             expect(mockCacheSet).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('US 거래소 결과가 없고 지수 폴백이 성공할 때', () => {
+        it('^ 접두사 검색으로 찾은 지수 정보를 반환한다', async () => {
+            mockFilterUsExchanges.mockReturnValueOnce([]);
+            mockSearchBySymbol
+                .mockResolvedValueOnce([]) // SPX 일반 검색 → 빈 결과
+                .mockResolvedValueOnce([makeFmpResult('^SPX')]); // ^SPX 지수 검색
+
+            const result = await getAssetInfoAction('SPX');
+            expect(result).not.toBeNull();
+            expect(result!.symbol).toBe('SPX');
+        });
+
+        it('fmpSymbol을 ^SYMBOL 형식으로 설정한다', async () => {
+            mockFilterUsExchanges.mockReturnValueOnce([]);
+            mockSearchBySymbol
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce([makeFmpResult('^SPX')]);
+
+            const result = await getAssetInfoAction('SPX');
+            expect(result!.fmpSymbol).toBe('^SPX');
+        });
+
+        it('지수 검색 시 ^SYMBOL 형식으로 searchBySymbol을 호출한다', async () => {
+            mockFilterUsExchanges.mockReturnValueOnce([]);
+            mockSearchBySymbol
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce([makeFmpResult('^SPX')]);
+
+            await getAssetInfoAction('SPX');
+            expect(mockSearchBySymbol).toHaveBeenCalledWith('^SPX');
+        });
+
+        it('지수 검색도 실패하면 null을 반환한다', async () => {
+            mockFilterUsExchanges.mockReturnValueOnce([]);
+            mockFilterIndexResults.mockReturnValueOnce([]);
+            mockSearchBySymbol
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce([]);
+
+            const result = await getAssetInfoAction('SPX');
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('일반 주식 심볼일 때', () => {
+        it('fmpSymbol을 설정하지 않는다', async () => {
+            mockSearchBySymbol.mockResolvedValueOnce([makeFmpResult('AAPL')]);
+            mockGetKoreanNames.mockResolvedValueOnce({});
+
+            const result = await getAssetInfoAction('AAPL');
+            expect(result!.fmpSymbol).toBeUndefined();
         });
     });
 

--- a/src/__tests__/infrastructure/ticker/searchTickerAction.test.ts
+++ b/src/__tests__/infrastructure/ticker/searchTickerAction.test.ts
@@ -19,6 +19,10 @@ jest.mock('@/infrastructure/ticker/fmpTickerApi', () => ({
     searchBySymbol: jest.fn(),
     searchByName: jest.fn(),
     filterUsExchanges: jest.fn((results: unknown[]) => results),
+    filterIndexResults: jest.fn(() => []),
+    toDisplaySymbol: jest.fn((s: string) =>
+        s.startsWith('^') ? s.slice(1) : s
+    ),
     toTickerSearchResult: jest.fn((r: TickerSearchResult) => r),
 }));
 
@@ -37,6 +41,7 @@ import {
     searchBySymbol,
     searchByName,
     filterUsExchanges,
+    filterIndexResults,
     toTickerSearchResult,
 } from '@/infrastructure/ticker/fmpTickerApi';
 import {
@@ -50,6 +55,7 @@ const mockCreateCacheProvider = createCacheProvider as jest.Mock;
 const mockSearchBySymbol = searchBySymbol as jest.Mock;
 const mockSearchByName = searchByName as jest.Mock;
 const mockFilterUsExchanges = filterUsExchanges as jest.Mock;
+const mockFilterIndexResults = filterIndexResults as jest.Mock;
 const mockToTickerSearchResult = toTickerSearchResult as jest.Mock;
 const mockSearchByKoreanName = searchByKoreanName as jest.Mock;
 const mockGetKoreanNames = getKoreanNames as jest.Mock;
@@ -157,13 +163,14 @@ describe('searchTickerAction', () => {
     });
 
     describe('영어 쿼리이고 캐시 미스일 때', () => {
-        it('FMP API를 병렬로 호출한다', async () => {
+        it('FMP API를 병렬로 호출한다 (심볼, 이름, 지수 검색 포함)', async () => {
             mockCacheGet.mockResolvedValueOnce(null);
 
             await searchTickerAction('AAPL');
 
             expect(mockSearchBySymbol).toHaveBeenCalledWith('AAPL');
             expect(mockSearchByName).toHaveBeenCalledWith('AAPL');
+            expect(mockSearchBySymbol).toHaveBeenCalledWith('^AAPL');
         });
 
         it('US 거래소 필터링을 적용한다', async () => {
@@ -240,6 +247,49 @@ describe('searchTickerAction', () => {
                 symbol: string;
             }>;
             expect(savedEntries.every(e => e.symbol !== 'EXTRA')).toBe(true);
+        });
+    });
+
+    describe('지수 심볼 검색일 때', () => {
+        it('^{query} 형식으로 searchBySymbol을 추가 호출한다', async () => {
+            await searchTickerAction('SPX');
+            expect(mockSearchBySymbol).toHaveBeenCalledWith('^SPX');
+        });
+
+        it('^ 접두사 검색 결과가 있으면 지수 결과를 포함한다', async () => {
+            const indexFmpResult = {
+                symbol: '^SPX',
+                name: 'S&P 500',
+                exchange: 'SNP',
+                exchangeFullName: 'SNP',
+            };
+            mockFilterIndexResults.mockReturnValueOnce([indexFmpResult]);
+            mockSearchBySymbol
+                .mockResolvedValueOnce([]) // SPX 일반 검색
+                .mockResolvedValueOnce([indexFmpResult]); // ^SPX 지수 검색
+
+            await searchTickerAction('SPX');
+            expect(mockFilterIndexResults).toHaveBeenCalledWith([
+                indexFmpResult,
+            ]);
+        });
+
+        it('지수 결과의 ^ 접두사가 제거된 심볼로 toTickerSearchResult를 호출한다', async () => {
+            const indexFmpResult = {
+                symbol: '^SPX',
+                name: 'S&P 500',
+                exchange: 'SNP',
+                exchangeFullName: 'SNP',
+            };
+            mockFilterIndexResults.mockReturnValueOnce([indexFmpResult]);
+            mockSearchBySymbol
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce([indexFmpResult]);
+
+            await searchTickerAction('SPX');
+            expect(mockToTickerSearchResult).toHaveBeenCalledWith(
+                expect.objectContaining({ symbol: 'SPX' })
+            );
         });
     });
 

--- a/src/__tests__/infrastructure/ticker/searchTickerAction.test.ts
+++ b/src/__tests__/infrastructure/ticker/searchTickerAction.test.ts
@@ -256,6 +256,21 @@ describe('searchTickerAction', () => {
             expect(mockSearchBySymbol).toHaveBeenCalledWith('^SPX');
         });
 
+        it('7자 이상 쿼리에서는 지수 검색을 건너뛴다', async () => {
+            await searchTickerAction('TOOLONG');
+            expect(mockSearchBySymbol).not.toHaveBeenCalledWith('^TOOLONG');
+        });
+
+        it('공백이 포함된 쿼리에서는 지수 검색을 건너뛴다', async () => {
+            await searchTickerAction('S P X');
+            expect(mockSearchBySymbol).not.toHaveBeenCalledWith('^S P X');
+        });
+
+        it('^ 로 시작하는 쿼리에서는 지수 검색을 건너뛴다', async () => {
+            await searchTickerAction('^SPX');
+            expect(mockSearchBySymbol).not.toHaveBeenCalledWith('^^SPX');
+        });
+
         it('^ 접두사 검색 결과가 있으면 지수 결과를 포함한다', async () => {
             const indexFmpResult = {
                 symbol: '^SPX',

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -153,7 +153,12 @@ export default async function SymbolPage({ params, searchParams }: Props) {
 
     await queryClient.prefetchQuery({
         queryKey: QUERY_KEYS.bars(symbol, initialTimeframe),
-        queryFn: () => fetchBarsWithIndicators(symbol, initialTimeframe),
+        queryFn: () =>
+            fetchBarsWithIndicators(
+                symbol,
+                initialTimeframe,
+                assetInfo.fmpSymbol
+            ),
     });
 
     return (

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -97,6 +97,7 @@ interface ChartContentProps {
     initialAnalysisFailed: boolean;
     /** 모바일 바텀시트에 렌더링할 콘텐츠가 변경될 때 호출된다. Suspense 경계 밖에서 시트를 유지하기 위해 상위로 끌어올린다. */
     onMobileSheetContent: (content: ReactNode) => void;
+    fmpSymbol?: string;
 }
 
 export function ChartContent({
@@ -106,8 +107,9 @@ export function ChartContent({
     initialAnalysis,
     initialAnalysisFailed,
     onMobileSheetContent,
+    fmpSymbol,
 }: ChartContentProps) {
-    const { bars, indicators } = useBars({ symbol, timeframe });
+    const { bars, indicators } = useBars({ symbol, timeframe, fmpSymbol });
 
     const {
         analysis,

--- a/src/components/symbol-page/SymbolPageClient.tsx
+++ b/src/components/symbol-page/SymbolPageClient.tsx
@@ -123,6 +123,7 @@ export function SymbolPageClient({
                                 initialAnalysis={initialAnalysis}
                                 initialAnalysisFailed={initialAnalysisFailed}
                                 onMobileSheetContent={setMobileSheetContent}
+                                fmpSymbol={assetInfo?.fmpSymbol}
                             />
                         </Suspense>
                     </ErrorBoundary>

--- a/src/components/symbol-page/hooks/useBars.ts
+++ b/src/components/symbol-page/hooks/useBars.ts
@@ -4,6 +4,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import type { Bar, BarsData, IndicatorResult, Timeframe } from '@/domain/types';
 import { getBarsAction } from '@/infrastructure/market/getBarsAction';
 import { QUERY_KEYS } from '@/lib/queryConfig';
+import { useAssetInfo } from '@/components/symbol-page/hooks/useAssetInfo';
 
 interface UseBarsOptions {
     symbol: string;
@@ -16,9 +17,10 @@ interface UseBarsResult {
 }
 
 export function useBars({ symbol, timeframe }: UseBarsOptions): UseBarsResult {
+    const assetInfo = useAssetInfo(symbol);
     const { data } = useSuspenseQuery<BarsData, Error>({
         queryKey: QUERY_KEYS.bars(symbol, timeframe),
-        queryFn: () => getBarsAction(symbol, timeframe),
+        queryFn: () => getBarsAction(symbol, timeframe, assetInfo?.fmpSymbol),
     });
 
     return { bars: data.bars, indicators: data.indicators };

--- a/src/components/symbol-page/hooks/useBars.ts
+++ b/src/components/symbol-page/hooks/useBars.ts
@@ -4,11 +4,11 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import type { Bar, BarsData, IndicatorResult, Timeframe } from '@/domain/types';
 import { getBarsAction } from '@/infrastructure/market/getBarsAction';
 import { QUERY_KEYS } from '@/lib/queryConfig';
-import { useAssetInfo } from '@/components/symbol-page/hooks/useAssetInfo';
 
 interface UseBarsOptions {
     symbol: string;
     timeframe: Timeframe;
+    fmpSymbol?: string;
 }
 
 interface UseBarsResult {
@@ -16,11 +16,14 @@ interface UseBarsResult {
     indicators: IndicatorResult;
 }
 
-export function useBars({ symbol, timeframe }: UseBarsOptions): UseBarsResult {
-    const assetInfo = useAssetInfo(symbol);
+export function useBars({
+    symbol,
+    timeframe,
+    fmpSymbol,
+}: UseBarsOptions): UseBarsResult {
     const { data } = useSuspenseQuery<BarsData, Error>({
         queryKey: QUERY_KEYS.bars(symbol, timeframe),
-        queryFn: () => getBarsAction(symbol, timeframe, assetInfo?.fmpSymbol),
+        queryFn: () => getBarsAction(symbol, timeframe, fmpSymbol),
     });
 
     return { bars: data.bars, indicators: data.indicators };

--- a/src/components/symbol-page/hooks/useTimeframeChange.ts
+++ b/src/components/symbol-page/hooks/useTimeframeChange.ts
@@ -24,9 +24,8 @@ export function useTimeframeChange(symbol: string): UseTimeframeChangeResult {
 
     const searchParams = useSearchParams();
     const tf = searchParams.get(TIMEFRAME_QUERY_PARAM);
-    const timeframe = isValidTimeframe(tf) ? tf : DEFAULT_TIMEFRAME;
-
     const assetInfo = useAssetInfo(symbol);
+    const timeframe = isValidTimeframe(tf) ? tf : DEFAULT_TIMEFRAME;
     const queryClient = useQueryClient();
     const router = useRouter();
 

--- a/src/components/symbol-page/hooks/useTimeframeChange.ts
+++ b/src/components/symbol-page/hooks/useTimeframeChange.ts
@@ -7,6 +7,7 @@ import type { BarsData, Timeframe } from '@/domain/types';
 import { DEFAULT_TIMEFRAME, isValidTimeframe } from '@/domain/constants/market';
 import { getBarsAction } from '@/infrastructure/market/getBarsAction';
 import { QUERY_KEYS } from '@/lib/queryConfig';
+import { useAssetInfo } from '@/components/symbol-page/hooks/useAssetInfo';
 
 const TIMEFRAME_QUERY_PARAM = 'tf';
 
@@ -25,6 +26,7 @@ export function useTimeframeChange(symbol: string): UseTimeframeChangeResult {
     const tf = searchParams.get(TIMEFRAME_QUERY_PARAM);
     const timeframe = isValidTimeframe(tf) ? tf : DEFAULT_TIMEFRAME;
 
+    const assetInfo = useAssetInfo(symbol);
     const queryClient = useQueryClient();
     const router = useRouter();
 
@@ -41,7 +43,8 @@ export function useTimeframeChange(symbol: string): UseTimeframeChangeResult {
             // 렌더 전에 쿼리 캐시에 데이터(또는 진행 중인 Promise)를 넣어둔다.
             void queryClient.prefetchQuery<BarsData>({
                 queryKey: QUERY_KEYS.bars(symbol, nextTimeframe),
-                queryFn: () => getBarsAction(symbol, nextTimeframe),
+                queryFn: () =>
+                    getBarsAction(symbol, nextTimeframe, assetInfo?.fmpSymbol),
             });
             startTransition(() => {
                 setTimeframeChangeCount(c => c + 1);
@@ -51,7 +54,7 @@ export function useTimeframeChange(symbol: string): UseTimeframeChangeResult {
                 );
             });
         },
-        [timeframe, queryClient, symbol, router]
+        [timeframe, queryClient, symbol, router, assetInfo?.fmpSymbol]
     );
 
     return { timeframe, timeframeChangeCount, handleTimeframeChange };

--- a/src/components/symbol-page/hooks/useTimeframeChange.ts
+++ b/src/components/symbol-page/hooks/useTimeframeChange.ts
@@ -23,11 +23,12 @@ export function useTimeframeChange(symbol: string): UseTimeframeChangeResult {
     const [, startTransition] = useTransition();
 
     const searchParams = useSearchParams();
-    const tf = searchParams.get(TIMEFRAME_QUERY_PARAM);
     const assetInfo = useAssetInfo(symbol);
-    const timeframe = isValidTimeframe(tf) ? tf : DEFAULT_TIMEFRAME;
     const queryClient = useQueryClient();
     const router = useRouter();
+
+    const tf = searchParams.get(TIMEFRAME_QUERY_PARAM);
+    const timeframe = isValidTimeframe(tf) ? tf : DEFAULT_TIMEFRAME;
 
     const handleTimeframeChange = useCallback(
         (nextTimeframe: Timeframe): void => {

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -432,6 +432,8 @@ export interface AssetInfo {
     symbol: string;
     name: string;
     koreanName?: string;
+    /** FMP API 심볼 (지수의 경우 ^ 접두사 포함, 예: ^SPX). 일반 주식은 undefined. */
+    fmpSymbol?: string;
 }
 
 export type CategoryId =

--- a/src/infrastructure/market/barsApi.ts
+++ b/src/infrastructure/market/barsApi.ts
@@ -17,18 +17,18 @@ function computeFromDay(timeframe: Timeframe, now: Date): string {
 
 // new Date()는 'use cache' 경계 바깥에서 계산하여 동적 값이 캐시 키에 포함되도록 한다.
 async function fetchBarsWithIndicatorsCached(
-    symbol: string,
+    fmpSymbol: string,
     timeframe: Timeframe,
     fromDay: string
 ): Promise<BarsData> {
     'use cache';
     cacheLife('minutes');
-    cacheTag(`bars:${symbol}:${timeframe}`);
+    cacheTag(`bars:${fmpSymbol}:${timeframe}`);
 
     const limit = TIMEFRAME_BARS_LIMIT[timeframe];
     const provider = createMarketDataProvider();
     const bars = await provider.getBars({
-        symbol,
+        symbol: fmpSymbol,
         timeframe,
         limit,
         from: fromDay,
@@ -40,8 +40,9 @@ async function fetchBarsWithIndicatorsCached(
 
 export async function fetchBarsWithIndicators(
     symbol: string,
-    timeframe: Timeframe
+    timeframe: Timeframe,
+    fmpSymbol?: string
 ): Promise<BarsData> {
     const fromDay = computeFromDay(timeframe, new Date());
-    return fetchBarsWithIndicatorsCached(symbol, timeframe, fromDay);
+    return fetchBarsWithIndicatorsCached(fmpSymbol ?? symbol, timeframe, fromDay);
 }

--- a/src/infrastructure/market/barsApi.ts
+++ b/src/infrastructure/market/barsApi.ts
@@ -44,5 +44,9 @@ export async function fetchBarsWithIndicators(
     fmpSymbol?: string
 ): Promise<BarsData> {
     const fromDay = computeFromDay(timeframe, new Date());
-    return fetchBarsWithIndicatorsCached(fmpSymbol ?? symbol, timeframe, fromDay);
+    return fetchBarsWithIndicatorsCached(
+        fmpSymbol ?? symbol,
+        timeframe,
+        fromDay
+    );
 }

--- a/src/infrastructure/market/fmp.ts
+++ b/src/infrastructure/market/fmp.ts
@@ -186,24 +186,20 @@ export class FmpProvider implements MarketDataProvider {
     // from 파라미터는 from 쿼리로, before 파라미터는 to 쿼리로 변환합니다.
     // Daily(1Day) 타임프레임은 /stable/historical-price-eod/full 엔드포인트를 사용합니다.
     async getBars(options: GetBarsOptions): Promise<Bar[]> {
-        const { symbol, timeframe, before, from } = options;
-
-        console.log(
-            `[FMP][${new Date().toISOString()}] getBars called: ${symbol} ${timeframe} from=${from}`
-        );
+        const { symbol: fmpSymbol, timeframe, before, from } = options;
 
         const fromDate = from !== undefined ? from.substring(0, 10) : undefined;
         const endDate =
             before !== undefined ? before.substring(0, 10) : undefined;
 
         if (timeframe === '1Day') {
-            return this.getDailyBars(symbol, fromDate, endDate);
+            return this.getDailyBars(fmpSymbol, fromDate, endDate);
         }
 
         // timeframe !== '1Day' is guaranteed by the branch above
         const intradayTimeframe = timeframe as Exclude<Timeframe, '1Day'>;
         const fmpTimeframe = FMP_INTRADAY_TIMEFRAME_MAP[intradayTimeframe];
-        return this.getIntradayBars(symbol, fmpTimeframe, fromDate, endDate);
+        return this.getIntradayBars(fmpSymbol, fmpTimeframe, fromDate, endDate);
     }
 
     private async getIntradayBars(

--- a/src/infrastructure/market/getBarsAction.ts
+++ b/src/infrastructure/market/getBarsAction.ts
@@ -5,7 +5,8 @@ import type { BarsData, Timeframe } from '@/domain/types';
 
 export async function getBarsAction(
     symbol: string,
-    timeframe: Timeframe
+    timeframe: Timeframe,
+    fmpSymbol?: string
 ): Promise<BarsData> {
-    return fetchBarsWithIndicators(symbol, timeframe);
+    return fetchBarsWithIndicators(symbol, timeframe, fmpSymbol);
 }

--- a/src/infrastructure/ticker/fmpTickerApi.ts
+++ b/src/infrastructure/ticker/fmpTickerApi.ts
@@ -23,6 +23,18 @@ export function filterUsExchanges(
     );
 }
 
+// FMP는 지수 심볼에 ^ 접두사를 붙여 반환한다 (예: ^SPX, ^DJI)
+export function filterIndexResults(
+    results: FmpSearchResult[]
+): FmpSearchResult[] {
+    return results.filter(r => r.symbol.startsWith('^'));
+}
+
+// ^ 접두사를 제거하여 URL/표시용 심볼로 변환한다 (예: ^SPX → SPX)
+export function toDisplaySymbol(fmpSymbol: string): string {
+    return fmpSymbol.startsWith('^') ? fmpSymbol.slice(1) : fmpSymbol;
+}
+
 async function fetchFmpEndpoint(
     endpoint: 'search-symbol' | 'search-name',
     query: string

--- a/src/infrastructure/ticker/getAssetInfoAction.ts
+++ b/src/infrastructure/ticker/getAssetInfoAction.ts
@@ -11,7 +11,9 @@ import {
 import {
     searchBySymbol,
     filterUsExchanges,
+    filterIndexResults,
 } from '@/infrastructure/ticker/fmpTickerApi';
+import type { FmpSearchResult } from '@/infrastructure/ticker/types';
 import {
     getKoreanNames,
     setKoreanTickers,
@@ -19,6 +21,14 @@ import {
 import { translateCompanyNames } from '@/infrastructure/ticker/koreanTranslator';
 import { isValidTickerFormat } from '@/domain/ticker';
 import type { AssetInfo, KoreanTickerEntry } from '@/domain/types';
+
+async function findIndexMatch(
+    symbol: string
+): Promise<FmpSearchResult | undefined> {
+    const results = await searchBySymbol(`^${symbol}`);
+    const indexResults = filterIndexResults(results);
+    return indexResults.find(r => r.symbol === `^${symbol}`) ?? indexResults[0];
+}
 
 async function translateAndCache(
     symbol: string,
@@ -77,7 +87,9 @@ const resolveAssetInfo = cache(
 
         const fmpResults = await searchBySymbol(upper);
         const usResults = filterUsExchanges(fmpResults);
-        const match = usResults.find(r => r.symbol === upper) ?? usResults[0];
+        const usMatch = usResults.find(r => r.symbol === upper) ?? usResults[0];
+        const indexMatch = usMatch ? undefined : await findIndexMatch(upper);
+        const match = usMatch ?? indexMatch;
 
         if (!match) return null;
 
@@ -90,6 +102,7 @@ const resolveAssetInfo = cache(
             symbol: upper,
             name,
             ...(koreanName && { koreanName }),
+            ...(indexMatch && { fmpSymbol: indexMatch.symbol }),
         };
 
         if (!koreanName) {

--- a/src/infrastructure/ticker/getAssetInfoAction.ts
+++ b/src/infrastructure/ticker/getAssetInfoAction.ts
@@ -34,7 +34,8 @@ async function translateAndCache(
     symbol: string,
     name: string,
     exchange: string,
-    exchangeFullName: string
+    exchangeFullName: string,
+    fmpSymbol?: string
 ): Promise<void> {
     const translated = await translateCompanyNames([{ symbol, name }]);
     const koreanName = translated[symbol];
@@ -55,7 +56,7 @@ async function translateAndCache(
         await cacheProvider
             .set(
                 cacheKey,
-                { symbol, name, koreanName },
+                { symbol, name, koreanName, ...(fmpSymbol && { fmpSymbol }) },
                 ASSET_INFO_CACHE_TTL_WITH_KOREAN
             )
             .catch(error =>
@@ -87,9 +88,11 @@ const resolveAssetInfo = cache(
 
         const fmpResults = await searchBySymbol(upper);
         const usResults = filterUsExchanges(fmpResults);
-        const usMatch = usResults.find(r => r.symbol === upper) ?? usResults[0];
-        const indexMatch = usMatch ? undefined : await findIndexMatch(upper);
-        const match = usMatch ?? indexMatch;
+        const exactUsMatch = usResults.find(r => r.symbol === upper);
+        const indexMatch = exactUsMatch
+            ? undefined
+            : await findIndexMatch(upper);
+        const match = exactUsMatch ?? indexMatch ?? usResults[0];
 
         if (!match) return null;
 
@@ -111,7 +114,8 @@ const resolveAssetInfo = cache(
                     upper,
                     name,
                     exchange,
-                    exchangeFullName
+                    exchangeFullName,
+                    indexMatch?.symbol
                 ).catch(error =>
                     console.error('Asset info translateAndCache failed:', error)
                 )

--- a/src/infrastructure/ticker/searchTickerAction.ts
+++ b/src/infrastructure/ticker/searchTickerAction.ts
@@ -11,6 +11,8 @@ import {
     searchBySymbol,
     searchByName,
     filterUsExchanges,
+    filterIndexResults,
+    toDisplaySymbol,
     toTickerSearchResult,
 } from '@/infrastructure/ticker/fmpTickerApi';
 import {
@@ -60,26 +62,35 @@ export async function searchTickerAction(
         return results.slice(0, MAX_SEARCH_RESULTS);
     }
 
-    const cache = createCacheProvider();
+    const cacheProvider = createCacheProvider();
     const cacheKey = buildTickerSearchCacheKey(trimmed);
 
-    if (cache) {
+    if (cacheProvider) {
         try {
-            const cached = await cache.get<TickerSearchResult[]>(cacheKey);
+            const cached =
+                await cacheProvider.get<TickerSearchResult[]>(cacheKey);
             if (cached) return cached;
         } catch (error) {
             console.error('Ticker search cache get failed:', error);
         }
     }
 
-    const [symbolResults, nameResults] = await Promise.all([
+    const [symbolResults, nameResults, indexResults] = await Promise.all([
         searchBySymbol(trimmed),
         searchByName(trimmed),
+        searchBySymbol(`^${trimmed}`),
     ]);
+
+    const toIndexResult = (r: (typeof indexResults)[number]) =>
+        toTickerSearchResult({ ...r, symbol: toDisplaySymbol(r.symbol) });
 
     const merged = deduplicateResults([
         ...filterUsExchanges(symbolResults).map(toTickerSearchResult),
         ...filterUsExchanges(nameResults).map(toTickerSearchResult),
+        // 정규 검색 결과에 포함된 지수 심볼 (FMP가 ^ prefix 결과를 함께 반환하는 경우)
+        ...filterIndexResults(symbolResults).map(toIndexResult),
+        // ^{trimmed} 직접 검색 결과 (심볼 직접 입력 시)
+        ...filterIndexResults(indexResults).map(toIndexResult),
     ]);
 
     const koreanNames = await getKoreanNames(merged.map(r => r.symbol));
@@ -100,9 +111,9 @@ export async function searchTickerAction(
 
     const final = enriched.slice(0, MAX_SEARCH_RESULTS);
 
-    if (cache) {
+    if (cacheProvider) {
         waitUntil(
-            cache
+            cacheProvider
                 .set(cacheKey, final, TICKER_SEARCH_CACHE_TTL)
                 .catch(error =>
                     console.error('Ticker search cache set failed:', error)

--- a/src/infrastructure/ticker/searchTickerAction.ts
+++ b/src/infrastructure/ticker/searchTickerAction.ts
@@ -22,8 +22,14 @@ import {
 } from '@/infrastructure/ticker/koreanNameStore';
 import { translateCompanyNames } from '@/infrastructure/ticker/koreanTranslator';
 import type { TickerSearchResult, KoreanTickerEntry } from '@/domain/types';
+import type { FmpSearchResult } from '@/infrastructure/ticker/types';
 
 const MAX_SEARCH_RESULTS = 10;
+const MAX_INDEX_SYMBOL_LENGTH = 6;
+
+function toIndexTickerResult(r: FmpSearchResult): TickerSearchResult {
+    return toTickerSearchResult({ ...r, symbol: toDisplaySymbol(r.symbol) });
+}
 
 async function translateAndCache(
     unmapped: TickerSearchResult[]
@@ -75,22 +81,23 @@ export async function searchTickerAction(
         }
     }
 
+    const shouldSearchIndex =
+        !trimmed.startsWith('^') &&
+        !trimmed.includes(' ') &&
+        trimmed.length <= MAX_INDEX_SYMBOL_LENGTH;
+
     const [symbolResults, nameResults, indexResults] = await Promise.all([
         searchBySymbol(trimmed),
         searchByName(trimmed),
-        searchBySymbol(`^${trimmed}`),
+        shouldSearchIndex ? searchBySymbol(`^${trimmed}`) : Promise.resolve([]),
     ]);
 
-    const toIndexResult = (r: (typeof indexResults)[number]) =>
-        toTickerSearchResult({ ...r, symbol: toDisplaySymbol(r.symbol) });
-
     const merged = deduplicateResults([
+        // 지수 심볼 우선 (사용자가 'SPX' 입력 시 주식 부분 일치보다 지수를 먼저 노출)
+        ...filterIndexResults(symbolResults).map(toIndexTickerResult),
+        ...filterIndexResults(indexResults).map(toIndexTickerResult),
         ...filterUsExchanges(symbolResults).map(toTickerSearchResult),
         ...filterUsExchanges(nameResults).map(toTickerSearchResult),
-        // 정규 검색 결과에 포함된 지수 심볼 (FMP가 ^ prefix 결과를 함께 반환하는 경우)
-        ...filterIndexResults(symbolResults).map(toIndexResult),
-        // ^{trimmed} 직접 검색 결과 (심볼 직접 입력 시)
-        ...filterIndexResults(indexResults).map(toIndexResult),
     ]);
 
     const koreanNames = await getKoreanNames(merged.map(r => r.symbol));

--- a/src/infrastructure/ticker/searchTickerAction.ts
+++ b/src/infrastructure/ticker/searchTickerAction.ts
@@ -94,7 +94,9 @@ export async function searchTickerAction(
 
     const merged = deduplicateResults([
         // 지수 심볼 우선 (사용자가 'SPX' 입력 시 주식 부분 일치보다 지수를 먼저 노출)
+        // FMP가 일반 심볼 검색 결과에 ^ 접두사 심볼을 함께 반환하는 경우를 처리
         ...filterIndexResults(symbolResults).map(toIndexTickerResult),
+        // ^{trimmed} 직접 검색 결과 (심볼 직접 입력 시)
         ...filterIndexResults(indexResults).map(toIndexTickerResult),
         ...filterUsExchanges(symbolResults).map(toTickerSearchResult),
         ...filterUsExchanges(nameResults).map(toTickerSearchResult),


### PR DESCRIPTION
## 관련 이슈

closes #325

## 구현 내용

지수 심볼(SPX, DJI, VIX 등)에 대한 동적 지원을 구현했습니다. 기존의 하드코딩된 INDEX_SYMBOLS 세트를 제거하고, AssetInfo.fmpSymbol 필드를 통해 FMP API 심볼을 관리합니다.

**주요 변경사항:**
- `src/domain/types.ts`: `AssetInfo`에 `fmpSymbol?: string` 필드 추가
- `src/infrastructure/ticker/getAssetInfoAction.ts`: 지수 fallback 경로에서 `fmpSymbol` 설정
- `src/infrastructure/market/barsApi.ts`: `fetchBarsWithIndicatorsCached`가 `fmpSymbol`을 직접 수신하고 캐시 태그에 적용
- `src/infrastructure/market/getBarsAction.ts`: `fmpSymbol?: string` 매개변수 추가
- `src/infrastructure/market/fmp.ts`: `isIndexSymbol` 사용 제거, 호출자로부터 심볼 직접 전달
- `src/app/[symbol]/page.tsx`: `assetInfo.fmpSymbol`을 `fetchBarsWithIndicators`로 전달
- `src/components/symbol-page/hooks/useBars.ts`: `useAssetInfo` 호출로 `fmpSymbol` 획득
- `src/components/symbol-page/hooks/useTimeframeChange.ts`: `useAssetInfo` 호출로 `fmpSymbol` 획득
- `src/infrastructure/ticker/fmpTickerApi.ts`: 테스트 업데이트
- `src/infrastructure/ticker/searchTickerAction.ts`: 테스트 업데이트
- 삭제: `src/domain/constants/index-symbols.ts` 및 `domain/ticker.ts`의 `isIndexSymbol`

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 인디케이터 초기 구간 null 반환 (0, NaN 없음)
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it
- [x] 초기 구간 null 케이스 테스트 포함
- [x] 매직 넘버 없음

## 변경 파일 목록

[수정]
- `src/domain/types.ts`
- `src/infrastructure/ticker/getAssetInfoAction.ts`
- `src/infrastructure/market/barsApi.ts`
- `src/infrastructure/market/getBarsAction.ts`
- `src/infrastructure/market/fmp.ts`
- `src/app/[symbol]/page.tsx`
- `src/components/symbol-page/hooks/useBars.ts`
- `src/components/symbol-page/hooks/useTimeframeChange.ts`
- `src/infrastructure/ticker/fmpTickerApi.ts`
- `src/infrastructure/ticker/searchTickerAction.ts`
- `src/__tests__/infrastructure/market/fmp.test.ts`
- `src/__tests__/infrastructure/market/getBarsAction.test.ts`
- `src/__tests__/infrastructure/ticker/fmpTickerApi.test.ts`
- `src/__tests__/infrastructure/ticker/getAssetInfoAction.test.ts`
- `src/__tests__/infrastructure/ticker/searchTickerAction.test.ts`

[삭제]
- `src/domain/constants/index-symbols.ts`

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build