### PR TITLE
feat: InfoTooltip for fundamental metrics + mobile overflow + tab z-index fix

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,5 +1,12 @@
 # Fix Log
 
+## [PR #426 Round 1 | feat/fundamental-info-tooltips-mobile-fixes | 2026-05-07]
+- B1: `ValuationCard.tsx`, `ProfitabilityCard.tsx`, `FinancialHealthCard.tsx`, `FutureDirectionCard.tsx` — `'use client'` 불필요하게 추가됨. RSC가 Client Component 자식을 렌더링할 때 부모에 `'use client'`가 필요 없음. 4개 파일에서 모두 제거.
+  - Rule: `'use client'`는 해당 컴포넌트 자체가 hooks/event handler/browser API를 사용할 때만 선언. Client Component를 import하는 RSC 부모는 directive 불필요.
+- S1 (적용): `FutureDirectionCard.tsx` — '컨센서스' 목표주가 항목 툴팁을 `'애널리스트 목표주가 하단·중앙·상단 범위'` → `'애널리스트 목표주가 평균치'`로 변경. 기존 설명이 '컨센서스' 단일 항목이 아닌 전체 범위를 설명하는 오류.
+- S2 (거부): `globals.css` `overflow-x: hidden` — iOS Safari layout viewport 확장 버그 대응 의도적 수정. sticky header는 y축만 사용, 자식 스크롤 컨테이너는 독립 overflow-x 설정.
+- S3 (거부): `SymbolLayoutHeader.tsx` `z-50` — Tailwind z-index 스케일 유틸리티 클래스. 매직 넘버 아님. vaul Drawer.Content(z-40) 위에 헤더를 올리기 위한 의도적 값.
+
 ## [PR #423 Round 7 (S2) | feat/news-thinking-budget-and-refresh | 2026-05-07]
 - S2: `src/components/news/hooks/useNewsPollingWithInvalidation.ts` 신규 훅 생성. `useQueryClient` + 캐시 무효화 로직을 `NewsList.tsx`에서 분리. `NewsList`는 `useNewsPollingWithInvalidation` 단일 호출로 단순화(useState 2개만 유지). `NewsList.test.tsx` mock 대상도 함께 교체(`useNewsCardPolling` → `useNewsPollingWithInvalidation`).
   - Rule: 단일 책임 — 컴포넌트는 렌더링에 집중, React Query 캐시 무효화 결정은 전용 훅으로 분리

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,6 +73,10 @@
     --font-mono: var(--font-geist-mono);
 }
 
