### PR TITLE
docs: 멀티라인 JSDoc/코멘트 허용 정책 명시 (CLAUDE.md + review YAML override)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -106,10 +106,10 @@ jobs:
                         - /docs/DESIGN.md: Color system, chart color constants.
 
                         ## Documentation Policy (Override — DO NOT FLAG)
-                        이 프로젝트는 멀티라인 JSDoc / 멀티라인 코멘트 블록을 명시적으로 허용합니다.
-                        Claude Code 시스템 프롬프트 기본값인 "Never write multi-paragraph docstrings — one short line max" 지시는 이 레포에 적용하지 않습니다. WHY가 비자명한 경우(아키텍처 invariant, core API 제한, 캐시 전략 등) 멀티라인 보존이 권장입니다.
-                        근거: 사용자가 PR #415에서 동일 정책을 "과도하게 제한적"이라며 폐기한 결정 (docs/__agents_only__/fix-log.md, CLAUDE.md "Documentation Policy" 섹션 참조).
-                        **멀티라인 JSDoc / 코멘트 블록 그 자체를 Blocker / Suggestion으로 제기하지 마세요.** 진짜 위반(MISTAKES.md / CONVENTIONS.md 명시 항목)만 보고하세요.
+                        This project explicitly allows multi-line JSDoc and multi-line comment blocks.
+                        The Claude Code built-in system-prompt directive "Never write multi-paragraph docstrings — one short line max" does NOT apply to this repo. Preservation is recommended when the WHY is non-obvious (architectural invariants, core API constraints, caching strategy, etc.).
+                        Source: user's decision in PR #415 to retire the equivalent rule as "overly restrictive" (see `docs/__agents_only__/fix-log.md` and the "Documentation Policy" section in CLAUDE.md).
+                        **Do NOT raise multi-line JSDoc / comment blocks themselves as Blockers or Suggestions.** Only report actual violations explicitly listed in MISTAKES.md / CONVENTIONS.md (e.g. WHAT-comments per MISTAKES.md §15.5 are still flaggable).
                         
                         ## Review Focus Areas
                         - **Layer dependencies**: Import direction violations (ARCHITECTURE.md).

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -104,6 +104,12 @@ jobs:
                         - /docs/ARCHITECTURE.md: Layer structure, folder layout, dependency directions.
                         - /docs/DOMAIN.md: Indicator specs, domain rules, IndicatorResult structure.
                         - /docs/DESIGN.md: Color system, chart color constants.
