### PR TITLE
fix: OpenInterest 차트 호버 툴팁 개선

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,6 +1,22 @@
 
 # Fix Log
 
+## [PR #442 Round 2 | fix/oi-tooltip-floating | 2026-05-22]
+- B1: `src/components/options/OpenInterestChart.tsx` — Hook 선언 순서 위반. `useMemo`(derived)가 `useRef`(containerRef)/`useState`(hoveredIndex, tooltipPos)보다 먼저 선언돼 있었음. CONVENTIONS.md "Custom Hook Declaration Order"에 맞춰 useRef/useState를 함수 본문 최상단으로 끌어올리고 useMemo는 그 다음에 배치.
+  - Rule: MISTAKES.md §17 / CONVENTIONS.md Custom Hook Declaration Order.
+- B2: 같은 파일 — tooltip 위치를 인라인 style(`{ left, top }`)로 주고 있었음. CSS 커스텀 프로퍼티(`--tooltip-x`, `--tooltip-y`) + Tailwind arbitrary value(`top-[var(--tooltip-y)] left-[var(--tooltip-x)]`) 패턴으로 변환. `style` 객체는 `as CSSProperties` 단언이 필요해 React import도 갱신.
+  - Rule: MISTAKES.md §19 — 동적 런타임 값도 CSS 커스텀 프로퍼티 + Tailwind arbitrary로 처리.
+- B3: 같은 파일 — `role="tooltip"`만 있고 id 없음, hit-rect의 `aria-describedby`도 누락. `TOOLTIP_ELEMENT_ID = 'oi-chart-tooltip'` 상수로 anchor를 만들고 tooltip div의 `id`와 각 hit-rect의 `aria-describedby`에 연결.
+  - Rule: MISTAKES.md Accessibility §3 — ARIA tooltip 패턴.
+- B4: 같은 파일 — tooltip 위치 계산에 viewport 경계 체크 없음(`-translate-x-1/2 -translate-y-full`만 적용). `computeTooltipPos` 헬퍼 추가: 좌우는 `TOOLTIP_HALF_WIDTH_PX + TOOLTIP_VIEWPORT_PADDING_PX` 이내로 clamp, 상단은 `TOOLTIP_APPROX_HEIGHT_PX + offset` 이상으로 clamp.
+  - Rule: MISTAKES.md UX §2 — Tooltip 위치 계산 시 뷰포트 경계 체크 필요.
+- H1: 같은 파일 — `oiByStrike`가 만기 전환으로 짧아지면 `hoveredIndex`가 stale 상태로 남아 `hoveredRow.strike` 접근 시 런타임 에러 가능. `hoveredRow = (hoveredIndex !== null && oiByStrike[hoveredIndex]) || null` 패턴으로 인덱스 lookup 결과를 직접 정규화.
+  - Rule: FF Predictability — 데이터 변경 사이의 stale state도 안전하게 처리.
+- M1: 같은 파일 — `onPointerMove`에서 매번 `getBoundingClientRect()` 호출 → 마우스 빠르게 움직이면 reflow 폭증. `cachedRectRef`(useRef)로 enter 시점 한 번 측정 후 캐시; move는 캐시된 rect만 사용. touchmove 같은 enter-skip 경로엔 lazy 측정 fallback 추가.
+  - Rule: 성능 — DOMRect 측정은 reflow를 강제하므로 mousemove 핸들러 안에서 반복 호출 금지.
+- M2: 같은 파일 — tooltip 위치 계산의 매직 넘버 `8` (커서 위로 띄우는 오프셋) 등을 module-level 상수로 추출. `TOOLTIP_CURSOR_OFFSET_Y_PX`, `TOOLTIP_HALF_WIDTH_PX`, `TOOLTIP_VIEWPORT_PADDING_PX`, `TOOLTIP_APPROX_HEIGHT_PX` 4종.
+  - Rule: MISTAKES.md §13 — 매직 넘버 module-level 상수 추출.
+
 ## [PR #441 Round 6 | fix/symbol-options-issues | 2026-05-22]
 - S1: `src/components/options/OpenInterestChart.tsx` — 렌더 함수 안에서 `const bw = barWidth(count)`(내부에서 `slotWidth(count)` 호출)과 `const sw = slotWidth(count)`가 동일한 `CHART_WIDTH / count`를 두 번 계산했음. `barWidth` 헬퍼를 제거하고 `const sw = slotWidth(count); const bw = sw * BAR_WIDTH_FILL_RATIO;`로 인라인 처리해 중복 연산을 제거.
   - Rule: MISTAKES.md §2 — 동일 값을 한 함수 안에서 여러 번 계산하면 local const로 한 번만 계산해 재사용.

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,6 +1,14 @@
 
 # Fix Log
 
+## [PR #442 Round 5 | fix/oi-tooltip-floating | 2026-05-22]
+- S1: `src/components/options/OpenInterestChart.tsx` — tooltip JSX 주석이 "`hidden`으로 숨겨 스크린리더가 대상을 찾되 시각적으로만 숨김"이라고 표기. 실제로 HTML `hidden` 속성은 접근성 트리에서도 완전히 제거함. 사실관계 정정: "screen reader도 참조를 따라올 수 없지만 하단 sr-only 테이블이 대체 제공하므로 pointer-only tooltip에선 허용 가능 트레이드오프"로 재작성.
+  - Rule: MISTAKES.md §15.3 — 사실관계가 잘못된 주석은 미래 독자에게 오해를 준다.
+- S2: 같은 파일 — `hoveredRow` 표현이 `||` 기반(`(hoveredIndex !== null && oiByStrike[hoveredIndex]) || null`)이라 row 객체 falsy 처리에 암묵 의존. `??` ternary(`hoveredIndex !== null ? (oiByStrike[hoveredIndex] ?? null) : null`)로 "배열 범위 초과 → null" 의도를 명시화.
+  - Rule: CONVENTIONS.md FP — 의도가 명확한 표현 방식 선호.
+- S3: `src/components/options/utils/computeTooltipPos.ts` (신규) + `src/__tests__/components/options/computeTooltipPos.test.ts` (신규) — pure 함수 `computeTooltipPos`와 tooltip 레이아웃 상수 6종을 별도 utility 파일로 분리하고 5건 단위 테스트 추가(가운데 정상 / 좌측 클램핑 / 우측 클램핑 / 상단 클램핑 / container 오프셋 상대좌표). OpenInterestChart.tsx는 named import로 전환.
+  - Rule: CONVENTIONS.md Coverage Targets — pure utility functions may be freely tested. 클램핑 분기는 상수(TOOLTIP_HALF_WIDTH_PX 등) 변경 시 회귀가 즉시 잡히도록 명시 검증.
+
 ## [PR #442 Round 4 | fix/oi-tooltip-floating | 2026-05-22]
 - B1: `src/components/options/OpenInterestChart.tsx` — `handlePointerEnter` / `handlePointerMove` / `handlePointerLeave` 세 핸들러가 파생 변수(`maxPainX`, `currentPriceX`, `peakOiLabel`)보다 앞에 선언됨. CONVENTIONS.md 처방 순서(`파생 변수 → 핸들러`)에 맞춰 핸들러를 `peakOiLabel` 뒤로 이동.
   - Rule: MISTAKES.md §17 — Hook 선언 순서: useState/useRef → useQuery/useMutation → useCallback/useMemo → 파생 변수 → 핸들러 → useEffect.

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,6 +1,14 @@
 
 # Fix Log
 