+html {
+    overflow-x: hidden;
+}
+
 body {
     color: var(--color-secondary-50);
     background-color: var(--color-secondary-900);

--- a/src/components/fundamental/sections/FinancialHealthCard.tsx
+++ b/src/components/fundamental/sections/FinancialHealthCard.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type {
     FundamentalRatiosInput,
     FundamentalFinancialScoresInput,

--- a/src/components/fundamental/sections/FinancialHealthCard.tsx
+++ b/src/components/fundamental/sections/FinancialHealthCard.tsx
@@ -1,9 +1,12 @@
+'use client';
+
 import type {
     FundamentalRatiosInput,
     FundamentalFinancialScoresInput,
     FundamentalCashFlowInput,
 } from '@y0ngha/siglens-core';
 import { cn } from '@/lib/cn';
+import { InfoTooltip } from '@/components/ui/InfoTooltip';
 
 interface FinancialHealthCardProps {
     ratios: FundamentalRatiosInput | null;
@@ -25,9 +28,10 @@ interface HealthMetricProps {
     value: string;
     hint?: string;
     badge?: { text: string; variant: BadgeVariant };
+    tooltip?: string;
 }
 
-function HealthMetric({ label, value, hint, badge }: HealthMetricProps) {
+function HealthMetric({ label, value, hint, badge, tooltip }: HealthMetricProps) {
     const badgeClass =
         badge === undefined ? '' : BADGE_VARIANT_CLASS[badge.variant];
 
@@ -35,6 +39,7 @@ function HealthMetric({ label, value, hint, badge }: HealthMetricProps) {
         <div className="border-secondary-700 flex items-baseline justify-between gap-4 border-b py-2.5 last:border-b-0">
             <div>
                 <span className="text-sm font-medium">{label}</span>
+                {tooltip !== undefined && <InfoTooltip>{tooltip}</InfoTooltip>}
                 {hint !== undefined && (
                     <span className="text-secondary-400 ml-1.5 text-xs">
                         {hint}
@@ -113,6 +118,7 @@ export function FinancialHealthCard({
                             : '—'
                     }
                     hint="Debt Ratio (TTM)"
+                    tooltip="총자산 대비 총부채. 0.5 이하 양호, 높을수록 재무 위험"
                 />
                 <HealthMetric
                     label="유동 비율"
@@ -123,6 +129,7 @@ export function FinancialHealthCard({
                             : '—'
                     }
                     hint="Current Ratio (TTM)"
+                    tooltip="유동자산 ÷ 유동부채. 1.5 이상 양호, 1 미만이면 단기 유동성 위험"
                 />
                 <HealthMetric
                     label="영업 현금흐름"
@@ -139,6 +146,7 @@ export function FinancialHealthCard({
                     }
                     hint="파산 위험 지수"
                     badge={altmanBadge(scores?.altmanZScore ?? null)}
+                    tooltip="파산 위험 예측. 2.99↑ 안전 / 1.81~2.99 경계 / 이하 위험"
                 />
                 <HealthMetric
                     label="피오트로스키 F-Score"
@@ -150,6 +158,7 @@ export function FinancialHealthCard({
                     }
                     hint="재무 건강 점수 (0–9)"
                     badge={piotroskiBadge(scores?.piotroskiScore ?? null)}
+                    tooltip="9가지 재무 기준 합산. 8~9 강함 / 5~7 보통 / 4↓ 약함"
                 />
             </div>
         </section>

--- a/src/components/fundamental/sections/FinancialHealthCard.tsx
+++ b/src/components/fundamental/sections/FinancialHealthCard.tsx
@@ -31,7 +31,13 @@ interface HealthMetricProps {
     tooltip?: string;
 }
 
-function HealthMetric({ label, value, hint, badge, tooltip }: HealthMetricProps) {
+function HealthMetric({
+    label,
+    value,
+    hint,
+    badge,
+    tooltip,
+}: HealthMetricProps) {
     const badgeClass =
         badge === undefined ? '' : BADGE_VARIANT_CLASS[badge.variant];
 

--- a/src/components/fundamental/sections/FutureDirectionCard.tsx
+++ b/src/components/fundamental/sections/FutureDirectionCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { CSSProperties } from 'react';
 import type {
     FundamentalAnalystEstimateInput,
@@ -5,6 +7,7 @@ import type {
     FundamentalPriceTargetConsensusInput,
     FundamentalPriceTargetSummaryInput,
 } from '@y0ngha/siglens-core';
+import { InfoTooltip } from '@/components/ui/InfoTooltip';
 
 interface FutureDirectionCardProps {
     estimates: FundamentalAnalystEstimateInput | null;
@@ -155,7 +158,6 @@ function GradesBar({ strongBuy, buy, hold, sell, strongSell }: GradesBarProps) {
     );
 }
 
-/** RSC section: analyst consensus — EPS/revenue estimates, buy/sell breakdown bar, and price target range. */
 export function FutureDirectionCard({
     estimates,
     grades,
@@ -186,6 +188,9 @@ export function FutureDirectionCard({
                         <div className="bg-secondary-800/40 rounded-lg px-4 py-3">
                             <dt className="text-secondary-400 text-xs">
                                 EPS 컨센서스
+                                <InfoTooltip>
+                                    애널리스트 EPS 평균 추정치. 실제 발표와 비교해 어닝 서프라이즈를 가늠
+                                </InfoTooltip>
                             </dt>
                             <dd className="mt-1 font-mono text-lg font-semibold tabular-nums">
                                 {fmtUsd(estimates.estimatedEpsAvg)}
@@ -194,6 +199,9 @@ export function FutureDirectionCard({
                         <div className="bg-secondary-800/40 rounded-lg px-4 py-3">
                             <dt className="text-secondary-400 text-xs">
                                 매출 컨센서스
+                                <InfoTooltip>
+                                    애널리스트 매출 평균 추정치. 성장성 기대치
+                                </InfoTooltip>
                             </dt>
                             <dd className="mt-1 font-mono text-lg font-semibold tabular-nums">
                                 {fmtBig(estimates.estimatedRevenueAvg)}
@@ -214,16 +222,23 @@ export function FutureDirectionCard({
                             // data is structurally [string, number | null] per the priceTargetSummary shape.
                             (
                                 [
-                                    ['하단', ptConsensus.targetLow],
-                                    ['중앙값', ptConsensus.targetMedian],
-                                    ['컨센서스', ptConsensus.targetConsensus],
-                                    ['상단', ptConsensus.targetHigh],
-                                ] as [string, number | null][]
-                            ) // 위 리터럴 entries가 항상 [라벨, ptConsensus 필드] 튜플이므로 narrowing 안전.
-                                .map(([label, val]) => (
+                                    ['하단', ptConsensus.targetLow, undefined],
+                                    ['중앙값', ptConsensus.targetMedian, undefined],
+                                    [
+                                        '컨센서스',
+                                        ptConsensus.targetConsensus,
+                                        '애널리스트 목표주가 하단·중앙·상단 범위',
+                                    ],
+                                    ['상단', ptConsensus.targetHigh, undefined],
+                                ] as [string, number | null, string | undefined][]
+                            ) // 위 리터럴 entries가 항상 [라벨, ptConsensus 필드, tooltip?] 튜플이므로 narrowing 안전.
+                                .map(([label, val, tooltip]) => (
                                     <div key={label}>
                                         <dt className="text-secondary-400 text-xs">
                                             {label}
+                                            {tooltip !== undefined && (
+                                                <InfoTooltip>{tooltip}</InfoTooltip>
+                                            )}
                                         </dt>
                                         <dd className="font-mono text-sm font-medium tabular-nums">
                                             {fmtUsd(val)}
@@ -263,6 +278,9 @@ export function FutureDirectionCard({
                 <div>
                     <h3 className="text-secondary-400 mb-1 text-xs font-medium tracking-widest uppercase">
                         투자의견 컨센서스
+                        <InfoTooltip>
+                            애널리스트 매수/중립/매도 의견 분포
+                        </InfoTooltip>
                     </h3>
                     <GradesBar
                         strongBuy={grades.strongBuy}

--- a/src/components/fundamental/sections/FutureDirectionCard.tsx
+++ b/src/components/fundamental/sections/FutureDirectionCard.tsx
@@ -189,7 +189,8 @@ export function FutureDirectionCard({
                             <dt className="text-secondary-400 text-xs">
                                 EPS 컨센서스
                                 <InfoTooltip>
-                                    애널리스트 EPS 평균 추정치. 실제 발표와 비교해 어닝 서프라이즈를 가늠
+                                    애널리스트 EPS 평균 추정치. 실제 발표와
+                                    비교해 어닝 서프라이즈를 가늠
                                 </InfoTooltip>
                             </dt>
                             <dd className="mt-1 font-mono text-lg font-semibold tabular-nums">
@@ -223,21 +224,31 @@ export function FutureDirectionCard({
                             (
                                 [
                                     ['하단', ptConsensus.targetLow, undefined],
-                                    ['중앙값', ptConsensus.targetMedian, undefined],
+                                    [
+                                        '중앙값',
+                                        ptConsensus.targetMedian,
+                                        undefined,
+                                    ],
                                     [
                                         '컨센서스',
                                         ptConsensus.targetConsensus,
                                         '애널리스트 목표주가 하단·중앙·상단 범위',
                                     ],
                                     ['상단', ptConsensus.targetHigh, undefined],
-                                ] as [string, number | null, string | undefined][]
+                                ] as [
+                                    string,
+                                    number | null,
+                                    string | undefined,
+                                ][]
                             ) // 위 리터럴 entries가 항상 [라벨, ptConsensus 필드, tooltip?] 튜플이므로 narrowing 안전.
                                 .map(([label, val, tooltip]) => (
                                     <div key={label}>
                                         <dt className="text-secondary-400 text-xs">
                                             {label}
                                             {tooltip !== undefined && (
-                                                <InfoTooltip>{tooltip}</InfoTooltip>
+                                                <InfoTooltip>
+                                                    {tooltip}
+                                                </InfoTooltip>
                                             )}
                                         </dt>
                                         <dd className="font-mono text-sm font-medium tabular-nums">

--- a/src/components/fundamental/sections/FutureDirectionCard.tsx
+++ b/src/components/fundamental/sections/FutureDirectionCard.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { CSSProperties } from 'react';
 import type {
     FundamentalAnalystEstimateInput,
@@ -232,7 +230,7 @@ export function FutureDirectionCard({
                                     [
                                         '컨센서스',
                                         ptConsensus.targetConsensus,
-                                        '애널리스트 목표주가 하단·중앙·상단 범위',
+                                        '애널리스트 목표주가 평균치',
                                     ],
                                     ['상단', ptConsensus.targetHigh, undefined],
                                 ] as [

--- a/src/components/fundamental/sections/ProfitabilityCard.tsx
+++ b/src/components/fundamental/sections/ProfitabilityCard.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { CSSProperties } from 'react';
 import type { FundamentalRatiosInput } from '@y0ngha/siglens-core';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';

--- a/src/components/fundamental/sections/ProfitabilityCard.tsx
+++ b/src/components/fundamental/sections/ProfitabilityCard.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import type { CSSProperties } from 'react';
 import type { FundamentalRatiosInput } from '@y0ngha/siglens-core';
+import { InfoTooltip } from '@/components/ui/InfoTooltip';
 
 interface ProfitabilityCardProps {
     ratios: FundamentalRatiosInput;
@@ -9,9 +12,10 @@ interface MetricBarProps {
     label: string;
     value: number | null;
     description: string;
+    tooltip?: string;
 }
 
-function MetricBar({ label, value, description }: MetricBarProps) {
+function MetricBar({ label, value, description, tooltip }: MetricBarProps) {
     const displayValue = value !== null ? `${(value * 100).toFixed(1)}%` : '—';
 
     // Clamp fill width 0–100% for progress bar visualisation (ratio expected 0–1)
@@ -23,6 +27,7 @@ function MetricBar({ label, value, description }: MetricBarProps) {
             <div className="flex items-baseline justify-between gap-2">
                 <div>
                     <span className="text-sm font-medium">{label}</span>
+                    {tooltip !== undefined && <InfoTooltip>{tooltip}</InfoTooltip>}
                     <span className="text-secondary-400 ml-1.5 text-xs">
                         {description}
                     </span>
@@ -68,21 +73,25 @@ export function ProfitabilityCard({ ratios }: ProfitabilityCardProps) {
                     label="ROE"
                     value={ratios.returnOnEquityTTM}
                     description="자기자본이익률"
+                    tooltip="자기자본이익률. 주주 자본 대비 순이익 비율"
                 />
                 <MetricBar
                     label="ROA"
                     value={ratios.returnOnAssetsTTM}
                     description="총자산이익률"
+                    tooltip="총자산이익률. 자산 전체 활용 효율성 지표"
                 />
                 <MetricBar
                     label="영업이익률"
                     value={ratios.operatingProfitMarginTTM}
                     description="Operating Margin"
+                    tooltip="매출 대비 영업이익 비율. 핵심 사업 수익성"
                 />
                 <MetricBar
                     label="순이익률"
                     value={ratios.netProfitMarginTTM}
                     description="Net Margin"
+                    tooltip="매출 대비 순이익 비율. 전체 비용 차감 후 실질 수익성"
                 />
             </div>
         </section>

--- a/src/components/fundamental/sections/ProfitabilityCard.tsx
+++ b/src/components/fundamental/sections/ProfitabilityCard.tsx
@@ -27,7 +27,9 @@ function MetricBar({ label, value, description, tooltip }: MetricBarProps) {
             <div className="flex items-baseline justify-between gap-2">
                 <div>
                     <span className="text-sm font-medium">{label}</span>
-                    {tooltip !== undefined && <InfoTooltip>{tooltip}</InfoTooltip>}
+                    {tooltip !== undefined && (
+                        <InfoTooltip>{tooltip}</InfoTooltip>
+                    )}
                     <span className="text-secondary-400 ml-1.5 text-xs">
                         {description}
                     </span>

--- a/src/components/fundamental/sections/ValuationCard.tsx
+++ b/src/components/fundamental/sections/ValuationCard.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import type { FundamentalValuationMetrics } from '@y0ngha/siglens-core';
+import { InfoTooltip } from '@/components/ui/InfoTooltip';
 
 interface ValuationCardProps {
     metrics: FundamentalValuationMetrics;
@@ -9,9 +12,10 @@ interface MetricRowProps {
     value: number | null;
     description: string;
     digits?: number;
+    tooltip?: string;
 }
 
-function MetricRow({ label, value, description, digits = 2 }: MetricRowProps) {
+function MetricRow({ label, value, description, digits = 2, tooltip }: MetricRowProps) {
     const formatted =
         value !== null
             ? new Intl.NumberFormat('ko-KR', {
@@ -25,6 +29,7 @@ function MetricRow({ label, value, description, digits = 2 }: MetricRowProps) {
                 <span className="text-sm font-medium" translate="no">
                     {label}
                 </span>
+                {tooltip !== undefined && <InfoTooltip>{tooltip}</InfoTooltip>}
                 <span className="text-secondary-400 ml-1.5 text-xs">
                     {description}
                 </span>
@@ -36,7 +41,6 @@ function MetricRow({ label, value, description, digits = 2 }: MetricRowProps) {
     );
 }
 
-/** RSC section: TTM valuation multiples — PER, PSR, PBR, PEG, EV/EBITDA, EPS. */
 export function ValuationCard({ metrics }: ValuationCardProps) {
     return (
         <section
@@ -55,32 +59,38 @@ export function ValuationCard({ metrics }: ValuationCardProps) {
                     value={metrics.peRatioTTM}
                     description="주가수익비율 (TTM)"
                     digits={1}
+                    tooltip="주가수익비율. 주가 ÷ 주당순이익. 낮을수록 저평가 가능성"
                 />
                 <MetricRow
                     label="PSR"
                     value={metrics.priceToSalesRatioTTM}
                     description="주가매출비율 (TTM)"
+                    tooltip="주가매출비율. 성장주·적자기업 평가에 주로 사용"
                 />
                 <MetricRow
                     label="PBR"
                     value={metrics.pbRatioTTM}
                     description="주가순자산비율 (TTM)"
+                    tooltip="주가순자산비율. 1 미만이면 장부가 이하 거래"
                 />
                 <MetricRow
                     label="PEG"
                     value={metrics.pegRatioTTM}
                     description="성장가치비율 (TTM)"
+                    tooltip="성장가치비율. PER ÷ 이익성장률. 1 미만이면 성장 대비 저평가"
                 />
                 <MetricRow
                     label="EV/EBITDA"
                     value={metrics.enterpriseValueOverEBITDATTM}
                     description="기업가치/EBITDA (TTM)"
                     digits={1}
+                    tooltip="기업 전체 가치(부채 포함) ÷ 세전이익·감가상각 전이익"
                 />
                 <MetricRow
                     label="EPS"
                     value={metrics.epsTTM}
                     description="주당순이익 (TTM)"
+                    tooltip="주당순이익. 순이익 ÷ 발행주식수"
                 />
             </div>
         </section>

--- a/src/components/fundamental/sections/ValuationCard.tsx
+++ b/src/components/fundamental/sections/ValuationCard.tsx
@@ -15,7 +15,13 @@ interface MetricRowProps {
     tooltip?: string;
 }
 
-function MetricRow({ label, value, description, digits = 2, tooltip }: MetricRowProps) {
+function MetricRow({
+    label,
+    value,
+    description,
+    digits = 2,
+    tooltip,
+}: MetricRowProps) {
     const formatted =
         value !== null
             ? new Intl.NumberFormat('ko-KR', {

--- a/src/components/fundamental/sections/ValuationCard.tsx
+++ b/src/components/fundamental/sections/ValuationCard.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { FundamentalValuationMetrics } from '@y0ngha/siglens-core';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
 

--- a/src/components/symbol-page/SymbolLayoutHeader.tsx
+++ b/src/components/symbol-page/SymbolLayoutHeader.tsx
@@ -38,7 +38,7 @@ export function SymbolLayoutHeader({ symbol }: SymbolLayoutHeaderProps) {
     } = useSymbolModel();
 
     return (
-        <header className="px-4 py-3">
+        <header className="relative z-50 px-4 py-3">
             <div className="flex items-center justify-between gap-4">
                 <div className="flex min-w-0 items-center gap-2">
                     <Link


### PR DESCRIPTION
## 관련 이슈

(이슈 번호 없음 - 기술 개선사항)

## 구현 내용

- Add ⓘ tooltip icons to all financial term labels in ValuationCard, ProfitabilityCard, FinancialHealthCard, FutureDirectionCard (18 terms total)
- Fix floating chat button appearing off-screen on narrow mobile devices (`html { overflow-x: hidden }`)
- Fix tab navigation blocked during AI analysis on mobile by giving the layout header `relative z-50` above vaul Drawer.Content (z-40)

## 변경 파일 목록

[수정]
- src/app/globals.css
- src/components/symbol-page/SymbolLayoutHeader.tsx
- src/components/fundamental/sections/ValuationCard.tsx
- src/components/fundamental/sections/ProfitabilityCard.tsx
- src/components/fundamental/sections/FinancialHealthCard.tsx
- src/components/fundamental/sections/FutureDirectionCard.tsx

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build