### PR TITLE
refactor: news-card 분석 DB-first 필터링 추가

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -211,6 +211,14 @@
 - Rule: Narrowing guard comments must accurately describe which variable is being constrained
 - Context: Comment should explain that isOAuthProvider checks the URL param, not a profile field.
 
+## [PR #425 Round 1 | refactor/news-card-db-first | 2026-05-07]
+- B1: `src/__tests__/actions/news/ensureNewsCardsAnalyzedAction.test.ts` — Missing mockListBySymbol mock setup in beforeEach. Added `mockListBySymbol = jest.fn().mockResolvedValue([])` and `listBySymbol: mockListBySymbol` to MockNewsRepository.mockImplementation. Default empty array keeps all existing tests passing (all items treated as unanalyzed).
+  - Rule: MISTAKES.md Tests #6 — Mocked dependencies in beforeEach must cover all methods called in the action under test
+- B2: `src/__tests__/actions/news/ensureNewsCardsAnalyzedAction.test.ts` — Missing test cases for DB-first filtering logic. Added new describe block "DB-first 필터링은" with two test cases: (1) "모든 아이템이 이미 분석 완료(analyzedAt != null)이면 카드 분석을 호출하지 않는다" — verifies early return when all items analyzed; (2) "분석 완료된 아이템은 건너뛰고 미분석 아이템만 카드 분석을 호출한다" — verifies mixed state filtering.
+  - Rule: MISTAKES.md Tests §12 — Test coverage for critical business paths; DB-first filtering is the core refactor logic
+- Suggestion: `src/actions/news/ensureNewsCardsAnalyzedAction.ts:124` — Removed WHAT comment "// DB-first filter: skip items that already have analysis results." Kept the WHY comment "// Read the current DB state after upsert so newly inserted rows are included."
+  - Rule: Comments should explain WHY, not redundantly describe WHAT the code already shows
+
 ## [Multi-domain audit + 7-task patch | Round 2 (approved) | 2026-05-07]
 - B3: `src/__tests__/components/chat/hooks/useChat.test.tsx:79` — ESLint react/display-name error: anonymous component returned from makeWrapper(). Fixed by giving it a named function declaration TestQueryWrapper.
   - Rule: MISTAKES.md Components Rule 9 — Custom hooks in test wrapper components must have display name

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -225,6 +225,13 @@
 - Rule: Narrowing guard comments must accurately describe which variable is being constrained
 - Context: Comment should explain that isOAuthProvider checks the URL param, not a profile field.
 
+## [PR #425 Round 3 | refactor/news-card-db-first | 2026-05-07]
+- S1: Added "listBySymbol 실패 시 에러를 전파한다" test case inside "DB-first 필터링은" describe block. Verifies that listBySymbol rejection propagates (fail-fast design for DB-wide outage detection).
+  - Rule: MISTAKES.md Tests §12 — Test coverage for critical business paths
+  - Context: Ensures error handling path is exercised when DB query fails; confirm that rejection surfaces to caller instead of being silently swallowed
+- S2: Updated comment at ensureNewsCardsAnalyzedAction.ts line 135 from "Analyze and persist unanalyzed items in parallel — each polls its own worker." to "Each item polls its own background worker independently." (removed WHAT prefix, kept WHY context).
+  - Rule: Comments should explain WHY, not redundantly describe WHAT the code already shows
+
 ## [PR #425 Round 1 | refactor/news-card-db-first | 2026-05-07]
 - B1: `src/__tests__/actions/news/ensureNewsCardsAnalyzedAction.test.ts` — Missing mockListBySymbol mock setup in beforeEach. Added `mockListBySymbol = jest.fn().mockResolvedValue([])` and `listBySymbol: mockListBySymbol` to MockNewsRepository.mockImplementation. Default empty array keeps all existing tests passing (all items treated as unanalyzed).
   - Rule: MISTAKES.md Tests #6 — Mocked dependencies in beforeEach must cover all methods called in the action under test

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,19 @@
 # Fix Log
 
