### PR TITLE
refactor: state-machine 인디케이터 O(N) 최적화

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -84,6 +84,35 @@ function calculateRSI(closes: number[], period: number): (number | null)[] { ...
 // ✅ function child(parentVar: T) { ... }  // extracted, explicit params
 ```
 
+**Exception — Local state-accumulator mutation is allowed when `reduce + spread` causes O(N²) complexity:**
+
+State-machine based indicators where each step depends on the previous accumulated result
+cannot use `reduce + [...acc, value]` without incurring O(N²) time complexity.
+In these cases, a function-local mutable accumulator (pre-allocated array + index assignment,
+or a `for` loop with index) is permitted.
+
+The following conditions must all be satisfied:
+1. The function maintains a pure contract (same input → same output, no side effects)
+2. Input arguments (`bars`, `state`, etc.) are never mutated
+3. The return value is a completed, externally immutable array
+
+```typescript
+// ❌ O(N²) — spread inside reduce creates a new array on every iteration
+const results = bars.reduce((acc, bar) => {
+    return [...acc, compute(bar)];
+}, [] as Result[]);
+
+// ✅ O(N) — pre-allocated array with index assignment (local mutation only)
+const results: Result[] = new Array(bars.length);
+let state = initialState;
+for (let i = 0; i < bars.length; i++) {
+    const { state: next, result } = nextState(state, bars[i]);
+    results[i] = result;
+    state = next;
+}
+return results;
+```
+
 ### Priority by Layer
 
 ```

--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -198,6 +198,14 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 9. Custom hooks in components/ without 'use client' directive
    → Every hook file under components/ must declare 'use client' at the top
    → Hooks are Client Components and will fail without the directive when parent is async Server Component
+
+10. setState called directly in useEffect body (react-hooks/set-state-in-effect)
+    → If the state being reset logically belongs to "mutation starts", move it to useMutation's onMutate callback
+    → onMutate fires synchronously before the mutationFn, satisfies the linter, and centralizes reset logic
+    ❌ useEffect(() => { setPollError(null); setAnalysisResult(null); mutate(...); }, [deps])
+    ✅ useMutation({ onMutate: () => { setPollError(null); setAnalysisResult(null); }, ... })
+    → For state that must reset on every mutate call site, onMutate is the single source of truth
+    → Note: useCallback does NOT help — the linter traces into useCallback bodies and still flags setState
 ```
 
 ---

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -111,3 +111,8 @@
 - Violation: findIndexMatch 반환 타입을 `ReturnType<typeof filterIndexResults>[number] | undefined`로 표현
 - Rule: TypeScript — 재사용 가능하거나 의미를 전달해야 하는 반환 타입은 구조적 유틸리티 타입 대신 명시적 named type으로 표현
 - Context: `filterIndexResults`가 `FmpSearchResult[]`를 반환하므로 해당 표현식은 `FmpSearchResult | undefined`와 동일; 명시적 타입 사용이 더 가독성 높음
+
+## [PR #327 | refactor/324/state-machine-인디케이터-O-N-최적화 | 2026-04-18]
+- Violation: period-based indicator 테스트에 toBeCloseTo 수치 검증 누락
+- Rule: MISTAKES.md Tests #12 — Every period-based indicator test must include toBeCloseTo checks against manually-calculated expected values
+- Context: calculateSupertrend 리팩터링 PR에서 기존 테스트가 방향성(up/down) 부등호만 검증하고 실제 계산값을 검증하지 않아 리뷰어에게 Blocker 지적 받음

--- a/src/__tests__/domain/indicators/parabolicSar.test.ts
+++ b/src/__tests__/domain/indicators/parabolicSar.test.ts
@@ -148,6 +148,19 @@ describe('calculateParabolicSAR', () => {
             });
         });
 
+        it('첫 번째 유효 SAR 값이 명세와 일치한다', () => {
+            // bars[1].close(11) >= bars[0].close(9) → initialTrend='up'
+            // initialState.sar = bars[0].low = 8 → result[1].sar = 8
+            const bars = makeBars([
+                { high: 10, low: 8, close: 9 },
+                { high: 12, low: 10, close: 11 },
+                { high: 14, low: 12, close: 13 },
+            ]);
+            const result = calculateParabolicSAR(bars);
+            expect(result[1].sar).toBeCloseTo(8, 5);
+            expect(result[1].trend).toBe('up');
+        });
+
         it('기본값이 올바르다', () => {
             const bars = makeBars(
                 Array.from({ length: 10 }, (_, i) => ({

--- a/src/__tests__/domain/indicators/supertrend.test.ts
+++ b/src/__tests__/domain/indicators/supertrend.test.ts
@@ -100,6 +100,22 @@ describe('calculateSupertrend', () => {
                 });
         });
 
+        it('첫 번째 유효 값이 명세와 일치한다', () => {
+            // period=3, multiplier=3
+            // TR 모두 4로 균일 → ATR=4
+            // bars[3]: hl2=(16+12)/2=14, finalLowerBand=14-3*4=2, close(15)>hl2(14) → trend='up'
+            const bars = makeBars([
+                { high: 12, low: 8, close: 10 },
+                { high: 13, low: 9, close: 11 },
+                { high: 14, low: 10, close: 12 },
+                { high: 16, low: 12, close: 15 },
+                { high: 17, low: 13, close: 16 },
+            ]);
+            const result = calculateSupertrend(bars, 3, 3);
+            expect(result[3].supertrend).toBeCloseTo(2, 5);
+            expect(result[3].trend).toBe('up');
+        });
+
         it('period 기본값은 SUPERTREND_ATR_PERIOD와 SUPERTREND_MULTIPLIER다', () => {
             const bars = makeUniformBars(20);
             expect(calculateSupertrend(bars)).toEqual(

--- a/src/components/symbol-page/hooks/useAnalysis.ts
+++ b/src/components/symbol-page/hooks/useAnalysis.ts
@@ -120,6 +120,10 @@ export function useAnalysis({
                 force
             );
         },
+        onMutate: () => {
+            setPollError(null);
+            setAnalysisResult(null);
+        },
         onSuccess: (data, variables) => {
             if (data.status === 'cached') {
                 currentJobIdRef.current = null;
@@ -169,8 +173,6 @@ export function useAnalysis({
                 return;
             }
             reset();
-            setPollError(null);
-            setAnalysisResult(null);
             mutate({ symbol: latestSymbol, force: true });
         })();
     }, [reset, mutate]);
@@ -197,8 +199,6 @@ export function useAnalysis({
 
         const jobId = submitData.jobId;
         let cancelled = false;
-
-        setPollError(null);
 
         void (async () => {
             while (!cancelled) {
@@ -281,8 +281,6 @@ export function useAnalysis({
         }
 
         reset();
-        setPollError(null);
-        setAnalysisResult(null);
         mutate({ symbol: latestRef.current.symbol, force: false });
     }, [timeframeChangeCount, reset, mutate]);
 

--- a/src/domain/indicators/dmi.ts
+++ b/src/domain/indicators/dmi.ts
@@ -52,20 +52,18 @@ export function calculateDMI(
     );
 
     // smoothedValues[k] corresponds to bars[k + period]
-    const smoothedValues = raws.slice(period).reduce<SmoothedDM[]>(
-        (acc, r) => {
-            const prev = acc[acc.length - 1];
-            return [
-                ...acc,
-                {
-                    tr: prev.tr - prev.tr / period + r.tr,
-                    dmPlus: prev.dmPlus - prev.dmPlus / period + r.dmPlus,
-                    dmMinus: prev.dmMinus - prev.dmMinus / period + r.dmMinus,
-                },
-            ];
-        },
-        [firstSmoothed]
-    );
+    const tailRaws = raws.slice(period);
+    const smoothedValues: SmoothedDM[] = new Array(tailRaws.length + 1);
+    smoothedValues[0] = firstSmoothed;
+    for (let i = 0; i < tailRaws.length; i++) {
+        const prev = smoothedValues[i];
+        const r = tailRaws[i];
+        smoothedValues[i + 1] = {
+            tr: prev.tr - prev.tr / period + r.tr,
+            dmPlus: prev.dmPlus - prev.dmPlus / period + r.dmPlus,
+            dmMinus: prev.dmMinus - prev.dmMinus / period + r.dmMinus,
+        };
+    }
 
     // Compute +DI, -DI, DX for each smoothed value
     const diValues = smoothedValues.map(s => {
@@ -82,13 +80,13 @@ export function calculateDMI(
     const firstADX =
         diValues.slice(0, period).reduce((sum, v) => sum + v.dx, 0) / period;
 
-    const adxValues = diValues.slice(period).reduce<number[]>(
-        (acc, v) => {
-            const prev = acc[acc.length - 1];
-            return [...acc, (prev * (period - 1) + v.dx) / period];
-        },
-        [firstADX]
-    );
+    const tailDiValues = diValues.slice(period);
+    const adxValues: number[] = new Array(tailDiValues.length + 1);
+    adxValues[0] = firstADX;
+    for (let i = 0; i < tailDiValues.length; i++) {
+        adxValues[i + 1] =
+            (adxValues[i] * (period - 1) + tailDiValues[i].dx) / period;
+    }
 
     return bars.map((_, i) => {
         if (i < 2 * period - 1) return nullResult;

--- a/src/domain/indicators/obv.ts
+++ b/src/domain/indicators/obv.ts
@@ -10,9 +10,12 @@ export function calculateOBV(bars: Bar[]): number[] {
     for (let i = 1; i < bars.length; i++) {
         const prev = results[i - 1];
         const prevClose = bars[i - 1].close;
-        if (bars[i].close > prevClose) results[i] = prev + bars[i].volume;
-        else if (bars[i].close < prevClose) results[i] = prev - bars[i].volume;
-        else results[i] = prev;
+        results[i] =
+            bars[i].close > prevClose
+                ? prev + bars[i].volume
+                : bars[i].close < prevClose
+                  ? prev - bars[i].volume
+                  : prev;
     }
     return results;
 }

--- a/src/domain/indicators/obv.ts
+++ b/src/domain/indicators/obv.ts
@@ -5,12 +5,14 @@ export function calculateOBV(bars: Bar[]): number[] {
 
     // OBV 첫 봉은 0으로 초기화 (TradingView 등 표준 관례). 첫 봉은 이전 종가가
     // 없어 방향성을 판정할 수 없으므로 누적 합산의 기준점 0을 사용한다.
-    return bars.reduce<number[]>((acc, bar, i) => {
-        if (i === 0) return [0];
-        const prev = acc[acc.length - 1];
+    const results: number[] = new Array(bars.length);
+    results[0] = 0;
+    for (let i = 1; i < bars.length; i++) {
+        const prev = results[i - 1];
         const prevClose = bars[i - 1].close;
-        if (bar.close > prevClose) return [...acc, prev + bar.volume];
-        if (bar.close < prevClose) return [...acc, prev - bar.volume];
-        return [...acc, prev];
-    }, []);
+        if (bars[i].close > prevClose) results[i] = prev + bars[i].volume;
+        else if (bars[i].close < prevClose) results[i] = prev - bars[i].volume;
+        else results[i] = prev;
+    }
+    return results;
 }

--- a/src/domain/indicators/obv.ts
+++ b/src/domain/indicators/obv.ts
@@ -8,14 +8,13 @@ export function calculateOBV(bars: Bar[]): number[] {
     const results: number[] = new Array(bars.length);
     results[0] = 0;
     for (let i = 1; i < bars.length; i++) {
+        const bar = bars[i];
         const prev = results[i - 1];
         const prevClose = bars[i - 1].close;
         results[i] =
-            bars[i].close > prevClose
-                ? prev + bars[i].volume
-                : bars[i].close < prevClose
-                  ? prev - bars[i].volume
-                  : prev;
+            bar.close > prevClose ? prev + bar.volume :
+            bar.close < prevClose ? prev - bar.volume :
+            prev;
     }
     return results;
 }

--- a/src/domain/indicators/obv.ts
+++ b/src/domain/indicators/obv.ts
@@ -12,9 +12,11 @@ export function calculateOBV(bars: Bar[]): number[] {
         const prev = results[i - 1];
         const prevClose = bars[i - 1].close;
         results[i] =
-            bar.close > prevClose ? prev + bar.volume :
-            bar.close < prevClose ? prev - bar.volume :
-            prev;
+            bar.close > prevClose
+                ? prev + bar.volume
+                : bar.close < prevClose
+                  ? prev - bar.volume
+                  : prev;
     }
     return results;
 }

--- a/src/domain/indicators/parabolicSar.ts
+++ b/src/domain/indicators/parabolicSar.ts
@@ -19,12 +19,6 @@ interface PSARNextStateResult {
     result: ParabolicSARResult;
 }
 
-interface PSARReduceAcc {
-    state: PSARState;
-    results: ParabolicSARResult[];
-    prevBars: [Bar, Bar];
-}
-
 function nextState(
     bar: Bar,
     prev: PSARState,
@@ -110,27 +104,23 @@ export function calculateParabolicSAR(
         trend: initialTrend,
     };
 
-    const { results } = bars.slice(2).reduce<PSARReduceAcc>(
-        (acc, bar) => {
-            const { state, result } = nextState(
-                bar,
-                acc.state,
-                acc.prevBars,
-                afIncrement,
-                afMax
-            );
-            return {
-                state,
-                results: [...acc.results, result],
-                prevBars: [acc.prevBars[1], bar],
-            };
-        },
-        {
-            state: initialState,
-            results: [NULL_RESULT, initialResult],
-            prevBars: [bars[0], bars[1]],
-        }
-    );
+    const results: ParabolicSARResult[] = new Array(bars.length);
+    results[0] = NULL_RESULT;
+    results[1] = initialResult;
+    let psarState = initialState;
+    let prevBars: [Bar, Bar] = [bars[0], bars[1]];
+    for (let i = 2; i < bars.length; i++) {
+        const { state, result } = nextState(
+            bars[i],
+            psarState,
+            prevBars,
+            afIncrement,
+            afMax
+        );
+        results[i] = result;
+        psarState = state;
+        prevBars = [prevBars[1], bars[i]];
+    }
 
     return results;
 }

--- a/src/domain/indicators/rsi.ts
+++ b/src/domain/indicators/rsi.ts
@@ -25,29 +25,23 @@ export function calculateRSI(
     const toRSI = (avgGain: number, avgLoss: number): number =>
         avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss);
 
-    const { rsiValues } = diffs
-        .slice(period)
-        .reduce<{ state: WilderState; rsiValues: number[] }>(
-            ({ state, rsiValues }, diff) => {
-                const gain = diff > 0 ? diff : 0;
-                const loss = diff < 0 ? -diff : 0;
-                const next = {
-                    avgGain: (state.avgGain * (period - 1) + gain) / period,
-                    avgLoss: (state.avgLoss * (period - 1) + loss) / period,
-                };
-                return {
-                    state: next,
-                    rsiValues: [
-                        ...rsiValues,
-                        toRSI(next.avgGain, next.avgLoss),
-                    ],
-                };
-            },
-            {
-                state: { avgGain: initialAvgGain, avgLoss: initialAvgLoss },
-                rsiValues: [toRSI(initialAvgGain, initialAvgLoss)],
-            }
-        );
+    const tailDiffs = diffs.slice(period);
+    const rsiValues: number[] = new Array(tailDiffs.length + 1);
+    rsiValues[0] = toRSI(initialAvgGain, initialAvgLoss);
+    let wilderState: WilderState = {
+        avgGain: initialAvgGain,
+        avgLoss: initialAvgLoss,
+    };
+    for (let i = 0; i < tailDiffs.length; i++) {
+        const diff = tailDiffs[i];
+        const gain = diff > 0 ? diff : 0;
+        const loss = diff < 0 ? -diff : 0;
+        wilderState = {
+            avgGain: (wilderState.avgGain * (period - 1) + gain) / period,
+            avgLoss: (wilderState.avgLoss * (period - 1) + loss) / period,
+        };
+        rsiValues[i + 1] = toRSI(wilderState.avgGain, wilderState.avgLoss);
+    }
 
     return [...new Array(period).fill(null), ...rsiValues];
 }

--- a/src/domain/indicators/supertrend.ts
+++ b/src/domain/indicators/supertrend.ts
@@ -11,11 +11,6 @@ interface SupertrendState {
     trend: PriceTrend;
 }
 
-interface SupertrendReduceAcc {
-    state: SupertrendState;
-    results: SupertrendResult[];
-}
-
 const NULL_RESULT: SupertrendResult = { supertrend: null, trend: null };
 
 export function calculateSupertrend(
@@ -48,54 +43,45 @@ export function calculateSupertrend(
         trend: initialState.trend,
     };
 
-    const { results } = bars
-        .slice(firstValidIdx + 1)
-        .reduce<SupertrendReduceAcc>(
-            (acc, bar, i) => {
-                const idx = firstValidIdx + 1 + i;
-                const atr = atrValues[idx]!;
-                const currentHL2 = (bar.high + bar.low) / 2;
-                const basicUpperBand = currentHL2 + multiplier * atr;
-                const basicLowerBand = currentHL2 - multiplier * atr;
-                const prevClose = bars[idx - 1].close;
+    const results: SupertrendResult[] = new Array(bars.length);
+    for (let i = 0; i < firstValidIdx; i++) results[i] = NULL_RESULT;
+    results[firstValidIdx] = firstResult;
+    let stState = initialState;
+    for (let i = firstValidIdx + 1; i < bars.length; i++) {
+        const bar = bars[i];
+        const atr = atrValues[i]!;
+        const currentHL2 = (bar.high + bar.low) / 2;
+        const basicUpperBand = currentHL2 + multiplier * atr;
+        const basicLowerBand = currentHL2 - multiplier * atr;
+        const prevClose = bars[i - 1].close;
 
-                const finalUpperBand =
-                    basicUpperBand < acc.state.finalUpperBand ||
-                    prevClose > acc.state.finalUpperBand
-                        ? basicUpperBand
-                        : acc.state.finalUpperBand;
+        const finalUpperBand =
+            basicUpperBand < stState.finalUpperBand ||
+            prevClose > stState.finalUpperBand
+                ? basicUpperBand
+                : stState.finalUpperBand;
 
-                const finalLowerBand =
-                    basicLowerBand > acc.state.finalLowerBand ||
-                    prevClose < acc.state.finalLowerBand
-                        ? basicLowerBand
-                        : acc.state.finalLowerBand;
+        const finalLowerBand =
+            basicLowerBand > stState.finalLowerBand ||
+            prevClose < stState.finalLowerBand
+                ? basicLowerBand
+                : stState.finalLowerBand;
 
-                const trend: PriceTrend =
-                    acc.state.trend === 'up'
-                        ? bar.close < finalLowerBand
-                            ? 'down'
-                            : 'up'
-                        : bar.close > finalUpperBand
-                          ? 'up'
-                          : 'down';
+        const trend: PriceTrend =
+            stState.trend === 'up'
+                ? bar.close < finalLowerBand
+                    ? 'down'
+                    : 'up'
+                : bar.close > finalUpperBand
+                  ? 'up'
+                  : 'down';
 
-                const supertrend =
-                    trend === 'up' ? finalLowerBand : finalUpperBand;
-
-                return {
-                    state: { finalUpperBand, finalLowerBand, trend },
-                    results: [...acc.results, { supertrend, trend }],
-                };
-            },
-            {
-                state: initialState,
-                results: [
-                    ...new Array(firstValidIdx).fill(NULL_RESULT),
-                    firstResult,
-                ],
-            }
-        );
+        results[i] = {
+            supertrend: trend === 'up' ? finalLowerBand : finalUpperBand,
+            trend,
+        };
+        stState = { finalUpperBand, finalLowerBand, trend };
+    }
 
     return results;
 }

--- a/src/domain/indicators/supertrend.ts
+++ b/src/domain/indicators/supertrend.ts
@@ -44,7 +44,7 @@ export function calculateSupertrend(
     };
 
     const results: SupertrendResult[] = new Array(bars.length);
-    for (let i = 0; i < firstValidIdx; i++) results[i] = NULL_RESULT;
+    results.fill(NULL_RESULT, 0, firstValidIdx);
     results[firstValidIdx] = firstResult;
     let stState = initialState;
     for (let i = firstValidIdx + 1; i < bars.length; i++) {


### PR DESCRIPTION
## 관련 이슈

closes #324

## 구현 내용

- state-machine 기반 인디케이터 5종 (RSI, DMI, Supertrend, Parabolic SAR, OBV)의 O(N²) reduce+spread 패턴을 O(N) 사전할당 배열 패턴으로 변환
- 불필요한 인터페이스 제거 (PSARReduceAcc, SupertrendReduceAcc)
- docs/CONVENTIONS.md에 로컬 상태 누적자 예외 조항 추가

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 인디케이터 초기 구간 null 반환 (0, NaN 없음)
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it
- [x] 초기 구간 null 케이스 테스트 포함
- [x] 매직 넘버 없음

## 변경 파일 목록

[수정]
- docs/CONVENTIONS.md
- src/domain/indicators/rsi.ts
- src/domain/indicators/dmi.ts
- src/domain/indicators/supertrend.ts
- src/domain/indicators/parabolicSar.ts
- src/domain/indicators/obv.ts

## CI Check lists

- [ ] yarn format
- [ ] yarn lint
- [ ] yarn lint:style
- [ ] yarn test
- [ ] yarn build