### PR TITLE
fix: cancel analysis jobs on page unload

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,6 +1,7 @@
 
 # Fix Log
 
+
 ## [PR #432 Round 2 | feat/pagehide-cancel | 2026-05-09]
 - Violation: None — review-agent approved with zero findings
 - Rule: N/A

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,6 +1,11 @@
 
 # Fix Log
 
+## [PR #432 Round 2 | feat/pagehide-cancel | 2026-05-09]
+- Violation: None — review-agent approved with zero findings
+- Rule: N/A
+- Context: All round 1 findings fixed and approved; no additional issues identified in round 2.
+
 ## [PR #430 Round 2 | feat/analysis-key-routing | 2026-05-08]
 - Violation: `getCurrentUser()` called outside try-catch in `submitOverallAnalysisAction.ts` while the same call is inside try in the other 3 sibling actions — asymmetric failure handling
   - Rule: MISTAKES.md I/O & Error Handling #1 — When one I/O operation in a module is protected with try-catch, all I/O operations at the same call depth must be equivalently protected

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -2,6 +2,14 @@
 # Fix Log
 
 
+## [PR #432 Round 4 | fix/cancel-job-on-page-unload | 2026-05-09]
+- Violation: `getPageHideJobs = useCallback(...)` and `usePageHideCancel(...)` placed after two `useEffect` blocks in `useOverallAnalysis.ts`
+  - Rule: MISTAKES.md §17 — useCallback/useMemo must be declared before all useEffect blocks
+  - Context: The three other hooks (useFundamentalAnalysis, useNewsAnalysis, useAnalysis) had the correct order; useOverallAnalysis was missed during the round 3 fix
+- Violation: `route.ts` body validation used `!j.type` (falsy check only), allowing invalid type strings (e.g. `"unknown"`) to pass and silently return 204
+  - Rule: Infrastructure Functions — validate all inputs at API boundaries; invalid values must return 400
+  - Context: Added `VALID_JOB_TYPES` Set check so unrecognized job types are rejected with 400 rather than logged as a warning and treated as success
+
 ## [PR #432 Round 2 | feat/pagehide-cancel | 2026-05-09]
 - Violation: None — review-agent approved with zero findings
 - Rule: N/A

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -81,12 +81,6 @@
 - S3 (skipped — False Positive): `src/infrastructure/auth/finalizeOAuthSignupAction.ts` — reviewer suggested changing `tx as unknown as SiglensDatabase` to `tx as SiglensDatabase`. Reverted: `PgTransaction<NeonHttpQueryResultHKT, ...>` doesn't overlap with `NeonHttpDatabase<...>` (SiglensDatabase), causing TS error 2352. The double cast is required.
 
 
-## [PR #420 Round 11 | master | 2026-05-05]
-- B3: `ConsentCheckboxGroup.tsx` — error `<p>` had no `id`; invalid checkboxes had no `aria-describedby` connection to error message. Added `const errorId = useId()`, `id={errorId}` on error element, `errorId` prop on ConsentRow, `aria-describedby: errorId` on checkbox inputs.
-  - Rule: ARIA accessibility — form inputs with errors must have aria-describedby pointing to error message
-- S1: `route.ts` ([provider] callback) — `let token; try { token = await ... } catch { return ... }` imperative pattern (MISTAKES.md §14). Replaced with declarative `const token = await pendingStore.save({...}).catch(() => null); if (!token) return ...`
-  - Rule: MISTAKES.md §14 — Imperative exception handling within try-catch should use declarative .catch() or ?. chains
-
 ## [PR #420 Round 8 | master | 2026-05-05]
 - B3: `registerAction.test.ts` `expect.anything()` → `expect.objectContaining({ emailTokens, db })` 명시 검증. db mock에 `transaction` 함수 추가.
   - Rule: 의존성 주입 검증 — db 인자 포함 여부 명시

--- a/src/__tests__/components/fundamental/hooks/useFundamentalAnalysis.test.tsx
+++ b/src/__tests__/components/fundamental/hooks/useFundamentalAnalysis.test.tsx
@@ -5,11 +5,13 @@ import { useFundamentalAnalysis } from '@/components/fundamental/hooks/useFundam
 import { cancelFundamentalAnalysisJobAction } from '@/infrastructure/market/cancelFundamentalAnalysisJobAction';
 import { pollFundamentalAnalysisAction } from '@/infrastructure/market/pollFundamentalAnalysisAction';
 import { submitFundamentalAnalysisAction } from '@/infrastructure/market/submitFundamentalAnalysisAction';
+import { CANCEL_JOBS_API_PATH } from '@/lib/cancelJobsApi';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { FundamentalAnalysisResponse } from '@y0ngha/siglens-core';
 import type { ReactNode } from 'react';
 import { renderToString } from 'react-dom/server';
+import { readBlobText } from '@/__tests__/utils/readBlobText';
 
 jest.mock('@/infrastructure/market/submitFundamentalAnalysisAction', () => ({
     submitFundamentalAnalysisAction: jest.fn(),
@@ -216,6 +218,111 @@ describe('useFundamentalAnalysis', () => {
             unmount();
 
             expect(mockCancel).not.toHaveBeenCalled();
+        });
+
+        describe('pagehide', () => {
+            let sendBeaconMock: jest.Mock;
+
+            beforeEach(() => {
+                sendBeaconMock = jest.fn();
+                Object.defineProperty(navigator, 'sendBeacon', {
+                    value: sendBeaconMock,
+                    configurable: true,
+                    writable: true,
+                });
+            });
+
+            it('polling 중 pagehide 발화 시 sendBeacon으로 cancel을 전송한다', async () => {
+                mockSubmit.mockResolvedValue({
+                    status: 'submitted',
+                    jobId: 'job-fundamental-123',
+                });
+                mockPoll.mockImplementation(() => new Promise(() => {}));
+
+                renderHook(
+                    () =>
+                        useFundamentalAnalysis(
+                            'AAPL',
+                            'gemini-2.5-flash-lite'
+                        ),
+                    { wrapper: makeWrapper() }
+                );
+
+                await waitFor(() => {
+                    expect(mockPoll).toHaveBeenCalled();
+                });
+
+                window.dispatchEvent(new Event('pagehide'));
+
+                expect(sendBeaconMock).toHaveBeenCalledTimes(1);
+                const [url, blob] = sendBeaconMock.mock.calls[0] as [
+                    string,
+                    Blob,
+                ];
+                expect(url).toBe(CANCEL_JOBS_API_PATH);
+                expect(blob.type).toBe('application/json');
+
+                const text = await readBlobText(blob);
+                expect(JSON.parse(text)).toEqual({
+                    jobs: [
+                        { jobId: 'job-fundamental-123', type: 'fundamental' },
+                    ],
+                });
+            });
+
+            it('job 없을 때 pagehide 발화해도 sendBeacon을 호출하지 않는다', async () => {
+                mockSubmit.mockResolvedValue({
+                    status: 'cached',
+                    result: FUNDAMENTAL_RESULT,
+                });
+
+                renderHook(
+                    () =>
+                        useFundamentalAnalysis(
+                            'AAPL',
+                            'gemini-2.5-flash-lite'
+                        ),
+                    { wrapper: makeWrapper() }
+                );
+
+                await waitFor(() => {
+                    expect(mockSubmit).toHaveBeenCalled();
+                });
+
+                window.dispatchEvent(new Event('pagehide'));
+
+                expect(sendBeaconMock).not.toHaveBeenCalled();
+            });
+
+            it('pagehide 발화 후 unmount 시 이중 cancel이 발생하지 않는다', async () => {
+                mockSubmit.mockResolvedValue({
+                    status: 'submitted',
+                    jobId: 'job-fundamental-123',
+                });
+                mockPoll.mockImplementation(() => new Promise(() => {}));
+
+                const { unmount } = renderHook(
+                    () =>
+                        useFundamentalAnalysis(
+                            'AAPL',
+                            'gemini-2.5-flash-lite'
+                        ),
+                    { wrapper: makeWrapper() }
+                );
+
+                await waitFor(() => {
+                    expect(mockPoll).toHaveBeenCalled();
+                });
+
+                // pagehide가 ref를 null로 만든다
+                window.dispatchEvent(new Event('pagehide'));
+                expect(sendBeaconMock).toHaveBeenCalledTimes(1);
+
+                // unmount 시 ref가 null이므로 cancelFundamentalAnalysisJobAction은 호출되지 않는다
+                unmount();
+
+                expect(mockCancel).not.toHaveBeenCalled();
+            });
         });
     });
 });