+## [PR #425 Round 2 | refactor/news-card-db-first | 2026-05-07]
+
+- B1: Added expect(mockListBySymbol).toHaveBeenCalledWith('AAPL', NEWS_LOOKBACK_MS) assertion to "모든 아이템이 이미 분석 완료" test. Added NEWS_LOOKBACK_MS import from @/infrastructure/market/newsLookback.
+- Rule: MISTAKES.md Tests §12 — Test coverage for critical business paths requires explicit assertions verifying the expected function calls and arguments
+- Context: DB-first filtering test enhanced to verify that listBySymbol was called with correct symbol and lookback parameters, ensuring the filtering logic correctly queries the database
+
+- S1: Added listBySymbol: jest.fn().mockResolvedValue([]) to module-level DrizzleNewsRepository mock factory.
+- Rule: MISTAKES.md Tests §6 — Mocked dependencies in beforeEach must cover all methods called in the action under test
+- Context: MockNewsRepository now includes the listBySymbol method mock to cover all DB queries used by ensureNewsCardsAnalyzedAction
+
+- S2: Added if (fresh.length === 0) return; early return before repo.listBySymbol() call in ensureNewsCardsAnalyzedAction.ts. Added expect(mockListBySymbol).not.toHaveBeenCalled() to '뉴스가 없으면' test.
+- Rule: MISTAKES.md Coding Paradigm §1 / Performance — skip unnecessary DB queries when input data is empty; guard expensive operations with early returns
+- Context: When no fresh news items exist, skip the DB lookup entirely; test verifies the optimization by asserting listBySymbol was never called
+
 ## [PR #423 Round 7 (S2) | feat/news-thinking-budget-and-refresh | 2026-05-07]
 - S2: `src/components/news/hooks/useNewsPollingWithInvalidation.ts` 신규 훅 생성. `useQueryClient` + 캐시 무효화 로직을 `NewsList.tsx`에서 분리. `NewsList`는 `useNewsPollingWithInvalidation` 단일 호출로 단순화(useState 2개만 유지). `NewsList.test.tsx` mock 대상도 함께 교체(`useNewsCardPolling` → `useNewsPollingWithInvalidation`).
   - Rule: 단일 책임 — 컴포넌트는 렌더링에 집중, React Query 캐시 무효화 결정은 전용 훅으로 분리

--- a/src/__tests__/infrastructure/market/ensureNewsCardsAnalyzedAction.test.ts
+++ b/src/__tests__/infrastructure/market/ensureNewsCardsAnalyzedAction.test.ts
@@ -304,7 +304,10 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
 
             await ensureNewsCardsAnalyzedAction('AAPL');
 
-            expect(mockListBySymbol).toHaveBeenCalledWith('AAPL', NEWS_LOOKBACK_MS);
+            expect(mockListBySymbol).toHaveBeenCalledWith(
+                'AAPL',
+                NEWS_LOOKBACK_MS
+            );
             expect(mockSubmitNewsCardAnalysis).not.toHaveBeenCalled();
         });
 

--- a/src/__tests__/infrastructure/market/ensureNewsCardsAnalyzedAction.test.ts
+++ b/src/__tests__/infrastructure/market/ensureNewsCardsAnalyzedAction.test.ts
@@ -1,5 +1,6 @@
 import { ensureNewsCardsAnalyzedAction } from '@/infrastructure/market/ensureNewsCardsAnalyzedAction';
 import { DISABLED_THINKING_BUDGET } from '@/infrastructure/market/newsAnalysisConstants';
+import { NEWS_LOOKBACK_MS } from '@/infrastructure/market/newsLookback';
 import {
     submitNewsCardAnalysis,
     pollNewsCardAnalysis,
@@ -40,6 +41,7 @@ jest.mock('@/infrastructure/db/newsRepository', () => ({
     DrizzleNewsRepository: jest.fn().mockImplementation(() => ({
         upsertNewsItem: jest.fn(),
         attachAnalysis: jest.fn(),
+        listBySymbol: jest.fn().mockResolvedValue([]),
     })),
 }));
 
@@ -302,6 +304,7 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
 
             await ensureNewsCardsAnalyzedAction('AAPL');
 
+            expect(mockListBySymbol).toHaveBeenCalledWith('AAPL', NEWS_LOOKBACK_MS);
             expect(mockSubmitNewsCardAnalysis).not.toHaveBeenCalled();
         });
 
