### PR TITLE
feat: tier + BYOK forwarding for analysis actions

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,6 +1,22 @@
 
 # Fix Log
 
+## [PR #430 Round 2 | feat/analysis-key-routing | 2026-05-08]
+- Violation: `getCurrentUser()` called outside try-catch in `submitOverallAnalysisAction.ts` while the same call is inside try in the other 3 sibling actions — asymmetric failure handling
+  - Rule: MISTAKES.md I/O & Error Handling #1 — When one I/O operation in a module is protected with try-catch, all I/O operations at the same call depth must be equivalently protected
+  - Context: Only `submitOverallAnalysisAction` had `getCurrentUser()` before the try block; moving it inside ensures auth failures are caught and returned as `unexpected_error` instead of propagating uncaught
+- Violation: Anonymous `catch {}` blocks in all 4 action files swallow error info silently — no logging, no diagnostics
+  - Rule: MISTAKES.md Infrastructure Functions #3 — No debug artifacts, but errors must not be silently swallowed; log with `console.error` before returning gracefully
+  - Context: `catch {}` → `catch (err) { console.error('[submitXxxAction] unexpected error:', err); }` applied to all 4 submit action files (submitAnalysisAction, submitFundamentalAnalysisAction, submitNewsAnalysisAction, submitOverallAnalysisAction)
+
+## [PR #430 | feat/analysis-key-routing | 2026-05-08]
+- Violation: `AnalysisGateBlockedResult` interface defined independently in 4 action files instead of being centralized in `byokGate.ts`
+  - Rule: MISTAKES.md Architecture #1 — Shared infrastructure interfaces must be defined once in the module that owns them, not duplicated in consumers
+  - Context: Each of the 4 action files redeclared the same interface with identical shape; moved to byokGate.ts as the single source of truth and re-exported from consumers
+- Violation: `AnalysisGateErrorCode` type duplicated in `submitAnalysisAction.ts` despite already being defined in `byokGate.ts`
+  - Rule: MISTAKES.md Coding Paradigm #6 — Repeating identical type/logic across modules without a shared source
+  - Context: `buildGateError` was moved to byokGate.ts in a previous refactor but its dependent type was left behind as a stale duplicate; removed
+
 ## [PR #428 Round 16 | feat/per-stock-fear-greed-ui | 2026-05-08]
 - S1: `src/components/symbol-page/hooks/useDefaultModelId.ts` JSDoc — `'모든 분석 탭(뉴스·펀더·종합·차트 패널 내 공포지수 카드)'` → `'AI 분석 탭(뉴스, 펀더멘털, 종합)'`. fear-greed는 AI 모델이 필요 없는 순수 산출(`computeFearGreedIndex`)이라 이 hook을 사용하지 않음. NewsAugment 제거 라운드에서 잘못 갱신된 주석을 정확한 소비자 목록으로 정정.
   - Rule: MISTAKES.md §11 — JSDoc에 명시된 소비자 목록과 실제 사용처 동기화

--- a/src/__tests__/domain/analysis/gate.test.ts
+++ b/src/__tests__/domain/analysis/gate.test.ts
@@ -1,0 +1,48 @@
+import {
+    isGateBlockedResult,
+    GATE_ERROR_CODES,
+    type AnalysisGateBlockedResult,
+} from '@/domain/analysis/gate';
+
+describe('isGateBlockedResult', () => {
+    it('returns true for AnalysisGateBlockedResult shape', () => {
+        const r: AnalysisGateBlockedResult = {
+            status: 'error',
+            error: { code: 'tier_premium_blocked', message: 'msg' },
+        };
+        expect(isGateBlockedResult(r)).toBe(true);
+    });
+
+    it('returns true for all known gate codes', () => {
+        for (const code of GATE_ERROR_CODES) {
+            expect(
+                isGateBlockedResult({ status: 'error', error: { code, message: '' } })
+            ).toBe(true);
+        }
+    });
+
+    it('returns false for unknown code', () => {
+        expect(
+            isGateBlockedResult({
+                status: 'error',
+                error: { code: 'fetch_failed', message: '' },
+            })
+        ).toBe(false);
+    });
+
+    it('returns false when error is a string', () => {
+        expect(
+            isGateBlockedResult({ status: 'error', error: 'some message' })
+        ).toBe(false);
+    });
+
+    it('returns false when error is null', () => {
+        expect(isGateBlockedResult({ status: 'error', error: null })).toBe(false);
+    });
+
+    it('returns false when error has no code field', () => {
+        expect(
+            isGateBlockedResult({ status: 'error', error: { message: 'no code' } })
+        ).toBe(false);
+    });
+});

--- a/src/__tests__/domain/analysis/gate.test.ts
+++ b/src/__tests__/domain/analysis/gate.test.ts
@@ -16,7 +16,10 @@ describe('isGateBlockedResult', () => {
     it('returns true for all known gate codes', () => {
         for (const code of GATE_ERROR_CODES) {
             expect(
-                isGateBlockedResult({ status: 'error', error: { code, message: '' } })
+                isGateBlockedResult({
+                    status: 'error',
+                    error: { code, message: '' },
+                })
             ).toBe(true);
         }
     });
@@ -37,12 +40,17 @@ describe('isGateBlockedResult', () => {
     });
 
     it('returns false when error is null', () => {
-        expect(isGateBlockedResult({ status: 'error', error: null })).toBe(false);
+        expect(isGateBlockedResult({ status: 'error', error: null })).toBe(
+            false
+        );
     });
 
     it('returns false when error has no code field', () => {
         expect(
-            isGateBlockedResult({ status: 'error', error: { message: 'no code' } })
+            isGateBlockedResult({
+                status: 'error',
+                error: { message: 'no code' },
+            })
         ).toBe(false);
     });
 });

--- a/src/__tests__/infrastructure/market/byokGate.test.ts
+++ b/src/__tests__/infrastructure/market/byokGate.test.ts
@@ -118,6 +118,15 @@ describe('resolveTierAndByok', () => {
             error: expect.objectContaining({ code: 'api_key_corrupted' }),
         });
     });
+
+    it('rethrows unexpected non-decryption errors', async () => {
+        mockGetUserTier.mockResolvedValue('free');
+        const boom = new Error('db connection failed');
+        mockFindByUserAndProvider.mockRejectedValue(boom);
+        await expect(resolveTierAndByok('u1', PREMIUM_MODEL)).rejects.toThrow(
+            boom
+        );
+    });
 });
 
 describe('buildGateError', () => {

--- a/src/__tests__/infrastructure/market/byokGate.test.ts
+++ b/src/__tests__/infrastructure/market/byokGate.test.ts
@@ -131,7 +131,9 @@ describe('resolveTierAndByok', () => {
     it('rethrows getUserTier errors', async () => {
         const boom = new Error('db tier lookup failed');
         mockGetUserTier.mockRejectedValue(boom);
-        await expect(resolveTierAndByok('u1', FREE_MODEL)).rejects.toThrow(boom);
+        await expect(resolveTierAndByok('u1', FREE_MODEL)).rejects.toThrow(
+            boom
+        );
     });
 });
 

--- a/src/__tests__/infrastructure/market/byokGate.test.ts
+++ b/src/__tests__/infrastructure/market/byokGate.test.ts
@@ -127,6 +127,12 @@ describe('resolveTierAndByok', () => {
             boom
         );
     });
+
+    it('rethrows getUserTier errors', async () => {
+        const boom = new Error('db tier lookup failed');
+        mockGetUserTier.mockRejectedValue(boom);
+        await expect(resolveTierAndByok('u1', FREE_MODEL)).rejects.toThrow(boom);
+    });
 });
 
 describe('buildGateError', () => {

--- a/src/__tests__/infrastructure/market/byokGate.test.ts
+++ b/src/__tests__/infrastructure/market/byokGate.test.ts
@@ -1,0 +1,144 @@
+jest.mock('server-only', () => ({}), { virtual: true });
+
+const mockGetUserTier = jest.fn();
+const mockFindByUserAndProvider = jest.fn();
+
+jest.mock('@/infrastructure/db/client', () => ({
+    getDatabaseClient: jest.fn(() => ({ db: {}, sql: () => null })),
+}));
+
+jest.mock('@/infrastructure/db/userRepository', () => ({
+    DrizzleUserRepository: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('@/infrastructure/tier/use-cases/getUserTier', () => ({
+    getUserTier: (...args: unknown[]) => mockGetUserTier(...args),
+}));
+
+jest.mock('@/infrastructure/db/userApiKeyRepository', () => {
+    const actual = jest.requireActual(
+        '@/infrastructure/db/userApiKeyRepository'
+    );
+    return {
+        ...actual,
+        DrizzleUserApiKeyRepository: jest.fn().mockImplementation(() => ({
+            findByUserAndProvider: mockFindByUserAndProvider,
+        })),
+    };
+});
+
+import { LlmApiKeyDecryptionFailedError } from '@/infrastructure/db/userApiKeyRepository';
+import {
+    resolveTierAndByok,
+    buildGateError,
+    isKnownModelId,
+} from '@/infrastructure/market/byokGate';
+import type { ModelId } from '@y0ngha/siglens-core';
+
+const FREE_MODEL = 'gemini-2.5-flash' as ModelId;
+const PREMIUM_MODEL = 'claude-opus-4-7' as ModelId;
+const UNKNOWN_MODEL = 'totally-not-a-model' as ModelId;
+
+describe('resolveTierAndByok', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockGetUserTier.mockResolvedValue('free');
+        mockFindByUserAndProvider.mockResolvedValue(null);
+    });
+
+    it('returns blocked invalid_model for unknown modelId', async () => {
+        const result = await resolveTierAndByok(null, UNKNOWN_MODEL);
+        expect(result).toEqual({
+            kind: 'blocked',
+            error: expect.objectContaining({ code: 'invalid_model' }),
+        });
+        expect(mockGetUserTier).not.toHaveBeenCalled();
+        expect(mockFindByUserAndProvider).not.toHaveBeenCalled();
+    });
+
+    it('returns allowed with tier=free when userId is null and model is free', async () => {
+        const result = await resolveTierAndByok(null, FREE_MODEL);
+        expect(result).toEqual({ kind: 'allowed', tier: 'free' });
+        expect(mockGetUserTier).not.toHaveBeenCalled();
+        expect(mockFindByUserAndProvider).not.toHaveBeenCalled();
+    });
+
+    it('returns blocked tier_premium_blocked when userId is null and model is premium', async () => {
+        const result = await resolveTierAndByok(null, PREMIUM_MODEL);
+        expect(result).toEqual({
+            kind: 'blocked',
+            error: expect.objectContaining({ code: 'tier_premium_blocked' }),
+        });
+        expect(mockFindByUserAndProvider).not.toHaveBeenCalled();
+    });
+
+    it('returns allowed without userApiKey for pro tier on premium model', async () => {
+        mockGetUserTier.mockResolvedValue('pro');
+        const result = await resolveTierAndByok('u1', PREMIUM_MODEL);
+        expect(result).toEqual({ kind: 'allowed', tier: 'pro' });
+        expect(mockFindByUserAndProvider).not.toHaveBeenCalled();
+    });
+
+    it('returns allowed without userApiKey for non-pro tier on free model', async () => {
+        mockGetUserTier.mockResolvedValue('member');
+        const result = await resolveTierAndByok('u1', FREE_MODEL);
+        expect(result).toEqual({ kind: 'allowed', tier: 'member' });
+        expect(mockFindByUserAndProvider).not.toHaveBeenCalled();
+    });
+
+    it('returns allowed with userApiKey for non-pro premium with BYOK record', async () => {
+        mockGetUserTier.mockResolvedValue('free');
+        mockFindByUserAndProvider.mockResolvedValue({ apiKey: 'sk-ant-byok' });
+        const result = await resolveTierAndByok('u1', PREMIUM_MODEL);
+        expect(result).toEqual({
+            kind: 'allowed',
+            tier: 'free',
+            userApiKey: 'sk-ant-byok',
+        });
+    });
+
+    it('returns blocked tier_premium_blocked for non-pro premium without BYOK record', async () => {
+        mockGetUserTier.mockResolvedValue('free');
+        mockFindByUserAndProvider.mockResolvedValue(null);
+        const result = await resolveTierAndByok('u1', PREMIUM_MODEL);
+        expect(result).toEqual({
+            kind: 'blocked',
+            error: expect.objectContaining({ code: 'tier_premium_blocked' }),
+        });
+    });
+
+    it('returns blocked api_key_corrupted on LlmApiKeyDecryptionFailedError', async () => {
+        mockGetUserTier.mockResolvedValue('free');
+        mockFindByUserAndProvider.mockRejectedValue(
+            new LlmApiKeyDecryptionFailedError('u1', 'anthropic')
+        );
+        const result = await resolveTierAndByok('u1', PREMIUM_MODEL);
+        expect(result).toEqual({
+            kind: 'blocked',
+            error: expect.objectContaining({ code: 'api_key_corrupted' }),
+        });
+    });
+});
+
+describe('buildGateError', () => {
+    it('returns error with correct code and message', () => {
+        const err = buildGateError('invalid_model');
+        expect(err.code).toBe('invalid_model');
+        expect(typeof err.message).toBe('string');
+        expect(err.message.length).toBeGreaterThan(0);
+    });
+});
+
+describe('isKnownModelId', () => {
+    it('returns true for a known free model', () => {
+        expect(isKnownModelId('gemini-2.5-flash')).toBe(true);
+    });
+
+    it('returns true for a known premium model', () => {
+        expect(isKnownModelId('claude-opus-4-7')).toBe(true);
+    });
+
+    it('returns false for an unknown model', () => {
+        expect(isKnownModelId('totally-not-a-model')).toBe(false);
+    });
+});

--- a/src/__tests__/infrastructure/market/submitAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitAnalysisAction.test.ts
@@ -1,5 +1,3 @@
-import type { AnalysisGateError } from '@/infrastructure/market/byokGate';
-
 jest.mock('@vercel/functions', () => ({
     waitUntil: jest.fn(),
 }));
@@ -20,7 +18,7 @@ jest.mock('@/infrastructure/market/byokGate', () => ({
     })),
 }));
 
-import { resolveTierAndByok } from '@/infrastructure/market/byokGate';
+import { resolveTierAndByok, type AnalysisGateError } from '@/infrastructure/market/byokGate';
 import { submitAnalysisAction } from '@/infrastructure/market/submitAnalysisAction';
 import type { ModelId, SubmitAnalysisGatedResult } from '@y0ngha/siglens-core';
 import { submitAnalysis } from '@y0ngha/siglens-core';

--- a/src/__tests__/infrastructure/market/submitAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitAnalysisAction.test.ts
@@ -18,13 +18,14 @@ jest.mock('@/infrastructure/market/byokGate', () => ({
     })),
 }));
 
-import {
-    resolveTierAndByok,
-    type AnalysisGateError,
-} from '@/infrastructure/market/byokGate';
+import { resolveTierAndByok } from '@/infrastructure/market/byokGate';
+import type { AnalysisGateError } from '@/domain/types';
 import { submitAnalysisAction } from '@/infrastructure/market/submitAnalysisAction';
-import type { ModelId, SubmitAnalysisGatedResult } from '@y0ngha/siglens-core';
-import { submitAnalysis } from '@y0ngha/siglens-core';
+import {
+    submitAnalysis,
+    type ModelId,
+    type SubmitAnalysisGatedResult,
+} from '@y0ngha/siglens-core';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
 
 const mockResolveTierAndByok = resolveTierAndByok as jest.MockedFunction<

--- a/src/__tests__/infrastructure/market/submitAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitAnalysisAction.test.ts
@@ -195,4 +195,25 @@ describe('submitAnalysisAction tier + BYOK gate', () => {
             })
         );
     });
+
+    it('returns unexpected_error result when an unexpected error is thrown', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockRejectedValue(
+            new Error('db connection failed')
+        );
+
+        const result = await submitAnalysisAction(
+            'AAPL',
+            'Apple',
+            '1Day',
+            false,
+            '^AAPL',
+            FREE_MODEL
+        );
+
+        expect(result).toMatchObject({
+            status: 'error',
+            error: expect.objectContaining({ code: 'unexpected_error' }),
+        });
+    });
 });

--- a/src/__tests__/infrastructure/market/submitAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitAnalysisAction.test.ts
@@ -18,7 +18,10 @@ jest.mock('@/infrastructure/market/byokGate', () => ({
     })),
 }));
 
-import { resolveTierAndByok, type AnalysisGateError } from '@/infrastructure/market/byokGate';
+import {
+    resolveTierAndByok,
+    type AnalysisGateError,
+} from '@/infrastructure/market/byokGate';
 import { submitAnalysisAction } from '@/infrastructure/market/submitAnalysisAction';
 import type { ModelId, SubmitAnalysisGatedResult } from '@y0ngha/siglens-core';
 import { submitAnalysis } from '@y0ngha/siglens-core';

