### PR TITLE
feat: 메인화면 H1·SEO 메타 서비스 확장 범위 반영하여 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -75,7 +75,7 @@ export default async function Home() {
     const howToJsonLd = {
         '@context': 'https://schema.org',
         '@type': 'HowTo',
-        name: `${SITE_NAME}로 미국 주식 AI 기술적 분석하는 방법`,
+        name: `${SITE_NAME}로 미국 주식 시장 분석·기술적 분석·AI 대화하는 방법`,
         description: `종목 티커를 입력하면 보조지표 ${skillCounts.indicators}종, 캔들 패턴 ${skillCounts.candlesticks}종, 차트 패턴 ${skillCounts.patterns}종, 전략 ${skillCounts.strategies}종, 지지/저항 ${skillCounts.supportResistance}종을 자동 분석합니다.`,
         step: [
             {
@@ -152,9 +152,9 @@ export default async function Home() {
                             SIGLENS
                         </p>
                         <h1 className="text-secondary-100 text-[2rem] leading-[1.15] font-bold tracking-tight text-balance sm:text-5xl lg:text-6xl">
-                            AI가 분석하는 미국 주식{' '}
+                            미국 주식,{' '}
                             <span className="text-primary-400 block sm:inline">
-                                기술적 분석
+                                AI가 읽어주는 시장과 차트
                             </span>
                         </h1>
                         <p className="text-secondary-400 mx-auto mt-4 max-w-lg text-base leading-relaxed text-balance sm:text-xl lg:mx-0">

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -4,9 +4,9 @@ export const SITE_URL =
 export const SITE_NAME = 'Siglens';
 
 export const SITE_DESCRIPTION =
-    '티커 입력 한 번으로 RSI·MACD·볼린저밴드·캔들 패턴·지지저항을 AI가 자동 분석합니다. 무료, 회원가입 불필요.';
+    '시장 흐름 파악부터 종목별 기술적 분석, AI와의 심층 대화까지 한 곳에서. RSI·MACD·볼린저밴드·캔들 패턴·지지저항 자동 분석과 오늘 주목할 종목을 무료로 확인하세요. 회원가입 불필요.';
 
-export const ROOT_TITLE = `미국 주식 AI 기술적 분석 — RSI·MACD·볼린저밴드 자동 해석 | ${SITE_NAME}`;
+export const ROOT_TITLE = `미국 주식 무료 AI 분석 — 시장 분석·기술적 분석·AI 대화 | ${SITE_NAME}`;
 
 export const ROOT_KEYWORDS = [
     'Siglens',


### PR DESCRIPTION
## 관련 이슈

Closes #336

## 구현 내용

- H1: "AI가 분석하는 미국 주식 기술적 분석" → "미국 주식, AI가 읽어주는 시장과 차트"
- ROOT_TITLE: "미국 주식 AI 기술적 분석 — RSI·MACD·볼린저밴드 자동 해석 | Siglens" → "미국 주식 무료 AI 분석 — 시장 분석·기술적 분석·AI 대화 | Siglens"
- SITE_DESCRIPTION: 기술 도구 나열 중심 → 서비스 전체 범위 반영
- HowTo Schema name: 기술적 분석 단일 플로우 → 시장 분석·기술적 분석·AI 대화 포함

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 인디케이터 초기 구간 null 반환 (0, NaN 없음)
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it
- [x] 초기 구간 null 케이스 테스트 포함
- [x] 매직 넘버 없음

## 변경 파일 목록

[수정]
- `src/app/page.tsx`: H1 업데이트 + HowTo Schema name 업데이트
- `src/lib/seo.ts`: ROOT_TITLE, SITE_DESCRIPTION 업데이트

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build