### PR TITLE
style: align auth/error components with web interface guidelines

### DIFF
--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -34,7 +34,17 @@ This file contains only **recurring gotchas** that agents keep missing despite e
    ✅ className="text-ui-danger"  // UI semantic token
    ✅ className="bg-brand-kakao"  // brand token registered in tailwind.config.ts
 
-0. Concurrent fetch without respecting provider rate limits
+0.7. Server Actions throwing uncaught exceptions instead of returning typed error results
+   → Server Actions must never propagate exceptions to the client; all throw paths must be caught
+   → Wrap entire action body in try-catch and return a consistent error shape (e.g., { ok: false, error: 'server_error' })
+   → Applies to all Server Actions (sync, async, file-backed, or calling external APIs)
+   → Unexpected throws (DB failure, API timeout, unhandled edge cases) propagate as 500 errors and break the client
+   ❌ export async function chatAction(input): Promise<ChatResult> { return getProviderForModel(model); }  // getProviderForModel may throw on unknown modelId
+   ❌ async function submitAnalysisAction(params) { return db.query(...); }  // DB failure throws uncaught to client
+   ✅ export async function chatAction(input): Promise<ChatResult | { ok: false; error: string }> { try { return getProviderForModel(model); } catch (e) { return { ok: false, error: 'server_error' }; } }
+   ✅ async function submitAnalysisAction(params): Promise<AnalysisResult> { try { return db.query(...); } catch (e) { return { status: 'error', axis: 'technical', error: e }; } }
+
+0.8. Concurrent fetch without respecting provider rate limits
    → Always use fetchInChunks or sequential await for multiple API calls
    → Never use Promise.all/Promise.allSettled when calls exceed FETCH_CONCURRENCY threshold
    → Rate limits: FMP=250/min, Alpaca=various, Gemini=API-tier dependent

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,13 +1,5 @@
 # Fix Log
 
-## [PR #415 Round 2 | chore/upgrade-siglens-core-0.7.3 | 2026-05-04]
-- Violation: chatAction's getProviderForModel/getServerPrimaryKey calls placed outside try-catch block — 0.7.3 throws on unknown modelId
-- Rule: Server Actions must not propagate exceptions to the client — all throw paths must be caught and returned as { ok: false, error: 'server_error' }
-- Context: Moved getProviderForModel + getServerPrimaryKey inside try block. Updated chatAction.test.ts to assert resolves({ ok: false }) instead of rejects.toThrow. Removed comment describing old behavior.
-
-- Violation: submitOverallAnalysisAction had no try-catch — unexpected throws (e.g. DB failure, core throw) would crash the Server Action
-- Rule: Server Actions must return typed error results instead of propagating uncaught exceptions
-- Context: Wrapped entire body in try-catch; returns { status: 'error', axis: 'technical', error: e } on failure. Added corresponding test case.
 
 ## [PR #415 Doc Policy Removal | chore/upgrade-siglens-core-0.7.3 | 2026-05-04]
 - Policy removed: MISTAKES.md Documentation Sync 규칙 4 (다중 라인 JSDoc 금지) — PR #415 review comments triggered by this rule were rejected; rule removed per user decision
@@ -243,3 +235,8 @@
 - Context: Removed method (never called from production), dropped unused between import, makeSelectOrderByDb mock, and 2 test cases. Cron and per-symbol use cases already covered by upsertMany and getNextForSymbol.
 
 
+
+## [PR #416 | fix/wig-cleanup | 2026-05-04]
+- Violation: SubmitButton.tsx had `focus-visible:ring-primary-500` without `focus-visible:ring-offset-2` / `ring-offset-{color}` while peer buttons in the same PR (DangerSubmitButton, error retry buttons, PasswordField toggle) all carried the offset pair
+- Rule: WAI-ARIA keyboard accessibility — same-color ring on same-color background needs ring-offset for sufficient contrast; cross-component consistency
+- Context: Added `focus-visible:ring-offset-secondary-900 focus-visible:ring-offset-2` to align with the form's AuthCardShell `bg-secondary-900/80` surrounding background.

