### PR TITLE
fix: AI briefing retryDelay 제한 추가 및 유료 키 폴백

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -21,7 +21,7 @@
 ## [Issue #349 | fix/349/briefing-retry-delay-paid-key-fallback | 2026-04-25]
 - Violation: 옵션 파라미터 이름(`maxDelayMs`)이 단순 지연 상한처럼 보이지만, 실제로는 한도 초과 시 루프를 즉시 중단하고 `AI_SERVER_UNSTABLE_CODE`를 throw하는 제어 흐름 부수 효과를 가짐
 - Rule: FF Predictability — 파라미터 이름은 호출 측이 타입과 이름만으로 동작을 예측할 수 있어야 한다. 숨겨진 제어 흐름 효과는 이름에 명시해야 함
-- Context: `withRetry`의 `maxDelayMs` 옵션이 delay cap처럼 보였으나 실제로는 abort-on-exceed 시맨틱. `abortIfDelayExceedsMs`로 이름을 변경하여 의도를 명확히 함
+- Context: `withRetry`의 `maxDelayMs` 옵션이 delay cap처럼 보였으나 실제로는 abort-on-exceed 시맨틱. `abortIfCumulativeDelayReachesMs`로 이름을 변경하여 의도를 명확히 함
 
 ## [PR #345 | feat/chat-model-selector | 2026-04-24]
 - Violation: `server_busy` 에러 메시지가 "위의 모델 선택기에서"처럼 UI 레이아웃 구조를 훅 레이어에서 직접 참조

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,14 @@
 # Fix Log
 
+## [PR #379 | fix/349/briefing-retry-delay-paid-key-fallback | 2026-04-25]
+- Violation: `withRetry`가 누적 지연 대신 개별 지연만 `delayLimit`과 비교하여, 여러 번의 짧은 재시도가 누적되어 총 대기 시간이 한도를 초과할 수 있었음
+- Rule: CONVENTIONS.md Predictability — PR 설명과 구현이 일치해야 함; "누적 재시도 지연 시간 제한"이라고 명시되어 있으면 구현도 누적값을 추적해야 함
+- Context: `worker/src/retry.ts`의 `withRetry`에서 `cumulativeDelay` 변수 추가로 실제 누적 지연 합산 후 비교하도록 수정
+
+- Violation: `callAnalysisAI`와 `callBriefingAI`가 Claude → Gemini 무료 키 → 유료 키 폴백 로직을 18줄씩 완전 중복 구현
+- Rule: MISTAKES.md Coding Paradigm #1 — "Across provider pairs: extract shared logic"
+- Context: `worker/src/index.ts`에서 `callGeminiWithKeyFallback` 헬퍼로 공통 로직 추출; `callAnalysisAI`, `callBriefingAI`는 각 지연 한도 상수만 전달하는 1줄로 단순화
+
 ## [Issue #349 | fix/349/briefing-retry-delay-paid-key-fallback | 2026-04-25]
 - Violation: 옵션 파라미터 이름(`maxDelayMs`)이 단순 지연 상한처럼 보이지만, 실제로는 한도 초과 시 루프를 즉시 중단하고 `AI_SERVER_UNSTABLE_CODE`를 throw하는 제어 흐름 부수 효과를 가짐
 - Rule: FF Predictability — 파라미터 이름은 호출 측이 타입과 이름만으로 동작을 예측할 수 있어야 한다. 숨겨진 제어 흐름 효과는 이름에 명시해야 함

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,10 @@
 # Fix Log
 
+## [Issue #349 | fix/349/briefing-retry-delay-paid-key-fallback | 2026-04-25]
+- Violation: 옵션 파라미터 이름(`maxDelayMs`)이 단순 지연 상한처럼 보이지만, 실제로는 한도 초과 시 루프를 즉시 중단하고 `AI_SERVER_UNSTABLE_CODE`를 throw하는 제어 흐름 부수 효과를 가짐
+- Rule: FF Predictability — 파라미터 이름은 호출 측이 타입과 이름만으로 동작을 예측할 수 있어야 한다. 숨겨진 제어 흐름 효과는 이름에 명시해야 함
+- Context: `withRetry`의 `maxDelayMs` 옵션이 delay cap처럼 보였으나 실제로는 abort-on-exceed 시맨틱. `abortIfDelayExceedsMs`로 이름을 변경하여 의도를 명확히 함
+
 ## [PR #345 | feat/chat-model-selector | 2026-04-24]
 - Violation: `server_busy` 에러 메시지가 "위의 모델 선택기에서"처럼 UI 레이아웃 구조를 훅 레이어에서 직접 참조
 - Rule: FF Coupling — 훅(로직 레이어)은 컴포넌트 레이아웃(UI 레이어) 위치를 알아서는 안 됨

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,14 @@
 # Fix Log
 
