### PR TITLE
chore: upgrade @y0ngha/siglens-core to 0.7.3

### DIFF
--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -757,29 +757,6 @@ This file contains only **recurring gotchas** that agents keep missing despite e
       - Add a compile-time check: `const _check: SkillCategory = SKILL_CATEGORIES[0];` paired with a satisfies clause on the array literal
       - Extract the mirror into a named const inside `siglens-core` itself and re-export
 
-4. Multi-line JSDoc blocks for single-line function descriptions — recurring across 11+ PR rounds
-   → All function comments must be single-line only; multi-line blocks add unnecessary verbosity
-   → This pattern persists in new code even though documented; enforce at code review
-   → Extract context/explanation into commit messages or documentation links if needed
-   → Applies to: file-top comments, component purpose descriptions, algorithm explanations, trust notes, type-export JSDoc
-   ❌ /**
-      * Handles authentication
-      * Sets up the session and applies cookies
-      */
-   ❌ /**
-      * We trust this source because...
-      * It undergoes validation at...
-      */
-   ❌ /**
-      * Caching configuration for news articles
-      * Defines TTL values for different news sources
-      */
-   ✅ // Handles authentication and session setup
-   ✅ // Trusted source (see validate-source.ts for detail)
-   ✅ // Caching configuration for news articles
-   → Recurring violation: 11+ consecutive PR rounds (R3, R7, R10, R11); appears in newly-written code
-   → Enforce: remove multi-line JSDoc from new features during PR review
-   → Applies to file-top blocks, type exports, component JSDoc, constant descriptions
 ```
 
 ---

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,18 @@
 # Fix Log
 
+## [PR #415 Round 2 | chore/upgrade-siglens-core-0.7.3 | 2026-05-04]
+- Violation: chatAction's getProviderForModel/getServerPrimaryKey calls placed outside try-catch block — 0.7.3 throws on unknown modelId
+- Rule: Server Actions must not propagate exceptions to the client — all throw paths must be caught and returned as { ok: false, error: 'server_error' }
+- Context: Moved getProviderForModel + getServerPrimaryKey inside try block. Updated chatAction.test.ts to assert resolves({ ok: false }) instead of rejects.toThrow. Removed comment describing old behavior.
+
+- Violation: submitOverallAnalysisAction had no try-catch — unexpected throws (e.g. DB failure, core throw) would crash the Server Action
+- Rule: Server Actions must return typed error results instead of propagating uncaught exceptions
+- Context: Wrapped entire body in try-catch; returns { status: 'error', axis: 'technical', error: e } on failure. Added corresponding test case.
+
+## [PR #415 Doc Policy Removal | chore/upgrade-siglens-core-0.7.3 | 2026-05-04]
+- Policy removed: MISTAKES.md Documentation Sync 규칙 4 (다중 라인 JSDoc 금지) — PR #415 review comments triggered by this rule were rejected; rule removed per user decision
+- Context: Three review comments (Blockers #3178568999, #3178569205 and Suggestion #3178569415) cited the multi-line JSDoc policy. User decided the policy was overly restrictive; removed from MISTAKES.md.
+
 ## [chore/upgrade-siglens-core-0.7.3 | Round 1 | 2026-05-04]
 - Violation: None — review-agent approved with zero findings
 - Rule: N/A

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,10 @@
 # Fix Log
 
+## [chore/upgrade-siglens-core-0.7.3 | Round 1 | 2026-05-04]
+- Violation: None — review-agent approved with zero findings
+- Rule: N/A
+- Context: Branch upgrades @y0ngha/siglens-core from 0.7.2 to 0.7.3 and applies five fixes for consumer-side breakages (useOverallAnalysis limit_error case, submitOverallAnalysisAction newsItems rename, chatAction key semantics, router comment). All changes approved on round 1.
+
 ## [Tasks 2.12–2.14 R1 | feat/fundamental-news-analysis | 2026-05-02]
 - Violation: SymbolPageHeader.tsx had orphaned border-secondary-700 class (border color with no border-direction after border-b removal)
 - Rule: MISTAKES.md rule 4 — Remove logic/code that has no effect (dead CSS)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@tanstack/react-query": "^5.95.2",
         "@upstash/redis": "^1.37.0",
         "@vercel/functions": "^3.4.3",
-        "@y0ngha/siglens-core": "0.7.2",
+        "@y0ngha/siglens-core": "0.7.3",
         "bcryptjs": "^3.0.3",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",

--- a/src/__tests__/infrastructure/chat/chatAction.test.ts
+++ b/src/__tests__/infrastructure/chat/chatAction.test.ts
@@ -458,23 +458,20 @@ describe('chatAction 함수는', () => {
     });
 
     describe('알 수 없는 provider 처리', () => {
-        it('getServerPrimaryKey가 알 수 없는 provider를 받으면 에러가 전파된다', async () => {
-            // getServerPrimaryKey is called outside the try block — the throw propagates
-            // rather than being caught as server_error.
+        it('알 수 없는 provider로 요청하면 server_error를 반환한다', async () => {
             mockGetProviderForModel.mockReturnValueOnce(
                 'unknown' as unknown as LlmProvider
             );
 
-            await expect(
-                chatAction(
-                    'AAPL',
-                    '1Day',
-                    MINIMAL_ANALYSIS,
-                    [],
-                    '질문',
-                    'gemini-2.5-flash'
-                )
-            ).rejects.toThrow('Unhandled LLM provider');
+            const result = await chatAction(
+                'AAPL',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '질문',
+                'gemini-2.5-flash'
+            );
+            expect(result).toEqual({ ok: false, error: 'server_error' });
         });
     });
 });

--- a/src/__tests__/infrastructure/chat/chatAction.test.ts
+++ b/src/__tests__/infrastructure/chat/chatAction.test.ts
@@ -92,7 +92,7 @@ function makeHeadersMap(xForwardedFor?: string) {
 describe('chatAction 함수는', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        process.env.GEMINI_CHAT_API_KEY = 'gemini-paid-key';
+        process.env.GEMINI_CHAT_API_KEY = 'gemini-server-key';
         delete process.env.GEMINI_CHAT_FREE_API_KEY;
         delete process.env.ANTHROPIC_CHAT_API_KEY;
         delete process.env.OPENAI_CHAT_API_KEY;
@@ -118,7 +118,7 @@ describe('chatAction 함수는', () => {
     });
 
     describe('Gemini 모델을 사용할 때', () => {
-        it('free Gemini 모델은 서버 paid key로 요청한다', async () => {
+        it('free Gemini 모델은 GEMINI_CHAT_API_KEY를 freeApiKey로 전달한다', async () => {
             const result = await chatAction(
                 'AAPL',
                 '1Day',
@@ -131,15 +131,15 @@ describe('chatAction 함수는', () => {
             expect(result).toBe(SUCCESS_RESULT);
             expect(mockRequestChatCompletion).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    paidApiKey: 'gemini-paid-key',
-                    freeApiKey: undefined,
+                    freeApiKey: 'gemini-server-key',
+                    paidApiKey: undefined,
                     model: 'gemini-2.5-flash',
                 }),
                 { callAiProvider: callAiProviderRouter }
             );
         });
 
-        it('GEMINI_CHAT_FREE_API_KEY가 설정되면 freeApiKey도 함께 전달한다', async () => {
+        it('GEMINI_CHAT_FREE_API_KEY가 설정되면 freeApiKey로 우선 사용한다', async () => {
             process.env.GEMINI_CHAT_FREE_API_KEY = 'gemini-free-key';
 
             await chatAction(
@@ -153,8 +153,8 @@ describe('chatAction 함수는', () => {
 
             expect(mockRequestChatCompletion).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    paidApiKey: 'gemini-paid-key',
                     freeApiKey: 'gemini-free-key',
+                    paidApiKey: undefined,
                 }),
                 expect.anything()
             );
@@ -162,7 +162,7 @@ describe('chatAction 함수는', () => {
     });
 
     describe('Anthropic 모델을 사용할 때', () => {
-        it('free Anthropic 모델은 서버 paid key로 요청하고 freeApiKey는 undefined이다', async () => {
+        it('free Anthropic 모델은 ANTHROPIC_CHAT_API_KEY를 freeApiKey로 전달한다', async () => {
             process.env.ANTHROPIC_CHAT_API_KEY = 'anthr-key';
             delete process.env.GEMINI_CHAT_API_KEY;
 
@@ -177,8 +177,8 @@ describe('chatAction 함수는', () => {
 
             expect(mockRequestChatCompletion).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    paidApiKey: 'anthr-key',
-                    freeApiKey: undefined,
+                    freeApiKey: 'anthr-key',
+                    paidApiKey: undefined,
                     model: 'claude-haiku-3-5',
                 }),
                 { callAiProvider: callAiProviderRouter }
@@ -187,7 +187,7 @@ describe('chatAction 함수는', () => {
     });
 
     describe('OpenAI 모델을 사용할 때', () => {
-        it('free OpenAI 모델은 서버 paid key로 요청하고 freeApiKey는 undefined이다', async () => {
+        it('free OpenAI 모델은 OPENAI_CHAT_API_KEY를 freeApiKey로 전달한다', async () => {
             process.env.OPENAI_CHAT_API_KEY = 'oai-key';
             delete process.env.GEMINI_CHAT_API_KEY;
 
@@ -202,8 +202,8 @@ describe('chatAction 함수는', () => {
 
             expect(mockRequestChatCompletion).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    paidApiKey: 'oai-key',
-                    freeApiKey: undefined,
+                    freeApiKey: 'oai-key',
+                    paidApiKey: undefined,
                     model: 'gpt-5-mini',
                 }),
                 { callAiProvider: callAiProviderRouter }
@@ -212,7 +212,7 @@ describe('chatAction 함수는', () => {
     });
 
     describe('서버 키가 없을 때', () => {
-        it('Gemini 서버 paid key가 미설정이면 server_error를 반환하고 core를 호출하지 않는다', async () => {
+        it('Gemini 서버 primary key가 미설정이면 server_error를 반환하고 core를 호출하지 않는다', async () => {
             delete process.env.GEMINI_CHAT_API_KEY;
 
             const result = await chatAction(
@@ -228,7 +228,7 @@ describe('chatAction 함수는', () => {
             expect(mockRequestChatCompletion).not.toHaveBeenCalled();
         });
 
-        it('Anthropic 서버 paid key가 미설정이면 server_error를 반환하고 core를 호출하지 않는다', async () => {
+        it('Anthropic 서버 primary key가 미설정이면 server_error를 반환하고 core를 호출하지 않는다', async () => {
             const result = await chatAction(
                 'AAPL',
                 '1Day',
@@ -242,7 +242,7 @@ describe('chatAction 함수는', () => {
             expect(mockRequestChatCompletion).not.toHaveBeenCalled();
         });
 
-        it('OpenAI 서버 paid key가 미설정이면 server_error를 반환하고 core를 호출하지 않는다', async () => {
+        it('OpenAI 서버 primary key가 미설정이면 server_error를 반환하고 core를 호출하지 않는다', async () => {
             const result = await chatAction(
                 'AAPL',
                 '1Day',
@@ -277,13 +277,14 @@ describe('chatAction 함수는', () => {
 
             expect(mockRequestChatCompletion).toHaveBeenCalledWith(
                 expect.objectContaining({
+                    freeApiKey: 'anthr-key',
                     paidApiKey: undefined,
                 }),
                 expect.anything()
             );
         });
 
-        it('premium 모델이고 로그인 + 사용자 키 등록이면 사용자 키를 전달한다', async () => {
+        it('premium 모델이고 로그인 + 사용자 키 등록이면 paidApiKey로 사용자 키를 전달한다', async () => {
             const mockFindByUserAndProvider = jest
                 .fn()
                 .mockResolvedValue({ apiKey: 'user-personal-key' });
@@ -313,6 +314,7 @@ describe('chatAction 함수는', () => {
 
             expect(mockRequestChatCompletion).toHaveBeenCalledWith(
                 expect.objectContaining({
+                    freeApiKey: 'anthr-key',
                     paidApiKey: 'user-personal-key',
                 }),
                 expect.anything()
@@ -352,6 +354,7 @@ describe('chatAction 함수는', () => {
 
             expect(mockRequestChatCompletion).toHaveBeenCalledWith(
                 expect.objectContaining({
+                    freeApiKey: 'anthr-key',
                     paidApiKey: undefined,
                 }),
                 expect.anything()
@@ -455,8 +458,8 @@ describe('chatAction 함수는', () => {
     });
 
     describe('알 수 없는 provider 처리', () => {
-        it('getServerPaidKey가 알 수 없는 provider를 받으면 에러가 전파된다', async () => {
-            // getServerPaidKey is called outside the try block — the throw propagates
+        it('getServerPrimaryKey가 알 수 없는 provider를 받으면 에러가 전파된다', async () => {
+            // getServerPrimaryKey is called outside the try block — the throw propagates
             // rather than being caught as server_error.
             mockGetProviderForModel.mockReturnValueOnce(
                 'unknown' as unknown as LlmProvider

--- a/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
@@ -192,4 +192,20 @@ describe('submitOverallAnalysisAction 함수는', () => {
 
         expect(result).toBe(SUBMITTED_RESULT);
     });
+
+    it('내부에서 예외가 발생하면 status: error를 반환한다', async () => {
+        mockListBySymbol.mockResolvedValue([]);
+        mockGetNextForSymbol.mockResolvedValue(null);
+        mockSubmitOverallAnalysis.mockRejectedValueOnce(
+            new Error('unexpected')
+        );
+
+        const result = await submitOverallAnalysisAction(
+            'AAPL',
+            '1Day',
+            MODEL_ID
+        );
+
+        expect(result).toMatchObject({ status: 'error', axis: 'technical' });
+    });
 });

--- a/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
@@ -150,8 +150,8 @@ describe('submitOverallAnalysisAction 함수는', () => {
         await submitOverallAnalysisAction('AAPL', '1Day', MODEL_ID);
 
         const callArg = mockSubmitOverallAnalysis.mock.calls[0]?.[0];
-        expect(callArg?.news).toHaveLength(1);
-        const item = callArg?.news[0] as EnrichedNewsItem;
+        expect(callArg?.newsItems).toHaveLength(1);
+        const item = callArg?.newsItems?.[0] as EnrichedNewsItem;
         expect(item.card.titleKo).toBe('애플 실적 예상치 상회');
     });
 

--- a/src/components/overall/hooks/useOverallAnalysis.ts
+++ b/src/components/overall/hooks/useOverallAnalysis.ts
@@ -121,6 +121,14 @@ async function runOverallAnalysis(
         return;
     }
 
+    if (submitted.status === 'limit_error') {
+        ctx.setState({
+            status: 'error',
+            error: '오늘 분석 한도를 모두 사용했어요. 내일 다시 시도해 주세요.',
+        });
+        return;
+    }
+
     // status === 'submitted' — start polling
     const { jobId } = submitted;
     ctx.setState({ status: 'polling' });

--- a/src/infrastructure/ai/router.ts
+++ b/src/infrastructure/ai/router.ts
@@ -7,7 +7,9 @@ import { callOpenaiChat } from '@/infrastructure/ai/openai';
 export async function callAiProviderRouter(
     options: CallAiProviderOptions
 ): Promise<string> {
-    // Safe cast: getProviderForModel matches model prefix and defaults to 'openai' for unknown strings.
+    // 0.7.3: getProviderForModel throws on unknown modelId (previously defaulted to 'openai').
+    // Callers (chatAction / submitAnalysisAction) validate the model upstream, so the cast is
+    // safe in normal flow; the throw surfaces wiring bugs instead of silently misrouting.
     const provider = getProviderForModel(options.model as ModelId);
     switch (provider) {
         case 'anthropic':

--- a/src/infrastructure/chat/chatAction.ts
+++ b/src/infrastructure/chat/chatAction.ts
@@ -27,10 +27,21 @@ async function getClientIp(): Promise<string> {
     );
 }
 
-function getServerPaidKey(provider: LlmProvider): string | undefined {
+/**
+ * Server-owned primary chat key per provider, mapped to core's `freeApiKey`.
+ *
+ * 0.7.3 semantics: `freeApiKey` is the server-owned primary credential that
+ * core forwards to the AI provider. Without it core returns `server_error`
+ * for every request. Google additionally honors `GEMINI_CHAT_FREE_API_KEY`
+ * as the preferred primary; it falls back to `GEMINI_CHAT_API_KEY`.
+ */
+function getServerPrimaryKey(provider: LlmProvider): string | undefined {
     switch (provider) {
         case 'google':
-            return process.env.GEMINI_CHAT_API_KEY;
+            return (
+                process.env.GEMINI_CHAT_FREE_API_KEY ??
+                process.env.GEMINI_CHAT_API_KEY
+            );
         case 'anthropic':
             return process.env.ANTHROPIC_CHAT_API_KEY;
         case 'openai':
@@ -42,29 +53,22 @@ function getServerPaidKey(provider: LlmProvider): string | undefined {
     }
 }
 
-function getServerFreeKey(provider: LlmProvider): string | undefined {
-    // Only Google provides a free-quota fallback key; other providers use the paid key exclusively.
-    switch (provider) {
-        case 'google':
-            return process.env.GEMINI_CHAT_FREE_API_KEY;
-        case 'anthropic':
-        case 'openai':
-            return undefined;
-        default: {
-            const exhausted: never = provider;
-            throw new Error(`Unhandled LLM provider: ${String(exhausted)}`);
-        }
-    }
-}
-
-async function resolvePaidApiKey(
+/**
+ * Resolve user-registered BYOK key for the given premium model, mapped to
+ * core's `paidApiKey` (the fallback credential).
+ *
+ * 0.7.3 semantics: free-tier models do not require a BYOK; core covers them
+ * via `freeApiKey` alone. Premium models on a non-pro tier require a BYOK —
+ * returning `undefined` lets core respond with `user_api_key_required` so
+ * the UI can prompt the user to register a key.
+ */
+async function resolveUserByokKey(
     model: ModelId,
-    provider: LlmProvider,
-    serverPaidKey: string
+    provider: LlmProvider
 ): Promise<string | undefined> {
     // Safe cast: ModelId ⊆ string; Array.includes widens the argument type to string.
     if ((TIER_CONFIG.models.free as readonly string[]).includes(model)) {
-        return serverPaidKey;
+        return undefined;
     }
     const user = await getCurrentUser();
     if (!user) return undefined;
@@ -72,7 +76,6 @@ async function resolvePaidApiKey(
     const repo = new DrizzleUserApiKeyRepository(db);
     const record = await repo.findByUserAndProvider(user.id, provider);
     return record?.apiKey;
-    // undefined → requestChatCompletion returns user_api_key_required
 }
 
 export async function chatAction(
@@ -84,14 +87,14 @@ export async function chatAction(
     model: ModelId = GEMINI_2_5_FLASH_MODEL
 ): Promise<ChatActionResult> {
     const provider = getProviderForModel(model);
-    const serverPaidKey = getServerPaidKey(provider);
-    if (!serverPaidKey) {
+    const freeApiKey = getServerPrimaryKey(provider);
+    if (!freeApiKey) {
         return { ok: false, error: 'server_error' };
     }
 
     try {
         const [paidApiKey, clientIp] = await Promise.all([
-            resolvePaidApiKey(model, provider, serverPaidKey),
+            resolveUserByokKey(model, provider),
             getClientIp(),
         ]);
 
@@ -104,7 +107,7 @@ export async function chatAction(
                 history,
                 userMessage,
                 model,
-                freeApiKey: getServerFreeKey(provider),
+                freeApiKey,
                 paidApiKey,
             },
             {

--- a/src/infrastructure/chat/chatAction.ts
+++ b/src/infrastructure/chat/chatAction.ts
@@ -86,13 +86,13 @@ export async function chatAction(
     userMessage: string,
     model: ModelId = GEMINI_2_5_FLASH_MODEL
 ): Promise<ChatActionResult> {
-    const provider = getProviderForModel(model);
-    const freeApiKey = getServerPrimaryKey(provider);
-    if (!freeApiKey) {
-        return { ok: false, error: 'server_error' };
-    }
-
     try {
+        const provider = getProviderForModel(model);
+        const freeApiKey = getServerPrimaryKey(provider);
+        if (!freeApiKey) {
+            return { ok: false, error: 'server_error' };
+        }
+
         const [paidApiKey, clientIp] = await Promise.all([
             resolveUserByokKey(model, provider),
             getClientIp(),

--- a/src/infrastructure/market/submitOverallAnalysisAction.ts
+++ b/src/infrastructure/market/submitOverallAnalysisAction.ts
@@ -43,7 +43,7 @@ export async function submitOverallAnalysisAction(
         timeframe,
         modelId,
         fundamentalProvider: new FmpFundamentalClient(),
-        news: enrichedNews,
+        newsItems: enrichedNews,
         upcomingCalendar: next !== null ? [next] : [],
         // Pre-Phase 4: no tier/usage/userApiKey overrides needed.
         technical: {},

--- a/src/infrastructure/market/submitOverallAnalysisAction.ts
+++ b/src/infrastructure/market/submitOverallAnalysisAction.ts
@@ -25,28 +25,32 @@ export async function submitOverallAnalysisAction(
     timeframe: Timeframe,
     modelId: SubmitOverallAnalysisOptions['modelId']
 ): Promise<SubmitOverallAnalysisResult> {
-    const { db } = getDatabaseClient();
-    const newsRepo = new DrizzleNewsRepository(db);
-    const calRepo = new DrizzleEarningsCalendarRepository(db);
+    try {
+        const { db } = getDatabaseClient();
+        const newsRepo = new DrizzleNewsRepository(db);
+        const calRepo = new DrizzleEarningsCalendarRepository(db);
 
-    const [rows, next] = await Promise.all([
-        newsRepo.listBySymbol(symbol, NEWS_LOOKBACK_MS),
-        calRepo.getNextForSymbol(symbol, todayKstIsoDate()),
-    ]);
+        const [rows, next] = await Promise.all([
+            newsRepo.listBySymbol(symbol, NEWS_LOOKBACK_MS),
+            calRepo.getNextForSymbol(symbol, todayKstIsoDate()),
+        ]);
 
-    const enrichedNews: ReadonlyArray<EnrichedNewsItem> = rows
-        .filter(isEnrichedRow)
-        .map(toEnrichedNewsItem);
+        const enrichedNews: ReadonlyArray<EnrichedNewsItem> = rows
+            .filter(isEnrichedRow)
+            .map(toEnrichedNewsItem);
 
-    return submitOverallAnalysis({
-        symbol,
-        timeframe,
-        modelId,
-        fundamentalProvider: new FmpFundamentalClient(),
-        newsItems: enrichedNews,
-        upcomingCalendar: next !== null ? [next] : [],
-        // Pre-Phase 4: no tier/usage/userApiKey overrides needed.
-        technical: {},
-        waitUntil,
-    });
+        return await submitOverallAnalysis({
+            symbol,
+            timeframe,
+            modelId,
+            fundamentalProvider: new FmpFundamentalClient(),
+            newsItems: enrichedNews,
+            upcomingCalendar: next !== null ? [next] : [],
+            // Pre-Phase 4: no tier/usage/userApiKey overrides needed.
+            technical: {},
+            waitUntil,
+        });
+    } catch (e) {
+        return { status: 'error', axis: 'technical', error: e };
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3742,12 +3742,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@y0ngha/siglens-core@npm:0.7.2":
-  version: 0.7.2
-  resolution: "@y0ngha/siglens-core@npm:0.7.2::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.7.2%2F3867aa5edc4246a5c38b65dc4c7bb54b86b49840"
+"@y0ngha/siglens-core@npm:0.7.3":
+  version: 0.7.3
+  resolution: "@y0ngha/siglens-core@npm:0.7.3::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.7.3%2Fd2b8db34a781198679221eaf71b2b2a969df4725"
   peerDependencies:
     "@upstash/redis": ^1.37.0
-  checksum: 10c0/b4b60eacc55b3c3cc1df5a0ebc74d5882cd5185515004f125e91dfc3e77ce05d6868491682660b1bd70c71b7078565dfe90f9aaa4d82bbe82340faf4195c4ecc
+  checksum: 10c0/5c1206c2520f69d72dcc1ced2541c5bab20a6501b5764055054470b0d957a7471e0d6104676591abead5fbbb2b9ca7782594e40eafdffe57cbd3788f7270b9b6
   languageName: node
   linkType: hard
 
@@ -10913,7 +10913,7 @@ __metadata:
     "@types/react-dom": "npm:^19"
     "@upstash/redis": "npm:^1.37.0"
     "@vercel/functions": "npm:^3.4.3"
-    "@y0ngha/siglens-core": "npm:0.7.2"
+    "@y0ngha/siglens-core": "npm:0.7.3"
     babel-plugin-react-compiler: "npm:^1.0.0"
     bcryptjs: "npm:^3.0.3"
     clsx: "npm:^2.1.1"


### PR DESCRIPTION
## 관련 이슈

N/A — siglens-core 0.7.3 의존성 업그레이드에 따른 consumer-side 수정

## 구현 내용

### 1. chatAction의 API 키 시맨틱 재배선 (주요 변경)
`freeApiKey`/`paidApiKey`의 역할이 0.7.3에서 변경됨에 따라 chatAction을 수정:
- `freeApiKey`: 서버 소유 primary key (항상 필수). 무료 모델(Claude 3.5 Haiku, OpenAI GPT-4o Mini 등) 및 pro 사용자의 기본 모델에 사용됨
- `paidApiKey`: 사용자 BYOK fallback (pro 사용자만, premium 모델용). 

**회귀 방지**: 비-pro 사용자가 Anthropic/OpenAI 무료 채팅 모델을 사용할 때 발생하던 `server_error` 제거

### 2. SubmitOverallAnalysisLimitError 분기 추가
siglens-core 0.7.3에서 새로운 `SubmitOverallAnalysisLimitError` 예외가 도입됨에 따라:
- useOverallAnalysis에 `'limit_error'` 케이스 분기 추가
- 컴파일 에러 + 잠재 런타임 크래시 차단

### 3. OverallDependencyInputs.news → newsItems 이름 변경
- submitOverallAnalysisAction 호출부 수정: `news:` → `newsItems:`
- 대응하는 테스트 케이스 정리

### 4. getProviderForModel의 unknown modelId throw 동작 대응
- 0.7.3에서 unknown modelId에 대해 default 대신 throw하도록 변경
- router.ts 주석 갱신으로 의도 명확화

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 인디케이터 초기 구간 null 반환 (0, NaN 없음)
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it
- [x] 초기 구간 null 케이스 테스트 포함
- [x] 매직 넘버 없음

## 변경 파일 목록

[수정]
- package.json — siglens-core 0.7.2 → 0.7.3
- yarn.lock — 의존성 업데이트
- src/components/overall/hooks/useOverallAnalysis.ts — limit_error 분기 추가
- src/infrastructure/market/submitOverallAnalysisAction.ts — newsItems 호출부 수정
- src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts — newsItems 테스트 정리
- src/infrastructure/chat/chatAction.ts — freeApiKey/paidApiKey 시맨틱 재배선
- src/__tests__/infrastructure/chat/chatAction.test.ts — API 키 기대값 재작성
- src/infrastructure/ai/router.ts — 주석 갱신

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build