--- a/src/components/auth/AuthFieldGroup.tsx
+++ b/src/components/auth/AuthFieldGroup.tsx
@@ -43,7 +43,7 @@ export function AuthFieldGroup({
                 onChange={onChange}
                 aria-invalid={!!error}
                 aria-describedby={error ? errorId : undefined}
-                className="border-secondary-700 bg-secondary-950 text-secondary-50 placeholder:text-secondary-500 h-12 w-full rounded-md border px-4 text-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/40 focus:outline-none"
+                className="border-secondary-700 bg-secondary-950 text-secondary-50 placeholder:text-secondary-500 focus:border-primary-500 focus:ring-primary-500/40 h-12 w-full rounded-md border px-4 text-sm focus:ring-2 focus:outline-none"
             />
             {error ? (
                 <p

--- a/src/components/auth/DeleteAccountConfirm.tsx
+++ b/src/components/auth/DeleteAccountConfirm.tsx
@@ -110,7 +110,7 @@ export function DeleteAccountConfirm({ userEmail }: DeleteAccountConfirmProps) {
             <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
                 <Link
                     href="/account"
-                    className="text-secondary-200 border-secondary-700 hover:bg-secondary-800 focus-visible:ring-primary-500 inline-flex h-12 items-center justify-center rounded-md border px-5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none sm:flex-1"
+                    className="text-secondary-200 border-secondary-700 hover:bg-secondary-800 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-900 inline-flex h-12 items-center justify-center rounded-md border px-5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none sm:flex-1"
                 >
                     취소
                 </Link>

--- a/src/components/auth/PasswordField.tsx
+++ b/src/components/auth/PasswordField.tsx
@@ -56,14 +56,14 @@ export function PasswordField({
                     onBlur={() => setCapsLock(false)}
                     aria-invalid={!!error}
                     aria-describedby={describedBy}
-                    className="border-secondary-700 bg-secondary-950 text-secondary-50 placeholder:text-secondary-500 h-12 w-full rounded-md border px-4 pr-12 text-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/40 focus:outline-none"
+                    className="border-secondary-700 bg-secondary-950 text-secondary-50 placeholder:text-secondary-500 focus:border-primary-500 focus:ring-primary-500/40 h-12 w-full rounded-md border px-4 pr-12 text-sm focus:ring-2 focus:outline-none"
                 />
                 <button
                     type="button"
                     onClick={() => setVisible(v => !v)}
                     aria-label={visible ? '비밀번호 숨기기' : '비밀번호 보이기'}
                     aria-pressed={visible}
-                    className="text-secondary-400 hover:text-secondary-200 absolute inset-y-0 right-0 flex w-12 items-center justify-center focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+                    className="text-secondary-400 hover:text-secondary-200 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-950 absolute inset-y-0 right-0 flex w-12 items-center justify-center rounded-r-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
                 >
                     <span aria-hidden>{visible ? '🙈' : '👁'}</span>
                 </button>

--- a/src/components/auth/SubmitButton.tsx
+++ b/src/components/auth/SubmitButton.tsx
@@ -17,7 +17,7 @@ export function SubmitButton({
             type="submit"
             disabled={pending}
             aria-busy={pending}
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-md bg-blue-600 font-semibold text-white transition-colors hover:bg-blue-700 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none active:bg-blue-800 disabled:opacity-60 motion-reduce:transition-none"
+            className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 active:bg-primary-800 flex h-12 w-full items-center justify-center gap-2 rounded-md font-semibold text-white transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:opacity-60 motion-reduce:transition-none"
         >
             {pending ? (
                 <>

--- a/src/components/auth/SubmitButton.tsx
+++ b/src/components/auth/SubmitButton.tsx
@@ -17,7 +17,7 @@ export function SubmitButton({
             type="submit"
             disabled={pending}
             aria-busy={pending}
-            className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 active:bg-primary-800 flex h-12 w-full items-center justify-center gap-2 rounded-md font-semibold text-white transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:opacity-60 motion-reduce:transition-none"
+            className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-900 active:bg-primary-800 flex h-12 w-full items-center justify-center gap-2 rounded-md font-semibold text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-60 motion-reduce:transition-none"
         >
             {pending ? (
                 <>

--- a/src/components/fundamental/FundamentalAiSummaryError.tsx
+++ b/src/components/fundamental/FundamentalAiSummaryError.tsx
@@ -26,7 +26,7 @@ export function FundamentalAiSummaryError({
             <button
                 type="button"
                 onClick={resetErrorBoundary}
-                className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 mt-4 rounded px-3 py-1.5 text-xs text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-800 mt-4 rounded px-3 py-1.5 text-xs text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
             >
                 다시 시도
             </button>

--- a/src/components/fundamental/sections/PeersTable.tsx
+++ b/src/components/fundamental/sections/PeersTable.tsx
@@ -39,7 +39,7 @@ export function PeersTable({ peers }: PeersTableProps) {
                                 <td className="py-2.5 pr-4">
                                     <Link
                                         href={`/${peer.symbol}/fundamental`}
-                                        className="text-primary-400 font-mono font-medium hover:underline"
+                                        className="text-primary-400 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-800 rounded-sm font-mono font-medium hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
                                         translate="no"
                                     >
                                         {peer.symbol}

--- a/src/components/fundamental/sections/ProfileCard.tsx
+++ b/src/components/fundamental/sections/ProfileCard.tsx
@@ -62,7 +62,7 @@ export function ProfileCard({ profile }: ProfileCardProps) {
                                 href={profile.website}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="hover:text-secondary-100 text-secondary-400 underline underline-offset-2 transition-colors"
+                                className="hover:text-secondary-100 text-secondary-400 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-800 rounded-sm underline underline-offset-2 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
                                 translate="no"
                             >
                                 {profile.website.replace(/^https?:\/\//, '')}

--- a/src/components/news/NewsAiSummaryError.tsx
+++ b/src/components/news/NewsAiSummaryError.tsx
@@ -26,7 +26,7 @@ export function NewsAiSummaryError({
             <button
                 type="button"
                 onClick={resetErrorBoundary}
-                className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 mt-4 rounded px-3 py-1.5 text-xs text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-800 mt-4 rounded px-3 py-1.5 text-xs text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
             >
                 다시 시도
             </button>


### PR DESCRIPTION
## 관련 이슈

Vercel Web Interface Guidelines 점검

## 구현 내용

Vercel Web Interface Guidelines 점검에서 발견된 9개 페이지의 자식 컴포넌트 수정:

- focus-visible ring-offset 누락 추가 (NewsAiSummaryError, FundamentalAiSummaryError, DeleteAccountConfirm 취소 버튼)
- 외부 링크/테이블 링크에 focus-visible 스타일 신규 추가 (ProfileCard 외부 링크, PeersTable 티커 링크)
- PasswordField 비밀번호 표시 토글에 ring-offset 추가
- 인증 폼 색 토큰 통일: blue-* → primary-* (PasswordField input, AuthFieldGroup input, SubmitButton)

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] 스타일 전용 변경 (로직 변경 없음)

## 변경 파일 목록

[수정]
- src/components/auth/AuthFieldGroup.tsx
- src/components/auth/DeleteAccountConfirm.tsx
- src/components/auth/PasswordField.tsx
- src/components/auth/SubmitButton.tsx
- src/components/fundamental/FundamentalAiSummaryError.tsx
- src/components/fundamental/sections/PeersTable.tsx
- src/components/fundamental/sections/ProfileCard.tsx
- src/components/news/NewsAiSummaryError.tsx

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] review-agent approved (round 1)