--- a/src/__tests__/infrastructure/market/submitAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitAnalysisAction.test.ts
@@ -14,7 +14,10 @@ jest.mock('@/infrastructure/auth/getCurrentUser', () => ({
 
 jest.mock('@/infrastructure/market/byokGate', () => ({
     resolveTierAndByok: jest.fn(),
-    buildGateError: jest.fn((code: string) => ({ code, message: `mock-${code}` })),
+    buildGateError: jest.fn((code: string) => ({
+        code,
+        message: `mock-${code}`,
+    })),
 }));
 
 import { resolveTierAndByok } from '@/infrastructure/market/byokGate';

--- a/src/__tests__/infrastructure/market/submitAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitAnalysisAction.test.ts
@@ -1,51 +1,36 @@
-const mockGetCurrentUser = jest.fn();
-const mockGetUserTier = jest.fn();
-const mockFindByUserAndProvider = jest.fn();
+import type { AnalysisGateError } from '@/infrastructure/market/byokGate';
 
 jest.mock('@vercel/functions', () => ({
     waitUntil: jest.fn(),
 }));
 
 jest.mock('@y0ngha/siglens-core', () => ({
-    ...jest.requireActual('@y0ngha/siglens-core'),
     submitAnalysis: jest.fn(),
 }));
 
 jest.mock('@/infrastructure/auth/getCurrentUser', () => ({
-    getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
+    getCurrentUser: jest.fn(),
 }));
 
-jest.mock('@/infrastructure/db/client', () => ({
-    getDatabaseClient: jest.fn(() => ({ db: {}, sql: () => null })),
+jest.mock('@/infrastructure/market/byokGate', () => ({
+    resolveTierAndByok: jest.fn(),
+    buildGateError: jest.fn((code: string) => ({ code, message: `mock-${code}` })),
 }));
 
-jest.mock('@/infrastructure/db/userRepository', () => ({
-    DrizzleUserRepository: jest.fn().mockImplementation(() => ({})),
-}));
-
-jest.mock('@/infrastructure/tier/use-cases/getUserTier', () => ({
-    getUserTier: (...args: unknown[]) => mockGetUserTier(...args),
-}));
-
-jest.mock('@/infrastructure/db/userApiKeyRepository', () => {
-    const actual = jest.requireActual(
-        '@/infrastructure/db/userApiKeyRepository'
-    );
-    return {
-        ...actual,
-        DrizzleUserApiKeyRepository: jest.fn().mockImplementation(() => ({
-            findByUserAndProvider: mockFindByUserAndProvider,
-        })),
-    };
-});
-
-import { LlmApiKeyDecryptionFailedError } from '@/infrastructure/db/userApiKeyRepository';
+import { resolveTierAndByok } from '@/infrastructure/market/byokGate';
 import { submitAnalysisAction } from '@/infrastructure/market/submitAnalysisAction';
 import type { ModelId, SubmitAnalysisGatedResult } from '@y0ngha/siglens-core';
 import { submitAnalysis } from '@y0ngha/siglens-core';
+import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
 
+const mockResolveTierAndByok = resolveTierAndByok as jest.MockedFunction<
+    typeof resolveTierAndByok
+>;
 const mockSubmitAnalysis = submitAnalysis as jest.MockedFunction<
     typeof submitAnalysis
+>;
+const mockGetCurrentUser = getCurrentUser as jest.MockedFunction<
+    typeof getCurrentUser
 >;
 
 const cachedResult: SubmitAnalysisGatedResult = {
@@ -55,25 +40,47 @@ const cachedResult: SubmitAnalysisGatedResult = {
 
 const FREE_MODEL = 'gemini-2.5-flash-lite' as ModelId;
 const PREMIUM_MODEL = 'claude-opus-4-7' as ModelId;
-const UNKNOWN_MODEL = 'totally-not-a-model' as ModelId;
+
+const gateError: AnalysisGateError = {
+    code: 'tier_premium_blocked',
+    message: 'mock-tier_premium_blocked',
+};
 
 describe('submitAnalysisAction tier + BYOK gate', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockSubmitAnalysis.mockResolvedValue(cachedResult);
         mockGetCurrentUser.mockResolvedValue(null);
-        mockGetUserTier.mockResolvedValue('free');
-        mockFindByUserAndProvider.mockResolvedValue(null);
     });
 
-    it('modelId 미지정 시 core submitAnalysis로 그대로 위임한다', async () => {
-        await submitAnalysisAction('AAPL', 'Apple', '1Day', true, '^AAPL');
-        expect(mockSubmitAnalysis).toHaveBeenCalledTimes(1);
-        expect(mockGetUserTier).not.toHaveBeenCalled();
-    });
+    it('returns blocked result when gate.kind === "blocked"', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'blocked',
+            error: gateError,
+        });
 
-    it('free tier + free model 게스트는 통과한다', async () => {
         const result = await submitAnalysisAction(
+            'AAPL',
+            'Apple',
+            '1Day',
+            false,
+            '^AAPL',
+            PREMIUM_MODEL
+        );
+
+        expect(result).toEqual({ status: 'error', error: gateError });
+        expect(mockSubmitAnalysis).not.toHaveBeenCalled();
+    });
+
+    it('forwards tierContext to siglens-core when modelId is set', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'member' as never,
+        });
+
+        await submitAnalysisAction(
             'AAPL',
             'Apple',
             '1Day',
@@ -81,50 +88,7 @@ describe('submitAnalysisAction tier + BYOK gate', () => {
             '^AAPL',
             FREE_MODEL
         );
-        expect(result).toBe(cachedResult);
-        expect(mockSubmitAnalysis).toHaveBeenCalledWith(
-            'AAPL',
-            'Apple',
-            '1Day',
-            false,
-            '^AAPL',
-            expect.objectContaining({ modelId: FREE_MODEL })
-        );
-    });
 
-    it('free tier + premium model + BYOK 미등록 게스트는 차단한다', async () => {
-        const result = await submitAnalysisAction(
-            'AAPL',
-            'Apple',
-            '1Day',
-            false,
-            '^AAPL',
-            PREMIUM_MODEL
-        );
-        expect(result).toEqual({
-            status: 'error',
-            error: expect.objectContaining({ code: 'tier_premium_blocked' }),
-        });
-        expect(mockSubmitAnalysis).not.toHaveBeenCalled();
-    });
-
-    it('free tier + premium model + BYOK 등록 시 통과하고 userApiKey가 core로 전달된다', async () => {
-        mockGetCurrentUser.mockResolvedValue({ id: 'u1' });
-        mockGetUserTier.mockResolvedValue('free');
-        mockFindByUserAndProvider.mockResolvedValue({
-            apiKey: 'sk-ant-byok',
-        });
-
-        const result = await submitAnalysisAction(
-            'AAPL',
-            'Apple',
-            '1Day',
-            false,
-            '^AAPL',
-            PREMIUM_MODEL
-        );
-
-        expect(result).toBe(cachedResult);
         expect(mockSubmitAnalysis).toHaveBeenCalledWith(
             'AAPL',
             'Apple',
@@ -132,18 +96,20 @@ describe('submitAnalysisAction tier + BYOK gate', () => {
             false,
             '^AAPL',
             expect.objectContaining({
-                modelId: PREMIUM_MODEL,
-                userApiKey: 'sk-ant-byok',
+                tierContext: { userId: 'u1', tier: 'member' },
             })
         );
     });
 
-    it('paid tier (pro) + premium model 은 BYOK 없이도 통과한다', async () => {
-        mockGetCurrentUser.mockResolvedValue({ id: 'u1' });
-        mockGetUserTier.mockResolvedValue('pro');
-        mockFindByUserAndProvider.mockResolvedValue(null);
+    it('forwards userApiKey when present in gate result', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'free' as never,
+            userApiKey: 'usr-key',
+        });
 
-        const result = await submitAnalysisAction(
+        await submitAnalysisAction(
             'AAPL',
             'Apple',
             '1Day',
@@ -152,53 +118,78 @@ describe('submitAnalysisAction tier + BYOK gate', () => {
             PREMIUM_MODEL
         );
 
-        expect(result).toBe(cachedResult);
-        // userApiKey must be absent — without BYOK, core uses its server-side
-        // server api key. Forwarding undefined/null/'' would all be wrong, so we
-        // pin the exact options shape rather than a partial match.
+        expect(mockSubmitAnalysis).toHaveBeenCalledWith(
+            'AAPL',
+            'Apple',
+            '1Day',
+            false,
+            '^AAPL',
+            expect.objectContaining({ userApiKey: 'usr-key' })
+        );
+    });
+
+    it('omits userApiKey when not in gate result', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'pro' as never,
+            // no userApiKey
+        });
+
+        await submitAnalysisAction(
+            'AAPL',
+            'Apple',
+            '1Day',
+            false,
+            '^AAPL',
+            PREMIUM_MODEL
+        );
+
         const lastCall = mockSubmitAnalysis.mock.calls.at(-1);
         expect(lastCall).toBeDefined();
         const opts = lastCall![5] as Record<string, unknown>;
-        expect(opts.modelId).toBe(PREMIUM_MODEL);
         expect(opts).not.toHaveProperty('userApiKey');
     });
 
-    it('알 수 없는 modelId는 invalid_model로 차단한다', async () => {
-        const result = await submitAnalysisAction(
-            'AAPL',
-            'Apple',
-            '1Day',
-            false,
-            '^AAPL',
-            UNKNOWN_MODEL
-        );
-        expect(result).toEqual({
-            status: 'error',
-            error: expect.objectContaining({ code: 'invalid_model' }),
-        });
-        expect(mockSubmitAnalysis).not.toHaveBeenCalled();
+    it('bypasses gate and uses default model when modelId is undefined', async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+
+        await submitAnalysisAction('AAPL', 'Apple', '1Day', true, '^AAPL');
+
+        expect(mockResolveTierAndByok).not.toHaveBeenCalled();
+        expect(mockSubmitAnalysis).toHaveBeenCalledTimes(1);
+        const lastCall = mockSubmitAnalysis.mock.calls.at(-1);
+        const opts = lastCall![5] as Record<string, unknown>;
+        expect(opts).not.toHaveProperty('tierContext');
+        expect(opts).not.toHaveProperty('userApiKey');
     });
 
-    it('BYOK 복호화 실패 시 api_key_corrupted로 차단한다', async () => {
-        mockGetCurrentUser.mockResolvedValue({ id: 'u1' });
-        mockGetUserTier.mockResolvedValue('free');
-        mockFindByUserAndProvider.mockRejectedValue(
-            new LlmApiKeyDecryptionFailedError('u1', 'anthropic')
-        );
+    it('passes null userId when getCurrentUser returns null', async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'free' as never,
+        });
 
-        const result = await submitAnalysisAction(
+        await submitAnalysisAction(
             'AAPL',
             'Apple',
             '1Day',
             false,
             '^AAPL',
-            PREMIUM_MODEL
+            FREE_MODEL
         );
 
-        expect(result).toEqual({
-            status: 'error',
-            error: expect.objectContaining({ code: 'api_key_corrupted' }),
-        });
-        expect(mockSubmitAnalysis).not.toHaveBeenCalled();
+        expect(mockResolveTierAndByok).toHaveBeenCalledWith(null, FREE_MODEL);
+        expect(mockSubmitAnalysis).toHaveBeenCalledWith(
+            'AAPL',
+            'Apple',
+            '1Day',
+            false,
+            '^AAPL',
+            expect.objectContaining({
+                tierContext: { userId: null, tier: 'free' },
+            })
+        );
     });
 });

--- a/src/__tests__/infrastructure/market/submitFundamentalAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitFundamentalAnalysisAction.test.ts
@@ -34,7 +34,10 @@ jest.mock('@/infrastructure/market/byokGate', () => ({
 import { submitFundamentalAnalysis } from '@y0ngha/siglens-core';
 import { FmpFundamentalClient } from '@/infrastructure/fmp/fundamentalClient';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import { resolveTierAndByok, type AnalysisGateError } from '@/infrastructure/market/byokGate';
+import {
+    resolveTierAndByok,
+    type AnalysisGateError,
+} from '@/infrastructure/market/byokGate';
 import { submitFundamentalAnalysisAction } from '@/infrastructure/market/submitFundamentalAnalysisAction';
 import type {
     ModelId,

--- a/src/__tests__/infrastructure/market/submitFundamentalAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitFundamentalAnalysisAction.test.ts
@@ -1,10 +1,4 @@
-import { submitFundamentalAnalysisAction } from '@/infrastructure/market/submitFundamentalAnalysisAction';
-import { submitFundamentalAnalysis } from '@y0ngha/siglens-core';
-import { FmpFundamentalClient } from '@/infrastructure/fmp/fundamentalClient';
-import type {
-    ModelId,
-    SubmitFundamentalAnalysisResult,
-} from '@y0ngha/siglens-core';
+import type { AnalysisGateError } from '@/infrastructure/market/byokGate';
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -23,14 +17,35 @@ jest.mock('@/infrastructure/fmp/fundamentalClient', () => ({
     FmpFundamentalClient: jest.fn().mockImplementation(() => ({})),
 }));
 
+jest.mock('@/infrastructure/auth/getCurrentUser', () => ({
+    getCurrentUser: jest.fn(),
+}));
+
+jest.mock('@/infrastructure/market/byokGate', () => ({
+    resolveTierAndByok: jest.fn(),
+    buildGateError: jest.fn((code: string) => ({ code, message: `mock-${code}` })),
+}));
+
 // ---------------------------------------------------------------------------
-// Typed mock
+// Typed mocks & fixtures
 // ---------------------------------------------------------------------------
 
-const mockSubmitFundamentalAnalysis =
-    submitFundamentalAnalysis as jest.MockedFunction<
-        typeof submitFundamentalAnalysis
-    >;
+import { submitFundamentalAnalysis } from '@y0ngha/siglens-core';
+import { FmpFundamentalClient } from '@/infrastructure/fmp/fundamentalClient';
+import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
+import { resolveTierAndByok } from '@/infrastructure/market/byokGate';
+import { submitFundamentalAnalysisAction } from '@/infrastructure/market/submitFundamentalAnalysisAction';
+import type { ModelId, SubmitFundamentalAnalysisResult } from '@y0ngha/siglens-core';
+
+const mockSubmitFundamentalAnalysis = submitFundamentalAnalysis as jest.MockedFunction<
+    typeof submitFundamentalAnalysis
+>;
+const mockGetCurrentUser = getCurrentUser as jest.MockedFunction<
+    typeof getCurrentUser
+>;
+const mockResolveTierAndByok = resolveTierAndByok as jest.MockedFunction<
+    typeof resolveTierAndByok
+>;
 
 const CACHED_RESULT: SubmitFundamentalAnalysisResult = {
     status: 'cached',
@@ -42,6 +57,14 @@ const SUBMITTED_RESULT: SubmitFundamentalAnalysisResult = {
     jobId: 'job-fundamental-001',
 };
 
+const MODEL_ID = 'gemini-2.5-flash' as ModelId;
+const PREMIUM_MODEL = 'claude-opus-4-7' as ModelId;
+
+const gateError: AnalysisGateError = {
+    code: 'tier_premium_blocked',
+    message: 'mock-tier_premium_blocked',
+};
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -49,20 +72,30 @@ const SUBMITTED_RESULT: SubmitFundamentalAnalysisResult = {
 describe('submitFundamentalAnalysisAction 함수는', () => {
     beforeEach(() => {
         mockSubmitFundamentalAnalysis.mockReset();
+        mockGetCurrentUser.mockReset();
+        mockResolveTierAndByok.mockReset();
+
+        mockGetCurrentUser.mockResolvedValue(null);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'free' as never,
+        });
+        mockSubmitFundamentalAnalysis.mockResolvedValue(SUBMITTED_RESULT);
     });
+
+    // -------------------------------------------------------------------------
+    // Existing core logic tests
+    // -------------------------------------------------------------------------
 
     it('siglens-core submitFundamentalAnalysis에 symbol과 modelId를 전달한다', async () => {
         mockSubmitFundamentalAnalysis.mockResolvedValueOnce(CACHED_RESULT);
 
-        await submitFundamentalAnalysisAction(
-            'AAPL',
-            'gemini-2.5-flash' as ModelId
-        );
+        await submitFundamentalAnalysisAction('AAPL', MODEL_ID);
 
         expect(mockSubmitFundamentalAnalysis).toHaveBeenCalledWith(
             expect.objectContaining({
                 symbol: 'AAPL',
-                modelId: 'gemini-2.5-flash',
+                modelId: MODEL_ID,
             })
         );
     });
@@ -70,10 +103,7 @@ describe('submitFundamentalAnalysisAction 함수는', () => {
     it('FmpFundamentalClient 인스턴스를 dataProvider로 전달한다', async () => {
         mockSubmitFundamentalAnalysis.mockResolvedValueOnce(CACHED_RESULT);
 
-        await submitFundamentalAnalysisAction(
-            'TSLA',
-            'gemini-2.5-flash' as ModelId
-        );
+        await submitFundamentalAnalysisAction('TSLA', MODEL_ID);
 
         const call = mockSubmitFundamentalAnalysis.mock.calls[0]?.[0];
         expect(call?.dataProvider).toBeDefined();
@@ -83,10 +113,7 @@ describe('submitFundamentalAnalysisAction 함수는', () => {
     it('underlying 함수의 cached 결과를 그대로 반환한다', async () => {
         mockSubmitFundamentalAnalysis.mockResolvedValueOnce(CACHED_RESULT);
 
-        const result = await submitFundamentalAnalysisAction(
-            'AAPL',
-            'gemini-2.5-flash' as ModelId
-        );
+        const result = await submitFundamentalAnalysisAction('AAPL', MODEL_ID);
 
         expect(result).toBe(CACHED_RESULT);
     });
@@ -94,11 +121,82 @@ describe('submitFundamentalAnalysisAction 함수는', () => {
     it('underlying 함수의 submitted 결과를 그대로 반환한다', async () => {
         mockSubmitFundamentalAnalysis.mockResolvedValueOnce(SUBMITTED_RESULT);
 
-        const result = await submitFundamentalAnalysisAction(
-            'AAPL',
-            'gemini-2.5-flash' as ModelId
-        );
+        const result = await submitFundamentalAnalysisAction('AAPL', MODEL_ID);
 
         expect(result).toBe(SUBMITTED_RESULT);
+    });
+
+    // -------------------------------------------------------------------------
+    // Gate behavior tests
+    // -------------------------------------------------------------------------
+
+    it('returns blocked result when gate.kind === "blocked"', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'blocked',
+            error: gateError,
+        });
+
+        const result = await submitFundamentalAnalysisAction('AAPL', PREMIUM_MODEL);
+
+        expect(result).toEqual({ status: 'error', error: gateError });
+        // Gate fires before expensive provider fetch
+        expect(mockSubmitFundamentalAnalysis).not.toHaveBeenCalled();
+    });
+
+    it('forwards tier="member" to siglens-core when gate allowed', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'member' as never,
+        });
+
+        await submitFundamentalAnalysisAction('AAPL', MODEL_ID);
+
+        expect(mockSubmitFundamentalAnalysis).toHaveBeenCalledWith(
+            expect.objectContaining({ tier: 'member' })
+        );
+    });
+
+    it('forwards userApiKey when present in gate result', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'free' as never,
+            userApiKey: 'usr-key',
+        });
+
+        await submitFundamentalAnalysisAction('AAPL', PREMIUM_MODEL);
+
+        expect(mockSubmitFundamentalAnalysis).toHaveBeenCalledWith(
+            expect.objectContaining({ userApiKey: 'usr-key' })
+        );
+    });
+
+    it('omits userApiKey when not in gate result', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'pro' as never,
+            // no userApiKey
+        });
+
+        await submitFundamentalAnalysisAction('AAPL', PREMIUM_MODEL);
+
+        const callArg = mockSubmitFundamentalAnalysis.mock.calls[0]?.[0];
+        expect(callArg).toBeDefined();
+        expect(callArg).not.toHaveProperty('userApiKey');
+    });
+
+    it('passes null userId when getCurrentUser returns null', async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'free' as never,
+        });
+
+        await submitFundamentalAnalysisAction('AAPL', MODEL_ID);
+
+        expect(mockResolveTierAndByok).toHaveBeenCalledWith(null, MODEL_ID);
     });
 });

--- a/src/__tests__/infrastructure/market/submitFundamentalAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitFundamentalAnalysisAction.test.ts
@@ -1,5 +1,3 @@
-import type { AnalysisGateError } from '@/infrastructure/market/byokGate';
-
 // ---------------------------------------------------------------------------
 // Module mocks
 // ---------------------------------------------------------------------------
@@ -36,7 +34,7 @@ jest.mock('@/infrastructure/market/byokGate', () => ({
 import { submitFundamentalAnalysis } from '@y0ngha/siglens-core';
 import { FmpFundamentalClient } from '@/infrastructure/fmp/fundamentalClient';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import { resolveTierAndByok } from '@/infrastructure/market/byokGate';
+import { resolveTierAndByok, type AnalysisGateError } from '@/infrastructure/market/byokGate';
 import { submitFundamentalAnalysisAction } from '@/infrastructure/market/submitFundamentalAnalysisAction';
 import type {
     ModelId,

--- a/src/__tests__/infrastructure/market/submitFundamentalAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitFundamentalAnalysisAction.test.ts
@@ -23,7 +23,10 @@ jest.mock('@/infrastructure/auth/getCurrentUser', () => ({
 
 jest.mock('@/infrastructure/market/byokGate', () => ({
     resolveTierAndByok: jest.fn(),
-    buildGateError: jest.fn((code: string) => ({ code, message: `mock-${code}` })),
+    buildGateError: jest.fn((code: string) => ({
+        code,
+        message: `mock-${code}`,
+    })),
 }));
 
 // ---------------------------------------------------------------------------
@@ -35,11 +38,15 @@ import { FmpFundamentalClient } from '@/infrastructure/fmp/fundamentalClient';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
 import { resolveTierAndByok } from '@/infrastructure/market/byokGate';
 import { submitFundamentalAnalysisAction } from '@/infrastructure/market/submitFundamentalAnalysisAction';
-import type { ModelId, SubmitFundamentalAnalysisResult } from '@y0ngha/siglens-core';
+import type {
+    ModelId,
+    SubmitFundamentalAnalysisResult,
+} from '@y0ngha/siglens-core';
 
-const mockSubmitFundamentalAnalysis = submitFundamentalAnalysis as jest.MockedFunction<
-    typeof submitFundamentalAnalysis
->;
+const mockSubmitFundamentalAnalysis =
+    submitFundamentalAnalysis as jest.MockedFunction<
+        typeof submitFundamentalAnalysis
+    >;
 const mockGetCurrentUser = getCurrentUser as jest.MockedFunction<
     typeof getCurrentUser
 >;
@@ -137,7 +144,10 @@ describe('submitFundamentalAnalysisAction 함수는', () => {
             error: gateError,
         });
 
-        const result = await submitFundamentalAnalysisAction('AAPL', PREMIUM_MODEL);
+        const result = await submitFundamentalAnalysisAction(
+            'AAPL',
+            PREMIUM_MODEL
+        );
 
         expect(result).toEqual({ status: 'error', error: gateError });
         // Gate fires before expensive provider fetch

--- a/src/__tests__/infrastructure/market/submitFundamentalAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitFundamentalAnalysisAction.test.ts
@@ -31,18 +31,16 @@ jest.mock('@/infrastructure/market/byokGate', () => ({
 // Typed mocks & fixtures
 // ---------------------------------------------------------------------------
 
-import { submitFundamentalAnalysis } from '@y0ngha/siglens-core';
+import {
+    submitFundamentalAnalysis,
+    type ModelId,
+    type SubmitFundamentalAnalysisResult,
+} from '@y0ngha/siglens-core';
 import { FmpFundamentalClient } from '@/infrastructure/fmp/fundamentalClient';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import {
-    resolveTierAndByok,
-    type AnalysisGateError,
-} from '@/infrastructure/market/byokGate';
+import { resolveTierAndByok } from '@/infrastructure/market/byokGate';
+import type { AnalysisGateError } from '@/domain/types';
 import { submitFundamentalAnalysisAction } from '@/infrastructure/market/submitFundamentalAnalysisAction';
-import type {
-    ModelId,
-    SubmitFundamentalAnalysisResult,
-} from '@y0ngha/siglens-core';
 
 const mockSubmitFundamentalAnalysis =
     submitFundamentalAnalysis as jest.MockedFunction<

--- a/src/__tests__/infrastructure/market/submitFundamentalAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitFundamentalAnalysisAction.test.ts
@@ -209,4 +209,18 @@ describe('submitFundamentalAnalysisAction 함수는', () => {
 
         expect(mockResolveTierAndByok).toHaveBeenCalledWith(null, MODEL_ID);
     });
+
+    it('returns unexpected_error result when an unexpected error is thrown', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockRejectedValue(
+            new Error('db connection failed')
+        );
+
+        const result = await submitFundamentalAnalysisAction('AAPL', MODEL_ID);
+
+        expect(result).toMatchObject({
+            status: 'error',
+            error: expect.objectContaining({ code: 'unexpected_error' }),
+        });
+    });
 });

--- a/src/__tests__/infrastructure/market/submitFundamentalAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitFundamentalAnalysisAction.test.ts
@@ -90,10 +90,6 @@ describe('submitFundamentalAnalysisAction 함수는', () => {
         mockSubmitFundamentalAnalysis.mockResolvedValue(SUBMITTED_RESULT);
     });
 
-    // -------------------------------------------------------------------------
-    // Existing core logic tests
-    // -------------------------------------------------------------------------
-
     it('siglens-core submitFundamentalAnalysis에 symbol과 modelId를 전달한다', async () => {
         mockSubmitFundamentalAnalysis.mockResolvedValueOnce(CACHED_RESULT);
 
@@ -132,10 +128,6 @@ describe('submitFundamentalAnalysisAction 함수는', () => {
 
         expect(result).toBe(SUBMITTED_RESULT);
     });
-
-    // -------------------------------------------------------------------------
-    // Gate behavior tests
-    // -------------------------------------------------------------------------
 
     it('returns blocked result when gate.kind === "blocked"', async () => {
         mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);

--- a/src/__tests__/infrastructure/market/submitNewsAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitNewsAnalysisAction.test.ts
@@ -47,7 +47,10 @@ import { DrizzleNewsRepository } from '@/infrastructure/db/newsRepository';
 import { DrizzleEarningsCalendarRepository } from '@/infrastructure/db/earningsCalendarRepository';
 import { submitNewsAnalysis } from '@y0ngha/siglens-core';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import { resolveTierAndByok, type AnalysisGateError } from '@/infrastructure/market/byokGate';
+import {
+    resolveTierAndByok,
+    type AnalysisGateError,
+} from '@/infrastructure/market/byokGate';
 import { submitNewsAnalysisAction } from '@/infrastructure/market/submitNewsAnalysisAction';
 import type {
     ModelId,

--- a/src/__tests__/infrastructure/market/submitNewsAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitNewsAnalysisAction.test.ts
@@ -1,5 +1,3 @@
-import type { AnalysisGateError } from '@/infrastructure/market/byokGate';
-
 // ---------------------------------------------------------------------------
 // Module mocks
 // ---------------------------------------------------------------------------
@@ -49,7 +47,7 @@ import { DrizzleNewsRepository } from '@/infrastructure/db/newsRepository';
 import { DrizzleEarningsCalendarRepository } from '@/infrastructure/db/earningsCalendarRepository';
 import { submitNewsAnalysis } from '@y0ngha/siglens-core';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import { resolveTierAndByok } from '@/infrastructure/market/byokGate';
+import { resolveTierAndByok, type AnalysisGateError } from '@/infrastructure/market/byokGate';
 import { submitNewsAnalysisAction } from '@/infrastructure/market/submitNewsAnalysisAction';
 import type {
     ModelId,

--- a/src/__tests__/infrastructure/market/submitNewsAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitNewsAnalysisAction.test.ts
@@ -313,4 +313,22 @@ describe('submitNewsAnalysisAction 함수는', () => {
 
         expect(mockResolveTierAndByok).toHaveBeenCalledWith(null, MODEL_ID);
     });
+
+    it('returns unexpected_error result when an unexpected error is thrown', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockRejectedValue(
+            new Error('db connection failed')
+        );
+
+        const result = await submitNewsAnalysisAction(
+            'AAPL',
+            'Apple Inc.',
+            MODEL_ID
+        );
+
+        expect(result).toMatchObject({
+            status: 'error',
+            error: expect.objectContaining({ code: 'unexpected_error' }),
+        });
+    });
 });

--- a/src/__tests__/infrastructure/market/submitNewsAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitNewsAnalysisAction.test.ts
@@ -45,19 +45,17 @@ jest.mock('@/infrastructure/market/byokGate', () => ({
 
 import { DrizzleNewsRepository } from '@/infrastructure/db/newsRepository';
 import { DrizzleEarningsCalendarRepository } from '@/infrastructure/db/earningsCalendarRepository';
-import { submitNewsAnalysis } from '@y0ngha/siglens-core';
-import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
 import {
-    resolveTierAndByok,
-    type AnalysisGateError,
-} from '@/infrastructure/market/byokGate';
-import { submitNewsAnalysisAction } from '@/infrastructure/market/submitNewsAnalysisAction';
-import type {
-    ModelId,
-    SubmitNewsAnalysisResult,
-    EnrichedNewsItem,
-    EarningsCalendarItem,
+    submitNewsAnalysis,
+    type ModelId,
+    type SubmitNewsAnalysisResult,
+    type EnrichedNewsItem,
+    type EarningsCalendarItem,
 } from '@y0ngha/siglens-core';
+import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
+import { resolveTierAndByok } from '@/infrastructure/market/byokGate';
+import type { AnalysisGateError } from '@/domain/types';
+import { submitNewsAnalysisAction } from '@/infrastructure/market/submitNewsAnalysisAction';
 
 const MockNewsRepository = DrizzleNewsRepository as jest.MockedClass<
     typeof DrizzleNewsRepository

--- a/src/__tests__/infrastructure/market/submitNewsAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitNewsAnalysisAction.test.ts
@@ -35,7 +35,10 @@ jest.mock('@/infrastructure/auth/getCurrentUser', () => ({
 
 jest.mock('@/infrastructure/market/byokGate', () => ({
     resolveTierAndByok: jest.fn(),
-    buildGateError: jest.fn((code: string) => ({ code, message: `mock-${code}` })),
+    buildGateError: jest.fn((code: string) => ({
+        code,
+        message: `mock-${code}`,
+    })),
 }));
 
 // ---------------------------------------------------------------------------
@@ -243,7 +246,11 @@ describe('submitNewsAnalysisAction 함수는', () => {
             error: gateError,
         });
 
-        const result = await submitNewsAnalysisAction('AAPL', 'Apple Inc.', PREMIUM_MODEL);
+        const result = await submitNewsAnalysisAction(
+            'AAPL',
+            'Apple Inc.',
+            PREMIUM_MODEL
+        );
 
         expect(result).toEqual({ status: 'error', error: gateError });
         expect(mockSubmitNewsAnalysis).not.toHaveBeenCalled();

--- a/src/__tests__/infrastructure/market/submitNewsAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitNewsAnalysisAction.test.ts
@@ -160,10 +160,6 @@ describe('submitNewsAnalysisAction 함수는', () => {
         mockSubmitNewsAnalysis.mockResolvedValue(SUBMITTED_RESULT);
     });
 
-    // -------------------------------------------------------------------------
-    // Existing core logic tests
-    // -------------------------------------------------------------------------
-
     it('symbol과 modelId를 siglens-core submitNewsAnalysis에 전달한다', async () => {
         mockListBySymbol.mockResolvedValue([ANALYZED_ROW]);
         mockGetNextForSymbol.mockResolvedValue(null);
@@ -234,10 +230,6 @@ describe('submitNewsAnalysisAction 함수는', () => {
 
         expect(result).toBe(noNewsResult);
     });
-
-    // -------------------------------------------------------------------------
-    // Gate behavior tests
-    // -------------------------------------------------------------------------
 
     it('returns blocked result when gate.kind === "blocked"', async () => {
         mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);

--- a/src/__tests__/infrastructure/market/submitNewsAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitNewsAnalysisAction.test.ts
@@ -1,11 +1,4 @@
-import { submitNewsAnalysisAction } from '@/infrastructure/market/submitNewsAnalysisAction';
-import { submitNewsAnalysis } from '@y0ngha/siglens-core';
-import type {
-    ModelId,
-    SubmitNewsAnalysisResult,
-    EnrichedNewsItem,
-    EarningsCalendarItem,
-} from '@y0ngha/siglens-core';
+import type { AnalysisGateError } from '@/infrastructure/market/byokGate';
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -36,12 +29,31 @@ jest.mock('@/infrastructure/db/earningsCalendarRepository', () => ({
     })),
 }));
 
+jest.mock('@/infrastructure/auth/getCurrentUser', () => ({
+    getCurrentUser: jest.fn(),
+}));
+
+jest.mock('@/infrastructure/market/byokGate', () => ({
+    resolveTierAndByok: jest.fn(),
+    buildGateError: jest.fn((code: string) => ({ code, message: `mock-${code}` })),
+}));
+
 // ---------------------------------------------------------------------------
 // Typed mocks & fixtures
 // ---------------------------------------------------------------------------
 
 import { DrizzleNewsRepository } from '@/infrastructure/db/newsRepository';
 import { DrizzleEarningsCalendarRepository } from '@/infrastructure/db/earningsCalendarRepository';
+import { submitNewsAnalysis } from '@y0ngha/siglens-core';
+import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
+import { resolveTierAndByok } from '@/infrastructure/market/byokGate';
+import { submitNewsAnalysisAction } from '@/infrastructure/market/submitNewsAnalysisAction';
+import type {
+    ModelId,
+    SubmitNewsAnalysisResult,
+    EnrichedNewsItem,
+    EarningsCalendarItem,
+} from '@y0ngha/siglens-core';
 
 const MockNewsRepository = DrizzleNewsRepository as jest.MockedClass<
     typeof DrizzleNewsRepository
@@ -52,6 +64,12 @@ const MockCalRepository = DrizzleEarningsCalendarRepository as jest.MockedClass<
 
 const mockSubmitNewsAnalysis = submitNewsAnalysis as jest.MockedFunction<
     typeof submitNewsAnalysis
+>;
+const mockGetCurrentUser = getCurrentUser as jest.MockedFunction<
+    typeof getCurrentUser
+>;
+const mockResolveTierAndByok = resolveTierAndByok as jest.MockedFunction<
+    typeof resolveTierAndByok
 >;
 
 /** An analyzed DB news row (has titleKo, summaryKo, sentiment, category). */
@@ -99,6 +117,12 @@ const SUBMITTED_RESULT: SubmitNewsAnalysisResult = {
 };
 
 const MODEL_ID = 'gemini-2.5-flash' as ModelId;
+const PREMIUM_MODEL = 'claude-opus-4-7' as ModelId;
+
+const gateError: AnalysisGateError = {
+    code: 'tier_premium_blocked',
+    message: 'mock-tier_premium_blocked',
+};
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -112,9 +136,11 @@ describe('submitNewsAnalysisAction 함수는', () => {
         mockSubmitNewsAnalysis.mockReset();
         MockNewsRepository.mockClear();
         MockCalRepository.mockClear();
+        mockGetCurrentUser.mockReset();
+        mockResolveTierAndByok.mockReset();
 
-        mockListBySymbol = jest.fn();
-        mockGetNextForSymbol = jest.fn();
+        mockListBySymbol = jest.fn().mockResolvedValue([ANALYZED_ROW]);
+        mockGetNextForSymbol = jest.fn().mockResolvedValue(null);
 
         MockNewsRepository.mockImplementation(
             () => ({ listBySymbol: mockListBySymbol }) as never
@@ -122,7 +148,18 @@ describe('submitNewsAnalysisAction 함수는', () => {
         MockCalRepository.mockImplementation(
             () => ({ getNextForSymbol: mockGetNextForSymbol }) as never
         );
+
+        mockGetCurrentUser.mockResolvedValue(null);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'free' as never,
+        });
+        mockSubmitNewsAnalysis.mockResolvedValue(SUBMITTED_RESULT);
     });
+
+    // -------------------------------------------------------------------------
+    // Existing core logic tests
+    // -------------------------------------------------------------------------
 
     it('symbol과 modelId를 siglens-core submitNewsAnalysis에 전달한다', async () => {
         mockListBySymbol.mockResolvedValue([ANALYZED_ROW]);
@@ -193,5 +230,80 @@ describe('submitNewsAnalysisAction 함수는', () => {
         );
 
         expect(result).toBe(noNewsResult);
+    });
+
+    // -------------------------------------------------------------------------
+    // Gate behavior tests
+    // -------------------------------------------------------------------------
+
+    it('returns blocked result when gate.kind === "blocked"', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'blocked',
+            error: gateError,
+        });
+
+        const result = await submitNewsAnalysisAction('AAPL', 'Apple Inc.', PREMIUM_MODEL);
+
+        expect(result).toEqual({ status: 'error', error: gateError });
+        expect(mockSubmitNewsAnalysis).not.toHaveBeenCalled();
+        // Gate fires before expensive DB fetches
+        expect(mockListBySymbol).not.toHaveBeenCalled();
+    });
+
+    it('forwards tier="member" to siglens-core when gate allowed', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'member' as never,
+        });
+
+        await submitNewsAnalysisAction('AAPL', 'Apple Inc.', MODEL_ID);
+
+        expect(mockSubmitNewsAnalysis).toHaveBeenCalledWith(
+            expect.objectContaining({ tier: 'member' })
+        );
+    });
+
+    it('forwards userApiKey when present in gate result', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'free' as never,
+            userApiKey: 'usr-key',
+        });
+
+        await submitNewsAnalysisAction('AAPL', 'Apple Inc.', PREMIUM_MODEL);
+
+        expect(mockSubmitNewsAnalysis).toHaveBeenCalledWith(
+            expect.objectContaining({ userApiKey: 'usr-key' })
+        );
+    });
+
+    it('omits userApiKey when not in gate result', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'pro' as never,
+            // no userApiKey
+        });
+
+        await submitNewsAnalysisAction('AAPL', 'Apple Inc.', PREMIUM_MODEL);
+
+        const callArg = mockSubmitNewsAnalysis.mock.calls[0]?.[0];
+        expect(callArg).toBeDefined();
+        expect(callArg).not.toHaveProperty('userApiKey');
+    });
+
+    it('passes null userId when getCurrentUser returns null', async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'free' as never,
+        });
+
+        await submitNewsAnalysisAction('AAPL', 'Apple Inc.', MODEL_ID);
+
+        expect(mockResolveTierAndByok).toHaveBeenCalledWith(null, MODEL_ID);
     });
 });

--- a/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
@@ -162,10 +162,6 @@ describe('submitOverallAnalysisAction 함수는', () => {
         mockSubmitOverallAnalysis.mockResolvedValue(SUBMITTED_RESULT);
     });
 
-    // -------------------------------------------------------------------------
-    // Existing core logic tests
-    // -------------------------------------------------------------------------
-
     it('symbol, timeframe, modelId를 submitOverallAnalysis에 전달한다', async () => {
         mockSubmitOverallAnalysis.mockResolvedValueOnce(SUBMITTED_RESULT);
 
@@ -263,10 +259,6 @@ describe('submitOverallAnalysisAction 함수는', () => {
             error: expect.objectContaining({ code: 'unexpected_error' }),
         });
     });
-
-    // -------------------------------------------------------------------------
-    // Gate behavior tests
-    // -------------------------------------------------------------------------
 
     it('returns blocked result when gate.kind === "blocked"', async () => {
         mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);

--- a/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
@@ -6,7 +6,6 @@ import type {
     EnrichedNewsItem,
     EarningsCalendarItem,
 } from '@y0ngha/siglens-core';
-import type { AnalysisGateError } from '@/infrastructure/market/byokGate';
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -60,7 +59,7 @@ jest.mock('@/infrastructure/market/byokGate', () => ({
 import { DrizzleNewsRepository } from '@/infrastructure/db/newsRepository';
 import { DrizzleEarningsCalendarRepository } from '@/infrastructure/db/earningsCalendarRepository';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import { resolveTierAndByok } from '@/infrastructure/market/byokGate';
+import { resolveTierAndByok, type AnalysisGateError } from '@/infrastructure/market/byokGate';
 
 const MockNewsRepository = DrizzleNewsRepository as jest.MockedClass<
     typeof DrizzleNewsRepository

--- a/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
@@ -258,7 +258,10 @@ describe('submitOverallAnalysisAction 함수는', () => {
             MODEL_ID
         );
 
-        expect(result).toMatchObject({ status: 'error', axis: 'technical' });
+        expect(result).toMatchObject({
+            status: 'error',
+            error: expect.objectContaining({ code: 'unexpected_error' }),
+        });
     });
 
     // -------------------------------------------------------------------------

--- a/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
@@ -59,7 +59,10 @@ jest.mock('@/infrastructure/market/byokGate', () => ({
 import { DrizzleNewsRepository } from '@/infrastructure/db/newsRepository';
 import { DrizzleEarningsCalendarRepository } from '@/infrastructure/db/earningsCalendarRepository';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import { resolveTierAndByok, type AnalysisGateError } from '@/infrastructure/market/byokGate';
+import {
+    resolveTierAndByok,
+    type AnalysisGateError,
+} from '@/infrastructure/market/byokGate';
 
 const MockNewsRepository = DrizzleNewsRepository as jest.MockedClass<
     typeof DrizzleNewsRepository

--- a/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
@@ -47,7 +47,10 @@ jest.mock('@/infrastructure/auth/getCurrentUser', () => ({
 
 jest.mock('@/infrastructure/market/byokGate', () => ({
     resolveTierAndByok: jest.fn(),
-    buildGateError: jest.fn((code: string) => ({ code, message: `mock-${code}` })),
+    buildGateError: jest.fn((code: string) => ({
+        code,
+        message: `mock-${code}`,
+    })),
 }));
 
 // ---------------------------------------------------------------------------
@@ -288,7 +291,12 @@ describe('submitOverallAnalysisAction 함수는', () => {
             tier: 'member' as never,
         });
 
-        await submitOverallAnalysisAction('AAPL', 'Apple Inc.', '1Day', MODEL_ID);
+        await submitOverallAnalysisAction(
+            'AAPL',
+            'Apple Inc.',
+            '1Day',
+            MODEL_ID
+        );
 
         const callArg = mockSubmitOverallAnalysis.mock.calls[0]?.[0];
         expect(callArg).toMatchObject({
@@ -305,7 +313,12 @@ describe('submitOverallAnalysisAction 함수는', () => {
             userApiKey: 'usr-key',
         });
 
-        await submitOverallAnalysisAction('AAPL', 'Apple Inc.', '1Day', PREMIUM_MODEL);
+        await submitOverallAnalysisAction(
+            'AAPL',
+            'Apple Inc.',
+            '1Day',
+            PREMIUM_MODEL
+        );
 
         expect(mockSubmitOverallAnalysis).toHaveBeenCalledWith(
             expect.objectContaining({ userApiKey: 'usr-key' })
@@ -320,7 +333,12 @@ describe('submitOverallAnalysisAction 함수는', () => {
             // no userApiKey
         });
 
-        await submitOverallAnalysisAction('AAPL', 'Apple Inc.', '1Day', PREMIUM_MODEL);
+        await submitOverallAnalysisAction(
+            'AAPL',
+            'Apple Inc.',
+            '1Day',
+            PREMIUM_MODEL
+        );
 
         const callArg = mockSubmitOverallAnalysis.mock.calls[0]?.[0];
         expect(callArg).toBeDefined();
@@ -334,7 +352,12 @@ describe('submitOverallAnalysisAction 함수는', () => {
             tier: 'free' as never,
         });
 
-        await submitOverallAnalysisAction('AAPL', 'Apple Inc.', '1Day', MODEL_ID);
+        await submitOverallAnalysisAction(
+            'AAPL',
+            'Apple Inc.',
+            '1Day',
+            MODEL_ID
+        );
 
         expect(mockResolveTierAndByok).toHaveBeenCalledWith(null, MODEL_ID);
     });
@@ -346,7 +369,12 @@ describe('submitOverallAnalysisAction 함수는', () => {
             tier: 'pro' as never,
         });
 
-        await submitOverallAnalysisAction('AAPL', 'Apple Inc.', '1Day', MODEL_ID);
+        await submitOverallAnalysisAction(
+            'AAPL',
+            'Apple Inc.',
+            '1Day',
+            MODEL_ID
+        );
 
         const callArg = mockSubmitOverallAnalysis.mock.calls[0]?.[0];
         expect(callArg?.technical).toMatchObject({

--- a/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
@@ -1,10 +1,10 @@
 import { submitOverallAnalysisAction } from '@/infrastructure/market/submitOverallAnalysisAction';
-import { submitOverallAnalysis } from '@y0ngha/siglens-core';
-import type {
-    ModelId,
-    SubmitOverallAnalysisResult,
-    EnrichedNewsItem,
-    EarningsCalendarItem,
+import {
+    submitOverallAnalysis,
+    type ModelId,
+    type SubmitOverallAnalysisResult,
+    type EnrichedNewsItem,
+    type EarningsCalendarItem,
 } from '@y0ngha/siglens-core';
 
 // ---------------------------------------------------------------------------
@@ -59,10 +59,8 @@ jest.mock('@/infrastructure/market/byokGate', () => ({
 import { DrizzleNewsRepository } from '@/infrastructure/db/newsRepository';
 import { DrizzleEarningsCalendarRepository } from '@/infrastructure/db/earningsCalendarRepository';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import {
-    resolveTierAndByok,
-    type AnalysisGateError,
-} from '@/infrastructure/market/byokGate';
+import { resolveTierAndByok } from '@/infrastructure/market/byokGate';
+import type { AnalysisGateError } from '@/domain/types';
 
 const MockNewsRepository = DrizzleNewsRepository as jest.MockedClass<
     typeof DrizzleNewsRepository

--- a/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
+++ b/src/__tests__/infrastructure/market/submitOverallAnalysisAction.test.ts
@@ -6,6 +6,7 @@ import type {
     EnrichedNewsItem,
     EarningsCalendarItem,
 } from '@y0ngha/siglens-core';
+import type { AnalysisGateError } from '@/infrastructure/market/byokGate';
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -40,12 +41,23 @@ jest.mock('@/infrastructure/db/earningsCalendarRepository', () => ({
     })),
 }));
 
+jest.mock('@/infrastructure/auth/getCurrentUser', () => ({
+    getCurrentUser: jest.fn(),
+}));
+
+jest.mock('@/infrastructure/market/byokGate', () => ({
+    resolveTierAndByok: jest.fn(),
+    buildGateError: jest.fn((code: string) => ({ code, message: `mock-${code}` })),
+}));
+
 // ---------------------------------------------------------------------------
 // Typed mocks & fixtures
 // ---------------------------------------------------------------------------
 
 import { DrizzleNewsRepository } from '@/infrastructure/db/newsRepository';
 import { DrizzleEarningsCalendarRepository } from '@/infrastructure/db/earningsCalendarRepository';
+import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
+import { resolveTierAndByok } from '@/infrastructure/market/byokGate';
 
 const MockNewsRepository = DrizzleNewsRepository as jest.MockedClass<
     typeof DrizzleNewsRepository
@@ -56,6 +68,12 @@ const MockCalRepository = DrizzleEarningsCalendarRepository as jest.MockedClass<
 
 const mockSubmitOverallAnalysis = submitOverallAnalysis as jest.MockedFunction<
     typeof submitOverallAnalysis
+>;
+const mockGetCurrentUser = getCurrentUser as jest.MockedFunction<
+    typeof getCurrentUser
+>;
+const mockResolveTierAndByok = resolveTierAndByok as jest.MockedFunction<
+    typeof resolveTierAndByok
 >;
 
 const ANALYZED_ROW = {
@@ -101,6 +119,12 @@ const SUBMITTED_RESULT: SubmitOverallAnalysisResult = {
 };
 
 const MODEL_ID = 'gemini-2.5-flash' as ModelId;
+const PREMIUM_MODEL = 'claude-opus-4-7' as ModelId;
+
+const gateError: AnalysisGateError = {
+    code: 'tier_premium_blocked',
+    message: 'mock-tier_premium_blocked',
+};
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -112,11 +136,13 @@ describe('submitOverallAnalysisAction 함수는', () => {
 
     beforeEach(() => {
         mockSubmitOverallAnalysis.mockReset();
+        mockGetCurrentUser.mockReset();
+        mockResolveTierAndByok.mockReset();
         MockNewsRepository.mockClear();
         MockCalRepository.mockClear();
 
-        mockListBySymbol = jest.fn();
-        mockGetNextForSymbol = jest.fn();
+        mockListBySymbol = jest.fn().mockResolvedValue([]);
+        mockGetNextForSymbol = jest.fn().mockResolvedValue(null);
 
         MockNewsRepository.mockImplementation(
             () => ({ listBySymbol: mockListBySymbol }) as never
@@ -124,11 +150,20 @@ describe('submitOverallAnalysisAction 함수는', () => {
         MockCalRepository.mockImplementation(
             () => ({ getNextForSymbol: mockGetNextForSymbol }) as never
         );
+
+        mockGetCurrentUser.mockResolvedValue(null);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'free' as never,
+        });
+        mockSubmitOverallAnalysis.mockResolvedValue(SUBMITTED_RESULT);
     });
 
+    // -------------------------------------------------------------------------
+    // Existing core logic tests
+    // -------------------------------------------------------------------------
+
     it('symbol, timeframe, modelId를 submitOverallAnalysis에 전달한다', async () => {
-        mockListBySymbol.mockResolvedValue([]);
-        mockGetNextForSymbol.mockResolvedValue(null);
         mockSubmitOverallAnalysis.mockResolvedValueOnce(SUBMITTED_RESULT);
 
         await submitOverallAnalysisAction(
@@ -149,7 +184,6 @@ describe('submitOverallAnalysisAction 함수는', () => {
 
     it('titleKo가 null인 미분석 뉴스를 필터링하고 enrichedNews만 전달한다', async () => {
         mockListBySymbol.mockResolvedValue([ANALYZED_ROW, UNANALYZED_ROW]);
-        mockGetNextForSymbol.mockResolvedValue(null);
         mockSubmitOverallAnalysis.mockResolvedValueOnce(SUBMITTED_RESULT);
 
         await submitOverallAnalysisAction(
@@ -166,7 +200,6 @@ describe('submitOverallAnalysisAction 함수는', () => {
     });
 
     it('다음 실적 발표가 있으면 upcomingCalendar에 포함한다', async () => {
-        mockListBySymbol.mockResolvedValue([]);
         mockGetNextForSymbol.mockResolvedValue(NEXT_EARNINGS);
         mockSubmitOverallAnalysis.mockResolvedValueOnce(SUBMITTED_RESULT);
 
@@ -183,8 +216,6 @@ describe('submitOverallAnalysisAction 함수는', () => {
     });
 
     it('다음 실적 발표가 없으면 upcomingCalendar는 빈 배열이다', async () => {
-        mockListBySymbol.mockResolvedValue([]);
-        mockGetNextForSymbol.mockResolvedValue(null);
         mockSubmitOverallAnalysis.mockResolvedValueOnce(SUBMITTED_RESULT);
 
         await submitOverallAnalysisAction(
@@ -200,8 +231,6 @@ describe('submitOverallAnalysisAction 함수는', () => {
     });
 
     it('underlying 함수의 결과를 그대로 반환한다', async () => {
-        mockListBySymbol.mockResolvedValue([]);
-        mockGetNextForSymbol.mockResolvedValue(null);
         mockSubmitOverallAnalysis.mockResolvedValueOnce(SUBMITTED_RESULT);
 
         const result = await submitOverallAnalysisAction(
@@ -215,8 +244,6 @@ describe('submitOverallAnalysisAction 함수는', () => {
     });
 
     it('내부에서 예외가 발생하면 status: error를 반환한다', async () => {
-        mockListBySymbol.mockResolvedValue([]);
-        mockGetNextForSymbol.mockResolvedValue(null);
         mockSubmitOverallAnalysis.mockRejectedValueOnce(
             new Error('unexpected')
         );
@@ -229,5 +256,101 @@ describe('submitOverallAnalysisAction 함수는', () => {
         );
 
         expect(result).toMatchObject({ status: 'error', axis: 'technical' });
+    });
+
+    // -------------------------------------------------------------------------
+    // Gate behavior tests
+    // -------------------------------------------------------------------------
+
+    it('returns blocked result when gate.kind === "blocked"', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'blocked',
+            error: gateError,
+        });
+
+        const result = await submitOverallAnalysisAction(
+            'AAPL',
+            'Apple Inc.',
+            '1Day',
+            PREMIUM_MODEL
+        );
+
+        expect(result).toEqual({ status: 'error', error: gateError });
+        // Gate fires before expensive DB fetch
+        expect(mockSubmitOverallAnalysis).not.toHaveBeenCalled();
+    });
+
+    it('forwards tier as top-level and technical axis tierContext when gate allowed', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'member' as never,
+        });
+
+        await submitOverallAnalysisAction('AAPL', 'Apple Inc.', '1Day', MODEL_ID);
+
+        const callArg = mockSubmitOverallAnalysis.mock.calls[0]?.[0];
+        expect(callArg).toMatchObject({
+            tier: 'member',
+            technical: { tierContext: { tier: 'member' } },
+        });
+    });
+
+    it('forwards userApiKey as top-level when present in gate result', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'free' as never,
+            userApiKey: 'usr-key',
+        });
+
+        await submitOverallAnalysisAction('AAPL', 'Apple Inc.', '1Day', PREMIUM_MODEL);
+
+        expect(mockSubmitOverallAnalysis).toHaveBeenCalledWith(
+            expect.objectContaining({ userApiKey: 'usr-key' })
+        );
+    });
+
+    it('omits userApiKey when not in gate result', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'pro' as never,
+            // no userApiKey
+        });
+
+        await submitOverallAnalysisAction('AAPL', 'Apple Inc.', '1Day', PREMIUM_MODEL);
+
+        const callArg = mockSubmitOverallAnalysis.mock.calls[0]?.[0];
+        expect(callArg).toBeDefined();
+        expect(callArg).not.toHaveProperty('userApiKey');
+    });
+
+    it('passes null userId when getCurrentUser returns null', async () => {
+        mockGetCurrentUser.mockResolvedValue(null);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'free' as never,
+        });
+
+        await submitOverallAnalysisAction('AAPL', 'Apple Inc.', '1Day', MODEL_ID);
+
+        expect(mockResolveTierAndByok).toHaveBeenCalledWith(null, MODEL_ID);
+    });
+
+    it('technical axis tierContext.userId matches the resolved userId', async () => {
+        mockGetCurrentUser.mockResolvedValue({ id: 'user-abc' } as never);
+        mockResolveTierAndByok.mockResolvedValue({
+            kind: 'allowed',
+            tier: 'pro' as never,
+        });
+
+        await submitOverallAnalysisAction('AAPL', 'Apple Inc.', '1Day', MODEL_ID);
+
+        const callArg = mockSubmitOverallAnalysis.mock.calls[0]?.[0];
+        expect(callArg?.technical).toMatchObject({
+            tierContext: { userId: 'user-abc', tier: 'pro' },
+        });
     });
 });

--- a/src/components/fundamental/hooks/useFundamentalAnalysis.ts
+++ b/src/components/fundamental/hooks/useFundamentalAnalysis.ts
@@ -7,7 +7,7 @@ import type {
     ModelId,
 } from '@y0ngha/siglens-core';
 import { submitFundamentalAnalysisAction } from '@/infrastructure/market/submitFundamentalAnalysisAction';
-import type { AnalysisGateBlockedResult } from '@/infrastructure/market/submitFundamentalAnalysisAction';
+import { isGateBlockedResult } from '@/domain/analysis/gate';
 import { pollFundamentalAnalysisAction } from '@/infrastructure/market/pollFundamentalAnalysisAction';
 import { cancelFundamentalAnalysisJobAction } from '@/infrastructure/market/cancelFundamentalAnalysisJobAction';
 import { sleep } from '@/lib/sleep';
@@ -18,33 +18,6 @@ export type FundamentalAnalysisState =
     | { status: 'loading' }
     | { status: 'done'; result: FundamentalAnalysisResponse }
     | { status: 'error'; error: Error; retry: () => void };
-
-/**
- * Narrows to AnalysisGateBlockedResult by checking for the gate-specific error shape.
- * AnalysisGateBlockedResult.error is { code: AnalysisGateErrorCode, message }.
- * SubmitFundamentalAnalysisLimitError.error is AnalysisLimitError (also an object),
- * so we distinguish by matching against known gate codes.
- */
-const GATE_ERROR_CODES = [
-    'tier_premium_blocked',
-    'invalid_model',
-    'api_key_corrupted',
-    'unexpected_error',
-] as const;
-
-function isGateBlockedResult(result: {
-    status: 'error';
-    error?: unknown;
-}): result is AnalysisGateBlockedResult {
-    return (
-        typeof result.error === 'object' &&
-        result.error !== null &&
-        'code' in result.error &&
-        (GATE_ERROR_CODES as readonly string[]).includes(
-            (result.error as { code: string }).code
-        )
-    );
-}
 
 // AbortSignal로 unmount 시 폴링을 즉시 종료한다.
 // onJobId는 두 번째 인자(expectedCurrent)를 받으면 ref가 일치할 때만 갱신한다 →
@@ -65,7 +38,6 @@ async function fetchFundamentalAnalysis(
         if (isGateBlockedResult(submitted)) {
             throw new Error(submitted.error.message);
         }
-        // SubmitFundamentalAnalysisLimitError / SubmitFundamentalAnalysisFetchError
         const message =
             submitted.code === 'fetch_failed'
                 ? (submitted.error ?? '데이터를 불러오지 못했습니다.')

--- a/src/components/fundamental/hooks/useFundamentalAnalysis.ts
+++ b/src/components/fundamental/hooks/useFundamentalAnalysis.ts
@@ -7,6 +7,7 @@ import type {
     ModelId,
 } from '@y0ngha/siglens-core';
 import { submitFundamentalAnalysisAction } from '@/infrastructure/market/submitFundamentalAnalysisAction';
+import type { AnalysisGateBlockedResult } from '@/infrastructure/market/submitFundamentalAnalysisAction';
 import { pollFundamentalAnalysisAction } from '@/infrastructure/market/pollFundamentalAnalysisAction';
 import { cancelFundamentalAnalysisJobAction } from '@/infrastructure/market/cancelFundamentalAnalysisJobAction';
 import { sleep } from '@/lib/sleep';
@@ -17,6 +18,32 @@ export type FundamentalAnalysisState =
     | { status: 'loading' }
     | { status: 'done'; result: FundamentalAnalysisResponse }
     | { status: 'error'; error: Error; retry: () => void };
+
+/**
+ * Narrows to AnalysisGateBlockedResult by checking for the gate-specific error shape.
+ * AnalysisGateBlockedResult.error is { code: AnalysisGateErrorCode, message }.
+ * SubmitFundamentalAnalysisLimitError.error is AnalysisLimitError (also an object),
+ * so we distinguish by matching against known gate codes.
+ */
+const GATE_ERROR_CODES = [
+    'tier_premium_blocked',
+    'invalid_model',
+    'api_key_corrupted',
+    'unexpected_error',
+] as const;
+
+function isGateBlockedResult(
+    result: { status: 'error'; error?: unknown }
+): result is AnalysisGateBlockedResult {
+    return (
+        typeof result.error === 'object' &&
+        result.error !== null &&
+        'code' in result.error &&
+        (GATE_ERROR_CODES as readonly string[]).includes(
+            (result.error as { code: string }).code
+        )
+    );
+}
 
 // AbortSignal로 unmount 시 폴링을 즉시 종료한다.
 // onJobId는 두 번째 인자(expectedCurrent)를 받으면 ref가 일치할 때만 갱신한다 →
@@ -32,6 +59,12 @@ async function fetchFundamentalAnalysis(
 
     if (submitted.status === 'cached') return submitted.result;
     if (submitted.status === 'error') {
+        // AnalysisGateBlockedResult: error is { code: AnalysisGateErrorCode, message }
+        // — no top-level `code` field. Handle before the existing SubmitFundamentalAnalysisResult variants.
+        if (isGateBlockedResult(submitted)) {
+            throw new Error(submitted.error.message);
+        }
+        // SubmitFundamentalAnalysisLimitError / SubmitFundamentalAnalysisFetchError
         const message =
             submitted.code === 'fetch_failed'
                 ? (submitted.error ?? '데이터를 불러오지 못했습니다.')

--- a/src/components/fundamental/hooks/useFundamentalAnalysis.ts
+++ b/src/components/fundamental/hooks/useFundamentalAnalysis.ts
@@ -32,9 +32,10 @@ const GATE_ERROR_CODES = [
     'unexpected_error',
 ] as const;
 
-function isGateBlockedResult(
-    result: { status: 'error'; error?: unknown }
-): result is AnalysisGateBlockedResult {
+function isGateBlockedResult(result: {
+    status: 'error';
+    error?: unknown;
+}): result is AnalysisGateBlockedResult {
     return (
         typeof result.error === 'object' &&
         result.error !== null &&

--- a/src/components/fundamental/hooks/useFundamentalAnalysis.ts
+++ b/src/components/fundamental/hooks/useFundamentalAnalysis.ts
@@ -33,8 +33,7 @@ async function fetchFundamentalAnalysis(
 
     if (submitted.status === 'cached') return submitted.result;
     if (submitted.status === 'error') {
-        // AnalysisGateBlockedResult: error is { code: AnalysisGateErrorCode, message }
-        // — no top-level `code` field. Handle before the existing SubmitFundamentalAnalysisResult variants.
+        // Handle before the existing SubmitFundamentalAnalysisResult variants.
         if (isGateBlockedResult(submitted)) {
             throw new Error(submitted.error.message);
         }

--- a/src/components/fundamental/hooks/useFundamentalAnalysis.ts
+++ b/src/components/fundamental/hooks/useFundamentalAnalysis.ts
@@ -72,6 +72,9 @@ async function fetchFundamentalAnalysis(
                 : '사용량 한도를 초과했습니다.';
         throw new Error(message);
     }
+    if (submitted.status === 'key_error') {
+        throw new Error(submitted.error);
+    }
 
     onJobId(submitted.jobId);
     try {

--- a/src/components/news/hooks/useNewsAnalysis.ts
+++ b/src/components/news/hooks/useNewsAnalysis.ts
@@ -36,8 +36,7 @@ async function fetchNewsAnalysis(
 
     if (submitted.status === 'cached') return submitted.result;
     if (submitted.status === 'error') {
-        // AnalysisGateBlockedResult: error is { code: AnalysisGateErrorCode, message }
-        // — no top-level `code` field. Handle before the existing SubmitNewsAnalysisResult variants.
+        // Handle before the existing SubmitNewsAnalysisResult variants.
         if (isGateBlockedResult(submitted)) {
             throw new Error(submitted.error.message);
         }

--- a/src/components/news/hooks/useNewsAnalysis.ts
+++ b/src/components/news/hooks/useNewsAnalysis.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { NewsAnalysisResponse, ModelId } from '@y0ngha/siglens-core';
 import { submitNewsAnalysisAction } from '@/infrastructure/market/submitNewsAnalysisAction';
-import type { AnalysisGateBlockedResult } from '@/infrastructure/market/submitNewsAnalysisAction';
+import { isGateBlockedResult } from '@/domain/analysis/gate';
 import { pollNewsAnalysisAction } from '@/infrastructure/market/pollNewsAnalysisAction';
 import { cancelNewsAnalysisJobAction } from '@/infrastructure/market/cancelNewsAnalysisJobAction';
 import { sleep } from '@/lib/sleep';
@@ -15,33 +15,6 @@ export type NewsAnalysisState =
     | { status: 'loading' }
     | { status: 'done'; result: NewsAnalysisResponse }
     | { status: 'error'; error: Error; retry: () => void };
-
-/**
- * Narrows to AnalysisGateBlockedResult by checking for the gate-specific error shape.
- * AnalysisGateBlockedResult.error is { code: AnalysisGateErrorCode, message }.
- * SubmitNewsAnalysisLimitError.error is AnalysisLimitError (also an object),
- * so we distinguish by matching against known gate codes.
- */
-const GATE_ERROR_CODES = [
-    'tier_premium_blocked',
-    'invalid_model',
-    'api_key_corrupted',
-    'unexpected_error',
-] as const;
-
-function isGateBlockedResult(result: {
-    status: 'error';
-    error?: unknown;
-}): result is AnalysisGateBlockedResult {
-    return (
-        typeof result.error === 'object' &&
-        result.error !== null &&
-        'code' in result.error &&
-        (GATE_ERROR_CODES as readonly string[]).includes(
-            (result.error as { code: string }).code
-        )
-    );
-}
 
 // AbortSignal로 unmount 시 폴링을 즉시 종료한다.
 // onJobId는 두 번째 인자(expectedCurrent)를 받으면 ref가 일치할 때만 갱신한다 →
@@ -68,7 +41,6 @@ async function fetchNewsAnalysis(
         if (isGateBlockedResult(submitted)) {
             throw new Error(submitted.error.message);
         }
-        // SubmitNewsAnalysisNoNewsError / SubmitNewsAnalysisLimitError
         if (submitted.code === 'no_news') {
             throw new Error(
                 '분석할 뉴스가 없습니다. 잠시 후 다시 시도해 주세요.'

--- a/src/components/news/hooks/useNewsAnalysis.ts
+++ b/src/components/news/hooks/useNewsAnalysis.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { NewsAnalysisResponse, ModelId } from '@y0ngha/siglens-core';
 import { submitNewsAnalysisAction } from '@/infrastructure/market/submitNewsAnalysisAction';
+import type { AnalysisGateBlockedResult } from '@/infrastructure/market/submitNewsAnalysisAction';
 import { pollNewsAnalysisAction } from '@/infrastructure/market/pollNewsAnalysisAction';
 import { cancelNewsAnalysisJobAction } from '@/infrastructure/market/cancelNewsAnalysisJobAction';
 import { sleep } from '@/lib/sleep';
@@ -14,6 +15,32 @@ export type NewsAnalysisState =
     | { status: 'loading' }
     | { status: 'done'; result: NewsAnalysisResponse }
     | { status: 'error'; error: Error; retry: () => void };
+
+/**
+ * Narrows to AnalysisGateBlockedResult by checking for the gate-specific error shape.
+ * AnalysisGateBlockedResult.error is { code: AnalysisGateErrorCode, message }.
+ * SubmitNewsAnalysisLimitError.error is AnalysisLimitError (also an object),
+ * so we distinguish by matching against known gate codes.
+ */
+const GATE_ERROR_CODES = [
+    'tier_premium_blocked',
+    'invalid_model',
+    'api_key_corrupted',
+    'unexpected_error',
+] as const;
+
+function isGateBlockedResult(
+    result: { status: 'error'; error?: unknown }
+): result is AnalysisGateBlockedResult {
+    return (
+        typeof result.error === 'object' &&
+        result.error !== null &&
+        'code' in result.error &&
+        (GATE_ERROR_CODES as readonly string[]).includes(
+            (result.error as { code: string }).code
+        )
+    );
+}
 
 // AbortSignal로 unmount 시 폴링을 즉시 종료한다.
 // onJobId는 두 번째 인자(expectedCurrent)를 받으면 ref가 일치할 때만 갱신한다 →
@@ -35,6 +62,12 @@ async function fetchNewsAnalysis(
 
     if (submitted.status === 'cached') return submitted.result;
     if (submitted.status === 'error') {
+        // AnalysisGateBlockedResult: error is { code: AnalysisGateErrorCode, message }
+        // — no top-level `code` field. Handle before the existing SubmitNewsAnalysisResult variants.
+        if (isGateBlockedResult(submitted)) {
+            throw new Error(submitted.error.message);
+        }
+        // SubmitNewsAnalysisNoNewsError / SubmitNewsAnalysisLimitError
         if (submitted.code === 'no_news') {
             throw new Error(
                 '분석할 뉴스가 없습니다. 잠시 후 다시 시도해 주세요.'

--- a/src/components/news/hooks/useNewsAnalysis.ts
+++ b/src/components/news/hooks/useNewsAnalysis.ts
@@ -79,6 +79,9 @@ async function fetchNewsAnalysis(
         }
         throw new Error('분석 중 오류가 발생했습니다.');
     }
+    if (submitted.status === 'key_error') {
+        throw new Error(submitted.error);
+    }
 
     onJobId(submitted.jobId);
     try {

--- a/src/components/news/hooks/useNewsAnalysis.ts
+++ b/src/components/news/hooks/useNewsAnalysis.ts
@@ -29,9 +29,10 @@ const GATE_ERROR_CODES = [
     'unexpected_error',
 ] as const;
 
-function isGateBlockedResult(
-    result: { status: 'error'; error?: unknown }
-): result is AnalysisGateBlockedResult {
+function isGateBlockedResult(result: {
+    status: 'error';
+    error?: unknown;
+}): result is AnalysisGateBlockedResult {
     return (
         typeof result.error === 'object' &&
         result.error !== null &&

--- a/src/components/overall/hooks/useOverallAnalysis.ts
+++ b/src/components/overall/hooks/useOverallAnalysis.ts
@@ -86,9 +86,10 @@ const GATE_ERROR_CODES = [
     'unexpected_error',
 ] as const;
 
-function isGateBlockedResult(
-    result: { status: 'error'; error?: unknown }
-): result is AnalysisGateBlockedResult {
+function isGateBlockedResult(result: {
+    status: 'error';
+    error?: unknown;
+}): result is AnalysisGateBlockedResult {
     return (
         typeof result.error === 'object' &&
         result.error !== null &&

--- a/src/components/overall/hooks/useOverallAnalysis.ts
+++ b/src/components/overall/hooks/useOverallAnalysis.ts
@@ -9,7 +9,7 @@ import type {
     Timeframe,
 } from '@y0ngha/siglens-core';
 import { submitOverallAnalysisAction } from '@/infrastructure/market/submitOverallAnalysisAction';
-import type { AnalysisGateBlockedResult } from '@/infrastructure/market/submitOverallAnalysisAction';
+import { isGateBlockedResult } from '@/domain/analysis/gate';
 import { pollOverallAnalysisAction } from '@/infrastructure/market/pollOverallAnalysisAction';
 import { pollAnalysisAction } from '@/infrastructure/market/pollAnalysisAction';
 import { pollFundamentalAnalysisAction } from '@/infrastructure/market/pollFundamentalAnalysisAction';
@@ -71,33 +71,6 @@ class OverallAnalysisError extends Error {
         super(message);
         this.name = 'OverallAnalysisError';
     }
-}
-
-/**
- * Narrows to AnalysisGateBlockedResult by checking for the gate-specific error shape.
- * AnalysisGateBlockedResult.error is { code: AnalysisGateErrorCode, message }.
- * SubmitOverallAnalysisError.error is unknown (may be string or object), so we
- * distinguish by matching against known gate codes.
- */
-const GATE_ERROR_CODES = [
-    'tier_premium_blocked',
-    'invalid_model',
-    'api_key_corrupted',
-    'unexpected_error',
-] as const;
-
-function isGateBlockedResult(result: {
-    status: 'error';
-    error?: unknown;
-}): result is AnalysisGateBlockedResult {
-    return (
-        typeof result.error === 'object' &&
-        result.error !== null &&
-        'code' in result.error &&
-        (GATE_ERROR_CODES as readonly string[]).includes(
-            (result.error as { code: string }).code
-        )
-    );
 }
 
 function throwIfAborted(signal: AbortSignal): void {
@@ -276,7 +249,6 @@ async function fetchOverallAnalysis(
         if (isGateBlockedResult(submitted)) {
             throw new OverallAnalysisError(submitted.error.message, undefined);
         }
-        // SubmitOverallAnalysisError: has axis + error payload (string or unknown).
         throw new OverallAnalysisError(
             typeof submitted.error === 'string'
                 ? submitted.error

--- a/src/components/overall/hooks/useOverallAnalysis.ts
+++ b/src/components/overall/hooks/useOverallAnalysis.ts
@@ -9,6 +9,7 @@ import type {
     Timeframe,
 } from '@y0ngha/siglens-core';
 import { submitOverallAnalysisAction } from '@/infrastructure/market/submitOverallAnalysisAction';
+import type { AnalysisGateBlockedResult } from '@/infrastructure/market/submitOverallAnalysisAction';
 import { pollOverallAnalysisAction } from '@/infrastructure/market/pollOverallAnalysisAction';
 import { pollAnalysisAction } from '@/infrastructure/market/pollAnalysisAction';
 import { pollFundamentalAnalysisAction } from '@/infrastructure/market/pollFundamentalAnalysisAction';
@@ -58,8 +59,9 @@ const AXIS_ORDER: readonly OverallAxis[] = ['technical', 'fundamental', 'news'];
 const MAX_SUBMIT_RETRY_DEPTH = 3;
 
 /**
- * submitOverallAnalysisAction이 axis 정보와 함께 에러를 돌려줄 수 있으므로
- * 커스텀 에러 클래스로 axis를 보존한다.
+ * submitOverallAnalysisAction이 axis 정보와 함께 에러를 돌려줄 수 있어
+ * 커스텀 에러 클래스로 axis를 보존한다. 게이트 오류(AnalysisGateBlockedResult)는
+ * axis가 없으므로 undefined로 전달된다.
  */
 class OverallAnalysisError extends Error {
     constructor(
@@ -69,6 +71,32 @@ class OverallAnalysisError extends Error {
         super(message);
         this.name = 'OverallAnalysisError';
     }
+}
+
+/**
+ * Narrows to AnalysisGateBlockedResult by checking for the gate-specific error shape.
+ * AnalysisGateBlockedResult.error is { code: AnalysisGateErrorCode, message }.
+ * SubmitOverallAnalysisError.error is unknown (may be string or object), so we
+ * distinguish by matching against known gate codes.
+ */
+const GATE_ERROR_CODES = [
+    'tier_premium_blocked',
+    'invalid_model',
+    'api_key_corrupted',
+    'unexpected_error',
+] as const;
+
+function isGateBlockedResult(
+    result: { status: 'error'; error?: unknown }
+): result is AnalysisGateBlockedResult {
+    return (
+        typeof result.error === 'object' &&
+        result.error !== null &&
+        'code' in result.error &&
+        (GATE_ERROR_CODES as readonly string[]).includes(
+            (result.error as { code: string }).code
+        )
+    );
 }
 
 function throwIfAborted(signal: AbortSignal): void {
@@ -243,6 +271,11 @@ async function fetchOverallAnalysis(
     if (submitted.status === 'cached') return submitted.result;
 
     if (submitted.status === 'error') {
+        // AnalysisGateBlockedResult: error is { code: AnalysisGateErrorCode, message }, no axis.
+        if (isGateBlockedResult(submitted)) {
+            throw new OverallAnalysisError(submitted.error.message, undefined);
+        }
+        // SubmitOverallAnalysisError: has axis + error payload (string or unknown).
         throw new OverallAnalysisError(
             typeof submitted.error === 'string'
                 ? submitted.error

--- a/src/components/overall/hooks/useOverallAnalysis.ts
+++ b/src/components/overall/hooks/useOverallAnalysis.ts
@@ -290,6 +290,9 @@ async function fetchOverallAnalysis(
             '오늘 분석 한도를 모두 사용했어요. 내일 다시 시도해 주세요.'
         );
     }
+    if (submitted.status === 'key_error') {
+        throw new OverallAnalysisError(submitted.error, undefined);
+    }
 
     const { jobId } = submitted;
     trackedUpdate({ phase: 'overall', jobId });

--- a/src/components/symbol-page/hooks/useAnalysis.ts
+++ b/src/components/symbol-page/hooks/useAnalysis.ts
@@ -199,6 +199,9 @@ export function useAnalysis({
                 setIsPolling(true);
                 // submitted 단계에서는 쿨다운을 시작하지 않는다.
                 // polling 완료(done) 시에만 쿨다운을 시작한다.
+            } else if (data.status === 'key_error') {
+                currentJobIdRef.current = null;
+                setPollError(data.error);
             } else {
                 // tier gate / 일일 사용 한도 초과
                 currentJobIdRef.current = null;

--- a/src/domain/analysis/gate.ts
+++ b/src/domain/analysis/gate.ts
@@ -45,8 +45,9 @@ const GATE_ERROR_CODE_KEYS: Record<AnalysisGateErrorCode, true> = {
  * so the array stays in sync with the {@link AnalysisGateErrorCode} union
  * automatically.
  */
-export const GATE_ERROR_CODES: readonly AnalysisGateErrorCode[] =
-    Object.keys(GATE_ERROR_CODE_KEYS) as AnalysisGateErrorCode[];
+export const GATE_ERROR_CODES: readonly AnalysisGateErrorCode[] = Object.keys(
+    GATE_ERROR_CODE_KEYS
+) as AnalysisGateErrorCode[];
 
 /**
  * Type guard distinguishing `AnalysisGateBlockedResult` from sibling

--- a/src/domain/analysis/gate.ts
+++ b/src/domain/analysis/gate.ts
@@ -1,0 +1,69 @@
+/**
+ * Analysis gate types and runtime guards.
+ *
+ * These describe siglens-side denial outcomes from the BYOK/tier gate
+ * (`resolveTierAndByok` in infrastructure). The types live in the domain
+ * layer so consumer hooks can narrow on action results without depending
+ * on the infrastructure implementation.
+ */
+
+/** Machine-readable codes for siglens-side analysis gate denials. */
+export type AnalysisGateErrorCode =
+    | 'tier_premium_blocked'
+    | 'invalid_model'
+    | 'api_key_corrupted'
+    | 'unexpected_error';
+
+/** Structured gate error returned from action layer. */
+export interface AnalysisGateError {
+    code: AnalysisGateErrorCode;
+    message: string;
+}
+
+/** Gate denial result — mirrors core's `{ status: 'error' }` discriminator. */
+export interface AnalysisGateBlockedResult {
+    status: 'error';
+    error: AnalysisGateError;
+}
+
+/**
+ * All gate error codes as a runtime array. Used by `isGateBlockedResult`
+ * to distinguish gate denials from other `status: 'error'` variants
+ * (e.g. SubmitXxxLimitError) which also have an `error.code` field.
+ *
+ * Keep in sync with {@link AnalysisGateErrorCode}.
+ */
+export const GATE_ERROR_CODES: readonly AnalysisGateErrorCode[] = [
+    'tier_premium_blocked',
+    'invalid_model',
+    'api_key_corrupted',
+    'unexpected_error',
+];
+
+/**
+ * Type guard distinguishing `AnalysisGateBlockedResult` from sibling
+ * `status: 'error'` variants whose `error` is a different shape
+ * (e.g. `SubmitFundamentalAnalysisLimitError.error` is `AnalysisLimitError`).
+ *
+ * The shape check (`'code' in error` + known-codes lookup) catches the
+ * gate-specific code values; non-gate `status: 'error'` results have
+ * different code namespaces (`'fetch_failed'`, `'no_news'`,
+ * `'usage_limit_exceeded'`) and won't match.
+ */
+export function isGateBlockedResult(result: {
+    status: 'error';
+    error?: unknown;
+}): result is AnalysisGateBlockedResult {
+    if (typeof result.error !== 'object' || result.error === null) {
+        return false;
+    }
+    if (!('code' in result.error)) {
+        return false;
+    }
+    // After 'code' in result.error, TS narrows result.error to `object & {code: unknown}`.
+    // The array's element type is the literal union AnalysisGateErrorCode, but
+    // .includes() on a literal-union array refuses non-literal arguments —
+    // widen to readonly string[] for the lookup. Safe: read-only check, no mutation.
+    const code = (result.error as { code: unknown }).code;
+    return (GATE_ERROR_CODES as readonly string[]).includes(code as string);
+}

--- a/src/domain/analysis/gate.ts
+++ b/src/domain/analysis/gate.ts
@@ -78,5 +78,8 @@ export function isGateBlockedResult(result: {
     // TypeScript doesn't narrow 'object' + 'in' check to { code: unknown } — TS limitation.
     const code = (result.error as { code: unknown }).code;
     // typeof guard avoids casting unknown to string; non-string code returns false.
-    return typeof code === 'string' && (GATE_ERROR_CODES as readonly string[]).includes(code);
+    return (
+        typeof code === 'string' &&
+        (GATE_ERROR_CODES as readonly string[]).includes(code)
+    );
 }

--- a/src/domain/analysis/gate.ts
+++ b/src/domain/analysis/gate.ts
@@ -27,18 +27,26 @@ export interface AnalysisGateBlockedResult {
 }
 
 /**
- * All gate error codes as a runtime array. Used by `isGateBlockedResult`
- * to distinguish gate denials from other `status: 'error'` variants
- * (e.g. SubmitXxxLimitError) which also have an `error.code` field.
+ * Marker record forcing compile-time exhaustiveness for {@link GATE_ERROR_CODES}.
  *
- * Keep in sync with {@link AnalysisGateErrorCode}.
+ * The `Record<AnalysisGateErrorCode, true>` type ensures every union member
+ * appears as a key — adding a new code to `AnalysisGateErrorCode` will fail
+ * to compile until added here. The values are unused; only keys are read.
  */
-export const GATE_ERROR_CODES: readonly AnalysisGateErrorCode[] = [
-    'tier_premium_blocked',
-    'invalid_model',
-    'api_key_corrupted',
-    'unexpected_error',
-];
+const GATE_ERROR_CODE_KEYS: Record<AnalysisGateErrorCode, true> = {
+    tier_premium_blocked: true,
+    invalid_model: true,
+    api_key_corrupted: true,
+    unexpected_error: true,
+};
+
+/**
+ * All gate error codes as a runtime array. Derived from {@link GATE_ERROR_CODE_KEYS}
+ * so the array stays in sync with the {@link AnalysisGateErrorCode} union
+ * automatically.
+ */
+export const GATE_ERROR_CODES: readonly AnalysisGateErrorCode[] =
+    Object.keys(GATE_ERROR_CODE_KEYS) as AnalysisGateErrorCode[];
 
 /**
  * Type guard distinguishing `AnalysisGateBlockedResult` from sibling

--- a/src/domain/analysis/gate.ts
+++ b/src/domain/analysis/gate.ts
@@ -45,6 +45,8 @@ const GATE_ERROR_CODE_KEYS: Record<AnalysisGateErrorCode, true> = {
  * so the array stays in sync with the {@link AnalysisGateErrorCode} union
  * automatically.
  */
+// Object.keys widens to string[], but GATE_ERROR_CODE_KEYS: Record<AnalysisGateErrorCode, true>
+// guarantees every union member appears as a key — TS limitation, not a runtime risk.
 export const GATE_ERROR_CODES: readonly AnalysisGateErrorCode[] = Object.keys(
     GATE_ERROR_CODE_KEYS
 ) as AnalysisGateErrorCode[];
@@ -69,7 +71,6 @@ export function isGateBlockedResult(result: {
     if (!('code' in result.error)) {
         return false;
     }
-    // After 'code' in result.error, TS narrows result.error to `object & {code: unknown}`.
     // The array's element type is the literal union AnalysisGateErrorCode, but
     // .includes() on a literal-union array refuses non-literal arguments —
     // widen to readonly string[] for the lookup. Safe: read-only check, no mutation.

--- a/src/domain/analysis/gate.ts
+++ b/src/domain/analysis/gate.ts
@@ -74,6 +74,9 @@ export function isGateBlockedResult(result: {
     // The array's element type is the literal union AnalysisGateErrorCode, but
     // .includes() on a literal-union array refuses non-literal arguments —
     // widen to readonly string[] for the lookup. Safe: read-only check, no mutation.
+    // result.error is proven non-null object with 'code' property by the guards above.
+    // TypeScript doesn't narrow 'object' + 'in' check to { code: unknown } — TS limitation.
     const code = (result.error as { code: unknown }).code;
-    return (GATE_ERROR_CODES as readonly string[]).includes(code as string);
+    // typeof guard avoids casting unknown to string; non-string code returns false.
+    return typeof code === 'string' && (GATE_ERROR_CODES as readonly string[]).includes(code);
 }

--- a/src/domain/llm/modelTier.ts
+++ b/src/domain/llm/modelTier.ts
@@ -1,14 +1,8 @@
-import { isFreeModel } from '@y0ngha/siglens-core';
+import { TIER_CONFIG } from '@y0ngha/siglens-core';
 import type { ModelId } from '@y0ngha/siglens-core';
 
-/**
- * Returns true if the model is in the free tier (i.e., the platform/server pays
- * for inference). Delegates to siglens-core's `isFreeModel` for a single
- * source of truth across analysis and chat call sites.
- *
- * Like `isFreeModel`, this is a classifier of the model's intrinsic tier class
- * — it intentionally ignores `enableTierRestrictions`.
- */
+// Returns true if the model is in the free tier. Does not use getAllowedModels to avoid tier-restriction bypass.
 export function isFreeChatModel(model: ModelId): boolean {
-    return isFreeModel(model);
+    // includes() requires string[], not readonly ModelId[] — widening is safe since TIER_CONFIG.models.free is always strings.
+    return (TIER_CONFIG.models.free as readonly string[]).includes(model);
 }

--- a/src/domain/llm/modelTier.ts
+++ b/src/domain/llm/modelTier.ts
@@ -1,8 +1,14 @@
-import { TIER_CONFIG } from '@y0ngha/siglens-core';
+import { isFreeModel } from '@y0ngha/siglens-core';
 import type { ModelId } from '@y0ngha/siglens-core';
 
-// Returns true if the model is in the free tier. Does not use getAllowedModels to avoid tier-restriction bypass.
+/**
+ * Returns true if the model is in the free tier (i.e., the platform/server pays
+ * for inference). Delegates to siglens-core's `isFreeModel` for a single
+ * source of truth across analysis and chat call sites.
+ *
+ * Like `isFreeModel`, this is a classifier of the model's intrinsic tier class
+ * — it intentionally ignores `enableTierRestrictions`.
+ */
 export function isFreeChatModel(model: ModelId): boolean {
-    // includes() requires string[], not readonly ModelId[] — widening is safe since TIER_CONFIG.models.free is always strings.
-    return (TIER_CONFIG.models.free as readonly string[]).includes(model);
+    return isFreeModel(model);
 }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -96,6 +96,12 @@ export type {
 } from '@/domain/llm/types';
 export type { LlmProvider } from '@/domain/llm/constants';
 
+export type {
+    AnalysisGateError,
+    AnalysisGateBlockedResult,
+    AnalysisGateErrorCode,
+} from '@/domain/analysis/gate';
+
 export type ContactFormField = 'title' | 'email' | 'content';
 
 export type ContactFormErrorCode =

--- a/src/infrastructure/market/byokGate.ts
+++ b/src/infrastructure/market/byokGate.ts
@@ -1,0 +1,114 @@
+import 'server-only';
+
+import {
+    TIER_CONFIG,
+    getProviderForModel,
+    isPremiumModel,
+    type ModelId,
+    type Tier,
+} from '@y0ngha/siglens-core';
+import { getDatabaseClient } from '@/infrastructure/db/client';
+import {
+    DrizzleUserApiKeyRepository,
+    LlmApiKeyDecryptionFailedError,
+} from '@/infrastructure/db/userApiKeyRepository';
+import { getUserTier } from '@/infrastructure/tier/use-cases/getUserTier';
+import { DrizzleUserRepository } from '@/infrastructure/db/userRepository';
+
+/** Machine-readable codes for siglens-side analysis gate denials. */
+export type AnalysisGateErrorCode =
+    | 'tier_premium_blocked'
+    | 'invalid_model'
+    | 'api_key_corrupted';
+
+export interface AnalysisGateError {
+    code: AnalysisGateErrorCode;
+    message: string;
+}
+
+const GATE_MESSAGES: Record<AnalysisGateErrorCode, string> = {
+    tier_premium_blocked:
+        '선택한 모델은 프리미엄 등급에서만 사용 가능합니다. API 키를 등록하거나 등급을 업그레이드해 주세요.',
+    invalid_model: '알 수 없는 모델입니다.',
+    api_key_corrupted:
+        '저장된 API 키를 복호화하지 못했습니다. 키를 다시 등록해 주세요.',
+};
+
+export function buildGateError(code: AnalysisGateErrorCode): AnalysisGateError {
+    return { code, message: GATE_MESSAGES[code] };
+}
+
+/** TIER_CONFIG.models의 어느 등급에든 등재된 modelId인지 검사. */
+export function isKnownModelId(modelId: string): boolean {
+    // `TIER_CONFIG.models` values are typed as `readonly TierModel[]` (string-
+    // literal union). Widening to `readonly string[]` lets `.includes(modelId: string)`
+    // accept the wider arg; same pattern as in the original submitAnalysisAction.
+    const allTiers = Object.values(TIER_CONFIG.models) as readonly (
+        readonly string[]
+    )[];
+    return allTiers.some(models => models.includes(modelId));
+}
+
+export type ByokOutcome =
+    | { kind: 'allowed'; tier: Tier; userApiKey?: string }
+    | { kind: 'blocked'; error: AnalysisGateError };
+
+/**
+ * Tier 조회 + BYOK 게이트.
+ *
+ * @param userId - 인증된 사용자 ID. null이면 free tier로 처리.
+ * @param modelId - 선택된 모델.
+ * @returns `allowed`: tier + (있으면) userApiKey. `blocked`: 게이트 사유.
+ */
+export async function resolveTierAndByok(
+    userId: string | null,
+    modelId: ModelId
+): Promise<ByokOutcome> {
+    if (!isKnownModelId(modelId)) {
+        return { kind: 'blocked', error: buildGateError('invalid_model') };
+    }
+
+    const tier =
+        userId === null
+            ? 'free'
+            : await getUserTier(
+                  { userId },
+                  { users: new DrizzleUserRepository(getDatabaseClient().db) }
+              );
+
+    const premium = isPremiumModel(modelId);
+
+    // pro 또는 free 모델 → server pays, no BYOK needed.
+    if (tier === 'pro' || !premium) {
+        return { kind: 'allowed', tier };
+    }
+
+    // non-pro + premium → BYOK 필수.
+    if (userId === null) {
+        return {
+            kind: 'blocked',
+            error: buildGateError('tier_premium_blocked'),
+        };
+    }
+
+    const llmProvider = getProviderForModel(modelId);
+    try {
+        const repo = new DrizzleUserApiKeyRepository(getDatabaseClient().db);
+        const record = await repo.findByUserAndProvider(userId, llmProvider);
+        if (record === null) {
+            return {
+                kind: 'blocked',
+                error: buildGateError('tier_premium_blocked'),
+            };
+        }
+        return { kind: 'allowed', tier, userApiKey: record.apiKey };
+    } catch (error) {
+        if (error instanceof LlmApiKeyDecryptionFailedError) {
+            return {
+                kind: 'blocked',
+                error: buildGateError('api_key_corrupted'),
+            };
+        }
+        throw error;
+    }
+}

--- a/src/infrastructure/market/byokGate.ts
+++ b/src/infrastructure/market/byokGate.ts
@@ -43,9 +43,9 @@ export function isKnownModelId(modelId: string): boolean {
     // `TIER_CONFIG.models` values are typed as `readonly TierModel[]` (string-
     // literal union). Widening to `readonly string[]` lets `.includes(modelId: string)`
     // accept the wider arg; same pattern as in the original submitAnalysisAction.
-    const allTiers = Object.values(TIER_CONFIG.models) as readonly (
-        readonly string[]
-    )[];
+    const allTiers = Object.values(
+        TIER_CONFIG.models
+    ) as readonly (readonly string[])[];
     return allTiers.some(models => models.includes(modelId));
 }
 

--- a/src/infrastructure/market/byokGate.ts
+++ b/src/infrastructure/market/byokGate.ts
@@ -14,24 +14,18 @@ import {
 } from '@/infrastructure/db/userApiKeyRepository';
 import { getUserTier } from '@/infrastructure/tier/use-cases/getUserTier';
 import { DrizzleUserRepository } from '@/infrastructure/db/userRepository';
+import type {
+    AnalysisGateError,
+    AnalysisGateErrorCode,
+    AnalysisGateBlockedResult,
+} from '@/domain/analysis/gate';
 
-/** Machine-readable codes for siglens-side analysis gate denials. */
-export type AnalysisGateErrorCode =
-    | 'tier_premium_blocked'
-    | 'invalid_model'
-    | 'api_key_corrupted'
-    | 'unexpected_error';
-
-export interface AnalysisGateError {
-    code: AnalysisGateErrorCode;
-    message: string;
-}
-
-/** Gate denial result mirroring core's `{ status: 'error' }` discriminator. */
-export interface AnalysisGateBlockedResult {
-    status: 'error';
-    error: AnalysisGateError;
-}
+// Re-export for action files that imported from byokGate
+export type {
+    AnalysisGateError,
+    AnalysisGateErrorCode,
+    AnalysisGateBlockedResult,
+};
 
 const GATE_MESSAGES: Record<AnalysisGateErrorCode, string> = {
     tier_premium_blocked:

--- a/src/infrastructure/market/byokGate.ts
+++ b/src/infrastructure/market/byokGate.ts
@@ -17,15 +17,7 @@ import { DrizzleUserRepository } from '@/infrastructure/db/userRepository';
 import type {
     AnalysisGateError,
     AnalysisGateErrorCode,
-    AnalysisGateBlockedResult,
 } from '@/domain/analysis/gate';
-
-// Re-export for action files that imported from byokGate
-export type {
-    AnalysisGateError,
-    AnalysisGateErrorCode,
-    AnalysisGateBlockedResult,
-};
 
 const GATE_MESSAGES: Record<AnalysisGateErrorCode, string> = {
     tier_premium_blocked:

--- a/src/infrastructure/market/byokGate.ts
+++ b/src/infrastructure/market/byokGate.ts
@@ -19,11 +19,18 @@ import { DrizzleUserRepository } from '@/infrastructure/db/userRepository';
 export type AnalysisGateErrorCode =
     | 'tier_premium_blocked'
     | 'invalid_model'
-    | 'api_key_corrupted';
+    | 'api_key_corrupted'
+    | 'unexpected_error';
 
 export interface AnalysisGateError {
     code: AnalysisGateErrorCode;
     message: string;
+}
+
+/** Gate denial result mirroring core's `{ status: 'error' }` discriminator. */
+export interface AnalysisGateBlockedResult {
+    status: 'error';
+    error: AnalysisGateError;
 }
 
 const GATE_MESSAGES: Record<AnalysisGateErrorCode, string> = {
@@ -32,21 +39,25 @@ const GATE_MESSAGES: Record<AnalysisGateErrorCode, string> = {
     invalid_model: '알 수 없는 모델입니다.',
     api_key_corrupted:
         '저장된 API 키를 복호화하지 못했습니다. 키를 다시 등록해 주세요.',
+    unexpected_error:
+        '예상치 못한 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
 };
 
 export function buildGateError(code: AnalysisGateErrorCode): AnalysisGateError {
     return { code, message: GATE_MESSAGES[code] };
 }
 
+// Module-level cache: TIER_CONFIG is frozen, this is computed once at module load.
+// `TIER_CONFIG.models` values are typed as `readonly TierModel[]` (string-literal
+// union). Widening to `readonly string[]` lets `.includes(modelId: string)` accept
+// the wider arg; TS cannot express this constraint — runtime is guaranteed by TIER_CONFIG.
+const ALL_TIER_MODEL_LISTS = Object.values(
+    TIER_CONFIG.models
+) as readonly (readonly string[])[];
+
 /** TIER_CONFIG.models의 어느 등급에든 등재된 modelId인지 검사. */
 export function isKnownModelId(modelId: string): boolean {
-    // `TIER_CONFIG.models` values are typed as `readonly TierModel[]` (string-
-    // literal union). Widening to `readonly string[]` lets `.includes(modelId: string)`
-    // accept the wider arg; same pattern as in the original submitAnalysisAction.
-    const allTiers = Object.values(
-        TIER_CONFIG.models
-    ) as readonly (readonly string[])[];
-    return allTiers.some(models => models.includes(modelId));
+    return ALL_TIER_MODEL_LISTS.some(models => models.includes(modelId));
 }
 
 export type ByokOutcome =

--- a/src/infrastructure/market/byokGate.ts
+++ b/src/infrastructure/market/byokGate.ts
@@ -94,7 +94,7 @@ export async function resolveTierAndByok(
         return { kind: 'allowed', tier };
     }
 
-    // non-pro + premium → BYOK 필수.
+    // userId가 없으면 BYOK를 조회할 주체가 없어 차단.
     if (userId === null) {
         return {
             kind: 'blocked',

--- a/src/infrastructure/market/submitAnalysisAction.ts
+++ b/src/infrastructure/market/submitAnalysisAction.ts
@@ -14,9 +14,6 @@ import {
     type AnalysisGateBlockedResult,
 } from '@/infrastructure/market/byokGate';
 
-// Re-export for consumers
-export type { AnalysisGateBlockedResult };
-
 /** Final return type — core's gated result + our siglens-side gate errors. */
 export type SubmitAnalysisActionResult =
     | SubmitAnalysisGatedResult
@@ -32,10 +29,7 @@ export async function submitAnalysisAction(
     modelId?: ModelId
 ): Promise<SubmitAnalysisActionResult> {
     try {
-        const user = await getCurrentUser();
-        const userId = user?.id ?? null;
-
-        // No model selected → preserve previous behavior (core picks a default).
+        // No model selected → preserve previous behavior; no user lookup needed.
         if (modelId === undefined) {
             return await submitAnalysis(
                 symbol,
@@ -46,6 +40,9 @@ export async function submitAnalysisAction(
                 { waitUntil, modelId }
             );
         }
+
+        const user = await getCurrentUser();
+        const userId = user?.id ?? null;
 
         const gate = await resolveTierAndByok(userId, modelId);
         if (gate.kind === 'blocked') {

--- a/src/infrastructure/market/submitAnalysisAction.ts
+++ b/src/infrastructure/market/submitAnalysisAction.ts
@@ -29,7 +29,7 @@ export async function submitAnalysisAction(
     modelId?: ModelId
 ): Promise<SubmitAnalysisActionResult> {
     try {
-        // No model selected → preserve previous behavior; no user lookup needed.
+        // no user lookup needed when modelId is absent
         if (modelId === undefined) {
             return await submitAnalysis(
                 symbol,

--- a/src/infrastructure/market/submitAnalysisAction.ts
+++ b/src/infrastructure/market/submitAnalysisAction.ts
@@ -8,7 +8,10 @@ import {
     type Timeframe,
 } from '@y0ngha/siglens-core';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import { resolveTierAndByok, buildGateError } from '@/infrastructure/market/byokGate';
+import {
+    resolveTierAndByok,
+    buildGateError,
+} from '@/infrastructure/market/byokGate';
 import type { AnalysisGateBlockedResult } from '@/domain/types';
 
 /** Final return type — core's gated result + our siglens-side gate errors. */

--- a/src/infrastructure/market/submitAnalysisAction.ts
+++ b/src/infrastructure/market/submitAnalysisAction.ts
@@ -67,7 +67,8 @@ export async function submitAnalysisAction(
                     : {}),
             }
         );
-    } catch {
+    } catch (err) {
+        console.error('[submitAnalysisAction] unexpected error:', err);
         return { status: 'error', error: buildGateError('unexpected_error') };
     }
 }

--- a/src/infrastructure/market/submitAnalysisAction.ts
+++ b/src/infrastructure/market/submitAnalysisAction.ts
@@ -62,6 +62,8 @@ export async function submitAnalysisAction(
         waitUntil,
         modelId,
         tierContext: { userId, tier: gate.tier },
-        ...(gate.userApiKey !== undefined ? { userApiKey: gate.userApiKey } : {}),
+        ...(gate.userApiKey !== undefined
+            ? { userApiKey: gate.userApiKey }
+            : {}),
     });
 }

--- a/src/infrastructure/market/submitAnalysisAction.ts
+++ b/src/infrastructure/market/submitAnalysisAction.ts
@@ -8,11 +8,8 @@ import {
     type Timeframe,
 } from '@y0ngha/siglens-core';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import {
-    resolveTierAndByok,
-    buildGateError,
-    type AnalysisGateBlockedResult,
-} from '@/infrastructure/market/byokGate';
+import { resolveTierAndByok, buildGateError } from '@/infrastructure/market/byokGate';
+import type { AnalysisGateBlockedResult } from '@/domain/types';
 
 /** Final return type — core's gated result + our siglens-side gate errors. */
 export type SubmitAnalysisActionResult =

--- a/src/infrastructure/market/submitAnalysisAction.ts
+++ b/src/infrastructure/market/submitAnalysisAction.ts
@@ -10,19 +10,12 @@ import {
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
 import {
     resolveTierAndByok,
-    type AnalysisGateError,
+    buildGateError,
+    type AnalysisGateBlockedResult,
 } from '@/infrastructure/market/byokGate';
 
-export type AnalysisGateErrorCode =
-    | 'tier_premium_blocked'
-    | 'invalid_model'
-    | 'api_key_corrupted';
-
-/** Gate denial result mirroring core's `{ status: 'error' }` discriminator. */
-export interface AnalysisGateBlockedResult {
-    status: 'error';
-    error: AnalysisGateError;
-}
+// Re-export for consumers
+export type { AnalysisGateBlockedResult };
 
 /** Final return type — core's gated result + our siglens-side gate errors. */
 export type SubmitAnalysisActionResult =
@@ -38,32 +31,43 @@ export async function submitAnalysisAction(
     fmpSymbol?: string,
     modelId?: ModelId
 ): Promise<SubmitAnalysisActionResult> {
-    const user = await getCurrentUser();
-    const userId = user?.id ?? null;
+    try {
+        const user = await getCurrentUser();
+        const userId = user?.id ?? null;
 
-    // No model selected → preserve previous behavior (core picks a default).
-    if (modelId === undefined) {
-        return submitAnalysis(
+        // No model selected → preserve previous behavior (core picks a default).
+        if (modelId === undefined) {
+            return await submitAnalysis(
+                symbol,
+                companyName,
+                timeframe,
+                force,
+                fmpSymbol,
+                { waitUntil, modelId }
+            );
+        }
+
+        const gate = await resolveTierAndByok(userId, modelId);
+        if (gate.kind === 'blocked') {
+            return { status: 'error', error: gate.error };
+        }
+
+        return await submitAnalysis(
             symbol,
             companyName,
             timeframe,
             force,
             fmpSymbol,
-            { waitUntil, modelId }
+            {
+                waitUntil,
+                modelId,
+                tierContext: { userId, tier: gate.tier },
+                ...(gate.userApiKey !== undefined
+                    ? { userApiKey: gate.userApiKey }
+                    : {}),
+            }
         );
+    } catch {
+        return { status: 'error', error: buildGateError('unexpected_error') };
     }
-
-    const gate = await resolveTierAndByok(userId, modelId);
-    if (gate.kind === 'blocked') {
-        return { status: 'error', error: gate.error };
-    }
-
-    return submitAnalysis(symbol, companyName, timeframe, force, fmpSymbol, {
-        waitUntil,
-        modelId,
-        tierContext: { userId, tier: gate.tier },
-        ...(gate.userApiKey !== undefined
-            ? { userApiKey: gate.userApiKey }
-            : {}),
-    });
 }

--- a/src/infrastructure/market/submitAnalysisAction.ts
+++ b/src/infrastructure/market/submitAnalysisAction.ts
@@ -2,33 +2,21 @@
 
 import { waitUntil } from '@vercel/functions';
 import {
-    TIER_CONFIG,
-    getProviderForModel,
     submitAnalysis,
     type ModelId,
     type SubmitAnalysisGatedResult,
     type Timeframe,
 } from '@y0ngha/siglens-core';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import { getDatabaseClient } from '@/infrastructure/db/client';
 import {
-    DrizzleUserApiKeyRepository,
-    LlmApiKeyDecryptionFailedError,
-} from '@/infrastructure/db/userApiKeyRepository';
-import { getUserTier } from '@/infrastructure/tier/use-cases/getUserTier';
-import { DrizzleUserRepository } from '@/infrastructure/db/userRepository';
+    resolveTierAndByok,
+    type AnalysisGateError,
+} from '@/infrastructure/market/byokGate';
 
-/** Machine-readable codes for siglens-side analysis gate denials. */
 export type AnalysisGateErrorCode =
     | 'tier_premium_blocked'
     | 'invalid_model'
     | 'api_key_corrupted';
-
-/** Gate error attached to the analysis submission result. */
-export interface AnalysisGateError {
-    code: AnalysisGateErrorCode;
-    message: string;
-}
 
 /** Gate denial result mirroring core's `{ status: 'error' }` discriminator. */
 export interface AnalysisGateBlockedResult {
@@ -40,85 +28,6 @@ export interface AnalysisGateBlockedResult {
 export type SubmitAnalysisActionResult =
     | SubmitAnalysisGatedResult
     | AnalysisGateBlockedResult;
-
-const GATE_MESSAGES: Record<AnalysisGateErrorCode, string> = {
-    tier_premium_blocked:
-        '선택한 모델은 프리미엄 등급에서만 사용 가능합니다. API 키를 등록하거나 등급을 업그레이드해 주세요.',
-    invalid_model: '알 수 없는 모델입니다.',
-    api_key_corrupted:
-        '저장된 API 키를 복호화하지 못했습니다. 키를 다시 등록해 주세요.',
-};
-
-function buildGateError(
-    code: AnalysisGateErrorCode
-): AnalysisGateBlockedResult {
-    return {
-        status: 'error',
-        error: { code, message: GATE_MESSAGES[code] },
-    };
-}
-
-/** TIER_CONFIG.models의 어느 등급에든 등재된 modelId인지 검사 (미등록 ID는 차단). */
-function isKnownModelId(modelId: string): boolean {
-    // `TIER_CONFIG.models` values are typed as `readonly TierModel[]` (string
-    // literal union). Widening to `readonly string[]` is a TS structural
-    // limitation for `.includes(modelId: string)` — `Array.prototype.includes`
-    // refuses non-literal arguments otherwise. The cast is safe because we
-    // only read members; we never write back through this view.
-    const allTiers = Object.values(
-        TIER_CONFIG.models
-    ) as readonly (readonly string[])[];
-    return allTiers.some(models => models.includes(modelId));
-}
-
-type ByokOutcome =
-    | { kind: 'allowed'; userApiKey?: string }
-    | { kind: 'blocked'; result: AnalysisGateBlockedResult };
-
-/** Resolves BYOK outcome for a known modelId: free → allowed, premium → tier+BYOK gate. */
-async function resolveByokOutcome(
-    userId: string | null,
-    modelId: ModelId,
-    isFreeModel: boolean,
-    isTierAllowed: boolean
-): Promise<ByokOutcome> {
-    if (isFreeModel) {
-        return { kind: 'allowed' };
-    }
-    // Premium model — require BYOK unless the user's tier already includes it.
-    if (userId === null) {
-        return {
-            kind: 'blocked',
-            result: buildGateError('tier_premium_blocked'),
-        };
-    }
-
-    const llmProvider = getProviderForModel(modelId);
-    try {
-        const repo = new DrizzleUserApiKeyRepository(getDatabaseClient().db);
-        const record = await repo.findByUserAndProvider(userId, llmProvider);
-        if (!isTierAllowed) {
-            if (record === null) {
-                return {
-                    kind: 'blocked',
-                    result: buildGateError('tier_premium_blocked'),
-                };
-            }
-            // Tier doesn't cover the model but user has BYOK — use it.
-            return { kind: 'allowed', userApiKey: record.apiKey };
-        }
-        // Tier covers the model: server pays regardless of BYOK registration.
-        return { kind: 'allowed' };
-    } catch (error) {
-        if (error instanceof LlmApiKeyDecryptionFailedError) {
-            return {
-                kind: 'blocked',
-                result: buildGateError('api_key_corrupted'),
-            };
-        }
-        throw error;
-    }
-}
 
 /** 서버사이드 tier + BYOK 게이트 후 core의 submitAnalysis에 위임. */
 export async function submitAnalysisAction(
@@ -132,7 +41,7 @@ export async function submitAnalysisAction(
     const user = await getCurrentUser();
     const userId = user?.id ?? null;
 
-    // No model selected → preserve previous behavior (let core pick a default).
+    // No model selected → preserve previous behavior (core picks a default).
     if (modelId === undefined) {
         return submitAnalysis(
             symbol,
@@ -140,50 +49,19 @@ export async function submitAnalysisAction(
             timeframe,
             force,
             fmpSymbol,
-            {
-                waitUntil,
-                modelId,
-            }
+            { waitUntil, modelId }
         );
     }
 
-    if (!isKnownModelId(modelId)) {
-        return buildGateError('invalid_model');
+    const gate = await resolveTierAndByok(userId, modelId);
+    if (gate.kind === 'blocked') {
+        return { status: 'error', error: gate.error };
     }
 
-    const tier =
-        userId === null
-            ? 'free'
-            : await getUserTier(
-                  { userId },
-                  {
-                      users: new DrizzleUserRepository(getDatabaseClient().db),
-                  }
-              );
-
-    // Widening `readonly TierModel[]` → `readonly string[]` is a TS-only
-    // operation: same reasoning as `isKnownModelId` above. `.includes` cannot
-    // accept the wider `string` against the literal-union without it.
-    const freeModels = TIER_CONFIG.models.free as readonly string[];
-    const tierModels = TIER_CONFIG.models[tier] as readonly string[];
-    const isFreeModel = freeModels.includes(modelId);
-    const isTierAllowed = tierModels.includes(modelId);
-
-    const byok = await resolveByokOutcome(
-        userId,
-        modelId,
-        isFreeModel,
-        isTierAllowed
-    );
-    if (byok.kind === 'blocked') return byok.result;
-
-    // Only include userApiKey when actually present so consumers can
-    // distinguish "no BYOK" from "BYOK = undefined" via `'userApiKey' in opts`.
     return submitAnalysis(symbol, companyName, timeframe, force, fmpSymbol, {
         waitUntil,
         modelId,
-        ...(byok.userApiKey !== undefined
-            ? { userApiKey: byok.userApiKey }
-            : {}),
+        tierContext: { userId, tier: gate.tier },
+        ...(gate.userApiKey !== undefined ? { userApiKey: gate.userApiKey } : {}),
     });
 }

--- a/src/infrastructure/market/submitFundamentalAnalysisAction.ts
+++ b/src/infrastructure/market/submitFundamentalAnalysisAction.ts
@@ -14,9 +14,6 @@ import {
     type AnalysisGateBlockedResult,
 } from '@/infrastructure/market/byokGate';
 
-// Re-export for consumers
-export type { AnalysisGateBlockedResult };
-
 /** Final return type — core's fundamental result + our siglens-side gate errors. */
 export type SubmitFundamentalAnalysisActionResult =
     | SubmitFundamentalAnalysisResult

--- a/src/infrastructure/market/submitFundamentalAnalysisAction.ts
+++ b/src/infrastructure/market/submitFundamentalAnalysisAction.ts
@@ -7,16 +7,42 @@ import {
     type SubmitFundamentalAnalysisResult,
 } from '@y0ngha/siglens-core';
 import { FmpFundamentalClient } from '@/infrastructure/fmp/fundamentalClient';
+import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
+import {
+    resolveTierAndByok,
+    type AnalysisGateError,
+} from '@/infrastructure/market/byokGate';
 
-/** Server Action: submit a fundamental analysis job; delegates to siglens-core with FMP provider; returns `cached | submitted | error`. */
+/** Gate denial result mirroring core's `{ status: 'error' }` discriminator. */
+export interface AnalysisGateBlockedResult {
+    status: 'error';
+    error: AnalysisGateError;
+}
+
+/** Final return type — core's fundamental result + our siglens-side gate errors. */
+export type SubmitFundamentalAnalysisActionResult =
+    | SubmitFundamentalAnalysisResult
+    | AnalysisGateBlockedResult;
+
+/** Server Action: tier + BYOK gate, then submit fundamental analysis via siglens-core with FMP provider; returns `cached | submitted | error`. */
 export async function submitFundamentalAnalysisAction(
     symbol: string,
     modelId: SubmitFundamentalAnalysisOptions['modelId']
-): Promise<SubmitFundamentalAnalysisResult> {
+): Promise<SubmitFundamentalAnalysisActionResult> {
+    const user = await getCurrentUser();
+    const userId = user?.id ?? null;
+
+    const gate = await resolveTierAndByok(userId, modelId);
+    if (gate.kind === 'blocked') {
+        return { status: 'error', error: gate.error };
+    }
+
     return submitFundamentalAnalysis({
         symbol,
         modelId,
         dataProvider: new FmpFundamentalClient(),
         waitUntil,
+        tier: gate.tier,
+        ...(gate.userApiKey !== undefined ? { userApiKey: gate.userApiKey } : {}),
     });
 }

--- a/src/infrastructure/market/submitFundamentalAnalysisAction.ts
+++ b/src/infrastructure/market/submitFundamentalAnalysisAction.ts
@@ -8,7 +8,10 @@ import {
 } from '@y0ngha/siglens-core';
 import { FmpFundamentalClient } from '@/infrastructure/fmp/fundamentalClient';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import { resolveTierAndByok, buildGateError } from '@/infrastructure/market/byokGate';
+import {
+    resolveTierAndByok,
+    buildGateError,
+} from '@/infrastructure/market/byokGate';
 import type { AnalysisGateBlockedResult } from '@/domain/types';
 
 /** Final return type — core's fundamental result + our siglens-side gate errors. */

--- a/src/infrastructure/market/submitFundamentalAnalysisAction.ts
+++ b/src/infrastructure/market/submitFundamentalAnalysisAction.ts
@@ -43,6 +43,8 @@ export async function submitFundamentalAnalysisAction(
         dataProvider: new FmpFundamentalClient(),
         waitUntil,
         tier: gate.tier,
-        ...(gate.userApiKey !== undefined ? { userApiKey: gate.userApiKey } : {}),
+        ...(gate.userApiKey !== undefined
+            ? { userApiKey: gate.userApiKey }
+            : {}),
     });
 }

--- a/src/infrastructure/market/submitFundamentalAnalysisAction.ts
+++ b/src/infrastructure/market/submitFundamentalAnalysisAction.ts
@@ -46,7 +46,8 @@ export async function submitFundamentalAnalysisAction(
                 ? { userApiKey: gate.userApiKey }
                 : {}),
         });
-    } catch {
+    } catch (err) {
+        console.error('[submitFundamentalAnalysisAction] unexpected error:', err);
         return { status: 'error', error: buildGateError('unexpected_error') };
     }
 }

--- a/src/infrastructure/market/submitFundamentalAnalysisAction.ts
+++ b/src/infrastructure/market/submitFundamentalAnalysisAction.ts
@@ -10,14 +10,12 @@ import { FmpFundamentalClient } from '@/infrastructure/fmp/fundamentalClient';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
 import {
     resolveTierAndByok,
-    type AnalysisGateError,
+    buildGateError,
+    type AnalysisGateBlockedResult,
 } from '@/infrastructure/market/byokGate';
 
-/** Gate denial result mirroring core's `{ status: 'error' }` discriminator. */
-export interface AnalysisGateBlockedResult {
-    status: 'error';
-    error: AnalysisGateError;
-}
+// Re-export for consumers
+export type { AnalysisGateBlockedResult };
 
 /** Final return type — core's fundamental result + our siglens-side gate errors. */
 export type SubmitFundamentalAnalysisActionResult =
@@ -29,22 +27,26 @@ export async function submitFundamentalAnalysisAction(
     symbol: string,
     modelId: SubmitFundamentalAnalysisOptions['modelId']
 ): Promise<SubmitFundamentalAnalysisActionResult> {
-    const user = await getCurrentUser();
-    const userId = user?.id ?? null;
+    try {
+        const user = await getCurrentUser();
+        const userId = user?.id ?? null;
 
-    const gate = await resolveTierAndByok(userId, modelId);
-    if (gate.kind === 'blocked') {
-        return { status: 'error', error: gate.error };
+        const gate = await resolveTierAndByok(userId, modelId);
+        if (gate.kind === 'blocked') {
+            return { status: 'error', error: gate.error };
+        }
+
+        return await submitFundamentalAnalysis({
+            symbol,
+            modelId,
+            dataProvider: new FmpFundamentalClient(),
+            waitUntil,
+            tier: gate.tier,
+            ...(gate.userApiKey !== undefined
+                ? { userApiKey: gate.userApiKey }
+                : {}),
+        });
+    } catch {
+        return { status: 'error', error: buildGateError('unexpected_error') };
     }
-
-    return submitFundamentalAnalysis({
-        symbol,
-        modelId,
-        dataProvider: new FmpFundamentalClient(),
-        waitUntil,
-        tier: gate.tier,
-        ...(gate.userApiKey !== undefined
-            ? { userApiKey: gate.userApiKey }
-            : {}),
-    });
 }

--- a/src/infrastructure/market/submitFundamentalAnalysisAction.ts
+++ b/src/infrastructure/market/submitFundamentalAnalysisAction.ts
@@ -8,11 +8,8 @@ import {
 } from '@y0ngha/siglens-core';
 import { FmpFundamentalClient } from '@/infrastructure/fmp/fundamentalClient';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import {
-    resolveTierAndByok,
-    buildGateError,
-    type AnalysisGateBlockedResult,
-} from '@/infrastructure/market/byokGate';
+import { resolveTierAndByok, buildGateError } from '@/infrastructure/market/byokGate';
+import type { AnalysisGateBlockedResult } from '@/domain/types';
 
 /** Final return type — core's fundamental result + our siglens-side gate errors. */
 export type SubmitFundamentalAnalysisActionResult =

--- a/src/infrastructure/market/submitFundamentalAnalysisAction.ts
+++ b/src/infrastructure/market/submitFundamentalAnalysisAction.ts
@@ -47,7 +47,10 @@ export async function submitFundamentalAnalysisAction(
                 : {}),
         });
     } catch (err) {
-        console.error('[submitFundamentalAnalysisAction] unexpected error:', err);
+        console.error(
+            '[submitFundamentalAnalysisAction] unexpected error:',
+            err
+        );
         return { status: 'error', error: buildGateError('unexpected_error') };
     }
 }

--- a/src/infrastructure/market/submitNewsAnalysisAction.ts
+++ b/src/infrastructure/market/submitNewsAnalysisAction.ts
@@ -17,11 +17,8 @@ import {
 } from '@/infrastructure/market/newsEnrichment';
 import { todayKstIsoDate } from '@/infrastructure/utils/dateKey';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import {
-    resolveTierAndByok,
-    buildGateError,
-    type AnalysisGateBlockedResult,
-} from '@/infrastructure/market/byokGate';
+import { resolveTierAndByok, buildGateError } from '@/infrastructure/market/byokGate';
+import type { AnalysisGateBlockedResult } from '@/domain/types';
 
 /** Final return type — core's news result + our siglens-side gate errors. */
 export type SubmitNewsAnalysisActionResult =

--- a/src/infrastructure/market/submitNewsAnalysisAction.ts
+++ b/src/infrastructure/market/submitNewsAnalysisAction.ts
@@ -19,14 +19,12 @@ import { todayKstIsoDate } from '@/infrastructure/utils/dateKey';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
 import {
     resolveTierAndByok,
-    type AnalysisGateError,
+    buildGateError,
+    type AnalysisGateBlockedResult,
 } from '@/infrastructure/market/byokGate';
 
-/** Gate denial result mirroring core's `{ status: 'error' }` discriminator. */
-export interface AnalysisGateBlockedResult {
-    status: 'error';
-    error: AnalysisGateError;
-}
+// Re-export for consumers
+export type { AnalysisGateBlockedResult };
 
 /** Final return type — core's news result + our siglens-side gate errors. */
 export type SubmitNewsAnalysisActionResult =
@@ -39,37 +37,41 @@ export async function submitNewsAnalysisAction(
     companyName: string,
     modelId: SubmitNewsAnalysisOptions['modelId']
 ): Promise<SubmitNewsAnalysisActionResult> {
-    const user = await getCurrentUser();
-    const userId = user?.id ?? null;
+    try {
+        const user = await getCurrentUser();
+        const userId = user?.id ?? null;
 
-    const gate = await resolveTierAndByok(userId, modelId);
-    if (gate.kind === 'blocked') {
-        return { status: 'error', error: gate.error };
+        const gate = await resolveTierAndByok(userId, modelId);
+        if (gate.kind === 'blocked') {
+            return { status: 'error', error: gate.error };
+        }
+
+        const { db } = getDatabaseClient();
+        const newsRepo = new DrizzleNewsRepository(db);
+        const calRepo = new DrizzleEarningsCalendarRepository(db);
+
+        const [rows, next] = await Promise.all([
+            newsRepo.listBySymbol(symbol, NEWS_ANALYSIS_LOOKBACK_MS),
+            calRepo.getNextForSymbol(symbol, todayKstIsoDate()),
+        ]);
+
+        const enrichedNews: ReadonlyArray<EnrichedNewsItem> = rows
+            .filter(isEnrichedRow)
+            .map(toEnrichedNewsItem);
+
+        return await submitNewsAnalysis({
+            symbol,
+            companyName,
+            modelId,
+            news: enrichedNews,
+            upcomingCalendar: next !== null ? [next] : [],
+            waitUntil,
+            tier: gate.tier,
+            ...(gate.userApiKey !== undefined
+                ? { userApiKey: gate.userApiKey }
+                : {}),
+        });
+    } catch {
+        return { status: 'error', error: buildGateError('unexpected_error') };
     }
-
-    const { db } = getDatabaseClient();
-    const newsRepo = new DrizzleNewsRepository(db);
-    const calRepo = new DrizzleEarningsCalendarRepository(db);
-
-    const [rows, next] = await Promise.all([
-        newsRepo.listBySymbol(symbol, NEWS_ANALYSIS_LOOKBACK_MS),
-        calRepo.getNextForSymbol(symbol, todayKstIsoDate()),
-    ]);
-
-    const enrichedNews: ReadonlyArray<EnrichedNewsItem> = rows
-        .filter(isEnrichedRow)
-        .map(toEnrichedNewsItem);
-
-    return submitNewsAnalysis({
-        symbol,
-        companyName,
-        modelId,
-        news: enrichedNews,
-        upcomingCalendar: next !== null ? [next] : [],
-        waitUntil,
-        tier: gate.tier,
-        ...(gate.userApiKey !== undefined
-            ? { userApiKey: gate.userApiKey }
-            : {}),
-    });
 }

--- a/src/infrastructure/market/submitNewsAnalysisAction.ts
+++ b/src/infrastructure/market/submitNewsAnalysisAction.ts
@@ -16,13 +16,37 @@ import {
     toEnrichedNewsItem,
 } from '@/infrastructure/market/newsEnrichment';
 import { todayKstIsoDate } from '@/infrastructure/utils/dateKey';
+import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
+import {
+    resolveTierAndByok,
+    type AnalysisGateError,
+} from '@/infrastructure/market/byokGate';
 
-/** Server Action: load last-7d enriched news from DB + next earnings, then submit via siglens-core; returns `cached | submitted | error`. */
+/** Gate denial result mirroring core's `{ status: 'error' }` discriminator. */
+export interface AnalysisGateBlockedResult {
+    status: 'error';
+    error: AnalysisGateError;
+}
+
+/** Final return type — core's news result + our siglens-side gate errors. */
+export type SubmitNewsAnalysisActionResult =
+    | SubmitNewsAnalysisResult
+    | AnalysisGateBlockedResult;
+
+/** Server Action: tier + BYOK gate, then load last-7d enriched news from DB + next earnings, then submit via siglens-core; returns `cached | submitted | error`. */
 export async function submitNewsAnalysisAction(
     symbol: string,
     companyName: string,
     modelId: SubmitNewsAnalysisOptions['modelId']
-): Promise<SubmitNewsAnalysisResult> {
+): Promise<SubmitNewsAnalysisActionResult> {
+    const user = await getCurrentUser();
+    const userId = user?.id ?? null;
+
+    const gate = await resolveTierAndByok(userId, modelId);
+    if (gate.kind === 'blocked') {
+        return { status: 'error', error: gate.error };
+    }
+
     const { db } = getDatabaseClient();
     const newsRepo = new DrizzleNewsRepository(db);
     const calRepo = new DrizzleEarningsCalendarRepository(db);
@@ -43,5 +67,7 @@ export async function submitNewsAnalysisAction(
         news: enrichedNews,
         upcomingCalendar: next !== null ? [next] : [],
         waitUntil,
+        tier: gate.tier,
+        ...(gate.userApiKey !== undefined ? { userApiKey: gate.userApiKey } : {}),
     });
 }

--- a/src/infrastructure/market/submitNewsAnalysisAction.ts
+++ b/src/infrastructure/market/submitNewsAnalysisAction.ts
@@ -17,7 +17,10 @@ import {
 } from '@/infrastructure/market/newsEnrichment';
 import { todayKstIsoDate } from '@/infrastructure/utils/dateKey';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import { resolveTierAndByok, buildGateError } from '@/infrastructure/market/byokGate';
+import {
+    resolveTierAndByok,
+    buildGateError,
+} from '@/infrastructure/market/byokGate';
 import type { AnalysisGateBlockedResult } from '@/domain/types';
 
 /** Final return type — core's news result + our siglens-side gate errors. */

--- a/src/infrastructure/market/submitNewsAnalysisAction.ts
+++ b/src/infrastructure/market/submitNewsAnalysisAction.ts
@@ -71,7 +71,8 @@ export async function submitNewsAnalysisAction(
                 ? { userApiKey: gate.userApiKey }
                 : {}),
         });
-    } catch {
+    } catch (err) {
+        console.error('[submitNewsAnalysisAction] unexpected error:', err);
         return { status: 'error', error: buildGateError('unexpected_error') };
     }
 }

--- a/src/infrastructure/market/submitNewsAnalysisAction.ts
+++ b/src/infrastructure/market/submitNewsAnalysisAction.ts
@@ -68,6 +68,8 @@ export async function submitNewsAnalysisAction(
         upcomingCalendar: next !== null ? [next] : [],
         waitUntil,
         tier: gate.tier,
-        ...(gate.userApiKey !== undefined ? { userApiKey: gate.userApiKey } : {}),
+        ...(gate.userApiKey !== undefined
+            ? { userApiKey: gate.userApiKey }
+            : {}),
     });
 }

--- a/src/infrastructure/market/submitNewsAnalysisAction.ts
+++ b/src/infrastructure/market/submitNewsAnalysisAction.ts
@@ -23,9 +23,6 @@ import {
     type AnalysisGateBlockedResult,
 } from '@/infrastructure/market/byokGate';
 
-// Re-export for consumers
-export type { AnalysisGateBlockedResult };
-
 /** Final return type — core's news result + our siglens-side gate errors. */
 export type SubmitNewsAnalysisActionResult =
     | SubmitNewsAnalysisResult

--- a/src/infrastructure/market/submitOverallAnalysisAction.ts
+++ b/src/infrastructure/market/submitOverallAnalysisAction.ts
@@ -21,14 +21,12 @@ import { todayKstIsoDate } from '@/infrastructure/utils/dateKey';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
 import {
     resolveTierAndByok,
-    type AnalysisGateError,
+    buildGateError,
+    type AnalysisGateBlockedResult,
 } from '@/infrastructure/market/byokGate';
 
-/** Gate denial result mirroring core's `{ status: 'error' }` discriminator. */
-export interface AnalysisGateBlockedResult {
-    status: 'error';
-    error: AnalysisGateError;
-}
+// Re-export for consumers
+export type { AnalysisGateBlockedResult };
 
 /** Final return type — core's overall result + our siglens-side gate errors. */
 export type SubmitOverallAnalysisActionResult =
@@ -45,12 +43,12 @@ export async function submitOverallAnalysisAction(
     const user = await getCurrentUser();
     const userId = user?.id ?? null;
 
-    const gate = await resolveTierAndByok(userId, modelId);
-    if (gate.kind === 'blocked') {
-        return { status: 'error', error: gate.error };
-    }
-
     try {
+        const gate = await resolveTierAndByok(userId, modelId);
+        if (gate.kind === 'blocked') {
+            return { status: 'error', error: gate.error };
+        }
+
         const { db } = getDatabaseClient();
         const newsRepo = new DrizzleNewsRepository(db);
         const calRepo = new DrizzleEarningsCalendarRepository(db);
@@ -79,7 +77,7 @@ export async function submitOverallAnalysisAction(
                 ? { userApiKey: gate.userApiKey }
                 : {}),
         });
-    } catch (e) {
-        return { status: 'error', axis: 'technical', error: e };
+    } catch {
+        return { status: 'error', error: buildGateError('unexpected_error') };
     }
 }

--- a/src/infrastructure/market/submitOverallAnalysisAction.ts
+++ b/src/infrastructure/market/submitOverallAnalysisAction.ts
@@ -19,11 +19,8 @@ import {
 } from '@/infrastructure/market/newsEnrichment';
 import { todayKstIsoDate } from '@/infrastructure/utils/dateKey';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import {
-    resolveTierAndByok,
-    buildGateError,
-    type AnalysisGateBlockedResult,
-} from '@/infrastructure/market/byokGate';
+import { resolveTierAndByok, buildGateError } from '@/infrastructure/market/byokGate';
+import type { AnalysisGateBlockedResult } from '@/domain/types';
 
 /** Final return type — core's overall result + our siglens-side gate errors. */
 export type SubmitOverallAnalysisActionResult =

--- a/src/infrastructure/market/submitOverallAnalysisAction.ts
+++ b/src/infrastructure/market/submitOverallAnalysisAction.ts
@@ -75,7 +75,9 @@ export async function submitOverallAnalysisAction(
             technical: { tierContext: { userId, tier: gate.tier } },
             waitUntil,
             tier: gate.tier,
-            ...(gate.userApiKey !== undefined ? { userApiKey: gate.userApiKey } : {}),
+            ...(gate.userApiKey !== undefined
+                ? { userApiKey: gate.userApiKey }
+                : {}),
         });
     } catch (e) {
         return { status: 'error', axis: 'technical', error: e };

--- a/src/infrastructure/market/submitOverallAnalysisAction.ts
+++ b/src/infrastructure/market/submitOverallAnalysisAction.ts
@@ -40,10 +40,10 @@ export async function submitOverallAnalysisAction(
     timeframe: Timeframe,
     modelId: SubmitOverallAnalysisOptions['modelId']
 ): Promise<SubmitOverallAnalysisActionResult> {
-    const user = await getCurrentUser();
-    const userId = user?.id ?? null;
-
     try {
+        const user = await getCurrentUser();
+        const userId = user?.id ?? null;
+
         const gate = await resolveTierAndByok(userId, modelId);
         if (gate.kind === 'blocked') {
             return { status: 'error', error: gate.error };
@@ -77,7 +77,8 @@ export async function submitOverallAnalysisAction(
                 ? { userApiKey: gate.userApiKey }
                 : {}),
         });
-    } catch {
+    } catch (err) {
+        console.error('[submitOverallAnalysisAction] unexpected error:', err);
         return { status: 'error', error: buildGateError('unexpected_error') };
     }
 }

--- a/src/infrastructure/market/submitOverallAnalysisAction.ts
+++ b/src/infrastructure/market/submitOverallAnalysisAction.ts
@@ -25,9 +25,6 @@ import {
     type AnalysisGateBlockedResult,
 } from '@/infrastructure/market/byokGate';
 
-// Re-export for consumers
-export type { AnalysisGateBlockedResult };
-
 /** Final return type — core's overall result + our siglens-side gate errors. */
 export type SubmitOverallAnalysisActionResult =
     | SubmitOverallAnalysisResult

--- a/src/infrastructure/market/submitOverallAnalysisAction.ts
+++ b/src/infrastructure/market/submitOverallAnalysisAction.ts
@@ -18,14 +18,38 @@ import {
     toEnrichedNewsItem,
 } from '@/infrastructure/market/newsEnrichment';
 import { todayKstIsoDate } from '@/infrastructure/utils/dateKey';
+import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
+import {
+    resolveTierAndByok,
+    type AnalysisGateError,
+} from '@/infrastructure/market/byokGate';
 
-/** Server Action: submit a 3-axis overall analysis job; loads enriched news + earnings from DB, injects FMP provider; returns `cached | submitted | pending_dependencies | error`. */
+/** Gate denial result mirroring core's `{ status: 'error' }` discriminator. */
+export interface AnalysisGateBlockedResult {
+    status: 'error';
+    error: AnalysisGateError;
+}
+
+/** Final return type — core's overall result + our siglens-side gate errors. */
+export type SubmitOverallAnalysisActionResult =
+    | SubmitOverallAnalysisResult
+    | AnalysisGateBlockedResult;
+
+/** Server Action: tier + BYOK gate, then submit a 3-axis overall analysis job; loads enriched news + earnings from DB, injects FMP provider; returns `cached | submitted | pending_dependencies | error`. */
 export async function submitOverallAnalysisAction(
     symbol: string,
     companyName: string,
     timeframe: Timeframe,
     modelId: SubmitOverallAnalysisOptions['modelId']
-): Promise<SubmitOverallAnalysisResult> {
+): Promise<SubmitOverallAnalysisActionResult> {
+    const user = await getCurrentUser();
+    const userId = user?.id ?? null;
+
+    const gate = await resolveTierAndByok(userId, modelId);
+    if (gate.kind === 'blocked') {
+        return { status: 'error', error: gate.error };
+    }
+
     try {
         const { db } = getDatabaseClient();
         const newsRepo = new DrizzleNewsRepository(db);
@@ -48,9 +72,10 @@ export async function submitOverallAnalysisAction(
             fundamentalProvider: new FmpFundamentalClient(),
             newsItems: enrichedNews,
             upcomingCalendar: next !== null ? [next] : [],
-            // Pre-Phase 4: no tier/usage/userApiKey overrides needed.
-            technical: {},
+            technical: { tierContext: { userId, tier: gate.tier } },
             waitUntil,
+            tier: gate.tier,
+            ...(gate.userApiKey !== undefined ? { userApiKey: gate.userApiKey } : {}),
         });
     } catch (e) {
         return { status: 'error', axis: 'technical', error: e };

--- a/src/infrastructure/market/submitOverallAnalysisAction.ts
+++ b/src/infrastructure/market/submitOverallAnalysisAction.ts
@@ -19,7 +19,10 @@ import {
 } from '@/infrastructure/market/newsEnrichment';
 import { todayKstIsoDate } from '@/infrastructure/utils/dateKey';
 import { getCurrentUser } from '@/infrastructure/auth/getCurrentUser';
-import { resolveTierAndByok, buildGateError } from '@/infrastructure/market/byokGate';
+import {
+    resolveTierAndByok,
+    buildGateError,
+} from '@/infrastructure/market/byokGate';
 import type { AnalysisGateBlockedResult } from '@/domain/types';
 
 /** Final return type — core's overall result + our siglens-side gate errors. */


### PR DESCRIPTION
## Summary

4개 분석 action(`submitAnalysisAction`, `submitNewsAnalysisAction`, `submitFundamentalAnalysisAction`, `submitOverallAnalysisAction`)이 tier + BYOK API key를 조회하여 siglens-core로 전달한다.

### 변경

1. **`src/infrastructure/market/byokGate.ts` 신규** — tier 조회 + BYOK DB 조회를 공유 헬퍼로 추출 (`resolveTierAndByok`). 기존 `submitAnalysisAction.ts`에 인라인되어 있던 로직을 4개 action에서 모두 재사용.
2. **4개 action 리팩토** — 모두 동일 패턴: `getCurrentUser` → `resolveTierAndByok` → 게이트 차단 시 `{ status: 'error', error }` 반환, 통과 시 siglens-core에 `tier` (또는 `tierContext`) + 조건부 `userApiKey` 전달.
3. **종합 분석**: top-level `tier` + `userApiKey` 전달 (siglens-core dependency resolver가 3개 axis로 전파). technical axis는 추가로 `tierContext: { userId, tier }` 명시.

### 결함 수정

- pro 티어 + 프리미엄 모델 분석이 깨져 있던 문제 해결 (worker가 `tier === 'pro'` 시 자체 서버 키 사용)
- BYOK 유저(non-pro + 프리미엄)의 뉴스/펀더멘털/종합 분석 정상화

### 코드 구조

| 파일 | 변경 |
|---|---|
| `src/infrastructure/market/byokGate.ts` | 신규 — `resolveTierAndByok`, `AnalysisGateError`, `isKnownModelId` |
| `src/infrastructure/market/submitAnalysisAction.ts` | 189줄 → 63줄 (인라인 BYOK 로직 → 헬퍼 사용) |
| `src/infrastructure/market/submitNewsAnalysisAction.ts` | tier + BYOK 전달 |
| `src/infrastructure/market/submitFundamentalAnalysisAction.ts` | tier + BYOK 전달 |
| `src/infrastructure/market/submitOverallAnalysisAction.ts` | tier + BYOK 전달 (top-level) |

## Prerequisites

**의존성: `@y0ngha/siglens-core` 신버전 필요.** 머지 전에 `package.json`의 버전을 업데이트해야 합니다:

- 현재: `"@y0ngha/siglens-core": "0.9.2"`
- 머지 시 변경: `"@y0ngha/siglens-core": "<release after siglens-core PR #84>"`

이 PR의 코드는 다음 신규 export를 의존:
- `isPremiumModel(model, config?)`
- `tier?: Tier`, `userApiKey?: string` 옵션 필드 (4개 분석 함수)
- 종합 분석 dependency resolver의 axis 전파

## Test plan

- [x] yarn test — 1565/1565 통과 (개발 시 portal 링크로 검증)
- [x] yarn lint — 통과
- [x] byokGate.ts 자체 테스트: 12 케이스 (7 resolveTierAndByok + 1 buildGateError + 4 isKnownModelId)
- [ ] 신버전 siglens-core publish 후 yarn build (next build) 통합 검증
- [ ] 통합 시나리오:
  - [ ] pro 유저 + 프리미엄 모델 분석 → 정상 처리
  - [ ] free/member 유저 + BYOK 등록 + 프리미엄 모델 → 정상 처리
  - [ ] free/member 유저 + 프리미엄 모델 + BYOK 미등록 → `tier_premium_blocked` UI 표시
  - [ ] 무료 모델 분석 → 모든 티어에서 정상

## Release order

1. ✅ siglens-worker PR — backward-compatible
2. ✅ siglens-core PR #84 — 신버전 릴리즈 필요
3. **이 PR** — siglens-core 신버전 사용

## Follow-up

다음은 별도 PR로 진행 예정:
- `src/domain/llm/modelTier.ts`의 인라인 `TIER_CONFIG.models.free.includes()` 패턴을 `isFreeModel`로 위임 (portal-link 환경에서 일부 컴포넌트 테스트가 깨지는 이슈가 있어 본 PR에서는 revert함; 정식 publish된 version에선 정상 동작 예상)

Spec: `siglens-core/docs/superpowers/specs/2026-05-08-analysis-api-key-routing-design.md` (gitignored, 로컬 보관)