+## [PR #379 Round 2 | fix/349/briefing-retry-delay-paid-key-fallback | 2026-04-25]
+- Violation: `withRetry` JSDoc 블록이 4줄 다중 단락 — 단일 줄 요약 규칙 위반
+- Rule: MISTAKES.md Documentation Sync #3 — Single-line summaries only; multi-paragraph docstrings must be condensed to one line per function
+- Context: `retry.ts`의 `withRetry` 함수와 `AI_SERVER_UNSTABLE_CODE` 상수 JSDoc, `index.ts`의 `getThinkingBudgetSequence`·`callGeminiReducingBudget` JSDoc 모두 단일 줄로 압축
+
+- Violation: 엔드포인트 전용 상수(`ANALYSIS_FREE_KEY_MAX_RETRY_DELAY_MS`, `BRIEFING_MAX_RETRY_DELAY_MS`)가 범용 retry 유틸리티 모듈에 export되어 불필요한 결합 발생
+- Rule: FF Cohesion 원칙 — 파일을 수정하면 함께 바뀌어야 할 파일을 같은 위치에 두어야 한다
+- Context: 두 상수는 `index.ts`에서만 사용되므로 `retry.ts`에서 제거하고 `index.ts` 상수 블록으로 이동
+
 ## [PR #379 | fix/349/briefing-retry-delay-paid-key-fallback | 2026-04-25]
 - Violation: `withRetry`가 누적 지연 대신 개별 지연만 `delayLimit`과 비교하여, 여러 번의 짧은 재시도가 누적되어 총 대기 시간이 한도를 초과할 수 있었음
 - Rule: CONVENTIONS.md Predictability — PR 설명과 구현이 일치해야 함; "누적 재시도 지연 시간 제한"이라고 명시되어 있으면 구현도 누적값을 추적해야 함

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -96,13 +96,22 @@ async function callGeminiReducingBudget(
     throw new Error('All thinking budget steps exhausted');
 }
 
