### PR TITLE
feat: 챗봇 멀티 provider 모델 선택 (Claude/Gemini/ChatGPT)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,15 @@
 # https://site.financialmodelingprep.com/developer
 FMP_API_KEY=
 
-# ── AI (Analysis & Chatbot) ────────────────────────────────────────────────
-# Primary paid key — AI analysis reports + chatbot primary
+# ── AI — Chatbot ──────────────────────────────────────────────────────────
+# Primary paid key per provider — covers free-tier models (server pays).
 # https://aistudio.google.com/apikey
-GEMINI_API_KEY=
-# Free-tier fallback — chatbot fallback when paid key quota is exhausted
+GEMINI_CHAT_API_KEY=
+# https://console.anthropic.com/settings/keys
+ANTHROPIC_CHAT_API_KEY=
+# https://platform.openai.com/api-keys
+OPENAI_CHAT_API_KEY=
+# Free-quota fallback (Gemini only) — fallback when GEMINI_CHAT_API_KEY quota is exhausted
 GEMINI_CHAT_FREE_API_KEY=
 
 # ── Ticker Translation ─────────────────────────────────────────────────────

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -31,6 +31,11 @@
 - Rule: 운영 DB에 이미 적용된 마이그레이션은 사후 편집 금지 — 보정이 필요하면 새 forward migration 추가
 - Context: 두 마이그레이션 모두 _journal에 등재되어 적용된 상태. 0004를 retroactive 수정하지 않고 0005에 사후 보존 사유와 향후 처리 가이드를 SQL 주석으로 명시.
 
+## [PR #408 Round 2 | feat/73/챗봇-멀티-provider-모델-선택 | 2026-05-02]
+- Violation: anthropic.ts의 `!block || block.type !== 'text'` 복합 조건에서 `block.type !== 'text'` 분기 미테스트
+- Rule: MISTAKES.md Infrastructure Functions #2 / Tests #7 — 100% 분기 커버리지 + provider 쌍 대칭성
+- Context: anthropic.test.ts에 tool_use 블록 반환 케이스 추가. openai.test.ts의 null/empty 파싱 에러 2개와 대칭.
+
 ## [PR #408 코멘트 반영 | feat/73/챗봇-멀티-provider-모델-선택 | 2026-05-02]
 - Violation: router.ts에서 상대 경로 import 사용 (`./anthropic`, `./gemini`, `./openai`)
 - Rule: MISTAKES.md 7.6 — 모든 import는 path alias 사용 필수

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -31,6 +31,19 @@
 - Rule: 운영 DB에 이미 적용된 마이그레이션은 사후 편집 금지 — 보정이 필요하면 새 forward migration 추가
 - Context: 두 마이그레이션 모두 _journal에 등재되어 적용된 상태. 0004를 retroactive 수정하지 않고 0005에 사후 보존 사유와 향후 처리 가이드를 SQL 주석으로 명시.
 
+## [PR #408 코멘트 반영 | feat/73/챗봇-멀티-provider-모델-선택 | 2026-05-02]
+- Violation: router.ts에서 상대 경로 import 사용 (`./anthropic`, `./gemini`, `./openai`)
+- Rule: MISTAKES.md 7.6 — 모든 import는 path alias 사용 필수
+- Context: src/infrastructure/ai/router.ts의 세 import를 `@/infrastructure/ai/...`로 교체.
+
+- Violation: OpenAI 빈 응답 시 빈 문자열 반환 — Anthropic(에러 throw)과 비대칭
+- Rule: MISTAKES.md Tests 7 — provider 쌍은 에러 처리도 대칭이어야 함
+- Context: callOpenai에서 choices[0]?.message.content == null이면 에러를 throw하도록 수정.
+
+- Violation: UserApiKeyRequiredModal 바깥 wrapper div에 aria-hidden="true"로 모달 전체가 접근성 트리에서 제거됨
+- Rule: MISTAKES.md Accessibility 1.5, 7 — aria-hidden은 장식적 컨텐츠에만 사용, 사용자가 읽어야 할 컨텐츠에 금지
+- Context: backdrop div의 aria-hidden="true" 제거. role="dialog" aria-modal="true" 내부 div가 접근성 트리에 노출됨.
+
 ## [PR #403 Round 5 | feat/398/contact-us-form | 2026-05-02]
 - Violation: 새로 만든 파일이 git에 추가되지 않은 채 PR 푸시되어 빌드가 차단됨
 - Rule: PR_FIX_FLOW Step 1-7 — 픽스 적용 후 모든 신규 파일을 commit/push 전에 git add로 추적해야 함
@@ -120,17 +133,9 @@
 - Rule: MISTAKES.md Design 1 / FF Cohesion — 함께 변해야 하는 상수는 single source of truth에 모아야 함
 - Context: claude-retry/gemini-retry/chatgpt-retry 세 파일이 `AI_RETRY_MAX_ATTEMPTS = 5`와 `AI_RETRY_DELAY_MS = 5000`을 각자 정의. 모두 retry.ts로 이동해 공유.
 
-- Violation: 동일 utility 함수(isMaxTokensError) 중복 구현
-- Rule: MISTAKES.md Coding Paradigm 1 — 새 함수 작성 전 기존 helper 확인
-- Context: claude-retry.ts와 gemini-retry.ts 양쪽이 `isMaxTokensError`를 동일 로직으로 정의. retry.ts에 `hasErrorCode(error, code)`로 추출하여 양쪽이 import.
-
 - Violation: 에러 처리 의도와 retryable 플래그 모순
 - Rule: MISTAKES.md Predictability 6 — 인터페이스/구현/문서 정합성
 - Context: chatgpt.ts에서 `finish_reason === 'length'` 처리 시 주석은 "재시도해도 결과는 같다"라고 적었지만 `{ retryable: true }`로 throw. ChatGPT는 budget 축소 등 mitigation이 없으므로 non-retryable로 변경.
-
-- Violation: process.env 값을 type alias로 force-cast (검증 없이 `as`)
-- Rule: MISTAKES.md TypeScript 7 — `as` 캐스트 시 runtime 보장 또는 가드 명시
-- Context: config.ts에서 `process.env.AI_PROVIDER as AIProviderType`, BRIEFING_CLAUDE_MODEL/BRIEFING_GEMINI_MODEL을 검증 없이 cast. parseAIProvider/parseBriefingModel 함수로 runtime 검증 후 throw 처리.
 
 - Violation: Array.find 후 type narrow를 위한 중복 type check
 - Rule: MISTAKES.md Coding Paradigm 4 — 결과에 영향 없는 로직 제거

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "fetch-this-week-tasks": "cd scripts/fetch-this-week-tasks && node --env-file=.env index.js"
     },
     "dependencies": {
+        "@anthropic-ai/sdk": "^0.92.0",
         "@google/genai": "^1.50.1",
         "@neondatabase/serverless": "^1.1.0",
         "@tanstack/react-query": "^5.95.2",
@@ -39,6 +40,7 @@
         "drizzle-orm": "^0.45.2",
         "lightweight-charts": "^5.1.0",
         "next": "16.2.0",
+        "openai": "^6.35.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-error-boundary": "^6.1.1",

--- a/src/__tests__/infrastructure/ai/anthropic.test.ts
+++ b/src/__tests__/infrastructure/ai/anthropic.test.ts
@@ -116,7 +116,23 @@ describe('callAnthropicChat', () => {
                     ...BASE_OPTIONS,
                     primaryApiKey: undefined,
                 })
-            ).rejects.toThrow();
+            ).rejects.toThrow('Anthropic returned no text content');
+        });
+
+        it('content[0]이 text 타입이 아니면 에러를 던진다', async () => {
+            mockCreate.mockResolvedValue({
+                content: [
+                    { type: 'tool_use', id: 'call_1', name: 'tool', input: {} },
+                ],
+                stop_reason: 'tool_use',
+            });
+
+            await expect(
+                callAnthropicChat({
+                    ...BASE_OPTIONS,
+                    primaryApiKey: undefined,
+                })
+            ).rejects.toThrow('Anthropic returned no text content');
         });
     });
 });

--- a/src/__tests__/infrastructure/ai/anthropic.test.ts
+++ b/src/__tests__/infrastructure/ai/anthropic.test.ts
@@ -36,7 +36,9 @@ describe('callAnthropicChat', () => {
             expect(result).toBe('Hello');
             expect(MockAnthropic).toHaveBeenCalledWith({ apiKey: 'pk' });
             expect(mockCreate).toHaveBeenCalledTimes(1);
-            expect(mockCreate.mock.calls[0][0]).toMatchObject({ model: 'claude-haiku-3-5' });
+            expect(mockCreate.mock.calls[0][0]).toMatchObject({
+                model: 'claude-haiku-3-5',
+            });
         });
 
         it('primary key가 실패하면 fallback key로 재시도한다', async () => {
@@ -71,7 +73,9 @@ describe('callAnthropicChat', () => {
             });
 
             expect(result).toBe('Fallback only');
-            expect(MockAnthropic).toHaveBeenCalledWith({ apiKey: 'fallback-key' });
+            expect(MockAnthropic).toHaveBeenCalledWith({
+                apiKey: 'fallback-key',
+            });
             expect(mockCreate).toHaveBeenCalledTimes(1);
         });
     });

