### PR TITLE
feat: 메인화면 SubTitle 서비스 확장 범위 반영하여 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -158,7 +158,8 @@ export default async function Home() {
                             </span>
                         </h1>
                         <p className="text-secondary-400 mx-auto mt-4 max-w-lg text-base leading-relaxed text-balance sm:text-xl lg:mx-0">
-                            시장 흐름부터 종목별 기술적 분석, AI 대화까지 &mdash; 한 곳에서.
+                            시장 흐름부터 종목별 기술적 분석, AI 대화까지
+                            &mdash; 한 곳에서.
                         </p>
                         <div
                             id="search"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -158,7 +158,7 @@ export default async function Home() {
                             </span>
                         </h1>
                         <p className="text-secondary-400 mx-auto mt-4 max-w-lg text-base leading-relaxed text-balance sm:text-xl lg:mx-0">
-                            종목 티커를 입력하면 차트와 지표를 즉시 분석합니다.
+                            시장 흐름부터 종목별 기술적 분석, AI 대화까지 &mdash; 한 곳에서.
                         </p>
                         <div
                             id="search"


### PR DESCRIPTION
## 관련 이슈

closes #334

## 구현 내용

메인화면의 서브타이틀을 서비스의 확장된 범위를 반영하도록 수정했습니다.

**Before**
```
종목 티커를 입력하면 차트와 지표를 즉시 분석합니다.
```

**After**
```
시장 흐름부터 종목별 기술적 분석, AI 대화까지 — 한 곳에서.
```

## 변경 파일 목록

[수정]
- `src/app/page.tsx`: 홈페이지 서브타이틀 업데이트

## CI Check lists

- [ ] yarn format
- [ ] yarn lint
- [ ] yarn lint:style
- [ ] yarn test
- [ ] yarn build