+interface GeminiWithFallbackOptions {
+    maxAttempts?: number;
+    signal?: AbortSignal;
+    abortIfDelayExceedsMs?: number;
+}
+
 async function callGeminiWithFallback(
     prompt: string,
     apiKey: string,
-    maxAttempts: number = AI_RETRY_MAX_ATTEMPTS,
-    signal?: AbortSignal,
-    abortIfDelayExceedsMs?: number
+    options: GeminiWithFallbackOptions = {}
 ): Promise<string> {
+    const {
+        maxAttempts = AI_RETRY_MAX_ATTEMPTS,
+        signal,
+        abortIfDelayExceedsMs,
+    } = options;
     return withRetry(() => callGeminiReducingBudget(prompt, apiKey, signal), {
         maxAttempts,
         baseDelayMs: AI_RETRY_DELAY_MS,
@@ -117,37 +126,40 @@ async function callGeminiWithFallback(
     // }
 }
 
-async function callAnalysisAI(
+async function callGeminiWithKeyFallback(
     prompt: string,
-    signal?: AbortSignal
+    signal: AbortSignal | undefined,
+    freeKeyDelayLimit: number
 ): Promise<string> {
-    if (config.aiProvider === 'claude') {
-        return callClaude(prompt, signal);
-    }
-
     const { freeApiKey, apiKey } = config.gemini;
 
     if (freeApiKey) {
         try {
-            return await callGeminiWithFallback(
-                prompt,
-                freeApiKey,
-                AI_RETRY_MAX_ATTEMPTS_FREE,
+            return await callGeminiWithFallback(prompt, freeApiKey, {
+                maxAttempts: AI_RETRY_MAX_ATTEMPTS_FREE,
                 signal,
-                ANALYSIS_FREE_KEY_MAX_RETRY_DELAY_MS
-            );
-        } catch {
+                abortIfDelayExceedsMs: freeKeyDelayLimit,
+            });
+        } catch (err) {
+            if (err instanceof Error && err.name === 'AbortError') throw err;
             console.warn(
                 '[Worker] Free API key exhausted. Switching to paid key.'
             );
         }
     }
 
-    return callGeminiWithFallback(
+    return callGeminiWithFallback(prompt, apiKey, { signal });
+}
+
+async function callAnalysisAI(
+    prompt: string,
+    signal?: AbortSignal
+): Promise<string> {
+    if (config.aiProvider === 'claude') return callClaude(prompt, signal);
+    return callGeminiWithKeyFallback(
         prompt,
-        apiKey,
-        AI_RETRY_MAX_ATTEMPTS,
-        signal
+        signal,
+        ANALYSIS_FREE_KEY_MAX_RETRY_DELAY_MS
     );
 }
 
@@ -155,33 +167,11 @@ async function callBriefingAI(
     prompt: string,
     signal?: AbortSignal
 ): Promise<string> {
-    if (config.aiProvider === 'claude') {
-        return callClaude(prompt, signal);
-    }
-
-    const { freeApiKey, apiKey } = config.gemini;
-
-    if (freeApiKey) {
-        try {
-            return await callGeminiWithFallback(
-                prompt,
-                freeApiKey,
-                AI_RETRY_MAX_ATTEMPTS_FREE,
-                signal,
-                BRIEFING_MAX_RETRY_DELAY_MS
-            );
-        } catch {
-            console.warn(
-                '[Worker] Free API key exhausted. Switching to paid key.'
-            );
-        }
-    }
-
-    return callGeminiWithFallback(
+    if (config.aiProvider === 'claude') return callClaude(prompt, signal);
+    return callGeminiWithKeyFallback(
         prompt,
-        apiKey,
-        AI_RETRY_MAX_ATTEMPTS,
-        signal
+        signal,
+        BRIEFING_MAX_RETRY_DELAY_MS
     );
 }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -143,7 +143,12 @@ async function callAnalysisAI(
         }
     }
 
-    return callGeminiWithFallback(prompt, apiKey, AI_RETRY_MAX_ATTEMPTS, signal);
+    return callGeminiWithFallback(
+        prompt,
+        apiKey,
+        AI_RETRY_MAX_ATTEMPTS,
+        signal
+    );
 }
 
 async function callBriefingAI(
@@ -172,7 +177,12 @@ async function callBriefingAI(
         }
     }
 
-    return callGeminiWithFallback(prompt, apiKey, AI_RETRY_MAX_ATTEMPTS, signal);
+    return callGeminiWithFallback(
+        prompt,
+        apiKey,
+        AI_RETRY_MAX_ATTEMPTS,
+        signal
+    );
 }
 
 const app = express();

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,10 +1,16 @@
-import { constants } from 'node:http2';
-import express, { type Request, type Response } from 'express';
 import { Redis } from '@upstash/redis';
+import express, { type Request, type Response } from 'express';
+import { constants } from 'node:http2';
+import { callClaude } from './claude.js';
 import { config } from './config.js';
 import { callGemini, MAX_TOKENS_CODE } from './gemini.js';
-import { callClaude } from './claude.js';
 import { withRetry } from './retry.js';
+
+interface GeminiWithFallbackOptions {
+    maxAttempts?: number;
+    signal?: AbortSignal;
+    abortIfCumulativeDelayReachesMs?: number;
+}
 
 const {
     HTTP_STATUS_BAD_REQUEST,
@@ -86,12 +92,6 @@ async function callGeminiReducingBudget(
     throw new Error('All thinking budget steps exhausted');
 }
 
-interface GeminiWithFallbackOptions {
-    maxAttempts?: number;
-    signal?: AbortSignal;
-    abortIfDelayExceedsMs?: number;
-}
-
 async function callGeminiWithFallback(
     prompt: string,
     apiKey: string,
@@ -100,12 +100,12 @@ async function callGeminiWithFallback(
     const {
         maxAttempts = AI_RETRY_MAX_ATTEMPTS,
         signal,
-        abortIfDelayExceedsMs,
+        abortIfCumulativeDelayReachesMs,
     } = options;
     return withRetry(() => callGeminiReducingBudget(prompt, apiKey, signal), {
         maxAttempts,
         baseDelayMs: AI_RETRY_DELAY_MS,
-        abortIfDelayExceedsMs,
+        abortIfCumulativeDelayReachesMs,
     });
     // TODO: fallback model 임시 비활성화
     // free API key의 할당량이 key 단위로 공유되어 fallback도 즉시 실패하는 문제 확인 필요
@@ -128,7 +128,7 @@ async function callGeminiWithKeyFallback(
             return await callGeminiWithFallback(prompt, freeApiKey, {
                 maxAttempts: AI_RETRY_MAX_ATTEMPTS_FREE,
                 signal,
-                abortIfDelayExceedsMs: freeKeyDelayLimit,
+                abortIfCumulativeDelayReachesMs: freeKeyDelayLimit,
             });
         } catch (err) {
             if (err instanceof Error && err.name === 'AbortError') throw err;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4,11 +4,7 @@ import { Redis } from '@upstash/redis';
 import { config } from './config.js';
 import { callGemini, MAX_TOKENS_CODE } from './gemini.js';
 import { callClaude } from './claude.js';
-import {
-    withRetry,
-    ANALYSIS_FREE_KEY_MAX_RETRY_DELAY_MS,
-    BRIEFING_MAX_RETRY_DELAY_MS,
-} from './retry.js';
+import { withRetry } from './retry.js';
 
 const {
     HTTP_STATUS_BAD_REQUEST,
@@ -21,6 +17,8 @@ const JOB_TTL_SECONDS = 3600;
 const AI_RETRY_MAX_ATTEMPTS = 5;
 const AI_RETRY_MAX_ATTEMPTS_FREE = 3;
 const AI_RETRY_DELAY_MS = 5000;
+const ANALYSIS_FREE_KEY_MAX_RETRY_DELAY_MS = 30_000;
+const BRIEFING_MAX_RETRY_DELAY_MS = 10_000;
 
 // 진행 중인 job의 AbortController를 보관 — /cancel 엔드포인트 수신 시 즉시 abort 가능
 const activeJobs = new Map<string, AbortController>();
@@ -34,11 +32,7 @@ function isMaxTokensError(error: unknown): boolean {
     );
 }
 
-/**
- * MAX_TOKENS 발생 시 시도할 thinkingBudget 단계.
- * initial → initial/2 → 8192 → 4096 → 2048 → 0(thinking off)
- * 엄격한 감소 순서를 보장하기 위해 이전 값보다 작은 경우만 포함한다.
- */
+/** MAX_TOKENS 발생 시 시도할 thinkingBudget 단계 시퀀스를 반환한다 (엄격한 감소 순서). */
 function getThinkingBudgetSequence(initial: number): number[] {
     const candidates = [initial, Math.floor(initial / 2), 8192, 4096, 2048, 0];
     return candidates.reduce<number[]>((acc, budget) => {
@@ -49,11 +43,7 @@ function getThinkingBudgetSequence(initial: number): number[] {
     }, []);
 }
 
-/**
- * MAX_TOKENS 발생 시 thinkingBudget을 단계적으로 낮춰가며 1회씩 시도한다.
- * 429/5xx 등 일시적 에러는 재시도하지 않고 그대로 throw하여
- * 외부 withRetry 레이어에서 처리하도록 한다.
- */
+/** MAX_TOKENS 발생 시 thinkingBudget을 단계적으로 낮춰가며 시도; 일시적 에러는 outer withRetry로 전파한다. */
 async function callGeminiReducingBudget(
     prompt: string,
     apiKey: string,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4,7 +4,11 @@ import { Redis } from '@upstash/redis';
 import { config } from './config.js';
 import { callGemini, MAX_TOKENS_CODE } from './gemini.js';
 import { callClaude } from './claude.js';
-import { withRetry } from './retry.js';
+import {
+    withRetry,
+    ANALYSIS_FREE_KEY_MAX_RETRY_DELAY_MS,
+    BRIEFING_MAX_RETRY_DELAY_MS,
+} from './retry.js';
 
 const {
     HTTP_STATUS_BAD_REQUEST,
@@ -37,13 +41,12 @@ function isMaxTokensError(error: unknown): boolean {
  */
 function getThinkingBudgetSequence(initial: number): number[] {
     const candidates = [initial, Math.floor(initial / 2), 8192, 4096, 2048, 0];
-    const result: number[] = [];
-    for (const budget of candidates) {
-        if (result.length === 0 || budget < result[result.length - 1]) {
-            result.push(budget);
+    return candidates.reduce<number[]>((acc, budget) => {
+        if (acc.length === 0 || budget < acc[acc.length - 1]) {
+            return [...acc, budget];
         }
-    }
-    return result;
+        return acc;
+    }, []);
 }
 
 /**
@@ -97,11 +100,13 @@ async function callGeminiWithFallback(
     prompt: string,
     apiKey: string,
     maxAttempts: number = AI_RETRY_MAX_ATTEMPTS,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    abortIfDelayExceedsMs?: number
 ): Promise<string> {
     return withRetry(() => callGeminiReducingBudget(prompt, apiKey, signal), {
         maxAttempts,
         baseDelayMs: AI_RETRY_DELAY_MS,
+        abortIfDelayExceedsMs,
     });
     // TODO: fallback model 임시 비활성화
     // free API key의 할당량이 key 단위로 공유되어 fallback도 즉시 실패하는 문제 확인 필요
@@ -112,7 +117,10 @@ async function callGeminiWithFallback(
     // }
 }
 
-async function callAI(prompt: string, signal?: AbortSignal): Promise<string> {
+async function callAnalysisAI(
+    prompt: string,
+    signal?: AbortSignal
+): Promise<string> {
     if (config.aiProvider === 'claude') {
         return callClaude(prompt, signal);
     }
@@ -125,7 +133,8 @@ async function callAI(prompt: string, signal?: AbortSignal): Promise<string> {
                 prompt,
                 freeApiKey,
                 AI_RETRY_MAX_ATTEMPTS_FREE,
-                signal
+                signal,
+                ANALYSIS_FREE_KEY_MAX_RETRY_DELAY_MS
             );
         } catch {
             console.warn(
@@ -134,12 +143,36 @@ async function callAI(prompt: string, signal?: AbortSignal): Promise<string> {
         }
     }
 
-    return callGeminiWithFallback(
-        prompt,
-        apiKey,
-        AI_RETRY_MAX_ATTEMPTS,
-        signal
-    );
+    return callGeminiWithFallback(prompt, apiKey, AI_RETRY_MAX_ATTEMPTS, signal);
+}
+
+async function callBriefingAI(
+    prompt: string,
+    signal?: AbortSignal
+): Promise<string> {
+    if (config.aiProvider === 'claude') {
+        return callClaude(prompt, signal);
+    }
+
+    const { freeApiKey, apiKey } = config.gemini;
+
+    if (freeApiKey) {
+        try {
+            return await callGeminiWithFallback(
+                prompt,
+                freeApiKey,
+                AI_RETRY_MAX_ATTEMPTS_FREE,
+                signal,
+                BRIEFING_MAX_RETRY_DELAY_MS
+            );
+        } catch {
+            console.warn(
+                '[Worker] Free API key exhausted. Switching to paid key.'
+            );
+        }
+    }
+
+    return callGeminiWithFallback(prompt, apiKey, AI_RETRY_MAX_ATTEMPTS, signal);
 }
 
 const app = express();
@@ -262,7 +295,7 @@ async function processJob(
     });
 
     try {
-        const result = await callAI(prompt, controller.signal);
+        const result = await callAnalysisAI(prompt, controller.signal);
 
         if (!result || result.trim() === '') {
             throw new Error('AI returned an empty response');
@@ -360,7 +393,7 @@ async function processBriefingJob(
     });
 
     try {
-        const text = await callAI(prompt, controller.signal);
+        const text = await callBriefingAI(prompt, controller.signal);
 
         if (!text || text.trim() === '') {
             throw new Error('AI returned an empty response');

--- a/worker/src/retry.ts
+++ b/worker/src/retry.ts
@@ -4,6 +4,12 @@
  */
 export const AI_SERVER_UNSTABLE_CODE = 'AI_SERVER_UNSTABLE';
 
+/** 일반 분석(/analyze) — free 키 rate limit 시 최대 허용 지연. 초과 시 즉시 유료 키로 전환한다. */
+export const ANALYSIS_FREE_KEY_MAX_RETRY_DELAY_MS = 30_000;
+
+/** AI 브리핑(/briefing) — 약 10초 이내 완료 목표. 초과 시 즉시 유료 키로 전환한다. */
+export const BRIEFING_MAX_RETRY_DELAY_MS = 10_000;
+
 type ErrorKind = 'rate_limit' | 'server_error' | 'retryable' | 'none';
 
 const RETRY_ALLOWABLE_TIME_MS = 300_000;
@@ -88,11 +94,22 @@ function sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/**
+ * withRetry options
+ * - abortIfDelayExceedsMs: 계산된 재시도 지연이 이 값 이상이면 대기 없이 즉시 루프를 종료하고
+ *   AI_SERVER_UNSTABLE_CODE를 throw한다. 호출 측에서 유료 키로의 전환 등 다음 단계를 처리해야 한다.
+ *   미지정 시 RETRY_ALLOWABLE_TIME_MS(300초)가 기본값으로 적용된다.
+ */
 export async function withRetry<T>(
     fn: () => Promise<T>,
-    options: { maxAttempts: number; baseDelayMs: number }
+    options: {
+        maxAttempts: number;
+        baseDelayMs: number;
+        abortIfDelayExceedsMs?: number;
+    }
 ): Promise<T> {
-    const { maxAttempts, baseDelayMs } = options;
+    const { maxAttempts, baseDelayMs, abortIfDelayExceedsMs } = options;
+    const delayLimit = abortIfDelayExceedsMs ?? RETRY_ALLOWABLE_TIME_MS;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         try {
@@ -107,32 +124,26 @@ export async function withRetry<T>(
                 throw error;
             }
 
-            if (kind === 'rate_limit') {
-                const delay = get429RetryDelay(error) ?? baseDelayMs;
+            const delay =
+                kind === 'rate_limit'
+                    ? (get429RetryDelay(error) ?? baseDelayMs)
+                    : baseDelayMs * Math.pow(2, attempt - 1);
 
-                if (delay >= RETRY_ALLOWABLE_TIME_MS) {
-                    console.warn(
-                        `[Retry] Do not attempt to retry beyond the allowable time. Response received: ${delay}`
-                    );
-                    break;
-                }
-
+            if (delay >= delayLimit) {
                 console.warn(
-                    `[Retry] Attempt ${attempt}/${maxAttempts} failed (429). Retrying in ${delay}ms...`,
-                    error
+                    `[Retry] Retry delay (${delay}ms) exceeds limit (${delayLimit}ms). Aborting retries.`
                 );
-                await sleep(delay);
-            } else {
-                // server_error | retryable → 지수 백오프
-                const delay = baseDelayMs * Math.pow(2, attempt - 1);
-                console.warn(
-                    `[Retry] Attempt ${attempt}/${maxAttempts} failed (5xx). Retrying in ${delay}ms...`,
-                    error
-                );
-                await sleep(delay);
+                break;
             }
+
+            const label = kind === 'rate_limit' ? '429' : '5xx';
+            console.warn(
+                `[Retry] Attempt ${attempt}/${maxAttempts} failed (${label}). Retrying in ${delay}ms...`,
+                error
+            );
+            await sleep(delay);
         }
     }
-    // unreachable — for 루프가 항상 return 또는 throw
+    // break로 루프를 정상 종료한 경우(delay 한도 초과) 또는 maxAttempts 소진 시 도달
     throw new Error(AI_SERVER_UNSTABLE_CODE);
 }

--- a/worker/src/retry.ts
+++ b/worker/src/retry.ts
@@ -110,6 +110,7 @@ export async function withRetry<T>(
 ): Promise<T> {
     const { maxAttempts, baseDelayMs, abortIfDelayExceedsMs } = options;
     const delayLimit = abortIfDelayExceedsMs ?? RETRY_ALLOWABLE_TIME_MS;
+    let cumulativeDelay = 0;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         try {
@@ -129,9 +130,9 @@ export async function withRetry<T>(
                     ? (get429RetryDelay(error) ?? baseDelayMs)
                     : baseDelayMs * Math.pow(2, attempt - 1);
 
-            if (delay >= delayLimit) {
+            if (cumulativeDelay + delay >= delayLimit) {
                 console.warn(
-                    `[Retry] Retry delay (${delay}ms) exceeds limit (${delayLimit}ms). Aborting retries.`
+                    `[Retry] Cumulative retry delay (${cumulativeDelay + delay}ms) would exceed limit (${delayLimit}ms). Aborting retries.`
                 );
                 break;
             }
@@ -141,9 +142,10 @@ export async function withRetry<T>(
                 `[Retry] Attempt ${attempt}/${maxAttempts} failed (${label}). Retrying in ${delay}ms...`,
                 error
             );
+            cumulativeDelay += delay;
             await sleep(delay);
         }
     }
-    // break로 루프를 정상 종료한 경우(delay 한도 초과) 또는 maxAttempts 소진 시 도달
+    // delay 한도 초과로 break된 경우에만 도달
     throw new Error(AI_SERVER_UNSTABLE_CODE);
 }

--- a/worker/src/retry.ts
+++ b/worker/src/retry.ts
@@ -85,17 +85,19 @@ function sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-/** 누적 지연이 abortIfDelayExceedsMs를 초과하면 즉시 루프를 중단하고 AI_SERVER_UNSTABLE_CODE를 throw한다. */
+/** 누적 지연이 abortIfCumulativeDelayReachesMs 이상이면 즉시 루프를 중단하고 AI_SERVER_UNSTABLE_CODE를 throw한다. */
 export async function withRetry<T>(
     fn: () => Promise<T>,
     options: {
         maxAttempts: number;
         baseDelayMs: number;
-        abortIfDelayExceedsMs?: number;
+        abortIfCumulativeDelayReachesMs?: number;
     }
 ): Promise<T> {
-    const { maxAttempts, baseDelayMs, abortIfDelayExceedsMs } = options;
-    const delayLimit = abortIfDelayExceedsMs ?? RETRY_ALLOWABLE_TIME_MS;
+    const { maxAttempts, baseDelayMs, abortIfCumulativeDelayReachesMs } =
+        options;
+    const delayLimit =
+        abortIfCumulativeDelayReachesMs ?? RETRY_ALLOWABLE_TIME_MS;
     let cumulativeDelay = 0;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {

--- a/worker/src/retry.ts
+++ b/worker/src/retry.ts
@@ -1,14 +1,5 @@
-/**
- * 5xx 에러로 모든 재시도가 소진되었음을 나타내는 센티넬 에러 코드.
- * 클라이언트(useAnalysis.ts)에서 동일한 문자열로 매칭하여 사용자 안내 메시지를 표시한다.
- */
+/** useAnalysis.ts가 이 문자열로 매칭하여 사용자 안내 메시지를 표시하는 5xx 소진 센티넬 코드. */
 export const AI_SERVER_UNSTABLE_CODE = 'AI_SERVER_UNSTABLE';
-
-/** 일반 분석(/analyze) — free 키 rate limit 시 최대 허용 지연. 초과 시 즉시 유료 키로 전환한다. */
-export const ANALYSIS_FREE_KEY_MAX_RETRY_DELAY_MS = 30_000;
-
-/** AI 브리핑(/briefing) — 약 10초 이내 완료 목표. 초과 시 즉시 유료 키로 전환한다. */
-export const BRIEFING_MAX_RETRY_DELAY_MS = 10_000;
 
 type ErrorKind = 'rate_limit' | 'server_error' | 'retryable' | 'none';
 
@@ -94,12 +85,7 @@ function sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-/**
- * withRetry options
- * - abortIfDelayExceedsMs: 계산된 재시도 지연이 이 값 이상이면 대기 없이 즉시 루프를 종료하고
- *   AI_SERVER_UNSTABLE_CODE를 throw한다. 호출 측에서 유료 키로의 전환 등 다음 단계를 처리해야 한다.
- *   미지정 시 RETRY_ALLOWABLE_TIME_MS(300초)가 기본값으로 적용된다.
- */
+/** 누적 지연이 abortIfDelayExceedsMs를 초과하면 즉시 루프를 중단하고 AI_SERVER_UNSTABLE_CODE를 throw한다. */
 export async function withRetry<T>(
     fn: () => Promise<T>,
     options: {


### PR DESCRIPTION
## 관련 이슈

closes #349

## 구현 내용

- `withRetry`에 `abortIfDelayExceedsMs` 옵션 추가로 누적 재시도 지연 시간이 지정값을 초과하면 중단
- 상수 추가:
  - `ANALYSIS_FREE_KEY_MAX_RETRY_DELAY_MS = 30_000` (분석 엔드포인트용)
  - `BRIEFING_MAX_RETRY_DELAY_MS = 10_000` (브리핑 엔드포인트용)
- `callAI` 함수를 `callAnalysisAI`와 `callBriefingAI`로 분리하여 엔드포인트별 재시도 정책 적용
- rate_limit과 server_error 브랜치의 중복된 지연 제한 로직 통합
- `getThinkingBudgetSequence` 리팩토링 (for...of+push → reduce)

## 변경 파일 목록

[수정]
- `worker/src/retry.ts`: 재시도 정책 개선
- `worker/src/index.ts`: callAI 분리 및 함수 리팩토링
- `docs/__agents_only__/fix-log.md`: 구현 완료 기록

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build