@@ -331,6 +334,7 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
         await ensureNewsCardsAnalyzedAction('AAPL');
 
         expect(mockUpsertNewsItem).not.toHaveBeenCalled();
+        expect(mockListBySymbol).not.toHaveBeenCalled();
         expect(mockSubmitNewsCardAnalysis).not.toHaveBeenCalled();
     });
 });

--- a/src/__tests__/infrastructure/market/ensureNewsCardsAnalyzedAction.test.ts
+++ b/src/__tests__/infrastructure/market/ensureNewsCardsAnalyzedAction.test.ts
@@ -329,6 +329,16 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
                 expect.objectContaining({ item: NEWS_ITEM_1 })
             );
         });
+
+        it('listBySymbol 실패 시 에러를 전파한다', async () => {
+            mockFetchNews.mockResolvedValue([NEWS_ITEM_1]);
+            mockListBySymbol.mockRejectedValue(new Error('DB connection lost'));
+
+            await expect(ensureNewsCardsAnalyzedAction('AAPL')).rejects.toThrow(
+                'DB connection lost'
+            );
+            expect(mockSubmitNewsCardAnalysis).not.toHaveBeenCalled();
+        });
     });
 
     it('뉴스가 없으면 upsert와 카드 분석을 호출하지 않는다', async () => {

--- a/src/__tests__/infrastructure/market/ensureNewsCardsAnalyzedAction.test.ts
+++ b/src/__tests__/infrastructure/market/ensureNewsCardsAnalyzedAction.test.ts
@@ -122,6 +122,7 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
     let mockFetchNews: jest.Mock;
     let mockUpsertNewsItem: jest.Mock;
     let mockAttachAnalysis: jest.Mock;
+    let mockListBySymbol: jest.Mock;
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -131,6 +132,7 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
         mockFetchNews = jest.fn();
         mockUpsertNewsItem = jest.fn().mockResolvedValue(undefined);
         mockAttachAnalysis = jest.fn().mockResolvedValue(undefined);
+        mockListBySymbol = jest.fn().mockResolvedValue([]);
 
         MockFmpNewsClient.mockImplementation(
             () => ({ fetchNews: mockFetchNews }) as never
@@ -140,6 +142,7 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
                 ({
                     upsertNewsItem: mockUpsertNewsItem,
                     attachAnalysis: mockAttachAnalysis,
+                    listBySymbol: mockListBySymbol,
                 }) as never
         );
     });
@@ -288,6 +291,38 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
 
         expect(mockSubmitNewsCardAnalysis).toHaveBeenCalledTimes(2);
         expect(mockAttachAnalysis).toHaveBeenCalledTimes(1);