--- a/src/__tests__/infrastructure/ai/anthropic.test.ts
+++ b/src/__tests__/infrastructure/ai/anthropic.test.ts
@@ -1,0 +1,118 @@
+const mockCreate = jest.fn();
+const MockAnthropic = jest.fn().mockImplementation(() => ({
+    messages: { create: mockCreate },
+}));
+
+jest.mock('@anthropic-ai/sdk', () => ({
+    __esModule: true,
+    default: MockAnthropic,
+}));
+
+import { callAnthropicChat } from '@/infrastructure/ai/anthropic';
+
+const BASE_OPTIONS = {
+    fallbackApiKey: 'fallback-key',
+    model: 'claude-haiku-3-5',
+    contents: 'Hello',
+} as const;
+
+describe('callAnthropicChat', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('primary key 동작', () => {
+        it('primary key가 있고 성공하면 응답 텍스트를 반환한다', async () => {
+            mockCreate.mockResolvedValue({
+                content: [{ type: 'text', text: 'Hello' }],
+                stop_reason: 'end_turn',
+            });
+
+            const result = await callAnthropicChat({
+                ...BASE_OPTIONS,
+                primaryApiKey: 'pk',
+            });
+
+            expect(result).toBe('Hello');
+            expect(MockAnthropic).toHaveBeenCalledWith({ apiKey: 'pk' });
+            expect(mockCreate).toHaveBeenCalledTimes(1);
+            expect(mockCreate.mock.calls[0][0]).toMatchObject({ model: 'claude-haiku-3-5' });
+        });
+
+        it('primary key가 실패하면 fallback key로 재시도한다', async () => {
+            mockCreate
+                .mockRejectedValueOnce(new Error('rate limit'))
+                .mockResolvedValueOnce({
+                    content: [{ type: 'text', text: 'Fallback response' }],
+                    stop_reason: 'end_turn',
+                });
+
+            const result = await callAnthropicChat({
+                ...BASE_OPTIONS,
+                primaryApiKey: 'pk',
+                fallbackApiKey: 'fk',
+            });
+
+            expect(result).toBe('Fallback response');
+            expect(MockAnthropic).toHaveBeenCalledWith({ apiKey: 'pk' });
+            expect(MockAnthropic).toHaveBeenCalledWith({ apiKey: 'fk' });
+            expect(mockCreate).toHaveBeenCalledTimes(2);
+        });
+
+        it('primary key가 undefined이면 primary 호출 없이 fallback을 직접 호출한다', async () => {
+            mockCreate.mockResolvedValue({
+                content: [{ type: 'text', text: 'Fallback only' }],
+                stop_reason: 'end_turn',
+            });
+
+            const result = await callAnthropicChat({
+                ...BASE_OPTIONS,
+                primaryApiKey: undefined,
+            });
+
+            expect(result).toBe('Fallback only');
+            expect(MockAnthropic).toHaveBeenCalledWith({ apiKey: 'fallback-key' });
+            expect(mockCreate).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('fallback key 동작', () => {
+        it('primary와 fallback 모두 실패하면 에러가 전파된다', async () => {
+            mockCreate.mockRejectedValue(new Error('all failed'));
+
+            await expect(
+                callAnthropicChat({
+                    ...BASE_OPTIONS,
+                    primaryApiKey: 'pk',
+                })
+            ).rejects.toThrow('all failed');
+        });
+
+        it('primaryApiKey가 undefined이고 fallback도 실패하면 에러가 전파된다', async () => {
+            mockCreate.mockRejectedValue(new Error('fallback failed'));
+
+            await expect(
+                callAnthropicChat({
+                    ...BASE_OPTIONS,
+                    primaryApiKey: undefined,
+                })
+            ).rejects.toThrow('fallback failed');
+        });
+    });
+
+    describe('응답 파싱', () => {
+        it('content 배열이 비어있으면 에러를 던진다', async () => {
+            mockCreate.mockResolvedValue({
+                content: [],
+                stop_reason: 'end_turn',
+            });
+
+            await expect(
+                callAnthropicChat({
+                    ...BASE_OPTIONS,
+                    primaryApiKey: undefined,
+                })
+            ).rejects.toThrow();
+        });
+    });
+});

--- a/src/__tests__/infrastructure/ai/openai.test.ts
+++ b/src/__tests__/infrastructure/ai/openai.test.ts
@@ -1,0 +1,111 @@
+const mockCreate = jest.fn();
+const MockOpenAI = jest.fn().mockImplementation(() => ({
+    chat: { completions: { create: mockCreate } },
+}));
+
+jest.mock('openai', () => ({
+    __esModule: true,
+    default: MockOpenAI,
+}));
+
+import { callOpenaiChat } from '@/infrastructure/ai/openai';
+
+const BASE_OPTIONS = {
+    fallbackApiKey: 'fallback-key',
+    model: 'gpt-5-mini',
+    contents: 'Hello',
+} as const;
+
+describe('callOpenaiChat', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('primary key 동작', () => {
+        it('primary key가 있고 성공하면 응답 텍스트를 반환한다', async () => {
+            mockCreate.mockResolvedValue({
+                choices: [{ message: { content: 'Hi' } }],
+            });
+
+            const result = await callOpenaiChat({
+                ...BASE_OPTIONS,
+                primaryApiKey: 'pk',
+            });
+
+            expect(result).toBe('Hi');
+            expect(MockOpenAI).toHaveBeenCalledWith({ apiKey: 'pk' });
+            expect(mockCreate).toHaveBeenCalledTimes(1);
+        });
+
+        it('primary key가 실패하면 fallback key로 재시도한다', async () => {
+            mockCreate
+                .mockRejectedValueOnce(new Error('quota exceeded'))
+                .mockResolvedValueOnce({
+                    choices: [{ message: { content: 'Fallback response' } }],
+                });
+
+            const result = await callOpenaiChat({
+                ...BASE_OPTIONS,
+                primaryApiKey: 'pk',
+                fallbackApiKey: 'fk',
+            });
+
+            expect(result).toBe('Fallback response');
+            expect(MockOpenAI).toHaveBeenCalledWith({ apiKey: 'pk' });
+            expect(MockOpenAI).toHaveBeenCalledWith({ apiKey: 'fk' });
+            expect(mockCreate).toHaveBeenCalledTimes(2);
+        });
+
+        it('primary key가 undefined이면 primary 호출 없이 fallback을 직접 호출한다', async () => {
+            mockCreate.mockResolvedValue({
+                choices: [{ message: { content: 'Fallback only' } }],
+            });
+
+            const result = await callOpenaiChat({
+                ...BASE_OPTIONS,
+                primaryApiKey: undefined,
+            });
+
+            expect(result).toBe('Fallback only');
+            expect(MockOpenAI).toHaveBeenCalledWith({ apiKey: 'fallback-key' });
+            expect(mockCreate).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('fallback key 동작', () => {
+        it('primary와 fallback 모두 실패하면 에러가 전파된다', async () => {
+            mockCreate.mockRejectedValue(new Error('all failed'));
+
+            await expect(
+                callOpenaiChat({
+                    ...BASE_OPTIONS,
+                    primaryApiKey: 'pk',
+                })
+            ).rejects.toThrow('all failed');
+        });
+
+        it('primaryApiKey가 undefined이고 fallback도 실패하면 에러가 전파된다', async () => {
+            mockCreate.mockRejectedValue(new Error('fallback failed'));
+
+            await expect(
+                callOpenaiChat({
+                    ...BASE_OPTIONS,
+                    primaryApiKey: undefined,
+                })
+            ).rejects.toThrow('fallback failed');
+        });
+    });
+
+    describe('응답 파싱', () => {
+        it('choices 배열이 비어있으면 빈 문자열을 반환한다', async () => {
+            mockCreate.mockResolvedValue({ choices: [] });
+
+            const result = await callOpenaiChat({
+                ...BASE_OPTIONS,
+                primaryApiKey: undefined,
+            });
+
+            expect(result).toBe('');
+        });
+    });
+});

--- a/src/__tests__/infrastructure/ai/openai.test.ts
+++ b/src/__tests__/infrastructure/ai/openai.test.ts
@@ -35,6 +35,9 @@ describe('callOpenaiChat', () => {
             expect(result).toBe('Hi');
             expect(MockOpenAI).toHaveBeenCalledWith({ apiKey: 'pk' });
             expect(mockCreate).toHaveBeenCalledTimes(1);
+            expect(mockCreate.mock.calls[0][0]).toMatchObject({
+                model: 'gpt-5-mini',
+            });
         });
 
         it('primary key가 실패하면 fallback key로 재시도한다', async () => {
@@ -97,15 +100,28 @@ describe('callOpenaiChat', () => {
     });
 
     describe('응답 파싱', () => {
-        it('choices 배열이 비어있으면 빈 문자열을 반환한다', async () => {
-            mockCreate.mockResolvedValue({ choices: [] });
-
-            const result = await callOpenaiChat({
-                ...BASE_OPTIONS,
-                primaryApiKey: undefined,
+        it('응답 content가 null이면 에러를 던진다', async () => {
+            mockCreate.mockResolvedValue({
+                choices: [{ message: { content: null } }],
             });
 
-            expect(result).toBe('');
+            await expect(
+                callOpenaiChat({
+                    ...BASE_OPTIONS,
+                    primaryApiKey: undefined,
+                })
+            ).rejects.toThrow('OpenAI returned no text content');
+        });
+
+        it('choices 배열이 비어있으면 에러를 던진다', async () => {
+            mockCreate.mockResolvedValue({ choices: [] });
+
+            await expect(
+                callOpenaiChat({
+                    ...BASE_OPTIONS,
+                    primaryApiKey: undefined,
+                })
+            ).rejects.toThrow('OpenAI returned no text content');
         });
     });
 });

--- a/src/__tests__/infrastructure/ai/router.test.ts
+++ b/src/__tests__/infrastructure/ai/router.test.ts
@@ -15,9 +15,16 @@ import { callAnthropicChat } from '@/infrastructure/ai/anthropic';
 import { callOpenaiChat } from '@/infrastructure/ai/openai';
 import { callGeminiWithKeyFallback } from '@/infrastructure/ai/gemini';
 
-const mockCallAnthropicChat = callAnthropicChat as jest.MockedFunction<typeof callAnthropicChat>;
-const mockCallOpenaiChat = callOpenaiChat as jest.MockedFunction<typeof callOpenaiChat>;
-const mockCallGeminiWithKeyFallback = callGeminiWithKeyFallback as jest.MockedFunction<typeof callGeminiWithKeyFallback>;
+const mockCallAnthropicChat = callAnthropicChat as jest.MockedFunction<
+    typeof callAnthropicChat
+>;
+const mockCallOpenaiChat = callOpenaiChat as jest.MockedFunction<
+    typeof callOpenaiChat
+>;
+const mockCallGeminiWithKeyFallback =
+    callGeminiWithKeyFallback as jest.MockedFunction<
+        typeof callGeminiWithKeyFallback
+    >;
 
 const BASE_OPTIONS = {
     primaryApiKey: 'pk',

--- a/src/__tests__/infrastructure/ai/router.test.ts
+++ b/src/__tests__/infrastructure/ai/router.test.ts
@@ -1,0 +1,77 @@
+jest.mock('@/infrastructure/ai/anthropic', () => ({
+    callAnthropicChat: jest.fn(),
+}));
+
+jest.mock('@/infrastructure/ai/openai', () => ({
+    callOpenaiChat: jest.fn(),
+}));
+
+jest.mock('@/infrastructure/ai/gemini', () => ({
+    callGeminiWithKeyFallback: jest.fn(),
+}));
+
+import { callAiProviderRouter } from '@/infrastructure/ai/router';
+import { callAnthropicChat } from '@/infrastructure/ai/anthropic';
+import { callOpenaiChat } from '@/infrastructure/ai/openai';
+import { callGeminiWithKeyFallback } from '@/infrastructure/ai/gemini';
+
+const mockCallAnthropicChat = callAnthropicChat as jest.MockedFunction<typeof callAnthropicChat>;
+const mockCallOpenaiChat = callOpenaiChat as jest.MockedFunction<typeof callOpenaiChat>;
+const mockCallGeminiWithKeyFallback = callGeminiWithKeyFallback as jest.MockedFunction<typeof callGeminiWithKeyFallback>;
+
+const BASE_OPTIONS = {
+    primaryApiKey: 'pk',
+    fallbackApiKey: 'fk',
+    contents: 'Hello',
+} as const;
+
+describe('callAiProviderRouter', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockCallAnthropicChat.mockResolvedValue('anthropic response');
+        mockCallOpenaiChat.mockResolvedValue('openai response');
+        mockCallGeminiWithKeyFallback.mockResolvedValue('gemini response');
+    });
+
+    describe('Anthropic 모델 라우팅', () => {
+        it('claude-haiku-3-5 모델은 callAnthropicChat에 위임하고 다른 어댑터는 호출하지 않는다', async () => {
+            const options = { ...BASE_OPTIONS, model: 'claude-haiku-3-5' };
+
+            const result = await callAiProviderRouter(options);
+
+            expect(result).toBe('anthropic response');
+            expect(mockCallAnthropicChat).toHaveBeenCalledTimes(1);
+            expect(mockCallAnthropicChat).toHaveBeenCalledWith(options);
+            expect(mockCallOpenaiChat).not.toHaveBeenCalled();
+            expect(mockCallGeminiWithKeyFallback).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Google 모델 라우팅', () => {
+        it('gemini-2.5-flash 모델은 callGeminiWithKeyFallback에 위임하고 다른 어댑터는 호출하지 않는다', async () => {
+            const options = { ...BASE_OPTIONS, model: 'gemini-2.5-flash' };
+
+            const result = await callAiProviderRouter(options);
+
+            expect(result).toBe('gemini response');
+            expect(mockCallGeminiWithKeyFallback).toHaveBeenCalledTimes(1);
+            expect(mockCallGeminiWithKeyFallback).toHaveBeenCalledWith(options);
+            expect(mockCallAnthropicChat).not.toHaveBeenCalled();
+            expect(mockCallOpenaiChat).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('OpenAI 모델 라우팅', () => {
+        it('gpt-5-mini 모델은 callOpenaiChat에 위임하고 다른 어댑터는 호출하지 않는다', async () => {
+            const options = { ...BASE_OPTIONS, model: 'gpt-5-mini' };
+
+            const result = await callAiProviderRouter(options);
+
+            expect(result).toBe('openai response');
+            expect(mockCallOpenaiChat).toHaveBeenCalledTimes(1);
+            expect(mockCallOpenaiChat).toHaveBeenCalledWith(options);
+            expect(mockCallAnthropicChat).not.toHaveBeenCalled();
+            expect(mockCallGeminiWithKeyFallback).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/__tests__/infrastructure/ai/router.test.ts
+++ b/src/__tests__/infrastructure/ai/router.test.ts
@@ -10,10 +10,23 @@ jest.mock('@/infrastructure/ai/gemini', () => ({
     callGeminiWithKeyFallback: jest.fn(),
 }));
 
+jest.mock('@y0ngha/siglens-core', () => {
+    const actual = jest.requireActual<typeof import('@y0ngha/siglens-core')>(
+        '@y0ngha/siglens-core'
+    );
+    return {
+        getProviderForModel: jest
+            .fn()
+            .mockImplementation(actual.getProviderForModel),
+    };
+});
+
 import { callAiProviderRouter } from '@/infrastructure/ai/router';
 import { callAnthropicChat } from '@/infrastructure/ai/anthropic';
 import { callOpenaiChat } from '@/infrastructure/ai/openai';
 import { callGeminiWithKeyFallback } from '@/infrastructure/ai/gemini';
+import { getProviderForModel } from '@y0ngha/siglens-core';
+import type { LlmProvider } from '@y0ngha/siglens-core';
 
 const mockCallAnthropicChat = callAnthropicChat as jest.MockedFunction<
     typeof callAnthropicChat
@@ -25,6 +38,9 @@ const mockCallGeminiWithKeyFallback =
     callGeminiWithKeyFallback as jest.MockedFunction<
         typeof callGeminiWithKeyFallback
     >;
+const mockGetProviderForModel = getProviderForModel as jest.MockedFunction<
+    typeof getProviderForModel
+>;
 
 const BASE_OPTIONS = {
     primaryApiKey: 'pk',
@@ -38,6 +54,11 @@ describe('callAiProviderRouter', () => {
         mockCallAnthropicChat.mockResolvedValue('anthropic response');
         mockCallOpenaiChat.mockResolvedValue('openai response');
         mockCallGeminiWithKeyFallback.mockResolvedValue('gemini response');
+        mockGetProviderForModel.mockImplementation(
+            jest.requireActual<typeof import('@y0ngha/siglens-core')>(
+                '@y0ngha/siglens-core'
+            ).getProviderForModel
+        );
     });
 
     describe('Anthropic 모델 라우팅', () => {
@@ -79,6 +100,21 @@ describe('callAiProviderRouter', () => {
             expect(mockCallOpenaiChat).toHaveBeenCalledWith(options);
             expect(mockCallAnthropicChat).not.toHaveBeenCalled();
             expect(mockCallGeminiWithKeyFallback).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('알 수 없는 provider 처리', () => {
+        it('알 수 없는 provider이면 에러를 던진다', async () => {
+            mockGetProviderForModel.mockReturnValueOnce(
+                'unknown' as unknown as LlmProvider
+            );
+
+            await expect(
+                callAiProviderRouter({
+                    ...BASE_OPTIONS,
+                    model: 'gemini-2.5-flash',
+                })
+            ).rejects.toThrow('Unhandled AI provider');
         });
     });
 });

--- a/src/__tests__/infrastructure/ai/utils.test.ts
+++ b/src/__tests__/infrastructure/ai/utils.test.ts
@@ -1,0 +1,67 @@
+import { toProviderTurns } from '@/infrastructure/ai/utils';
+import type { GeminiContent } from '@y0ngha/siglens-core';
+
+describe('toProviderTurns', () => {
+    describe('string contents', () => {
+        it('문자열이면 단일 user 턴으로 반환한다', () => {
+            const result = toProviderTurns('Hello');
+            expect(result).toEqual([{ role: 'user', content: 'Hello' }]);
+        });
+    });
+
+    describe('GeminiContent[] contents', () => {
+        it('role이 user인 턴은 user로 변환한다', () => {
+            const contents: GeminiContent[] = [
+                { role: 'user', parts: [{ text: 'Hi' }] },
+            ];
+            const result = toProviderTurns(contents);
+            expect(result).toEqual([{ role: 'user', content: 'Hi' }]);
+        });
+
+        it('role이 model인 턴은 assistant로 변환한다', () => {
+            const contents: GeminiContent[] = [
+                { role: 'model', parts: [{ text: 'Hello back' }] },
+            ];
+            const result = toProviderTurns(contents);
+            expect(result).toEqual([
+                { role: 'assistant', content: 'Hello back' },
+            ]);
+        });
+
+        it('복수 part의 text를 이어붙여 content를 구성한다', () => {
+            const contents: GeminiContent[] = [
+                {
+                    role: 'user',
+                    parts: [{ text: 'Hello ' }, { text: 'world' }],
+                },
+            ];
+            const result = toProviderTurns(contents);
+            expect(result).toEqual([{ role: 'user', content: 'Hello world' }]);
+        });
+
+        it('part.text가 undefined이면 빈 문자열로 처리한다', () => {
+            const contents: GeminiContent[] = [
+                {
+                    role: 'user',
+                    parts: [{ text: undefined as unknown as string }],
+                },
+            ];
+            const result = toProviderTurns(contents);
+            expect(result).toEqual([{ role: 'user', content: '' }]);
+        });
+
+        it('user/model 교대 히스토리를 순서대로 변환한다', () => {
+            const contents: GeminiContent[] = [
+                { role: 'user', parts: [{ text: 'Q1' }] },
+                { role: 'model', parts: [{ text: 'A1' }] },
+                { role: 'user', parts: [{ text: 'Q2' }] },
+            ];
+            const result = toProviderTurns(contents);
+            expect(result).toEqual([
+                { role: 'user', content: 'Q1' },
+                { role: 'assistant', content: 'A1' },
+                { role: 'user', content: 'Q2' },
+            ]);
+        });
+    });
+});

--- a/src/__tests__/infrastructure/ai/utils.test.ts
+++ b/src/__tests__/infrastructure/ai/utils.test.ts
@@ -10,6 +10,11 @@ describe('toProviderTurns', () => {
     });
 
     describe('GeminiContent[] contents', () => {
+        it('빈 배열이면 빈 배열을 반환한다', () => {
+            const result = toProviderTurns([]);
+            expect(result).toEqual([]);
+        });
+
         it('role이 user인 턴은 user로 변환한다', () => {
             const contents: GeminiContent[] = [
                 { role: 'user', parts: [{ text: 'Hi' }] },

--- a/src/__tests__/infrastructure/chat/chatAction.test.ts
+++ b/src/__tests__/infrastructure/chat/chatAction.test.ts
@@ -2,8 +2,13 @@ import { chatAction } from '@/infrastructure/chat/chatAction';
 import {
     GEMINI_2_5_FLASH_MODEL,
     requestChatCompletion,
+    getProviderForModel,
 } from '@y0ngha/siglens-core';
-import type { AnalysisResponse, ChatActionResult } from '@y0ngha/siglens-core';
+import type {
+    AnalysisResponse,
+    ChatActionResult,
+    LlmProvider,
+} from '@y0ngha/siglens-core';
 import { headers } from 'next/headers';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
 import { getAuthDatabaseClient } from '@/infrastructure/auth/db';
@@ -14,10 +19,18 @@ jest.mock('next/headers', () => ({
     headers: jest.fn(),
 }));
 
-jest.mock('@y0ngha/siglens-core', () => ({
-    ...jest.requireActual('@y0ngha/siglens-core'),
-    requestChatCompletion: jest.fn(),
-}));
+jest.mock('@y0ngha/siglens-core', () => {
+    const actual = jest.requireActual<typeof import('@y0ngha/siglens-core')>(
+        '@y0ngha/siglens-core'
+    );
+    return {
+        ...actual,
+        requestChatCompletion: jest.fn(),
+        getProviderForModel: jest
+            .fn()
+            .mockImplementation(actual.getProviderForModel),
+    };
+});
 
 jest.mock('@/infrastructure/ai/router', () => ({
     callAiProviderRouter: jest.fn(),
@@ -41,6 +54,9 @@ const mockRequestChatCompletion = requestChatCompletion as jest.MockedFunction<
 >;
 const mockGetCurrentUser = getCurrentUser as jest.MockedFunction<
     typeof getCurrentUser
+>;
+const mockGetProviderForModel = getProviderForModel as jest.MockedFunction<
+    typeof getProviderForModel
 >;
 
 const MINIMAL_ANALYSIS: AnalysisResponse = {
@@ -87,6 +103,11 @@ describe('chatAction 함수는', () => {
         );
         mockRequestChatCompletion.mockResolvedValue(SUCCESS_RESULT);
         mockGetCurrentUser.mockResolvedValue(null);
+        mockGetProviderForModel.mockImplementation(
+            jest.requireActual<typeof import('@y0ngha/siglens-core')>(
+                '@y0ngha/siglens-core'
+            ).getProviderForModel
+        );
     });
 
     afterEach(() => {
@@ -430,6 +451,27 @@ describe('chatAction 함수는', () => {
                     callAiProvider: callAiProviderRouter,
                 })
             );
+        });
+    });
+
+    describe('알 수 없는 provider 처리', () => {
+        it('getServerPaidKey가 알 수 없는 provider를 받으면 에러가 전파된다', async () => {
+            // getServerPaidKey is called outside the try block — the throw propagates
+            // rather than being caught as server_error.
+            mockGetProviderForModel.mockReturnValueOnce(
+                'unknown' as unknown as LlmProvider
+            );
+
+            await expect(
+                chatAction(
+                    'AAPL',
+                    '1Day',
+                    MINIMAL_ANALYSIS,
+                    [],
+                    '질문',
+                    'gemini-2.5-flash'
+                )
+            ).rejects.toThrow('Unhandled LLM provider');
         });
     });
 });

--- a/src/__tests__/infrastructure/chat/chatAction.test.ts
+++ b/src/__tests__/infrastructure/chat/chatAction.test.ts
@@ -121,7 +121,14 @@ describe('chatAction 함수는', () => {
         it('GEMINI_CHAT_FREE_API_KEY가 설정되면 freeApiKey도 함께 전달한다', async () => {
             process.env.GEMINI_CHAT_FREE_API_KEY = 'gemini-free-key';
 
-            await chatAction('AAPL', '1Day', MINIMAL_ANALYSIS, [], '질문', 'gemini-2.5-flash');
+            await chatAction(
+                'AAPL',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '질문',
+                'gemini-2.5-flash'
+            );
 
             expect(mockRequestChatCompletion).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -228,11 +235,23 @@ describe('chatAction 함수는', () => {
         });
 
         it('premium 모델이고 로그인 + 사용자 키 등록이면 사용자 키를 전달한다', async () => {
-            const mockFindByUserAndProvider = jest.fn().mockResolvedValue({ apiKey: 'user-personal-key' });
-            (DrizzleUserApiKeyRepository as jest.MockedClass<typeof DrizzleUserApiKeyRepository>)
-                .mockImplementation(() => ({ findByUserAndProvider: mockFindByUserAndProvider } as unknown as DrizzleUserApiKeyRepository));
+            const mockFindByUserAndProvider = jest
+                .fn()
+                .mockResolvedValue({ apiKey: 'user-personal-key' });
+            (
+                DrizzleUserApiKeyRepository as jest.MockedClass<
+                    typeof DrizzleUserApiKeyRepository
+                >
+            ).mockImplementation(
+                () =>
+                    ({
+                        findByUserAndProvider: mockFindByUserAndProvider,
+                    }) as unknown as DrizzleUserApiKeyRepository
+            );
             (getAuthDatabaseClient as jest.Mock).mockReturnValue({ db: {} });
-            mockGetCurrentUser.mockResolvedValue({ id: 'user-1' } as Awaited<ReturnType<typeof getCurrentUser>>);
+            mockGetCurrentUser.mockResolvedValue({ id: 'user-1' } as Awaited<
+                ReturnType<typeof getCurrentUser>
+            >);
 
             await chatAction(
                 'AAPL',
@@ -250,15 +269,28 @@ describe('chatAction 함수는', () => {
                 expect.anything()
             );
             expect(DrizzleUserApiKeyRepository).toHaveBeenCalledWith({});
-            expect(mockFindByUserAndProvider).toHaveBeenCalledWith('user-1', 'anthropic');
+            expect(mockFindByUserAndProvider).toHaveBeenCalledWith(
+                'user-1',
+                'anthropic'
+            );
         });
 
         it('premium 모델이고 로그인했지만 키 미등록이면 paidApiKey를 undefined로 전달한다', async () => {
             const mockFindByUserAndProvider = jest.fn().mockResolvedValue(null);
-            (DrizzleUserApiKeyRepository as jest.MockedClass<typeof DrizzleUserApiKeyRepository>)
-                .mockImplementation(() => ({ findByUserAndProvider: mockFindByUserAndProvider } as unknown as DrizzleUserApiKeyRepository));
+            (
+                DrizzleUserApiKeyRepository as jest.MockedClass<
+                    typeof DrizzleUserApiKeyRepository
+                >
+            ).mockImplementation(
+                () =>
+                    ({
+                        findByUserAndProvider: mockFindByUserAndProvider,
+                    }) as unknown as DrizzleUserApiKeyRepository
+            );
             (getAuthDatabaseClient as jest.Mock).mockReturnValue({ db: {} });
-            mockGetCurrentUser.mockResolvedValue({ id: 'user-1' } as Awaited<ReturnType<typeof getCurrentUser>>);
+            mockGetCurrentUser.mockResolvedValue({ id: 'user-1' } as Awaited<
+                ReturnType<typeof getCurrentUser>
+            >);
 
             await chatAction(
                 'AAPL',
@@ -286,7 +318,14 @@ describe('chatAction 함수는', () => {
                 >
             );
 
-            await chatAction('AAPL', '1Day', MINIMAL_ANALYSIS, [], '질문', 'gemini-2.5-flash');
+            await chatAction(
+                'AAPL',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '질문',
+                'gemini-2.5-flash'
+            );
 
             expect(mockRequestChatCompletion).toHaveBeenCalledWith(
                 expect.objectContaining({ clientIp: '1.2.3.4' }),
@@ -296,10 +335,19 @@ describe('chatAction 함수는', () => {
 
         it('x-forwarded-for 헤더가 없으면 unknown을 전달한다', async () => {
             mockHeaders.mockResolvedValue(
-                makeHeadersMap() as unknown as Awaited<ReturnType<typeof headers>>
+                makeHeadersMap() as unknown as Awaited<
+                    ReturnType<typeof headers>
+                >
             );
 
-            await chatAction('AAPL', '1Day', MINIMAL_ANALYSIS, [], '질문', 'gemini-2.5-flash');
+            await chatAction(
+                'AAPL',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '질문',
+                'gemini-2.5-flash'
+            );
 
             expect(mockRequestChatCompletion).toHaveBeenCalledWith(
                 expect.objectContaining({ clientIp: 'unknown' }),
@@ -325,7 +373,9 @@ describe('chatAction 함수는', () => {
 
     describe('에러 처리', () => {
         it('core use-case가 에러를 던지면 server_error를 반환한다', async () => {
-            mockRequestChatCompletion.mockRejectedValue(new Error('core failed'));
+            mockRequestChatCompletion.mockRejectedValue(
+                new Error('core failed')
+            );
 
             const result = await chatAction(
                 'AAPL',

--- a/src/__tests__/infrastructure/chat/chatAction.test.ts
+++ b/src/__tests__/infrastructure/chat/chatAction.test.ts
@@ -191,7 +191,7 @@ describe('chatAction 함수는', () => {
     });
 
     describe('서버 키가 없을 때', () => {
-        it('서버 paid key가 미설정이면 server_error를 반환하고 core를 호출하지 않는다', async () => {
+        it('Gemini 서버 paid key가 미설정이면 server_error를 반환하고 core를 호출하지 않는다', async () => {
             delete process.env.GEMINI_CHAT_API_KEY;
 
             const result = await chatAction(
@@ -201,6 +201,34 @@ describe('chatAction 함수는', () => {
                 [],
                 '질문',
                 'gemini-2.5-flash'
+            );
+
+            expect(result).toEqual({ ok: false, error: 'server_error' });
+            expect(mockRequestChatCompletion).not.toHaveBeenCalled();
+        });
+
+        it('Anthropic 서버 paid key가 미설정이면 server_error를 반환하고 core를 호출하지 않는다', async () => {
+            const result = await chatAction(
+                'AAPL',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '질문',
+                'claude-haiku-3-5'
+            );
+
+            expect(result).toEqual({ ok: false, error: 'server_error' });
+            expect(mockRequestChatCompletion).not.toHaveBeenCalled();
+        });
+
+        it('OpenAI 서버 paid key가 미설정이면 server_error를 반환하고 core를 호출하지 않는다', async () => {
+            const result = await chatAction(
+                'AAPL',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '질문',
+                'gpt-5-mini'
             );
 
             expect(result).toEqual({ ok: false, error: 'server_error' });

--- a/src/__tests__/infrastructure/chat/chatAction.test.ts
+++ b/src/__tests__/infrastructure/chat/chatAction.test.ts
@@ -1,12 +1,14 @@
 import { chatAction } from '@/infrastructure/chat/chatAction';
 import {
-    GEMINI_2_5_FLASH_LITE_MODEL,
     GEMINI_2_5_FLASH_MODEL,
     requestChatCompletion,
 } from '@y0ngha/siglens-core';
 import type { AnalysisResponse, ChatActionResult } from '@y0ngha/siglens-core';
-import { callGeminiWithKeyFallback } from '@/infrastructure/ai/gemini';
 import { headers } from 'next/headers';
+import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
+import { getAuthDatabaseClient } from '@/infrastructure/auth/db';
+import { DrizzleUserApiKeyRepository } from '@/infrastructure/db/userApiKeyRepository';
+import { callAiProviderRouter } from '@/infrastructure/ai/router';
 
 jest.mock('next/headers', () => ({
     headers: jest.fn(),
@@ -14,19 +16,31 @@ jest.mock('next/headers', () => ({
 
 jest.mock('@y0ngha/siglens-core', () => ({
     ...jest.requireActual('@y0ngha/siglens-core'),
-    GEMINI_2_5_FLASH_MODEL: 'gemini-2.5-flash',
-    GEMINI_2_5_FLASH_LITE_MODEL: 'gemini-2.5-flash-lite',
-    VALID_CHAT_MODELS: ['gemini-2.5-flash', 'gemini-2.5-flash-lite'],
     requestChatCompletion: jest.fn(),
 }));
 
-jest.mock('@/infrastructure/ai/gemini', () => ({
-    callGeminiWithKeyFallback: jest.fn(),
+jest.mock('@/infrastructure/ai/router', () => ({
+    callAiProviderRouter: jest.fn(),
+}));
+
+jest.mock('@/infrastructure/auth/getCurrentUser', () => ({
+    getCurrentUser: jest.fn(),
+}));
+
+jest.mock('@/infrastructure/auth/db', () => ({
+    getAuthDatabaseClient: jest.fn(),
+}));
+
+jest.mock('@/infrastructure/db/userApiKeyRepository', () => ({
+    DrizzleUserApiKeyRepository: jest.fn(),
 }));
 
 const mockHeaders = headers as jest.MockedFunction<typeof headers>;
 const mockRequestChatCompletion = requestChatCompletion as jest.MockedFunction<
     typeof requestChatCompletion
+>;
+const mockGetCurrentUser = getCurrentUser as jest.MockedFunction<
+    typeof getCurrentUser
 >;
 
 const MINIMAL_ANALYSIS: AnalysisResponse = {
@@ -62,149 +76,282 @@ function makeHeadersMap(xForwardedFor?: string) {
 describe('chatAction 함수는', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        process.env.GEMINI_API_KEY = 'paid-api-key';
+        process.env.GEMINI_CHAT_API_KEY = 'gemini-paid-key';
         delete process.env.GEMINI_CHAT_FREE_API_KEY;
+        delete process.env.ANTHROPIC_CHAT_API_KEY;
+        delete process.env.OPENAI_CHAT_API_KEY;
         mockHeaders.mockResolvedValue(
             makeHeadersMap('1.2.3.4') as unknown as Awaited<
                 ReturnType<typeof headers>
             >
         );
         mockRequestChatCompletion.mockResolvedValue(SUCCESS_RESULT);
+        mockGetCurrentUser.mockResolvedValue(null);
     });
 
     afterEach(() => {
-        delete process.env.GEMINI_API_KEY;
+        delete process.env.GEMINI_CHAT_API_KEY;
         delete process.env.GEMINI_CHAT_FREE_API_KEY;
+        delete process.env.ANTHROPIC_CHAT_API_KEY;
+        delete process.env.OPENAI_CHAT_API_KEY;
     });
 
-    it('core 채팅 use-case에 요청 정보를 위임하고 결과를 반환한다', async () => {
-        const history = [{ role: 'user' as const, content: '이전 질문' }];
+    describe('Gemini 모델을 사용할 때', () => {
+        it('free Gemini 모델은 서버 paid key로 요청한다', async () => {
+            const result = await chatAction(
+                'AAPL',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '지금 사도 돼?',
+                'gemini-2.5-flash'
+            );
 
-        const result = await chatAction(
-            'AAPL',
-            '1Day',
-            MINIMAL_ANALYSIS,
-            history,
-            '지금 사도 돼?',
-            GEMINI_2_5_FLASH_LITE_MODEL
-        );
+            expect(result).toBe(SUCCESS_RESULT);
+            expect(mockRequestChatCompletion).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    paidApiKey: 'gemini-paid-key',
+                    freeApiKey: undefined,
+                    model: 'gemini-2.5-flash',
+                }),
+                { callAiProvider: callAiProviderRouter }
+            );
+        });
 
-        expect(result).toBe(SUCCESS_RESULT);
-        expect(mockRequestChatCompletion).toHaveBeenCalledWith(
-            {
-                clientIp: '1.2.3.4',
-                symbol: 'AAPL',
-                timeframe: '1Day',
-                analysis: MINIMAL_ANALYSIS,
-                history,
-                userMessage: '지금 사도 돼?',
-                model: GEMINI_2_5_FLASH_LITE_MODEL,
-                freeApiKey: undefined,
-                paidApiKey: 'paid-api-key',
-            },
-            { callAiProvider: callGeminiWithKeyFallback }
-        );
+        it('GEMINI_CHAT_FREE_API_KEY가 설정되면 freeApiKey도 함께 전달한다', async () => {
+            process.env.GEMINI_CHAT_FREE_API_KEY = 'gemini-free-key';
+
+            await chatAction('AAPL', '1Day', MINIMAL_ANALYSIS, [], '질문', 'gemini-2.5-flash');
+
+            expect(mockRequestChatCompletion).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    paidApiKey: 'gemini-paid-key',
+                    freeApiKey: 'gemini-free-key',
+                }),
+                expect.anything()
+            );
+        });
     });
 
-    it('model을 생략하면 core의 기본 채팅 모델을 전달한다', async () => {
-        await chatAction('AAPL', '1Day', MINIMAL_ANALYSIS, [], '질문');
+    describe('Anthropic 모델을 사용할 때', () => {
+        it('free Anthropic 모델은 서버 paid key로 요청하고 freeApiKey는 undefined이다', async () => {
+            process.env.ANTHROPIC_CHAT_API_KEY = 'anthr-key';
+            delete process.env.GEMINI_CHAT_API_KEY;
 
-        expect(mockRequestChatCompletion).toHaveBeenCalledWith(
-            expect.objectContaining({
-                model: GEMINI_2_5_FLASH_MODEL,
-            }),
-            expect.objectContaining({
-                callAiProvider: callGeminiWithKeyFallback,
-            })
-        );
+            await chatAction(
+                'AAPL',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '질문',
+                'claude-haiku-3-5'
+            );
+
+            expect(mockRequestChatCompletion).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    paidApiKey: 'anthr-key',
+                    freeApiKey: undefined,
+                    model: 'claude-haiku-3-5',
+                }),
+                { callAiProvider: callAiProviderRouter }
+            );
+        });
     });
 
-    it('free API key가 있으면 core use-case에 함께 전달한다', async () => {
-        process.env.GEMINI_CHAT_FREE_API_KEY = 'free-api-key';
+    describe('OpenAI 모델을 사용할 때', () => {
+        it('free OpenAI 모델은 서버 paid key로 요청하고 freeApiKey는 undefined이다', async () => {
+            process.env.OPENAI_CHAT_API_KEY = 'oai-key';
+            delete process.env.GEMINI_CHAT_API_KEY;
 
-        await chatAction('AAPL', '1Day', MINIMAL_ANALYSIS, [], '질문');
+            await chatAction(
+                'AAPL',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '질문',
+                'gpt-5-mini'
+            );
 
-        expect(mockRequestChatCompletion).toHaveBeenCalledWith(
-            expect.objectContaining({
-                freeApiKey: 'free-api-key',
-                paidApiKey: 'paid-api-key',
-            }),
-            expect.anything()
-        );
+            expect(mockRequestChatCompletion).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    paidApiKey: 'oai-key',
+                    freeApiKey: undefined,
+                    model: 'gpt-5-mini',
+                }),
+                { callAiProvider: callAiProviderRouter }
+            );
+        });
     });
 
-    it('x-forwarded-for에 여러 IP가 있으면 첫 번째 IP만 전달한다', async () => {
-        mockHeaders.mockResolvedValue(
-            makeHeadersMap('1.2.3.4, 5.6.7.8') as unknown as Awaited<
-                ReturnType<typeof headers>
-            >
-        );
+    describe('서버 키가 없을 때', () => {
+        it('서버 paid key가 미설정이면 server_error를 반환하고 core를 호출하지 않는다', async () => {
+            delete process.env.GEMINI_CHAT_API_KEY;
 
-        await chatAction('AAPL', '1Day', MINIMAL_ANALYSIS, [], '질문');
+            const result = await chatAction(
+                'AAPL',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '질문',
+                'gemini-2.5-flash'
+            );
 
-        expect(mockRequestChatCompletion).toHaveBeenCalledWith(
-            expect.objectContaining({
-                clientIp: '1.2.3.4',
-            }),
-            expect.anything()
-        );
+            expect(result).toEqual({ ok: false, error: 'server_error' });
+            expect(mockRequestChatCompletion).not.toHaveBeenCalled();
+        });
     });
 
-    it('x-forwarded-for 헤더가 없으면 unknown을 전달한다', async () => {
-        mockHeaders.mockResolvedValue(
-            makeHeadersMap() as unknown as Awaited<ReturnType<typeof headers>>
-        );
+    describe('premium 모델 + 사용자 API key 조회', () => {
+        beforeEach(() => {
+            process.env.ANTHROPIC_CHAT_API_KEY = 'anthr-key';
+            delete process.env.GEMINI_CHAT_API_KEY;
+        });
 
-        await chatAction('AAPL', '1Day', MINIMAL_ANALYSIS, [], '질문');
+        it('premium 모델이고 로그인되지 않았으면 paidApiKey를 undefined로 전달한다', async () => {
+            mockGetCurrentUser.mockResolvedValue(null);
 
-        expect(mockRequestChatCompletion).toHaveBeenCalledWith(
-            expect.objectContaining({
-                clientIp: 'unknown',
-            }),
-            expect.anything()
-        );
+            await chatAction(
+                'AAPL',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '질문',
+                'claude-opus-4-7'
+            );
+
+            expect(mockRequestChatCompletion).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    paidApiKey: undefined,
+                }),
+                expect.anything()
+            );
+        });
+
+        it('premium 모델이고 로그인 + 사용자 키 등록이면 사용자 키를 전달한다', async () => {
+            const mockFindByUserAndProvider = jest.fn().mockResolvedValue({ apiKey: 'user-personal-key' });
+            (DrizzleUserApiKeyRepository as jest.MockedClass<typeof DrizzleUserApiKeyRepository>)
+                .mockImplementation(() => ({ findByUserAndProvider: mockFindByUserAndProvider } as unknown as DrizzleUserApiKeyRepository));
+            (getAuthDatabaseClient as jest.Mock).mockReturnValue({ db: {} });
+            mockGetCurrentUser.mockResolvedValue({ id: 'user-1' } as Awaited<ReturnType<typeof getCurrentUser>>);
+
+            await chatAction(
+                'AAPL',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '질문',
+                'claude-opus-4-7'
+            );
+
+            expect(mockRequestChatCompletion).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    paidApiKey: 'user-personal-key',
+                }),
+                expect.anything()
+            );
+            expect(DrizzleUserApiKeyRepository).toHaveBeenCalledWith({});
+            expect(mockFindByUserAndProvider).toHaveBeenCalledWith('user-1', 'anthropic');
+        });
+
+        it('premium 모델이고 로그인했지만 키 미등록이면 paidApiKey를 undefined로 전달한다', async () => {
+            const mockFindByUserAndProvider = jest.fn().mockResolvedValue(null);
+            (DrizzleUserApiKeyRepository as jest.MockedClass<typeof DrizzleUserApiKeyRepository>)
+                .mockImplementation(() => ({ findByUserAndProvider: mockFindByUserAndProvider } as unknown as DrizzleUserApiKeyRepository));
+            (getAuthDatabaseClient as jest.Mock).mockReturnValue({ db: {} });
+            mockGetCurrentUser.mockResolvedValue({ id: 'user-1' } as Awaited<ReturnType<typeof getCurrentUser>>);
+
+            await chatAction(
+                'AAPL',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '질문',
+                'claude-opus-4-7'
+            );
+
+            expect(mockRequestChatCompletion).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    paidApiKey: undefined,
+                }),
+                expect.anything()
+            );
+        });
     });
 
-    it('GEMINI_API_KEY 미설정 시 server_error를 반환한다', async () => {
-        delete process.env.GEMINI_API_KEY;
+    describe('클라이언트 IP 처리', () => {
+        it('x-forwarded-for에 여러 IP가 있으면 첫 번째 IP만 전달한다', async () => {
+            mockHeaders.mockResolvedValue(
+                makeHeadersMap('1.2.3.4, 5.6.7.8') as unknown as Awaited<
+                    ReturnType<typeof headers>
+                >
+            );
 
-        const result = await chatAction(
-            'AAPL',
-            '1Day',
-            MINIMAL_ANALYSIS,
-            [],
-            '질문'
-        );
+            await chatAction('AAPL', '1Day', MINIMAL_ANALYSIS, [], '질문', 'gemini-2.5-flash');
 
-        expect(result).toEqual({ ok: false, error: 'server_error' });
-        expect(mockRequestChatCompletion).not.toHaveBeenCalled();
+            expect(mockRequestChatCompletion).toHaveBeenCalledWith(
+                expect.objectContaining({ clientIp: '1.2.3.4' }),
+                expect.anything()
+            );
+        });
+
+        it('x-forwarded-for 헤더가 없으면 unknown을 전달한다', async () => {
+            mockHeaders.mockResolvedValue(
+                makeHeadersMap() as unknown as Awaited<ReturnType<typeof headers>>
+            );
+
+            await chatAction('AAPL', '1Day', MINIMAL_ANALYSIS, [], '질문', 'gemini-2.5-flash');
+
+            expect(mockRequestChatCompletion).toHaveBeenCalledWith(
+                expect.objectContaining({ clientIp: 'unknown' }),
+                expect.anything()
+            );
+        });
+
+        it('headers() 조회가 실패하면 server_error를 반환한다', async () => {
+            mockHeaders.mockRejectedValue(new Error('headers unavailable'));
+
+            const result = await chatAction(
+                'AAPL',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '질문',
+                'gemini-2.5-flash'
+            );
+
+            expect(result).toEqual({ ok: false, error: 'server_error' });
+        });
     });
 
-    it('headers 조회 실패 시 server_error를 반환한다', async () => {
-        mockHeaders.mockRejectedValue(new Error('headers unavailable'));
+    describe('에러 처리', () => {
+        it('core use-case가 에러를 던지면 server_error를 반환한다', async () => {
+            mockRequestChatCompletion.mockRejectedValue(new Error('core failed'));
 
-        const result = await chatAction(
-            'AAPL',
-            '1Day',
-            MINIMAL_ANALYSIS,
-            [],
-            '질문'
-        );
+            const result = await chatAction(
+                'AAPL',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '질문',
+                'gemini-2.5-flash'
+            );
 
-        expect(result).toEqual({ ok: false, error: 'server_error' });
+            expect(result).toEqual({ ok: false, error: 'server_error' });
+        });
     });
 
-    it('core use-case가 에러를 던지면 server_error를 반환한다', async () => {
-        mockRequestChatCompletion.mockRejectedValue(new Error('core failed'));
+    describe('기본 모델', () => {
+        it('model을 생략하면 GEMINI_2_5_FLASH_MODEL을 core에 전달한다', async () => {
+            await chatAction('AAPL', '1Day', MINIMAL_ANALYSIS, [], '질문');
 
-        const result = await chatAction(
-            'AAPL',
-            '1Day',
-            MINIMAL_ANALYSIS,
-            [],
-            '질문'
-        );
-
-        expect(result).toEqual({ ok: false, error: 'server_error' });
+            expect(mockRequestChatCompletion).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    model: GEMINI_2_5_FLASH_MODEL,
+                }),
+                expect.objectContaining({
+                    callAiProvider: callAiProviderRouter,
+                })
+            );
+        });
     });
 });

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -7,11 +7,9 @@ import {
     GEMINI_2_5_FLASH_MODEL,
     VALID_CHAT_MODELS,
     getProviderForModel,
-} from '@y0ngha/siglens-core';
-import type {
-    AnalysisResponse,
-    ModelId,
-    Timeframe,
+    type AnalysisResponse,
+    type ModelId,
+    type Timeframe,
 } from '@y0ngha/siglens-core';
 import { cn } from '@/lib/cn';
 import { useChat } from '@/components/chat/hooks/useChat';

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -3,7 +3,11 @@
 import { useRef, useState } from 'react';
 import { usePopoverToggle } from '@/components/hooks/usePopoverToggle';
 import { MarkdownText } from '@/components/ui/MarkdownText';
-import { GEMINI_2_5_FLASH_MODEL, VALID_CHAT_MODELS, getProviderForModel } from '@y0ngha/siglens-core';
+import {
+    GEMINI_2_5_FLASH_MODEL,
+    VALID_CHAT_MODELS,
+    getProviderForModel,
+} from '@y0ngha/siglens-core';
 import type {
     AnalysisResponse,
     ModelId,
@@ -30,8 +34,14 @@ const MODEL_DISPLAY_MAP: Partial<Record<ModelId, ChatModelDisplay>> = {
         fullName: 'Gemini 2.5 Flash Lite',
     },
     'gemini-2.5-pro': { label: 'Pro', fullName: 'Gemini 2.5 Pro' },
-    'gemini-3.1-pro-preview': { label: '3.1 Pro', fullName: 'Gemini 3.1 Pro Preview' },
-    'gemini-3-flash-preview': { label: 'Flash 3', fullName: 'Gemini 3 Flash Preview' },
+    'gemini-3.1-pro-preview': {
+        label: '3.1 Pro',
+        fullName: 'Gemini 3.1 Pro Preview',
+    },
+    'gemini-3-flash-preview': {
+        label: 'Flash 3',
+        fullName: 'Gemini 3 Flash Preview',
+    },
     'claude-haiku-3-5': { label: 'Haiku', fullName: 'Claude Haiku 3.5' },
     'claude-sonnet-4-6': { label: 'Sonnet', fullName: 'Claude Sonnet 4.6' },
     'claude-opus-4-7': { label: 'Opus', fullName: 'Claude Opus 4.7' },

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -3,34 +3,44 @@
 import { useRef, useState } from 'react';
 import { usePopoverToggle } from '@/components/hooks/usePopoverToggle';
 import { MarkdownText } from '@/components/ui/MarkdownText';
-import { VALID_CHAT_MODELS } from '@y0ngha/siglens-core';
+import { GEMINI_2_5_FLASH_MODEL, VALID_CHAT_MODELS, getProviderForModel } from '@y0ngha/siglens-core';
 import type {
     AnalysisResponse,
-    ChatModel,
+    ModelId,
     Timeframe,
 } from '@y0ngha/siglens-core';
 import { cn } from '@/lib/cn';
 import { useChat } from '@/components/chat/hooks/useChat';
 import { useChatInput } from '@/components/chat/hooks/useChatInput';
+import { useCurrentUser } from '@/components/hooks/useCurrentUser';
+import { UserApiKeyRequiredModal } from '@/components/chat/UserApiKeyRequiredModal';
 
 interface ChatModelOption {
-    id: ChatModel;
+    id: ModelId;
     label: string;
     fullName: string;
 }
 
 type ChatModelDisplay = Pick<ChatModelOption, 'label' | 'fullName'>;
 
-const MODEL_DISPLAY_MAP: Partial<Record<ChatModel, ChatModelDisplay>> = {
+const MODEL_DISPLAY_MAP: Partial<Record<ModelId, ChatModelDisplay>> = {
     'gemini-2.5-flash': { label: 'Flash', fullName: 'Gemini 2.5 Flash' },
     'gemini-2.5-flash-lite': {
         label: 'Flash Lite',
         fullName: 'Gemini 2.5 Flash Lite',
     },
     'gemini-2.5-pro': { label: 'Pro', fullName: 'Gemini 2.5 Pro' },
+    'gemini-3.1-pro-preview': { label: '3.1 Pro', fullName: 'Gemini 3.1 Pro Preview' },
+    'gemini-3-flash-preview': { label: 'Flash 3', fullName: 'Gemini 3 Flash Preview' },
+    'claude-haiku-3-5': { label: 'Haiku', fullName: 'Claude Haiku 3.5' },
+    'claude-sonnet-4-6': { label: 'Sonnet', fullName: 'Claude Sonnet 4.6' },
+    'claude-opus-4-7': { label: 'Opus', fullName: 'Claude Opus 4.7' },
+    'gpt-5-mini': { label: 'GPT Mini', fullName: 'GPT-5 Mini' },
+    'gpt-5.4': { label: 'GPT 5.4', fullName: 'GPT-5.4' },
+    'gpt-5.5': { label: 'GPT 5.5', fullName: 'GPT-5.5' },
 };
 
-function getModelDisplay(id: ChatModel): ChatModelDisplay {
+function getModelDisplay(id: ModelId): ChatModelDisplay {
     return MODEL_DISPLAY_MAP[id] ?? { label: id, fullName: id };
 }
 
@@ -68,6 +78,8 @@ export function ChatPanel({
         dropdownRef,
     ]);
 
+    const { data: currentUser } = useCurrentUser();
+
     const {
         messages,
         loadingPhase,
@@ -77,6 +89,8 @@ export function ChatPanel({
         dismissAnalysisUpdated,
         selectedModel,
         handleModelChange,
+        apiKeyModalOpen,
+        closeApiKeyModal,
     } = useChat({ symbol, timeframe, analysis, isAnalysisReady });
 
     const {
@@ -238,6 +252,17 @@ export function ChatPanel({
 
                 <div ref={messagesEndRef} />
             </div>
+
+            <UserApiKeyRequiredModal
+                open={apiKeyModalOpen}
+                onClose={closeApiKeyModal}
+                provider={getProviderForModel(selectedModel)}
+                loggedIn={!!currentUser}
+                onSwitchToFree={() => {
+                    handleModelChange(GEMINI_2_5_FLASH_MODEL);
+                    closeApiKeyModal();
+                }}
+            />
 
             {/* 입력 영역 */}
             <div className="border-secondary-700 border-t px-3 py-2">

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { usePopoverToggle } from '@/components/hooks/usePopoverToggle';
 import { MarkdownText } from '@/components/ui/MarkdownText';
 import {
@@ -112,6 +112,11 @@ export function ChatPanel({
         handleSubmit,
         handleKeyDown,
     } = useChatInput({ messages, loadingPhase, isAnalysisReady, sendMessage });
+
+    const handleSwitchToFreeModel = useCallback(() => {
+        handleModelChange(GEMINI_2_5_FLASH_MODEL);
+        closeApiKeyModal();
+    }, [handleModelChange, closeApiKeyModal]);
 
     const selectedModelOption = getModelDisplay(selectedModel);
 
@@ -268,10 +273,7 @@ export function ChatPanel({
                 onClose={closeApiKeyModal}
                 provider={getProviderForModel(selectedModel)}
                 loggedIn={!!currentUser}
-                onSwitchToFree={() => {
-                    handleModelChange(GEMINI_2_5_FLASH_MODEL);
-                    closeApiKeyModal();
-                }}
+                onSwitchToFree={handleSwitchToFreeModel}
             />
 
             {/* 입력 영역 */}

--- a/src/components/chat/UserApiKeyRequiredModal.tsx
+++ b/src/components/chat/UserApiKeyRequiredModal.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import Link from 'next/link';
+import { useFocusTrap } from '@/components/hooks/useFocusTrap';
+import { useEscapeKey } from '@/components/hooks/useEscapeKey';
+import { cn } from '@/lib/cn';
+import type { LlmProvider } from '@y0ngha/siglens-core';
+
+const PROVIDER_DISPLAY: Record<LlmProvider, string> = {
+    anthropic: 'Anthropic',
+    google: 'Google',
+    openai: 'OpenAI',
+};
+
+interface UserApiKeyRequiredModalProps {
+    open: boolean;
+    onClose: () => void;
+    provider: LlmProvider;
+    loggedIn: boolean;
+    onSwitchToFree: () => void;
+}
+
+export function UserApiKeyRequiredModal({
+    open,
+    onClose,
+    provider,
+    loggedIn,
+    onSwitchToFree,
+}: UserApiKeyRequiredModalProps) {
+    const dialogRef = useRef<HTMLDivElement>(null);
+
+    useFocusTrap(dialogRef, open);
+    useEscapeKey(onClose, open);
+
+    useEffect(() => {
+        if (open) {
+            dialogRef.current?.focus();
+        }
+    }, [open]);
+
+    if (!open) return null;
+
+    const ctaHref = loggedIn ? '/account/api-keys' : '/auth/sign-up';
+    const ctaLabel = loggedIn ? 'API 키 등록하기' : '회원가입하기';
+    const bodyText = loggedIn
+        ? 'API 키를 등록하면 이 모델을 사용할 수 있어요.'
+        : '회원가입하고 본인의 API 키를 등록하면 이 모델을 사용할 수 있어요.';
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm bg-secondary-950/80"
+            aria-hidden="true"
+        >
+            <div
+                ref={dialogRef}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="api-key-modal-title"
+                tabIndex={-1}
+                className={cn(
+                    'border border-secondary-700 bg-secondary-800 rounded-xl shadow-2xl w-full max-w-sm outline-none'
+                )}
+            >
+                <div className="border-b border-secondary-700 flex items-center justify-between px-5 py-4">
+                    <h2
+                        id="api-key-modal-title"
+                        className="text-secondary-100 text-sm font-semibold"
+                    >
+                        {PROVIDER_DISPLAY[provider]} API 키가 필요해요
+                    </h2>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        aria-label="닫기"
+                        className="text-secondary-500 hover:text-secondary-300 focus-visible:ring-primary-500 rounded p-1 transition-colors focus-visible:ring-1 focus-visible:outline-none"
+                    >
+                        ✕
+                    </button>
+                </div>
+
+                <div className="px-5 py-4 flex flex-col gap-4">
+                    <p className="text-secondary-400 text-sm leading-relaxed">
+                        {bodyText}
+                    </p>
+
+                    <div className="flex flex-col gap-2">
+                        <Link
+                            href={ctaHref}
+                            onClick={onClose}
+                            className="bg-primary-600 hover:bg-primary-500 focus-visible:ring-primary-500 flex h-9 items-center justify-center rounded-lg px-4 text-sm font-medium text-white transition-colors focus-visible:ring-1 focus-visible:outline-none"
+                        >
+                            {ctaLabel}
+                        </Link>
+
+                        <button
+                            type="button"
+                            onClick={onSwitchToFree}
+                            className="text-secondary-400 hover:text-secondary-200 focus-visible:ring-primary-500 flex h-9 items-center justify-center rounded-lg border border-secondary-700 px-4 text-sm transition-colors focus-visible:ring-1 focus-visible:outline-none"
+                        >
+                            무료 모델로 계속하기
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/chat/UserApiKeyRequiredModal.tsx
+++ b/src/components/chat/UserApiKeyRequiredModal.tsx
@@ -49,7 +49,7 @@ export function UserApiKeyRequiredModal({
 
     return (
         <div
-            className="fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm bg-secondary-950/80"
+            className="bg-secondary-950/80 fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm"
             aria-hidden="true"
         >
             <div
@@ -59,10 +59,10 @@ export function UserApiKeyRequiredModal({
                 aria-labelledby="api-key-modal-title"
                 tabIndex={-1}
                 className={cn(
-                    'border border-secondary-700 bg-secondary-800 rounded-xl shadow-2xl w-full max-w-sm outline-none'
+                    'border-secondary-700 bg-secondary-800 w-full max-w-sm rounded-xl border shadow-2xl outline-none'
                 )}
             >
-                <div className="border-b border-secondary-700 flex items-center justify-between px-5 py-4">
+                <div className="border-secondary-700 flex items-center justify-between border-b px-5 py-4">
                     <h2
                         id="api-key-modal-title"
                         className="text-secondary-100 text-sm font-semibold"
@@ -79,7 +79,7 @@ export function UserApiKeyRequiredModal({
                     </button>
                 </div>
 
-                <div className="px-5 py-4 flex flex-col gap-4">
+                <div className="flex flex-col gap-4 px-5 py-4">
                     <p className="text-secondary-400 text-sm leading-relaxed">
                         {bodyText}
                     </p>
@@ -96,7 +96,7 @@ export function UserApiKeyRequiredModal({
                         <button
                             type="button"
                             onClick={onSwitchToFree}
-                            className="text-secondary-400 hover:text-secondary-200 focus-visible:ring-primary-500 flex h-9 items-center justify-center rounded-lg border border-secondary-700 px-4 text-sm transition-colors focus-visible:ring-1 focus-visible:outline-none"
+                            className="text-secondary-400 hover:text-secondary-200 focus-visible:ring-primary-500 border-secondary-700 flex h-9 items-center justify-center rounded-lg border px-4 text-sm transition-colors focus-visible:ring-1 focus-visible:outline-none"
                         >
                             무료 모델로 계속하기
                         </button>

--- a/src/components/chat/UserApiKeyRequiredModal.tsx
+++ b/src/components/chat/UserApiKeyRequiredModal.tsx
@@ -4,7 +4,6 @@ import { useRef, useEffect } from 'react';
 import Link from 'next/link';
 import { useFocusTrap } from '@/components/hooks/useFocusTrap';
 import { useEscapeKey } from '@/components/hooks/useEscapeKey';
-import { cn } from '@/lib/cn';
 import type { LlmProvider } from '@y0ngha/siglens-core';
 
 const PROVIDER_DISPLAY: Record<LlmProvider, string> = {
@@ -48,19 +47,14 @@ export function UserApiKeyRequiredModal({
         : '회원가입하고 본인의 API 키를 등록하면 이 모델을 사용할 수 있어요.';
 
     return (
-        <div
-            className="bg-secondary-950/80 fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm"
-            aria-hidden="true"
-        >
+        <div className="bg-secondary-950/80 fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm">
             <div
                 ref={dialogRef}
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby="api-key-modal-title"
                 tabIndex={-1}
-                className={cn(
-                    'border-secondary-700 bg-secondary-800 w-full max-w-sm rounded-xl border shadow-2xl outline-none'
-                )}
+                className="border-secondary-700 bg-secondary-800 w-full max-w-sm rounded-xl border shadow-2xl outline-none"
             >
                 <div className="border-secondary-700 flex items-center justify-between border-b px-5 py-4">
                     <h2

--- a/src/components/chat/UserApiKeyRequiredModal.tsx
+++ b/src/components/chat/UserApiKeyRequiredModal.tsx
@@ -82,7 +82,7 @@ export function UserApiKeyRequiredModal({
                         <Link
                             href={ctaHref}
                             onClick={onClose}
-                            className="bg-primary-600 hover:bg-primary-500 focus-visible:ring-primary-500 flex h-9 items-center justify-center rounded-lg px-4 text-sm font-medium text-white transition-colors focus-visible:ring-1 focus-visible:outline-none"
+                            className="bg-primary-600 hover:bg-primary-500 focus-visible:ring-primary-500 text-secondary-50 flex h-9 items-center justify-center rounded-lg px-4 text-sm font-medium transition-colors focus-visible:ring-1 focus-visible:outline-none"
                         >
                             {ctaLabel}
                         </Link>

--- a/src/components/chat/hooks/useChat.ts
+++ b/src/components/chat/hooks/useChat.ts
@@ -16,7 +16,7 @@ import type {
     ChatErrorCode,
     ChatLoadingPhase,
     ChatMessage,
-    ChatModel,
+    ModelId,
     Timeframe,
 } from '@y0ngha/siglens-core';
 import { chatAction } from '@/infrastructure/chat/chatAction';
@@ -47,9 +47,11 @@ const ERROR_MESSAGES: Record<ChatErrorCode, string> = {
     server_error: '일시적인 오류가 발생했어요. 다시 시도해주세요.',
     model_not_allowed:
         '선택한 모델은 현재 회원 등급에서 사용할 수 없어요. 다른 모델을 선택해주세요.',
+    user_api_key_required:
+        '이 모델은 본인 API 키가 필요해요. 키를 등록하면 사용할 수 있어요.',
 };
 
-function isValidChatModel(value: string): value is ChatModel {
+function isValidChatModel(value: string): value is ModelId {
     return VALID_CHAT_MODELS.some(model => model === value);
 }
 
@@ -79,8 +81,10 @@ export interface UseChatReturn {
     remainingTokens: number | null;
     sendMessage: (text: string) => Promise<void>;
     dismissAnalysisUpdated: () => void;
-    selectedModel: ChatModel;
-    handleModelChange: (model: ChatModel) => void;
+    selectedModel: ModelId;
+    handleModelChange: (model: ModelId) => void;
+    apiKeyModalOpen: boolean;
+    closeApiKeyModal: () => void;
 }
 
 export function useChat({
@@ -94,9 +98,10 @@ export function useChat({
         null
     );
     const [analysisUpdated, setAnalysisUpdated] = useState(false);
-    const [selectedModel, setSelectedModel] = useState<ChatModel>(
+    const [selectedModel, setSelectedModel] = useState<ModelId>(
         GEMINI_2_5_FLASH_MODEL
     );
+    const [apiKeyModalOpen, setApiKeyModalOpen] = useState(false);
 
     const phaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     // null on first render — treated as "not yet compared" to prevent false banner on mount
@@ -168,6 +173,9 @@ export function useChat({
                     result.remainingTokens
                 );
             }
+            if (!result.ok && result.error === 'user_api_key_required') {
+                setApiKeyModalOpen(true);
+            }
         },
         onError: () => {
             setMessages(prev => [
@@ -197,9 +205,11 @@ export function useChat({
         setAnalysisUpdated(false);
     }, []);
 
-    const handleModelChange = useCallback((model: ChatModel) => {
+    const handleModelChange = useCallback((model: ModelId) => {
         setSelectedModel(model);
     }, []);
+
+    const closeApiKeyModal = useCallback(() => setApiKeyModalOpen(false), []);
 
     // Sync latest-value refs after commit (useLayoutEffect is safe in concurrent React;
     // inline render assignments can be stale under interrupted/discarded renders)
@@ -321,5 +331,7 @@ export function useChat({
         dismissAnalysisUpdated,
         selectedModel,
         handleModelChange,
+        apiKeyModalOpen,
+        closeApiKeyModal,
     };
 }

--- a/src/infrastructure/ai/anthropic.ts
+++ b/src/infrastructure/ai/anthropic.ts
@@ -1,5 +1,9 @@
 import Anthropic from '@anthropic-ai/sdk';
-import type { AiContents, CallAiProviderOptions, GeminiContent } from '@y0ngha/siglens-core';
+import type {
+    AiContents,
+    CallAiProviderOptions,
+    GeminiContent,
+} from '@y0ngha/siglens-core';
 
 const ANTHROPIC_MAX_TOKENS = 8192;
 
@@ -16,7 +20,7 @@ function toAnthropicMessages(contents: AiContents): Anthropic.MessageParam[] {
     }
     return contents.map((turn: GeminiContent) => ({
         role: turn.role === 'model' ? 'assistant' : 'user',
-        content: turn.parts.map((p) => p.text).join(''),
+        content: turn.parts.map(p => p.text).join(''),
     }));
 }
 
@@ -31,11 +35,15 @@ async function callAnthropic({
         model,
         max_tokens: ANTHROPIC_MAX_TOKENS,
         messages: toAnthropicMessages(contents),
-        ...(systemInstruction !== undefined ? { system: systemInstruction } : {}),
+        ...(systemInstruction !== undefined
+            ? { system: systemInstruction }
+            : {}),
     });
     const block = response.content[0];
     if (!block || block.type !== 'text') {
-        throw new Error(`Anthropic returned no text content (stop_reason: ${response.stop_reason})`);
+        throw new Error(
+            `Anthropic returned no text content (stop_reason: ${response.stop_reason})`
+        );
     }
     return block.text;
 }
@@ -50,10 +58,20 @@ export async function callAnthropicChat({
 }: CallAiProviderOptions): Promise<string> {
     if (primaryApiKey) {
         try {
-            return await callAnthropic({ apiKey: primaryApiKey, model, contents, systemInstruction });
+            return await callAnthropic({
+                apiKey: primaryApiKey,
+                model,
+                contents,
+                systemInstruction,
+            });
         } catch {
             // primary key failed (quota/rate limit) — fall through to fallback key
         }
     }
-    return callAnthropic({ apiKey: fallbackApiKey, model, contents, systemInstruction });
+    return callAnthropic({
+        apiKey: fallbackApiKey,
+        model,
+        contents,
+        systemInstruction,
+    });
 }

--- a/src/infrastructure/ai/anthropic.ts
+++ b/src/infrastructure/ai/anthropic.ts
@@ -12,9 +12,7 @@ interface AnthropicCallOptions {
 }
 
 function toAnthropicMessages(contents: AiContents): Anthropic.MessageParam[] {
-    // Safe cast: toProviderTurns returns { role: 'user' | 'assistant'; content: string }[]
-    // which is structurally compatible with MessageParam — role is always one of the two
-    // valid literals and string satisfies string | ContentBlockParam[] at runtime.
+    // Safe cast: ProviderTurn is structurally compatible with MessageParam (role literals + string content).
     return toProviderTurns(contents) as Anthropic.MessageParam[];
 }
 

--- a/src/infrastructure/ai/anthropic.ts
+++ b/src/infrastructure/ai/anthropic.ts
@@ -1,9 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
-import type {
-    AiContents,
-    CallAiProviderOptions,
-    GeminiContent,
-} from '@y0ngha/siglens-core';
+import type { AiContents, CallAiProviderOptions } from '@y0ngha/siglens-core';
+import { toProviderTurns } from '@/infrastructure/ai/utils';
 
 const ANTHROPIC_MAX_TOKENS = 8192;
 
@@ -15,13 +12,10 @@ interface AnthropicCallOptions {
 }
 
 function toAnthropicMessages(contents: AiContents): Anthropic.MessageParam[] {
-    if (typeof contents === 'string') {
-        return [{ role: 'user', content: contents }];
-    }
-    return contents.map((turn: GeminiContent) => ({
-        role: turn.role === 'model' ? 'assistant' : 'user',
-        content: turn.parts.map(p => p.text).join(''),
-    }));
+    // Safe cast: toProviderTurns returns { role: 'user' | 'assistant'; content: string }[]
+    // which is structurally compatible with MessageParam — role is always one of the two
+    // valid literals and string satisfies string | ContentBlockParam[] at runtime.
+    return toProviderTurns(contents) as Anthropic.MessageParam[];
 }
 
 async function callAnthropic({

--- a/src/infrastructure/ai/anthropic.ts
+++ b/src/infrastructure/ai/anthropic.ts
@@ -1,0 +1,59 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { AiContents, CallAiProviderOptions, GeminiContent } from '@y0ngha/siglens-core';
+
+const ANTHROPIC_MAX_TOKENS = 8192;
+
+interface AnthropicCallOptions {
+    apiKey: string;
+    model: string;
+    contents: AiContents;
+    systemInstruction?: string;
+}
+
+function toAnthropicMessages(contents: AiContents): Anthropic.MessageParam[] {
+    if (typeof contents === 'string') {
+        return [{ role: 'user', content: contents }];
+    }
+    return contents.map((turn: GeminiContent) => ({
+        role: turn.role === 'model' ? 'assistant' : 'user',
+        content: turn.parts.map((p) => p.text).join(''),
+    }));
+}
+
+async function callAnthropic({
+    apiKey,
+    model,
+    contents,
+    systemInstruction,
+}: AnthropicCallOptions): Promise<string> {
+    const client = new Anthropic({ apiKey });
+    const response = await client.messages.create({
+        model,
+        max_tokens: ANTHROPIC_MAX_TOKENS,
+        messages: toAnthropicMessages(contents),
+        ...(systemInstruction !== undefined ? { system: systemInstruction } : {}),
+    });
+    const block = response.content[0];
+    if (!block || block.type !== 'text') {
+        throw new Error(`Anthropic returned no text content (stop_reason: ${response.stop_reason})`);
+    }
+    return block.text;
+}
+
+/** Call Anthropic with primary→fallback key fallback; primary errors are swallowed, fallback errors propagate. */
+export async function callAnthropicChat({
+    primaryApiKey,
+    fallbackApiKey,
+    model,
+    contents,
+    systemInstruction,
+}: CallAiProviderOptions): Promise<string> {
+    if (primaryApiKey) {
+        try {
+            return await callAnthropic({ apiKey: primaryApiKey, model, contents, systemInstruction });
+        } catch {
+            // primary key failed (quota/rate limit) — fall through to fallback key
+        }
+    }
+    return callAnthropic({ apiKey: fallbackApiKey, model, contents, systemInstruction });
+}

--- a/src/infrastructure/ai/openai.ts
+++ b/src/infrastructure/ai/openai.ts
@@ -1,9 +1,6 @@
 import OpenAI from 'openai';
-import type {
-    AiContents,
-    CallAiProviderOptions,
-    GeminiContent,
-} from '@y0ngha/siglens-core';
+import type { AiContents, CallAiProviderOptions } from '@y0ngha/siglens-core';
+import { toProviderTurns } from '@/infrastructure/ai/utils';
 
 interface OpenAiCallOptions {
     apiKey: string;
@@ -20,17 +17,12 @@ function toOpenAiMessages(
         systemInstruction !== undefined
             ? [{ role: 'system', content: systemInstruction }]
             : [];
-
-    if (typeof contents === 'string') {
-        return [...system, { role: 'user', content: contents }];
-    }
-
-    const turns: OpenAI.ChatCompletionMessageParam[] = contents.map(
-        (turn: GeminiContent) => ({
-            role: turn.role === 'model' ? 'assistant' : 'user',
-            content: turn.parts.map(p => p.text).join(''),
-        })
-    );
+    // Safe cast: toProviderTurns returns { role: 'user' | 'assistant'; content: string }[]
+    // which is structurally compatible with ChatCompletionMessageParam — role is always one
+    // of the two valid literals and string satisfies the content union at runtime.
+    const turns = toProviderTurns(
+        contents
+    ) as OpenAI.ChatCompletionMessageParam[];
     return [...system, ...turns];
 }
 
@@ -45,7 +37,11 @@ async function callOpenai({
         model,
         messages: toOpenAiMessages(contents, systemInstruction),
     });
-    return response.choices[0]?.message.content ?? '';
+    const content = response.choices[0]?.message.content;
+    if (content == null) {
+        throw new Error('OpenAI returned no text content');
+    }
+    return content;
 }
 
 /** Call OpenAI with primary→fallback key fallback; primary errors are swallowed, fallback errors propagate. */

--- a/src/infrastructure/ai/openai.ts
+++ b/src/infrastructure/ai/openai.ts
@@ -17,9 +17,7 @@ function toOpenAiMessages(
         systemInstruction !== undefined
             ? [{ role: 'system', content: systemInstruction }]
             : [];
-    // Safe cast: toProviderTurns returns { role: 'user' | 'assistant'; content: string }[]
-    // which is structurally compatible with ChatCompletionMessageParam — role is always one
-    // of the two valid literals and string satisfies the content union at runtime.
+    // Safe cast: ProviderTurn is structurally compatible with ChatCompletionMessageParam (role literals + string content).
     const turns = toProviderTurns(
         contents
     ) as OpenAI.ChatCompletionMessageParam[];

--- a/src/infrastructure/ai/openai.ts
+++ b/src/infrastructure/ai/openai.ts
@@ -1,5 +1,9 @@
 import OpenAI from 'openai';
-import type { AiContents, CallAiProviderOptions, GeminiContent } from '@y0ngha/siglens-core';
+import type {
+    AiContents,
+    CallAiProviderOptions,
+    GeminiContent,
+} from '@y0ngha/siglens-core';
 
 interface OpenAiCallOptions {
     apiKey: string;
@@ -10,7 +14,7 @@ interface OpenAiCallOptions {
 
 function toOpenAiMessages(
     contents: AiContents,
-    systemInstruction?: string,
+    systemInstruction?: string
 ): OpenAI.ChatCompletionMessageParam[] {
     const system: OpenAI.ChatCompletionMessageParam[] =
         systemInstruction !== undefined
@@ -24,8 +28,8 @@ function toOpenAiMessages(
     const turns: OpenAI.ChatCompletionMessageParam[] = contents.map(
         (turn: GeminiContent) => ({
             role: turn.role === 'model' ? 'assistant' : 'user',
-            content: turn.parts.map((p) => p.text).join(''),
-        }),
+            content: turn.parts.map(p => p.text).join(''),
+        })
     );
     return [...system, ...turns];
 }
@@ -54,10 +58,20 @@ export async function callOpenaiChat({
 }: CallAiProviderOptions): Promise<string> {
     if (primaryApiKey) {
         try {
-            return await callOpenai({ apiKey: primaryApiKey, model, contents, systemInstruction });
+            return await callOpenai({
+                apiKey: primaryApiKey,
+                model,
+                contents,
+                systemInstruction,
+            });
         } catch {
             // primary key failed (quota/rate limit) — fall through to fallback key
         }
     }
-    return callOpenai({ apiKey: fallbackApiKey, model, contents, systemInstruction });
+    return callOpenai({
+        apiKey: fallbackApiKey,
+        model,
+        contents,
+        systemInstruction,
+    });
 }

--- a/src/infrastructure/ai/openai.ts
+++ b/src/infrastructure/ai/openai.ts
@@ -1,0 +1,63 @@
+import OpenAI from 'openai';
+import type { AiContents, CallAiProviderOptions, GeminiContent } from '@y0ngha/siglens-core';
+
+interface OpenAiCallOptions {
+    apiKey: string;
+    model: string;
+    contents: AiContents;
+    systemInstruction?: string;
+}
+
+function toOpenAiMessages(
+    contents: AiContents,
+    systemInstruction?: string,
+): OpenAI.ChatCompletionMessageParam[] {
+    const system: OpenAI.ChatCompletionMessageParam[] =
+        systemInstruction !== undefined
+            ? [{ role: 'system', content: systemInstruction }]
+            : [];
+
+    if (typeof contents === 'string') {
+        return [...system, { role: 'user', content: contents }];
+    }
+
+    const turns: OpenAI.ChatCompletionMessageParam[] = contents.map(
+        (turn: GeminiContent) => ({
+            role: turn.role === 'model' ? 'assistant' : 'user',
+            content: turn.parts.map((p) => p.text).join(''),
+        }),
+    );
+    return [...system, ...turns];
+}
+
+async function callOpenai({
+    apiKey,
+    model,
+    contents,
+    systemInstruction,
+}: OpenAiCallOptions): Promise<string> {
+    const client = new OpenAI({ apiKey });
+    const response = await client.chat.completions.create({
+        model,
+        messages: toOpenAiMessages(contents, systemInstruction),
+    });
+    return response.choices[0]?.message.content ?? '';
+}
+
+/** Call OpenAI with primary→fallback key fallback; primary errors are swallowed, fallback errors propagate. */
+export async function callOpenaiChat({
+    primaryApiKey,
+    fallbackApiKey,
+    model,
+    contents,
+    systemInstruction,
+}: CallAiProviderOptions): Promise<string> {
+    if (primaryApiKey) {
+        try {
+            return await callOpenai({ apiKey: primaryApiKey, model, contents, systemInstruction });
+        } catch {
+            // primary key failed (quota/rate limit) — fall through to fallback key
+        }
+    }
+    return callOpenai({ apiKey: fallbackApiKey, model, contents, systemInstruction });
+}

--- a/src/infrastructure/ai/router.ts
+++ b/src/infrastructure/ai/router.ts
@@ -1,8 +1,8 @@
 import { getProviderForModel } from '@y0ngha/siglens-core';
 import type { CallAiProviderOptions, ModelId } from '@y0ngha/siglens-core';
-import { callAnthropicChat } from './anthropic';
-import { callGeminiWithKeyFallback } from './gemini';
-import { callOpenaiChat } from './openai';
+import { callAnthropicChat } from '@/infrastructure/ai/anthropic';
+import { callGeminiWithKeyFallback } from '@/infrastructure/ai/gemini';
+import { callOpenaiChat } from '@/infrastructure/ai/openai';
 
 export async function callAiProviderRouter(
     options: CallAiProviderOptions

--- a/src/infrastructure/ai/router.ts
+++ b/src/infrastructure/ai/router.ts
@@ -7,8 +7,7 @@ import { callOpenaiChat } from '@/infrastructure/ai/openai';
 export async function callAiProviderRouter(
     options: CallAiProviderOptions
 ): Promise<string> {
-    // Safe cast: getProviderForModel never throws — unknown strings fall through to
-    // prefix matching ('claude-'/'gemini-') and default to 'openai'.
+    // Safe cast: getProviderForModel matches model prefix and defaults to 'openai' for unknown strings.
     const provider = getProviderForModel(options.model as ModelId);
     switch (provider) {
         case 'anthropic':

--- a/src/infrastructure/ai/router.ts
+++ b/src/infrastructure/ai/router.ts
@@ -4,7 +4,9 @@ import { callAnthropicChat } from './anthropic';
 import { callGeminiWithKeyFallback } from './gemini';
 import { callOpenaiChat } from './openai';
 
-export async function callAiProviderRouter(options: CallAiProviderOptions): Promise<string> {
+export async function callAiProviderRouter(
+    options: CallAiProviderOptions
+): Promise<string> {
     // Safe cast: getProviderForModel never throws — unknown strings fall through to
     // prefix matching ('claude-'/'gemini-') and default to 'openai'.
     const provider = getProviderForModel(options.model as ModelId);

--- a/src/infrastructure/ai/router.ts
+++ b/src/infrastructure/ai/router.ts
@@ -1,0 +1,23 @@
+import { getProviderForModel } from '@y0ngha/siglens-core';
+import type { CallAiProviderOptions, ModelId } from '@y0ngha/siglens-core';
+import { callAnthropicChat } from './anthropic';
+import { callGeminiWithKeyFallback } from './gemini';
+import { callOpenaiChat } from './openai';
+
+export async function callAiProviderRouter(options: CallAiProviderOptions): Promise<string> {
+    // Safe cast: getProviderForModel never throws — unknown strings fall through to
+    // prefix matching ('claude-'/'gemini-') and default to 'openai'.
+    const provider = getProviderForModel(options.model as ModelId);
+    switch (provider) {
+        case 'anthropic':
+            return callAnthropicChat(options);
+        case 'openai':
+            return callOpenaiChat(options);
+        case 'google':
+            return callGeminiWithKeyFallback(options);
+        default: {
+            const exhausted: never = provider;
+            throw new Error(`Unhandled AI provider: ${String(exhausted)}`);
+        }
+    }
+}

--- a/src/infrastructure/ai/utils.ts
+++ b/src/infrastructure/ai/utils.ts
@@ -5,7 +5,6 @@ export interface ProviderTurn {
     content: string;
 }
 
-// Converts AiContents to provider-neutral user/assistant turns shared by all AI adapters.
 export function toProviderTurns(contents: AiContents): ProviderTurn[] {
     if (typeof contents === 'string') {
         return [{ role: 'user', content: contents }];

--- a/src/infrastructure/ai/utils.ts
+++ b/src/infrastructure/ai/utils.ts
@@ -11,8 +11,7 @@ export function toProviderTurns(contents: AiContents): ProviderTurn[] {
         return [{ role: 'user', content: contents }];
     }
     return contents.map((turn: GeminiContent) => ({
-        role:
-            turn.role === 'model' ? ('assistant' as const) : ('user' as const),
+        role: turn.role === 'model' ? 'assistant' : 'user',
         content: turn.parts.map(p => p.text ?? '').join(''),
     }));
 }

--- a/src/infrastructure/ai/utils.ts
+++ b/src/infrastructure/ai/utils.ts
@@ -1,0 +1,18 @@
+import type { AiContents, GeminiContent } from '@y0ngha/siglens-core';
+
+export interface ProviderTurn {
+    role: 'user' | 'assistant';
+    content: string;
+}
+
+// Converts AiContents to provider-neutral user/assistant turns shared by all AI adapters.
+export function toProviderTurns(contents: AiContents): ProviderTurn[] {
+    if (typeof contents === 'string') {
+        return [{ role: 'user', content: contents }];
+    }
+    return contents.map((turn: GeminiContent) => ({
+        role:
+            turn.role === 'model' ? ('assistant' as const) : ('user' as const),
+        content: turn.parts.map(p => p.text ?? '').join(''),
+    }));
+}

--- a/src/infrastructure/chat/chatAction.ts
+++ b/src/infrastructure/chat/chatAction.ts
@@ -2,17 +2,23 @@
 
 import {
     GEMINI_2_5_FLASH_MODEL,
+    TIER_CONFIG,
+    getProviderForModel,
     requestChatCompletion,
 } from '@y0ngha/siglens-core';
 import type {
     AnalysisResponse,
     ChatActionResult,
     ChatMessage,
-    ChatModel,
+    LlmProvider,
+    ModelId,
     Timeframe,
 } from '@y0ngha/siglens-core';
 import { headers } from 'next/headers';
-import { callGeminiWithKeyFallback } from '@/infrastructure/ai/gemini';
+import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
+import { getAuthDatabaseClient } from '@/infrastructure/auth/db';
+import { DrizzleUserApiKeyRepository } from '@/infrastructure/db/userApiKeyRepository';
+import { callAiProviderRouter } from '@/infrastructure/ai/router';
 
 async function getClientIp(): Promise<string> {
     const headersList = await headers();
@@ -21,21 +27,73 @@ async function getClientIp(): Promise<string> {
     );
 }
 
+function getServerPaidKey(provider: LlmProvider): string | undefined {
+    switch (provider) {
+        case 'google':
+            return process.env.GEMINI_CHAT_API_KEY;
+        case 'anthropic':
+            return process.env.ANTHROPIC_CHAT_API_KEY;
+        case 'openai':
+            return process.env.OPENAI_CHAT_API_KEY;
+        default: {
+            const exhausted: never = provider;
+            throw new Error(`Unhandled LLM provider: ${String(exhausted)}`);
+        }
+    }
+}
+
+function getServerFreeKey(provider: LlmProvider): string | undefined {
+    // Only Google provides a free-quota fallback key; other providers use the paid key exclusively.
+    switch (provider) {
+        case 'google':
+            return process.env.GEMINI_CHAT_FREE_API_KEY;
+        case 'anthropic':
+        case 'openai':
+            return undefined;
+        default: {
+            const exhausted: never = provider;
+            throw new Error(`Unhandled LLM provider: ${String(exhausted)}`);
+        }
+    }
+}
+
+async function resolvePaidApiKey(
+    model: ModelId,
+    provider: LlmProvider,
+    serverPaidKey: string,
+): Promise<string | undefined> {
+    if ((TIER_CONFIG.models.free as readonly string[]).includes(model)) {
+        return serverPaidKey;
+    }
+    const user = await getCurrentUser();
+    if (!user) return undefined;
+    const { db } = getAuthDatabaseClient();
+    const repo = new DrizzleUserApiKeyRepository(db);
+    const record = await repo.findByUserAndProvider(user.id, provider);
+    return record?.apiKey;
+    // undefined → requestChatCompletion returns user_api_key_required
+}
+
 export async function chatAction(
     symbol: string,
     timeframe: Timeframe,
     analysis: AnalysisResponse,
     history: ChatMessage[],
     userMessage: string,
-    model: ChatModel = GEMINI_2_5_FLASH_MODEL
+    model: ModelId = GEMINI_2_5_FLASH_MODEL
 ): Promise<ChatActionResult> {
-    const paidApiKey = process.env.GEMINI_API_KEY;
-    if (!paidApiKey) {
+    const provider = getProviderForModel(model);
+    const serverPaidKey = getServerPaidKey(provider);
+    if (!serverPaidKey) {
         return { ok: false, error: 'server_error' };
     }
 
     try {
-        const clientIp = await getClientIp();
+        const [paidApiKey, clientIp] = await Promise.all([
+            resolvePaidApiKey(model, provider, serverPaidKey),
+            getClientIp(),
+        ]);
+
         return await requestChatCompletion(
             {
                 clientIp,
@@ -45,11 +103,11 @@ export async function chatAction(
                 history,
                 userMessage,
                 model,
-                freeApiKey: process.env.GEMINI_CHAT_FREE_API_KEY,
+                freeApiKey: getServerFreeKey(provider),
                 paidApiKey,
             },
             {
-                callAiProvider: callGeminiWithKeyFallback,
+                callAiProvider: callAiProviderRouter,
             }
         );
     } catch {

--- a/src/infrastructure/chat/chatAction.ts
+++ b/src/infrastructure/chat/chatAction.ts
@@ -60,7 +60,7 @@ function getServerFreeKey(provider: LlmProvider): string | undefined {
 async function resolvePaidApiKey(
     model: ModelId,
     provider: LlmProvider,
-    serverPaidKey: string,
+    serverPaidKey: string
 ): Promise<string | undefined> {
     if ((TIER_CONFIG.models.free as readonly string[]).includes(model)) {
         return serverPaidKey;

--- a/src/infrastructure/chat/chatAction.ts
+++ b/src/infrastructure/chat/chatAction.ts
@@ -62,8 +62,7 @@ async function resolvePaidApiKey(
     provider: LlmProvider,
     serverPaidKey: string
 ): Promise<string | undefined> {
-    // Safe cast: TIER_CONFIG.models.free is readonly ModelId[] and ModelId ⊆ string;
-    // Array.prototype.includes widens the parameter type to string when called with a string arg.
+    // Safe cast: ModelId ⊆ string; Array.includes widens the argument type to string.
     if ((TIER_CONFIG.models.free as readonly string[]).includes(model)) {
         return serverPaidKey;
     }

--- a/src/infrastructure/chat/chatAction.ts
+++ b/src/infrastructure/chat/chatAction.ts
@@ -62,6 +62,8 @@ async function resolvePaidApiKey(
     provider: LlmProvider,
     serverPaidKey: string
 ): Promise<string | undefined> {
+    // Safe cast: TIER_CONFIG.models.free is readonly ModelId[] and ModelId ⊆ string;
+    // Array.prototype.includes widens the parameter type to string when called with a string arg.
     if ((TIER_CONFIG.models.free as readonly string[]).includes(model)) {
         return serverPaidKey;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@anthropic-ai/sdk@npm:^0.92.0":
+  version: 0.92.0
+  resolution: "@anthropic-ai/sdk@npm:0.92.0"
+  dependencies:
+    json-schema-to-ts: "npm:^3.1.1"
+  peerDependencies:
+    zod: ^3.25.0 || ^4.0.0
+  peerDependenciesMeta:
+    zod:
+      optional: true
+  bin:
+    anthropic-ai-sdk: bin/cli
+  checksum: 10c0/a06f2ebc4dce6e3ee36e3cc938b9fb952a6eebaa3b4478351770d0bf264aa3cb141a5a6854cdc93d1693218415d626338f66d0c446e1d1fa2402a02dcd890610
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.27.1, @babel/code-frame@npm:^7.28.6, @babel/code-frame@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/code-frame@npm:7.29.0"
@@ -342,6 +358,13 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/b0c392a35624883ac480277401ac7d92d8646b66e33639f5d350de7a6723924265985ae11ab9ebd551740ded261c443eaa9a87ea19def9763ca1e0d78c97dea8
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.18.3":
+  version: 7.29.2
+  resolution: "@babel/runtime@npm:7.29.2"
+  checksum: 10c0/30b80a0140d16467792e1bbeb06f655b0dab70407da38dfac7fedae9c859f9ae9d846ef14ad77bd3814c064295fe9b1bc551f1541ea14646ae9f22b71a8bc17a
   languageName: node
   linkType: hard
 
@@ -8004,6 +8027,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-schema-to-ts@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "json-schema-to-ts@npm:3.1.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.18.3"
+    ts-algebra: "npm:^2.0.0"
+  checksum: 10c0/609bae04aa5e860a11b6d30ccf41445fae1c7f66fb600c1d170257cf33aa468aa9d03aa046428c3688aff0ff450c2b0c76584b66fa4a5d0da8e33799e4c439a6
+  languageName: node
+  linkType: hard
+
 "json-schema-traverse@npm:^0.4.1":
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
@@ -9446,6 +9479,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"openai@npm:^6.35.0":
+  version: 6.35.0
+  resolution: "openai@npm:6.35.0"
+  peerDependencies:
+    ws: ^8.18.0
+    zod: ^3.25 || ^4.0
+  peerDependenciesMeta:
+    ws:
+      optional: true
+    zod:
+      optional: true
+  bin:
+    openai: bin/cli
+  checksum: 10c0/b5be8c9c26b8991bc06e94d2de9ec046d7e8497f3828f8ff3cd7796cfd5e39e464a52afa2f4959003183e61a909c6ee261ca4380a61cb1f2e9a56629058314ed
+  languageName: node
+  linkType: hard
+
 "optionator@npm:^0.9.3":
   version: 0.9.4
   resolution: "optionator@npm:0.9.4"
@@ -10709,6 +10759,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "siglens@workspace:."
   dependencies:
+    "@anthropic-ai/sdk": "npm:^0.92.0"
     "@google/genai": "npm:^1.50.1"
     "@neondatabase/serverless": "npm:^1.1.0"
     "@release-it/conventional-changelog": "npm:^10.0.6"
@@ -10734,6 +10785,7 @@ __metadata:
     jest: "npm:^30.2.0"
     lightweight-charts: "npm:^5.1.0"
     next: "npm:16.2.0"
+    openai: "npm:^6.35.0"
     prettier: "npm:^3.7.4"
     prettier-plugin-tailwindcss: "npm:^0.7.2"
     react: "npm:19.2.4"
@@ -11451,6 +11503,13 @@ __metadata:
   version: 2.2.0
   resolution: "trough@npm:2.2.0"
   checksum: 10c0/58b671fc970e7867a48514168894396dd94e6d9d6456aca427cc299c004fe67f35ed7172a36449086b2edde10e78a71a284ec0076809add6834fb8f857ccb9b0
+  languageName: node
+  linkType: hard
+
+"ts-algebra@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "ts-algebra@npm:2.0.0"
+  checksum: 10c0/4ae93bec1bada635bba425854eec323dad50b6ffe86bc04ad2d7f9ce3fb129d673dcf483e19a6e70d07a3a9083e6a0a7f4e004bb8d2164cddc60cc9540ba187f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

멀티 provider 챗봇 모델 선택 기능을 추가합니다.

- Claude (Anthropic), Google Gemini, OpenAI ChatGPT 3개 provider 지원
- 무료 기본 모델(Claude 3.5 Sonnet, Gemini 2.0 Flash, ChatGPT 4o Mini) 제공
- 프리미엄 모델(Claude 3 Opus, Gemini 2.0 Pro, ChatGPT 4 Turbo) 사용자 API 키로 구동
- siglens-core 0.7.1 버전 의존도 최신화

## Paywall UX

프리미엄 모델 선택 시 `user_api_key_required` 에러가 발생하면:
- 로그인 사용자: API 키 입력 모달(`UserApiKeyRequiredModal`) 표시
- 게스트 사용자: 회원가입 유도 모달 표시

## Test Coverage

28개 신규 테스트 추가:
- `anthropic.test.ts`: 7 tests (primary→fallback key 토글, 에러 핸들링)
- `openai.test.ts`: 7 tests (동일 패턴)
- `router.test.ts`: 3 tests (provider 라우팅)
- `chatAction.test.ts`: 14 tests (멀티 provider, 사용자 API 키 조회, 병렬 처리)

전체 903개 테스트 통과

## Out of Scope

- API 키 등록 페이지: #402로 추적 예정
- 분석 페이지 모델 선택: #402로 추적 예정