### PR TITLE
fix: 채팅/분석 API 키 라우팅 수정 및 채팅 말풍선 너비 개선

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,3 +68,7 @@ NEXT_PUBLIC_ADSENSE_ENABLED=false
 # GitHub token with read:packages scope — for installing @y0ngha/siglens-core
 # https://github.com/settings/tokens
 SIGLENS_GITHUB_TOKEN=
+
+# ── Worker ───────────────────────────────────────────────────────
+WORKER_URL=
+WORKER_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env.local
+.env.production
 .env.yaml
 .env
 

--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -597,6 +597,12 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 ## Accessibility (WAI-ARIA)
 
 ```
+0.5. Error logging in catch blocks prevents debugging
+   → Unexpected errors in catch blocks must log details before returning error results
+   → Logging makes root cause analysis possible; returning error silently hides debugging info
+   ❌ catch (err) { return { error: 'service_unavailable' }; }  // no visibility into root cause
+   ✅ catch (err) { console.error('[moduleName] operation failed:', err); return { error: 'service_unavailable' }; }
+
 1. Overwriting native ARIA role of semantic elements
    → Native roles (paragraph, complementary) must not be replaced with role attributes
    → Use <div role="note"> instead of <p role="note"> or <aside role="note">
@@ -652,10 +658,13 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 4. Missing focus-visible:ring on interactive buttons
    → All interactive buttons must have keyboard focus indicator
    → Apply focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500 to every button
+   → When button's background color matches ring color, add ring-offset to ensure sufficient contrast (WCAG 1.4.11 Non-text Contrast)
    ❌ <button className="px-4 py-2 bg-primary-600">Click</button>  // no focus indicator
+   ❌ <button className="px-4 py-2 bg-secondary-900 focus-visible:ring-secondary-900">  // ring and bg same color, insufficient contrast
    ✅ <button className="px-4 py-2 bg-primary-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500">Click</button>
+   ✅ <button className="px-4 py-2 bg-secondary-900 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-secondary-950">Click</button>  // offset ensures contrast
    → Includes: TabsPill, DropdownPortal buttons, info icons, action buttons in AnalysisPanel, IndicatorToolbar
-   → Omission violates keyboard accessibility (WCAG 2.4.7 Focus Visible)
+   → Omission violates keyboard accessibility (WCAG 2.4.7 Focus Visible, WCAG 1.4.11 Non-text Contrast)
 
 5. Interactive info icons using <span title="..."> only — not keyboard accessible
    → Tooltips must be keyboard-accessible; title attribute ignored by keyboard users and screen readers

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -23,16 +23,6 @@
 - S2: `usePageShowReload.ts` moved from `src/components/auth/hooks/` to `src/components/hooks/` (generic bfcache hook placed in auth feature subfolder instead of global hooks dir, MISTAKES.md Components §15). Updated import in OAuthConsentForm.tsx.
   - Rule: MISTAKES.md Components §15 — Feature-agnostic utilities belong in global directories, not feature-specific subdirs
 
-## [PR #420 Round 10 | master | 2026-05-05]
-- S1: `pendingOAuthSignupStore.ts` — object literal methods missing explicit return type annotations. Added explicit return types to all 4 methods (save, peek, consume, delete).
-  - Rule: MISTAKES.md §0 — explicit return type annotations for methods
-
-## [PR #420 Round 9 | master | 2026-05-05]
-- M1: `registerAction.ts` — catch block returned `service_unavailable` without logging unexpected runtime errors, making debugging difficult. Added `console.error('[registerAction] unexpected error:', err)` before returning error.
-  - Rule: Error logging in catch blocks — debugging requires visibility into root causes
-- M2: `finalizeOAuthSignupAction.ts` — transaction .catch() and outer catch block redirected to serviceUnavailable without logging, making root cause analysis impossible. Added `console.error('[finalizeOAuthSignupAction] transaction failed:', err)` in .catch() and `console.error('[finalizeOAuthSignupAction] unexpected error:', err)` in outer catch.
-  - Rule: Error logging in catch blocks — debugging requires visibility into root causes
-
 ## [PR #420 Round 8 | master | 2026-05-05]
 - B3: `registerAction.test.ts` `expect.anything()` → `expect.objectContaining({ emailTokens, db })` 명시 검증. db mock에 `transaction` 함수 추가.
   - Rule: 의존성 주입 검증 — db 인자 포함 여부 명시
@@ -210,22 +200,6 @@
 - Rule: MISTAKES.md Coding Paradigm 0 — Non-null return type implies value is always assigned; use const + ternary/null coalescing
 - Context: Must guarantee createdUserId is assigned before return in all code paths.
 
-
-## [PR #420 Round 18 | master | 2026-05-05]
-- B1: `src/__tests__/infrastructure/auth/finalizeOAuthSignupAction.test.ts` — outer catch second branch (non-NEXT_REDIRECT error → service_unavailable redirect) was untested. Added `'예상치 못한 내부 에러 발생 시 service_unavailable로 리다이렉트한다'` test using `mockCreateStore.mockImplementation(() => { throw new Error(...) })`. Pattern: cancelOAuthSignupAction.test.ts had the equivalent test added in Round 15; finalizeOAuthSignupAction.test.ts had been missed.
-  - Rule: MISTAKES.md Infrastructure §2 — 100% branch coverage
-- S1: `db/scripts/migrate.ts` — `runMigrations` function was missing explicit `Promise<void>` return type. Added.
-  - Rule: MISTAKES.md §0 — explicit return type annotations for functions
-- S2: `src/__tests__/infrastructure/auth/registerAction.test.ts` — outer catch second branch (`return { error: { code: 'service_unavailable', ... } }` for non-NEXT_REDIRECT errors) was untested. Added import for `getDatabaseClient` + `mockGetDatabaseClient` mock, and `'예상치 못한 내부 에러 발생 시 service_unavailable을 반환한다'` test.
-  - Rule: MISTAKES.md Infrastructure §2 — 100% branch coverage
-
-## [PR #420 Round 17 | master | 2026-05-05]
-- B1: `src/__tests__/app/api/auth/callback/route.test.ts` — `pendingStore === null` branch (Redis unconfigured path) was not tested. Added `describe('pendingStore 미설정')` with test verifying `oauth_unknown` redirect when `createPendingOAuthSignupStoreFromEnv` returns null.
-  - Rule: MISTAKES.md §22 — 100% branch coverage
-- B2: `src/__tests__/infrastructure/auth/use-cases/registerUser.test.ts` — `created === null` branch inside the transaction was not explicitly tested. Added `'clears the verified marker even when createEmailUser returns null (tx null branch)'` test, verifying that the `finally` block clears the email token even in the null-return code path.
-  - Rule: MISTAKES.md §22 — 100% branch coverage
-- S1: `src/__tests__/app/api/auth/callback/route.test.ts` — Removed 5 WHAT-comment section headers (`// Module mocks`, `// Imports (after mocks)`, `// Typed mocks`, `// Fixtures`, `// Tests`).
-  - Rule: MISTAKES.md §15.4 — comments should explain WHY, not WHAT
 
 ## [PR #420 Round 16 | master | 2026-05-05]
 - B1: `src/infrastructure/auth/use-cases/types.ts` — 6 dead `SocialLoginUser*` type definitions were left after `socialLoginUser.ts` was deleted. Removed `SocialLoginUserErrorCode`, `SocialLoginUserInput`, `SocialLoginUserError`, `SocialLoginUserDependencies`, `SocialLoginUserOptions`, `SocialLoginUserResult`, and their unused imports (`OAuthProvider`, `OAuthUserRepository`).

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,19 +1,9 @@
 # Fix Log
 
 ## [PR #420 Round 15 | master | 2026-05-05]
-- B1: `src/__tests__/infrastructure/auth/cancelOAuthSignupAction.test.ts` — `redirect` mock was `jest.fn()` (not throwing), so the outer try-catch block was never exercised. Fixed by changing mock to throw NEXT_REDIRECT (matching other test files in PR), updating all tests to use `rejects.toThrow('NEXT_REDIRECT')`, and adding a new test for unexpected internal error → /login redirect (outer catch Branch 2).
-  - Rule: MISTAKES.md Infrastructure §2 — 100% branch coverage
-- B2: `src/__tests__/infrastructure/auth/registerAction.test.ts` — `!privacyTerms || !tosTerms` OR condition's second branch (`tosTerms` null while `privacyTerms` exists) was never tested due to short-circuit evaluation. Fixed by adding two separate tests: one for `privacyTerms` only null, one for `tosTerms` only null.
-  - Rule: MISTAKES.md Infrastructure §2 — 100% branch coverage
-- S1: `src/domain/auth/formTypes.ts` — `FinalizeOAuthSignupState.error` was an inline object type. Extracted to named `FinalizeOAuthSignupError` type alias.
-  - Rule: MISTAKES.md TypeScript §5/§5.2 — inline object types should use named type aliases
-- S2: `src/__tests__/infrastructure/auth/registerAction.test.ts` — email normalization behavior test was missing. Added `'email 키가 없으면 빈 문자열로 처리한다'` test using `makeConsentFormData({ email: '' })`.
-  - Rule: Test coverage — email normalization edge case should have dedicated test
 - S3 (skipped — False Positive): `src/infrastructure/auth/finalizeOAuthSignupAction.ts` — reviewer suggested changing `tx as unknown as SiglensDatabase` to `tx as SiglensDatabase`. Reverted: `PgTransaction<NeonHttpQueryResultHKT, ...>` doesn't overlap with `NeonHttpDatabase<...>` (SiglensDatabase), causing TS error 2352. The double cast is required.
 
 ## [PR #420 Round 14 | master | 2026-05-05]
-- B1: `src/__tests__/infrastructure/auth/registerAction.test.ts` — success case used `expect.anything()` as second argument to `toHaveBeenCalledWith()`. MISTAKES.md Tests §15/§16 forbids `expect.anything()`. Replaced with `expect.objectContaining({ emailTokens: expect.objectContaining({set, get, delete}), db: expect.objectContaining({transaction}) })`.
-  - Rule: MISTAKES.md Tests §15/§16 — forbids `expect.anything()` in assertion
 - B2: `db/scripts/seedTerms.ts` — used relative imports (`../../src/infrastructure/db/...`) instead of `@/` path aliases. Changed all three imports to use `@/infrastructure/db/...`.
   - Rule: MISTAKES.md CONVENTIONS.md — path aliases must use `@/` for better maintainability
 - S1: `src/components/legal/PolicyMarkdownBody.tsx` — focus ring on Link/anchor elements was missing `ring-offset` pair (`focus-visible:ring-offset-secondary-950 focus-visible:ring-offset-2`). Added the ring-offset classes.
@@ -21,47 +11,21 @@
 - S2: `src/app/privacy/page.tsx`, `src/app/terms/page.tsx`, `src/app/signup/oauth/consent/page.tsx` — Suspense boundaries were missing fallback prop (showing blank during DB fetch). Added `fallback={<div className="animate-pulse" aria-hidden="true" />}`.
   - Rule: Suspense fallback — must provide visible loading indicator; missing fallback shows blank page to user during async fetch
 
-## [PR #420 Round 13 | master | 2026-05-05]
-- B1: `finalizeOAuthSignupAction.test.ts` — `if (!created) { throw new Error('createOAuthUser returned null') }` branch inside transaction not covered. Added test that overrides MockUserRepo to return null from createOAuthUser and asserts redirect to /login?error=service_unavailable (MISTAKES.md Infrastructure §2 — 100% branch coverage).
-  - Rule: MISTAKES.md Infrastructure §2 — 100% branch coverage
-- S1: `finalizeOAuthSignupAction.test.ts` — SAMPLE_TERMS_P/T fixtures had `createdAt: new Date()` which is not a field in TermsRecord interface. Removed `createdAt` from both fixtures.
-  - Rule: MISTAKES.md Tests §2 — mock keys must match actual return type
-- S2: `db/scripts/seedTerms.ts` — sequential for...of + await loop for independent upsertFromSeed calls. Converted to Promise.all(seeds.map(async seed => { ... })) for parallel execution (MISTAKES.md §5 — prefer declarative patterns).
-  - Rule: MISTAKES.md §5 — prefer declarative patterns over imperative loops
-
 ## [PR #420 Round 12 | master | 2026-05-05]
-- B1: `ConsentCheckboxGroup.test.tsx` — test queries `getByRole('alert')` but component now renders `role="status"`; test would fail at runtime (MISTAKES.md Tests §1 — test must sync with implementation). Changed query to `getByRole('status')` and updated test description accordingly.
-  - Rule: MISTAKES.md Tests §1 — test must sync with implementation
-- S1: `OAuthConsentForm.test.tsx` — `jest.mock('@/infrastructure/auth/cancelOAuthSignupAction', ...)` is dead; OAuthConsentForm receives cancelAction as a prop, never imports the action. Removed the unnecessary mock.
-  - Rule: MISTAKES.md §4 — Remove logic/code that has no effect (dead code)
 - S2: `route.ts` ([provider] callback) — 3 WHAT-comments (`Existing OAuth account → immediate login`, `Email already registered`, `New user →`) violate CLAUDE.md comment policy; code already expresses intent. Removed all 3 comments.
   - Rule: CLAUDE.md comment policy — comments should explain WHY, not WHAT (code expresses WHAT)
 
 ## [PR #420 Round 11 | master | 2026-05-05]
-- B1: `cancelOAuthSignupAction.ts` — entire action body not wrapped in outer try-catch; unexpected exceptions would propagate to client (MISTAKES.md §0.7). Wrapped in outer try-catch; re-throws NEXT_REDIRECT, falls back to redirect('/login') for other errors.
-  - Rule: MISTAKES.md §0.7 — Server Actions must catch all throws, never propagate to client
-- B2: `ConsentCheckboxGroup.tsx` — `role="alert"` + `aria-live="polite"` conflict; role="alert" implicitly sets aria-live="assertive", creating unpredictable screen reader behavior. Changed to `role="status"` (keeps explicit aria-live="polite").
-  - Rule: ARIA semantics — role="alert" conflicts with explicit aria-live="polite"
 - B3: `ConsentCheckboxGroup.tsx` — error `<p>` had no `id`; invalid checkboxes had no `aria-describedby` connection to error message. Added `const errorId = useId()`, `id={errorId}` on error element, `errorId` prop on ConsentRow, `aria-describedby: errorId` on checkbox inputs.
   - Rule: ARIA accessibility — form inputs with errors must have aria-describedby pointing to error message
 - S1: `route.ts` ([provider] callback) — `let token; try { token = await ... } catch { return ... }` imperative pattern (MISTAKES.md §14). Replaced with declarative `const token = await pendingStore.save({...}).catch(() => null); if (!token) return ...`
   - Rule: MISTAKES.md §14 — Imperative exception handling within try-catch should use declarative .catch() or ?. chains
 - S2: `usePageShowReload.ts` moved from `src/components/auth/hooks/` to `src/components/hooks/` (generic bfcache hook placed in auth feature subfolder instead of global hooks dir, MISTAKES.md Components §15). Updated import in OAuthConsentForm.tsx.
   - Rule: MISTAKES.md Components §15 — Feature-agnostic utilities belong in global directories, not feature-specific subdirs
-- S3: `seedTerms.ts` — imperative `for (let i = 0; ...)` index loop for version gap detection. Replaced with declarative `findIndex` pattern.
-  - Rule: MISTAKES.md §5 — Declarative patterns (map, filter, reduce, findIndex) preferred over imperative loops
 
 ## [PR #420 Round 10 | master | 2026-05-05]
-- B1: `ConsentCheckboxGroup.tsx` — `text-white` raw Tailwind color used for checkmark SVG icon. MISTAKES.md §0.5 prohibits raw color references. Changed to `text-secondary-50` (design system semantic token).
-  - Rule: MISTAKES.md §0.5 — Use design system semantic tokens, not raw Tailwind colors
-- B2: `registerAction.test.ts` — 2 occurrences of `expect.anything()` as second argument in `toHaveBeenCalledWith()`. MISTAKES.md Tests §15/§16 forbids `expect.anything()`. Replaced with `expect.objectContaining({ emailTokens: expect.objectContaining({...}), db: expect.objectContaining({...}) })`. Also moved `agreedTermsIds` test from `'입력 정규화'` describe block to new `'약관 ID 전달'` describe block (correct category).
-  - Rule: MISTAKES.md Tests §15/§16 — forbids `expect.anything()` in assertion
-- B3: `termsRepository.test.ts` — `InsertedRow.kind: 'privacy' | 'tos'` inline union instead of named type. MISTAKES.md TypeScript §5/§5.2 requires named type alias. Added `import type { TermsKind }` and changed to `kind: TermsKind`.
-  - Rule: MISTAKES.md TypeScript §5/§5.2 — inline union literals should use named type aliases
 - S1: `pendingOAuthSignupStore.ts` — object literal methods missing explicit return type annotations. Added explicit return types to all 4 methods (save, peek, consume, delete).
   - Rule: MISTAKES.md §0 — explicit return type annotations for methods
-- S2: `legal-toc.test.ts` — missing test for github-slugger duplicate slug deduplication behavior. Added test verifying -1, -2 suffix for repeated headings.
-  - Rule: Test coverage — slug deduplication is internal utility behavior and should have dedicated test
 
 ## [PR #420 Round 9 | master | 2026-05-05]
 - M1: `registerAction.ts` — catch block returned `service_unavailable` without logging unexpected runtime errors, making debugging difficult. Added `console.error('[registerAction] unexpected error:', err)` before returning error.
@@ -70,16 +34,8 @@
   - Rule: Error logging in catch blocks — debugging requires visibility into root causes
 
 ## [PR #420 Round 8 | master | 2026-05-05]
-- B1: `tryParse` catch 분기 미테스트 — `pendingOAuthSignupStore.test.ts`에 corrupted JSON 케이스 추가.
-  - Rule: MISTAKES.md Infrastructure §2 — 100% branch coverage
-- B2: `termsRepository.test.ts` mock row `effective_date`(snake_case) → `effectiveDate`(camelCase) 수정, `findActive` 성공 케이스에 `effectiveDate` 검증 추가.
-  - Rule: MISTAKES.md Tests §2 — mock 키가 실제 반환 타입과 일치해야 함
 - B3: `registerAction.test.ts` `expect.anything()` → `expect.objectContaining({ emailTokens, db })` 명시 검증. db mock에 `transaction` 함수 추가.
   - Rule: 의존성 주입 검증 — db 인자 포함 여부 명시
-
-## [PR #420 Round 7 | master | 2026-05-05]
-- B1/B2/B3: `isSecureCookieEnv()` 동일 함수 내 2회 중복 호출 — `finalizeOAuthSignupAction.ts`, `registerAction.ts`, `route.ts` 세 파일 모두 `const secure = isSecureCookieEnv()`로 추출 후 재사용.
-  - Rule: MISTAKES.md §2 — 동일 함수 내 중복 호출 금지
 
 ## [PR #420 Round 6 | master | 2026-05-04]
 - B1: `formatKoreanDate` 타임존 버그 — `getFullYear/Month/Date`는 프로세스 로컬(UTC) 기준이라 KST 날짜가 하루 밀림. `Intl.DateTimeFormat('ko-KR', { timeZone: 'Asia/Seoul' })`로 교체.
@@ -90,35 +46,17 @@
 - S2: `[WebkitTapHighlightColor:transparent]` → `[-webkit-tap-highlight-color:transparent]` (Tailwind arbitrary 벤더 접두사 소문자 하이픈)
 
 ## [PR #420 Round 5 | master | 2026-05-04]
-- B1: `OAuthConsentForm.tsx` — `formError` dead code 제거. `FinalizeOAuthSignupState.error.code`가 `'consent_required'` 리터럴이므로 `!== 'consent_required'` 조건은 항상 false. `formError` 변수·`AuthErrorAlert` 블록 제거.
-  - Rule: MISTAKES.md §4 — Remove logic/code that has no effect
 - S1: `finalizeOAuthSignupAction.ts` — 소비처 없는 `export type { FinalizeOAuthSignupState }` re-export 제거 (YAGNI).
 
-## [PR #420 Round 4 | master | 2026-05-04]
-- B2: `cancelOAuthSignupAction.test.ts` 분기 미테스트 — store null 케이스, store.delete() throw 케이스 두 테스트 추가.
-  - Rule: MISTAKES.md Infrastructure §2 — 100% branch coverage
-
 ## [PR #420 Round 3 | master | 2026-05-04]
-- B1: `OAuthConsentForm.tsx` had `import type { cancelOAuthSignupAction } from '@/infrastructure/auth/cancelOAuthSignupAction'` — component `.tsx` files cannot import from infrastructure even with `import type`. Replaced `typeof cancelOAuthSignupAction` with explicit `(formData: FormData) => Promise<void>` signature, removed the import.
-  - Rule: MISTAKES.md Architecture §0 — component .tsx: infrastructure import prohibited (including `import type`)
 - S1: `route.ts` GET handler — `pendingStore.save()` not wrapped in try-catch. Redis failure would cause unhandled 500. Wrapped in try-catch, redirects to `oauth_unknown` on failure (consistent with existing error handling pattern).
 
 ## [PR #420 Round 2 | master | 2026-05-04]
-- B3: `ParsedSeed.kind` inline union literal `'privacy' | 'tos'` — should use `TermsKind` named alias from `constants.ts` for single source of truth.
-  - Rule: MISTAKES.md §5.2 — inline union literals should use named type aliases
 - S1: Replaced custom `slugify` in `legal-toc.ts` with `github-slugger` (already transitive dep). Added `transformIgnorePatterns` to `jest.config.js` to handle ESM-only package.
 
 ## [PR #420 Round 1 | master | 2026-05-04]
-- B2: `finalizeOAuthSignupAction` missing outer try-catch — MISTAKES.md Coding Paradigm 0.7 (Server Actions must catch all throws, never propagate to client). Wrapped full body; re-throws NEXT_REDIRECT, redirects on other errors.
-  - Rule: MISTAKES.md Coding Paradigm 0.7 — Server Actions must catch all throws
-- B3: `CheckboxBoxProps` defined inline in component parameter — MISTAKES.md Components 13 requires named interface declared above component. Extracted interface above `CheckboxBox`.
-  - Rule: MISTAKES.md Components 13 — props interfaces must be named and declared above component
-- B5: `seedTerms.ts` used `list.push()` (array mutation) — MISTAKES.md §5 prohibits array mutation via push. Changed to spread: `[...list, seed.version]`.
-  - Rule: MISTAKES.md §5 — no array mutation via push
 - B6: `[...versions].sort()` — spread was unnecessary since `toSorted()` doesn't mutate. Changed to `versions.toSorted()`.
 - B7: `legal-toc.ts` used imperative `for + push` — refactored to declarative `map`.
-- B8: `OAuthConsentForm.tsx` had inline `useEffect` for pageshow event — MISTAKES.md Components 7 requires DOM event listeners in useEffect to be extracted to custom hooks. Extracted to `usePageShowReload` hook.
-  - Rule: MISTAKES.md Components 7 — DOM event listeners in useEffect must be extracted to custom hooks
 - Fix: `consent/page.tsx` had `export const dynamic = 'force-dynamic'` incompatible with `cacheComponents: true`. Removed — searchParams already makes page dynamic.
 - Fix: `privacy/page.tsx`, `terms/page.tsx` — DB access in async page component triggers "Uncached data outside Suspense" with `cacheComponents: true`. Split into inner async components wrapped in Suspense.
 
@@ -144,15 +82,6 @@
 - Suggestion S2 적용: SymbolPageClient bottomSlot 주석 WHAT → WHY로 교체
 - Rule: 주석은 코드로 자명하지 않은 이유를 적는다
 - Context: "차트 컨테이너 아래에 렌더" → "서버 컴포넌트가 SEO용 cross-link를 주입하기 위한 슬롯".
-
-## [PR #417 Round 3 | worktree-seo-overhaul-49 | 2026-05-04]
-- Violation: backtesting/page.tsx 면책 고지가 `<aside>`로 감싸져 있어 ARIA `complementary` role이 적용 — 면책 고지는 보완 콘텐츠가 아니라 필수 법적 노트
-- Rule: ARIA semantics — `<aside>`는 제거해도 메인 콘텐츠 이해에 지장이 없는 보완 콘텐츠 전용
-- Context: P4.6에서 `<footer>` → `<aside>`(글로벌 Footer landmark 중복 회피) 변경. R1 reviewer가 footer 원복 권고 → 거절(글로벌 Footer 충돌). R3 reviewer가 `<div role="note" aria-label>` 옵션 제시. 두 우려 모두 해소되는 third path를 채택.
-
-- Violation: overall/page.tsx 인트로 `<section>`에 accessible name 없음 — 스크린 리더 랜드마크 탐색에서 generic으로 처리
-- Rule: ARIA — `<section>`은 aria-labelledby로 접근 가능 이름이 명시되어야 랜드마크로 인식
-- Context: P1.1에서 visible static SEO 콘텐츠 블록을 `<section>`으로 추가. 내부 `<h2>`에 id 부여하고 `<section aria-labelledby>`로 연결.
 
 ## [PR #417 Round 1 | worktree-seo-overhaul-49 | 2026-05-04]
 - Violation: schema.org `Article.datePublished` set to `new Date().toISOString()` (request time) — Googlebot interprets every crawl as a fresh publication
@@ -276,14 +205,6 @@
 - Violation: NewsDisplayItem.sentiment and .category were `string | null`, losing type safety
 - Rule: MISTAKES.md TypeScript 7 — Using `as` type assertions instead of type guards; DB columns backed by domain enums must be cast at repository boundary
 - Context: Now typed `NewsSentiment | null` / `NewsCategory | null` from @y0ngha/siglens-core with trust model comment in toNewsRow: "DB는 sentiment/category를 raw text로 저장하므로 LLM 결과를 신뢰해 좁혀준다."