+## [PR #442 Round 4 | fix/oi-tooltip-floating | 2026-05-22]
+- B1: `src/components/options/OpenInterestChart.tsx` — `handlePointerEnter` / `handlePointerMove` / `handlePointerLeave` 세 핸들러가 파생 변수(`maxPainX`, `currentPriceX`, `peakOiLabel`)보다 앞에 선언됨. CONVENTIONS.md 처방 순서(`파생 변수 → 핸들러`)에 맞춰 핸들러를 `peakOiLabel` 뒤로 이동.
+  - Rule: MISTAKES.md §17 — Hook 선언 순서: useState/useRef → useQuery/useMutation → useCallback/useMemo → 파생 변수 → 핸들러 → useEffect.
+- S1: 같은 파일 — `TOOLTIP_HALF_WIDTH_PX = 90`이 className `min-w-[180px]`의 절반에 의존하지만 두 값이 별도라 한쪽만 바뀌면 클램핑 오작동. `TOOLTIP_MIN_WIDTH_PX = 180` single source of truth 도입 후 `TOOLTIP_HALF_WIDTH_PX = TOOLTIP_MIN_WIDTH_PX / 2`로 파생. className에서도 `min-w-[var(--tooltip-min-w)]` + style에 `--tooltip-min-w` 변수 주입해 한 곳에서 관리.
+  - Rule: MISTAKES.md §15 / drift 방지 — 동일 값을 두 표현(상수 + 클래스 리터럴)에 중복하면 silent drift 위험.
+- S2: 같은 파일 — `TOOLTIP_HALF_WIDTH_PX` 주석 첫 구절 "Tooltip의 가로 절반 너비" 제거. 상수명이 이미 표현. WHY(클램핑 용도)만 남김. S1과 함께 주석을 새 single source 의도("anchor 좌우로 절반씩 뻗으므로 절반 너비")로 재작성.
+  - Rule: MISTAKES.md §15.3 — WHAT 코멘트 금지.
+
 ## [PR #442 Round 3 | fix/oi-tooltip-floating | 2026-05-22]
 - B1: `src/components/options/OpenInterestChart.tsx` — Hook 선언 순서 재정정. CONVENTIONS.md 순서는 useState → useRef인데 R2에서 useRef를 먼저 선언해 두 번 반전됐다. useState 2개를 먼저, useRef 2개를 뒤로.
   - Rule: CONVENTIONS.md Custom Hook Declaration Order / MISTAKES.md §17. **이전 라운드(R2)에서 같은 룰에 대한 정정 → 부분 회귀**. 이번엔 useState → useRef 순서로 명확히 고정.

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,6 +1,20 @@
 
 # Fix Log
 
+## [PR #442 Round 3 | fix/oi-tooltip-floating | 2026-05-22]
+- B1: `src/components/options/OpenInterestChart.tsx` — Hook 선언 순서 재정정. CONVENTIONS.md 순서는 useState → useRef인데 R2에서 useRef를 먼저 선언해 두 번 반전됐다. useState 2개를 먼저, useRef 2개를 뒤로.
+  - Rule: CONVENTIONS.md Custom Hook Declaration Order / MISTAKES.md §17. **이전 라운드(R2)에서 같은 룰에 대한 정정 → 부분 회귀**. 이번엔 useState → useRef 순서로 명확히 고정.
+- B2: 같은 파일 — `{ x: number; y: number }` 인라인 객체 타입이 useState 타입 파라미터와 (R2의) `computeTooltipPos` 반환 타입 두 곳에 중복. 컴포넌트 위에 `TooltipPosition` 인터페이스를 추출해 모두 명명된 타입으로 통일.
+  - Rule: MISTAKES.md TypeScript §5.3 — 함수 반환 타입과 상태 타입에 인라인 객체 리터럴 금지.
+- S1: 같은 파일 — `computeTooltipPos`가 컴포넌트 상태/ref를 클로저하지 않음에도 컴포넌트 안에 정의돼 매 렌더마다 재생성. module-level 순수 함수로 추출.
+  - Rule: MISTAKES.md §20 / CONVENTIONS.md FP — 클로저 의존이 없는 헬퍼는 module-level로.
+- S2: 같은 파일 — `const rawX = event.clientX - rect.left` 위 "viewport 기준 좌표 → container 기준 좌표" 코멘트가 WHAT. 제거. 그 아래 클램핑 WHY 코멘트는 유지.
+  - Rule: MISTAKES.md §15.3 — WHAT 코멘트 금지.
+- S3: 같은 파일 — `as CSSProperties` safe-cast에 guarantee 주석 추가. CSS 커스텀 프로퍼티(--*)는 런타임 유효하지만 React `CSSProperties` 타입에 포함 안 되는 TS 한계 우회임을 명시.
+  - Rule: MISTAKES.md TypeScript §7 — 모든 safe-cast `as`에 guarantee 주석 필수.
+- S4: 같은 파일 — hit-rect의 `aria-describedby={TOOLTIP_ELEMENT_ID}`가 가리키는 tooltip div가 hover 시에만 조건부 렌더링되어 스크린리더가 anchor를 찾지 못함. tooltip div를 항상 DOM에 두고 비활성 시 `hidden` 속성으로 숨기는 WAI-ARIA tooltip 패턴 적용. 내부 컨텐츠는 hoveredRow가 있을 때만 렌더.
+  - Rule: WAI-ARIA tooltip 패턴 — describedby anchor는 항상 DOM에 있어야 한다.
+
 ## [PR #442 Round 2 | fix/oi-tooltip-floating | 2026-05-22]
 - B1: `src/components/options/OpenInterestChart.tsx` — Hook 선언 순서 위반. `useMemo`(derived)가 `useRef`(containerRef)/`useState`(hoveredIndex, tooltipPos)보다 먼저 선언돼 있었음. CONVENTIONS.md "Custom Hook Declaration Order"에 맞춰 useRef/useState를 함수 본문 최상단으로 끌어올리고 useMemo는 그 다음에 배치.
   - Rule: MISTAKES.md §17 / CONVENTIONS.md Custom Hook Declaration Order.

