### PR TITLE
style: 홈 히어로 브랜딩 개선

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -78,45 +78,35 @@ body {
     background-color: var(--color-secondary-900);
 }
 
-.hero-grid {
-    background-image:
+.hero-report-lines {
+    background:
         linear-gradient(
-            to right,
-            var(--color-secondary-700) 1px,
-            transparent 1px
+            180deg,
+            color-mix(in oklch, var(--color-secondary-900) 70%, transparent) 0%,
+            transparent 42%
         ),
         linear-gradient(
-            to bottom,
-            var(--color-secondary-700) 1px,
-            transparent 1px
+            to right,
+            transparent 0,
+            transparent calc(100% - 10vw),
+            color-mix(in oklch, var(--color-secondary-700) 40%, transparent)
+                calc(100% - 10vw),
+            transparent calc(100% - 10vw + 1px)
         );
-    background-size: 48px 48px;
-    opacity: 0.5;
-    mask-image: radial-gradient(ellipse 60% 50% at 50% 50%, black, transparent);
 }
 
-.hero-ambient {
-    background: linear-gradient(
-        180deg,
-        color-mix(in oklch, var(--color-primary-900) 20%, transparent) 0%,
-        transparent 50%
+.hero-report-lines::before {
+    position: absolute;
+    top: 0;
+    right: 10vw;
+    left: 15vw;
+    height: 1px;
+    content: '';
+    background: color-mix(
+        in oklch,
+        var(--color-secondary-700) 45%,
+        transparent
     );
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .hero-grid {
-        animation: grid-fade 8s ease-in-out infinite alternate;
-    }
-}
-
-@keyframes grid-fade {
-    from {
-        opacity: 0.4;
-    }
-
-    to {
-        opacity: 0.7;
-    }
 }
 
 @layer base {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -154,7 +154,7 @@ export default async function Home() {
                 검색으로 건너뛰기
             </a>
             <main className="flex flex-1 flex-col">
-                <section className="bg-secondary-950 relative flex flex-col items-center justify-center overflow-hidden px-6 py-12 text-center sm:py-16 lg:min-h-[calc(100svh-9rem)] lg:items-start lg:pr-[10vw] lg:pl-[15vw] lg:text-left">
+                <section className="relative flex flex-col items-center justify-center overflow-hidden px-6 py-12 text-center sm:py-16 lg:items-start lg:pr-[10vw] lg:pl-[15vw] lg:text-left">
                     <div
                         aria-hidden="true"
                         className="hero-report-lines pointer-events-none absolute inset-0"
@@ -177,7 +177,7 @@ export default async function Home() {
                         </p>
                         <div
                             id="search"
-                            className="mt-8 flex w-full justify-center sm:max-w-xl lg:justify-start"
+                            className="mt-8 flex w-full justify-center lg:justify-start"
                         >
                             <SymbolSearchPanel />
                         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -154,29 +154,26 @@ export default async function Home() {
                 검색으로 건너뛰기
             </a>
             <main className="flex flex-1 flex-col">
-                <section className="relative flex flex-1 flex-col items-center justify-center px-6 py-10 text-center sm:py-14 lg:items-start lg:pr-[10vw] lg:pl-[15vw] lg:text-left">
+                <section className="bg-secondary-950 relative flex flex-col items-center justify-center overflow-hidden px-6 py-12 text-center sm:py-16 lg:min-h-[calc(100svh-9rem)] lg:items-start lg:pr-[10vw] lg:pl-[15vw] lg:text-left">
                     <div
                         aria-hidden="true"
-                        className="hero-grid pointer-events-none absolute inset-0"
-                    />
-                    <div
-                        aria-hidden="true"
-                        className="hero-ambient pointer-events-none absolute inset-0"
+                        className="hero-report-lines pointer-events-none absolute inset-0"
                     />
                     <div className="relative w-full max-w-4xl">
-                        <p className="text-secondary-400 mb-6 font-mono text-xs tracking-[0.3em] uppercase">
-                            SIGLENS
+                        <p className="text-secondary-400 mb-5 font-mono text-[0.68rem] leading-relaxed tracking-[0.18em] uppercase sm:text-xs">
+                            미국 주식 AI 분석 플랫폼, SIGLENS
                         </p>
-                        <h1 className="text-secondary-100 mx-auto max-w-xs text-[2rem] leading-[1.15] font-bold tracking-tight text-balance sm:max-w-none sm:text-5xl lg:mx-0 lg:text-6xl">
-                            미국 주식,{' '}
-                            <span className="text-primary-400">
-                                AI가 읽어주는
-                                <br className="sm:hidden" /> 시장과 차트
+                        <h1 className="text-secondary-100 mx-auto max-w-sm text-[2.2rem] leading-[1.1] font-bold tracking-tight text-balance sm:max-w-2xl sm:text-5xl lg:mx-0 lg:text-6xl">
+                            복잡한 차트 분석을
+                            <br />
+                            <span className="text-primary-300">
+                                한 번에 정리합니다
                             </span>
                         </h1>
-                        <p className="text-secondary-400 mx-auto mt-4 max-w-xs text-base leading-relaxed sm:max-w-lg sm:text-xl lg:mx-0">
-                            오늘 주목할 섹터부터 종목별 기술적 분석, AI 대화까지
-                            한 번에.
+                        <p className="text-secondary-400 mx-auto mt-5 max-w-sm text-base leading-relaxed sm:max-w-2xl sm:text-lg lg:mx-0">
+                            티커를 입력하면 RSI, MACD, 볼린저밴드 등 보조지표{' '}
+                            {skillCounts.indicators}종과 차트 패턴, 전략 신호를
+                            AI가 분석해 핵심 근거만 보여줍니다.
                         </p>
                         <div
                             id="search"
@@ -187,7 +184,7 @@ export default async function Home() {
                         <div className="mt-6 flex justify-center lg:justify-start">
                             <Link
                                 href="/market"
-                                className="text-primary-400 hover:text-primary-300 inline-flex items-center gap-1 text-sm font-semibold tracking-wider uppercase transition-colors"
+                                className="text-primary-400 hover:text-primary-300 inline-flex items-center gap-1 text-sm font-semibold transition-colors"
                             >
                                 오늘 주목할 종목 →
                             </Link>

--- a/src/components/home/HowItWorks.tsx
+++ b/src/components/home/HowItWorks.tsx
@@ -3,12 +3,12 @@ import type { SkillCounts } from '@y0ngha/siglens-core';
 
 export function HowItWorksSkeleton() {
     return (
-        <section className="px-6 py-10 lg:px-[15vw]">
+        <section className="bg-secondary-950 px-6 pt-2 pb-12 lg:px-[15vw]">
             <div className="bg-secondary-700/50 mb-6 h-3.5 w-24 animate-pulse rounded" />
             <div className="flex flex-col gap-4 md:flex-row">
                 {[0, 1, 2].map(i => (
                     <Fragment key={i}>
-                        <div className="bg-secondary-800/50 border-secondary-700 flex-1 rounded-lg border p-6">
+                        <div className="border-secondary-800 bg-secondary-900/55 flex-1 rounded-lg border p-6">
                             <div className="bg-secondary-700/50 h-8 w-8 animate-pulse rounded" />
                             <div className="bg-secondary-700/50 mt-4 h-3.5 w-20 animate-pulse rounded" />
                             <div className="mt-2 space-y-1.5">
@@ -63,17 +63,17 @@ export function HowItWorks({ skillCounts }: HowItWorksProps) {
         },
     ];
     return (
-        <section className="px-6 py-10 lg:px-[15vw]">
-            <h2 className="text-secondary-200 mb-6 text-sm font-semibold tracking-wider uppercase">
+        <section className="bg-secondary-950 px-6 pt-2 pb-12 lg:px-[15vw]">
+            <h2 className="text-secondary-400 mb-6 text-sm font-semibold tracking-wider uppercase">
                 이용 방법
             </h2>
             <div className="flex flex-col gap-4 md:flex-row">
                 {STEPS.map((step, idx) => (
                     <Fragment key={step.number}>
-                        <div className="bg-secondary-800/50 border-secondary-700 flex-1 rounded-lg border p-6">
+                        <div className="border-secondary-800 bg-secondary-900/55 flex-1 rounded-lg border p-6">
                             <span
                                 aria-hidden="true"
-                                className="text-primary-600/40 font-mono text-3xl leading-none font-bold"
+                                className="text-primary-500/35 font-mono text-3xl leading-none font-bold"
                             >
                                 {step.number}
                             </span>

--- a/src/components/home/HowItWorks.tsx
+++ b/src/components/home/HowItWorks.tsx
@@ -3,12 +3,12 @@ import type { SkillCounts } from '@y0ngha/siglens-core';
 
 export function HowItWorksSkeleton() {
     return (
-        <section className="bg-secondary-950 px-6 pt-2 pb-12 lg:px-[15vw]">
+        <section className="px-6 py-10 lg:px-[15vw]">
             <div className="bg-secondary-700/50 mb-6 h-3.5 w-24 animate-pulse rounded" />
             <div className="flex flex-col gap-4 md:flex-row">
                 {[0, 1, 2].map(i => (
                     <Fragment key={i}>
-                        <div className="border-secondary-800 bg-secondary-900/55 flex-1 rounded-lg border p-6">
+                        <div className="bg-secondary-800/50 border-secondary-700 flex-1 rounded-lg border p-6">
                             <div className="bg-secondary-700/50 h-8 w-8 animate-pulse rounded" />
                             <div className="bg-secondary-700/50 mt-4 h-3.5 w-20 animate-pulse rounded" />
                             <div className="mt-2 space-y-1.5">
@@ -63,17 +63,17 @@ export function HowItWorks({ skillCounts }: HowItWorksProps) {
         },
     ];
     return (
-        <section className="bg-secondary-950 px-6 pt-2 pb-12 lg:px-[15vw]">
-            <h2 className="text-secondary-400 mb-6 text-sm font-semibold tracking-wider uppercase">
+        <section className="px-6 py-10 lg:px-[15vw]">
+            <h2 className="text-secondary-200 mb-6 text-sm font-semibold tracking-wider uppercase">
                 이용 방법
             </h2>
             <div className="flex flex-col gap-4 md:flex-row">
                 {STEPS.map((step, idx) => (
                     <Fragment key={step.number}>
-                        <div className="border-secondary-800 bg-secondary-900/55 flex-1 rounded-lg border p-6">
+                        <div className="bg-secondary-800/50 border-secondary-700 flex-1 rounded-lg border p-6">
                             <span
                                 aria-hidden="true"
-                                className="text-primary-500/35 font-mono text-3xl leading-none font-bold"
+                                className="text-primary-600/40 font-mono text-3xl leading-none font-bold"
                             >
                                 {step.number}
                             </span>

--- a/src/components/layout/HeaderUserMenu.tsx
+++ b/src/components/layout/HeaderUserMenu.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import Link from 'next/link';
-import { useRef } from 'react';
-import type { Tier } from '@y0ngha/siglens-core';
 import { LogoutButton } from '@/components/auth/LogoutButton';
 import { useCurrentUser } from '@/components/hooks/useCurrentUser';
 import { useEscapeKey } from '@/components/hooks/useEscapeKey';
 import { usePopoverToggle } from '@/components/hooks/usePopoverToggle';
 import { TIER_LABEL } from '@/lib/auth/tierLabel';
 import { cn } from '@/lib/cn';
+import type { Tier } from '@y0ngha/siglens-core';
+import Link from 'next/link';
+import { useRef } from 'react';
 
 const TIER_DOT_COLOR: Record<Tier, string> = {
     free: 'bg-secondary-500',
@@ -41,13 +41,13 @@ export function HeaderUserMenu() {
             <nav aria-label="인증" className="flex items-center gap-2">
                 <Link
                     href="/login"
-                    className="text-secondary-200 hover:text-secondary-50 hidden min-h-11 items-center rounded px-3 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none sm:inline-flex"
+                    className="text-secondary-200 hover:text-secondary-50 focus-visible:ring-primary-500 hidden min-h-11 items-center rounded px-3 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none sm:inline-flex"
                 >
                     로그인
                 </Link>
                 <Link
                     href="/signup"
-                    className="inline-flex min-h-11 items-center rounded bg-blue-600 px-3 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+                    className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 inline-flex min-h-11 items-center rounded px-3 text-sm font-semibold text-white transition-colors focus-visible:ring-2 focus-visible:outline-none"
                 >
                     회원가입
                 </Link>

--- a/src/components/search/TickerAutocomplete.tsx
+++ b/src/components/search/TickerAutocomplete.tsx
@@ -84,7 +84,7 @@ export function TickerAutocomplete({
                     onChange={handleChange}
                     onKeyDown={handleKeyDown}
                     onFocus={handleFocus}
-                    placeholder="종목 입력 (예: AAPL, 애플)"
+                    placeholder="종목 입력… 예: AAPL, 애플"
                     className={cn(
                         INPUT_BASE,
                         INPUT_SIZE[size],


### PR DESCRIPTION
## 관련 이슈

없음 (orchestrator에서 이슈 번호 미제공)

## 구현 내용

- 홈페이지 히어로 카피와 배경 스타일을 새 브랜딩 톤으로 개선
- HowItWorks 섹션의 배경 및 카드 톤을 히어로와 맞춤
- 티커 검색 placeholder 문구 업데이트

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 인디케이터 초기 구간 null 반환 (0, NaN 없음)
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it
- [x] 초기 구간 null 케이스 테스트 포함
- [x] 매직 넘버 없음

## 변경 파일 목록

[생성]

없음

[수정]

- src/app/page.tsx
- src/app/globals.css
- src/components/search/TickerAutocomplete.tsx
- src/components/home/HowItWorks.tsx

## CI Check lists

- [ ] yarn format
- [ ] yarn lint
- [ ] yarn lint:style
- [ ] yarn test
- [ ] yarn build