-
-
-
-## [PR #416 | fix/wig-cleanup | 2026-05-04]
-- Violation: SubmitButton.tsx had `focus-visible:ring-primary-500` without `focus-visible:ring-offset-2` / `ring-offset-{color}` while peer buttons in the same PR (DangerSubmitButton, error retry buttons, PasswordField toggle) all carried the offset pair
-- Rule: WAI-ARIA keyboard accessibility — same-color ring on same-color background needs ring-offset for sufficient contrast; cross-component consistency
-- Context: Added `focus-visible:ring-offset-secondary-900 focus-visible:ring-offset-2` to align with the form's AuthCardShell `bg-secondary-900/80` surrounding background.
-
 ## [Phase 7 OAuth Consent Flow | Spec compliance R2 | 2026-05-04]
 - Violation: finalizeOAuthSignupAction.ts variable `let createdUserId` may be uninitialized from TypeScript perspective when returned
 - Rule: MISTAKES.md Coding Paradigm 0 — Non-null return type implies value is always assigned; use const + ternary/null coalescing

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,15 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
     allowedDevOrigins: ['172.30.1.26'],
 
+    images: {
+        remotePatterns: [
+            {
+                protocol: 'https',
+                hostname: 'lh3.googleusercontent.com',
+            },
+        ],
+    },
+
     // React Compiler (Next.js 16 stable)
     reactCompiler: true,
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "@tanstack/react-query": "^5.95.2",
         "@upstash/redis": "^1.37.0",
         "@vercel/functions": "^3.4.3",
-        "@y0ngha/siglens-core": "0.7.3",
+        "@y0ngha/siglens-core": "0.7.4",
         "bcryptjs": "^3.0.3",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "db:generate": "dotenv -e .env.local -- drizzle-kit generate",
         "db:migrate": "dotenv -e .env.local -- node_modules/.bin/tsx db/scripts/migrate.ts",
         "db:seed:terms": "dotenv -e .env.local -- node_modules/.bin/tsx db/scripts/seedTerms.ts",
+        "db:migrate:tickers": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seed-korean-tickers.ts",
         "test": "jest",
         "test-watch": "jest --watch",
         "test-coverage": "jest --coverage",

