### PR TITLE
fix: 마켓 페이지 섹터 시그널 등락률 오류

### DIFF
--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -11,6 +11,15 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 ## Coding Paradigm
 
 ```
+0. Concurrent fetch without respecting provider rate limits
+   → Always use fetchInChunks or sequential await for multiple API calls
+   → Never use Promise.all/Promise.allSettled when calls exceed FETCH_CONCURRENCY threshold
+   → Rate limits: FMP=250/min, Alpaca=various, Gemini=API-tier dependent
+   ❌ Promise.allSettled(SECTOR_STOCKS.map(fetchQuote))  // parallel, exceeds rate limit
+   ❌ Promise.all([fetchInChunks(...), fetchInChunks(...)])  // doubles concurrency to 20 when limit is 10
+   ✅ Use fetchInChunks(items, FETCH_CONCURRENCY) for sequential chunked execution
+   ✅ for await (const batch of chunks) { const results = await Promise.all(batch); }
+
 1. Reimplementing the same algorithm
    → Check for existing helpers before writing a new function
    → Separate number[]-based helpers from Bar[]-based wrappers for reuse
@@ -239,6 +248,14 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 ## Components
 
 ```
+0. Duplicate import statements from same module
+   → ESLint import/no-duplicates rule: always consolidate imports from the same module into a single statement
+   → Prevents accidental divergence between import blocks and makes dependencies clear
+   ❌ import { formatUsdPrice } from '@/lib/priceFormat';
+      // ... code ...
+      import { formatPriceChange } from '@/lib/priceFormat';
+   ✅ import { formatUsdPrice, formatPriceChange } from '@/lib/priceFormat';
+
 1. External callback prop in useEffect dependency array → infinite loops
    → Use useEffectEvent to wrap callback props
 

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,6 @@
 # Fix Log
 
+
 ## [PR #380 Round 4 | fix/350/thinking-budget-preservation-across-retries | 2026-04-25]
 - Violation: 테스트 설명 문구 "starts from half when initial equals a mid-range candidate"가 실제 동작 불일치
 - Rule: MISTAKES.md Tests #9 — 설명이 실제 검증 내용을 정확히 반영해야 함
@@ -72,10 +73,6 @@
 - Rule: defensive numerical handling — degenerate distribution 에서 정책 결정이 필요
 - Context: all-equal 입력 시 `below / (len-1) = 0/0` 또는 0 반환으로 "최소값" 으로 분류되어 squeeze 조건 통과. 0.5 중립값 반환으로 수정
 
-## [PR #331 | feat/329/panel-c-sector-signal-discovery | 2026-04-19]
-- Violation: 68~74 종목에 대한 Promise.allSettled 병렬 fetch — FMP rate limit 초과 가능
-- Rule: API 호출 시 provider rate limit 고려한 concurrency 제한 필수
-- Context: `sectorSignalsApi.ts` 가 `Promise.allSettled(SECTOR_STOCKS.map(...))` 로 전체 동시 실행. `fetchInChunks` 헬퍼로 청크 10개씩 순차 처리로 변경
 
 ## [PR #330 Round 2 | feature/issue-328-market-summary-panel | 2026-04-19]
 - Violation: Lightweight Charts dispose 이후 `unsubscribeCrosshairMove` 직접 호출
@@ -130,10 +127,6 @@
 
 
 ## [PR #344 Round 4 | refactor/343/라우팅-계층-중복-제거-ui-로직-분리 | 2026-04-21]
-- Violation: `IndexCard.tsx`에서 `@/lib/priceFormat`을 두 개의 별도 import 구문으로 사용
-- Rule: ESLint `import/no-duplicates` — 동일 모듈은 단일 import 구문으로 통합
-- Context: `import { formatUsdPrice, formatPriceChange } from '@/lib/priceFormat'`으로 병합
-
 - Violation: `useSectorSignalState.ts`의 `handleSectorChange`, `handleTimeframeChange`가 `useCallback` 미적용
 - Rule: CONVENTIONS.md — 안정화된 `updateUrl`을 호출하는 핸들러는 `useCallback`으로 참조 안정화 필요
 - Context: `useCallback`으로 래핑. deps: `[updateUrl, activeTimeframe]`, `[updateUrl, activeSector]`