+    });
+
+    describe('DB-first 필터링은', () => {
+        it('모든 아이템이 이미 분석 완료(analyzedAt != null)이면 카드 분석을 호출하지 않는다', async () => {
+            mockFetchNews.mockResolvedValue([NEWS_ITEM_1]);
+            mockListBySymbol.mockResolvedValue([
+                { id: NEWS_ITEM_1.id, analyzedAt: new Date('2025-07-01') },
+            ]);
+
+            await ensureNewsCardsAnalyzedAction('AAPL');
+
+            expect(mockSubmitNewsCardAnalysis).not.toHaveBeenCalled();
+        });
+
+        it('분석 완료된 아이템은 건너뛰고 미분석 아이템만 카드 분석을 호출한다', async () => {
+            mockFetchNews.mockResolvedValue([NEWS_ITEM_1, NEWS_ITEM_2]);
+            mockListBySymbol.mockResolvedValue([
+                { id: NEWS_ITEM_1.id, analyzedAt: new Date('2025-07-01') },
+                { id: NEWS_ITEM_2.id, analyzedAt: null },
+            ]);
+            mockSubmitNewsCardAnalysis.mockResolvedValue(CACHED_RESULT);
+
+            await ensureNewsCardsAnalyzedAction('AAPL');
+
+            expect(mockSubmitNewsCardAnalysis).toHaveBeenCalledTimes(1);
+            expect(mockSubmitNewsCardAnalysis).toHaveBeenCalledWith(
+                expect.objectContaining({ item: NEWS_ITEM_2 })
+            );
+            expect(mockSubmitNewsCardAnalysis).not.toHaveBeenCalledWith(
+                expect.objectContaining({ item: NEWS_ITEM_1 })
+            );
+        });
     });
 
     it('뉴스가 없으면 upsert와 카드 분석을 호출하지 않는다', async () => {

--- a/src/infrastructure/market/ensureNewsCardsAnalyzedAction.ts
+++ b/src/infrastructure/market/ensureNewsCardsAnalyzedAction.ts
@@ -132,7 +132,7 @@ export async function ensureNewsCardsAnalyzedAction(
 
     if (unanalyzed.length === 0) return;
 
-    // Analyze and persist unanalyzed items in parallel — each polls its own worker.
+    // Each item polls its own background worker independently.
     const analyzeSettled = await Promise.allSettled(
         unanalyzed.map(item => analyzeAndPersist(item, repo))
     );

--- a/src/infrastructure/market/ensureNewsCardsAnalyzedAction.ts
+++ b/src/infrastructure/market/ensureNewsCardsAnalyzedAction.ts
@@ -121,7 +121,6 @@ export async function ensureNewsCardsAnalyzedAction(
         );
     }
 
-    // DB-first filter: skip items that already have analysis results.
     // Read the current DB state after upsert so newly inserted rows are included.
     const rows = await repo.listBySymbol(symbol, NEWS_LOOKBACK_MS);
     const analyzedIds = new Set(

--- a/src/infrastructure/market/ensureNewsCardsAnalyzedAction.ts
+++ b/src/infrastructure/market/ensureNewsCardsAnalyzedAction.ts
@@ -121,6 +121,8 @@ export async function ensureNewsCardsAnalyzedAction(
         );
     }
 
+    if (fresh.length === 0) return;
+
     // Read the current DB state after upsert so newly inserted rows are included.
     const rows = await repo.listBySymbol(symbol, NEWS_LOOKBACK_MS);
     const analyzedIds = new Set(

--- a/src/infrastructure/market/ensureNewsCardsAnalyzedAction.ts
+++ b/src/infrastructure/market/ensureNewsCardsAnalyzedAction.ts
@@ -4,6 +4,7 @@ import { getDatabaseClient } from '@/infrastructure/db/client';
 import { DrizzleNewsRepository } from '@/infrastructure/db/newsRepository';
 import { FmpNewsClient } from '@/infrastructure/fmp/newsClient';
 import { DISABLED_THINKING_BUDGET } from '@/infrastructure/market/newsAnalysisConstants';
+import { NEWS_LOOKBACK_MS } from '@/infrastructure/market/newsLookback';
 import { sleep } from '@/lib/sleep';
 import {
     pollNewsCardAnalysis,
@@ -22,11 +23,10 @@ const POLL_MAX_ATTEMPTS = 30;
  * Submit card analysis for a single item and wait for the worker to finish,
  * then persist the result to DB via `attachAnalysis`.
  *
- * Design: submitNewsCardAnalysis fires a background worker on the first call
- * (`submitted`) and returns the cached result on subsequent calls (`cached`).
- * Previous code only called attachAnalysis on `cached`, so the DB was always
- * one page-load behind. This function polls until done on `submitted` so the
- * DB is populated in the same waitUntil pass.
+ * Caller guarantees that `item` has not been analyzed yet (analyzedAt === null).
+ * The `cached` branch is kept for type compatibility with siglens-core 0.7.11;
+ * it will be removed once siglens-core ≥ 0.7.12 is deployed and the `cached`
+ * variant is dropped from `SubmitNewsCardAnalysisResult`.
  */
 async function analyzeAndPersist(
     item: NewsItem,
@@ -67,6 +67,11 @@ async function analyzeAndPersist(
  * Server Action: fetch fresh FMP news for `symbol`, upsert to DB, and
  * trigger per-card AI analysis for each item — polling until each worker
  * finishes so the result is persisted to DB in the same pass.
+ *
+ * DB-first: items that already have `analyzedAt` set are skipped — the DB
+ * is the primary store for news-card analysis results. This eliminates Redis
+ * result-caching for per-card analyses (siglens-core ≥ 0.7.12 removes the
+ * Redis write on the core side as well).
  *
  * Designed to run inside `waitUntil` so it doesn't block the response stream.
  * Per-item errors are logged and never thrown; other items continue normally.
@@ -116,14 +121,24 @@ export async function ensureNewsCardsAnalyzedAction(
         );
     }
 
-    // Analyze and persist all items in parallel — each polls its own worker.
+    // DB-first filter: skip items that already have analysis results.
+    // Read the current DB state after upsert so newly inserted rows are included.
+    const rows = await repo.listBySymbol(symbol, NEWS_LOOKBACK_MS);
+    const analyzedIds = new Set(
+        rows.filter(r => r.analyzedAt !== null).map(r => r.id)
+    );
+    const unanalyzed = fresh.filter(item => !analyzedIds.has(item.id));
+
+    if (unanalyzed.length === 0) return;
+
+    // Analyze and persist unanalyzed items in parallel — each polls its own worker.
     const analyzeSettled = await Promise.allSettled(
-        fresh.map(item => analyzeAndPersist(item, repo))
+        unanalyzed.map(item => analyzeAndPersist(item, repo))
     );
     const analyzeFailures = analyzeSettled.filter(r => r.status === 'rejected');
     if (analyzeFailures.length > 0) {
         console.error(
-            `[ensureNewsCardsAnalyzedAction] ${analyzeFailures.length}/${fresh.length} analyzeAndPersist failed`,
+            `[ensureNewsCardsAnalyzedAction] ${analyzeFailures.length}/${unanalyzed.length} analyzeAndPersist failed`,
             analyzeFailures.map(f =>
                 f.status === 'rejected' ? f.reason : null
             )


### PR DESCRIPTION
## 관련 이슈

해당 없음 (news-card Redis 캐싱 제거 설계 결정)

## 구현 내용

`ensureNewsCardsAnalyzedAction`에서 DB-first 필터링을 추가합니다.

**배경**: news-card 분석 결과가 이미 `news` 테이블(`analyzedAt`, `titleKo`, `summaryKo` 등)에 저장되고 있는데, 기존 코드는 모든 항목에 대해 `submitNewsCardAnalysis`를 호출해 Redis 캐시를 매번 확인하고 있었습니다. DB를 primary store로 삼아 Redis 의존도를 줄이는 설계 변경입니다.

**변경 내용**:
- upsert 완료 후 `repo.listBySymbol`로 현재 DB 상태 조회
- `analyzedAt != null`인 항목은 `analyzeAndPersist` 호출 자체를 건너뜀
- 미분석 항목이 없으면 early return
- `NEWS_LOOKBACK_MS` import 추가

**siglens-core 연계**: siglens-core `refactor/news-card-result-cache-removal` (PR #79)에서 `submitNewsCardAnalysis`의 Redis 캐시 체크를 제거합니다. 해당 PR이 배포(0.7.12)되면 이 PR의 `analyzeAndPersist` 내 `cached` 분기를 별도 PR로 제거할 예정입니다.

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] 반환 타입 명시
- [x] any 타입 없음

## 변경 파일 목록

[수정]
- `src/infrastructure/market/ensureNewsCardsAnalyzedAction.ts`

## CI Check lists

- [x] yarn lint