--- a/src/__tests__/components/analysis/ModelSelector.test.tsx
+++ b/src/__tests__/components/analysis/ModelSelector.test.tsx
@@ -71,7 +71,11 @@ describe('ModelSelector', () => {
 
         const flashOption = screen
             .getAllByRole('option')
-            .find(o => o.textContent?.includes('Flash') && !o.textContent?.includes('Lite'));
+            .find(
+                o =>
+                    o.textContent?.includes('Flash') &&
+                    !o.textContent?.includes('Lite')
+            );
         await user.click(flashOption!);
 
         expect(onModelChange).toHaveBeenCalledWith('gemini-2.5-flash');

--- a/src/__tests__/components/analysis/ModelSelector.test.tsx
+++ b/src/__tests__/components/analysis/ModelSelector.test.tsx
@@ -3,38 +3,32 @@
  */
 
 import '@testing-library/jest-dom';
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ModelSelector } from '@/components/analysis/ModelSelector';
-import type { AIProvider, ModelId } from '@y0ngha/siglens-core';
-
-jest.mock('@/domain/llm/providerDefaults', () => ({
-    resolveDefaultModelForProvider: jest.fn((provider: string) =>
-        provider === 'chatgpt' ? null : `${provider}-model`
-    ),
-}));
+import type { ModelId } from '@y0ngha/siglens-core';
 
 const ALLOWED_MODELS: readonly ModelId[] = [
+    'gemini-2.5-flash-lite',
+    'gemini-2.5-flash',
     'claude-sonnet-4-6',
-    'gemini-2.5-pro',
 ] as const;
 
 function renderSelector(
     props: Partial<{
-        selectedProvider: AIProvider;
-        onProviderChange: (p: AIProvider) => void;
+        selectedModel: ModelId;
+        onModelChange: (m: ModelId) => void;
         allowedModels: readonly ModelId[];
         disabled: boolean;
     }> = {}
 ) {
-    const onProviderChange = props.onProviderChange ?? jest.fn();
+    const onModelChange = props.onModelChange ?? jest.fn();
     return {
-        onProviderChange,
+        onModelChange,
         ...render(
             <ModelSelector
-                selectedProvider={props.selectedProvider ?? 'claude'}
-                onProviderChange={onProviderChange}
+                selectedModel={props.selectedModel ?? 'gemini-2.5-flash-lite'}
+                onModelChange={onModelChange}
                 allowedModels={props.allowedModels ?? ALLOWED_MODELS}
                 disabled={props.disabled}
             />
@@ -43,105 +37,68 @@ function renderSelector(
 }
 
 describe('ModelSelector', () => {
-    it('renders 3 provider options', () => {
+    it('renders trigger button with selected model label', () => {
+        renderSelector({ selectedModel: 'gemini-2.5-flash-lite' });
+        expect(
+            screen.getByRole('button', { name: 'AI 분석 모델 선택' })
+        ).toBeInTheDocument();
+        expect(screen.getByText('Flash Lite')).toBeInTheDocument();
+    });
+
+    it('opens dropdown on trigger click and shows allowed models', async () => {
+        const user = userEvent.setup();
         renderSelector();
-        const options = screen.getAllByRole('radio');
-        expect(options).toHaveLength(3);
-    });
 
-    it('selected provider has aria-checked="true", others have aria-checked="false"', () => {
-        renderSelector({ selectedProvider: 'gemini' });
-        const options = screen.getAllByRole('radio');
-
-        const claudeOption = options.find(
-            o => o.getAttribute('data-provider') === 'claude'
-        );
-        const geminiOption = options.find(
-            o => o.getAttribute('data-provider') === 'gemini'
-        );
-        const chatgptOption = options.find(
-            o => o.getAttribute('data-provider') === 'chatgpt'
+        await user.click(
+            screen.getByRole('button', { name: 'AI 분석 모델 선택' })
         );
 
-        expect(claudeOption).toHaveAttribute('aria-checked', 'false');
-        expect(geminiOption).toHaveAttribute('aria-checked', 'true');
-        expect(chatgptOption).toHaveAttribute('aria-checked', 'false');
+        const listbox = screen.getByRole('listbox');
+        expect(listbox).toBeInTheDocument();
+        expect(screen.getByText('Flash')).toBeInTheDocument();
+        expect(screen.getByText('Sonnet')).toBeInTheDocument();
     });
 
-    it('clicking an unlocked option calls onProviderChange with correct provider', async () => {
+    it('clicking a model option calls onModelChange and closes dropdown', async () => {
         const user = userEvent.setup();
-        const { onProviderChange } = renderSelector({
-            selectedProvider: 'claude',
+        const { onModelChange } = renderSelector({
+            selectedModel: 'gemini-2.5-flash-lite',
         });
 
-        const geminiOption = screen
-            .getAllByRole('radio')
-            .find(o => o.getAttribute('data-provider') === 'gemini');
+        await user.click(
+            screen.getByRole('button', { name: 'AI 분석 모델 선택' })
+        );
 
-        await user.click(geminiOption!);
-        expect(onProviderChange).toHaveBeenCalledWith('gemini');
+        const flashOption = screen
+            .getAllByRole('option')
+            .find(o => o.textContent?.includes('Flash') && !o.textContent?.includes('Lite'));
+        await user.click(flashOption!);
+
+        expect(onModelChange).toHaveBeenCalledWith('gemini-2.5-flash');
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
     });
 
-    it('clicking a locked option does NOT call onProviderChange', async () => {
+    it('disabled prop prevents dropdown from opening', async () => {
         const user = userEvent.setup();
-        const { onProviderChange } = renderSelector({
-            selectedProvider: 'claude',
-        });
+        renderSelector({ disabled: true });
 
-        const chatgptOption = screen
-            .getAllByRole('radio')
-            .find(o => o.getAttribute('data-provider') === 'chatgpt');
+        await user.click(
+            screen.getByRole('button', { name: 'AI 분석 모델 선택' })
+        );
 
-        await user.click(chatgptOption!);
-        expect(onProviderChange).not.toHaveBeenCalled();
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
     });
 
-    it('ArrowRight moves selection to next option and fires onProviderChange', async () => {
+    it('Escape closes the dropdown', async () => {
         const user = userEvent.setup();
-        const { onProviderChange } = renderSelector({
-            selectedProvider: 'claude',
-        });
+        renderSelector();
 
-        const claudeOption = screen
-            .getAllByRole('radio')
-            .find(o => o.getAttribute('data-provider') === 'claude');
+        await user.click(
+            screen.getByRole('button', { name: 'AI 분석 모델 선택' })
+        );
+        expect(screen.getByRole('listbox')).toBeInTheDocument();
 
-        claudeOption!.focus();
-        await user.keyboard('{ArrowRight}');
-
-        // next non-locked after claude is gemini (chatgpt is locked)
-        expect(onProviderChange).toHaveBeenCalledWith('gemini');
-    });
-
-    it('ArrowLeft wraps from first to last non-locked option', async () => {
-        const user = userEvent.setup();
-        const { onProviderChange } = renderSelector({
-            selectedProvider: 'claude',
-        });
-
-        const claudeOption = screen
-            .getAllByRole('radio')
-            .find(o => o.getAttribute('data-provider') === 'claude');
-
-        claudeOption!.focus();
-        await user.keyboard('{ArrowLeft}');
-
-        // prev from claude wraps to last non-locked = gemini
-        expect(onProviderChange).toHaveBeenCalledWith('gemini');
-    });
-
-    it('disabled prop: all clicks are no-ops', async () => {
-        const user = userEvent.setup();
-        const { onProviderChange } = renderSelector({
-            selectedProvider: 'claude',
-            disabled: true,
-        });
-
-        const options = screen.getAllByRole('radio');
-        for (const option of options) {
-            await user.click(option);
-        }
-
-        expect(onProviderChange).not.toHaveBeenCalled();
+        await user.keyboard('{Escape}');
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
     });
 });

--- a/src/__tests__/components/layout/HeaderUserMenu.test.tsx
+++ b/src/__tests__/components/layout/HeaderUserMenu.test.tsx
@@ -27,6 +27,7 @@ describe('HeaderUserMenu', () => {
                     email: 'user@example.com',
                     name: 'Yongha',
                     tier: 'member',
+                    avatarUrl: null,
                 }}
             />
         );
@@ -38,6 +39,21 @@ describe('HeaderUserMenu', () => {
         expect(trigger).toHaveTextContent('Y');
     });
 
+    it('avatarUrl이 있으면 이미지를 렌더한다', () => {
+        render(
+            <HeaderUserMenu
+                currentUser={{
+                    email: 'user@example.com',
+                    name: 'Yongha',
+                    tier: 'member',
+                    avatarUrl: 'https://lh3.googleusercontent.com/a/avatar.jpg',
+                }}
+            />
+        );
+        const img = screen.getByRole('img');
+        expect(img).toBeInTheDocument();
+    });
+
     it('트리거 클릭시 메뉴가 열리고 이름과 이메일이 표시된다', () => {
         render(
             <HeaderUserMenu
@@ -45,6 +61,7 @@ describe('HeaderUserMenu', () => {
                     email: 'user@example.com',
                     name: 'Yongha',
                     tier: 'free',
+                    avatarUrl: null,
                 }}
             />
         );
@@ -65,6 +82,7 @@ describe('HeaderUserMenu', () => {
                     email: 'alice@example.com',
                     name: null,
                     tier: 'pro',
+                    avatarUrl: null,
                 }}
             />
         );

--- a/src/__tests__/infrastructure/auth/finalizeOAuthSignupAction.test.ts
+++ b/src/__tests__/infrastructure/auth/finalizeOAuthSignupAction.test.ts
@@ -97,7 +97,8 @@ function setupMocks(
         privacyTerms?: typeof SAMPLE_TERMS_P | null;
         tosTerms?: typeof SAMPLE_TERMS_T | null;
         existingUser?: { id: string } | null;
-        transactionThrows?: boolean;
+        createOAuthUserResult?: { id: string } | null;
+        insertManyThrows?: boolean;
     } = {}
 ): void {
     const {
@@ -107,7 +108,8 @@ function setupMocks(
         privacyTerms = SAMPLE_TERMS_P,
         tosTerms = SAMPLE_TERMS_T,
         existingUser = null,
-        transactionThrows = false,
+        createOAuthUserResult = { id: 'new-user-id' },
+        insertManyThrows = false,
     } = options;
 
     if (!storeAvailable) {
@@ -139,26 +141,21 @@ function setupMocks(
                 findByEmail: jest.fn().mockResolvedValue(existingUser),
                 createOAuthUser: jest
                     .fn()
-                    .mockResolvedValue({ id: 'new-user-id' }),
+                    .mockResolvedValue(createOAuthUserResult),
+                deleteUser: jest.fn().mockResolvedValue(true),
             }) as unknown as InstanceType<typeof DrizzleUserRepository>
     );
 
     MockAgreementRepo.mockImplementation(
         () =>
             ({
-                insertMany: jest.fn().mockResolvedValue(undefined),
+                insertMany: insertManyThrows
+                    ? jest.fn().mockRejectedValue(new Error('db error'))
+                    : jest.fn().mockResolvedValue(undefined),
             }) as unknown as InstanceType<typeof DrizzleAgreementRepository>
     );
 
-    const txMock = transactionThrows
-        ? jest.fn().mockRejectedValue(new Error('db error'))
-        : jest
-              .fn()
-              .mockImplementation(
-                  async (cb: (tx: unknown) => Promise<string>) => cb({})
-              );
-
-    mockGetAuthDb.mockReturnValue({ db: { transaction: txMock } });
+    mockGetAuthDb.mockReturnValue({ db: {} });
 }
 
 async function expectRedirectTo(
@@ -229,21 +226,29 @@ describe('finalizeOAuthSignupAction', () => {
         await expectRedirectTo('/login?error=oauth_email_conflict');
     });
 
-    it('redirects to service_unavailable when DB transaction throws', async () => {
-        setupMocks({ transactionThrows: true });
-        await expectRedirectTo('/login?error=service_unavailable');
-    });
+    it('redirects to service_unavailable when agreement insertion throws and compensates by deleting the user', async () => {
+        setupMocks({ insertManyThrows: true });
 
-    it('redirects to service_unavailable when createOAuthUser returns null inside transaction', async () => {
-        setupMocks();
+        const deleteUser = jest.fn().mockResolvedValue(true);
         MockUserRepo.mockImplementation(
             () =>
                 ({
                     findByEmail: jest.fn().mockResolvedValue(null),
-                    createOAuthUser: jest.fn().mockResolvedValue(null),
+                    createOAuthUser: jest
+                        .fn()
+                        .mockResolvedValue({ id: 'new-user-id' }),
+                    deleteUser,
                 }) as unknown as InstanceType<typeof DrizzleUserRepository>
         );
+
         await expectRedirectTo('/login?error=service_unavailable');
+
+        expect(deleteUser).toHaveBeenCalledWith('new-user-id');
+    });
+
+    it('redirects to oauth_email_conflict when createOAuthUser returns null (race condition)', async () => {
+        setupMocks({ createOAuthUserResult: null });
+        await expectRedirectTo('/login?error=oauth_email_conflict');
     });
 
     it('예상치 못한 내부 에러 발생 시 service_unavailable로 리다이렉트한다', async () => {

--- a/src/__tests__/infrastructure/auth/registerAction.test.ts
+++ b/src/__tests__/infrastructure/auth/registerAction.test.ts
@@ -6,7 +6,7 @@ jest.mock('next/navigation', () => ({
 }));
 jest.mock('@/infrastructure/db/client', () => ({
     getDatabaseClient: jest.fn(() => ({
-        db: { transaction: jest.fn() },
+        db: {},
         sql: () => null,
     })),
     resetDatabaseClientForTests: jest.fn(),
@@ -18,7 +18,7 @@ jest.mock('@/infrastructure/db/userRepository', () => ({
     DrizzleUserRepository: jest.fn().mockImplementation(() => ({})),
 }));
 jest.mock('@/infrastructure/db/agreementRepository', () => ({
-    DrizzleAgreementRepository: jest.fn().mockImplementation(() => ({})),
+    DrizzleAgreementRepository: jest.fn(),
 }));
 jest.mock('@/infrastructure/db/termsRepository', () => ({
     DrizzleTermsRepository: jest.fn(),
@@ -43,6 +43,7 @@ import { loginUser } from '@/infrastructure/auth/use-cases/loginUser';
 import { registerUser } from '@/infrastructure/auth/use-cases/registerUser';
 import { createEmailTokenStore } from '@/infrastructure/email/tokenStore';
 import { getDatabaseClient } from '@/infrastructure/db/client';
+import { DrizzleAgreementRepository } from '@/infrastructure/db/agreementRepository';
 import { DrizzleTermsRepository } from '@/infrastructure/db/termsRepository';
 import { AUTH_SERVICE_UNAVAILABLE_MESSAGE } from '@/infrastructure/auth/errorMessages';
 import { registerAction } from '@/infrastructure/auth/registerAction';
@@ -274,9 +275,7 @@ describe('registerAction', () => {
                         get: expect.any(Function),
                         delete: expect.any(Function),
                     }),
-                    db: expect.objectContaining({
-                        transaction: expect.any(Function),
-                    }),
+                    agreements: expect.any(DrizzleAgreementRepository),
                 })
             );
         });
@@ -308,9 +307,7 @@ describe('registerAction', () => {
                         get: expect.any(Function),
                         delete: expect.any(Function),
                     }),
-                    db: expect.objectContaining({
-                        transaction: expect.any(Function),
-                    }),
+                    agreements: expect.any(DrizzleAgreementRepository),
                 })
             );
         });
@@ -337,9 +334,7 @@ describe('registerAction', () => {
                         get: expect.any(Function),
                         delete: expect.any(Function),
                     }),
-                    db: expect.objectContaining({
-                        transaction: expect.any(Function),
-                    }),
+                    agreements: expect.any(DrizzleAgreementRepository),
                 })
             );
         });
@@ -367,9 +362,7 @@ describe('registerAction', () => {
                         get: expect.any(Function),
                         delete: expect.any(Function),
                     }),
-                    db: expect.objectContaining({
-                        transaction: expect.any(Function),
-                    }),
+                    agreements: expect.any(DrizzleAgreementRepository),
                 })
             );
         });
@@ -484,9 +477,7 @@ describe('registerAction', () => {
                         get: expect.any(Function),
                         delete: expect.any(Function),
                     }),
-                    db: expect.objectContaining({
-                        transaction: expect.any(Function),
-                    }),
+                    agreements: expect.any(DrizzleAgreementRepository),
                 })
             );
             expect(setSpy).toHaveBeenCalledWith(

--- a/src/__tests__/infrastructure/auth/use-cases/confirmPasswordReset.test.ts
+++ b/src/__tests__/infrastructure/auth/use-cases/confirmPasswordReset.test.ts
@@ -122,9 +122,11 @@ describe('confirmPasswordReset', () => {
     });
 
     it('returns expired_token error when the token does not exist', async () => {
-        const { dependencies, consumeToken, updatePassword } = makeDependencies({
-            peekedToken: null,
-        });
+        const { dependencies, consumeToken, updatePassword } = makeDependencies(
+            {
+                peekedToken: null,
+            }
+        );
 
         const result = await confirmPasswordReset(
             {
@@ -196,7 +198,8 @@ describe('confirmPasswordReset', () => {
     });
 
     it('returns invalid_token error when the supplied token does not match', async () => {
-        const { dependencies, consumeToken, updatePassword } = makeDependencies();
+        const { dependencies, consumeToken, updatePassword } =
+            makeDependencies();
 
         const result = await confirmPasswordReset(
             {
@@ -265,7 +268,8 @@ describe('confirmPasswordReset', () => {
             ok: false,
             error: {
                 code: 'same_password',
-                message: '현재 비밀번호와 동일한 비밀번호는 사용할 수 없습니다.',
+                message:
+                    '현재 비밀번호와 동일한 비밀번호는 사용할 수 없습니다.',
             },
         });
         expect(verifyPassword).toHaveBeenCalledWith(NEW_PASSWORD, 'old-hash');
@@ -334,7 +338,10 @@ describe('confirmPasswordReset', () => {
         );
 
         expect(result).toEqual({ ok: true });
-        expect(getToken).toHaveBeenCalledWith('password_reset', 'user@example.com');
+        expect(getToken).toHaveBeenCalledWith(
+            'password_reset',
+            'user@example.com'
+        );
         expect(consumeToken).toHaveBeenCalledWith(
             'password_reset',
             'user@example.com'
@@ -345,7 +352,13 @@ describe('confirmPasswordReset', () => {
             'user-1',
             'new-hashed-password'
         );
-        expect(callOrder).toEqual(['get', 'verify', 'consume', 'hash', 'update']);
+        expect(callOrder).toEqual([
+            'get',
+            'verify',
+            'consume',
+            'hash',
+            'update',
+        ]);
     });
 
     it('only one of two concurrent consumers updates the password', async () => {

--- a/src/__tests__/infrastructure/auth/use-cases/confirmPasswordReset.test.ts
+++ b/src/__tests__/infrastructure/auth/use-cases/confirmPasswordReset.test.ts
@@ -181,10 +181,9 @@ describe('confirmPasswordReset', () => {
         if (!result.ok) expect(result.error.code).toBe('invalid_token');
     });
 
-    it('returns same_password error when new password matches the current one', async () => {
-        const { dependencies, updatePassword, verifyPassword } = makeDependencies({
-            isSamePassword: true,
-        });
+    it('returns same_password error and does not consume the token', async () => {
+        const { dependencies, consumeToken, updatePassword, verifyPassword } =
+            makeDependencies({ isSamePassword: true });
 
         const result = await confirmPasswordReset(
             {
@@ -199,11 +198,11 @@ describe('confirmPasswordReset', () => {
             ok: false,
             error: {
                 code: 'same_password',
-                field: 'password',
                 message: '현재 비밀번호와 동일한 비밀번호는 사용할 수 없습니다.',
             },
         });
         expect(verifyPassword).toHaveBeenCalledWith(NEW_PASSWORD, 'old-hash');
+        expect(consumeToken).not.toHaveBeenCalled();
         expect(updatePassword).not.toHaveBeenCalled();
     });
 
@@ -291,7 +290,7 @@ describe('confirmPasswordReset', () => {
             'user-1',
             'new-hashed-password'
         );
-        expect(callOrder).toEqual(['consume', 'verify', 'hash', 'update']);
+        expect(callOrder).toEqual(['verify', 'consume', 'hash', 'update']);
     });
 
     it('only one of two concurrent consumers updates the password', async () => {

--- a/src/__tests__/infrastructure/auth/use-cases/confirmPasswordReset.test.ts
+++ b/src/__tests__/infrastructure/auth/use-cases/confirmPasswordReset.test.ts
@@ -23,39 +23,54 @@ const user: EmailAuthUserRecord = {
     updatedAt: new Date('2026-04-27T00:00:01.000Z'),
 };
 
+const VALID_TOKEN_VALUE: EmailTokenValue = {
+    status: 'pending',
+    tokenHash: STORED_TOKEN_HASH,
+};
+
 function makeDependencies(options?: {
-    storedToken?: EmailTokenValue | null;
+    /** Controls emailTokens.get return value. Defaults to VALID_TOKEN_VALUE. */
+    peekedToken?: EmailTokenValue | null;
+    /** Controls emailTokens.consume return value. Defaults to peekedToken. */
+    consumedToken?: EmailTokenValue | null;
     user?: EmailAuthUserRecord | null;
     updatePasswordResult?: boolean;
     hashedNewPassword?: string;
     isSamePassword?: boolean;
 }): {
     dependencies: ConfirmPasswordResetDependencies;
+    getToken: ReturnType<typeof jest.fn>;
     consumeToken: ReturnType<typeof jest.fn>;
     findEmailAuthUserByEmail: ReturnType<typeof jest.fn>;
     updatePassword: ReturnType<typeof jest.fn>;
     hashPassword: ReturnType<typeof jest.fn>;
     verifyPassword: ReturnType<typeof jest.fn>;
 } {
-    const defaultStored: EmailTokenValue = {
-        status: 'pending',
-        tokenHash: STORED_TOKEN_HASH,
-    };
-    const storedToken: EmailTokenValue | null =
-        options && 'storedToken' in options
-            ? (options.storedToken ?? null)
-            : defaultStored;
+    const peeked =
+        options && 'peekedToken' in options
+            ? (options.peekedToken ?? null)
+            : VALID_TOKEN_VALUE;
+    const consumed =
+        options && 'consumedToken' in options
+            ? (options.consumedToken ?? null)
+            : peeked;
     const foundUser = options && 'user' in options ? options.user : user;
     const updateResult = options?.updatePasswordResult ?? true;
     const hashed = options?.hashedNewPassword ?? 'new-hashed-password';
     const samePassword = options?.isSamePassword ?? false;
 
+    const getToken = jest
+        .fn<
+            Promise<EmailTokenValue | null>,
+            [purpose: EmailTokenPurpose, email: string]
+        >()
+        .mockResolvedValue(peeked);
     const consumeToken = jest
         .fn<
             Promise<EmailTokenValue | null>,
             [purpose: EmailTokenPurpose, email: string]
         >()
-        .mockResolvedValue(storedToken);
+        .mockResolvedValue(consumed);
     const findEmailAuthUserByEmail = jest.fn().mockResolvedValue(foundUser);
     const updatePassword = jest.fn().mockResolvedValue(updateResult);
     const hashPassword = jest.fn().mockResolvedValue(hashed);
@@ -73,13 +88,14 @@ function makeDependencies(options?: {
             },
             emailTokens: {
                 set: jest.fn(),
-                get: jest.fn(),
+                get: getToken,
                 delete: jest.fn(),
                 consume: consumeToken,
             },
             passwordHasher: { hashPassword },
             passwordVerifier: { verifyPassword },
         },
+        getToken,
         consumeToken,
         findEmailAuthUserByEmail,
         updatePassword,
@@ -90,7 +106,7 @@ function makeDependencies(options?: {
 
 describe('confirmPasswordReset', () => {
     it('returns weak_password error when password fails validation', async () => {
-        const { dependencies, consumeToken, updatePassword } =
+        const { dependencies, getToken, consumeToken, updatePassword } =
             makeDependencies();
 
         const result = await confirmPasswordReset(
@@ -100,13 +116,43 @@ describe('confirmPasswordReset', () => {
 
         expect(result.ok).toBe(false);
         if (!result.ok) expect(result.error.code).toBe('weak_password');
+        expect(getToken).not.toHaveBeenCalled();
         expect(consumeToken).not.toHaveBeenCalled();
         expect(updatePassword).not.toHaveBeenCalled();
     });
 
-    it('returns expired_token error when consume returns null', async () => {
+    it('returns expired_token error when the token does not exist', async () => {
+        const { dependencies, consumeToken, updatePassword } = makeDependencies({
+            peekedToken: null,
+        });
+
+        const result = await confirmPasswordReset(
+            {
+                email: 'user@example.com',
+                token: RAW_TOKEN,
+                newPassword: NEW_PASSWORD,
+            },
+            dependencies
+        );
+
+        expect(result).toEqual({
+            ok: false,
+            error: {
+                code: 'expired_token',
+                field: 'token',
+                message: '비밀번호 재설정 토큰이 만료되었습니다.',
+            },
+        });
+        // Token does not exist — consume must not be called.
+        expect(consumeToken).not.toHaveBeenCalled();
+        expect(updatePassword).not.toHaveBeenCalled();
+    });
+
+    it('returns expired_token error when consume returns null (TOCTOU race)', async () => {
+        // get succeeds (token existed at pre-validation time) but consume returns null
+        // because a concurrent caller won the race and consumed the token first.
         const { dependencies, updatePassword } = makeDependencies({
-            storedToken: null,
+            consumedToken: null,
         });
 
         const result = await confirmPasswordReset(
@@ -129,10 +175,47 @@ describe('confirmPasswordReset', () => {
         expect(updatePassword).not.toHaveBeenCalled();
     });
 
-    it('returns invalid_token error when consumed entry is in verified state', async () => {
-        const { dependencies } = makeDependencies({
-            storedToken: { status: 'verified' },
+    it('returns invalid_token error when token entry is in verified state', async () => {
+        const { dependencies, consumeToken } = makeDependencies({
+            peekedToken: { status: 'verified' },
         });
+
+        const result = await confirmPasswordReset(
+            {
+                email: 'user@example.com',
+                token: RAW_TOKEN,
+                newPassword: NEW_PASSWORD,
+            },
+            dependencies
+        );
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error.code).toBe('invalid_token');
+        // Caught at pre-validation — token must not be consumed.
+        expect(consumeToken).not.toHaveBeenCalled();
+    });
+
+    it('returns invalid_token error when the supplied token does not match', async () => {
+        const { dependencies, consumeToken, updatePassword } = makeDependencies();
+
+        const result = await confirmPasswordReset(
+            {
+                email: 'user@example.com',
+                token: 'wrong-token',
+                newPassword: NEW_PASSWORD,
+            },
+            dependencies
+        );
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error.code).toBe('invalid_token');
+        // Caught at pre-validation — token must not be consumed.
+        expect(consumeToken).not.toHaveBeenCalled();
+        expect(updatePassword).not.toHaveBeenCalled();
+    });
+
+    it('returns invalid_token error when the user no longer exists', async () => {
+        const { dependencies } = makeDependencies({ user: null });
 
         const result = await confirmPasswordReset(
             {
@@ -147,26 +230,10 @@ describe('confirmPasswordReset', () => {
         if (!result.ok) expect(result.error.code).toBe('invalid_token');
     });
 
-    it('returns invalid_token error when the supplied token does not match', async () => {
-        const { dependencies, updatePassword } = makeDependencies();
-
-        const result = await confirmPasswordReset(
-            {
-                email: 'user@example.com',
-                token: 'wrong-token',
-                newPassword: NEW_PASSWORD,
-            },
-            dependencies
-        );
-
-        expect(result.ok).toBe(false);
-        if (!result.ok) expect(result.error.code).toBe('invalid_token');
-        // The token has already been consumed atomically — there's no extra delete to make.
-        expect(updatePassword).not.toHaveBeenCalled();
-    });
-
-    it('returns invalid_token error when the user no longer exists', async () => {
-        const { dependencies } = makeDependencies({ user: null });
+    it('returns invalid_token error when the user has no password hash', async () => {
+        const { dependencies } = makeDependencies({
+            user: { ...user, passwordHash: null },
+        });
 
         const result = await confirmPasswordReset(
             {
@@ -206,24 +273,6 @@ describe('confirmPasswordReset', () => {
         expect(updatePassword).not.toHaveBeenCalled();
     });
 
-    it('returns invalid_token error when the user has no password hash', async () => {
-        const { dependencies } = makeDependencies({
-            user: { ...user, passwordHash: null },
-        });
-
-        const result = await confirmPasswordReset(
-            {
-                email: 'user@example.com',
-                token: RAW_TOKEN,
-                newPassword: NEW_PASSWORD,
-            },
-            dependencies
-        );
-
-        expect(result.ok).toBe(false);
-        if (!result.ok) expect(result.error.code).toBe('invalid_token');
-    });
-
     it('returns invalid_token when updatePassword fails', async () => {
         const { dependencies } = makeDependencies({
             updatePasswordResult: false,
@@ -242,24 +291,29 @@ describe('confirmPasswordReset', () => {
         if (!result.ok) expect(result.error.code).toBe('invalid_token');
     });
 
-    it('atomically consumes the token before any password update on success', async () => {
+    it('pre-validates then atomically consumes the token before any password update on success', async () => {
         const {
             dependencies,
+            getToken,
             consumeToken,
             updatePassword,
             hashPassword,
             verifyPassword,
         } = makeDependencies();
 
-        // Track call order: consume must happen before verify/hash/updatePassword.
+        // Track call order: get (pre-validate) → verify → consume (atomic) → hash → update.
         const callOrder: string[] = [];
-        consumeToken.mockImplementation(async () => {
-            callOrder.push('consume');
-            return { status: 'pending', tokenHash: STORED_TOKEN_HASH };
+        getToken.mockImplementation(async () => {
+            callOrder.push('get');
+            return VALID_TOKEN_VALUE;
         });
         verifyPassword.mockImplementation(async () => {
             callOrder.push('verify');
             return false;
+        });
+        consumeToken.mockImplementation(async () => {
+            callOrder.push('consume');
+            return VALID_TOKEN_VALUE;
         });
         hashPassword.mockImplementation(async () => {
             callOrder.push('hash');
@@ -280,6 +334,7 @@ describe('confirmPasswordReset', () => {
         );
 
         expect(result).toEqual({ ok: true });
+        expect(getToken).toHaveBeenCalledWith('password_reset', 'user@example.com');
         expect(consumeToken).toHaveBeenCalledWith(
             'password_reset',
             'user@example.com'
@@ -290,7 +345,7 @@ describe('confirmPasswordReset', () => {
             'user-1',
             'new-hashed-password'
         );
-        expect(callOrder).toEqual(['verify', 'consume', 'hash', 'update']);
+        expect(callOrder).toEqual(['get', 'verify', 'consume', 'hash', 'update']);
     });
 
     it('only one of two concurrent consumers updates the password', async () => {
@@ -304,7 +359,7 @@ describe('confirmPasswordReset', () => {
         consumeToken.mockImplementation(async () => {
             if (consumed) return null;
             consumed = true;
-            return { status: 'pending', tokenHash: STORED_TOKEN_HASH };
+            return VALID_TOKEN_VALUE;
         });
 
         const [resultA, resultB] = await Promise.all([

--- a/src/__tests__/infrastructure/auth/use-cases/confirmPasswordReset.test.ts
+++ b/src/__tests__/infrastructure/auth/use-cases/confirmPasswordReset.test.ts
@@ -28,12 +28,14 @@ function makeDependencies(options?: {
     user?: EmailAuthUserRecord | null;
     updatePasswordResult?: boolean;
     hashedNewPassword?: string;
+    isSamePassword?: boolean;
 }): {
     dependencies: ConfirmPasswordResetDependencies;
     consumeToken: ReturnType<typeof jest.fn>;
     findEmailAuthUserByEmail: ReturnType<typeof jest.fn>;
     updatePassword: ReturnType<typeof jest.fn>;
     hashPassword: ReturnType<typeof jest.fn>;
+    verifyPassword: ReturnType<typeof jest.fn>;
 } {
     const defaultStored: EmailTokenValue = {
         status: 'pending',
@@ -46,6 +48,7 @@ function makeDependencies(options?: {
     const foundUser = options && 'user' in options ? options.user : user;
     const updateResult = options?.updatePasswordResult ?? true;
     const hashed = options?.hashedNewPassword ?? 'new-hashed-password';
+    const samePassword = options?.isSamePassword ?? false;
 
     const consumeToken = jest
         .fn<
@@ -56,6 +59,7 @@ function makeDependencies(options?: {
     const findEmailAuthUserByEmail = jest.fn().mockResolvedValue(foundUser);
     const updatePassword = jest.fn().mockResolvedValue(updateResult);
     const hashPassword = jest.fn().mockResolvedValue(hashed);
+    const verifyPassword = jest.fn().mockResolvedValue(samePassword);
 
     return {
         dependencies: {
@@ -74,11 +78,13 @@ function makeDependencies(options?: {
                 consume: consumeToken,
             },
             passwordHasher: { hashPassword },
+            passwordVerifier: { verifyPassword },
         },
         consumeToken,
         findEmailAuthUserByEmail,
         updatePassword,
         hashPassword,
+        verifyPassword,
     };
 }
 
@@ -175,6 +181,32 @@ describe('confirmPasswordReset', () => {
         if (!result.ok) expect(result.error.code).toBe('invalid_token');
     });
 
+    it('returns same_password error when new password matches the current one', async () => {
+        const { dependencies, updatePassword, verifyPassword } = makeDependencies({
+            isSamePassword: true,
+        });
+
+        const result = await confirmPasswordReset(
+            {
+                email: 'user@example.com',
+                token: RAW_TOKEN,
+                newPassword: NEW_PASSWORD,
+            },
+            dependencies
+        );
+
+        expect(result).toEqual({
+            ok: false,
+            error: {
+                code: 'same_password',
+                field: 'password',
+                message: '현재 비밀번호와 동일한 비밀번호는 사용할 수 없습니다.',
+            },
+        });
+        expect(verifyPassword).toHaveBeenCalledWith(NEW_PASSWORD, 'old-hash');
+        expect(updatePassword).not.toHaveBeenCalled();
+    });
+
     it('returns invalid_token error when the user has no password hash', async () => {
         const { dependencies } = makeDependencies({
             user: { ...user, passwordHash: null },
@@ -212,14 +244,23 @@ describe('confirmPasswordReset', () => {
     });
 
     it('atomically consumes the token before any password update on success', async () => {
-        const { dependencies, consumeToken, updatePassword, hashPassword } =
-            makeDependencies();
+        const {
+            dependencies,
+            consumeToken,
+            updatePassword,
+            hashPassword,
+            verifyPassword,
+        } = makeDependencies();
 
-        // Track call order: consume must happen before hashPassword/updatePassword.
+        // Track call order: consume must happen before verify/hash/updatePassword.
         const callOrder: string[] = [];
         consumeToken.mockImplementation(async () => {
             callOrder.push('consume');
             return { status: 'pending', tokenHash: STORED_TOKEN_HASH };
+        });
+        verifyPassword.mockImplementation(async () => {
+            callOrder.push('verify');
+            return false;
         });
         hashPassword.mockImplementation(async () => {
             callOrder.push('hash');
@@ -244,12 +285,13 @@ describe('confirmPasswordReset', () => {
             'password_reset',
             'user@example.com'
         );
+        expect(verifyPassword).toHaveBeenCalledWith(NEW_PASSWORD, 'old-hash');
         expect(hashPassword).toHaveBeenCalledWith(NEW_PASSWORD);
         expect(updatePassword).toHaveBeenCalledWith(
             'user-1',
             'new-hashed-password'
         );
-        expect(callOrder).toEqual(['consume', 'hash', 'update']);
+        expect(callOrder).toEqual(['consume', 'verify', 'hash', 'update']);
     });
 
     it('only one of two concurrent consumers updates the password', async () => {

--- a/src/__tests__/infrastructure/auth/use-cases/registerUser.test.ts
+++ b/src/__tests__/infrastructure/auth/use-cases/registerUser.test.ts
@@ -1,22 +1,10 @@
-jest.mock('@/infrastructure/db/userRepository');
-jest.mock('@/infrastructure/db/agreementRepository');
-
 import { registerUser } from '@/infrastructure/auth/use-cases/registerUser';
 import type { RegisterUserDependencies } from '@/infrastructure/auth/use-cases/types';
-import { DrizzleUserRepository } from '@/infrastructure/db/userRepository';
-import { DrizzleAgreementRepository } from '@/infrastructure/db/agreementRepository';
 import type {
     EmailTokenPurpose,
     EmailTokenValue,
 } from '@/infrastructure/email/tokenStore';
 import type { AuthUserRecord } from '@/domain/auth/types';
-
-const MockUserRepo = DrizzleUserRepository as jest.MockedClass<
-    typeof DrizzleUserRepository
->;
-const MockAgreementRepo = DrizzleAgreementRepository as jest.MockedClass<
-    typeof DrizzleAgreementRepository
->;
 
 const createdAt = new Date('2026-04-26T00:00:00.000Z');
 const updatedAt = new Date('2026-04-26T00:00:01.000Z');
@@ -42,11 +30,11 @@ function makeDependencies(options?: {
     dependencies: RegisterUserDependencies;
     findByEmail: ReturnType<typeof jest.fn>;
     createEmailUser: ReturnType<typeof jest.fn>;
+    deleteUser: ReturnType<typeof jest.fn>;
     hashPassword: ReturnType<typeof jest.fn>;
     getToken: ReturnType<typeof jest.fn>;
     deleteToken: ReturnType<typeof jest.fn>;
     insertMany: ReturnType<typeof jest.fn>;
-    transaction: ReturnType<typeof jest.fn>;
 } {
     const findByEmail = jest
         .fn()
@@ -56,6 +44,7 @@ function makeDependencies(options?: {
             ? options.createdUser
             : makeUser('user@example.com');
     const createEmailUser = jest.fn().mockResolvedValue(createdUser);
+    const deleteUser = jest.fn().mockResolvedValue(true);
     const hashPassword = jest.fn().mockResolvedValue('hashed-password');
 
     const verificationState =
@@ -70,30 +59,6 @@ function makeDependencies(options?: {
         .mockResolvedValue(verificationState);
     const deleteToken = jest.fn().mockResolvedValue(undefined);
     const insertMany = jest.fn().mockResolvedValue(undefined);
-    const transaction = jest
-        .fn()
-        .mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) =>
-            cb({})
-        );
-
-    // Repo classes are instantiated inside the transaction with tx — set up
-    // the class mocks so any new DrizzleUserRepository(tx) returns our stubs.
-    MockUserRepo.mockImplementation(
-        () =>
-            ({
-                createEmailUser,
-                findByEmail,
-                findById: jest.fn(),
-                deleteUser: jest.fn(),
-                updatePassword: jest.fn(),
-            }) as unknown as InstanceType<typeof DrizzleUserRepository>
-    );
-    MockAgreementRepo.mockImplementation(
-        () =>
-            ({ insertMany }) as unknown as InstanceType<
-                typeof DrizzleAgreementRepository
-            >
-    );
 
     return {
         dependencies: {
@@ -101,9 +66,10 @@ function makeDependencies(options?: {
                 findByEmail,
                 findById: jest.fn(),
                 createEmailUser,
-                deleteUser: jest.fn(),
+                deleteUser,
                 updatePassword: jest.fn(),
             },
+            agreements: { insertMany },
             passwordHasher: { hashPassword },
             emailTokens: {
                 set: jest.fn(),
@@ -111,15 +77,14 @@ function makeDependencies(options?: {
                 delete: deleteToken,
                 consume: jest.fn(),
             },
-            db: { transaction },
         },
         findByEmail,
         createEmailUser,
+        deleteUser,
         hashPassword,
         getToken,
         deleteToken,
         insertMany,
-        transaction,
     };
 }
 
@@ -130,11 +95,6 @@ const DEFAULT_INPUT = {
 } as const;
 
 describe('registerUser', () => {
-    beforeEach(() => {
-        MockUserRepo.mockClear();
-        MockAgreementRepo.mockClear();
-    });
-
     it('rejects empty agreedTermsIds before any further processing', async () => {
         const { dependencies, findByEmail, hashPassword, getToken } =
             makeDependencies();
@@ -228,7 +188,20 @@ describe('registerUser', () => {
         const result = await registerUser(DEFAULT_INPUT, dependencies);
 
         expect(result.ok).toBe(false);
-        // Marker MUST stay so the user doesn't have to re-verify.
+        expect(deleteToken).not.toHaveBeenCalled();
+    });
+
+    it('preserves the verified marker when hashPassword throws', async () => {
+        const { dependencies, deleteToken } = makeDependencies();
+        (
+            dependencies.passwordHasher.hashPassword as jest.Mock
+        ).mockRejectedValueOnce(new Error('hash failure'));
+
+        await expect(registerUser(DEFAULT_INPUT, dependencies)).rejects.toThrow(
+            'hash failure'
+        );
+
+        // On failure the marker must be preserved so the user can retry without re-verifying.
         expect(deleteToken).not.toHaveBeenCalled();
     });
 
@@ -247,52 +220,41 @@ describe('registerUser', () => {
         expect(deleteToken).not.toHaveBeenCalled();
     });
 
-    it('preserves the verified marker when hashPassword throws', async () => {
-        const { dependencies, deleteToken } = makeDependencies();
-        (
-            dependencies.passwordHasher.hashPassword as jest.Mock
-        ).mockRejectedValueOnce(new Error('hash failure'));
-
-        await expect(registerUser(DEFAULT_INPUT, dependencies)).rejects.toThrow(
-            'hash failure'
-        );
-
-        // On failure the marker must be preserved so the user can retry without re-verifying.
-        expect(deleteToken).not.toHaveBeenCalled();
-    });
-
-    it('returns email_already_exists when createEmailUser races to a conflict', async () => {
-        const { dependencies, createEmailUser } = makeDependencies({
+    it('preserves the verified marker when createEmailUser returns null (race conflict)', async () => {
+        const { dependencies, deleteToken } = makeDependencies({
             createdUser: null,
         });
-        (createEmailUser as jest.Mock).mockResolvedValue(null);
 
         const result = await registerUser(DEFAULT_INPUT, dependencies);
 
         expect(result.ok).toBe(false);
         if (!result.ok) expect(result.error.code).toBe('email_already_exists');
-    });
-
-    it('preserves the verified marker when createEmailUser returns null (tx null branch)', async () => {
-        const { dependencies, deleteToken, createEmailUser } =
-            makeDependencies();
-        (createEmailUser as jest.Mock).mockResolvedValue(null);
-
-        const result = await registerUser(DEFAULT_INPUT, dependencies);
-
-        expect(result.ok).toBe(false);
-        if (!result.ok) expect(result.error.code).toBe('email_already_exists');
-        // email_already_exists (race) — preserve the marker, consistent with the pre-tx early-return path.
+        // email_already_exists (race) — preserve the marker, consistent with the pre-insert early-return path.
         expect(deleteToken).not.toHaveBeenCalled();
     });
 
-    it('inserts agreement rows for each agreedTermsId using tx inside a transaction', async () => {
-        const { dependencies, insertMany, transaction } = makeDependencies();
+    it('compensates by deleting the user when insertMany throws', async () => {
+        const { dependencies, deleteUser, deleteToken, insertMany } =
+            makeDependencies();
+        (insertMany as jest.Mock).mockRejectedValueOnce(
+            new Error('agreements insert failed')
+        );
+
+        await expect(registerUser(DEFAULT_INPUT, dependencies)).rejects.toThrow(
+            'agreements insert failed'
+        );
+
+        expect(deleteUser).toHaveBeenCalledWith('user-1');
+        // Verified marker must be preserved so the user can retry without re-verifying.
+        expect(deleteToken).not.toHaveBeenCalled();
+    });
+
+    it('inserts agreement rows for each agreedTermsId', async () => {
+        const { dependencies, insertMany } = makeDependencies();
 
         const result = await registerUser(DEFAULT_INPUT, dependencies);
 
         expect(result.ok).toBe(true);
-        expect(transaction).toHaveBeenCalledTimes(1);
         expect(insertMany).toHaveBeenCalledWith([
             expect.objectContaining({
                 termsId: 'terms-privacy-id',

--- a/src/__tests__/infrastructure/auth/use-cases/registerUser.test.ts
+++ b/src/__tests__/infrastructure/auth/use-cases/registerUser.test.ts
@@ -232,7 +232,7 @@ describe('registerUser', () => {
         expect(deleteToken).not.toHaveBeenCalled();
     });
 
-    it('clears the verified marker when createEmailUser throws', async () => {
+    it('preserves the verified marker when createEmailUser throws', async () => {
         const { dependencies, deleteToken, createEmailUser } =
             makeDependencies();
         (createEmailUser as jest.Mock).mockRejectedValueOnce(
@@ -243,15 +243,11 @@ describe('registerUser', () => {
             'database is on fire'
         );
 
-        // Even on failure, the marker MUST be cleared; otherwise it would linger
-        // for its 30-minute TTL and let the email be reused as "verified".
-        expect(deleteToken).toHaveBeenCalledWith(
-            'email_verification',
-            'user@example.com'
-        );
+        // On failure the marker must be preserved so the user can retry without re-verifying.
+        expect(deleteToken).not.toHaveBeenCalled();
     });
 
-    it('clears the verified marker when hashPassword throws', async () => {
+    it('preserves the verified marker when hashPassword throws', async () => {
         const { dependencies, deleteToken } = makeDependencies();
         (
             dependencies.passwordHasher.hashPassword as jest.Mock
@@ -261,10 +257,8 @@ describe('registerUser', () => {
             'hash failure'
         );
 
-        expect(deleteToken).toHaveBeenCalledWith(
-            'email_verification',
-            'user@example.com'
-        );
+        // On failure the marker must be preserved so the user can retry without re-verifying.
+        expect(deleteToken).not.toHaveBeenCalled();
     });
 
     it('returns email_already_exists when createEmailUser races to a conflict', async () => {
@@ -279,7 +273,7 @@ describe('registerUser', () => {
         if (!result.ok) expect(result.error.code).toBe('email_already_exists');
     });
 
-    it('clears the verified marker even when createEmailUser returns null (tx null branch)', async () => {
+    it('preserves the verified marker when createEmailUser returns null (tx null branch)', async () => {
         const { dependencies, deleteToken, createEmailUser } =
             makeDependencies();
         (createEmailUser as jest.Mock).mockResolvedValue(null);
@@ -288,11 +282,8 @@ describe('registerUser', () => {
 
         expect(result.ok).toBe(false);
         if (!result.ok) expect(result.error.code).toBe('email_already_exists');
-        // Marker must be cleared via finally even in the null-return path.
-        expect(deleteToken).toHaveBeenCalledWith(
-            'email_verification',
-            'user@example.com'
-        );
+        // email_already_exists (race) — preserve the marker, consistent with the pre-tx early-return path.
+        expect(deleteToken).not.toHaveBeenCalled();
     });
 
     it('inserts agreement rows for each agreedTermsId using tx inside a transaction', async () => {

--- a/src/__tests__/infrastructure/db/userRepository.test.ts
+++ b/src/__tests__/infrastructure/db/userRepository.test.ts
@@ -78,12 +78,12 @@ function makeDeleteDb(rows: unknown[]): {
     };
 }
 
-function makeTransactionDb(options: {
+function makeOAuthInsertDb(options: {
     userRows: unknown[];
     accountRows: unknown[];
+    deleteRows?: unknown[];
 }): {
     db: SiglensDatabase;
-    transaction: ReturnType<typeof jest.fn>;
     insert: ReturnType<typeof jest.fn>;
     userValues: ReturnType<typeof jest.fn>;
     accountValues: ReturnType<typeof jest.fn>;
@@ -91,7 +91,16 @@ function makeTransactionDb(options: {
     accountOnConflictDoNothing: ReturnType<typeof jest.fn>;
     userReturning: ReturnType<typeof jest.fn>;
     accountReturning: ReturnType<typeof jest.fn>;
+    deleteFn: ReturnType<typeof jest.fn>;
+    deleteWhere: ReturnType<typeof jest.fn>;
+    deleteReturning: ReturnType<typeof jest.fn>;
 } {
+    const deleteReturning = jest
+        .fn()
+        .mockResolvedValue(options.deleteRows ?? []);
+    const deleteWhere = jest.fn(() => ({ returning: deleteReturning }));
+    const deleteFn = jest.fn(() => ({ where: deleteWhere }));
+
     const userReturning = jest.fn().mockResolvedValue(options.userRows);
     const accountReturning = jest.fn().mockResolvedValue(options.accountRows);
     const userOnConflictDoNothing = jest.fn(() => ({
@@ -110,12 +119,9 @@ function makeTransactionDb(options: {
         .fn()
         .mockReturnValueOnce({ values: userValues })
         .mockReturnValueOnce({ values: accountValues });
-    const tx = { insert };
-    const transaction = jest.fn(async callback => callback(tx));
 
     return {
-        db: { transaction } as unknown as SiglensDatabase,
-        transaction,
+        db: { insert, delete: deleteFn } as unknown as SiglensDatabase,
         insert,
         userValues,
         accountValues,
@@ -123,16 +129,24 @@ function makeTransactionDb(options: {
         accountOnConflictDoNothing,
         userReturning,
         accountReturning,
+        deleteFn,
+        deleteWhere,
+        deleteReturning,
     };
 }
 
-function makeFailingTransactionDb(error: Error): {
+function makeFailingOAuthInsertDb(error: Error): {
     db: SiglensDatabase;
+    insert: ReturnType<typeof jest.fn>;
 } {
-    const transaction = jest.fn().mockRejectedValue(error);
+    const returning = jest.fn().mockRejectedValue(error);
+    const onConflictDoNothing = jest.fn(() => ({ returning }));
+    const values = jest.fn(() => ({ onConflictDoNothing }));
+    const insert = jest.fn(() => ({ values }));
 
     return {
-        db: { transaction } as unknown as SiglensDatabase,
+        db: { insert } as unknown as SiglensDatabase,
+        insert,
     };
 }
 
@@ -383,7 +397,7 @@ describe('DrizzleUserRepository', () => {
 
     it('creates a free-tier OAuth user and provider account link', async () => {
         const { db, userValues, accountValues, accountOnConflictDoNothing } =
-            makeTransactionDb({
+            makeOAuthInsertDb({
                 userRows: [userRecord],
                 accountRows: [{ id: 'oauth-account-1' }],
             });
@@ -419,7 +433,7 @@ describe('DrizzleUserRepository', () => {
     });
 
     it('creates an OAuth user with avatarUrl provided', async () => {
-        const { db, userValues } = makeTransactionDb({
+        const { db, userValues } = makeOAuthInsertDb({
             userRows: [userRecord],
             accountRows: [{ id: 'oauth-account-1' }],
         });
@@ -450,7 +464,7 @@ describe('DrizzleUserRepository', () => {
         });
 
         it('encrypts access and refresh tokens before storage', async () => {
-            const { db, accountValues } = makeTransactionDb({
+            const { db, accountValues } = makeOAuthInsertDb({
                 userRows: [userRecord],
                 accountRows: [{ id: 'oauth-account-1' }],
             });
@@ -486,9 +500,9 @@ describe('DrizzleUserRepository', () => {
             );
         });
 
-        it('throws and aborts the transaction when the encryption key is absent', async () => {
+        it('throws and does not write to DB when the encryption key is absent', async () => {
             delete process.env['OAUTH_TOKEN_ENCRYPTION_KEY'];
-            const { db, transaction } = makeTransactionDb({
+            const { db, insert } = makeOAuthInsertDb({
                 userRows: [userRecord],
                 accountRows: [{ id: 'oauth-account-1' }],
             });
@@ -504,13 +518,13 @@ describe('DrizzleUserRepository', () => {
                 })
             ).rejects.toThrow(/OAUTH_TOKEN_ENCRYPTION_KEY/);
 
-            // Transaction must NOT be opened when the encryption key is missing.
-            expect(transaction).not.toHaveBeenCalled();
+            // No DB writes must happen when the encryption key is missing.
+            expect(insert).not.toHaveBeenCalled();
         });
 
         it('throws when the encryption key is present but malformed (wrong length)', async () => {
             process.env['OAUTH_TOKEN_ENCRYPTION_KEY'] = 'deadbeef';
-            const { db, transaction } = makeTransactionDb({
+            const { db, insert } = makeOAuthInsertDb({
                 userRows: [userRecord],
                 accountRows: [{ id: 'oauth-account-1' }],
             });
@@ -524,14 +538,14 @@ describe('DrizzleUserRepository', () => {
                 })
             ).rejects.toThrow(/OAUTH_TOKEN_ENCRYPTION_KEY/);
 
-            expect(transaction).not.toHaveBeenCalled();
+            expect(insert).not.toHaveBeenCalled();
         });
     });
 
     it('returns null when OAuth user creation conflicts on email', async () => {
-        const { db, insert } = makeTransactionDb({
+        const { db, insert } = makeOAuthInsertDb({
             userRows: [],
-            accountRows: [{ id: 'oauth-account-1' }],
+            accountRows: [],
         });
         const repository = new DrizzleUserRepository(db);
 
@@ -545,10 +559,11 @@ describe('DrizzleUserRepository', () => {
         expect(result).toBeNull();
     });
 
-    it('returns null when OAuth provider account link conflicts', async () => {
-        const { db } = makeTransactionDb({
+    it('returns null and compensates by deleting the user when oauth account link conflicts', async () => {
+        const { db, insert, deleteFn, deleteWhere } = makeOAuthInsertDb({
             userRows: [userRecord],
             accountRows: [],
+            deleteRows: [{ id: 'user-1' }],
         });
         const repository = new DrizzleUserRepository(db);
 
@@ -558,12 +573,15 @@ describe('DrizzleUserRepository', () => {
             providerAccountId: 'provider-user-1',
         });
 
+        expect(insert).toHaveBeenCalledTimes(2);
+        expect(deleteFn).toHaveBeenCalledWith(users);
+        expect(deleteWhere).toHaveBeenCalledWith(expect.any(Object));
         expect(result).toBeNull();
     });
 
     it('rethrows unexpected OAuth user creation failures', async () => {
         const error = new Error('database unavailable');
-        const { db } = makeFailingTransactionDb(error);
+        const { db } = makeFailingOAuthInsertDb(error);
         const repository = new DrizzleUserRepository(db);
 
         await expect(

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -1,25 +1,24 @@
-import type { Metadata } from 'next';
-import { notFound } from 'next/navigation';
-import {
-    dehydrate,
-    HydrationBoundary,
-    QueryClient,
-} from '@tanstack/react-query';
-import { DEFAULT_TIMEFRAME, isValidTimeframe } from '@/domain/constants/market';
+import { SymbolPageClient } from '@/components/symbol-page/SymbolPageClient';
+import { JsonLd } from '@/components/ui/JsonLd';
 import { FALLBACK_ANALYSIS } from '@/domain/chat/fallbackAnalysis';
+import { DEFAULT_TIMEFRAME, isValidTimeframe } from '@/domain/constants/market';
+import { buildDisplayName } from '@/domain/ticker';
 import { getBarsAction } from '@/infrastructure/market/getBarsAction';
-import { getAssetInfoCached } from '@/infrastructure/ticker/getAssetInfoCached';
 import { countSkillFiles } from '@/infrastructure/skills/loader';
+import { getAssetInfoCached } from '@/infrastructure/ticker/getAssetInfoCached';
 import { QUERY_KEYS, QUERY_STALE_TIME_MS } from '@/lib/queryConfig';
 import {
     buildBreadcrumbJsonLd,
     buildSymbolSeoContent,
     SITE_NAME,
 } from '@/lib/seo';
-import { CrossLinkCards } from '@/components/symbol-page/CrossLinkCards';
-import { buildDisplayName } from '@/domain/ticker';
-import { SymbolPageClient } from '@/components/symbol-page/SymbolPageClient';
-import { JsonLd } from '@/components/ui/JsonLd';
+import {
+    dehydrate,
+    HydrationBoundary,
+    QueryClient,
+} from '@tanstack/react-query';
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 
 interface Props {
     params: Promise<{ symbol: string }>;
@@ -149,7 +148,8 @@ export default async function SymbolPage({ params, searchParams }: Props) {
                     initialAnalysisFailed={true}
                     indicatorCount={skillCounts.indicators}
                     bottomSlot={
-                        <CrossLinkCards symbol={ticker} current="chart" />
+                        // <CrossLinkCards symbol={ticker} current="chart" />
+                        null
                     }
                 />
             </HydrationBoundary>

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -83,6 +83,56 @@ async function AccountContent() {
     );
 }
 
+function SkeletonLine({ className }: { className?: string }) {
+    return (
+        <div
+            className={`bg-secondary-800 animate-pulse rounded ${className ?? ''}`}
+        />
+    );
+}
+
+function AccountContentSkeleton() {
+    return (
+        <>
+            {/* 프로필 섹션 */}
+            <section
+                aria-label="프로필 로딩 중"
+                className="ring-secondary-800 bg-secondary-900/80 space-y-4 rounded-2xl p-6 ring-1 backdrop-blur-xl"
+            >
+                <SkeletonLine className="h-6 w-16" />
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-[120px_1fr]">
+                    <SkeletonLine className="h-4 w-12" />
+                    <SkeletonLine className="h-4 w-48" />
+                    <SkeletonLine className="h-4 w-16" />
+                    <SkeletonLine className="h-4 w-24" />
+                    <SkeletonLine className="h-4 w-16" />
+                    <SkeletonLine className="h-4 w-16" />
+                </div>
+            </section>
+
+            {/* AI 모델 API 키 섹션 */}
+            <section
+                aria-label="AI 모델 API 키 로딩 중"
+                className="ring-secondary-800 bg-secondary-900/80 space-y-4 rounded-2xl p-6 ring-1 backdrop-blur-xl"
+            >
+                <SkeletonLine className="h-6 w-32" />
+                <SkeletonLine className="h-4 w-64" />
+                {[0, 1, 2].map(i => (
+                    <div
+                        key={i}
+                        className="ring-secondary-800 bg-secondary-900/60 rounded-xl p-4 ring-1"
+                    >
+                        <div className="flex items-center gap-2">
+                            <SkeletonLine className="h-4 w-20" />
+                            <SkeletonLine className="h-5 w-12 rounded-full" />
+                        </div>
+                    </div>
+                ))}
+            </section>
+        </>
+    );
+}
+
 export default function AccountPage() {
     return (
         <main className="bg-secondary-950 min-h-[calc(100dvh-3.5rem)] px-4 py-12">
@@ -95,7 +145,7 @@ export default function AccountPage() {
                         프로필 정보를 확인하고 계정을 관리합니다.
                     </p>
                 </header>
-                <Suspense>
+                <Suspense fallback={<AccountContentSkeleton />}>
                     <AccountContent />
                 </Suspense>
             </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -137,6 +137,7 @@ async function HeaderWithUser() {
               email: authUser.email,
               name: authUser.name,
               tier: authUser.tier,
+              avatarUrl: authUser.avatarUrl,
           }
         : null;
     return <Header currentUser={currentUser} />;

--- a/src/components/account/ApiKeyInput.tsx
+++ b/src/components/account/ApiKeyInput.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { EyeIcon } from '@/components/ui/EyeIcon';
+import { useState } from 'react';
+
+interface ApiKeyInputProps {
+    name: string;
+    placeholder?: string;
+    'aria-label'?: string;
+    'aria-describedby'?: string;
+}
+
+export function ApiKeyInput({
+    name,
+    placeholder,
+    'aria-label': ariaLabel,
+    'aria-describedby': ariaDescribedby,
+}: ApiKeyInputProps) {
+    const [visible, setVisible] = useState(false);
+
+    return (
+        <div className="relative min-w-0 flex-1">
+            <input
+                type={visible ? 'text' : 'password'}
+                name={name}
+                required
+                autoComplete="new-password"
+                placeholder={placeholder}
+                aria-label={ariaLabel}
+                aria-describedby={ariaDescribedby}
+                className="border-secondary-700 bg-secondary-950 text-secondary-50 placeholder:text-secondary-500 focus:border-primary-500 focus:ring-primary-500/40 h-10 w-full rounded-md border px-3 pr-10 font-mono text-sm focus:ring-2 focus:outline-none"
+            />
+            <button
+                type="button"
+                onClick={() => setVisible(v => !v)}
+                aria-label={visible ? 'API 키 숨기기' : 'API 키 보이기'}
+                aria-pressed={visible}
+                className="text-secondary-400 hover:text-secondary-200 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-950 absolute inset-y-0 right-0 flex w-10 items-center justify-center rounded-r-md focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none"
+            >
+                <EyeIcon isVisible={visible} className="h-4 w-4" />
+            </button>
+        </div>
+    );
+}

--- a/src/components/account/ApiKeySection.tsx
+++ b/src/components/account/ApiKeySection.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ApiKeyInput } from '@/components/account/ApiKeyInput';
 import { useApiKeyForms } from '@/components/account/hooks/useApiKeyForms';
 import type { ApiKeyActionState } from '@/domain/llm';
 import { LLM_PROVIDER_VALUES, type LlmProvider } from '@/domain/llm';
@@ -141,14 +142,11 @@ function ProviderCard({ provider, isRegistered }: ProviderCardProps) {
                     noValidate
                 >
                     <input type="hidden" name="provider" value={provider} />
-                    <input
-                        type="password"
+                    <ApiKeyInput
                         name="apiKey"
-                        required
                         placeholder={PROVIDER_PLACEHOLDERS[provider]}
                         aria-label={`${LLM_PROVIDER_LABELS[provider]} API 키`}
                         aria-describedby={saveStatusId}
-                        className="border-secondary-700 bg-secondary-950 text-secondary-50 placeholder:text-secondary-500 focus:border-primary-500 focus:ring-primary-500/40 h-10 min-w-0 flex-1 rounded-md border px-3 font-mono text-sm focus:ring-2 focus:outline-none"
                     />
                     <SubmitButton
                         label="저장"

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -309,7 +309,6 @@ function ChevronIcon({ isOpen }: ChevronIconProps) {
     );
 }
 
-
 type ConfidenceLevel = 'high' | 'medium';
 
 const CONFIDENCE_BADGE_CONFIG: Record<

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useId, useRef, useState } from 'react';
+import { EyeIcon } from '@/components/ui/EyeIcon';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { MarkdownText } from '@/components/ui/MarkdownText';
 import { usePointerTooltip } from '@/components/hooks/usePointerTooltip';
@@ -308,41 +309,6 @@ function ChevronIcon({ isOpen }: ChevronIconProps) {
     );
 }
 
-interface EyeIconProps {
-    isVisible: boolean;
-}
-
-function EyeIcon({ isVisible }: EyeIconProps) {
-    return isVisible ? (
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            className="h-3.5 w-3.5"
-        >
-            <path d="M10 12.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" />
-            <path
-                fillRule="evenodd"
-                d="M.664 10.59a1.651 1.651 0 0 1 0-1.186A10.004 10.004 0 0 1 10 3c4.257 0 7.893 2.66 9.336 6.41.147.381.146.804 0 1.186A10.004 10.004 0 0 1 10 17c-4.257 0-7.893-2.66-9.336-6.41ZM14 10a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z"
-                clipRule="evenodd"
-            />
-        </svg>
-    ) : (
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            className="h-3.5 w-3.5"
-        >
-            <path
-                fillRule="evenodd"
-                d="M3.28 2.22a.75.75 0 0 0-1.06 1.06l14.5 14.5a.75.75 0 1 0 1.06-1.06l-1.745-1.745a10.029 10.029 0 0 0 3.3-4.38 1.651 1.651 0 0 0 0-1.185A10.004 10.004 0 0 0 9.999 3a9.956 9.956 0 0 0-4.744 1.194L3.28 2.22ZM7.752 6.69l1.092 1.092a2.5 2.5 0 0 1 3.374 3.373l1.091 1.092a4 4 0 0 0-5.557-5.557Z"
-                clipRule="evenodd"
-            />
-            <path d="M10.748 13.93l2.523 2.523a10.003 10.003 0 0 1-3.27.547c-4.258 0-7.894-2.66-9.337-6.41a1.651 1.651 0 0 1 0-1.186A10.007 10.007 0 0 1 2.839 6.02L6.07 9.252a4 4 0 0 0 4.678 4.678Z" />
-        </svg>
-    );
-}
 
 type ConfidenceLevel = 'high' | 'medium';
 

--- a/src/components/analysis/ModelSelector.tsx
+++ b/src/components/analysis/ModelSelector.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useRef } from 'react';
 import { usePopoverToggle } from '@/components/hooks/usePopoverToggle';
-import type { ModelId } from '@y0ngha/siglens-core';
 import { cn } from '@/lib/cn';
+import { isFreeChatModel } from '@/domain/llm';
+import type { ModelId } from '@y0ngha/siglens-core';
+import { useRef } from 'react';
 
 interface ModelDisplay {
     label: string;
@@ -109,11 +110,11 @@ export function ModelSelector({
     };
 
     return (
-        <div className="flex flex-col gap-1.5">
-            <span className="text-secondary-500 text-xs font-medium tracking-[0.15em] uppercase">
+        <div className="mb-4 flex flex-row items-center gap-3">
+            <span className="text-secondary-500 text-xs font-medium tracking-[0.15em] whitespace-nowrap uppercase">
                 AI MODEL
             </span>
-            <div className="relative">
+            <div className="relative flex-1">
                 <button
                     ref={triggerRef}
                     type="button"
@@ -147,57 +148,66 @@ export function ModelSelector({
                         role="listbox"
                         aria-label="AI 분석 모델 목록"
                         onKeyDown={handleListboxKeyDown}
-                        className="border-secondary-600 bg-secondary-800 absolute top-full left-0 z-10 mt-1 w-full overflow-hidden rounded-lg border shadow-lg"
+                        className="border-secondary-600 bg-secondary-800 absolute top-full left-0 z-10 mt-1 w-full rounded-lg border shadow-lg"
                     >
-                        {allowedModels.map((modelId, i) => {
-                            const display = getModelDisplay(modelId);
-                            const isSelected = modelId === selectedModel;
-                            return (
-                                <div
-                                    key={modelId}
-                                    ref={el => {
-                                        optionRefs.current[i] = el;
-                                    }}
-                                    role="option"
-                                    tabIndex={isSelected ? 0 : -1}
-                                    aria-selected={isSelected}
-                                    onClick={() => {
-                                        onModelChange(modelId);
-                                        close();
-                                        triggerRef.current?.focus();
-                                    }}
-                                    onKeyDown={e => {
-                                        if (
-                                            e.key === 'Enter' ||
-                                            e.key === ' '
-                                        ) {
-                                            e.preventDefault();
+                        <div className="max-h-[264px] overflow-y-auto overscroll-contain">
+                            {allowedModels.map((modelId, i) => {
+                                const display = getModelDisplay(modelId);
+                                const isSelected = modelId === selectedModel;
+                                return (
+                                    <div
+                                        key={modelId}
+                                        ref={el => {
+                                            optionRefs.current[i] = el;
+                                        }}
+                                        role="option"
+                                        tabIndex={isSelected ? 0 : -1}
+                                        aria-selected={isSelected}
+                                        onClick={() => {
                                             onModelChange(modelId);
                                             close();
                                             triggerRef.current?.focus();
-                                        }
-                                    }}
-                                    className={cn(
-                                        'focus-visible:ring-primary-500 flex min-h-[44px] w-full cursor-pointer items-center gap-2 px-3 transition-colors focus-visible:ring-1 focus-visible:outline-none',
-                                        isSelected
-                                            ? 'text-primary-300 bg-primary-900/20'
-                                            : 'text-secondary-300 hover:bg-secondary-700'
-                                    )}
-                                >
-                                    <span className="w-3 text-[10px]">
-                                        {isSelected && '✓'}
-                                    </span>
-                                    <div>
-                                        <div className="text-[11px] font-medium">
-                                            {display.label}
-                                        </div>
-                                        <div className="text-secondary-500 text-[10px]">
-                                            {display.fullName}
+                                        }}
+                                        onKeyDown={e => {
+                                            if (
+                                                e.key === 'Enter' ||
+                                                e.key === ' '
+                                            ) {
+                                                e.preventDefault();
+                                                onModelChange(modelId);
+                                                close();
+                                                triggerRef.current?.focus();
+                                            }
+                                        }}
+                                        className={cn(
+                                            'focus-visible:ring-primary-500 flex min-h-11 w-full cursor-pointer items-center gap-2 px-3 transition-colors focus-visible:ring-1 focus-visible:outline-none',
+                                            isSelected
+                                                ? 'text-primary-300 bg-primary-900/20'
+                                                : 'text-secondary-300 hover:bg-secondary-700'
+                                        )}
+                                    >
+                                        <span className="w-3 text-[10px]">
+                                            {isSelected && '✓'}
+                                        </span>
+                                        <div className="flex flex-1 items-center justify-between gap-2">
+                                            <div>
+                                                <div className="text-[11px] font-medium">
+                                                    {display.label}
+                                                </div>
+                                                <div className="text-secondary-500 text-[10px]">
+                                                    {display.fullName}
+                                                </div>
+                                            </div>
+                                            {!isFreeChatModel(modelId) && (
+                                                <span className="text-ui-warning text-[9px] leading-none font-semibold uppercase">
+                                                    PRO
+                                                </span>
+                                            )}
                                         </div>
                                     </div>
-                                </div>
-                            );
-                        })}
+                                );
+                            })}
+                        </div>
                     </div>
                 )}
             </div>

--- a/src/components/analysis/ModelSelector.tsx
+++ b/src/components/analysis/ModelSelector.tsx
@@ -1,269 +1,206 @@
 'use client';
 
-import { useRef, useCallback, useMemo } from 'react';
-import type { AIProvider, ModelId } from '@y0ngha/siglens-core';
-import { resolveDefaultModelForProvider } from '@/domain/llm/providerDefaults';
+import { useRef } from 'react';
+import { usePopoverToggle } from '@/components/hooks/usePopoverToggle';
+import type { ModelId } from '@y0ngha/siglens-core';
 import { cn } from '@/lib/cn';
 
-const PROVIDER_ORDER: readonly AIProvider[] = ['claude', 'gemini', 'chatgpt'];
-
-const PROVIDER_DISPLAY_NAME: Record<AIProvider, string> = {
-    claude: 'CLAUDE',
-    gemini: 'GEMINI',
-    chatgpt: 'CHATGPT',
-};
-
-interface ProviderConfig {
-    provider: AIProvider;
-    displayName: string;
+interface ModelDisplay {
+    label: string;
+    fullName: string;
 }
 
-const PROVIDER_CONFIG: readonly ProviderConfig[] = PROVIDER_ORDER.map(
-    provider => ({
-        provider,
-        displayName: PROVIDER_DISPLAY_NAME[provider],
-    })
-);
+const MODEL_DISPLAY_MAP: Partial<Record<ModelId, ModelDisplay>> = {
+    'gemini-2.5-flash-lite': {
+        label: 'Flash Lite',
+        fullName: 'Gemini 2.5 Flash Lite',
+    },
+    'gemini-2.5-flash': { label: 'Flash', fullName: 'Gemini 2.5 Flash' },
+    'gemini-2.5-pro': { label: 'Pro', fullName: 'Gemini 2.5 Pro' },
+    'gemini-3.1-pro-preview': {
+        label: '3.1 Pro',
+        fullName: 'Gemini 3.1 Pro Preview',
+    },
+    'gemini-3-flash-preview': {
+        label: 'Flash 3',
+        fullName: 'Gemini 3 Flash Preview',
+    },
+    'claude-haiku-3-5': { label: 'Haiku', fullName: 'Claude Haiku 3.5' },
+    'claude-sonnet-4-6': { label: 'Sonnet', fullName: 'Claude Sonnet 4.6' },
+    'claude-opus-4-7': { label: 'Opus', fullName: 'Claude Opus 4.7' },
+    'gpt-5-mini': { label: 'GPT Mini', fullName: 'GPT-5 Mini' },
+    'gpt-5.4': { label: 'GPT 5.4', fullName: 'GPT-5.4' },
+    'gpt-5.5': { label: 'GPT 5.5', fullName: 'GPT-5.5' },
+};
+
+function getModelDisplay(id: ModelId): ModelDisplay {
+    return MODEL_DISPLAY_MAP[id] ?? { label: id, fullName: id };
+}
 
 interface ModelSelectorProps {
-    selectedProvider: AIProvider;
-    onProviderChange: (provider: AIProvider) => void;
+    selectedModel: ModelId;
+    onModelChange: (model: ModelId) => void;
     allowedModels: readonly ModelId[];
     disabled?: boolean;
 }
 
 export function ModelSelector({
-    selectedProvider,
-    onProviderChange,
+    selectedModel,
+    onModelChange,
     allowedModels,
     disabled = false,
 }: ModelSelectorProps) {
-    const groupRef = useRef<HTMLDivElement>(null);
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const dropdownRef = useRef<HTMLDivElement>(null);
+    const optionRefs = useRef<(HTMLDivElement | null)[]>([]);
+    const { isOpen, toggle, close } = usePopoverToggle([
+        triggerRef,
+        dropdownRef,
+    ]);
 
-    const resolvedModels = useMemo(
-        () =>
-            PROVIDER_CONFIG.map(({ provider, displayName }) => {
-                const modelId = resolveDefaultModelForProvider(
-                    provider,
-                    allowedModels
-                );
-                return {
-                    provider,
-                    displayName,
-                    modelId,
-                    isLocked: modelId === null,
-                };
-            }),
-        [allowedModels]
-    );
+    const selectedDisplay = getModelDisplay(selectedModel);
 
-    const handleSelect = useCallback(
-        (provider: AIProvider, isLocked: boolean): void => {
-            if (disabled || isLocked) return;
-            onProviderChange(provider);
-        },
-        [disabled, onProviderChange]
-    );
+    const handleToggle = () => {
+        if (disabled) return;
+        toggle();
+        if (!isOpen) {
+            const selectedIdx = allowedModels.indexOf(selectedModel);
+            setTimeout(() => optionRefs.current[selectedIdx]?.focus(), 0);
+        }
+    };
 
-    const handleKeyDown = useCallback(
-        (event: React.KeyboardEvent<HTMLDivElement>): void => {
-            if (disabled) return;
-
-            const nonLockedProviders = resolvedModels
-                .filter(m => !m.isLocked)
-                .map(m => m.provider);
-
-            if (nonLockedProviders.length === 0) return;
-
-            const currentIndex = nonLockedProviders.indexOf(selectedProvider);
-            const len = nonLockedProviders.length;
-            const nextProvider = (() => {
-                switch (event.key) {
-                    case 'ArrowRight': {
-                        event.preventDefault();
-                        return nonLockedProviders[(currentIndex + 1) % len];
-                    }
-                    case 'ArrowLeft': {
-                        event.preventDefault();
-                        return nonLockedProviders[
-                            (currentIndex - 1 + len) % len
-                        ];
-                    }
-                    case 'Home': {
-                        event.preventDefault();
-                        return nonLockedProviders[0];
-                    }
-                    case 'End': {
-                        event.preventDefault();
-                        return nonLockedProviders[len - 1];
-                    }
-                    case ' ':
-                    case 'Enter': {
-                        event.preventDefault();
-                        return undefined;
-                    }
-                    default:
-                        return undefined;
-                }
-            })();
-
-            if (nextProvider !== undefined) {
-                onProviderChange(nextProvider);
-                // Sync DOM focus to the newly selected option
-                const group = groupRef.current;
-                if (group !== null) {
-                    const button = group.querySelector<HTMLElement>(
-                        `[data-provider="${nextProvider}"]`
-                    );
-                    button?.focus();
-                }
+    const handleListboxKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+        const currentIndex = allowedModels.indexOf(selectedModel);
+        switch (e.key) {
+            case 'ArrowDown': {
+                e.preventDefault();
+                const nextIdx = (currentIndex + 1) % allowedModels.length;
+                onModelChange(allowedModels[nextIdx]!);
+                optionRefs.current[nextIdx]?.focus();
+                break;
             }
-        },
-        [disabled, resolvedModels, selectedProvider, onProviderChange]
-    );
+            case 'ArrowUp': {
+                e.preventDefault();
+                const prevIdx =
+                    (currentIndex - 1 + allowedModels.length) %
+                    allowedModels.length;
+                onModelChange(allowedModels[prevIdx]!);
+                optionRefs.current[prevIdx]?.focus();
+                break;
+            }
+            case 'Home':
+                e.preventDefault();
+                onModelChange(allowedModels[0]!);
+                optionRefs.current[0]?.focus();
+                break;
+            case 'End': {
+                e.preventDefault();
+                const lastIdx = allowedModels.length - 1;
+                onModelChange(allowedModels[lastIdx]!);
+                optionRefs.current[lastIdx]?.focus();
+                break;
+            }
+            case 'Escape':
+                e.preventDefault();
+                close();
+                triggerRef.current?.focus();
+                break;
+        }
+    };
 
     return (
         <div className="flex flex-col gap-1.5">
             <span className="text-secondary-500 text-xs font-medium tracking-[0.15em] uppercase">
                 AI MODEL
             </span>
-            <div
-                ref={groupRef}
-                role="radiogroup"
-                aria-label="AI 분석 모델 선택"
-                className="border-secondary-700 grid grid-cols-3 overflow-hidden rounded-md border"
-                onKeyDown={handleKeyDown}
-            >
-                {resolvedModels.map(
-                    ({ provider, displayName, modelId, isLocked }) => {
-                        const isSelected = provider === selectedProvider;
-                        const isEffectivelyDisabled = disabled || isLocked;
+            <div className="relative">
+                <button
+                    ref={triggerRef}
+                    type="button"
+                    onClick={handleToggle}
+                    disabled={disabled}
+                    aria-haspopup="listbox"
+                    aria-expanded={isOpen}
+                    aria-label="AI 분석 모델 선택"
+                    className={cn(
+                        'border-secondary-700 hover:bg-secondary-700/30 focus-visible:ring-primary-500 flex w-full items-center justify-between rounded-md border px-3 py-2 transition-colors focus-visible:ring-1 focus-visible:outline-none',
+                        disabled && 'cursor-not-allowed opacity-60'
+                    )}
+                >
+                    <span className="text-secondary-300 text-xs font-medium">
+                        {selectedDisplay.label}
+                    </span>
+                    <span
+                        className={cn(
+                            'text-secondary-500 text-xs transition-transform duration-150',
+                            isOpen && 'rotate-180'
+                        )}
+                        aria-hidden="true"
+                    >
+                        ▾
+                    </span>
+                </button>
 
-                        return (
-                            <div
-                                key={provider}
-                                role="radio"
-                                aria-checked={isSelected}
-                                aria-disabled={isEffectivelyDisabled}
-                                tabIndex={isSelected ? 0 : -1}
-                                data-provider={provider}
-                                title={isLocked ? 'Pro 등급 전용' : undefined}
-                                onClick={() => handleSelect(provider, isLocked)}
-                                onKeyDown={e => {
-                                    if (
-                                        (e.key === ' ' || e.key === 'Enter') &&
-                                        !isEffectivelyDisabled
-                                    ) {
-                                        e.preventDefault();
-                                        handleSelect(provider, isLocked);
-                                    }
-                                }}
-                                className={cn(
-                                    'relative flex cursor-pointer flex-col items-center gap-1 border-r px-2 py-2.5 transition-colors select-none last:border-r-0',
-                                    'focus-visible:ring-primary-500 focus-visible:ring-1 focus-visible:outline-none',
-                                    isSelected
-                                        ? 'border-r-secondary-700 bg-primary-500/10'
-                                        : 'border-r-secondary-700',
-                                    isEffectivelyDisabled
-                                        ? 'cursor-not-allowed opacity-60'
-                                        : !isSelected &&
-                                              'hover:bg-secondary-700/30'
-                                )}
-                            >
-                                {isLocked && (
-                                    <span
-                                        className="text-secondary-500 absolute top-1 right-1"
-                                        aria-hidden="true"
-                                    >
-                                        <svg
-                                            xmlns="http://www.w3.org/2000/svg"
-                                            viewBox="0 0 16 16"
-                                            fill="currentColor"
-                                            className="h-2.5 w-2.5"
-                                        >
-                                            <path
-                                                fillRule="evenodd"
-                                                d="M8 1a3.5 3.5 0 0 0-3.5 3.5V7A1.5 1.5 0 0 0 3 8.5v4A1.5 1.5 0 0 0 4.5 14h7a1.5 1.5 0 0 0 1.5-1.5v-4A1.5 1.5 0 0 0 11 7V4.5A3.5 3.5 0 0 0 8 1Zm2 6V4.5a2 2 0 1 0-4 0V7h4Z"
-                                                clipRule="evenodd"
-                                            />
-                                        </svg>
-                                    </span>
-                                )}
-
-                                <span aria-hidden="true">
-                                    {isSelected ? (
-                                        <span className="text-primary-300 text-sm">
-                                            ◆
-                                        </span>
-                                    ) : (
-                                        <span className="text-secondary-400 text-sm">
-                                            ◇
-                                        </span>
-                                    )}
-                                </span>
-
-                                <span className="sr-only">
-                                    {isSelected ? '선택됨' : '선택 안됨'}
-                                    {isLocked ? ', Pro 등급 전용' : ''}
-                                </span>
-
-                                <span
+                {isOpen && (
+                    <div
+                        ref={dropdownRef}
+                        role="listbox"
+                        aria-label="AI 분석 모델 목록"
+                        onKeyDown={handleListboxKeyDown}
+                        className="border-secondary-600 bg-secondary-800 absolute top-full left-0 z-10 mt-1 w-full overflow-hidden rounded-lg border shadow-lg"
+                    >
+                        {allowedModels.map((modelId, i) => {
+                            const display = getModelDisplay(modelId);
+                            const isSelected = modelId === selectedModel;
+                            return (
+                                <div
+                                    key={modelId}
+                                    ref={el => {
+                                        optionRefs.current[i] = el;
+                                    }}
+                                    role="option"
+                                    tabIndex={isSelected ? 0 : -1}
+                                    aria-selected={isSelected}
+                                    onClick={() => {
+                                        onModelChange(modelId);
+                                        close();
+                                        triggerRef.current?.focus();
+                                    }}
+                                    onKeyDown={e => {
+                                        if (
+                                            e.key === 'Enter' ||
+                                            e.key === ' '
+                                        ) {
+                                            e.preventDefault();
+                                            onModelChange(modelId);
+                                            close();
+                                            triggerRef.current?.focus();
+                                        }
+                                    }}
                                     className={cn(
-                                        'text-xs font-medium tracking-[0.15em] uppercase',
+                                        'focus-visible:ring-primary-500 flex min-h-[44px] w-full cursor-pointer items-center gap-2 px-3 transition-colors focus-visible:ring-1 focus-visible:outline-none',
                                         isSelected
-                                            ? 'text-primary-300'
-                                            : 'text-secondary-400'
+                                            ? 'text-primary-300 bg-primary-900/20'
+                                            : 'text-secondary-300 hover:bg-secondary-700'
                                     )}
                                 >
-                                    {displayName}
-                                </span>
-
-                                <span className="text-secondary-500 font-mono text-[10px] tabular-nums">
-                                    {modelId !== null
-                                        ? formatModelVariant(modelId)
-                                        : '—'}
-                                </span>
-                            </div>
-                        );
-                    }
+                                    <span className="w-3 text-[10px]">
+                                        {isSelected && '✓'}
+                                    </span>
+                                    <div>
+                                        <div className="text-[11px] font-medium">
+                                            {display.label}
+                                        </div>
+                                        <div className="text-secondary-500 text-[10px]">
+                                            {display.fullName}
+                                        </div>
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
                 )}
             </div>
         </div>
     );
-}
-
-// ModelId → 짧은 표시 문자열 변환 (e.g. "claude-sonnet-4-6" → "Sonnet 4.6")
-function formatModelVariant(modelId: ModelId): string {
-    // claude-* → extract after "claude-"
-    const claudeMatch = /^claude-(.+)$/.exec(modelId);
-    if (claudeMatch !== null) {
-        return claudeMatch[1]
-            .split('-')
-            .map(part => {
-                if (/^\d+$/.test(part)) return part;
-                return part.charAt(0).toUpperCase() + part.slice(1);
-            })
-            .join(' ')
-            .replace(/(\d) (\d)/g, '$1.$2');
-    }
-
-    // gemini-* → drop "gemini-" prefix
-    const geminiMatch = /^gemini-(.+)$/.exec(modelId);
-    if (geminiMatch !== null) {
-        return geminiMatch[1]
-            .split('-')
-            .map(part => {
-                if (/^\d/.test(part)) return part;
-                return part.charAt(0).toUpperCase() + part.slice(1);
-            })
-            .join(' ');
-    }
-
-    // gpt-* → drop "gpt-" prefix
-    const gptMatch = /^gpt-(.+)$/.exec(modelId);
-    if (gptMatch !== null) {
-        return gptMatch[1];
-    }
-
-    return modelId;
 }

--- a/src/components/analysis/ModelSelector.tsx
+++ b/src/components/analysis/ModelSelector.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { usePopoverToggle } from '@/components/hooks/usePopoverToggle';
-import { cn } from '@/lib/cn';
 import { isFreeChatModel } from '@/domain/llm';
+import { cn } from '@/lib/cn';
 import type { ModelId } from '@y0ngha/siglens-core';
 import { useRef } from 'react';
 
@@ -150,7 +150,7 @@ export function ModelSelector({
                         onKeyDown={handleListboxKeyDown}
                         className="border-secondary-600 bg-secondary-800 absolute top-full left-0 z-10 mt-1 w-full rounded-lg border shadow-lg"
                     >
-                        <div className="max-h-[264px] overflow-y-auto overscroll-contain">
+                        <div className="max-h-66 overflow-y-auto overscroll-contain">
                             {allowedModels.map((modelId, i) => {
                                 const display = getModelDisplay(modelId);
                                 const isSelected = modelId === selectedModel;

--- a/src/components/auth/AuthFieldGroup.tsx
+++ b/src/components/auth/AuthFieldGroup.tsx
@@ -6,6 +6,7 @@ interface AuthFieldGroupProps {
     autoComplete?: string;
     required?: boolean;
     defaultValue?: string;
+    value?: string;
     placeholder?: string;
     error?: string;
     onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -19,6 +20,7 @@ export function AuthFieldGroup({
     autoComplete,
     required,
     defaultValue,
+    value,
     placeholder,
     error,
     onChange,
@@ -39,6 +41,7 @@ export function AuthFieldGroup({
                 autoComplete={autoComplete}
                 required={required}
                 defaultValue={defaultValue}
+                {...(value !== undefined ? { value } : {})}
                 placeholder={placeholder}
                 onChange={onChange}
                 aria-invalid={!!error}

--- a/src/components/auth/ConsentCheckboxGroup.tsx
+++ b/src/components/auth/ConsentCheckboxGroup.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useEffect, useId, useRef } from 'react';
-import Link from 'next/link';
 import { cn } from '@/lib/cn';
 import { PRIVACY_PATH, TERMS_PATH } from '@/lib/legal';
+import Link from 'next/link';
+import { useEffect, useId, useRef } from 'react';
 
 interface ConsentCheckboxGroupProps {
     privacyChecked: boolean;
@@ -136,7 +136,7 @@ function ConsentRow({
         <label
             htmlFor={id}
             className={cn(
-                'group flex min-h-[44px] cursor-pointer flex-col gap-1 py-1 sm:flex-row sm:items-center sm:justify-between',
+                'group flex min-h-11 cursor-pointer flex-col gap-1 py-1 sm:flex-row sm:items-center sm:justify-between',
                 'border-l pl-3 transition-colors duration-200',
                 invalid
                     ? 'border-ui-danger'
@@ -210,7 +210,7 @@ export function ConsentCheckboxGroup({
             </p>
             <label
                 htmlFor={masterId}
-                className="flex min-h-[44px] cursor-pointer items-center gap-2 py-1"
+                className="flex min-h-11 cursor-pointer items-center gap-2 py-1"
             >
                 <CheckboxBox
                     checked={allChecked}

--- a/src/components/auth/PasswordField.tsx
+++ b/src/components/auth/PasswordField.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { EyeIcon } from '@/components/ui/EyeIcon';
 import { useState, type ReactNode } from 'react';
 
 interface PasswordFieldProps {
@@ -68,7 +69,7 @@ export function PasswordField({
                     aria-pressed={visible}
                     className="text-secondary-400 hover:text-secondary-200 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-950 absolute inset-y-0 right-0 flex w-12 items-center justify-center rounded-r-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
                 >
-                    <span aria-hidden>{visible ? '🙈' : '👁'}</span>
+                    <EyeIcon isVisible={visible} className="h-5 w-5" />
                 </button>
             </div>
             {capsLock ? (

--- a/src/components/auth/PasswordField.tsx
+++ b/src/components/auth/PasswordField.tsx
@@ -8,6 +8,7 @@ interface PasswordFieldProps {
     label: string;
     autoComplete: 'current-password' | 'new-password';
     required?: boolean;
+    value?: string;
     error?: string;
     hint?: ReactNode;
     describedById?: string;
@@ -20,6 +21,7 @@ export function PasswordField({
     label,
     autoComplete,
     required,
+    value,
     error,
     hint,
     describedById,
@@ -51,6 +53,7 @@ export function PasswordField({
                     type={visible ? 'text' : 'password'}
                     autoComplete={autoComplete}
                     required={required}
+                    {...(value !== undefined ? { value } : {})}
                     onChange={e => onChange?.(e.target.value)}
                     onKeyUp={e => setCapsLock(e.getModifierState('CapsLock'))}
                     onBlur={() => setCapsLock(false)}

--- a/src/components/auth/PasswordStrengthHint.tsx
+++ b/src/components/auth/PasswordStrengthHint.tsx
@@ -32,7 +32,7 @@ export function PasswordStrengthHint({
     descriptionId,
 }: PasswordStrengthHintProps) {
     return (
-        <ul id={descriptionId} className="mt-1 space-y-1 text-xs">
+        <ul id={descriptionId} className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs">
             {RULES.map(rule => {
                 const ok = rule.test(password);
                 return (

--- a/src/components/auth/PasswordStrengthHint.tsx
+++ b/src/components/auth/PasswordStrengthHint.tsx
@@ -32,7 +32,10 @@ export function PasswordStrengthHint({
     descriptionId,
 }: PasswordStrengthHintProps) {
     return (
-        <ul id={descriptionId} className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs">
+        <ul
+            id={descriptionId}
+            className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs"
+        >
             {RULES.map(rule => {
                 const ok = rule.test(password);
                 return (

--- a/src/components/auth/ResetPasswordForm.tsx
+++ b/src/components/auth/ResetPasswordForm.tsx
@@ -21,6 +21,7 @@ const EXPIRED_TOKEN_MESSAGE =
 function describeFormError(state: ResetPasswordFormState): string | null {
     if (state.error?.code === 'invalid_token') return INVALID_TOKEN_MESSAGE;
     if (state.error?.code === 'expired_token') return EXPIRED_TOKEN_MESSAGE;
+    if (state.error?.code === 'same_password') return state.error.message;
     if (state.error?.code === 'redis_unavailable') return state.error.message;
     return null;
 }
@@ -48,6 +49,8 @@ export function ResetPasswordForm({ email, token }: ResetPasswordFormProps) {
                 return;
             }
             setConfirmError(null);
+            setPassword('');
+            setConfirmPassword('');
             formAction(formData);
         },
         [formAction, password, confirmPassword]

--- a/src/components/auth/ResetPasswordForm.tsx
+++ b/src/components/auth/ResetPasswordForm.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useId, useState } from 'react';
-import type { ResetPasswordFormState } from '@/domain/types';
-import { useResetPasswordForm } from '@/components/hooks/useResetPasswordForm';
 import { AuthErrorAlert } from '@/components/auth/AuthErrorAlert';
 import { PasswordField } from '@/components/auth/PasswordField';
 import { PasswordStrengthHint } from '@/components/auth/PasswordStrengthHint';
 import { SubmitButton } from '@/components/auth/SubmitButton';
+import { useResetPasswordForm } from '@/components/hooks/useResetPasswordForm';
+import type { ResetPasswordFormState } from '@/domain/types';
+import { useCallback, useId, useState } from 'react';
 
 interface ResetPasswordFormProps {
     email: string;
@@ -38,8 +38,17 @@ export function ResetPasswordForm({ email, token }: ResetPasswordFormProps) {
     const [state, formAction] = useResetPasswordForm();
     const formError = describeFormError(state);
     const fieldError = describePasswordFieldError(state);
+
+    const handleAction = useCallback(
+        (formData: FormData) => {
+            setPassword('');
+            formAction(formData);
+        },
+        [formAction]
+    );
+
     return (
-        <form action={formAction} className="space-y-4" noValidate>
+        <form action={handleAction} className="space-y-4" noValidate>
             <input type="hidden" name="email" value={email} />
             <input type="hidden" name="token" value={token} />
             {formError ? <AuthErrorAlert message={formError} /> : null}

--- a/src/components/auth/ResetPasswordForm.tsx
+++ b/src/components/auth/ResetPasswordForm.tsx
@@ -34,6 +34,8 @@ function describePasswordFieldError(
 
 export function ResetPasswordForm({ email, token }: ResetPasswordFormProps) {
     const [password, setPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [confirmError, setConfirmError] = useState<string | null>(null);
     const hintId = useId();
     const [state, formAction] = useResetPasswordForm();
     const formError = describeFormError(state);
@@ -41,10 +43,14 @@ export function ResetPasswordForm({ email, token }: ResetPasswordFormProps) {
 
     const handleAction = useCallback(
         (formData: FormData) => {
-            setPassword('');
+            if (password !== confirmPassword) {
+                setConfirmError('비밀번호가 일치하지 않습니다.');
+                return;
+            }
+            setConfirmError(null);
             formAction(formData);
         },
-        [formAction]
+        [formAction, password, confirmPassword]
     );
 
     return (
@@ -58,7 +64,11 @@ export function ResetPasswordForm({ email, token }: ResetPasswordFormProps) {
                 label="새 비밀번호"
                 autoComplete="new-password"
                 required
-                onChange={setPassword}
+                value={password}
+                onChange={value => {
+                    setPassword(value);
+                    if (confirmError) setConfirmError(null);
+                }}
                 error={fieldError ?? undefined}
                 describedById={hintId}
                 hint={
@@ -67,6 +77,19 @@ export function ResetPasswordForm({ email, token }: ResetPasswordFormProps) {
                         descriptionId={hintId}
                     />
                 }
+            />
+            <PasswordField
+                id="reset-password-confirm"
+                name="confirmPassword"
+                label="새 비밀번호 확인"
+                autoComplete="new-password"
+                required
+                value={confirmPassword}
+                onChange={value => {
+                    setConfirmPassword(value);
+                    if (confirmError) setConfirmError(null);
+                }}
+                error={confirmError ?? undefined}
             />
             <SubmitButton label="비밀번호 변경" pendingLabel="변경 중…" />
         </form>

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useId,
+    useLayoutEffect,
+    useRef,
+    useState,
+} from 'react';
 import {
     useRequestEmailVerification,
     useVerifyEmail,
@@ -114,7 +121,9 @@ function SignupFormFlow({ next, onRestart }: SignupFormFlowProps) {
     // Next.js router cache가 useActionState를 이전 세션 값으로 hydrate한 채
     // 컴포넌트를 리마운트할 수 있다. 마운트 시점에 이미 non-initial 상태라면
     // 뒤로가기로 복원된 것이므로 paint 전에 1단계로 리셋한다.
-    const restoredFromCacheRef = useRef(emailState.submitted || codeState.verified);
+    const restoredFromCacheRef = useRef(
+        emailState.submitted || codeState.verified
+    );
     useLayoutEffect(() => {
         if (restoredFromCacheRef.current) {
             onRestart();

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useId, useState } from 'react';
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
 import {
     useRequestEmailVerification,
     useVerifyEmail,
@@ -80,6 +80,13 @@ export function SignupForm({ next }: SignupFormProps) {
         return () => window.removeEventListener('pageshow', handlePageShow);
     }, [handleRestart]);
 
+    // Next.js router cache로 컴포넌트가 메모리에 유지된 채 뒤로가기가 발생하면
+    // popstate 이벤트로 감지해 1단계로 초기화
+    useEffect(() => {
+        window.addEventListener('popstate', handleRestart);
+        return () => window.removeEventListener('popstate', handleRestart);
+    }, [handleRestart]);
+
     return (
         <SignupFormFlow key={resetKey} next={next} onRestart={handleRestart} />
     );
@@ -103,6 +110,16 @@ function SignupFormFlow({ next, onRestart }: SignupFormFlowProps) {
 
     // useActionState 결과에서 직접 derive — set-state-in-effect 회피.
     const phase = derivePhase(emailState.submitted, codeState.verified);
+
+    // Next.js router cache가 useActionState를 이전 세션 값으로 hydrate한 채
+    // 컴포넌트를 리마운트할 수 있다. 마운트 시점에 이미 non-initial 상태라면
+    // 뒤로가기로 복원된 것이므로 paint 전에 1단계로 리셋한다.
+    const restoredFromCacheRef = useRef(emailState.submitted || codeState.verified);
+    useLayoutEffect(() => {
+        if (restoredFromCacheRef.current) {
+            onRestart();
+        }
+    }, [onRestart]);
 
     const signupError = signupState.error;
     const signupEmailError =

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -91,6 +91,7 @@ interface SignupFormFlowProps extends SignupFormProps {
 
 function SignupFormFlow({ next, onRestart }: SignupFormFlowProps) {
     const [email, setEmail] = useState('');
+    const [name, setName] = useState('');
     const [password, setPassword] = useState('');
     const [privacyChecked, setPrivacyChecked] = useState(false);
     const [tosChecked, setTosChecked] = useState(false);
@@ -218,6 +219,8 @@ function SignupFormFlow({ next, onRestart }: SignupFormFlowProps) {
                         type="text"
                         autoComplete="name"
                         placeholder="다른 사용자에게 보이는 이름"
+                        value={name}
+                        onChange={event => setName(event.target.value)}
                     />
                     <PasswordField
                         id="signup-password"

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -225,6 +225,7 @@ function SignupFormFlow({ next, onRestart }: SignupFormFlowProps) {
                         label="비밀번호"
                         autoComplete="new-password"
                         required
+                        value={password}
                         error={signupPasswordError}
                         describedById={hintId}
                         onChange={setPassword}

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -319,7 +319,9 @@ export function ChatPanel({ symbol, onClose }: ChatPanelProps) {
                                                     e.key === ' '
                                                 ) {
                                                     e.preventDefault();
-                                                    handleModelChange(option.id);
+                                                    handleModelChange(
+                                                        option.id
+                                                    );
                                                     close();
                                                     triggerRef.current?.focus();
                                                 }
@@ -344,7 +346,9 @@ export function ChatPanel({ symbol, onClose }: ChatPanelProps) {
                                                         {option.fullName}
                                                     </div>
                                                 </div>
-                                                {!isFreeChatModel(option.id) && (
+                                                {!isFreeChatModel(
+                                                    option.id
+                                                ) && (
                                                     <span className="text-ui-warning text-[9px] leading-none font-semibold uppercase">
                                                         PRO
                                                     </span>

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -286,68 +286,73 @@ export function ChatPanel({ symbol, onClose }: ChatPanelProps) {
                                 aria-label="AI 모델 목록"
                                 onKeyDown={handleListboxKeyDown}
                                 className={cn(
-                                    'border-secondary-600 bg-secondary-800 absolute left-0 z-10 min-w-[160px] overflow-hidden rounded-lg border shadow-lg',
+                                    'border-secondary-600 bg-secondary-800 absolute left-0 z-10 min-w-[160px] rounded-lg border shadow-lg',
                                     opensUpward
                                         ? 'bottom-full mb-1'
                                         : 'top-full mt-1'
                                 )}
                             >
-                                {CHAT_MODEL_OPTIONS.map((option, i) => (
-                                    <div
-                                        key={option.id}
-                                        ref={el => {
-                                            optionRefs.current[i] = el;
-                                        }}
-                                        role="option"
-                                        tabIndex={
-                                            selectedModel === option.id ? 0 : -1
-                                        }
-                                        aria-selected={
-                                            selectedModel === option.id
-                                        }
-                                        onClick={() => {
-                                            handleModelChange(option.id);
-                                            close();
-                                            triggerRef.current?.focus();
-                                        }}
-                                        onKeyDown={e => {
-                                            if (
-                                                e.key === 'Enter' ||
-                                                e.key === ' '
-                                            ) {
-                                                e.preventDefault();
+                                <div className="max-h-[264px] overflow-y-auto overscroll-contain">
+                                    {CHAT_MODEL_OPTIONS.map((option, i) => (
+                                        <div
+                                            key={option.id}
+                                            ref={el => {
+                                                optionRefs.current[i] = el;
+                                            }}
+                                            role="option"
+                                            tabIndex={
+                                                selectedModel === option.id
+                                                    ? 0
+                                                    : -1
+                                            }
+                                            aria-selected={
+                                                selectedModel === option.id
+                                            }
+                                            onClick={() => {
                                                 handleModelChange(option.id);
                                                 close();
                                                 triggerRef.current?.focus();
-                                            }
-                                        }}
-                                        className={cn(
-                                            'focus-visible:ring-primary-500 flex min-h-[44px] w-full cursor-pointer items-center gap-2 px-3 transition-colors focus-visible:ring-1 focus-visible:outline-none',
-                                            selectedModel === option.id
-                                                ? 'text-primary-300 bg-primary-900/20'
-                                                : 'text-secondary-300 hover:bg-secondary-700'
-                                        )}
-                                    >
-                                        <span className="w-3 text-[10px]">
-                                            {selectedModel === option.id && '✓'}
-                                        </span>
-                                        <div className="flex flex-1 items-center justify-between gap-2">
-                                            <div>
-                                                <div className="text-[11px] font-medium">
-                                                    {option.label}
-                                                </div>
-                                                <div className="text-secondary-500 text-[10px]">
-                                                    {option.fullName}
-                                                </div>
-                                            </div>
-                                            {!isFreeChatModel(option.id) && (
-                                                <span className="text-ui-warning text-[9px] leading-none font-semibold uppercase">
-                                                    PRO
-                                                </span>
+                                            }}
+                                            onKeyDown={e => {
+                                                if (
+                                                    e.key === 'Enter' ||
+                                                    e.key === ' '
+                                                ) {
+                                                    e.preventDefault();
+                                                    handleModelChange(option.id);
+                                                    close();
+                                                    triggerRef.current?.focus();
+                                                }
+                                            }}
+                                            className={cn(
+                                                'focus-visible:ring-primary-500 flex min-h-[44px] w-full cursor-pointer items-center gap-2 px-3 transition-colors focus-visible:ring-1 focus-visible:outline-none',
+                                                selectedModel === option.id
+                                                    ? 'text-primary-300 bg-primary-900/20'
+                                                    : 'text-secondary-300 hover:bg-secondary-700'
                                             )}
+                                        >
+                                            <span className="w-3 text-[10px]">
+                                                {selectedModel === option.id &&
+                                                    '✓'}
+                                            </span>
+                                            <div className="flex flex-1 items-center justify-between gap-2">
+                                                <div>
+                                                    <div className="text-[11px] font-medium">
+                                                        {option.label}
+                                                    </div>
+                                                    <div className="text-secondary-500 text-[10px]">
+                                                        {option.fullName}
+                                                    </div>
+                                                </div>
+                                                {!isFreeChatModel(option.id) && (
+                                                    <span className="text-ui-warning text-[9px] leading-none font-semibold uppercase">
+                                                        PRO
+                                                    </span>
+                                                )}
+                                            </div>
                                         </div>
-                                    </div>
-                                ))}
+                                    ))}
+                                </div>
                             </div>
                         )}
                     </div>
@@ -396,7 +401,6 @@ export function ChatPanel({ symbol, onClose }: ChatPanelProps) {
                 <PremiumModelGateModal
                     mode={gateModal.mode}
                     providerLabel={LLM_PROVIDER_LABELS[gateModal.provider]}
-                    symbol={symbol}
                     onClose={dismissGate}
                 />
             )}

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -220,8 +220,8 @@ export function ChatPanel({ symbol, onClose }: ChatPanelProps) {
                             className={cn(
                                 'max-w-[85%] rounded-lg p-2.5 text-xs leading-relaxed',
                                 msg.role === 'user'
-                                    ? 'bg-primary-600/80 ml-auto rounded-tr-sm text-white'
-                                    : 'bg-secondary-700/50 text-secondary-200 rounded-tl-sm'
+                                    ? 'bg-primary-600/80 self-end rounded-tr-sm text-white'
+                                    : 'bg-secondary-700/50 text-secondary-200 self-start rounded-tl-sm'
                             )}
                         >
                             {msg.role === 'user' ? (
@@ -234,7 +234,7 @@ export function ChatPanel({ symbol, onClose }: ChatPanelProps) {
                 })}
 
                 {loadingPhase !== null && (
-                    <div className="bg-secondary-700/50 max-w-[85%] rounded-lg rounded-tl-sm p-2.5">
+                    <div className="bg-secondary-700/50 max-w-[85%] self-start rounded-lg rounded-tl-sm p-2.5">
                         <p className="text-secondary-400 text-xs">
                             {LOADING_MESSAGES[loadingPhase]}
                         </p>

--- a/src/components/contact/ContactSubmittedNotice.tsx
+++ b/src/components/contact/ContactSubmittedNotice.tsx
@@ -1,7 +1,3 @@
-const SUCCESS_TITLE = '문의가 접수되었습니다';
-const SUCCESS_DESCRIPTION =
-    '확인 후 입력하신 이메일로 답변드리겠습니다. 잠시만 기다려 주세요.';
-
 export function ContactSubmittedNotice() {
     return (
         <div
@@ -9,8 +5,13 @@ export function ContactSubmittedNotice() {
             aria-live="polite"
             className="border-secondary-800 bg-secondary-900/60 space-y-2 rounded-md border p-4 text-sm"
         >
-            <p className="text-secondary-100 font-semibold">{SUCCESS_TITLE}</p>
-            <p className="text-secondary-300">{SUCCESS_DESCRIPTION}</p>
+            <p className="text-secondary-100 font-semibold">
+                문의가 접수되었습니다
+            </p>
+            <p className="text-secondary-300">
+                확인 후 입력하신 이메일로 답변드리겠습니다.
+            </p>
+            <p className="text-secondary-300">잠시만 기다려 주세요.</p>
         </div>
     );
 }

--- a/src/components/layout/HeaderUserMenu.tsx
+++ b/src/components/layout/HeaderUserMenu.tsx
@@ -6,6 +6,7 @@ import { usePopoverToggle } from '@/components/hooks/usePopoverToggle';
 import { TIER_LABEL } from '@/lib/auth/tierLabel';
 import { cn } from '@/lib/cn';
 import type { Tier } from '@y0ngha/siglens-core';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRef } from 'react';
 
@@ -20,6 +21,7 @@ export interface HeaderUserMenuUser {
     readonly email: string;
     readonly name: string | null;
     readonly tier: Tier;
+    readonly avatarUrl: string | null;
 }
 
 interface HeaderUserMenuProps {
@@ -85,7 +87,17 @@ export function HeaderUserMenu({ currentUser, loading }: HeaderUserMenuProps) {
                 aria-label={`사용자 메뉴 (${tierLabel})`}
                 className="bg-secondary-800 text-secondary-100 hover:bg-secondary-700 focus-visible:ring-primary-500 relative flex size-10 items-center justify-center rounded-full text-sm font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none"
             >
-                <span aria-hidden>{initial}</span>
+                {currentUser.avatarUrl ? (
+                    <Image
+                        src={currentUser.avatarUrl}
+                        alt="아바타 이미지"
+                        width={40}
+                        height={40}
+                        className="size-full rounded-full object-cover"
+                    />
+                ) : (
+                    <span aria-hidden>{initial}</span>
+                )}
                 <span
                     aria-hidden
                     className={cn(

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -17,7 +17,7 @@ import { useAnalysis } from '@/components/symbol-page/hooks/useAnalysis';
 import { useAnalysisDerivedData } from '@/components/symbol-page/hooks/useAnalysisDerivedData';
 import { useAnalysisDisplay } from '@/components/symbol-page/hooks/useAnalysisDisplay';
 import { useActionPricesVisibility } from '@/components/symbol-page/hooks/useActionPricesVisibility';
-import { useSelectedProvider } from '@/components/symbol-page/hooks/useSelectedProvider';
+import { useSelectedModel } from '@/components/symbol-page/hooks/useSelectedModel';
 import { useUserTier } from '@/components/symbol-page/hooks/useUserTier';
 import {
     PANEL_MAX_WIDTH,
@@ -30,7 +30,6 @@ import { getAnalysisStatus } from '@/components/symbol-page/utils/analysisStatus
 import { SNAP_PEEK } from '@/components/symbol-page/constants/mobileSheet';
 import { useAnalysisProgress } from '@/components/symbol-page/hooks/useAnalysisProgress';
 import { usePublishSymbolChat } from '@/components/chat/hooks/useSymbolChat';
-import { resolveDefaultModelForProvider } from '@/domain/llm/providerDefaults';
 import { PWA_TRIGGER_EVENT } from '@/lib/pwaEvents';
 import { NewsAugment } from '@/components/symbol-page/NewsAugment';
 
@@ -125,8 +124,6 @@ export function ChartContent({
     const { actionPricesVisible, setActionPricesVisible } =
         useActionPricesVisibility();
 
-    const [selectedProvider, setSelectedProvider] = useSelectedProvider();
-
     // Resolve the user's tier from the server (guests fall back to 'free') so
     // the model picker reflects the actual entitlement instead of a hardcoded
     // value. The single source of truth for tier→model mapping lives in
@@ -134,12 +131,7 @@ export function ChartContent({
     const { tier } = useUserTier();
     const allowedModels = useMemo(() => getAllowedModels(tier), [tier]);
 
-    const modelId = useMemo(
-        () =>
-            resolveDefaultModelForProvider(selectedProvider, allowedModels) ??
-            undefined,
-        [selectedProvider, allowedModels]
-    );
+    const [modelId, setModelId] = useSelectedModel(allowedModels);
 
     const {
         analysis,
@@ -178,8 +170,8 @@ export function ChartContent({
         () => (
             <>
                 <ModelSelector
-                    selectedProvider={selectedProvider}
-                    onProviderChange={setSelectedProvider}
+                    selectedModel={modelId}
+                    onModelChange={setModelId}
                     allowedModels={allowedModels}
                     disabled={isAnalyzing}
                 />
@@ -205,8 +197,8 @@ export function ChartContent({
             </>
         ),
         [
-            selectedProvider,
-            setSelectedProvider,
+            modelId,
+            setModelId,
             allowedModels,
             isAnalyzing,
             symbol,

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -18,7 +18,10 @@ import { useAnalysisDerivedData } from '@/components/symbol-page/hooks/useAnalys
 import { useAnalysisDisplay } from '@/components/symbol-page/hooks/useAnalysisDisplay';
 import { useActionPricesVisibility } from '@/components/symbol-page/hooks/useActionPricesVisibility';
 import { useSelectedModel } from '@/components/symbol-page/hooks/useSelectedModel';
+import { useAnalysisModelGate } from '@/components/symbol-page/hooks/useAnalysisModelGate';
 import { useUserTier } from '@/components/symbol-page/hooks/useUserTier';
+import { PremiumModelGateModal } from '@/components/ui/PremiumModelGateModal';
+import { LLM_PROVIDER_LABELS } from '@/lib/llmProviderLabels';
 import {
     PANEL_MAX_WIDTH,
     PANEL_MIN_WIDTH,
@@ -132,6 +135,9 @@ export function ChartContent({
     const allowedModels = useMemo(() => getAllowedModels(tier), [tier]);
 
     const [modelId, setModelId] = useSelectedModel(allowedModels);
+    const { gateModal, dismissGate, handleModelChange } = useAnalysisModelGate(
+        { setModel: setModelId }
+    );
 
     const {
         analysis,
@@ -171,7 +177,7 @@ export function ChartContent({
             <>
                 <ModelSelector
                     selectedModel={modelId}
-                    onModelChange={setModelId}
+                    onModelChange={handleModelChange}
                     allowedModels={allowedModels}
                     disabled={isAnalyzing}
                 />
@@ -198,7 +204,7 @@ export function ChartContent({
         ),
         [
             modelId,
-            setModelId,
+            handleModelChange,
             allowedModels,
             isAnalyzing,
             symbol,
@@ -324,6 +330,14 @@ export function ChartContent({
             {/* 드래그 중 전체 화면 오버레이 — 텍스트 선택 방지 */}
             {isDragging && (
                 <div className="fixed inset-0 z-50 cursor-col-resize" />
+            )}
+
+            {gateModal !== null && (
+                <PremiumModelGateModal
+                    mode={gateModal.mode}
+                    providerLabel={LLM_PROVIDER_LABELS[gateModal.provider]}
+                    onClose={dismissGate}
+                />
             )}
         </div>
     );

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -135,9 +135,9 @@ export function ChartContent({
     const allowedModels = useMemo(() => getAllowedModels(tier), [tier]);
 
     const [modelId, setModelId] = useSelectedModel(allowedModels);
-    const { gateModal, dismissGate, handleModelChange } = useAnalysisModelGate(
-        { setModel: setModelId }
-    );
+    const { gateModal, dismissGate, handleModelChange } = useAnalysisModelGate({
+        setModel: setModelId,
+    });
 
     const {
         analysis,

--- a/src/components/symbol-page/SymbolPageClient.tsx
+++ b/src/components/symbol-page/SymbolPageClient.tsx
@@ -1,18 +1,18 @@
 'use client';
 
-import { Suspense, type ReactNode } from 'react';
-import dynamic from 'next/dynamic';
-import { ErrorBoundary } from 'react-error-boundary';
-import type { AnalysisResponse } from '@y0ngha/siglens-core';
-import { ChartSkeleton } from '@/components/chart/ChartSkeleton';
 import { ChartErrorFallback } from '@/components/chart/ChartErrorFallback';
-import { ChartContent } from '@/components/symbol-page/ChartContent';
-import { SymbolPageProvider } from '@/components/symbol-page/SymbolPageContext';
+import { ChartSkeleton } from '@/components/chart/ChartSkeleton';
 import { TimeframeSelector } from '@/components/chart/TimeframeSelector';
+import { useHydrated } from '@/components/hooks/useHydrated';
+import { ChartContent } from '@/components/symbol-page/ChartContent';
 import { useAssetInfo } from '@/components/symbol-page/hooks/useAssetInfo';
 import { useMobileSheet } from '@/components/symbol-page/hooks/useMobileSheet';
 import { useTimeframeChange } from '@/components/symbol-page/hooks/useTimeframeChange';
-import { useHydrated } from '@/components/hooks/useHydrated';
+import { SymbolPageProvider } from '@/components/symbol-page/SymbolPageContext';
+import type { AnalysisResponse } from '@y0ngha/siglens-core';
+import dynamic from 'next/dynamic';
+import { Suspense, type ReactNode } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 
 // vaul의 aria-hidden 주입이 hydration과 겹쳐 mismatch 발생 — ssr: false로 hydration 완료 후 마운트.
 const MobileAnalysisSheet = dynamic(

--- a/src/components/symbol-page/hooks/useAnalysisModelGate.ts
+++ b/src/components/symbol-page/hooks/useAnalysisModelGate.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { getProviderForModel, type ModelId, type LlmProvider } from '@y0ngha/siglens-core';
+import { isFreeChatModel } from '@/domain/llm';
+import type { GateMode } from '@/domain/llm';
+import { currentUserAction } from '@/infrastructure/auth/currentUserAction';
+import { getRegisteredProvidersAction } from '@/infrastructure/llm/getRegisteredProvidersAction';
+import { useQuery } from '@tanstack/react-query';
+import { QUERY_KEYS } from '@/lib/queryConfig';
+import { MS_PER_MINUTE } from '@/domain/constants/time';
+
+export interface AnalysisGateModalState {
+    mode: GateMode;
+    provider: LlmProvider;
+}
+
+const CURRENT_USER_STALE_MS = 5 * MS_PER_MINUTE;
+const REGISTERED_PROVIDERS_STALE_MS = MS_PER_MINUTE;
+
+interface UseAnalysisModelGateOptions {
+    setModel: (m: ModelId) => void;
+}
+
+interface UseAnalysisModelGateReturn {
+    gateModal: AnalysisGateModalState | null;
+    dismissGate: () => void;
+    /**
+     * Wraps setModel with a gate check.
+     * PRO 모델을 선택할 때 사용자 인증 및 API 키 등록 여부를 검사한다.
+     * 나중에 유료 구독제 도입 시 이 함수의 조건만 수정하면 된다.
+     */
+    handleModelChange: (model: ModelId) => void;
+}
+
+export function useAnalysisModelGate({
+    setModel,
+}: UseAnalysisModelGateOptions): UseAnalysisModelGateReturn {
+    const [gateModal, setGateModal] = useState<AnalysisGateModalState | null>(
+        null
+    );
+
+    const { data: currentUser } = useQuery({
+        queryKey: QUERY_KEYS.currentUser(),
+        queryFn: currentUserAction,
+        staleTime: CURRENT_USER_STALE_MS,
+    });
+
+    const { data: registeredProviders = [] } = useQuery({
+        queryKey: QUERY_KEYS.registeredProviders(),
+        queryFn: getRegisteredProvidersAction,
+        staleTime: REGISTERED_PROVIDERS_STALE_MS,
+    });
+
+    const handleModelChange = useCallback(
+        (model: ModelId): void => {
+            if (!isFreeChatModel(model)) {
+                const requiredProvider = getProviderForModel(model);
+                if (!currentUser) {
+                    setGateModal({ mode: 'auth', provider: requiredProvider });
+                    return;
+                }
+                if (
+                    !registeredProviders.some(
+                        p => p.provider === requiredProvider
+                    )
+                ) {
+                    setGateModal({ mode: 'byok', provider: requiredProvider });
+                    return;
+                }
+            }
+            setModel(model);
+        },
+        [currentUser, registeredProviders, setModel]
+    );
+
+    const dismissGate = useCallback((): void => {
+        setGateModal(null);
+    }, []);
+
+    return { gateModal, dismissGate, handleModelChange };
+}

--- a/src/components/symbol-page/hooks/useAnalysisModelGate.ts
+++ b/src/components/symbol-page/hooks/useAnalysisModelGate.ts
@@ -1,7 +1,11 @@
 'use client';
 
 import { useCallback, useState } from 'react';
-import { getProviderForModel, type ModelId, type LlmProvider } from '@y0ngha/siglens-core';
+import {
+    getProviderForModel,
+    type ModelId,
+    type LlmProvider,
+} from '@y0ngha/siglens-core';
 import { isFreeChatModel } from '@/domain/llm';
 import type { GateMode } from '@/domain/llm';
 import { currentUserAction } from '@/infrastructure/auth/currentUserAction';

--- a/src/components/symbol-page/hooks/useSelectedModel.ts
+++ b/src/components/symbol-page/hooks/useSelectedModel.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { startTransition, useCallback, useEffect, useState } from 'react';
+import { GEMINI_2_5_FLASH_LITE_MODEL, type ModelId } from '@y0ngha/siglens-core';
+import { LOCAL_STORAGE_ANALYSIS_MODEL_KEY } from '@/lib/storageKeys';
+
+const DEFAULT_MODEL: ModelId = GEMINI_2_5_FLASH_LITE_MODEL;
+
+export function useSelectedModel(
+    allowedModels: readonly ModelId[]
+): [ModelId, (m: ModelId) => void] {
+    const [selectedModel, setSelectedModelState] =
+        useState<ModelId>(DEFAULT_MODEL);
+
+    const setSelectedModel = useCallback((model: ModelId): void => {
+        if (typeof window !== 'undefined') {
+            localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY, model);
+        }
+        setSelectedModelState(model);
+    }, []);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        const stored = localStorage.getItem(
+            LOCAL_STORAGE_ANALYSIS_MODEL_KEY
+        ) as ModelId | null;
+        const resolved =
+            stored !== null && allowedModels.includes(stored)
+                ? stored
+                : DEFAULT_MODEL;
+        startTransition(() => setSelectedModelState(resolved));
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    // Re-validate when tier changes (e.g., user logs in/out)
+    useEffect(() => {
+        if (allowedModels.length > 0 && !allowedModels.includes(selectedModel)) {
+            const fallback = allowedModels.includes(DEFAULT_MODEL)
+                ? DEFAULT_MODEL
+                : (allowedModels[0] ?? DEFAULT_MODEL);
+            startTransition(() => setSelectedModelState(fallback));
+        }
+    }, [allowedModels, selectedModel]);
+
+    return [selectedModel, setSelectedModel];
+}

--- a/src/components/symbol-page/hooks/useSelectedModel.ts
+++ b/src/components/symbol-page/hooks/useSelectedModel.ts
@@ -1,7 +1,10 @@
 'use client';
 
 import { startTransition, useCallback, useEffect, useState } from 'react';
-import { GEMINI_2_5_FLASH_LITE_MODEL, type ModelId } from '@y0ngha/siglens-core';
+import {
+    GEMINI_2_5_FLASH_LITE_MODEL,
+    type ModelId,
+} from '@y0ngha/siglens-core';
 import { LOCAL_STORAGE_ANALYSIS_MODEL_KEY } from '@/lib/storageKeys';
 
 const DEFAULT_MODEL: ModelId = GEMINI_2_5_FLASH_LITE_MODEL;
@@ -34,7 +37,10 @@ export function useSelectedModel(
 
     // Re-validate when tier changes (e.g., user logs in/out)
     useEffect(() => {
-        if (allowedModels.length > 0 && !allowedModels.includes(selectedModel)) {
+        if (
+            allowedModels.length > 0 &&
+            !allowedModels.includes(selectedModel)
+        ) {
             const fallback = allowedModels.includes(DEFAULT_MODEL)
                 ? DEFAULT_MODEL
                 : (allowedModels[0] ?? DEFAULT_MODEL);

--- a/src/components/ui/EyeIcon.tsx
+++ b/src/components/ui/EyeIcon.tsx
@@ -1,0 +1,38 @@
+interface EyeIconProps {
+    isVisible: boolean;
+    className?: string;
+}
+
+export function EyeIcon({ isVisible, className = 'h-3.5 w-3.5' }: EyeIconProps) {
+    return isVisible ? (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className={className}
+            aria-hidden
+        >
+            <path d="M10 12.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" />
+            <path
+                fillRule="evenodd"
+                d="M.664 10.59a1.651 1.651 0 0 1 0-1.186A10.004 10.004 0 0 1 10 3c4.257 0 7.893 2.66 9.336 6.41.147.381.146.804 0 1.186A10.004 10.004 0 0 1 10 17c-4.257 0-7.893-2.66-9.336-6.41ZM14 10a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z"
+                clipRule="evenodd"
+            />
+        </svg>
+    ) : (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className={className}
+            aria-hidden
+        >
+            <path
+                fillRule="evenodd"
+                d="M3.28 2.22a.75.75 0 0 0-1.06 1.06l14.5 14.5a.75.75 0 1 0 1.06-1.06l-1.745-1.745a10.029 10.029 0 0 0 3.3-4.38 1.651 1.651 0 0 0 0-1.185A10.004 10.004 0 0 0 9.999 3a9.956 9.956 0 0 0-4.744 1.194L3.28 2.22ZM7.752 6.69l1.092 1.092a2.5 2.5 0 0 1 3.374 3.373l1.091 1.092a4 4 0 0 0-5.557-5.557Z"
+                clipRule="evenodd"
+            />
+            <path d="M10.748 13.93l2.523 2.523a10.003 10.003 0 0 1-3.27.547c-4.258 0-7.894-2.66-9.337-6.41a1.651 1.651 0 0 1 0-1.186A10.007 10.007 0 0 1 2.839 6.02L6.07 9.252a4 4 0 0 0 4.678 4.678Z" />
+        </svg>
+    );
+}

--- a/src/components/ui/EyeIcon.tsx
+++ b/src/components/ui/EyeIcon.tsx
@@ -3,7 +3,10 @@ interface EyeIconProps {
     className?: string;
 }
 
-export function EyeIcon({ isVisible, className = 'h-3.5 w-3.5' }: EyeIconProps) {
+export function EyeIcon({
+    isVisible,
+    className = 'h-3.5 w-3.5',
+}: EyeIconProps) {
     return isVisible ? (
         <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/components/ui/PremiumModelGateModal.tsx
+++ b/src/components/ui/PremiumModelGateModal.tsx
@@ -1,14 +1,15 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
-import Link from 'next/link';
-import { cn } from '@/lib/cn';
+import { useEscapeKey } from '@/components/hooks/useEscapeKey';
+import { useFocusTrap } from '@/components/hooks/useFocusTrap';
 import type { GateMode } from '@/domain/llm';
+import { cn } from '@/lib/cn';
+import Link from 'next/link';
+import { useEffect, useRef } from 'react';
 
 interface PremiumModelGateModalProps {
     mode: GateMode;
     providerLabel?: string;
-    symbol?: string;
     onClose: () => void;
 }
 
@@ -17,51 +18,43 @@ const TITLE_ID = 'premium-model-gate-title';
 export function PremiumModelGateModal({
     mode,
     providerLabel,
-    symbol,
     onClose,
 }: PremiumModelGateModalProps) {
-    const dialogRef = useRef<HTMLDialogElement>(null);
-    const closedRef = useRef(false);
+    const panelRef = useRef<HTMLDivElement>(null);
+
+    useFocusTrap(panelRef, true);
+    useEscapeKey(onClose, true);
+
+    useEffect(() => {
+        panelRef.current?.focus();
+    }, []);
 
     const isAuth = mode === 'auth';
     const iconColorClass = isAuth ? 'text-ui-warning' : 'text-ui-success';
     const title = isAuth ? '프리미엄 모델 사용 안내' : 'API 키 등록 필요';
     const body = isAuth
-        ? '프리미엄 모델을 사용하려면 로그인이 필요합니다.'
-        : `${providerLabel ?? ''} API 키를 등록하면 이 모델을 사용할 수 있습니다.`;
-
-    const safeClose = (): void => {
-        if (closedRef.current) return;
-        closedRef.current = true;
-        onClose();
-    };
-
-    const handleBackdropClick = (
-        e: React.MouseEvent<HTMLDialogElement>
-    ): void => {
-        if (e.target === dialogRef.current) {
-            safeClose();
-        }
-    };
-
-    useEffect(() => {
-        const dialog = dialogRef.current;
-        if (dialog === null) return;
-        dialog.showModal();
-        return () => {
-            dialog.close();
-        };
-    }, []);
+        ? '회원가입 후 API 키를 등록하면 이 모델을 사용할 수 있어요.'
+        : `${providerLabel ?? ''} API 키를 등록하면 이 모델을 사용할 수 있어요.`;
 
     return (
-        <dialog
-            ref={dialogRef}
-            aria-labelledby={TITLE_ID}
-            onClick={handleBackdropClick}
-            onClose={safeClose}
-            className="backdrop:bg-secondary-950/80 bg-transparent backdrop:backdrop-blur-sm"
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center p-4"
+            aria-modal="true"
         >
-            <div className="bg-secondary-900 ring-secondary-800 w-full max-w-sm rounded-2xl p-6 shadow-2xl ring-1">
+            {/* backdrop */}
+            <div
+                className="bg-secondary-950/80 absolute inset-0 backdrop-blur-sm"
+                onClick={onClose}
+                aria-hidden="true"
+            />
+
+            <div
+                ref={panelRef}
+                role="dialog"
+                aria-labelledby={TITLE_ID}
+                tabIndex={-1}
+                className="bg-secondary-900 ring-secondary-800 relative w-full max-w-sm rounded-2xl p-6 shadow-2xl ring-1 outline-none"
+            >
                 <div className="mb-4 flex flex-col items-center gap-3 text-center">
                     {/* inline SVG avoids lucide-react dependency */}
                     <svg
@@ -91,46 +84,38 @@ export function PremiumModelGateModal({
                     >
                         {title}
                     </h2>
-                    <p className="text-secondary-300 text-sm">{body}</p>
+                    <p className="text-secondary-300 text-sm leading-relaxed">
+                        {body}
+                    </p>
                 </div>
 
                 <div className="flex flex-col gap-2">
                     {isAuth ? (
-                        <>
-                            <Link
-                                href={
-                                    symbol !== undefined
-                                        ? `/login?next=/${symbol}`
-                                        : '/login'
-                                }
-                                className="bg-primary-600 hover:bg-primary-500 focus-visible:ring-primary-500 rounded-lg px-4 py-2 text-center text-sm font-medium text-white transition-colors focus-visible:ring-2 focus-visible:outline-none"
-                            >
-                                로그인
-                            </Link>
-                            <Link
-                                href="/signup"
-                                className="bg-secondary-700 hover:bg-secondary-600 text-secondary-200 focus-visible:ring-primary-500 rounded-lg px-4 py-2 text-center text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none"
-                            >
-                                회원가입
-                            </Link>
-                        </>
+                        <Link
+                            href="/signup"
+                            onClick={onClose}
+                            className="bg-primary-600 hover:bg-primary-500 focus-visible:ring-primary-500 flex h-10 items-center justify-center rounded-lg px-4 text-sm font-medium text-white transition-colors focus-visible:ring-2 focus-visible:outline-none"
+                        >
+                            회원가입 하러 가기
+                        </Link>
                     ) : (
                         <Link
                             href="/account"
-                            className="bg-primary-600 hover:bg-primary-500 focus-visible:ring-primary-500 rounded-lg px-4 py-2 text-center text-sm font-medium text-white transition-colors focus-visible:ring-2 focus-visible:outline-none"
+                            onClick={onClose}
+                            className="bg-primary-600 hover:bg-primary-500 focus-visible:ring-primary-500 flex h-10 items-center justify-center rounded-lg px-4 text-sm font-medium text-white transition-colors focus-visible:ring-2 focus-visible:outline-none"
                         >
-                            API 키 등록하러 가기
+                            등록하러 가기
                         </Link>
                     )}
                     <button
                         type="button"
-                        onClick={safeClose}
-                        className="text-secondary-400 hover:text-secondary-200 focus-visible:ring-primary-500 rounded-lg px-4 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none"
+                        onClick={onClose}
+                        className="text-secondary-400 hover:text-secondary-200 focus-visible:ring-primary-500 flex h-10 items-center justify-center rounded-lg px-4 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none"
                     >
                         닫기
                     </button>
                 </div>
             </div>
-        </dialog>
+        </div>
     );
 }

--- a/src/domain/auth/types.ts
+++ b/src/domain/auth/types.ts
@@ -57,7 +57,8 @@ export type VerifyEmailErrorCode =
 export type ConfirmPasswordResetErrorCode =
     | AuthValidationErrorCode
     | 'invalid_token'
-    | 'expired_token';
+    | 'expired_token'
+    | 'same_password';
 
 /** Structured error returned when password reset confirmation fails. */
 export interface ConfirmPasswordResetError {

--- a/src/infrastructure/auth/confirmPasswordResetAction.ts
+++ b/src/infrastructure/auth/confirmPasswordResetAction.ts
@@ -1,7 +1,10 @@
 'use server';
 
 import { DrizzleUserRepository } from '@/infrastructure/db/userRepository';
-import { bcryptPasswordHasher } from '@/infrastructure/auth/bcrypt';
+import {
+    bcryptPasswordHasher,
+    bcryptPasswordVerifier,
+} from '@/infrastructure/auth/bcrypt';
 import { confirmPasswordReset } from '@/infrastructure/auth/use-cases/confirmPasswordReset';
 import { createEmailTokenStore } from '@/infrastructure/email/tokenStore';
 import { redirect } from 'next/navigation';
@@ -37,6 +40,7 @@ export async function confirmPasswordResetAction(
             users: userRepo,
             emailTokens,
             passwordHasher: bcryptPasswordHasher,
+            passwordVerifier: bcryptPasswordVerifier,
         }
     );
 

--- a/src/infrastructure/auth/finalizeOAuthSignupAction.ts
+++ b/src/infrastructure/auth/finalizeOAuthSignupAction.ts
@@ -1,27 +1,26 @@
 'use server';
 
-import { cookies } from 'next/headers';
-import { redirect } from 'next/navigation';
+import type { FinalizeOAuthSignupState } from '@/domain/auth/formTypes';
+import { sanitizeNextPath } from '@/domain/auth/redirect';
 import { applyAuthCookie } from '@/infrastructure/auth/applyAuthCookie';
 import { createAuthHintCookie } from '@/infrastructure/auth/authHintCookie';
-import {
-    createAuthSession,
-    DEFAULT_SESSION_TTL_SECONDS,
-} from '@/infrastructure/auth/sessionCookie';
 import { getAuthDatabaseClient } from '@/infrastructure/auth/db';
-import { isSecureCookieEnv } from '@/infrastructure/auth/sessionCookieOptions';
-import { createPendingOAuthSignupStoreFromEnv } from '@/infrastructure/auth/pendingOAuthSignupStore';
-import { DrizzleAgreementRepository } from '@/infrastructure/db/agreementRepository';
-import { DrizzleSessionRepository } from '@/infrastructure/db/sessionRepository';
-import { DrizzleTermsRepository } from '@/infrastructure/db/termsRepository';
-import { DrizzleUserRepository } from '@/infrastructure/db/userRepository';
-import { sanitizeNextPath } from '@/domain/auth/redirect';
-import type { FinalizeOAuthSignupState } from '@/domain/auth/formTypes';
-import type { SiglensDatabase } from '@/infrastructure/db/types';
 import {
     CONSENT_REQUIRED_MESSAGE,
     OAUTH_ERROR_REDIRECT,
 } from '@/infrastructure/auth/errorMessages';
+import { createPendingOAuthSignupStoreFromEnv } from '@/infrastructure/auth/pendingOAuthSignupStore';
+import {
+    createAuthSession,
+    DEFAULT_SESSION_TTL_SECONDS,
+} from '@/infrastructure/auth/sessionCookie';
+import { isSecureCookieEnv } from '@/infrastructure/auth/sessionCookieOptions';
+import { DrizzleAgreementRepository } from '@/infrastructure/db/agreementRepository';
+import { DrizzleSessionRepository } from '@/infrastructure/db/sessionRepository';
+import { DrizzleTermsRepository } from '@/infrastructure/db/termsRepository';
+import { DrizzleUserRepository } from '@/infrastructure/db/userRepository';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 
 export async function finalizeOAuthSignupAction(
     _prev: FinalizeOAuthSignupState,
@@ -78,52 +77,48 @@ export async function finalizeOAuthSignupAction(
             redirect(OAUTH_ERROR_REDIRECT.emailConflict);
         }
 
-        // .catch(() => redirect(...)) — redirect() returns `never`, so the resolved type is `string | never` = `string`.
-        const createdUserId = await db
-            .transaction(async tx => {
-                // Safe: db.transaction always passes a SiglensDatabase tx to its callback.
-                const txDb = tx as unknown as SiglensDatabase;
-                const txUserRepo = new DrizzleUserRepository(txDb);
-                const txAgreementRepo = new DrizzleAgreementRepository(txDb);
-                const created = await txUserRepo.createOAuthUser({
-                    email: consumed.email,
-                    provider: consumed.provider,
-                    providerAccountId: consumed.providerAccountId,
-                    name: consumed.name,
-                    avatarUrl: consumed.avatarUrl,
-                    accessToken: consumed.accessToken,
-                    refreshToken: consumed.refreshToken,
-                    tokenExpiresAt: consumed.tokenExpiresAt
-                        ? new Date(consumed.tokenExpiresAt)
-                        : undefined,
-                });
-                if (!created) {
-                    throw new Error('createOAuthUser returned null');
-                }
-                const now = new Date();
-                await txAgreementRepo.insertMany([
-                    {
-                        userId: created.id,
-                        termsId: termsP.id,
-                        agreed: true,
-                        agreedAt: now,
-                    },
-                    {
-                        userId: created.id,
-                        termsId: termsT.id,
-                        agreed: true,
-                        agreedAt: now,
-                    },
-                ]);
-                return created.id;
-            })
-            .catch(() => {
-                return redirect(OAUTH_ERROR_REDIRECT.serviceUnavailable);
-            });
+        const createdUser = await userRepo.createOAuthUser({
+            email: consumed.email,
+            provider: consumed.provider,
+            providerAccountId: consumed.providerAccountId,
+            name: consumed.name,
+            avatarUrl: consumed.avatarUrl,
+            accessToken: consumed.accessToken,
+            refreshToken: consumed.refreshToken,
+            tokenExpiresAt: consumed.tokenExpiresAt
+                ? new Date(consumed.tokenExpiresAt)
+                : undefined,
+        });
+
+        if (!createdUser) {
+            redirect(OAUTH_ERROR_REDIRECT.emailConflict);
+        }
+
+        const agreementRepo = new DrizzleAgreementRepository(db);
+        const now = new Date();
+        try {
+            await agreementRepo.insertMany([
+                {
+                    userId: createdUser.id,
+                    termsId: termsP.id,
+                    agreed: true,
+                    agreedAt: now,
+                },
+                {
+                    userId: createdUser.id,
+                    termsId: termsT.id,
+                    agreed: true,
+                    agreedAt: now,
+                },
+            ]);
+        } catch {
+            await userRepo.deleteUser(createdUser.id);
+            redirect(OAUTH_ERROR_REDIRECT.serviceUnavailable);
+        }
 
         const secure = isSecureCookieEnv();
         const { cookie } = await createAuthSession({
-            userId: createdUserId,
+            userId: createdUser.id,
             sessions: sessionRepo,
             now: new Date(),
             secureCookie: secure,

--- a/src/infrastructure/auth/pendingOAuthSignupStore.ts
+++ b/src/infrastructure/auth/pendingOAuthSignupStore.ts
@@ -33,11 +33,12 @@ function buildKey(token: string): string {
     return `${NAMESPACE}:${token}`;
 }
 
-function tryParse(value: string | null): PendingOAuthSignup | null {
-    if (value === null) return null;
+function tryParse(value: unknown): PendingOAuthSignup | null {
+    if (value === null || value === undefined) return null;
+    // Upstash Redis auto-deserializes stored JSON, so value may already be an object.
+    if (typeof value === 'object') return value as PendingOAuthSignup;
+    if (typeof value !== 'string') return null;
     try {
-        // This value was serialized by save() via JSON.stringify(PendingOAuthSignup),
-        // so the shape is guaranteed as long as the key's TTL hasn't been corrupted externally.
         return JSON.parse(value) as PendingOAuthSignup;
     } catch {
         return null;
@@ -56,13 +57,11 @@ export function createPendingOAuthSignupStore(
             return token;
         },
         async peek(token: string): Promise<PendingOAuthSignup | null> {
-            // Safe: client.get() returns the value written by save() via JSON.stringify(PendingOAuthSignup).
-            const raw = (await client.get(buildKey(token))) as string | null;
+            const raw = await client.get(buildKey(token));
             return tryParse(raw);
         },
         async consume(token: string): Promise<PendingOAuthSignup | null> {
-            // Safe: client.getdel() atomically returns the value written by save() via JSON.stringify(PendingOAuthSignup) and deletes the key.
-            const raw = (await client.getdel(buildKey(token))) as string | null;
+            const raw = await client.getdel(buildKey(token));
             return tryParse(raw);
         },
         async delete(token: string): Promise<void> {

--- a/src/infrastructure/auth/registerAction.ts
+++ b/src/infrastructure/auth/registerAction.ts
@@ -1,28 +1,29 @@
 'use server';
 
-import { DrizzleSessionRepository } from '@/infrastructure/db/sessionRepository';
-import { DrizzleTermsRepository } from '@/infrastructure/db/termsRepository';
-import { DrizzleUserRepository } from '@/infrastructure/db/userRepository';
+import type { SignupFormState } from '@/domain/auth/formTypes';
+import { sanitizeNextPath } from '@/domain/auth/redirect';
+import { applyAuthCookie } from '@/infrastructure/auth/applyAuthCookie';
+import { createAuthHintCookie } from '@/infrastructure/auth/authHintCookie';
 import {
     bcryptPasswordHasher,
     bcryptPasswordVerifier,
 } from '@/infrastructure/auth/bcrypt';
-import { loginUser } from '@/infrastructure/auth/use-cases/loginUser';
-import { registerUser } from '@/infrastructure/auth/use-cases/registerUser';
-import { createEmailTokenStore } from '@/infrastructure/email/tokenStore';
-import { cookies } from 'next/headers';
-import { redirect } from 'next/navigation';
-import type { SignupFormState } from '@/domain/auth/formTypes';
-import { sanitizeNextPath } from '@/domain/auth/redirect';
-import { applyAuthCookie } from '@/infrastructure/auth/applyAuthCookie';
 import { getAuthDatabaseClient } from '@/infrastructure/auth/db';
 import {
     AUTH_SERVICE_UNAVAILABLE_MESSAGE,
     CONSENT_REQUIRED_MESSAGE,
 } from '@/infrastructure/auth/errorMessages';
-import { isSecureCookieEnv } from '@/infrastructure/auth/sessionCookieOptions';
-import { createAuthHintCookie } from '@/infrastructure/auth/authHintCookie';
 import { DEFAULT_SESSION_TTL_SECONDS } from '@/infrastructure/auth/sessionCookie';
+import { isSecureCookieEnv } from '@/infrastructure/auth/sessionCookieOptions';
+import { loginUser } from '@/infrastructure/auth/use-cases/loginUser';
+import { registerUser } from '@/infrastructure/auth/use-cases/registerUser';
+import { DrizzleAgreementRepository } from '@/infrastructure/db/agreementRepository';
+import { DrizzleSessionRepository } from '@/infrastructure/db/sessionRepository';
+import { DrizzleTermsRepository } from '@/infrastructure/db/termsRepository';
+import { DrizzleUserRepository } from '@/infrastructure/db/userRepository';
+import { createEmailTokenStore } from '@/infrastructure/email/tokenStore';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 
 const AUTO_LOGIN_FAILED_MESSAGE =
     '회원가입은 완료되었으나 자동 로그인에 실패했습니다. 로그인 페이지에서 다시 시도해주세요.';
@@ -66,6 +67,7 @@ export async function registerAction(
             termsRepo.findActive('privacy'),
             termsRepo.findActive('tos'),
         ]);
+
         if (!privacyTerms || !tosTerms) {
             return {
                 error: {
@@ -86,9 +88,9 @@ export async function registerAction(
             },
             {
                 users: userRepo,
+                agreements: new DrizzleAgreementRepository(db),
                 passwordHasher: bcryptPasswordHasher,
                 emailTokens,
-                db,
             }
         );
 
@@ -132,6 +134,7 @@ export async function registerAction(
         );
         redirect(next);
     } catch (err) {
+        console.error('Error in registerAction:', err);
         // Re-throw Next.js redirect (not an error — it's a control-flow signal).
         if (err instanceof Error && err.message.startsWith('NEXT_REDIRECT')) {
             throw err;

--- a/src/infrastructure/auth/use-cases/confirmPasswordReset.ts
+++ b/src/infrastructure/auth/use-cases/confirmPasswordReset.ts
@@ -45,6 +45,11 @@ function samePasswordError(): ConfirmPasswordResetError {
 
 // 동시성 계약: 비밀번호 업데이트 전에 토큰을 atomic consume(read+delete) → 동시 요청 둘이
 // 같은 토큰으로 모두 성공하지 못하도록 보장. consume race를 이긴 caller만 rehash 수행.
+//
+// same-password 체크는 토큰 소비 없이 링크를 재사용할 수 있어야 하므로 consume 이전에 수행한다.
+// 그러나 토큰 검증 없이 same-password 체크를 노출하면 유효하지 않은 토큰으로도 현재
+// 비밀번호를 probe할 수 있다. 이를 방지하기 위해 먼저 get(소비 없음)으로 토큰을 선검증한 뒤
+// same-password를 확인하고, 마지막으로 consume으로 원자적으로 소비·재검증한다(TOCTOU 방어).
 /** 비밀번호 재설정 토큰을 소비하고 사용자 비밀번호 해시를 교체. */
 export async function confirmPasswordReset(
     input: ConfirmPasswordResetInput,
@@ -57,39 +62,44 @@ export async function confirmPasswordReset(
     }
 
     const email = normalizeEmail(input.email);
+    const submittedHash = hashEmailToken(input.token);
 
-    // Check same-password before consuming the token so the link stays valid
-    // and the user can retry with a different password.
-    const user =
-        await dependencies.emailAuthUsers.findEmailAuthUserByEmail(email);
-    if (user !== null && user.passwordHash !== null) {
-        const isSamePassword = await dependencies.passwordVerifier.verifyPassword(
-            input.newPassword,
-            user.passwordHash
-        );
-        if (isSamePassword) {
-            return { ok: false, error: samePasswordError() };
-        }
+    // Step 1: pre-validate the token without consuming it.
+    const peeked = await dependencies.emailTokens.get(PURPOSE, email);
+    if (peeked === null) {
+        return { ok: false, error: expiredTokenError() };
+    }
+    if (peeked.status !== 'pending') {
+        return { ok: false, error: invalidTokenError() };
+    }
+    if (!safeCompareTokenHashes(submittedHash, peeked.tokenHash)) {
+        return { ok: false, error: invalidTokenError() };
     }
 
-    // Atomically consume the token. Any racing caller will receive null
-    // here and bail out with expired_token below.
-    const stored = await dependencies.emailTokens.consume(PURPOSE, email);
+    // Step 2: same-password check before consuming, so the link stays valid on retry.
+    const user =
+        await dependencies.emailAuthUsers.findEmailAuthUserByEmail(email);
+    if (user === null || user.passwordHash === null) {
+        return { ok: false, error: invalidTokenError() };
+    }
+    const isSamePassword = await dependencies.passwordVerifier.verifyPassword(
+        input.newPassword,
+        user.passwordHash
+    );
+    if (isSamePassword) {
+        return { ok: false, error: samePasswordError() };
+    }
 
+    // Step 3: atomically consume the token. Any racing caller receives null here.
+    // Re-validate the consumed value to guard against TOCTOU token replacement.
+    const stored = await dependencies.emailTokens.consume(PURPOSE, email);
     if (stored === null) {
         return { ok: false, error: expiredTokenError() };
     }
-
     if (stored.status !== 'pending') {
         return { ok: false, error: invalidTokenError() };
     }
-
-    const submittedHash = hashEmailToken(input.token);
     if (!safeCompareTokenHashes(submittedHash, stored.tokenHash)) {
-        return { ok: false, error: invalidTokenError() };
-    }
-
-    if (user === null || user.passwordHash === null) {
         return { ok: false, error: invalidTokenError() };
     }
 

--- a/src/infrastructure/auth/use-cases/confirmPasswordReset.ts
+++ b/src/infrastructure/auth/use-cases/confirmPasswordReset.ts
@@ -17,6 +17,8 @@ import type {
 const PURPOSE = 'password_reset' as const;
 const INVALID_TOKEN_MESSAGE = '비밀번호 재설정 토큰이 유효하지 않습니다.';
 const EXPIRED_TOKEN_MESSAGE = '비밀번호 재설정 토큰이 만료되었습니다.';
+const SAME_PASSWORD_MESSAGE =
+    '현재 비밀번호와 동일한 비밀번호는 사용할 수 없습니다.';
 
 function invalidTokenError(): ConfirmPasswordResetError {
     return {
@@ -31,6 +33,14 @@ function expiredTokenError(): ConfirmPasswordResetError {
         code: PASSWORD_RESET_EXPIRED_TOKEN_CODE,
         field: 'token',
         message: EXPIRED_TOKEN_MESSAGE,
+    };
+}
+
+function samePasswordError(): ConfirmPasswordResetError {
+    return {
+        code: 'same_password',
+        field: 'password',
+        message: SAME_PASSWORD_MESSAGE,
     };
 }
 
@@ -70,6 +80,14 @@ export async function confirmPasswordReset(
         await dependencies.emailAuthUsers.findEmailAuthUserByEmail(email);
     if (user === null || user.passwordHash === null) {
         return { ok: false, error: invalidTokenError() };
+    }
+
+    const isSamePassword = await dependencies.passwordVerifier.verifyPassword(
+        input.newPassword,
+        user.passwordHash
+    );
+    if (isSamePassword) {
+        return { ok: false, error: samePasswordError() };
     }
 
     const passwordHash = await dependencies.passwordHasher.hashPassword(

--- a/src/infrastructure/auth/use-cases/confirmPasswordReset.ts
+++ b/src/infrastructure/auth/use-cases/confirmPasswordReset.ts
@@ -39,7 +39,6 @@ function expiredTokenError(): ConfirmPasswordResetError {
 function samePasswordError(): ConfirmPasswordResetError {
     return {
         code: 'same_password',
-        field: 'password',
         message: SAME_PASSWORD_MESSAGE,
     };
 }
@@ -59,7 +58,21 @@ export async function confirmPasswordReset(
 
     const email = normalizeEmail(input.email);
 
-    // Atomically consume the token first. Any racing caller will receive null
+    // Check same-password before consuming the token so the link stays valid
+    // and the user can retry with a different password.
+    const user =
+        await dependencies.emailAuthUsers.findEmailAuthUserByEmail(email);
+    if (user !== null && user.passwordHash !== null) {
+        const isSamePassword = await dependencies.passwordVerifier.verifyPassword(
+            input.newPassword,
+            user.passwordHash
+        );
+        if (isSamePassword) {
+            return { ok: false, error: samePasswordError() };
+        }
+    }
+
+    // Atomically consume the token. Any racing caller will receive null
     // here and bail out with expired_token below.
     const stored = await dependencies.emailTokens.consume(PURPOSE, email);
 
@@ -76,18 +89,8 @@ export async function confirmPasswordReset(
         return { ok: false, error: invalidTokenError() };
     }
 
-    const user =
-        await dependencies.emailAuthUsers.findEmailAuthUserByEmail(email);
     if (user === null || user.passwordHash === null) {
         return { ok: false, error: invalidTokenError() };
-    }
-
-    const isSamePassword = await dependencies.passwordVerifier.verifyPassword(
-        input.newPassword,
-        user.passwordHash
-    );
-    if (isSamePassword) {
-        return { ok: false, error: samePasswordError() };
     }
 
     const passwordHash = await dependencies.passwordHasher.hashPassword(

--- a/src/infrastructure/auth/use-cases/registerUser.ts
+++ b/src/infrastructure/auth/use-cases/registerUser.ts
@@ -1,4 +1,3 @@
-import type { AuthUserRecord } from '@/domain/auth/types';
 import {
     normalizeEmail,
     validateEmail,
@@ -72,51 +71,41 @@ export async function registerUser(
         return { ok: false, error: emailAlreadyExistsError() };
     }
 
-    // Once we're past the email-already-exists gate, the verified marker has
-    // served its purpose. Clear it under finally so that an exception thrown by
-    // hashPassword / createEmailUser doesn't leave the marker pinned for its
-    // remaining 30-minute TTL (otherwise an attacker who could read DB could
-    // still treat the email as "already verified" until expiry).
-    let user: AuthUserRecord | null = null;
     const now = new Date();
-    try {
-        const passwordHash = await dependencies.passwordHasher.hashPassword(
-            input.password
-        );
-        // Use tx to ensure user creation and agreement insertion are atomic.
-        // Both DrizzleUserRepository and DrizzleAgreementRepository are
-        // instantiated with the transaction client so all queries run in the
-        // same Neon batch request.
-        user = await dependencies.db.transaction(async tx => {
-            // Safe: Transactor.transaction always passes a SiglensDatabase tx to its callback.
-            const txDb = tx as SiglensDatabase;
-            const created = await new DrizzleUserRepository(
-                txDb
-            ).createEmailUser({
-                email,
-                passwordHash,
-                name: input.name?.trim() || null,
-                avatarUrl: input.avatarUrl?.trim() || null,
-                emailVerified: true,
-            });
-            if (created === null) return null;
-            await new DrizzleAgreementRepository(txDb).insertMany(
-                input.agreedTermsIds.map(termsId => ({
-                    userId: created.id,
-                    termsId,
-                    agreed: true,
-                    agreedAt: now,
-                }))
-            );
-            return created;
+    const passwordHash = await dependencies.passwordHasher.hashPassword(
+        input.password
+    );
+    // Use tx to ensure user creation and agreement insertion are atomic.
+    // Both DrizzleUserRepository and DrizzleAgreementRepository are
+    // instantiated with the transaction client so all queries run in the
+    // same Neon batch request.
+    const user = await dependencies.db.transaction(async tx => {
+        // Safe: Transactor.transaction always passes a SiglensDatabase tx to its callback.
+        const txDb = tx as SiglensDatabase;
+        const created = await new DrizzleUserRepository(txDb).createEmailUser({
+            email,
+            passwordHash,
+            name: input.name?.trim() || null,
+            avatarUrl: input.avatarUrl?.trim() || null,
+            emailVerified: true,
         });
-    } finally {
-        await dependencies.emailTokens.delete(PURPOSE, email);
-    }
+        if (created === null) return null;
+        await new DrizzleAgreementRepository(txDb).insertMany(
+            input.agreedTermsIds.map(termsId => ({
+                userId: created.id,
+                termsId,
+                agreed: true,
+                agreedAt: now,
+            }))
+        );
+        return created;
+    });
 
     if (user === null) {
         return { ok: false, error: emailAlreadyExistsError() };
     }
 
+    // Registration succeeded — clear the verified marker now that it has served its purpose.
+    await dependencies.emailTokens.delete(PURPOSE, email);
     return { ok: true, user };
 }

--- a/src/infrastructure/auth/use-cases/registerUser.ts
+++ b/src/infrastructure/auth/use-cases/registerUser.ts
@@ -13,9 +13,6 @@ import type {
     RegisterUserInput,
     RegisterUserResult,
 } from '@/infrastructure/auth/use-cases/types';
-import { DrizzleAgreementRepository } from '@/infrastructure/db/agreementRepository';
-import { DrizzleUserRepository } from '@/infrastructure/db/userRepository';
-import type { SiglensDatabase } from '@/infrastructure/db/types';
 
 const PURPOSE = 'email_verification' as const;
 const EMAIL_ALREADY_EXISTS_MESSAGE = '이미 사용 중인 이메일입니다.';
@@ -75,34 +72,40 @@ export async function registerUser(
     const passwordHash = await dependencies.passwordHasher.hashPassword(
         input.password
     );
-    // Use tx to ensure user creation and agreement insertion are atomic.
-    // Both DrizzleUserRepository and DrizzleAgreementRepository are
-    // instantiated with the transaction client so all queries run in the
-    // same Neon batch request.
-    const user = await dependencies.db.transaction(async tx => {
-        // Safe: Transactor.transaction always passes a SiglensDatabase tx to its callback.
-        const txDb = tx as SiglensDatabase;
-        const created = await new DrizzleUserRepository(txDb).createEmailUser({
-            email,
-            passwordHash,
-            name: input.name?.trim() || null,
-            avatarUrl: input.avatarUrl?.trim() || null,
-            emailVerified: true,
-        });
-        if (created === null) return null;
-        await new DrizzleAgreementRepository(txDb).insertMany(
+
+    const user = await dependencies.users.createEmailUser({
+        email,
+        passwordHash,
+        name: input.name?.trim() || null,
+        avatarUrl: input.avatarUrl?.trim() || null,
+        emailVerified: true,
+    });
+
+    if (user === null) {
+        return { ok: false, error: emailAlreadyExistsError() };
+    }
+
+    // Insert agreements after user creation. On failure, compensate by
+    // deleting the user so the registration can be retried without hitting
+    // email_already_exists on the next attempt.
+    try {
+        await dependencies.agreements.insertMany(
             input.agreedTermsIds.map(termsId => ({
-                userId: created.id,
+                userId: user.id,
                 termsId,
                 agreed: true,
                 agreedAt: now,
             }))
         );
-        return created;
-    });
-
-    if (user === null) {
-        return { ok: false, error: emailAlreadyExistsError() };
+    } catch (err) {
+        // Best-effort rollback — log secondary failure so degradation is observable.
+        await dependencies.users.deleteUser(user.id).catch(deleteErr => {
+            console.warn(
+                '[registerUser] compensating delete failed — user row may be orphaned',
+                deleteErr
+            );
+        });
+        throw err;
     }
 
     // Registration succeeded — clear the verified marker now that it has served its purpose.

--- a/src/infrastructure/auth/use-cases/types.ts
+++ b/src/infrastructure/auth/use-cases/types.ts
@@ -194,6 +194,7 @@ export interface ConfirmPasswordResetDependencies {
     users: UserRepository;
     emailTokens: EmailTokenStore;
     passwordHasher: PasswordHasher;
+    passwordVerifier: PasswordVerifier;
 }
 
 export interface RequestEmailVerificationInput {

--- a/src/infrastructure/auth/use-cases/types.ts
+++ b/src/infrastructure/auth/use-cases/types.ts
@@ -1,3 +1,4 @@
+import type { AgreementRepository } from '@/infrastructure/db/agreementRepository';
 import type {
     AuthSessionRecord,
     AuthUserRecord,
@@ -50,16 +51,11 @@ export type RegisterUserResult =
     | { ok: true; user: AuthUserRecord }
     | { ok: false; error: RegisterUserError };
 
-/** Minimal database transactor contract for the use-case layer. */
-export interface Transactor {
-    transaction<T>(fn: (tx: unknown) => Promise<T>): Promise<T>;
-}
-
 export interface RegisterUserDependencies {
     users: UserRepository;
+    agreements: AgreementRepository;
     passwordHasher: PasswordHasher;
     emailTokens: EmailTokenStore;
-    db: Transactor;
 }
 
 export interface LoginUserInput {

--- a/src/infrastructure/chat/chatAction.ts
+++ b/src/infrastructure/chat/chatAction.ts
@@ -1,11 +1,11 @@
 'use server';
 
-import {
-    GEMINI_2_5_FLASH_MODEL,
-    TIER_CONFIG,
-    getProviderForModel,
-    requestChatCompletion,
-} from '@y0ngha/siglens-core';
+import { callAiProviderRouter } from '@/infrastructure/ai/router';
+import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
+import { getDatabaseClient } from '@/infrastructure/db/client';
+import { DrizzleUserApiKeyRepository } from '@/infrastructure/db/userApiKeyRepository';
+import { DrizzleUserRepository } from '@/infrastructure/db/userRepository';
+import { getUserTier } from '@/infrastructure/tier/use-cases/getUserTier';
 import type {
     AnalysisResponse,
     ChatActionResult,
@@ -14,12 +14,16 @@ import type {
     LlmProvider,
     ModelId,
     Timeframe,
+    UserTierContext,
+} from '@y0ngha/siglens-core';
+import {
+    DEFAULT_TIER,
+    GEMINI_2_5_FLASH_MODEL,
+    TIER_CONFIG,
+    getProviderForModel,
+    requestChatCompletion,
 } from '@y0ngha/siglens-core';
 import { headers } from 'next/headers';
-import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import { getAuthDatabaseClient } from '@/infrastructure/auth/db';
-import { DrizzleUserApiKeyRepository } from '@/infrastructure/db/userApiKeyRepository';
-import { callAiProviderRouter } from '@/infrastructure/ai/router';
 
 async function getClientIp(): Promise<string> {
     const headersList = await headers();
@@ -29,12 +33,8 @@ async function getClientIp(): Promise<string> {
 }
 
 /**
- * Server-owned primary chat key per provider, mapped to core's `freeApiKey`.
- *
- * 0.7.3 semantics: `freeApiKey` is the server-owned primary credential that
- * core forwards to the AI provider. Without it core returns `server_error`
- * for every request. Google additionally honors `GEMINI_CHAT_FREE_API_KEY`
- * as the preferred primary; it falls back to `GEMINI_CHAT_API_KEY`.
+ * Server-owned key per provider forwarded to core as `freeApiKey`.
+ * Used for free models (any tier) and pro-tier premium models.
  */
 function getServerPrimaryKey(provider: LlmProvider): string | undefined {
     switch (provider) {
@@ -55,28 +55,66 @@ function getServerPrimaryKey(provider: LlmProvider): string | undefined {
 }
 
 /**
- * Resolve user-registered BYOK key for the given premium model, mapped to
- * core's `paidApiKey` (the fallback credential).
+ * Resolve the user's tier and BYOK key for the given model.
  *
- * 0.7.3 semantics: free-tier models do not require a BYOK; core covers them
- * via `freeApiKey` alone. Premium models on a non-pro tier require a BYOK —
- * returning `undefined` lets core respond with `user_api_key_required` so
- * the UI can prompt the user to register a key.
+ * - Free models: no user context needed → default tier, no paidApiKey.
+ * - Premium models + no session: default tier, no paidApiKey → core
+ *   returns `user_api_key_required`.
+ * - Premium models + pro tier: server covers the cost → tier returned,
+ *   no paidApiKey (BYOK is ignored even if registered).
+ * - Premium models + non-pro tier: BYOK looked up from DB.
  */
-async function resolveUserByokKey(
+interface UserContext {
+    tierContext: UserTierContext;
+    paidApiKey: string | undefined;
+}
+
+async function resolveUserContext(
     model: ModelId,
     provider: LlmProvider
-): Promise<string | undefined> {
-    // Safe cast: ModelId ⊆ string; Array.includes widens the argument type to string.
-    if ((TIER_CONFIG.models.free as readonly string[]).includes(model)) {
-        return undefined;
+): Promise<UserContext> {
+    // Safe cast: ModelId ⊆ string; Array.includes refuses a wider string
+    // argument against a readonly literal-union without the widening cast.
+    const isFreeModel = (TIER_CONFIG.models.free as readonly string[]).includes(
+        model
+    );
+    if (isFreeModel) {
+        return {
+            tierContext: { userId: null, tier: DEFAULT_TIER },
+            paidApiKey: undefined,
+        };
     }
+
     const user = await getCurrentUser();
-    if (!user) return undefined;
-    const { db } = getAuthDatabaseClient();
-    const repo = new DrizzleUserApiKeyRepository(db);
-    const record = await repo.findByUserAndProvider(user.id, provider);
-    return record?.apiKey;
+    if (!user) {
+        return {
+            tierContext: { userId: null, tier: DEFAULT_TIER },
+            paidApiKey: undefined,
+        };
+    }
+
+    const { db } = getDatabaseClient();
+    const tier = await getUserTier(
+        { userId: user.id },
+        { users: new DrizzleUserRepository(db) }
+    );
+
+    // Pro tier: server covers premium model costs; BYOK not needed.
+    if (tier === 'pro') {
+        return {
+            tierContext: { userId: user.id, tier },
+            paidApiKey: undefined,
+        };
+    }
+
+    const record = await new DrizzleUserApiKeyRepository(db).findByUserAndProvider(
+        user.id,
+        provider
+    );
+    return {
+        tierContext: { userId: user.id, tier },
+        paidApiKey: record?.apiKey,
+    };
 }
 
 export async function chatAction(
@@ -103,8 +141,8 @@ export async function chatAction(
             return { ok: false, error: 'server_error' };
         }
 
-        const [paidApiKey, clientIp] = await Promise.all([
-            resolveUserByokKey(model, provider),
+        const [{ tierContext, paidApiKey }, clientIp] = await Promise.all([
+            resolveUserContext(model, provider),
             getClientIp(),
         ]);
 
@@ -119,6 +157,7 @@ export async function chatAction(
                 model,
                 freeApiKey,
                 paidApiKey,
+                tierContext,
                 // `undefined` (not `null`) when absent — core's optional field
                 // is `currentAnalysisContext?: CurrentAnalysisContext`.
                 ...(currentAnalysisContext !== null
@@ -129,7 +168,8 @@ export async function chatAction(
                 callAiProvider: callAiProviderRouter,
             }
         );
-    } catch {
+    } catch (err) {
+        console.error('Error occurred while fetching chat completion:', err);
         return { ok: false, error: 'server_error' };
     }
 }

--- a/src/infrastructure/chat/chatAction.ts
+++ b/src/infrastructure/chat/chatAction.ts
@@ -107,10 +107,9 @@ async function resolveUserContext(
         };
     }
 
-    const record = await new DrizzleUserApiKeyRepository(db).findByUserAndProvider(
-        user.id,
-        provider
-    );
+    const record = await new DrizzleUserApiKeyRepository(
+        db
+    ).findByUserAndProvider(user.id, provider);
     return {
         tierContext: { userId: user.id, tier },
         paidApiKey: record?.apiKey,

--- a/src/infrastructure/db/termsRepository.ts
+++ b/src/infrastructure/db/termsRepository.ts
@@ -70,12 +70,8 @@ export class DrizzleTermsRepository implements TermsRepository {
                 effectiveDate: input.effectiveDate,
                 body: input.body,
             })
-            .onConflictDoUpdate({
+            .onConflictDoNothing({
                 target: [terms.kind, terms.version],
-                set: {
-                    effectiveDate: input.effectiveDate,
-                    body: input.body,
-                },
             });
     }
 }

--- a/src/infrastructure/db/userRepository.ts
+++ b/src/infrastructure/db/userRepository.ts
@@ -18,8 +18,6 @@ import type {
     UserTierRepository,
 } from '@/infrastructure/db/types';
 
-class OAuthAccountConflictError extends Error {}
-
 function encryptOptional(
     token: string | undefined,
     encryptionKey: string
@@ -155,67 +153,64 @@ export class DrizzleUserRepository
     async createOAuthUser(
         input: CreateOAuthUserInput
     ): Promise<AuthUserRecord | null> {
-        // Resolve encryption key BEFORE opening the transaction so that a missing
+        // Resolve encryption key BEFORE any DB write so that a missing
         // OAUTH_TOKEN_ENCRYPTION_KEY aborts the entire operation instead of
         // silently persisting null tokens for fresh OAuth signups.
         const encryptionKey = requireOauthTokenEncryptionKey();
 
-        try {
-            return await this.db.transaction(async tx => {
-                const [user] = await tx
-                    .insert(users)
-                    .values({
-                        email: input.email,
-                        passwordHash: null,
-                        name: input.name ?? null,
-                        avatarUrl: input.avatarUrl ?? null,
-                        tier: DEFAULT_TIER,
-                        emailVerified: true,
-                    })
-                    .onConflictDoNothing({ target: users.email })
-                    .returning(authUserColumns);
+        const [user] = await this.db
+            .insert(users)
+            .values({
+                email: input.email,
+                passwordHash: null,
+                name: input.name ?? null,
+                avatarUrl: input.avatarUrl ?? null,
+                tier: DEFAULT_TIER,
+                emailVerified: true,
+            })
+            .onConflictDoNothing({ target: users.email })
+            .returning(authUserColumns);
 
-                if (user === undefined) {
-                    return null;
-                }
-
-                const [account] = await tx
-                    .insert(oauthAccounts)
-                    .values({
-                        userId: user.id,
-                        provider: input.provider,
-                        providerAccountId: input.providerAccountId,
-                        accessToken: encryptOptional(
-                            input.accessToken,
-                            encryptionKey
-                        ),
-                        refreshToken: encryptOptional(
-                            input.refreshToken,
-                            encryptionKey
-                        ),
-                        tokenExpiresAt: input.tokenExpiresAt ?? null,
-                    })
-                    .onConflictDoNothing({
-                        target: [
-                            oauthAccounts.provider,
-                            oauthAccounts.providerAccountId,
-                        ],
-                    })
-                    .returning({ id: oauthAccounts.id });
-
-                if (account === undefined) {
-                    throw new OAuthAccountConflictError();
-                }
-
-                return user;
-            });
-        } catch (error) {
-            if (error instanceof OAuthAccountConflictError) {
-                return null;
-            }
-
-            throw error;
+        if (user === undefined) {
+            return null;
         }
+
+        const [account] = await this.db
+            .insert(oauthAccounts)
+            .values({
+                userId: user.id,
+                provider: input.provider,
+                providerAccountId: input.providerAccountId,
+                accessToken: encryptOptional(input.accessToken, encryptionKey),
+                refreshToken: encryptOptional(
+                    input.refreshToken,
+                    encryptionKey
+                ),
+                tokenExpiresAt: input.tokenExpiresAt ?? null,
+            })
+            .onConflictDoNothing({
+                target: [
+                    oauthAccounts.provider,
+                    oauthAccounts.providerAccountId,
+                ],
+            })
+            .returning({ id: oauthAccounts.id });
+
+        if (account === undefined) {
+            await this.db
+                .delete(users)
+                .where(eq(users.id, user.id))
+                .returning({ id: users.id })
+                .catch(deleteErr => {
+                    console.warn(
+                        '[createOAuthUser] compensating delete failed — user row may be orphaned',
+                        deleteErr
+                    );
+                });
+            return null;
+        }
+
+        return user;
     }
 
     async getUserTier(userId: string): Promise<Tier | null> {

--- a/src/infrastructure/market/submitAnalysisAction.ts
+++ b/src/infrastructure/market/submitAnalysisAction.ts
@@ -97,17 +97,18 @@ async function resolveByokOutcome(
     try {
         const repo = new DrizzleUserApiKeyRepository(getDatabaseClient().db);
         const record = await repo.findByUserAndProvider(userId, llmProvider);
-        if (record === null) {
-            if (!isTierAllowed) {
+        if (!isTierAllowed) {
+            if (record === null) {
                 return {
                     kind: 'blocked',
                     result: buildGateError('tier_premium_blocked'),
                 };
             }
-            // Tier covers the model and BYOK is not registered — fall through.
-            return { kind: 'allowed' };
+            // Tier doesn't cover the model but user has BYOK — use it.
+            return { kind: 'allowed', userApiKey: record.apiKey };
         }
-        return { kind: 'allowed', userApiKey: record.apiKey };
+        // Tier covers the model: server pays regardless of BYOK registration.
+        return { kind: 'allowed' };
     } catch (error) {
         if (error instanceof LlmApiKeyDecryptionFailedError) {
             return {

--- a/src/infrastructure/ticker/use-cases/getAssetInfo.ts
+++ b/src/infrastructure/ticker/use-cases/getAssetInfo.ts
@@ -1,3 +1,4 @@
+import { waitUntil } from '@vercel/functions';
 import { isValidTickerFormat } from '@/domain/ticker';
 import { DrizzleAssetTranslationRepository } from '@/infrastructure/db/tickerRepository';
 import type {
@@ -190,18 +191,22 @@ export async function getAssetInfo(symbol: string): Promise<AssetInfo | null> {
     };
 
     if (koreanName) {
-        persistTranslation(upper, fmpSymbol, name, koreanName, cache).catch(e =>
-            console.warn('[getAssetInfo] persist failed', e)
+        waitUntil(
+            persistTranslation(upper, fmpSymbol, name, koreanName, cache).catch(
+                e => console.warn('[getAssetInfo] persist failed', e)
+            )
         );
         return info;
     }
 
-    translateAndPersist(
-        upper,
-        { symbol: fmpSymbol, name, exchange, exchangeFullName },
-        cache
-    ).catch(e =>
-        console.warn('[getAssetInfo] background translation failed', e)
+    waitUntil(
+        translateAndPersist(
+            upper,
+            { symbol: fmpSymbol, name, exchange, exchangeFullName },
+            cache
+        ).catch(e =>
+            console.warn('[getAssetInfo] background translation failed', e)
+        )
     );
 
     setCacheBestEffort(

--- a/src/lib/storageKeys.ts
+++ b/src/lib/storageKeys.ts
@@ -1,2 +1,3 @@
 export const LOCAL_STORAGE_PROVIDER_KEY = 'siglens:selected-provider';
-export const LOCAL_STORAGE_ANALYSIS_MODEL_KEY = 'siglens:selected-analysis-model';
+export const LOCAL_STORAGE_ANALYSIS_MODEL_KEY =
+    'siglens:selected-analysis-model';

--- a/src/lib/storageKeys.ts
+++ b/src/lib/storageKeys.ts
@@ -1,1 +1,2 @@
 export const LOCAL_STORAGE_PROVIDER_KEY = 'siglens:selected-provider';
+export const LOCAL_STORAGE_ANALYSIS_MODEL_KEY = 'siglens:selected-analysis-model';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3751,12 +3751,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@y0ngha/siglens-core@npm:0.7.3":
-  version: 0.7.3
-  resolution: "@y0ngha/siglens-core@npm:0.7.3::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.7.3%2Fd2b8db34a781198679221eaf71b2b2a969df4725"
+"@y0ngha/siglens-core@npm:0.7.4":
+  version: 0.7.4
+  resolution: "@y0ngha/siglens-core@npm:0.7.4::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.7.4%2F7ceccd0c0007683a4d795af897cdff6322f4755e"
   peerDependencies:
     "@upstash/redis": ^1.37.0
-  checksum: 10c0/5c1206c2520f69d72dcc1ced2541c5bab20a6501b5764055054470b0d957a7471e0d6104676591abead5fbbb2b9ca7782594e40eafdffe57cbd3788f7270b9b6
+  checksum: 10c0/44d83c38656e3dc0514774807b59d37d8a0204e9eb80edf2c8f13dfe0e761eccb326e41773a73710da5f1a49f71630bdd8e81d0d41bc0cb8e92d19cb0e10c5a9
   languageName: node
   linkType: hard
 
@@ -11255,7 +11255,7 @@ __metadata:
     "@types/react-dom": "npm:^19"
     "@upstash/redis": "npm:^1.37.0"
     "@vercel/functions": "npm:^3.4.3"
-    "@y0ngha/siglens-core": "npm:0.7.3"
+    "@y0ngha/siglens-core": "npm:0.7.4"
     babel-plugin-react-compiler: "npm:^1.0.0"
     bcryptjs: "npm:^3.0.3"
     clsx: "npm:^2.1.1"


### PR DESCRIPTION
## 관련 이슈

Bug fix (no specific issue number)

## 구현 내용

### 1. ChatPanel.tsx - 채팅 말풍선 너비 개선
- AI 메시지 말풍선이 컨테이너 전체 너비로 늘어나는 문제 수정
- flex-col 컨테이너에서 flex items가 기본적으로 늘어나는 동작으로 인한 이슈
- 사용자 메시지: `ml-auto` → `self-end` 변경
- AI 메시지 및 로딩 말풍선: `self-start` 추가

### 2. chatAction.ts - 채팅 API 키 라우팅 개선
- siglens-core v0.7.3 버그 패치 제거
- 새로운 `resolveUserContext()` 함수 도입: 사용자 실제 tier와 BYOK 키 함께 해결
- `tierContext` (실제 tier) 전달 → 이전엔 모든 사용자가 free tier로 기본값 설정
- 키 라우팅 로직:
  - Pro tier → 서버 키만 사용
  - Non-pro + BYOK → 사용자 키만 사용
  - Free 모델 → 서버 키 사용

### 3. submitAnalysisAction.ts - 분석 API 키 라우팅 수정
- `resolveByokOutcome` 수정: tier가 모델을 커버하는 경우 (`isTierAllowed = true`), 사용자 BYOK 등록 여부 무관하게 서버 키 사용

### 4. 패키지 업데이트
- `@y0ngha/siglens-core` 0.7.3 → 0.7.4 업데이트
- v0.7.4에는 `requestChatCompletion` API 키 라우팅 수정 포함

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] 반환 타입 명시
- [x] any 타입 없음

## 변경 파일 목록

[수정]
- src/components/chat/ChatPanel.tsx
- src/infrastructure/chat/chatAction.ts
- src/infrastructure/market/submitAnalysisAction.ts
- package.json
- yarn.lock

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [ ] yarn test
- [ ] yarn build