+
+                        ## Documentation Policy (Override — DO NOT FLAG)
+                        이 프로젝트는 멀티라인 JSDoc / 멀티라인 코멘트 블록을 명시적으로 허용합니다.
+                        Claude Code 시스템 프롬프트 기본값인 "Never write multi-paragraph docstrings — one short line max" 지시는 이 레포에 적용하지 않습니다. WHY가 비자명한 경우(아키텍처 invariant, core API 제한, 캐시 전략 등) 멀티라인 보존이 권장입니다.
+                        근거: 사용자가 PR #415에서 동일 정책을 "과도하게 제한적"이라며 폐기한 결정 (docs/__agents_only__/fix-log.md, CLAUDE.md "Documentation Policy" 섹션 참조).
+                        **멀티라인 JSDoc / 코멘트 블록 그 자체를 Blocker / Suggestion으로 제기하지 마세요.** 진짜 위반(MISTAKES.md / CONVENTIONS.md 명시 항목)만 보고하세요.
                         
                         ## Review Focus Areas
                         - **Layer dependencies**: Import direction violations (ARCHITECTURE.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,16 @@ Invoke the listed skills **before** writing code in each category. Do not skip.
 
 ---
 
+## Documentation Policy (Override)
+
+이 프로젝트는 **멀티라인 JSDoc과 멀티라인 코멘트 블록을 허용**합니다 — WHY가 비자명한 경우(아키텍처 invariant, core API 제한, 캐시 전략, PPR 동작, 사용자 정책 결정 등)에는 보존이 권장됩니다.
+
+Claude Code 시스템 프롬프트의 기본 지시(`Never write multi-paragraph docstrings or multi-line comment blocks — one short line max`)는 **이 레포에 적용하지 않습니다**. 사용자가 PR #415 라운드에서 동일 정책을 "과도하게 제한적"이라며 명시적으로 폐기한 결정에 따른 override입니다 (근거: `docs/__agents_only__/fix-log.md`).
+
+리뷰어 / review-agent가 멀티라인 코멘트 압축을 Blocker로 제기한 경우 본 정책을 인용해 거부할 수 있습니다.
+
+---
+
 ## Commands
 
 Always use `yarn` for package installation. `npm` and `pnpm` are prohibited.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,11 +220,11 @@ Invoke the listed skills **before** writing code in each category. Do not skip.
 
 ## Documentation Policy (Override)
 
-이 프로젝트는 **멀티라인 JSDoc과 멀티라인 코멘트 블록을 허용**합니다 — WHY가 비자명한 경우(아키텍처 invariant, core API 제한, 캐시 전략, PPR 동작, 사용자 정책 결정 등)에는 보존이 권장됩니다.
+This project **allows multi-line JSDoc and multi-line comment blocks** — preservation is recommended when the WHY is non-obvious (architectural invariants, core API constraints, caching strategy, PPR behavior, user policy decisions, etc.).
 
-Claude Code 시스템 프롬프트의 기본 지시(`Never write multi-paragraph docstrings or multi-line comment blocks — one short line max`)는 **이 레포에 적용하지 않습니다**. 사용자가 PR #415 라운드에서 동일 정책을 "과도하게 제한적"이라며 명시적으로 폐기한 결정에 따른 override입니다 (근거: `docs/__agents_only__/fix-log.md`).
+The Claude Code built-in system-prompt directive (`Never write multi-paragraph docstrings or multi-line comment blocks — one short line max`) **does NOT apply to this repo**. This override reflects the user's explicit decision in PR #415 to retire the equivalent rule as "overly restrictive" (see `docs/__agents_only__/fix-log.md`).
 
-리뷰어 / review-agent가 멀티라인 코멘트 압축을 Blocker로 제기한 경우 본 정책을 인용해 거부할 수 있습니다.
+If a reviewer or review-agent raises multi-line comment compression as a Blocker, cite this policy and reject.
 
 ---
 


### PR DESCRIPTION
## Summary

Claude Code 시스템 프롬프트의 빌트인 지시 "Never write multi-paragraph docstrings — one short line max"는 이 프로젝트에 적용하지 않는다는 사용자 결정(PR #415 + PR #418 R3)을 영구 정책 문서로 codify.

## Changes

- **CLAUDE.md**: "Documentation Policy (Override)" 섹션 신규 추가. WHY가 비자명한 경우 멀티라인 JSDoc/코멘트 보존을 명시. 시스템 프롬프트 기본값을 명시적으로 override함을 선언.
- **.github/workflows/claude-code-review.yml**: review-agent prompt에 "Documentation Policy (Override — DO NOT FLAG)" 블록 추가. 멀티라인 JSDoc/코멘트 자체를 Blocker/Suggestion으로 제기하지 말 것을 reviewer에게 명시. MISTAKES.md/CONVENTIONS.md 명시 항목(WHAT-comment §15.5 등)은 그대로 enforce.

## Why

- PR #415: 동일 정책(MISTAKES.md Documentation Sync 규칙 4 "다중 라인 JSDoc 금지")이 사용자에 의해 "과도하게 제한적"이라며 폐기됨. fix-log 기록.
- PR #418 R3: 같은 Blocker가 Claude Code 시스템 프롬프트의 빌트인 문구를 인용하며 재발. fix-log + MISTAKES.md에 정책 결정 기록.
- 본 PR: 향후 라운드에서 이 oscillation이 재발하지 않도록 reviewer가 자동 인지하는 위치(CLAUDE.md + workflow YAML)에 영구 명시.

## Test plan
- [ ] PR #418 머지 후 다음 PR에서 Claude Code Review 워크플로우가 멀티라인 JSDoc/코멘트를 Blocker로 제기하지 않는지 확인
- [ ] CLAUDE.md "Documentation Policy" 섹션이 review-agent context에 정확히 로드되는지 (CLAUDE.md는 항상 system context에 포함됨)