--- a/src/__tests__/components/options/computeTooltipPos.test.ts
+++ b/src/__tests__/components/options/computeTooltipPos.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for `computeTooltipPos`.
+ *
+ * Pure function — no DOM rendering needed. We hand-craft minimal pointer
+ * event / DOMRect shapes (only the fields the function reads) and cast
+ * through `unknown` to satisfy the public type signature.
+ */
+import type { PointerEvent } from 'react';
+import {
+    computeTooltipPos,
+    TOOLTIP_APPROX_HEIGHT_PX,
+    TOOLTIP_CURSOR_OFFSET_Y_PX,
+    TOOLTIP_HALF_WIDTH_PX,
+    TOOLTIP_VIEWPORT_PADDING_PX,
+} from '@/components/options/utils/computeTooltipPos';
+
+// 컨테이너 너비. 좌우 클램핑 경계가 양쪽 모두 유효하려면 절반 너비 + 패딩의
+// 두 배보다 충분히 커야 한다 (현재 값 196px).
+const CONTAINER_WIDTH = 600;
+const CONTAINER_HEIGHT = 240;
+
+function makeEvent(
+    clientX: number,
+    clientY: number
+): PointerEvent<SVGRectElement> {
+    return {
+        clientX,
+        clientY,
+    } as unknown as PointerEvent<SVGRectElement>;
+}
+
+function makeRect(): DOMRect {
+    return {
+        left: 0,
+        top: 0,
+        width: CONTAINER_WIDTH,
+        height: CONTAINER_HEIGHT,
+    } as DOMRect;
+}
+
+describe('computeTooltipPos', () => {
+    // 좌우 양쪽 클램핑이 모두 활성화될 수 있는 안전한 anchor x 범위.
+    const leftClampThreshold =
+        TOOLTIP_HALF_WIDTH_PX + TOOLTIP_VIEWPORT_PADDING_PX;
+    const rightClampThreshold =
+        CONTAINER_WIDTH - TOOLTIP_HALF_WIDTH_PX - TOOLTIP_VIEWPORT_PADDING_PX;
+    // 상단 클램핑이 시작되는 y의 최소값. cursor offset만큼 빼기 전이라
+    // `minY` 자체가 결과 y + offset이 된다.
+    const topClampMinAnchorY =
+        TOOLTIP_APPROX_HEIGHT_PX +
+        TOOLTIP_VIEWPORT_PADDING_PX +
+        TOOLTIP_CURSOR_OFFSET_Y_PX;
+
+    it('cursor가 컨테이너 가운데에 있을 때 raw 좌표에서 cursor offset만 빼서 반환한다', () => {
+        const event = makeEvent(300, 200);
+        const result = computeTooltipPos(event, makeRect());
+        expect(result.x).toBe(300);
+        expect(result.y).toBe(200 - TOOLTIP_CURSOR_OFFSET_Y_PX);
+    });
+
+    it('좌측 경계를 넘으면 x를 최소 안쪽 위치로 클램핑한다', () => {
+        const event = makeEvent(5, 200);
+        const result = computeTooltipPos(event, makeRect());
+        expect(result.x).toBe(leftClampThreshold);
+    });
+
+    it('우측 경계를 넘으면 x를 최대 안쪽 위치로 클램핑한다', () => {
+        const event = makeEvent(CONTAINER_WIDTH - 5, 200);
+        const result = computeTooltipPos(event, makeRect());
+        expect(result.x).toBe(rightClampThreshold);
+    });
+
+    it('상단 경계를 넘으면 y를 추정 카드 높이만큼 아래로 클램핑한다', () => {
+        const event = makeEvent(300, 10);
+        const result = computeTooltipPos(event, makeRect());
+        expect(result.y).toBe(topClampMinAnchorY - TOOLTIP_CURSOR_OFFSET_Y_PX);
+    });
+
+    it('container가 viewport 안쪽으로 오프셋된 경우에도 container 기준 상대 좌표를 반환한다', () => {
+        // container가 viewport에서 (100, 50) 오프셋된 상황을 가정. cursor가
+        // viewport 기준 (400, 250)에 있으면 container 기준 (300, 200)이다.
+        const offsetRect = {
+            left: 100,
+            top: 50,
+            width: CONTAINER_WIDTH,
+            height: CONTAINER_HEIGHT,
+        } as DOMRect;
+        const event = makeEvent(400, 250);
+        const result = computeTooltipPos(event, offsetRect);
+        expect(result.x).toBe(300);
+        expect(result.y).toBe(200 - TOOLTIP_CURSOR_OFFSET_Y_PX);
+    });
+});

--- a/src/components/options/OpenInterestChart.tsx
+++ b/src/components/options/OpenInterestChart.tsx
@@ -14,6 +14,12 @@ import {
 } from '@y0ngha/siglens-core';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { OpenInterestTooltip } from '@/components/options/utils/optionsTooltips';