--- a/src/__tests__/infrastructure/dashboard/sectorSignalsApi.test.ts
+++ b/src/__tests__/infrastructure/dashboard/sectorSignalsApi.test.ts
@@ -321,6 +321,27 @@ describe('getSectorSignals 함수는', () => {
             expect(apple?.changePercent).toBeCloseTo(expectedChange);
         });
 
+        it('getQuote가 실패(rejected)하면 bars 기반으로 price와 changePercent를 계산한다', async () => {
+            mockCacheGet.mockResolvedValue(null);
+            const oscillating = buildOscillatingBars(60);
+            mockGetBars.mockImplementation((opts: { symbol: string }) =>
+                opts.symbol === 'AAPL'
+                    ? Promise.resolve(oscillating)
+                    : Promise.resolve([])
+            );
+            mockGetQuote.mockRejectedValue(new Error('quote fetch failed'));
+
+            const result = await getSectorSignals();
+
+            const apple = result.stocks.find(s => s.symbol === 'AAPL');
+            const last = oscillating[oscillating.length - 1]!;
+            const prev = oscillating[oscillating.length - 2]!;
+            const expectedChange =
+                ((last.close - prev.close) / prev.close) * 100;
+            expect(apple?.price).toBe(last.close);
+            expect(apple?.changePercent).toBeCloseTo(expectedChange);
+        });
+
         it('이전 종가가 0일 때 changePercent는 0으로 계산된다', async () => {
             mockCacheGet.mockResolvedValue(null);
             // Build bars where prev.close === 0, with enough history to produce signals

--- a/src/__tests__/infrastructure/dashboard/sectorSignalsApi.test.ts
+++ b/src/__tests__/infrastructure/dashboard/sectorSignalsApi.test.ts
@@ -5,7 +5,7 @@ import { getSectorSignals } from '@/infrastructure/dashboard/sectorSignalsApi';
 import { createCacheProvider } from '@/infrastructure/cache/redis';
 import { createMarketDataProvider } from '@/infrastructure/market/factory';
 import { SECTOR_STOCKS } from '@/domain/constants/dashboard-tickers';
-import type { Bar, SectorSignalsResult } from '@/domain/types';
+import type { Bar, MarketQuote, SectorSignalsResult } from '@/domain/types';
 
 const mockCreateCacheProvider = createCacheProvider as jest.MockedFunction<
     typeof createCacheProvider
@@ -69,6 +69,7 @@ describe('getSectorSignals 함수는', () => {
         mockCacheDelete.mockReset();
         mockGetBars.mockReset();
         mockGetQuote.mockReset();
+        mockGetQuote.mockResolvedValue(null);
 
         mockCreateCacheProvider.mockReturnValue({
             get: mockCacheGet,
@@ -97,6 +98,7 @@ describe('getSectorSignals 함수는', () => {
 
             expect(result).toEqual(cached);
             expect(mockGetBars).not.toHaveBeenCalled();
+            expect(mockGetQuote).not.toHaveBeenCalled();
             expect(mockCacheSet).not.toHaveBeenCalled();
         });
 
@@ -151,6 +153,7 @@ describe('getSectorSignals 함수는', () => {
             await getSectorSignals();
 
             expect(mockGetBars).toHaveBeenCalledTimes(SECTOR_STOCKS.length);
+            expect(mockGetQuote).toHaveBeenCalledTimes(SECTOR_STOCKS.length);
             expect(mockCacheSet).toHaveBeenCalledTimes(1);
             const [key, payload, ttl] = mockCacheSet.mock.calls[0];
             expect(key).toBe('dashboard:signals:1Day:2026-04-19');
@@ -268,6 +271,54 @@ describe('getSectorSignals 함수는', () => {
                     apple.trend
                 );
             }
+        });
+
+        it('quote가 있으면 price와 changePercent를 quote 값으로 표시한다', async () => {
+            mockCacheGet.mockResolvedValue(null);
+            const oscillating = buildOscillatingBars(60);
+            mockGetBars.mockImplementation((opts: { symbol: string }) =>
+                opts.symbol === 'AAPL'
+                    ? Promise.resolve(oscillating)
+                    : Promise.resolve([])
+            );
+            const appleQuote: MarketQuote = {
+                symbol: 'AAPL',
+                price: 999,
+                changesPercentage: 3.5,
+                name: 'Apple Inc.',
+            };
+            mockGetQuote.mockImplementation((symbol: string) =>
+                symbol === 'AAPL'
+                    ? Promise.resolve(appleQuote)
+                    : Promise.resolve(null)
+            );
+
+            const result = await getSectorSignals();
+
+            const apple = result.stocks.find(s => s.symbol === 'AAPL');
+            expect(apple?.price).toBe(999);
+            expect(apple?.changePercent).toBe(3.5);
+        });
+
+        it('quote가 null이면 bars 기반으로 price와 changePercent를 계산한다', async () => {
+            mockCacheGet.mockResolvedValue(null);
+            const oscillating = buildOscillatingBars(60);
+            mockGetBars.mockImplementation((opts: { symbol: string }) =>
+                opts.symbol === 'AAPL'
+                    ? Promise.resolve(oscillating)
+                    : Promise.resolve([])
+            );
+            mockGetQuote.mockResolvedValue(null);
+
+            const result = await getSectorSignals();
+
+            const apple = result.stocks.find(s => s.symbol === 'AAPL');
+            const last = oscillating[oscillating.length - 1]!;
+            const prev = oscillating[oscillating.length - 2]!;
+            const expectedChange =
+                ((last.close - prev.close) / prev.close) * 100;
+            expect(apple?.price).toBe(last.close);
+            expect(apple?.changePercent).toBeCloseTo(expectedChange);
         });
 
         it('이전 종가가 0일 때 changePercent는 0으로 계산된다', async () => {

--- a/src/infrastructure/dashboard/sectorSignalsApi.ts
+++ b/src/infrastructure/dashboard/sectorSignalsApi.ts
@@ -76,11 +76,8 @@ function computeStockResult(
     const trend = classifyTrend(bars, indicators);
     const price = quote?.price ?? last.close;
     const changePercent =
-        quote !== null
-            ? quote.changesPercentage
-            : prev.close === 0
-              ? 0
-              : ((last.close - prev.close) / prev.close) * 100;
+        quote?.changesPercentage ??
+        (prev.close === 0 ? 0 : ((last.close - prev.close) / prev.close) * 100);
     return {
         symbol,
         koreanName,
@@ -126,18 +123,22 @@ export async function getSectorSignals(
     const fromIso = fromDate(timeframe, now);
     // DashboardTimeframe('15Min' | '1Hour' | '1Day') 는 Timeframe 의 부분집합 —
     // provider.getBars 시그니처에 맞추기 위한 안전한 widening.
-    const [barsResults, quoteResults] = await Promise.all([
-        fetchInChunks(SECTOR_STOCKS, FETCH_CONCURRENCY, s =>
+    // Sequential fetch to keep concurrent requests within FETCH_CONCURRENCY limit.
+    const barsResults = await fetchInChunks(
+        SECTOR_STOCKS,
+        FETCH_CONCURRENCY,
+        s =>
             provider.getBars({
                 symbol: s.symbol,
                 timeframe: timeframe as Timeframe,
                 from: fromIso,
             })
-        ),
-        fetchInChunks(SECTOR_STOCKS, FETCH_CONCURRENCY, s =>
-            provider.getQuote(s.symbol)
-        ),
-    ]);
+    );
+    const quoteResults = await fetchInChunks(
+        SECTOR_STOCKS,
+        FETCH_CONCURRENCY,
+        s => provider.getQuote(s.symbol)
+    );
 
     // barsResults[i] / quoteResults[i] are guaranteed defined — length === SECTOR_STOCKS.length
     const stocks = SECTOR_STOCKS.map((stockDef, i) => {

--- a/src/infrastructure/dashboard/sectorSignalsApi.ts
+++ b/src/infrastructure/dashboard/sectorSignalsApi.ts
@@ -1,6 +1,7 @@
 import type {
     Bar,
     DashboardTimeframe,
+    MarketQuote,
     SectorSignalsResult,
     StockSignalResult,
     Timeframe,
@@ -63,7 +64,8 @@ function computeStockResult(
     symbol: string,
     koreanName: string,
     sectorSymbol: string,
-    bars: Bar[]
+    bars: Bar[],
+    quote: MarketQuote | null
 ): StockSignalResult | null {
     if (bars.length < 2) return null;
     const last = bars[bars.length - 1];
@@ -72,13 +74,18 @@ function computeStockResult(
     const signals = detectSignals(bars, indicators);
     if (signals.length === 0) return null;
     const trend = classifyTrend(bars, indicators);
+    const price = quote?.price ?? last.close;
     const changePercent =
-        prev.close === 0 ? 0 : ((last.close - prev.close) / prev.close) * 100;
+        quote !== null
+            ? quote.changesPercentage
+            : prev.close === 0
+              ? 0
+              : ((last.close - prev.close) / prev.close) * 100;
     return {
         symbol,
         koreanName,
         sectorSymbol,
-        price: last.close,
+        price,
         changePercent,
         trend,
         signals,
@@ -117,31 +124,37 @@ export async function getSectorSignals(
 
     const provider = createMarketDataProvider();
     const fromIso = fromDate(timeframe, now);
-    const fetchResults = await fetchInChunks(
-        SECTOR_STOCKS,
-        FETCH_CONCURRENCY,
-        s =>
+    // DashboardTimeframe('15Min' | '1Hour' | '1Day') 는 Timeframe 의 부분집합 —
+    // provider.getBars 시그니처에 맞추기 위한 안전한 widening.
+    const [barsResults, quoteResults] = await Promise.all([
+        fetchInChunks(SECTOR_STOCKS, FETCH_CONCURRENCY, s =>
             provider.getBars({
                 symbol: s.symbol,
-                // DashboardTimeframe('15Min' | '1Hour' | '1Day') 는 Timeframe 의 부분집합 —
-                // provider.getBars 시그니처에 맞추기 위한 안전한 widening.
                 timeframe: timeframe as Timeframe,
                 from: fromIso,
             })
-    );
+        ),
+        fetchInChunks(SECTOR_STOCKS, FETCH_CONCURRENCY, s =>
+            provider.getQuote(s.symbol)
+        ),
+    ]);
 
-    // fetchResults[i] is guaranteed defined — SECTOR_STOCKS.length === fetchResults.length
+    // barsResults[i] / quoteResults[i] are guaranteed defined — length === SECTOR_STOCKS.length
     const stocks = SECTOR_STOCKS.map((stockDef, i) => {
-        const r = fetchResults[i]!;
-        if (r.status === 'rejected') {
+        const barsResult = barsResults[i]!;
+        if (barsResult.status === 'rejected') {
             // Graceful degradation: exclude failing symbol from the result set
             return null;
         }
+        const quoteResult = quoteResults[i]!;
+        const quote =
+            quoteResult.status === 'fulfilled' ? quoteResult.value : null;
         return computeStockResult(
             stockDef.symbol,
             stockDef.koreanName,
             stockDef.sectorSymbol,
-            r.value
+            barsResult.value,
+            quote
         );
     }).filter((s): s is StockSignalResult => s !== null);
 


### PR DESCRIPTION
## 관련 이슈

closes #347

## 구현 내용

Quote API를 통해 정확한 등락률 정보를 제공하는 기능을 구현했습니다.

- `computeStockResult`에 `MarketQuote | null` 파라미터 추가
- Quote API(changesPercentage)가 제공되면 해당 값 사용
- Quote 데이터가 없을 시 bar 기반 계산으로 폴백
- `getSectorSignals`에서 bar와 quote를 병렬 페칭 (Promise.all)
- 테스트 전체 갱신: mockGetQuote 기본값, 캐시 히트/미스 검증, quote 기반 및 폴백 동작 추가

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it
- [x] 매직 넘버 없음

## 변경 파일 목록

[수정]
- src/infrastructure/dashboard/sectorSignalsApi.ts
- src/__tests__/infrastructure/dashboard/sectorSignalsApi.test.ts

## CI Check lists

- [ ] yarn format
- [ ] yarn lint
- [ ] yarn lint:style
- [ ] yarn test
- [ ] yarn build