--- a/src/__tests__/components/fundamental/hooks/useFundamentalAnalysis.test.tsx
+++ b/src/__tests__/components/fundamental/hooks/useFundamentalAnalysis.test.tsx
@@ -241,10 +241,7 @@ describe('useFundamentalAnalysis', () => {
 
                 renderHook(
                     () =>
-                        useFundamentalAnalysis(
-                            'AAPL',
-                            'gemini-2.5-flash-lite'
-                        ),
+                        useFundamentalAnalysis('AAPL', 'gemini-2.5-flash-lite'),
                     { wrapper: makeWrapper() }
                 );
 
@@ -278,10 +275,7 @@ describe('useFundamentalAnalysis', () => {
 
                 renderHook(
                     () =>
-                        useFundamentalAnalysis(
-                            'AAPL',
-                            'gemini-2.5-flash-lite'
-                        ),
+                        useFundamentalAnalysis('AAPL', 'gemini-2.5-flash-lite'),
                     { wrapper: makeWrapper() }
                 );
 
@@ -303,10 +297,7 @@ describe('useFundamentalAnalysis', () => {
 
                 const { unmount } = renderHook(
                     () =>
-                        useFundamentalAnalysis(
-                            'AAPL',
-                            'gemini-2.5-flash-lite'
-                        ),
+                        useFundamentalAnalysis('AAPL', 'gemini-2.5-flash-lite'),
                     { wrapper: makeWrapper() }
                 );
 

--- a/src/__tests__/components/fundamental/hooks/useFundamentalAnalysis.test.tsx
+++ b/src/__tests__/components/fundamental/hooks/useFundamentalAnalysis.test.tsx
@@ -305,11 +305,9 @@ describe('useFundamentalAnalysis', () => {
                     expect(mockPoll).toHaveBeenCalled();
                 });
 
-                // pagehide가 ref를 null로 만든다
                 window.dispatchEvent(new Event('pagehide'));
                 expect(sendBeaconMock).toHaveBeenCalledTimes(1);
 
-                // unmount 시 ref가 null이므로 cancelFundamentalAnalysisJobAction은 호출되지 않는다
                 unmount();
 
                 expect(mockCancel).not.toHaveBeenCalled();

--- a/src/__tests__/components/hooks/usePageHideCancel.test.ts
+++ b/src/__tests__/components/hooks/usePageHideCancel.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+import { usePageHideCancel } from '@/components/hooks/usePageHideCancel';
+import { CANCEL_JOBS_API_PATH } from '@/lib/cancelJobsApi';
+import { renderHook } from '@testing-library/react';
+import { readBlobText } from '@/__tests__/utils/readBlobText';
+
+describe('usePageHideCancel', () => {
+    let sendBeaconMock: jest.Mock;
+
+    beforeEach(() => {
+        sendBeaconMock = jest.fn();
+        Object.defineProperty(navigator, 'sendBeacon', {
+            value: sendBeaconMock,
+            configurable: true,
+            writable: true,
+        });
+    });
+
+    it('pagehide 발화 시 sendBeacon을 CANCEL_JOBS_API_PATH로 호출한다', () => {
+        const getJobs = jest
+            .fn()
+            .mockReturnValue([{ jobId: 'job-123', type: 'analysis' }]);
+        renderHook(() => usePageHideCancel(getJobs));
+
+        window.dispatchEvent(new Event('pagehide'));
+
+        expect(sendBeaconMock).toHaveBeenCalledTimes(1);
+        expect(sendBeaconMock).toHaveBeenCalledWith(
+            CANCEL_JOBS_API_PATH,
+            expect.any(Blob)
+        );
+    });
+
+    it('Blob의 Content-Type이 application/json이다', () => {
+        const getJobs = jest
+            .fn()
+            .mockReturnValue([{ jobId: 'job-123', type: 'analysis' }]);
+        renderHook(() => usePageHideCancel(getJobs));
+
+        window.dispatchEvent(new Event('pagehide'));
+
+        const [, blob] = sendBeaconMock.mock.calls[0] as [string, Blob];
+        expect(blob.type).toBe('application/json');
+    });
+
+    it('Blob의 내용이 jobs 배열을 담은 올바른 JSON이다', async () => {
+        const jobs = [
+            { jobId: 'job-123', type: 'analysis' as const },
+            { jobId: 'job-456', type: 'fundamental' as const },
+        ];
+        const getJobs = jest.fn().mockReturnValue(jobs);
+        renderHook(() => usePageHideCancel(getJobs));
+
+        window.dispatchEvent(new Event('pagehide'));
+
+        const [, blob] = sendBeaconMock.mock.calls[0] as [string, Blob];
+        const text = await readBlobText(blob);
+        expect(JSON.parse(text)).toEqual({ jobs });
+    });
+
+    it('getJobs()가 null을 반환하면 sendBeacon을 호출하지 않는다', () => {
+        const getJobs = jest.fn().mockReturnValue(null);
+        renderHook(() => usePageHideCancel(getJobs));
+
+        window.dispatchEvent(new Event('pagehide'));
+
+        expect(sendBeaconMock).not.toHaveBeenCalled();
+    });
+
+    it('getJobs()가 빈 배열을 반환하면 sendBeacon을 호출하지 않는다', () => {
+        const getJobs = jest.fn().mockReturnValue([]);
+        renderHook(() => usePageHideCancel(getJobs));
+
+        window.dispatchEvent(new Event('pagehide'));
+
+        expect(sendBeaconMock).not.toHaveBeenCalled();
+    });
+
+    it('unmount 후 pagehide가 발화해도 sendBeacon을 호출하지 않는다', () => {
+        const getJobs = jest
+            .fn()
+            .mockReturnValue([{ jobId: 'job-123', type: 'analysis' }]);
+        const { unmount } = renderHook(() => usePageHideCancel(getJobs));
+
+        unmount();
+        window.dispatchEvent(new Event('pagehide'));
+
+        expect(sendBeaconMock).not.toHaveBeenCalled();
+    });
+
+    it('여러 job이 있으면 모두 payload에 포함된다', async () => {
+        const jobs = [
+            { jobId: 'job-t', type: 'analysis' as const },
+            { jobId: 'job-f', type: 'fundamental' as const },
+            { jobId: 'job-n', type: 'news' as const },
+        ];
+        const getJobs = jest.fn().mockReturnValue(jobs);
+        renderHook(() => usePageHideCancel(getJobs));
+
+        window.dispatchEvent(new Event('pagehide'));
+
+        const [, blob] = sendBeaconMock.mock.calls[0] as [string, Blob];
+        const text = await readBlobText(blob);
+        expect(JSON.parse(text)).toEqual({ jobs });
+    });
+});

--- a/src/__tests__/components/news/hooks/useNewsAnalysis.test.tsx
+++ b/src/__tests__/components/news/hooks/useNewsAnalysis.test.tsx
@@ -5,11 +5,13 @@ import { useNewsAnalysis } from '@/components/news/hooks/useNewsAnalysis';
 import { cancelNewsAnalysisJobAction } from '@/infrastructure/market/cancelNewsAnalysisJobAction';
 import { pollNewsAnalysisAction } from '@/infrastructure/market/pollNewsAnalysisAction';
 import { submitNewsAnalysisAction } from '@/infrastructure/market/submitNewsAnalysisAction';
+import { CANCEL_JOBS_API_PATH } from '@/lib/cancelJobsApi';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { NewsAnalysisResponse } from '@y0ngha/siglens-core';
 import type { ReactNode } from 'react';
 import { renderToString } from 'react-dom/server';
+import { readBlobText } from '@/__tests__/utils/readBlobText';
 
 jest.mock('@/infrastructure/market/submitNewsAnalysisAction', () => ({
     submitNewsAnalysisAction: jest.fn(),
@@ -229,6 +231,112 @@ describe('useNewsAnalysis', () => {
             unmount();
 
             expect(mockCancel).not.toHaveBeenCalled();
+        });
+
+        describe('pagehide', () => {
+            let sendBeaconMock: jest.Mock;
+
+            beforeEach(() => {
+                sendBeaconMock = jest.fn();
+                Object.defineProperty(navigator, 'sendBeacon', {
+                    value: sendBeaconMock,
+                    configurable: true,
+                    writable: true,
+                });
+            });
+
+            it('polling 중 pagehide 발화 시 sendBeacon으로 cancel을 전송한다', async () => {
+                mockSubmit.mockResolvedValue({
+                    status: 'submitted',
+                    jobId: 'job-news-123',
+                });
+                mockPoll.mockImplementation(() => new Promise(() => {}));
+
+                renderHook(
+                    () =>
+                        useNewsAnalysis(
+                            'AAPL',
+                            'Apple Inc.',
+                            'gemini-2.5-flash-lite'
+                        ),
+                    { wrapper: makeWrapper() }
+                );
+
+                await waitFor(() => {
+                    expect(mockPoll).toHaveBeenCalled();
+                });
+
+                window.dispatchEvent(new Event('pagehide'));
+
+                expect(sendBeaconMock).toHaveBeenCalledTimes(1);
+                const [url, blob] = sendBeaconMock.mock.calls[0] as [
+                    string,
+                    Blob,
+                ];
+                expect(url).toBe(CANCEL_JOBS_API_PATH);
+                expect(blob.type).toBe('application/json');
+
+                const text = await readBlobText(blob);
+                expect(JSON.parse(text)).toEqual({
+                    jobs: [{ jobId: 'job-news-123', type: 'news' }],
+                });
+            });
+
+            it('job 없을 때 pagehide 발화해도 sendBeacon을 호출하지 않는다', async () => {
+                mockSubmit.mockResolvedValue({
+                    status: 'cached',
+                    result: NEWS_RESULT,
+                });
+
+                renderHook(
+                    () =>
+                        useNewsAnalysis(
+                            'AAPL',
+                            'Apple Inc.',
+                            'gemini-2.5-flash-lite'
+                        ),
+                    { wrapper: makeWrapper() }
+                );
+
+                await waitFor(() => {
+                    expect(mockSubmit).toHaveBeenCalled();
+                });
+
+                window.dispatchEvent(new Event('pagehide'));
+
+                expect(sendBeaconMock).not.toHaveBeenCalled();
+            });
+
+            it('pagehide 발화 후 unmount 시 이중 cancel이 발생하지 않는다', async () => {
+                mockSubmit.mockResolvedValue({
+                    status: 'submitted',
+                    jobId: 'job-news-123',
+                });
+                mockPoll.mockImplementation(() => new Promise(() => {}));
+
+                const { unmount } = renderHook(
+                    () =>
+                        useNewsAnalysis(
+                            'AAPL',
+                            'Apple Inc.',
+                            'gemini-2.5-flash-lite'
+                        ),
+                    { wrapper: makeWrapper() }
+                );
+
+                await waitFor(() => {
+                    expect(mockPoll).toHaveBeenCalled();
+                });
+
+                // pagehide가 ref를 null로 만든다
+                window.dispatchEvent(new Event('pagehide'));
+                expect(sendBeaconMock).toHaveBeenCalledTimes(1);
+
+                // unmount 시 ref가 null이므로 cancelNewsAnalysisJobAction은 호출되지 않는다
+                unmount();
+
+                expect(mockCancel).not.toHaveBeenCalled();
+            });
         });
     });
 });

--- a/src/__tests__/components/news/hooks/useNewsAnalysis.test.tsx
+++ b/src/__tests__/components/news/hooks/useNewsAnalysis.test.tsx
@@ -328,11 +328,9 @@ describe('useNewsAnalysis', () => {
                     expect(mockPoll).toHaveBeenCalled();
                 });
 
-                // pagehide가 ref를 null로 만든다
                 window.dispatchEvent(new Event('pagehide'));
                 expect(sendBeaconMock).toHaveBeenCalledTimes(1);
 
-                // unmount 시 ref가 null이므로 cancelNewsAnalysisJobAction은 호출되지 않는다
                 unmount();
 
                 expect(mockCancel).not.toHaveBeenCalled();

--- a/src/__tests__/components/overall/hooks/useOverallAnalysis.test.tsx
+++ b/src/__tests__/components/overall/hooks/useOverallAnalysis.test.tsx
@@ -14,10 +14,12 @@ import { pollFundamentalAnalysisAction } from '@/infrastructure/market/pollFunda
 import { pollNewsAnalysisAction } from '@/infrastructure/market/pollNewsAnalysisAction';
 import { pollOverallAnalysisAction } from '@/infrastructure/market/pollOverallAnalysisAction';
 import { submitOverallAnalysisAction } from '@/infrastructure/market/submitOverallAnalysisAction';
+import { CANCEL_JOBS_API_PATH } from '@/lib/cancelJobsApi';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { OverallAnalysisResponse } from '@y0ngha/siglens-core';
 import type { ReactNode } from 'react';
+import { readBlobText } from '@/__tests__/utils/readBlobText';
 
 jest.mock('@/infrastructure/market/submitOverallAnalysisAction', () => ({
     submitOverallAnalysisAction: jest.fn(),
@@ -597,6 +599,115 @@ describe('useOverallAnalysis', () => {
             expect(mockCancelTechnical).not.toHaveBeenCalled();
             expect(mockCancelFundamental).not.toHaveBeenCalled();
             expect(mockCancelNews).not.toHaveBeenCalled();
+        });
+
+        describe('pagehide', () => {
+            let sendBeaconMock: jest.Mock;
+
+            beforeEach(() => {
+                sendBeaconMock = jest.fn();
+                Object.defineProperty(navigator, 'sendBeacon', {
+                    value: sendBeaconMock,
+                    configurable: true,
+                    writable: true,
+                });
+            });
+
+            it('overall polling 중 pagehide 발화 시 sendBeacon으로 overall job cancel을 전송한다', async () => {
+                mockSubmit.mockResolvedValue({
+                    status: 'submitted',
+                    jobId: 'overall-job-123',
+                });
+                mockPollOverall.mockImplementation(() => new Promise(() => {}));
+
+                const { result } = renderHook(
+                    () => useOverallAnalysis(...hookArgs()),
+                    { wrapper: makeWrapper() }
+                );
+
+                act(() => {
+                    result.current.trigger();
+                });
+
+                await waitFor(() => {
+                    expect(mockPollOverall).toHaveBeenCalled();
+                });
+
+                window.dispatchEvent(new Event('pagehide'));
+
+                expect(sendBeaconMock).toHaveBeenCalledTimes(1);
+                const [url, blob] = sendBeaconMock.mock.calls[0] as [
+                    string,
+                    Blob,
+                ];
+                expect(url).toBe(CANCEL_JOBS_API_PATH);
+                expect(blob.type).toBe('application/json');
+
+                const text = await readBlobText(blob);
+                expect(JSON.parse(text)).toEqual({
+                    jobs: [{ jobId: 'overall-job-123', type: 'overall' }],
+                });
+            });
+
+            it('pending_dependencies 중 pagehide 발화 시 각 axis job cancel을 sendBeacon으로 전송한다', async () => {
+                mockSubmit.mockResolvedValue(PENDING_DEPS);
+                mockPollTechnical.mockImplementation(
+                    () => new Promise(() => {})
+                );
+                mockPollFundamental.mockImplementation(
+                    () => new Promise(() => {})
+                );
+                mockPollNews.mockImplementation(() => new Promise(() => {}));
+
+                const { result } = renderHook(
+                    () => useOverallAnalysis(...hookArgs()),
+                    { wrapper: makeWrapper() }
+                );
+
+                act(() => {
+                    result.current.trigger();
+                });
+
+                await waitFor(() => {
+                    expect(mockPollTechnical).toHaveBeenCalled();
+                });
+
+                window.dispatchEvent(new Event('pagehide'));
+
+                expect(sendBeaconMock).toHaveBeenCalledTimes(1);
+                const [url, blob] = sendBeaconMock.mock.calls[0] as [
+                    string,
+                    Blob,
+                ];
+                expect(url).toBe(CANCEL_JOBS_API_PATH);
+                expect(blob.type).toBe('application/json');
+
+                const text = await readBlobText(blob);
+                const body = JSON.parse(text) as {
+                    jobs: { jobId: string; type: string }[];
+                };
+                expect(body.jobs).toEqual(
+                    expect.arrayContaining([
+                        { jobId: 'job-t', type: 'analysis' },
+                        { jobId: 'job-f', type: 'fundamental' },
+                        { jobId: 'job-n', type: 'news' },
+                    ])
+                );
+                expect(body.jobs).toHaveLength(3);
+            });
+
+            it('job 없을 때 pagehide 발화해도 sendBeacon을 호출하지 않는다', async () => {
+                const { result } = renderHook(
+                    () => useOverallAnalysis(...hookArgs()),
+                    { wrapper: makeWrapper() }
+                );
+
+                // trigger 없이 idle 상태에서 pagehide 발화
+                expect(result.current.state.status).toBe('idle');
+                window.dispatchEvent(new Event('pagehide'));
+
+                expect(sendBeaconMock).not.toHaveBeenCalled();
+            });
         });
     });
 });

--- a/src/__tests__/components/symbol-page/hooks/useAnalysis.test.tsx
+++ b/src/__tests__/components/symbol-page/hooks/useAnalysis.test.tsx
@@ -1,0 +1,244 @@
+/**
+ * @jest-environment jsdom
+ */
+import { useAnalysis } from '@/components/symbol-page/hooks/useAnalysis';
+import { cancelAnalysisJobAction } from '@/infrastructure/market/cancelAnalysisJobAction';
+import { pollAnalysisAction } from '@/infrastructure/market/pollAnalysisAction';
+import { getReanalyzeCooldownMs } from '@/infrastructure/market/reanalyzeCooldown';
+import { submitAnalysisAction } from '@/infrastructure/market/submitAnalysisAction';
+import { CANCEL_JOBS_API_PATH } from '@/lib/cancelJobsApi';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { AnalysisResponse, Timeframe } from '@y0ngha/siglens-core';
+import type { ReactNode } from 'react';
+import { readBlobText } from '@/__tests__/utils/readBlobText';
+
+jest.mock('@/infrastructure/market/submitAnalysisAction', () => ({
+    submitAnalysisAction: jest.fn(),
+}));
+
+jest.mock('@/infrastructure/market/pollAnalysisAction', () => ({
+    pollAnalysisAction: jest.fn(),
+}));
+
+jest.mock('@/infrastructure/market/cancelAnalysisJobAction', () => ({
+    cancelAnalysisJobAction: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/infrastructure/market/reanalyzeCooldown', () => ({
+    getReanalyzeCooldownMs: jest.fn().mockResolvedValue(0),
+    releaseReanalyzeCooldown: jest.fn().mockResolvedValue(undefined),
+    tryAcquireReanalyzeCooldown: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
+jest.mock('@/lib/sleep', () => ({
+    sleep: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockSubmit = submitAnalysisAction as jest.MockedFunction<
+    typeof submitAnalysisAction
+>;
+const mockPoll = pollAnalysisAction as jest.MockedFunction<
+    typeof pollAnalysisAction
+>;
+const mockCancel = cancelAnalysisJobAction as jest.MockedFunction<
+    typeof cancelAnalysisJobAction
+>;
+
+const INITIAL_ANALYSIS = {} as unknown as AnalysisResponse;
+
+const queryClients: QueryClient[] = [];
+
+function makeWrapper() {
+    const client = new QueryClient({
+        defaultOptions: {
+            mutations: { retry: false },
+            queries: { retry: false },
+        },
+    });
+    queryClients.push(client);
+    return function Wrapper({ children }: { children: ReactNode }) {
+        return (
+            <QueryClientProvider client={client}>
+                {children}
+            </QueryClientProvider>
+        );
+    };
+}
+
+interface PartialOptions {
+    symbol?: string;
+    initialAnalysisFailed?: boolean;
+    timeframeChangeCount?: number;
+    modelId?: string;
+}
+
+function makeOptions(overrides?: PartialOptions) {
+    return {
+        symbol: overrides?.symbol ?? 'AAPL',
+        companyName: 'Apple Inc.',
+        timeframe: '1Day' as Timeframe,
+        initialAnalysis: INITIAL_ANALYSIS,
+        initialAnalysisFailed: overrides?.initialAnalysisFailed ?? false,
+        timeframeChangeCount: overrides?.timeframeChangeCount ?? 0,
+        modelId: overrides?.modelId as never,
+    };
+}
+
+describe('useAnalysis', () => {
+    let sendBeaconMock: jest.Mock;
+
+    beforeEach(() => {
+        mockSubmit.mockReset();
+        mockPoll.mockReset();
+        mockCancel.mockReset();
+        mockCancel.mockResolvedValue(undefined);
+        (getReanalyzeCooldownMs as jest.Mock).mockResolvedValue(0);
+
+        sendBeaconMock = jest.fn();
+        Object.defineProperty(navigator, 'sendBeacon', {
+            value: sendBeaconMock,
+            configurable: true,
+            writable: true,
+        });
+    });
+
+    afterEach(() => {
+        queryClients.splice(0).forEach(client => client.clear());
+    });
+
+    describe('cancel', () => {
+        it('polling 중 unmount 시 진행 중인 job을 cancel한다', async () => {
+            mockSubmit.mockResolvedValue({
+                status: 'submitted',
+                jobId: 'job-analysis-123',
+            });
+            // never resolves → 루프가 첫 poll 호출 직후 멈춰 OOM을 방지한다
+            mockPoll.mockImplementation(() => new Promise(() => {}));
+
+            const { unmount } = renderHook(
+                () =>
+                    useAnalysis(
+                        makeOptions({ initialAnalysisFailed: true })
+                    ),
+                { wrapper: makeWrapper() }
+            );
+
+            await waitFor(() => {
+                expect(mockPoll).toHaveBeenCalled();
+            });
+
+            unmount();
+
+            expect(mockCancel).toHaveBeenCalledWith('job-analysis-123');
+        });
+
+        it('symbol 변경 시 진행 중인 job을 cancel한다', async () => {
+            mockSubmit.mockResolvedValue({
+                status: 'submitted',
+                jobId: 'job-analysis-123',
+            });
+            mockPoll.mockImplementation(() => new Promise(() => {}));
+
+            const { rerender } = renderHook(
+                ({ symbol }: { symbol: string }) =>
+                    useAnalysis(
+                        makeOptions({ symbol, initialAnalysisFailed: true })
+                    ),
+                {
+                    wrapper: makeWrapper(),
+                    initialProps: { symbol: 'AAPL' },
+                }
+            );
+
+            await waitFor(() => {
+                expect(mockPoll).toHaveBeenCalled();
+            });
+
+            rerender({ symbol: 'MSFT' });
+
+            expect(mockCancel).toHaveBeenCalledWith('job-analysis-123');
+        });
+
+        it('polling 중 pagehide 발화 시 sendBeacon으로 cancel을 전송한다', async () => {
+            mockSubmit.mockResolvedValue({
+                status: 'submitted',
+                jobId: 'job-analysis-123',
+            });
+            mockPoll.mockImplementation(() => new Promise(() => {}));
+
+            renderHook(
+                () =>
+                    useAnalysis(
+                        makeOptions({ initialAnalysisFailed: true })
+                    ),
+                { wrapper: makeWrapper() }
+            );
+
+            await waitFor(() => {
+                expect(mockPoll).toHaveBeenCalled();
+            });
+
+            window.dispatchEvent(new Event('pagehide'));
+
+            expect(sendBeaconMock).toHaveBeenCalledTimes(1);
+            const [url, blob] = sendBeaconMock.mock.calls[0] as [string, Blob];
+            expect(url).toBe(CANCEL_JOBS_API_PATH);
+            expect(blob.type).toBe('application/json');
+
+            const text = await readBlobText(blob);
+            expect(JSON.parse(text)).toEqual({
+                jobs: [{ jobId: 'job-analysis-123', type: 'analysis' }],
+            });
+        });
+
+        it('job 없을 때 pagehide 발화해도 sendBeacon을 호출하지 않는다', async () => {
+            mockSubmit.mockResolvedValue({
+                status: 'cached',
+                result: INITIAL_ANALYSIS,
+            });
+
+            renderHook(
+                () => useAnalysis(makeOptions()),
+                { wrapper: makeWrapper() }
+            );
+
+            await waitFor(() => {
+                expect(getReanalyzeCooldownMs).toHaveBeenCalled();
+            });
+
+            window.dispatchEvent(new Event('pagehide'));
+
+            expect(sendBeaconMock).not.toHaveBeenCalled();
+        });
+
+        it('pagehide 발화 후 unmount 시 이중 cancel이 발생하지 않는다', async () => {
+            mockSubmit.mockResolvedValue({
+                status: 'submitted',
+                jobId: 'job-analysis-123',
+            });
+            mockPoll.mockImplementation(() => new Promise(() => {}));
+
+            const { unmount } = renderHook(
+                () =>
+                    useAnalysis(
+                        makeOptions({ initialAnalysisFailed: true })
+                    ),
+                { wrapper: makeWrapper() }
+            );
+
+            await waitFor(() => {
+                expect(mockPoll).toHaveBeenCalled();
+            });
+
+            // pagehide가 ref를 null로 만든다
+            window.dispatchEvent(new Event('pagehide'));
+            expect(sendBeaconMock).toHaveBeenCalledTimes(1);
+
+            // unmount 시 ref가 null이므로 cancelAnalysisJobAction은 호출되지 않는다
+            unmount();
+
+            expect(mockCancel).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/__tests__/components/symbol-page/hooks/useAnalysis.test.tsx
+++ b/src/__tests__/components/symbol-page/hooks/useAnalysis.test.tsx
@@ -221,11 +221,9 @@ describe('useAnalysis', () => {
                 expect(mockPoll).toHaveBeenCalled();
             });
 
-            // pagehide가 ref를 null로 만든다
             window.dispatchEvent(new Event('pagehide'));
             expect(sendBeaconMock).toHaveBeenCalledTimes(1);
 
-            // unmount 시 ref가 null이므로 cancelAnalysisJobAction은 호출되지 않는다
             unmount();
 
             expect(mockCancel).not.toHaveBeenCalled();

--- a/src/__tests__/components/symbol-page/hooks/useAnalysis.test.tsx
+++ b/src/__tests__/components/symbol-page/hooks/useAnalysis.test.tsx
@@ -117,10 +117,7 @@ describe('useAnalysis', () => {
             mockPoll.mockImplementation(() => new Promise(() => {}));
 
             const { unmount } = renderHook(
-                () =>
-                    useAnalysis(
-                        makeOptions({ initialAnalysisFailed: true })
-                    ),
+                () => useAnalysis(makeOptions({ initialAnalysisFailed: true })),
                 { wrapper: makeWrapper() }
             );
 
@@ -168,10 +165,7 @@ describe('useAnalysis', () => {
             mockPoll.mockImplementation(() => new Promise(() => {}));
 
             renderHook(
-                () =>
-                    useAnalysis(
-                        makeOptions({ initialAnalysisFailed: true })
-                    ),
+                () => useAnalysis(makeOptions({ initialAnalysisFailed: true })),
                 { wrapper: makeWrapper() }
             );
 
@@ -198,10 +192,9 @@ describe('useAnalysis', () => {
                 result: INITIAL_ANALYSIS,
             });
 
-            renderHook(
-                () => useAnalysis(makeOptions()),
-                { wrapper: makeWrapper() }
-            );
+            renderHook(() => useAnalysis(makeOptions()), {
+                wrapper: makeWrapper(),
+            });
 
             await waitFor(() => {
                 expect(getReanalyzeCooldownMs).toHaveBeenCalled();
@@ -220,10 +213,7 @@ describe('useAnalysis', () => {
             mockPoll.mockImplementation(() => new Promise(() => {}));
 
             const { unmount } = renderHook(
-                () =>
-                    useAnalysis(
-                        makeOptions({ initialAnalysisFailed: true })
-                    ),
+                () => useAnalysis(makeOptions({ initialAnalysisFailed: true })),
                 { wrapper: makeWrapper() }
             );
 

--- a/src/__tests__/utils/readBlobText.ts
+++ b/src/__tests__/utils/readBlobText.ts
@@ -1,0 +1,12 @@
+/**
+ * Reads a Blob's text content using FileReader.
+ * Blob.prototype.text() is not available in the jsdom version used by this project.
+ */
+export function readBlobText(blob: Blob): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = reject;
+        reader.readAsText(blob);
+    });
+}

--- a/src/app/api/jobs/cancel/route.ts
+++ b/src/app/api/jobs/cancel/route.ts
@@ -5,7 +5,7 @@ import {
     cancelNewsAnalysisJob,
     cancelOverallAnalysisJob,
 } from '@y0ngha/siglens-core';
-import type { CancelJobsBody, JobType } from '@/lib/cancelJobsApi';
+import type { CancelJobEntry, CancelJobsBody } from '@/domain/types';
 
 const { HTTP_STATUS_BAD_REQUEST, HTTP_STATUS_NO_CONTENT } = constants;
 
@@ -14,7 +14,10 @@ export async function POST(request: Request): Promise<Response> {
     let jobs: CancelJobsBody['jobs'];
     try {
         const body: CancelJobsBody = await request.json();
-        if (!Array.isArray(body.jobs)) {
+        if (
+            !Array.isArray(body.jobs) ||
+            body.jobs.some(j => !j.jobId || !j.type)
+        ) {
             return new Response(null, { status: HTTP_STATUS_BAD_REQUEST });
         }
         jobs = body.jobs;
@@ -23,7 +26,7 @@ export async function POST(request: Request): Promise<Response> {
     }
 
     await Promise.allSettled(
-        jobs.map(({ jobId, type }: { jobId: string; type: JobType }) => {
+        jobs.map(({ jobId, type }: CancelJobEntry) => {
             switch (type) {
                 case 'analysis':
                     return cancelAnalysisJob(jobId);
@@ -33,6 +36,8 @@ export async function POST(request: Request): Promise<Response> {
                     return cancelNewsAnalysisJob(jobId);
                 case 'overall':
                     return cancelOverallAnalysisJob(jobId);
+                default:
+                    console.warn('[cancel route] unknown job type:', type);
             }
         })
     );

--- a/src/app/api/jobs/cancel/route.ts
+++ b/src/app/api/jobs/cancel/route.ts
@@ -1,0 +1,41 @@
+import { constants } from 'node:http2';
+import {
+    cancelAnalysisJob,
+    cancelFundamentalAnalysisJob,
+    cancelNewsAnalysisJob,
+    cancelOverallAnalysisJob,
+} from '@y0ngha/siglens-core';
+import type { CancelJobsBody, JobType } from '@/lib/cancelJobsApi';
+
+const { HTTP_STATUS_BAD_REQUEST, HTTP_STATUS_NO_CONTENT } = constants;
+
+/** Cancel one or more analysis jobs. Called via sendBeacon on pagehide. */
+export async function POST(request: Request): Promise<Response> {
+    let jobs: CancelJobsBody['jobs'];
+    try {
+        const body: CancelJobsBody = await request.json();
+        if (!Array.isArray(body.jobs)) {
+            return new Response(null, { status: HTTP_STATUS_BAD_REQUEST });
+        }
+        jobs = body.jobs;
+    } catch {
+        return new Response(null, { status: HTTP_STATUS_BAD_REQUEST });
+    }
+
+    await Promise.allSettled(
+        jobs.map(({ jobId, type }: { jobId: string; type: JobType }) => {
+            switch (type) {
+                case 'analysis':
+                    return cancelAnalysisJob(jobId);
+                case 'fundamental':
+                    return cancelFundamentalAnalysisJob(jobId);
+                case 'news':
+                    return cancelNewsAnalysisJob(jobId);
+                case 'overall':
+                    return cancelOverallAnalysisJob(jobId);
+            }
+        })
+    );
+
+    return new Response(null, { status: HTTP_STATUS_NO_CONTENT });
+}

--- a/src/app/api/jobs/cancel/route.ts
+++ b/src/app/api/jobs/cancel/route.ts
@@ -5,9 +5,16 @@ import {
     cancelNewsAnalysisJob,
     cancelOverallAnalysisJob,
 } from '@y0ngha/siglens-core';
-import type { CancelJobEntry, CancelJobsBody } from '@/domain/types';
+import type { CancelJobEntry, CancelJobsBody, JobType } from '@/domain/types';
 
 const { HTTP_STATUS_BAD_REQUEST, HTTP_STATUS_NO_CONTENT } = constants;
+
+const VALID_JOB_TYPES = new Set<JobType>([
+    'analysis',
+    'fundamental',
+    'news',
+    'overall',
+]);
 
 /** Cancel one or more analysis jobs. Called via sendBeacon on pagehide. */
 export async function POST(request: Request): Promise<Response> {
@@ -16,7 +23,12 @@ export async function POST(request: Request): Promise<Response> {
         const body: CancelJobsBody = await request.json();
         if (
             !Array.isArray(body.jobs) ||
-            body.jobs.some(j => !j.jobId || !j.type)
+            body.jobs.some(
+                j =>
+                    !j.jobId ||
+                    !j.type ||
+                    !VALID_JOB_TYPES.has(j.type as JobType)
+            )
         ) {
             return new Response(null, { status: HTTP_STATUS_BAD_REQUEST });
         }

--- a/src/app/api/jobs/cancel/route.ts
+++ b/src/app/api/jobs/cancel/route.ts
@@ -21,7 +21,8 @@ export async function POST(request: Request): Promise<Response> {
             return new Response(null, { status: HTTP_STATUS_BAD_REQUEST });
         }
         jobs = body.jobs;
-    } catch {
+    } catch (error) {
+        console.error('[cancel route] failed to parse request body:', error);
         return new Response(null, { status: HTTP_STATUS_BAD_REQUEST });
     }
 

--- a/src/components/fundamental/hooks/useFundamentalAnalysis.ts
+++ b/src/components/fundamental/hooks/useFundamentalAnalysis.ts
@@ -128,6 +128,23 @@ export function useFundamentalAnalysis(
         };
     }, [queryKey]);
 
+    // 브라우저 종료·새로고침·뒤로가기 등 페이지 언로드 시 진행 중인 job을 cancel한다.
+    // Server Action은 언로드 후 완료가 보장되지 않으므로 sendBeacon을 사용한다.
+    // ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
+    useEffect(() => {
+        function handlePageHide() {
+            const jobId = currentJobIdRef.current;
+            if (jobId === null) return;
+            currentJobIdRef.current = null;
+            navigator.sendBeacon(
+                '/api/jobs/cancel',
+                JSON.stringify({ jobs: [{ jobId, type: 'fundamental' }] })
+            );
+        }
+        window.addEventListener('pagehide', handlePageHide);
+        return () => window.removeEventListener('pagehide', handlePageHide);
+    }, []);
+
     if (query.isError) {
         return {
             status: 'error',

--- a/src/components/fundamental/hooks/useFundamentalAnalysis.ts
+++ b/src/components/fundamental/hooks/useFundamentalAnalysis.ts
@@ -14,6 +14,7 @@ import { sleep } from '@/lib/sleep';
 import { QUERY_KEYS } from '@/lib/queryConfig';
 import { FUNDAMENTAL_NEWS_POLL_INTERVAL_MS } from '@/lib/pollingConfig';
 import { usePageHideCancel } from '@/components/hooks/usePageHideCancel';
+import type { CancelJobEntry } from '@/domain/types';
 
 export type FundamentalAnalysisState =
     | { status: 'loading' }
@@ -106,6 +107,15 @@ export function useFundamentalAnalysis(
         void refetch();
     }, [refetch]);
 
+    // ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
+    const getPageHideJobs = useCallback((): CancelJobEntry[] | null => {
+        const jobId = currentJobIdRef.current;
+        if (jobId === null) return null;
+        currentJobIdRef.current = null;
+        return [{ jobId, type: 'fundamental' as const }];
+    }, []);
+    usePageHideCancel(getPageHideJobs);
+
     useEffect(() => {
         if (queryClient.getQueryData(queryKey) === undefined) {
             void refetch();
@@ -128,15 +138,6 @@ export function useFundamentalAnalysis(
             }
         };
     }, [queryKey]);
-
-    // ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
-    const getPageHideJobs = useCallback(() => {
-        const jobId = currentJobIdRef.current;
-        if (jobId === null) return null;
-        currentJobIdRef.current = null;
-        return [{ jobId, type: 'fundamental' as const }];
-    }, []);
-    usePageHideCancel(getPageHideJobs);
 
     if (query.isError) {
         return {

--- a/src/components/fundamental/hooks/useFundamentalAnalysis.ts
+++ b/src/components/fundamental/hooks/useFundamentalAnalysis.ts
@@ -13,6 +13,7 @@ import { cancelFundamentalAnalysisJobAction } from '@/infrastructure/market/canc
 import { sleep } from '@/lib/sleep';
 import { QUERY_KEYS } from '@/lib/queryConfig';
 import { FUNDAMENTAL_NEWS_POLL_INTERVAL_MS } from '@/lib/pollingConfig';
+import { usePageHideCancel } from '@/components/hooks/usePageHideCancel';
 
 export type FundamentalAnalysisState =
     | { status: 'loading' }
@@ -128,22 +129,14 @@ export function useFundamentalAnalysis(
         };
     }, [queryKey]);
 
-    // 브라우저 종료·새로고침·뒤로가기 등 페이지 언로드 시 진행 중인 job을 cancel한다.
-    // Server Action은 언로드 후 완료가 보장되지 않으므로 sendBeacon을 사용한다.
     // ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
-    useEffect(() => {
-        function handlePageHide() {
-            const jobId = currentJobIdRef.current;
-            if (jobId === null) return;
-            currentJobIdRef.current = null;
-            navigator.sendBeacon(
-                '/api/jobs/cancel',
-                JSON.stringify({ jobs: [{ jobId, type: 'fundamental' }] })
-            );
-        }
-        window.addEventListener('pagehide', handlePageHide);
-        return () => window.removeEventListener('pagehide', handlePageHide);
+    const getPageHideJobs = useCallback(() => {
+        const jobId = currentJobIdRef.current;
+        if (jobId === null) return null;
+        currentJobIdRef.current = null;
+        return [{ jobId, type: 'fundamental' as const }];
     }, []);
+    usePageHideCancel(getPageHideJobs);
 
     if (query.isError) {
         return {

--- a/src/components/hooks/usePageHideCancel.ts
+++ b/src/components/hooks/usePageHideCancel.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+import type { CancelJobEntry } from '@/domain/types';
+import { CANCEL_JOBS_API_PATH } from '@/lib/cancelJobsApi';
+
+/**
+ * pagehide 이벤트(탭 닫기·새로고침·뒤로가기 등 모든 언로드)에서 분석 job을 cancel한다.
+ * Server Action은 언로드 후 완료가 보장되지 않으므로 sendBeacon을 사용한다.
+ *
+ * @param getJobs - 언로드 시 취소할 job 목록을 반환하는 콜백. null이면 no-op.
+ *   콜백 내에서 ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
+ *   useCallback(fn, [])으로 감싸 안정적인 참조를 전달해야 한다.
+ */
+export function usePageHideCancel(
+    getJobs: () => CancelJobEntry[] | null
+): void {
+    useEffect(() => {
+        function handlePageHide() {
+            const jobs = getJobs();
+            if (!jobs || jobs.length === 0) return;
+            navigator.sendBeacon(
+                CANCEL_JOBS_API_PATH,
+                new Blob([JSON.stringify({ jobs })], {
+                    type: 'application/json',
+                })
+            );
+        }
+        window.addEventListener('pagehide', handlePageHide);
+        return () => window.removeEventListener('pagehide', handlePageHide);
+    }, [getJobs]);
+}

--- a/src/components/news/hooks/useNewsAnalysis.ts
+++ b/src/components/news/hooks/useNewsAnalysis.ts
@@ -134,6 +134,23 @@ export function useNewsAnalysis(
         };
     }, [queryKey]);
 
+    // 브라우저 종료·새로고침·뒤로가기 등 페이지 언로드 시 진행 중인 job을 cancel한다.
+    // Server Action은 언로드 후 완료가 보장되지 않으므로 sendBeacon을 사용한다.
+    // ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
+    useEffect(() => {
+        function handlePageHide() {
+            const jobId = currentJobIdRef.current;
+            if (jobId === null) return;
+            currentJobIdRef.current = null;
+            navigator.sendBeacon(
+                '/api/jobs/cancel',
+                JSON.stringify({ jobs: [{ jobId, type: 'news' }] })
+            );
+        }
+        window.addEventListener('pagehide', handlePageHide);
+        return () => window.removeEventListener('pagehide', handlePageHide);
+    }, []);
+
     if (query.isError) {
         return {
             status: 'error',

--- a/src/components/news/hooks/useNewsAnalysis.ts
+++ b/src/components/news/hooks/useNewsAnalysis.ts
@@ -10,6 +10,7 @@ import { cancelNewsAnalysisJobAction } from '@/infrastructure/market/cancelNewsA
 import { sleep } from '@/lib/sleep';
 import { QUERY_KEYS } from '@/lib/queryConfig';
 import { FUNDAMENTAL_NEWS_POLL_INTERVAL_MS } from '@/lib/pollingConfig';
+import { usePageHideCancel } from '@/components/hooks/usePageHideCancel';
 
 export type NewsAnalysisState =
     | { status: 'loading' }
@@ -134,22 +135,14 @@ export function useNewsAnalysis(
         };
     }, [queryKey]);
 
-    // 브라우저 종료·새로고침·뒤로가기 등 페이지 언로드 시 진행 중인 job을 cancel한다.
-    // Server Action은 언로드 후 완료가 보장되지 않으므로 sendBeacon을 사용한다.
     // ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
-    useEffect(() => {
-        function handlePageHide() {
-            const jobId = currentJobIdRef.current;
-            if (jobId === null) return;
-            currentJobIdRef.current = null;
-            navigator.sendBeacon(
-                '/api/jobs/cancel',
-                JSON.stringify({ jobs: [{ jobId, type: 'news' }] })
-            );
-        }
-        window.addEventListener('pagehide', handlePageHide);
-        return () => window.removeEventListener('pagehide', handlePageHide);
+    const getPageHideJobs = useCallback(() => {
+        const jobId = currentJobIdRef.current;
+        if (jobId === null) return null;
+        currentJobIdRef.current = null;
+        return [{ jobId, type: 'news' as const }];
     }, []);
+    usePageHideCancel(getPageHideJobs);
 
     if (query.isError) {
         return {

--- a/src/components/news/hooks/useNewsAnalysis.ts
+++ b/src/components/news/hooks/useNewsAnalysis.ts
@@ -11,6 +11,7 @@ import { sleep } from '@/lib/sleep';
 import { QUERY_KEYS } from '@/lib/queryConfig';
 import { FUNDAMENTAL_NEWS_POLL_INTERVAL_MS } from '@/lib/pollingConfig';
 import { usePageHideCancel } from '@/components/hooks/usePageHideCancel';
+import type { CancelJobEntry } from '@/domain/types';
 
 export type NewsAnalysisState =
     | { status: 'loading' }
@@ -115,6 +116,15 @@ export function useNewsAnalysis(
         void refetch();
     }, [refetch]);
 
+    // ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
+    const getPageHideJobs = useCallback((): CancelJobEntry[] | null => {
+        const jobId = currentJobIdRef.current;
+        if (jobId === null) return null;
+        currentJobIdRef.current = null;
+        return [{ jobId, type: 'news' as const }];
+    }, []);
+    usePageHideCancel(getPageHideJobs);
+
     useEffect(() => {
         if (queryClient.getQueryData(queryKey) === undefined) {
             void refetch();
@@ -134,15 +144,6 @@ export function useNewsAnalysis(
             }
         };
     }, [queryKey]);
-
-    // ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
-    const getPageHideJobs = useCallback(() => {
-        const jobId = currentJobIdRef.current;
-        if (jobId === null) return null;
-        currentJobIdRef.current = null;
-        return [{ jobId, type: 'news' as const }];
-    }, []);
-    usePageHideCancel(getPageHideJobs);
 
     if (query.isError) {
         return {

--- a/src/components/overall/hooks/useOverallAnalysis.ts
+++ b/src/components/overall/hooks/useOverallAnalysis.ts
@@ -21,7 +21,8 @@ import { cancelOverallAnalysisJobAction } from '@/infrastructure/market/cancelOv
 import { sleep } from '@/lib/sleep';
 import { QUERY_KEYS } from '@/lib/queryConfig';
 import { AUGMENT_AND_OVERALL_POLL_INTERVAL_MS } from '@/lib/pollingConfig';
-import type { CancelJobEntry } from '@/lib/cancelJobsApi';
+import type { CancelJobEntry } from '@/domain/types';
+import { usePageHideCancel } from '@/components/hooks/usePageHideCancel';
 import type {
     OverallAnalysisState,
     ProgressState,
@@ -426,39 +427,45 @@ export function useOverallAnalysis(
         };
     }, [queryKey]);
 
-    // 브라우저 종료·새로고침·뒤로가기 등 페이지 언로드 시 진행 중인 job을 cancel한다.
-    // Server Action은 언로드 후 완료가 보장되지 않으므로 sendBeacon을 사용한다.
     // ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
-    useEffect(() => {
-        function handlePageHide() {
-            const current = currentJobsRef.current;
-            if (current === null) return;
-            currentJobsRef.current = null;
+    const getPageHideJobs = useCallback((): CancelJobEntry[] | null => {
+        const current = currentJobsRef.current;
+        if (current === null) return null;
+        currentJobsRef.current = null;
 
-            let jobs: CancelJobEntry[];
-            if (current.phase === 'dependencies') {
-                const { technical, fundamental, news } = current.jobs;
-                jobs = [
-                    ...(technical !== undefined
-                        ? [{ jobId: technical, type: 'analysis' as const }]
-                        : []),
-                    ...(fundamental !== undefined
-                        ? [{ jobId: fundamental, type: 'fundamental' as const }]
-                        : []),
-                    ...(news !== undefined
-                        ? [{ jobId: news, type: 'news' as const }]
-                        : []),
-                ];
-            } else {
-                jobs = [{ jobId: current.jobId, type: 'overall' }];
-            }
+        const jobs: CancelJobEntry[] =
+            current.phase === 'dependencies'
+                ? [
+                      ...(current.jobs.technical !== undefined
+                          ? [
+                                {
+                                    jobId: current.jobs.technical,
+                                    type: 'analysis' as const,
+                                },
+                            ]
+                          : []),
+                      ...(current.jobs.fundamental !== undefined
+                          ? [
+                                {
+                                    jobId: current.jobs.fundamental,
+                                    type: 'fundamental' as const,
+                                },
+                            ]
+                          : []),
+                      ...(current.jobs.news !== undefined
+                          ? [
+                                {
+                                    jobId: current.jobs.news,
+                                    type: 'news' as const,
+                                },
+                            ]
+                          : []),
+                  ]
+                : [{ jobId: current.jobId, type: 'overall' as const }];
 
-            if (jobs.length === 0) return;
-            navigator.sendBeacon('/api/jobs/cancel', JSON.stringify({ jobs }));
-        }
-        window.addEventListener('pagehide', handlePageHide);
-        return () => window.removeEventListener('pagehide', handlePageHide);
+        return jobs.length > 0 ? jobs : null;
     }, []);
+    usePageHideCancel(getPageHideJobs);
 
     return { state, trigger };
 }

--- a/src/components/overall/hooks/useOverallAnalysis.ts
+++ b/src/components/overall/hooks/useOverallAnalysis.ts
@@ -21,6 +21,7 @@ import { cancelOverallAnalysisJobAction } from '@/infrastructure/market/cancelOv
 import { sleep } from '@/lib/sleep';
 import { QUERY_KEYS } from '@/lib/queryConfig';
 import { AUGMENT_AND_OVERALL_POLL_INTERVAL_MS } from '@/lib/pollingConfig';
+import type { CancelJobEntry } from '@/lib/cancelJobsApi';
 import type {
     OverallAnalysisState,
     ProgressState,
@@ -424,6 +425,40 @@ export function useOverallAnalysis(
             }
         };
     }, [queryKey]);
+
+    // 브라우저 종료·새로고침·뒤로가기 등 페이지 언로드 시 진행 중인 job을 cancel한다.
+    // Server Action은 언로드 후 완료가 보장되지 않으므로 sendBeacon을 사용한다.
+    // ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
+    useEffect(() => {
+        function handlePageHide() {
+            const current = currentJobsRef.current;
+            if (current === null) return;
+            currentJobsRef.current = null;
+
+            let jobs: CancelJobEntry[];
+            if (current.phase === 'dependencies') {
+                const { technical, fundamental, news } = current.jobs;
+                jobs = [
+                    ...(technical !== undefined
+                        ? [{ jobId: technical, type: 'analysis' as const }]
+                        : []),
+                    ...(fundamental !== undefined
+                        ? [{ jobId: fundamental, type: 'fundamental' as const }]
+                        : []),
+                    ...(news !== undefined
+                        ? [{ jobId: news, type: 'news' as const }]
+                        : []),
+                ];
+            } else {
+                jobs = [{ jobId: current.jobId, type: 'overall' }];
+            }
+
+            if (jobs.length === 0) return;
+            navigator.sendBeacon('/api/jobs/cancel', JSON.stringify({ jobs }));
+        }
+        window.addEventListener('pagehide', handlePageHide);
+        return () => window.removeEventListener('pagehide', handlePageHide);
+    }, []);
 
     return { state, trigger };
 }

--- a/src/components/overall/hooks/useOverallAnalysis.ts
+++ b/src/components/overall/hooks/useOverallAnalysis.ts
@@ -376,6 +376,46 @@ export function useOverallAnalysis(
         }
     }, [triggered, refetch]);
 
+    // ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
+    const getPageHideJobs = useCallback((): CancelJobEntry[] | null => {
+        const current = currentJobsRef.current;
+        if (current === null) return null;
+        currentJobsRef.current = null;
+
+        const jobs: CancelJobEntry[] =
+            current.phase === 'dependencies'
+                ? [
+                      ...(current.jobs.technical !== undefined
+                          ? [
+                                {
+                                    jobId: current.jobs.technical,
+                                    type: 'analysis' as const,
+                                },
+                            ]
+                          : []),
+                      ...(current.jobs.fundamental !== undefined
+                          ? [
+                                {
+                                    jobId: current.jobs.fundamental,
+                                    type: 'fundamental' as const,
+                                },
+                            ]
+                          : []),
+                      ...(current.jobs.news !== undefined
+                          ? [
+                                {
+                                    jobId: current.jobs.news,
+                                    type: 'news' as const,
+                                },
+                            ]
+                          : []),
+                  ]
+                : [{ jobId: current.jobId, type: 'overall' as const }];
+
+        return jobs.length > 0 ? jobs : null;
+    }, []);
+    usePageHideCancel(getPageHideJobs);
+
     useEffect(() => {
         if (queryClient.getQueryData(queryKeyRef.current) !== undefined) {
             setTriggered(true);
@@ -426,46 +466,6 @@ export function useOverallAnalysis(
             }
         };
     }, [queryKey]);
-
-    // ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
-    const getPageHideJobs = useCallback((): CancelJobEntry[] | null => {
-        const current = currentJobsRef.current;
-        if (current === null) return null;
-        currentJobsRef.current = null;
-
-        const jobs: CancelJobEntry[] =
-            current.phase === 'dependencies'
-                ? [
-                      ...(current.jobs.technical !== undefined
-                          ? [
-                                {
-                                    jobId: current.jobs.technical,
-                                    type: 'analysis' as const,
-                                },
-                            ]
-                          : []),
-                      ...(current.jobs.fundamental !== undefined
-                          ? [
-                                {
-                                    jobId: current.jobs.fundamental,
-                                    type: 'fundamental' as const,
-                                },
-                            ]
-                          : []),
-                      ...(current.jobs.news !== undefined
-                          ? [
-                                {
-                                    jobId: current.jobs.news,
-                                    type: 'news' as const,
-                                },
-                            ]
-                          : []),
-                  ]
-                : [{ jobId: current.jobId, type: 'overall' as const }];
-
-        return jobs.length > 0 ? jobs : null;
-    }, []);
-    usePageHideCancel(getPageHideJobs);
 
     return { state, trigger };
 }

--- a/src/components/symbol-page/hooks/useAnalysis.ts
+++ b/src/components/symbol-page/hooks/useAnalysis.ts
@@ -27,6 +27,7 @@ import {
 } from '@/infrastructure/market/reanalyzeCooldown';
 import { sleep } from '@/lib/sleep';
 import { CHART_ANALYSIS_POLL_INTERVAL_MS } from '@/lib/pollingConfig';
+import { usePageHideCancel } from '@/components/hooks/usePageHideCancel';
 
 interface AnalyzeMutationVariables {
     symbol: string;
@@ -440,7 +441,6 @@ export function useAnalysis({
         };
     }, [symbol, timeframe]);
 
-    // unmount 시 진행 중인 job을 cancel한다.
     // fire-and-forget이므로 useMutation 없이 직접 호출한다.
     useEffect(() => {
         return () => {
@@ -452,24 +452,16 @@ export function useAnalysis({
                 });
             }
         };
-    }, []);
+    }, [symbol]);
 
-    // 브라우저 종료·새로고침·뒤로가기 등 페이지 언로드 시 진행 중인 job을 cancel한다.
-    // Server Action은 언로드 후 완료가 보장되지 않으므로 sendBeacon을 사용한다.
     // ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
-    useEffect(() => {
-        function handlePageHide() {
-            const jobId = currentJobIdRef.current;
-            if (jobId === null) return;
-            currentJobIdRef.current = null;
-            navigator.sendBeacon(
-                '/api/jobs/cancel',
-                JSON.stringify({ jobs: [{ jobId, type: 'analysis' }] })
-            );
-        }
-        window.addEventListener('pagehide', handlePageHide);
-        return () => window.removeEventListener('pagehide', handlePageHide);
+    const getPageHideJobs = useCallback(() => {
+        const jobId = currentJobIdRef.current;
+        if (jobId === null) return null;
+        currentJobIdRef.current = null;
+        return [{ jobId, type: 'analysis' as const }];
     }, []);
+    usePageHideCancel(getPageHideJobs);
 
     return {
         analysis,

--- a/src/components/symbol-page/hooks/useAnalysis.ts
+++ b/src/components/symbol-page/hooks/useAnalysis.ts
@@ -440,6 +440,37 @@ export function useAnalysis({
         };
     }, [symbol, timeframe]);
 
+    // unmount 시 진행 중인 job을 cancel한다.
+    // fire-and-forget이므로 useMutation 없이 직접 호출한다.
+    useEffect(() => {
+        return () => {
+            const jobId = currentJobIdRef.current;
+            if (jobId !== null) {
+                currentJobIdRef.current = null;
+                void cancelAnalysisJobAction(jobId).catch(error => {
+                    console.warn('[useAnalysis] cancel failed', error);
+                });
+            }
+        };
+    }, []);
+
+    // 브라우저 종료·새로고침·뒤로가기 등 페이지 언로드 시 진행 중인 job을 cancel한다.
+    // Server Action은 언로드 후 완료가 보장되지 않으므로 sendBeacon을 사용한다.
+    // ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
+    useEffect(() => {
+        function handlePageHide() {
+            const jobId = currentJobIdRef.current;
+            if (jobId === null) return;
+            currentJobIdRef.current = null;
+            navigator.sendBeacon(
+                '/api/jobs/cancel',
+                JSON.stringify({ jobs: [{ jobId, type: 'analysis' }] })
+            );
+        }
+        window.addEventListener('pagehide', handlePageHide);
+        return () => window.removeEventListener('pagehide', handlePageHide);
+    }, []);
+
     return {
         analysis,
         analysisResult,

--- a/src/components/symbol-page/hooks/useAnalysis.ts
+++ b/src/components/symbol-page/hooks/useAnalysis.ts
@@ -28,6 +28,7 @@ import {
 import { sleep } from '@/lib/sleep';
 import { CHART_ANALYSIS_POLL_INTERVAL_MS } from '@/lib/pollingConfig';
 import { usePageHideCancel } from '@/components/hooks/usePageHideCancel';
+import type { CancelJobEntry } from '@/domain/types';
 
 interface AnalyzeMutationVariables {
     symbol: string;
@@ -269,6 +270,15 @@ export function useAnalysis({
         })();
     }, [reset, mutate]);
 
+    // ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
+    const getPageHideJobs = useCallback((): CancelJobEntry[] | null => {
+        const jobId = currentJobIdRef.current;
+        if (jobId === null) return null;
+        currentJobIdRef.current = null;
+        return [{ jobId, type: 'analysis' as const }];
+    }, []);
+    usePageHideCancel(getPageHideJobs);
+
     // 7. useLayoutEffect
     // symbol, timeframe의 최신 렌더 값을 DOM 커밋 전에 동기 갱신하여
     // mutation 호출 시점에 stale closure를 방지한다.
@@ -453,15 +463,6 @@ export function useAnalysis({
             }
         };
     }, [symbol]);
-
-    // ref를 null로 초기화해 unmount cleanup과의 이중 cancel을 방지한다.
-    const getPageHideJobs = useCallback(() => {
-        const jobId = currentJobIdRef.current;
-        if (jobId === null) return null;
-        currentJobIdRef.current = null;
-        return [{ jobId, type: 'analysis' as const }];
-    }, []);
-    usePageHideCancel(getPageHideJobs);
 
     return {
         analysis,

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -164,3 +164,7 @@ export interface ContextSwitchMessage {
 
 /** Chat display history union — `ChatMessage` (LLM-bound) + UI-only `ContextSwitchMessage`. */
 export type DisplayMessage = ChatMessage | ContextSwitchMessage;
+
+export type JobType = 'analysis' | 'fundamental' | 'news' | 'overall';
+export type CancelJobEntry = { jobId: string; type: JobType };
+export type CancelJobsBody = { jobs: CancelJobEntry[] };

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -166,5 +166,10 @@ export interface ContextSwitchMessage {
 export type DisplayMessage = ChatMessage | ContextSwitchMessage;
 
 export type JobType = 'analysis' | 'fundamental' | 'news' | 'overall';
-export type CancelJobEntry = { jobId: string; type: JobType };
-export type CancelJobsBody = { jobs: CancelJobEntry[] };
+export interface CancelJobEntry {
+    jobId: string;
+    type: JobType;
+}
+export interface CancelJobsBody {
+    jobs: CancelJobEntry[];
+}

--- a/src/lib/cancelJobsApi.ts
+++ b/src/lib/cancelJobsApi.ts
@@ -1,3 +1,1 @@
-export type JobType = 'analysis' | 'fundamental' | 'news' | 'overall';
-export type CancelJobEntry = { jobId: string; type: JobType };
-export type CancelJobsBody = { jobs: CancelJobEntry[] };
+export const CANCEL_JOBS_API_PATH = '/api/jobs/cancel';

--- a/src/lib/cancelJobsApi.ts
+++ b/src/lib/cancelJobsApi.ts
@@ -1,0 +1,3 @@
+export type JobType = 'analysis' | 'fundamental' | 'news' | 'overall';
+export type CancelJobEntry = { jobId: string; type: JobType };
+export type CancelJobsBody = { jobs: CancelJobEntry[] };


### PR DESCRIPTION
## Summary

- Add `POST /api/jobs/cancel` Route Handler that accepts `{ jobs: [{jobId, type}] }` and calls the appropriate siglens-core cancel functions via `Promise.allSettled`
- Add `pagehide` event listener to all 4 analysis hooks (`useAnalysis`, `useFundamentalAnalysis`, `useNewsAnalysis`, `useOverallAnalysis`) using `navigator.sendBeacon` — survives browser close unlike Server Actions
- Add unmount cleanup to `useAnalysis.ts` (was missing; the other 3 hooks already had it)
- Extract shared `JobType` / `CancelJobEntry` / `CancelJobsBody` types to `src/lib/cancelJobsApi.ts`

## Why `pagehide` instead of `beforeunload`
`beforeunload` is unreliable on iOS Safari for tab close. `pagehide` fires on tab close, refresh, hard navigation, and bfcache entry — all cases that require cancellation. It does **not** fire on tab switch.

## Why `sendBeacon` instead of Server Action
Server Actions are async fetch requests. The browser terminates them before completion on page unload. `navigator.sendBeacon` is OS-managed and guaranteed to deliver after page close.

## Coverage matrix

| Scenario | Before | After |
|---|---|---|
| Next.js client-side nav | ✅ `useEffect` cleanup | ✅ unchanged |
| Tab close / window close | ❌ | ✅ `pagehide` + sendBeacon |
| Refresh | ❌ | ✅ `pagehide` + sendBeacon |
| Back/forward (bfcache) | ❌ React doesn't unmount | ✅ `pagehide` + sendBeacon |
| Tab switch | ✅ no cancel (correct) | ✅ no cancel (pagehide doesn't fire) |
| iOS Safari tab close | ❌ beforeunload unreliable | ✅ pagehide reliable |

🤖 Generated with [Claude Code](https://claude.com/claude-code)