+import {
+    computeTooltipPos,
+    TOOLTIP_ELEMENT_ID,
+    TOOLTIP_MIN_WIDTH_PX,
+    type TooltipPosition,
+} from '@/components/options/utils/computeTooltipPos';
 import { findNearestStrikeIndex } from '@/domain/options/findNearestStrike';
 
 interface OpenInterestChartProps {
@@ -23,12 +29,6 @@ interface OpenInterestChartProps {
     chain: OptionsChain | null;
     /** Pre-computed metrics — `maxPain` drives the dashed guide line. */
     metrics: OptionsExpirationMetrics | null;
-}
-
-/** Container-relative coordinates the floating tooltip is anchored at. */
-interface TooltipPosition {
-    x: number;
-    y: number;
 }
 
 const SVG_WIDTH = 600;
@@ -84,22 +84,6 @@ const X_AXIS_LABEL_OFFSET_PX = 14;
 const ROTATED_LABEL_FONT_SIZE = 8;
 const STRAIGHT_LABEL_FONT_SIZE = 9;
 
-// Tooltip이 커서 위로 띄울 세로 오프셋 (px). 위로 띄워야 막대를 가리지 않는다.
-const TOOLTIP_CURSOR_OFFSET_Y_PX = 8;
-// Tooltip min-width의 단일 진실 원천 (px). className의 `min-w-[var(--tooltip-min-w)]`
-// 와 `TOOLTIP_HALF_WIDTH_PX` 둘 다 이 값에서 파생되므로, 이 상수만 바꾸면
-// 좌우 경계 클램핑과 실제 가시 너비가 자동으로 동기화된다.
-const TOOLTIP_MIN_WIDTH_PX = 180;
-// 좌우 경계 클램핑용 — `-translate-x-1/2`로 anchor 좌우로 절반씩 뻗으므로 절반 너비.
-const TOOLTIP_HALF_WIDTH_PX = TOOLTIP_MIN_WIDTH_PX / 2;
-// 뷰포트 경계와 tooltip 사이 여유 (px). 컨테이너 모서리에 딱 붙지 않도록.
-const TOOLTIP_VIEWPORT_PADDING_PX = 8;
-// Tooltip 카드 자체의 대략적 높이. 정확한 측정 대신 추정값으로 상단 클램핑에 사용.
-const TOOLTIP_APPROX_HEIGHT_PX = 110;
-// DOM tooltip id — `role="tooltip"` 요소와 hit-rect의 `aria-describedby`가
-// 공유하는 anchor. ARIA tooltip 패턴(MISTAKES.md Accessibility §3).
-const TOOLTIP_ELEMENT_ID = 'oi-chart-tooltip';
-
 function slotWidth(count: number): number {
     return CHART_WIDTH / count;
 }
@@ -143,36 +127,6 @@ function fmtOi(value: number): string {
     if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
     if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
     return String(value);
-}
-
-/**
- * Pure helper. Computes container-relative tooltip coordinates from a pointer
- * event, clamping to viewport boundaries so the tooltip can't escape the
- * chart container even when the cursor is near an edge.
- *
- * Defined at module scope (not inside the component) because it captures no
- * state or refs — only its arguments and module-level layout constants.
- */
-function computeTooltipPos(
-    event: PointerEvent<SVGRectElement>,
-    rect: DOMRect
-): TooltipPosition {
-    const rawX = event.clientX - rect.left;
-    const rawY = event.clientY - rect.top;
-    // 좌우 경계 클램핑 — tooltip은 `-translate-x-1/2`로 좌우 절반이
-    // anchor 좌우로 뻗어나가므로 절반 너비 + 여유만큼 안쪽에 고정.
-    const clampedX = Math.min(
-        Math.max(rawX, TOOLTIP_HALF_WIDTH_PX + TOOLTIP_VIEWPORT_PADDING_PX),
-        rect.width - TOOLTIP_HALF_WIDTH_PX - TOOLTIP_VIEWPORT_PADDING_PX
-    );
-    // 상단 경계 클램핑 — tooltip은 `-translate-y-full`로 anchor 위로
-    // 뻗으므로 anchor가 너무 위면 tooltip이 컨테이너 밖으로 튀어나간다.
-    const minY =
-        TOOLTIP_APPROX_HEIGHT_PX +
-        TOOLTIP_VIEWPORT_PADDING_PX +
-        TOOLTIP_CURSOR_OFFSET_Y_PX;
-    const clampedY = Math.max(rawY, minY);
-    return { x: clampedX, y: clampedY - TOOLTIP_CURSOR_OFFSET_Y_PX };
 }
 
 export function OpenInterestChart({
@@ -252,9 +206,11 @@ export function OpenInterestChart({
 
     // hoveredIndex 가드: oiByStrike가 chip 전환으로 짧아지는 사이에 hover state
     // 가 stale이 되면 `oiByStrike[hoveredIndex]`가 undefined가 될 수 있다.
-    // 직접 lookup 결과를 ||로 정규화해 stale index → null로 떨어뜨린다.
+    // `??`로 정규화해 "배열 범위 초과 → null" 의도를 명시(`||`의 암묵적 falsy
+    // 처리에 의존하지 않음 — row 객체는 항상 truthy라 의미 차이는 없지만
+    // 표현이 더 정확하다).
     const hoveredRow =
-        (hoveredIndex !== null && oiByStrike[hoveredIndex]) || null;
+        hoveredIndex !== null ? (oiByStrike[hoveredIndex] ?? null) : null;
 
     const maxPainX = maxPainIdx >= 0 ? barCenterX(maxPainIdx, count) : null;
     const currentPriceX =
@@ -477,9 +433,11 @@ export function OpenInterestChart({
                 })}
             </svg>
 
-            {/* WAI-ARIA tooltip 패턴: hit-rect의 `aria-describedby`가 가리키는
-                대상은 항상 DOM에 있어야 한다. 비활성 시 `hidden` 속성으로 숨겨
-                스크린리더가 대상을 찾되 시각적으로는 보이지 않게 한다. */}
+            {/* `aria-describedby`가 가리키는 대상은 항상 DOM에 있어야 한다.
+                `hidden` 속성으로 숨기면 접근성 트리에서도 제거되어 screen
+                reader가 참조를 따라올 수 없지만, 하단 `sr-only` 테이블이
+                전체 OI 데이터를 제공하므로 이 pointer-only tooltip에서는
+                허용 가능한 트레이드오프다. */}
             <div
                 id={TOOLTIP_ELEMENT_ID}
                 role="tooltip"

--- a/src/components/options/OpenInterestChart.tsx
+++ b/src/components/options/OpenInterestChart.tsx
@@ -25,6 +25,12 @@ interface OpenInterestChartProps {
     metrics: OptionsExpirationMetrics | null;
 }
 
+/** Container-relative coordinates the floating tooltip is anchored at. */
+interface TooltipPosition {
+    x: number;
+    y: number;
+}
+
 const SVG_WIDTH = 600;
 const SVG_HEIGHT = 240;
 const PAD_TOP = 30;
@@ -136,21 +142,48 @@ function fmtOi(value: number): string {
     return String(value);
 }
 
+/**
+ * Pure helper. Computes container-relative tooltip coordinates from a pointer
+ * event, clamping to viewport boundaries so the tooltip can't escape the
+ * chart container even when the cursor is near an edge.
+ *
+ * Defined at module scope (not inside the component) because it captures no
+ * state or refs — only its arguments and module-level layout constants.
+ */
+function computeTooltipPos(
+    event: PointerEvent<SVGRectElement>,
+    rect: DOMRect
+): TooltipPosition {
+    const rawX = event.clientX - rect.left;
+    const rawY = event.clientY - rect.top;
+    // 좌우 경계 클램핑 — tooltip은 `-translate-x-1/2`로 좌우 절반이
+    // anchor 좌우로 뻗어나가므로 절반 너비 + 여유만큼 안쪽에 고정.
+    const clampedX = Math.min(
+        Math.max(rawX, TOOLTIP_HALF_WIDTH_PX + TOOLTIP_VIEWPORT_PADDING_PX),
+        rect.width - TOOLTIP_HALF_WIDTH_PX - TOOLTIP_VIEWPORT_PADDING_PX
+    );
+    // 상단 경계 클램핑 — tooltip은 `-translate-y-full`로 anchor 위로
+    // 뻗으므로 anchor가 너무 위면 tooltip이 컨테이너 밖으로 튀어나간다.
+    const minY =
+        TOOLTIP_APPROX_HEIGHT_PX +
+        TOOLTIP_VIEWPORT_PADDING_PX +
+        TOOLTIP_CURSOR_OFFSET_Y_PX;
+    const clampedY = Math.max(rawY, minY);
+    return { x: clampedX, y: clampedY - TOOLTIP_CURSOR_OFFSET_Y_PX };
+}
+
 export function OpenInterestChart({
     underlyingPrice,
     chain,
     metrics,
 }: OpenInterestChartProps) {
+    const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+    const [tooltipPos, setTooltipPos] = useState<TooltipPosition | null>(null);
     const containerRef = useRef<HTMLDivElement | null>(null);
     // 컨테이너 DOMRect 캐시. pointerEnter 시 한 번 측정해 두고 pointerMove에서
     // 재사용한다 — move마다 `getBoundingClientRect`를 부르면 reflow를 매번
     // 트리거해 마우스가 빠르게 움직일 때 frame drop을 유발한다.
     const cachedRectRef = useRef<DOMRect | null>(null);
-    const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
-    const [tooltipPos, setTooltipPos] = useState<{
-        x: number;
-        y: number;
-    } | null>(null);
 
     const derived = useMemo(() => {
         if (!chain) return null;
@@ -219,29 +252,6 @@ export function OpenInterestChart({
     // 직접 lookup 결과를 ||로 정규화해 stale index → null로 떨어뜨린다.
     const hoveredRow =
         (hoveredIndex !== null && oiByStrike[hoveredIndex]) || null;
-
-    const computeTooltipPos = (
-        event: PointerEvent<SVGRectElement>,
-        rect: DOMRect
-    ): { x: number; y: number } => {
-        // viewport 기준 좌표 → container 기준 좌표.
-        const rawX = event.clientX - rect.left;
-        const rawY = event.clientY - rect.top;
-        // 좌우 경계 클램핑 — tooltip은 `-translate-x-1/2`로 좌우 절반이
-        // anchor 좌우로 뻗어나가므로 절반 너비 + 여유만큼 안쪽에 고정.
-        const clampedX = Math.min(
-            Math.max(rawX, TOOLTIP_HALF_WIDTH_PX + TOOLTIP_VIEWPORT_PADDING_PX),
-            rect.width - TOOLTIP_HALF_WIDTH_PX - TOOLTIP_VIEWPORT_PADDING_PX
-        );
-        // 상단 경계 클램핑 — tooltip은 `-translate-y-full`로 anchor 위로
-        // 뻗으므로 anchor가 너무 위면 tooltip이 컨테이너 밖으로 튀어나간다.
-        const minY =
-            TOOLTIP_APPROX_HEIGHT_PX +
-            TOOLTIP_VIEWPORT_PADDING_PX +
-            TOOLTIP_CURSOR_OFFSET_Y_PX;
-        const clampedY = Math.max(rawY, minY);
-        return { x: clampedX, y: clampedY - TOOLTIP_CURSOR_OFFSET_Y_PX };
-    };
 
     const handlePointerEnter = (
         event: PointerEvent<SVGRectElement>,
@@ -464,45 +474,57 @@ export function OpenInterestChart({
                 })}
             </svg>
 
-            {hoveredRow !== null && tooltipPos !== null && (
-                <div
-                    id={TOOLTIP_ELEMENT_ID}
-                    role="tooltip"
-                    className="border-secondary-600 bg-secondary-900/95 text-secondary-100 pointer-events-none absolute top-[var(--tooltip-y)] left-[var(--tooltip-x)] z-10 min-w-[180px] -translate-x-1/2 -translate-y-full rounded-md border px-3 py-2 text-xs shadow-lg backdrop-blur"
-                    style={
-                        {
-                            '--tooltip-x': `${tooltipPos.x}px`,
-                            '--tooltip-y': `${tooltipPos.y}px`,
-                        } as CSSProperties
-                    }
-                >
-                    <div className="text-secondary-300 mb-1 font-semibold tabular-nums">
-                        Strike ${hoveredRow.strike.toLocaleString()}
-                    </div>
-                    <div className="flex items-center justify-between gap-3">
-                        <span className="text-chart-bullish">Call OI</span>
-                        <span className="tabular-nums">
-                            {hoveredRow.callOpenInterest.toLocaleString()} 계약
-                        </span>
-                    </div>
-                    <div className="flex items-center justify-between gap-3">
-                        <span className="text-chart-bearish">Put OI</span>
-                        <span className="tabular-nums">
-                            {hoveredRow.putOpenInterest.toLocaleString()} 계약
-                        </span>
-                    </div>
-                    <div className="border-secondary-700 mt-1 flex items-center justify-between gap-3 border-t pt-1">
-                        <span className="text-secondary-400">합계</span>
-                        <span className="font-semibold tabular-nums">
-                            {(
-                                hoveredRow.callOpenInterest +
-                                hoveredRow.putOpenInterest
-                            ).toLocaleString()}{' '}
-                            계약
-                        </span>
-                    </div>
-                </div>
-            )}
+            {/* WAI-ARIA tooltip 패턴: hit-rect의 `aria-describedby`가 가리키는
+                대상은 항상 DOM에 있어야 한다. 비활성 시 `hidden` 속성으로 숨겨
+                스크린리더가 대상을 찾되 시각적으로는 보이지 않게 한다. */}
+            <div
+                id={TOOLTIP_ELEMENT_ID}
+                role="tooltip"
+                hidden={hoveredRow === null || tooltipPos === null}
+                className="border-secondary-600 bg-secondary-900/95 text-secondary-100 pointer-events-none absolute top-[var(--tooltip-y)] left-[var(--tooltip-x)] z-10 min-w-[180px] -translate-x-1/2 -translate-y-full rounded-md border px-3 py-2 text-xs shadow-lg backdrop-blur"
+                style={
+                    // CSS 커스텀 프로퍼티(--*)는 런타임에 유효하나 React의
+                    // CSSProperties 타입은 임의 `--*` 키를 포함하지 않아
+                    // 인덱스 시그니처가 막힘 — TS 한계 우회용 cast이며
+                    // 런타임 리스크는 없다.
+                    {
+                        '--tooltip-x': `${tooltipPos?.x ?? 0}px`,
+                        '--tooltip-y': `${tooltipPos?.y ?? 0}px`,
+                    } as CSSProperties
+                }
+            >
+                {hoveredRow !== null && (
+                    <>
+                        <div className="text-secondary-300 mb-1 font-semibold tabular-nums">
+                            Strike ${hoveredRow.strike.toLocaleString()}
+                        </div>
+                        <div className="flex items-center justify-between gap-3">
+                            <span className="text-chart-bullish">Call OI</span>
+                            <span className="tabular-nums">
+                                {hoveredRow.callOpenInterest.toLocaleString()}{' '}
+                                계약
+                            </span>
+                        </div>
+                        <div className="flex items-center justify-between gap-3">
+                            <span className="text-chart-bearish">Put OI</span>
+                            <span className="tabular-nums">
+                                {hoveredRow.putOpenInterest.toLocaleString()}{' '}
+                                계약
+                            </span>
+                        </div>
+                        <div className="border-secondary-700 mt-1 flex items-center justify-between gap-3 border-t pt-1">
+                            <span className="text-secondary-400">합계</span>
+                            <span className="font-semibold tabular-nums">
+                                {(
+                                    hoveredRow.callOpenInterest +
+                                    hoveredRow.putOpenInterest
+                                ).toLocaleString()}{' '}
+                                계약
+                            </span>
+                        </div>
+                    </>
+                )}
+            </div>
 
             <div className="text-secondary-500 mt-2 flex flex-wrap items-center gap-3 text-[10px]">
                 <span className="flex items-center gap-1">

--- a/src/components/options/OpenInterestChart.tsx
+++ b/src/components/options/OpenInterestChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useRef, useState, type PointerEvent } from 'react';
 import {
     type OptionsChain,
     type OptionsExpirationMetrics,
@@ -170,6 +170,13 @@ export function OpenInterestChart({
         };
     }, [chain, metrics, underlyingPrice]);
 
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+    const [tooltipPos, setTooltipPos] = useState<{
+        x: number;
+        y: number;
+    } | null>(null);
+
     if (!derived) {
         return (
             <p className="text-secondary-500 py-4 text-sm">
@@ -184,6 +191,29 @@ export function OpenInterestChart({
     const sw = slotWidth(count);
     const bw = sw * BAR_WIDTH_FILL_RATIO;
 
+    const handlePointerMove = (
+        event: PointerEvent<SVGRectElement>,
+        index: number
+    ): void => {
+        const container = containerRef.current;
+        if (!container) return;
+        const containerRect = container.getBoundingClientRect();
+        setHoveredIndex(index);
+        // container 기준 상대 좌표로 변환 — wrapper에 `position: relative`가
+        // 걸려 있고 tooltip은 absolute로 띄우므로, viewport 좌표를 빼서 정렬.
+        setTooltipPos({
+            x: event.clientX - containerRect.left,
+            y: event.clientY - containerRect.top,
+        });
+    };
+
+    const handlePointerLeave = (): void => {
+        setHoveredIndex(null);
+        setTooltipPos(null);
+    };
+
+    const hoveredRow = hoveredIndex !== null ? oiByStrike[hoveredIndex] : null;
+
     const maxPainX = maxPainIdx >= 0 ? barCenterX(maxPainIdx, count) : null;
     const currentPriceX =
         currentPriceIdx >= 0 ? barCenterX(currentPriceIdx, count) : null;
@@ -193,7 +223,10 @@ export function OpenInterestChart({
     const peakOiLabel = fmtOi(globalMax);
 
     return (
-        <div className="border-secondary-700 bg-secondary-800 space-y-2 rounded-xl border p-4">
+        <div
+            ref={containerRef}
+            className="border-secondary-700 bg-secondary-800 relative space-y-2 rounded-xl border p-4"
+        >
             <div className="flex items-center gap-1">
                 <span className="text-secondary-300 text-sm font-medium">
                     Open Interest 분포 (Strike별)
@@ -263,15 +296,6 @@ export function OpenInterestChart({
                         globalMax
                     );
                     const putH = barPixelHeight(row.putOpenInterest, globalMax);
-                    const totalOi = row.callOpenInterest + row.putOpenInterest;
-                    // 슬롯 전체 너비의 투명 hit-rect를 깔아 막대 사이 빈 공간도
-                    // hover 가능하게 한다(특히 OI가 한쪽만 있는 strike).
-                    const tooltipText = [
-                        `Strike $${row.strike.toLocaleString()}`,
-                        `Call OI ${row.callOpenInterest.toLocaleString()} 계약`,
-                        `Put OI ${row.putOpenInterest.toLocaleString()} 계약`,
-                        `합계 ${totalOi.toLocaleString()} 계약`,
-                    ].join('\n');
 
                     return (
                         <g key={row.strike}>
@@ -300,11 +324,13 @@ export function OpenInterestChart({
                                 y={PAD_TOP}
                                 width={sw}
                                 height={CHART_HEIGHT}
-                                fill="transparent"
+                                fill="white"
+                                fillOpacity={0}
                                 pointerEvents="all"
-                            >
-                                <title>{tooltipText}</title>
-                            </rect>
+                                onPointerEnter={e => handlePointerMove(e, i)}
+                                onPointerMove={e => handlePointerMove(e, i)}
+                                onPointerLeave={handlePointerLeave}
+                            />
                         </g>
                     );
                 })}
@@ -368,6 +394,43 @@ export function OpenInterestChart({
                     );
                 })}
             </svg>
+
+            {hoveredRow !== null && tooltipPos !== null && (
+                <div
+                    role="tooltip"
+                    className="border-secondary-600 bg-secondary-900/95 text-secondary-100 pointer-events-none absolute z-10 min-w-[180px] -translate-x-1/2 -translate-y-full rounded-md border px-3 py-2 text-xs shadow-lg backdrop-blur"
+                    style={{
+                        left: tooltipPos.x,
+                        top: tooltipPos.y - 8,
+                    }}
+                >
+                    <div className="text-secondary-300 mb-1 font-semibold tabular-nums">
+                        Strike ${hoveredRow.strike.toLocaleString()}
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                        <span className="text-chart-bullish">Call OI</span>
+                        <span className="tabular-nums">
+                            {hoveredRow.callOpenInterest.toLocaleString()} 계약
+                        </span>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                        <span className="text-chart-bearish">Put OI</span>
+                        <span className="tabular-nums">
+                            {hoveredRow.putOpenInterest.toLocaleString()} 계약
+                        </span>
+                    </div>
+                    <div className="border-secondary-700 mt-1 flex items-center justify-between gap-3 border-t pt-1">
+                        <span className="text-secondary-400">합계</span>
+                        <span className="tabular-nums font-semibold">
+                            {(
+                                hoveredRow.callOpenInterest +
+                                hoveredRow.putOpenInterest
+                            ).toLocaleString()}{' '}
+                            계약
+                        </span>
+                    </div>
+                </div>
+            )}
 
             <div className="text-secondary-500 mt-2 flex flex-wrap items-center gap-3 text-[10px]">
                 <span className="flex items-center gap-1">

--- a/src/components/options/OpenInterestChart.tsx
+++ b/src/components/options/OpenInterestChart.tsx
@@ -421,7 +421,7 @@ export function OpenInterestChart({
                     </div>
                     <div className="border-secondary-700 mt-1 flex items-center justify-between gap-3 border-t pt-1">
                         <span className="text-secondary-400">합계</span>
-                        <span className="tabular-nums font-semibold">
+                        <span className="font-semibold tabular-nums">
                             {(
                                 hoveredRow.callOpenInterest +
                                 hoveredRow.putOpenInterest

--- a/src/components/options/OpenInterestChart.tsx
+++ b/src/components/options/OpenInterestChart.tsx
@@ -86,9 +86,12 @@ const STRAIGHT_LABEL_FONT_SIZE = 9;
 
 // Tooltip이 커서 위로 띄울 세로 오프셋 (px). 위로 띄워야 막대를 가리지 않는다.
 const TOOLTIP_CURSOR_OFFSET_Y_PX = 8;
-// Tooltip의 가로 절반 너비. `min-w-[180px]`의 절반에 맞춘다. 뷰포트 좌우
-// 경계 클램핑 계산에 사용.
-const TOOLTIP_HALF_WIDTH_PX = 90;
+// Tooltip min-width의 단일 진실 원천 (px). className의 `min-w-[var(--tooltip-min-w)]`
+// 와 `TOOLTIP_HALF_WIDTH_PX` 둘 다 이 값에서 파생되므로, 이 상수만 바꾸면
+// 좌우 경계 클램핑과 실제 가시 너비가 자동으로 동기화된다.
+const TOOLTIP_MIN_WIDTH_PX = 180;
+// 좌우 경계 클램핑용 — `-translate-x-1/2`로 anchor 좌우로 절반씩 뻗으므로 절반 너비.
+const TOOLTIP_HALF_WIDTH_PX = TOOLTIP_MIN_WIDTH_PX / 2;
 // 뷰포트 경계와 tooltip 사이 여유 (px). 컨테이너 모서리에 딱 붙지 않도록.
 const TOOLTIP_VIEWPORT_PADDING_PX = 8;
 // Tooltip 카드 자체의 대략적 높이. 정확한 측정 대신 추정값으로 상단 클램핑에 사용.
@@ -253,6 +256,14 @@ export function OpenInterestChart({
     const hoveredRow =
         (hoveredIndex !== null && oiByStrike[hoveredIndex]) || null;
 
+    const maxPainX = maxPainIdx >= 0 ? barCenterX(maxPainIdx, count) : null;
+    const currentPriceX =
+        currentPriceIdx >= 0 ? barCenterX(currentPriceIdx, count) : null;
+
+    const labelIndices = pickLabelIndices(count, [maxPainIdx, currentPriceIdx]);
+    const rotateLabels = labelIndices.size > LABEL_ROTATION_THRESHOLD;
+    const peakOiLabel = fmtOi(globalMax);
+
     const handlePointerEnter = (
         event: PointerEvent<SVGRectElement>,
         index: number
@@ -291,14 +302,6 @@ export function OpenInterestChart({
         setHoveredIndex(null);
         setTooltipPos(null);
     };
-
-    const maxPainX = maxPainIdx >= 0 ? barCenterX(maxPainIdx, count) : null;
-    const currentPriceX =
-        currentPriceIdx >= 0 ? barCenterX(currentPriceIdx, count) : null;
-
-    const labelIndices = pickLabelIndices(count, [maxPainIdx, currentPriceIdx]);
-    const rotateLabels = labelIndices.size > LABEL_ROTATION_THRESHOLD;
-    const peakOiLabel = fmtOi(globalMax);
 
     return (
         <div
@@ -481,7 +484,7 @@ export function OpenInterestChart({
                 id={TOOLTIP_ELEMENT_ID}
                 role="tooltip"
                 hidden={hoveredRow === null || tooltipPos === null}
-                className="border-secondary-600 bg-secondary-900/95 text-secondary-100 pointer-events-none absolute top-[var(--tooltip-y)] left-[var(--tooltip-x)] z-10 min-w-[180px] -translate-x-1/2 -translate-y-full rounded-md border px-3 py-2 text-xs shadow-lg backdrop-blur"
+                className="border-secondary-600 bg-secondary-900/95 text-secondary-100 pointer-events-none absolute top-[var(--tooltip-y)] left-[var(--tooltip-x)] z-10 min-w-[var(--tooltip-min-w)] -translate-x-1/2 -translate-y-full rounded-md border px-3 py-2 text-xs shadow-lg backdrop-blur"
                 style={
                     // CSS 커스텀 프로퍼티(--*)는 런타임에 유효하나 React의
                     // CSSProperties 타입은 임의 `--*` 키를 포함하지 않아
@@ -490,6 +493,7 @@ export function OpenInterestChart({
                     {
                         '--tooltip-x': `${tooltipPos?.x ?? 0}px`,
                         '--tooltip-y': `${tooltipPos?.y ?? 0}px`,
+                        '--tooltip-min-w': `${TOOLTIP_MIN_WIDTH_PX}px`,
                     } as CSSProperties
                 }
             >

--- a/src/components/options/OpenInterestChart.tsx
+++ b/src/components/options/OpenInterestChart.tsx
@@ -230,10 +230,7 @@ export function OpenInterestChart({
         // 좌우 경계 클램핑 — tooltip은 `-translate-x-1/2`로 좌우 절반이
         // anchor 좌우로 뻗어나가므로 절반 너비 + 여유만큼 안쪽에 고정.
         const clampedX = Math.min(
-            Math.max(
-                rawX,
-                TOOLTIP_HALF_WIDTH_PX + TOOLTIP_VIEWPORT_PADDING_PX
-            ),
+            Math.max(rawX, TOOLTIP_HALF_WIDTH_PX + TOOLTIP_VIEWPORT_PADDING_PX),
             rect.width - TOOLTIP_HALF_WIDTH_PX - TOOLTIP_VIEWPORT_PADDING_PX
         );
         // 상단 경계 클램핑 — tooltip은 `-translate-y-full`로 anchor 위로
@@ -399,9 +396,7 @@ export function OpenInterestChart({
                                 fillOpacity={0}
                                 pointerEvents="all"
                                 aria-describedby={TOOLTIP_ELEMENT_ID}
-                                onPointerEnter={e =>
-                                    handlePointerEnter(e, i)
-                                }
+                                onPointerEnter={e => handlePointerEnter(e, i)}
                                 onPointerMove={e => handlePointerMove(e, i)}
                                 onPointerLeave={handlePointerLeave}
                             />
@@ -473,7 +468,7 @@ export function OpenInterestChart({
                 <div
                     id={TOOLTIP_ELEMENT_ID}
                     role="tooltip"
-                    className="border-secondary-600 bg-secondary-900/95 text-secondary-100 pointer-events-none absolute z-10 min-w-[180px] -translate-x-1/2 -translate-y-full rounded-md border px-3 py-2 text-xs shadow-lg backdrop-blur top-[var(--tooltip-y)] left-[var(--tooltip-x)]"
+                    className="border-secondary-600 bg-secondary-900/95 text-secondary-100 pointer-events-none absolute top-[var(--tooltip-y)] left-[var(--tooltip-x)] z-10 min-w-[180px] -translate-x-1/2 -translate-y-full rounded-md border px-3 py-2 text-xs shadow-lg backdrop-blur"
                     style={
                         {
                             '--tooltip-x': `${tooltipPos.x}px`,

--- a/src/components/options/OpenInterestChart.tsx
+++ b/src/components/options/OpenInterestChart.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { useMemo, useRef, useState, type PointerEvent } from 'react';
+import {
+    useMemo,
+    useRef,
+    useState,
+    type CSSProperties,
+    type PointerEvent,
+} from 'react';
 import {
     type OptionsChain,
     type OptionsExpirationMetrics,
@@ -72,6 +78,19 @@ const X_AXIS_LABEL_OFFSET_PX = 14;
 const ROTATED_LABEL_FONT_SIZE = 8;
 const STRAIGHT_LABEL_FONT_SIZE = 9;
 
+// Tooltip이 커서 위로 띄울 세로 오프셋 (px). 위로 띄워야 막대를 가리지 않는다.
+const TOOLTIP_CURSOR_OFFSET_Y_PX = 8;
+// Tooltip의 가로 절반 너비. `min-w-[180px]`의 절반에 맞춘다. 뷰포트 좌우
+// 경계 클램핑 계산에 사용.
+const TOOLTIP_HALF_WIDTH_PX = 90;
+// 뷰포트 경계와 tooltip 사이 여유 (px). 컨테이너 모서리에 딱 붙지 않도록.
+const TOOLTIP_VIEWPORT_PADDING_PX = 8;
+// Tooltip 카드 자체의 대략적 높이. 정확한 측정 대신 추정값으로 상단 클램핑에 사용.
+const TOOLTIP_APPROX_HEIGHT_PX = 110;
+// DOM tooltip id — `role="tooltip"` 요소와 hit-rect의 `aria-describedby`가
+// 공유하는 anchor. ARIA tooltip 패턴(MISTAKES.md Accessibility §3).
+const TOOLTIP_ELEMENT_ID = 'oi-chart-tooltip';
+
 function slotWidth(count: number): number {
     return CHART_WIDTH / count;
 }
@@ -122,6 +141,17 @@ export function OpenInterestChart({
     chain,
     metrics,
 }: OpenInterestChartProps) {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    // 컨테이너 DOMRect 캐시. pointerEnter 시 한 번 측정해 두고 pointerMove에서
+    // 재사용한다 — move마다 `getBoundingClientRect`를 부르면 reflow를 매번
+    // 트리거해 마우스가 빠르게 움직일 때 frame drop을 유발한다.
+    const cachedRectRef = useRef<DOMRect | null>(null);
+    const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+    const [tooltipPos, setTooltipPos] = useState<{
+        x: number;
+        y: number;
+    } | null>(null);
+
     const derived = useMemo(() => {
         if (!chain) return null;
         const oiByStrike = aggregateOpenInterest(chain);
@@ -170,13 +200,6 @@ export function OpenInterestChart({
         };
     }, [chain, metrics, underlyingPrice]);
 
-    const containerRef = useRef<HTMLDivElement | null>(null);
-    const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
-    const [tooltipPos, setTooltipPos] = useState<{
-        x: number;
-        y: number;
-    } | null>(null);
-
     if (!derived) {
         return (
             <p className="text-secondary-500 py-4 text-sm">
@@ -191,28 +214,76 @@ export function OpenInterestChart({
     const sw = slotWidth(count);
     const bw = sw * BAR_WIDTH_FILL_RATIO;
 
-    const handlePointerMove = (
+    // hoveredIndex 가드: oiByStrike가 chip 전환으로 짧아지는 사이에 hover state
+    // 가 stale이 되면 `oiByStrike[hoveredIndex]`가 undefined가 될 수 있다.
+    // 직접 lookup 결과를 ||로 정규화해 stale index → null로 떨어뜨린다.
+    const hoveredRow =
+        (hoveredIndex !== null && oiByStrike[hoveredIndex]) || null;
+
+    const computeTooltipPos = (
+        event: PointerEvent<SVGRectElement>,
+        rect: DOMRect
+    ): { x: number; y: number } => {
+        // viewport 기준 좌표 → container 기준 좌표.
+        const rawX = event.clientX - rect.left;
+        const rawY = event.clientY - rect.top;
+        // 좌우 경계 클램핑 — tooltip은 `-translate-x-1/2`로 좌우 절반이
+        // anchor 좌우로 뻗어나가므로 절반 너비 + 여유만큼 안쪽에 고정.
+        const clampedX = Math.min(
+            Math.max(
+                rawX,
+                TOOLTIP_HALF_WIDTH_PX + TOOLTIP_VIEWPORT_PADDING_PX
+            ),
+            rect.width - TOOLTIP_HALF_WIDTH_PX - TOOLTIP_VIEWPORT_PADDING_PX
+        );
+        // 상단 경계 클램핑 — tooltip은 `-translate-y-full`로 anchor 위로
+        // 뻗으므로 anchor가 너무 위면 tooltip이 컨테이너 밖으로 튀어나간다.
+        const minY =
+            TOOLTIP_APPROX_HEIGHT_PX +
+            TOOLTIP_VIEWPORT_PADDING_PX +
+            TOOLTIP_CURSOR_OFFSET_Y_PX;
+        const clampedY = Math.max(rawY, minY);
+        return { x: clampedX, y: clampedY - TOOLTIP_CURSOR_OFFSET_Y_PX };
+    };
+
+    const handlePointerEnter = (
         event: PointerEvent<SVGRectElement>,
         index: number
     ): void => {
         const container = containerRef.current;
         if (!container) return;
-        const containerRect = container.getBoundingClientRect();
+        const rect = container.getBoundingClientRect();
+        cachedRectRef.current = rect;
         setHoveredIndex(index);
-        // container 기준 상대 좌표로 변환 — wrapper에 `position: relative`가
-        // 걸려 있고 tooltip은 absolute로 띄우므로, viewport 좌표를 빼서 정렬.
-        setTooltipPos({
-            x: event.clientX - containerRect.left,
-            y: event.clientY - containerRect.top,
-        });
+        setTooltipPos(computeTooltipPos(event, rect));
+    };
+
+    const handlePointerMove = (
+        event: PointerEvent<SVGRectElement>,
+        index: number
+    ): void => {
+        const rect = cachedRectRef.current;
+        // enter 핸들러가 캐시를 채우기 전에 move가 발사되는 경로(예: 모바일
+        // touchmove)에서는 한 번 측정해 즉시 캐시한다 — 이후 move부터는
+        // 캐시된 rect만 사용해 reflow 비용 없음.
+        if (rect === null) {
+            const container = containerRef.current;
+            if (!container) return;
+            const measured = container.getBoundingClientRect();
+            cachedRectRef.current = measured;
+            setHoveredIndex(index);
+            setTooltipPos(computeTooltipPos(event, measured));
+            return;
+        }
+        if (hoveredIndex !== index) setHoveredIndex(index);
+        setTooltipPos(computeTooltipPos(event, rect));
     };
 
     const handlePointerLeave = (): void => {
+        cachedRectRef.current = null;
         setHoveredIndex(null);
         setTooltipPos(null);
     };
-
-    const hoveredRow = hoveredIndex !== null ? oiByStrike[hoveredIndex] : null;
 
     const maxPainX = maxPainIdx >= 0 ? barCenterX(maxPainIdx, count) : null;
     const currentPriceX =
@@ -327,7 +398,10 @@ export function OpenInterestChart({
                                 fill="white"
                                 fillOpacity={0}
                                 pointerEvents="all"
-                                onPointerEnter={e => handlePointerMove(e, i)}
+                                aria-describedby={TOOLTIP_ELEMENT_ID}
+                                onPointerEnter={e =>
+                                    handlePointerEnter(e, i)
+                                }
                                 onPointerMove={e => handlePointerMove(e, i)}
                                 onPointerLeave={handlePointerLeave}
                             />
@@ -397,12 +471,15 @@ export function OpenInterestChart({
 
             {hoveredRow !== null && tooltipPos !== null && (
                 <div
+                    id={TOOLTIP_ELEMENT_ID}
                     role="tooltip"
-                    className="border-secondary-600 bg-secondary-900/95 text-secondary-100 pointer-events-none absolute z-10 min-w-[180px] -translate-x-1/2 -translate-y-full rounded-md border px-3 py-2 text-xs shadow-lg backdrop-blur"
-                    style={{
-                        left: tooltipPos.x,
-                        top: tooltipPos.y - 8,
-                    }}
+                    className="border-secondary-600 bg-secondary-900/95 text-secondary-100 pointer-events-none absolute z-10 min-w-[180px] -translate-x-1/2 -translate-y-full rounded-md border px-3 py-2 text-xs shadow-lg backdrop-blur top-[var(--tooltip-y)] left-[var(--tooltip-x)]"
+                    style={
+                        {
+                            '--tooltip-x': `${tooltipPos.x}px`,
+                            '--tooltip-y': `${tooltipPos.y}px`,
+                        } as CSSProperties
+                    }
                 >
                     <div className="text-secondary-300 mb-1 font-semibold tabular-nums">
                         Strike ${hoveredRow.strike.toLocaleString()}

--- a/src/components/options/utils/computeTooltipPos.ts
+++ b/src/components/options/utils/computeTooltipPos.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure helpers and layout constants for the OI chart's floating tooltip.
+ *
+ * Extracted out of `OpenInterestChart.tsx` so the clamping math can be
+ * exercised by unit tests without instantiating React or the SVG container.
+ * The function is pure — its output depends only on its arguments and these
+ * module-level constants.
+ */
+import type { PointerEvent } from 'react';
+
+/** Container-relative coordinates the floating tooltip is anchored at. */
+export interface TooltipPosition {
+    x: number;
+    y: number;
+}
+
+// Tooltip이 커서 위로 띄울 세로 오프셋 (px). 위로 띄워야 막대를 가리지 않는다.
+export const TOOLTIP_CURSOR_OFFSET_Y_PX = 8;
+// Tooltip min-width의 단일 진실 원천 (px). className의 `min-w-[var(--tooltip-min-w)]`
+// 와 `TOOLTIP_HALF_WIDTH_PX` 둘 다 이 값에서 파생되므로, 이 상수만 바꾸면
+// 좌우 경계 클램핑과 실제 가시 너비가 자동으로 동기화된다.
+export const TOOLTIP_MIN_WIDTH_PX = 180;
+// 좌우 경계 클램핑용 — `-translate-x-1/2`로 anchor 좌우로 절반씩 뻗으므로 절반 너비.
+export const TOOLTIP_HALF_WIDTH_PX = TOOLTIP_MIN_WIDTH_PX / 2;
+// 뷰포트 경계와 tooltip 사이 여유 (px). 컨테이너 모서리에 딱 붙지 않도록.
+export const TOOLTIP_VIEWPORT_PADDING_PX = 8;
+// Tooltip 카드 자체의 대략적 높이. 정확한 측정 대신 추정값으로 상단 클램핑에 사용.
+export const TOOLTIP_APPROX_HEIGHT_PX = 110;
+// DOM tooltip id — `role="tooltip"` 요소와 hit-rect의 `aria-describedby`가
+// 공유하는 anchor. WAI-ARIA tooltip 패턴.
+export const TOOLTIP_ELEMENT_ID = 'oi-chart-tooltip';
+
+/**
+ * Compute container-relative tooltip coordinates from a pointer event,
+ * clamping to viewport boundaries so the tooltip can't escape the chart
+ * container even when the cursor is near an edge.
+ *
+ * Pure — captures no state or refs, only its arguments and the layout
+ * constants exported above.
+ */
+export function computeTooltipPos(
+    event: PointerEvent<SVGRectElement>,
+    rect: DOMRect
+): TooltipPosition {
+    const rawX = event.clientX - rect.left;
+    const rawY = event.clientY - rect.top;
+    // 좌우 경계 클램핑 — tooltip은 `-translate-x-1/2`로 좌우 절반이
+    // anchor 좌우로 뻗어나가므로 절반 너비 + 여유만큼 안쪽에 고정.
+    const clampedX = Math.min(
+        Math.max(rawX, TOOLTIP_HALF_WIDTH_PX + TOOLTIP_VIEWPORT_PADDING_PX),
+        rect.width - TOOLTIP_HALF_WIDTH_PX - TOOLTIP_VIEWPORT_PADDING_PX
+    );
+    // 상단 경계 클램핑 — tooltip은 `-translate-y-full`로 anchor 위로
+    // 뻗으므로 anchor가 너무 위면 tooltip이 컨테이너 밖으로 튀어나간다.
+    const minY =
+        TOOLTIP_APPROX_HEIGHT_PX +
+        TOOLTIP_VIEWPORT_PADDING_PX +
+        TOOLTIP_CURSOR_OFFSET_Y_PX;
+    const clampedY = Math.max(rawY, minY);
+    return { x: clampedX, y: clampedY - TOOLTIP_CURSOR_OFFSET_Y_PX };
+}


### PR DESCRIPTION
## 구현 내용

OpenInterestChart의 바 호버 상태에서 SVG 네이티브 `<title>` 요소를 제거하고, React 상태로 관리되는 떠있는(floating) 툴팁으로 교체했습니다.

### 문제점
- 네이티브 SVG `<title>` 툴팁은 `fill=transparent` 시맨틱과 macOS 네이티브 툴팁 지연으로 인해 신뢰도가 낮음 (사용자 보고: "커서를 올려도 안 보이네")
- 줌 레벨, 브라우저, 디바이스에 따라 표시 여부가 불안정함

### 변경 사항
- `useRef<HTMLDivElement>` 추가: 컨테이너 좌표 계산용
- `useState` 추가: 호버된 인덱스 + 포인터 위치 추적
- `onPointerEnter/Move/Leave` 핸들러 추가: 슬롯 전체 영역의 히트 테스트 (이제 `fill="white" fillOpacity={0}`로 신뢰도 높음)
- 절대 위치 떠있는 div: Strike / Call OI / Put OI / 합계 라인 표시, Tailwind 스타일링 (옵션 UI와 일관성)

### 테스트
- 타입 체크: ✅ 통과
- 기존 옵션 테스트 스위트 (79개): ✅ 모두 통과
- 수동 테스트 필요: 바 호버 시 즉시 떠있는 툴팁 표시 확인 (Strike/Call OI/Put OI/합계 포함), 크로스 브라우저 동작 확인

## 변경 파일 목록

[수정]
- `src/components/options/OpenInterestChart.tsx`: SVG title → React floating tooltip 마이그레이션, 호버 상태 관리

## 체크리스트

- [x] 타입 체크 통과
- [x] 기존 옵션 테스트 스위트 통과 (79 tests)
- [ ] 수동 테스트: 바 호버 시 완전한 OI 정보 표시 확인
- [ ] 수동 테스트: 크로스 브라우저 호환성 확인 (Chrome, Safari, Firefox)