### PR TITLE
feat(analysis): show analysis timestamp + stale banner in AnalysisPanel

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,6 +1,17 @@
 
 # Fix Log
 
+## [PR #445 Round 3 | fix/analysis-snapshot-ui | 2026-05-22]
+- S1: `src/components/analysis/AnalysisPanel.tsx` — `showStaleBanner` 파생 변수가 `captureNow` (useEffectEvent) + 새 `useEffect` 뒤에 위치해 MISTAKES.md §17 이상적 순서(derived → handlers → useEffect)와 어긋남. props/state만 의존하므로 핸들러·effect 앞으로 이동.
+  - Rule: MISTAKES.md §17 — Hook 선언 순서.
+- S2: `src/components/analysis/AnalysisPanel.tsx` — `<time aria-label="분석 완료 시각">`이 AT에 visible text(타임스탬프 값)를 덮어써 사용자가 실제 시각을 들을 수 없게 만듦. `aria-label` 제거. `<time dateTime={iso}>{formatted}</time>` 구조에서는 visible text가 SR로 그대로 읽혀 충분.
+  - Rule: WCAG 4.1.2 (Name, Role, Value) — `aria-label`은 의미 명확하지 않은 비텍스트 요소용. text content가 이미 정확한 정보면 abuse.
+- S3: PR diff 상의 "어차임" 오탈자는 워크트리 실제 파일에서 이미 "어차피"로 정상이라 코드 변경 없음. Reviewer가 본 diff 표시 오해로 추정.
+- S4: `src/__tests__/components/analysis/StaleAnalysisBanner.test.tsx` — `fireEvent.click`(JSDOM이 disabled 버튼 동작을 완전 재현하지 않음) → `@testing-library/user-event`의 `userEvent.click`으로 마이그레이션. 비동기 setup 패턴(`userEvent.setup()` + `await user.click(...)`)을 적용해 실제 브라우저 동작과 일치하는 disabled 버튼 click 차단을 검증.
+  - Rule: 회귀 신뢰도 — disabled 동작 같은 native 브라우저 동작은 userEvent로 검증해야 정확.
+- S5: `src/__tests__/domain/analysis/staleThreshold.test.ts` — `15Min`/`30Min` 버킷에 boundary 케이스 누락. `15Min` beyond(+1min → true), `30Min` within(-1min → false)을 추가해 5분 임계값을 공유하는 세 단기 버킷 모두 회귀 안전망 확보.
+  - Rule: MISTAKES.md §Tests — 임계값 버킷별 boundary 명시 검증.
+
 ## [PR #445 Round 2 | fix/analysis-snapshot-ui | 2026-05-22]
 - B1: `src/components/analysis/AnalysisPanel.tsx` — round 1에서 hydration 회피를 위해 추가한 `useEffect` + `setNow(new Date())`에 `// eslint-disable-next-line react-hooks/set-state-in-effect`를 사용했음. MISTAKES.md §13(eslint-disable 사용 금지) + §10(setState in useEffect의 canonical fix는 `useEffectEvent`) 위반. `captureNow = useEffectEvent(() => startTransition(() => setNow(new Date())))` 패턴으로 변경하고 useEffect는 `captureNow()` 호출만. 동일 워크트리 `useChat.ts:382` / `useDMIChart.ts` 패턴과 일치.
   - Rule: MISTAKES.md §13 — eslint-disable 억제 금지. §10 — `setState in useEffect` canonical = `useEffectEvent` + 내부에서 setState (필요 시 `startTransition`).

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,6 +1,14 @@
 
 # Fix Log
 
+## [PR #445 Round 2 | fix/analysis-snapshot-ui | 2026-05-22]
+- B1: `src/components/analysis/AnalysisPanel.tsx` — round 1에서 hydration 회피를 위해 추가한 `useEffect` + `setNow(new Date())`에 `// eslint-disable-next-line react-hooks/set-state-in-effect`를 사용했음. MISTAKES.md §13(eslint-disable 사용 금지) + §10(setState in useEffect의 canonical fix는 `useEffectEvent`) 위반. `captureNow = useEffectEvent(() => startTransition(() => setNow(new Date())))` 패턴으로 변경하고 useEffect는 `captureNow()` 호출만. 동일 워크트리 `useChat.ts:382` / `useDMIChart.ts` 패턴과 일치.
+  - Rule: MISTAKES.md §13 — eslint-disable 억제 금지. §10 — `setState in useEffect` canonical = `useEffectEvent` + 내부에서 setState (필요 시 `startTransition`).
+- S1: `src/components/analysis/StaleAnalysisBanner.tsx` — `disabled` 버튼의 `title` 속성은 키보드 포커스 시 노출되지 않음(WCAG 2.4.7). `aria-describedby="stale-banner-cooldown-tooltip"`로 가리키는 `<span id role="tooltip" className="sr-only">` 보조 요소를 추가해 SR/키보드 사용자도 쿨다운 이유를 인지할 수 있게 함. `title`은 마우스 사용자 fallback으로 유지.
+  - Rule: WCAG 2.4.7 (Focus Visible) / WCAG 4.1.2 (Name, Role, Value).
+- S2: `src/domain/analysis/staleThreshold.ts` — `5Min`/`15Min`/`30Min`이 모두 5분 임계값을 공유하는 정책이 의도적임에도 코드만으로는 알 수 없어 reviewer가 Question 제기. `STALE_THRESHOLD_MS` 위에 WHY 주석(단기는 5분 일률, 중기는 30분, 장기는 4시간)을 추가해 정책 합의를 코드 옆에 명시.
+  - Rule: FF Readability — non-obvious policy decision은 코드 옆 WHY 주석.
+
 ## [PR #445 Round 1 | fix/analysis-snapshot-ui | 2026-05-22]
 - B1: `src/components/analysis/StaleAnalysisBanner.tsx` — `'use client'` 디렉티브 누락. `<button onClick={onReanalyze}>` 등록은 컨벤션상 클라이언트 경계 명시가 필수. async Server Component 트리에서 import 시 runtime 오류 위험. 파일 첫 줄에 `'use client';` 추가.
   - Rule: CONVENTIONS.md L306 (Registers event handlers → `'use client'` 필수), components/CLAUDE.md L15. Phase 2.4 라운드 1의 내부 review-agent 권고("leaf parent already client니까 불필요")가 컨벤션 문자 해석과 충돌했고, 외부 reviewer가 정확히 지적 — 컨벤션 우선으로 결정.

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,6 +1,26 @@
 
 # Fix Log
 
+## [PR #445 Round 1 | fix/analysis-snapshot-ui | 2026-05-22]
+- B1: `src/components/analysis/StaleAnalysisBanner.tsx` — `'use client'` 디렉티브 누락. `<button onClick={onReanalyze}>` 등록은 컨벤션상 클라이언트 경계 명시가 필수. async Server Component 트리에서 import 시 runtime 오류 위험. 파일 첫 줄에 `'use client';` 추가.
+  - Rule: CONVENTIONS.md L306 (Registers event handlers → `'use client'` 필수), components/CLAUDE.md L15. Phase 2.4 라운드 1의 내부 review-agent 권고("leaf parent already client니까 불필요")가 컨벤션 문자 해석과 충돌했고, 외부 reviewer가 정확히 지적 — 컨벤션 우선으로 결정.
+- B2: `src/domain/analysis/staleThreshold.ts` — `isAnalysisStale`의 `now: Date = new Date()` 기본 파라미터가 `Date.now()` 호출과 동등한 부작용. 도메인 순수 함수 규칙 위반. 기본값 제거 후 `now`를 필수 인자로 선언하고 호출부(`AnalysisPanel.tsx`)에서 `new Date()`를 명시 주입.
+  - Rule: CONVENTIONS.md L397 (`No side effects: fetch, console.log, Date.now() are all prohibited` in domain layer).
+- B3: `src/__tests__/domain/analysis/staleThreshold.test.ts` — 경계값 테스트에서 `4 * MS_PER_HOUR`를 로컬 재정의해 production `STALE_THRESHOLD_MS['1Day']`와 silent drift 가능. `STALE_THRESHOLD_MS`를 `staleThreshold.ts`에서 export하고 테스트는 직접 import해 임계값 변경을 자동 추적하도록 변경.
+  - Rule: MISTAKES.md §Tests §4 — boundary 테스트 상수는 source에서 import (로컬 재정의 금지).
+- B4: `src/components/analysis/StaleAnalysisBanner.tsx` — 툴팁 문자열이 `재분석은 5분에 한 번만 실행할 수 있어요.`로 하드코딩됐는데 `reanalyzeCooldownMs` prop이 실제 ms 정책을 담음. 정책 변경 시 UI 텍스트가 drift. `Math.ceil(reanalyzeCooldownMs / MS_PER_MINUTE)`로 분 단위를 계산해 템플릿 리터럴로 메시지 생성.
+  - Rule: MISTAKES.md §15 drift trap — 상수와 표시 텍스트의 단일 source.
+- S1: `src/components/analysis/AnalysisPanel.tsx` — `analysis.analyzedAt !== undefined` 두 곳을 truthy check `analysis.analyzedAt`로 단순화. `OptionsAiAnalysis.tsx`(ternary 패턴)와 표현 일관화.
+  - Rule: FF Cohesion — 동일 의미는 동일 표현으로.
+- S2: `src/components/analysis/StaleAnalysisBanner.tsx` — `mb-3` className 제거. 부모(`AnalysisPanel`)의 outer wrapper가 `flex flex-col gap-4`로 자식 spacing을 일괄 처리하므로 자식의 `mb-3`은 중복 spacing.
+  - Rule: FF Cohesion — layout spacing single source of truth.
+- S3: `src/components/analysis/AnalysisPanel.tsx` — SSR/hydration mismatch 회피. `isAnalysisStale`이 렌더 중 `new Date()`를 평가하면 서버 시각과 클라이언트 시각이 다를 때 임계값 근처에서 stale 판정이 갈리며 hydration warning 발생. `now: Date | null` state로 client mount 후에만 시각을 캡쳐하고 `analyzedAt` 변경 시 재캡쳐 (`useEffect` + `react-hooks/set-state-in-effect` disable + WHY 주석). 첫 SSR/hydration 동안 banner는 노출되지 않는다.
+  - Rule: CONVENTIONS.md L374 (`new Date()` in Server Component → hydration mismatch).
+- S4: `src/__tests__/domain/analysis/staleThreshold.test.ts` — 30분 임계값 버킷(`1Hour`/`4Hour`) 경계 회귀를 잡기 위해 within(`1Hour`, 29min ago → false), beyond(`4Hour`, boundary + 1min → true) 케이스 추가.
+  - Rule: MISTAKES.md §Tests — 임계값 버킷별 boundary 명시 검증.
+- S5: `src/components/analysis/StaleAnalysisBanner.tsx` — UI 메시지 두 종(`STALE_MESSAGE`, `REANALYZE_LABEL`)을 컴포넌트 내 상수로 추출. 향후 동일 메시지를 다른 위치(예: 토스트, 모바일 시트)에서도 사용할 때 content drift 방지의 기반.
+  - Rule: 공통 UI 패턴 추출 시 message string은 상수로 통합.
+
 ## [PR #442 Round 5 | fix/oi-tooltip-floating | 2026-05-22]
 - S1: `src/components/options/OpenInterestChart.tsx` — tooltip JSX 주석이 "`hidden`으로 숨겨 스크린리더가 대상을 찾되 시각적으로만 숨김"이라고 표기. 실제로 HTML `hidden` 속성은 접근성 트리에서도 완전히 제거함. 사실관계 정정: "screen reader도 참조를 따라올 수 없지만 하단 sr-only 테이블이 대체 제공하므로 pointer-only tooltip에선 허용 가능 트레이드오프"로 재작성.
   - Rule: MISTAKES.md §15.3 — 사실관계가 잘못된 주석은 미래 독자에게 오해를 준다.

--- a/src/__tests__/components/analysis/StaleAnalysisBanner.test.tsx
+++ b/src/__tests__/components/analysis/StaleAnalysisBanner.test.tsx
@@ -31,4 +31,16 @@ describe('StaleAnalysisBanner', () => {
         const button = screen.getByRole('button', { name: /재분석/ });
         expect(button).toBeDisabled();
     });
+
+    it('does not invoke onReanalyze when the button is clicked while cooling down', () => {
+        const onReanalyze = jest.fn();
+        render(
+            <StaleAnalysisBanner
+                onReanalyze={onReanalyze}
+                reanalyzeCooldownMs={60_000}
+            />
+        );
+        fireEvent.click(screen.getByRole('button', { name: /재분석/ }));
+        expect(onReanalyze).not.toHaveBeenCalled();
+    });
 });

--- a/src/__tests__/components/analysis/StaleAnalysisBanner.test.tsx
+++ b/src/__tests__/components/analysis/StaleAnalysisBanner.test.tsx
@@ -3,11 +3,13 @@
  */
 
 import '@testing-library/jest-dom';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { StaleAnalysisBanner } from '@/components/analysis/StaleAnalysisBanner';
 
 describe('StaleAnalysisBanner', () => {
-    it('renders the stale message and triggers onReanalyze when clicked', () => {
+    it('renders the stale message and triggers onReanalyze when clicked', async () => {
+        const user = userEvent.setup();
         const onReanalyze = jest.fn();
         render(
             <StaleAnalysisBanner
@@ -18,7 +20,7 @@ describe('StaleAnalysisBanner', () => {
         expect(
             screen.getByText(/AI 분석 데이터가 오래되었습니다/)
         ).toBeInTheDocument();
-        fireEvent.click(screen.getByRole('button', { name: /재분석/ }));
+        await user.click(screen.getByRole('button', { name: /재분석/ }));
         expect(onReanalyze).toHaveBeenCalledTimes(1);
     });
 
@@ -34,7 +36,8 @@ describe('StaleAnalysisBanner', () => {
         expect(button).toBeDisabled();
     });
 
-    it('does not invoke onReanalyze when the button is clicked while cooling down', () => {
+    it('does not invoke onReanalyze when the button is clicked while cooling down', async () => {
+        const user = userEvent.setup();
         const onReanalyze = jest.fn();
         render(
             <StaleAnalysisBanner
@@ -42,7 +45,7 @@ describe('StaleAnalysisBanner', () => {
                 reanalyzeCooldownMs={60_000}
             />
         );
-        fireEvent.click(screen.getByRole('button', { name: /재분석/ }));
+        await user.click(screen.getByRole('button', { name: /재분석/ }));
         expect(onReanalyze).not.toHaveBeenCalled();
     });
 });

--- a/src/__tests__/components/analysis/StaleAnalysisBanner.test.tsx
+++ b/src/__tests__/components/analysis/StaleAnalysisBanner.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StaleAnalysisBanner } from '@/components/analysis/StaleAnalysisBanner';
+
+describe('StaleAnalysisBanner', () => {
+    it('renders the stale message and triggers onReanalyze when clicked', () => {
+        const onReanalyze = jest.fn();
+        render(
+            <StaleAnalysisBanner
+                onReanalyze={onReanalyze}
+                reanalyzeCooldownMs={0}
+            />
+        );
+        expect(screen.getByText(/AI 분석 데이터가 오래되었습니다/)).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: /재분석/ }));
+        expect(onReanalyze).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the reanalyze button while cooldown is active', () => {
+        const onReanalyze = jest.fn();
+        render(
+            <StaleAnalysisBanner
+                onReanalyze={onReanalyze}
+                reanalyzeCooldownMs={60_000}
+            />
+        );
+        const button = screen.getByRole('button', { name: /재분석/ });
+        expect(button).toBeDisabled();
+    });
+});

--- a/src/__tests__/components/analysis/StaleAnalysisBanner.test.tsx
+++ b/src/__tests__/components/analysis/StaleAnalysisBanner.test.tsx
@@ -15,7 +15,9 @@ describe('StaleAnalysisBanner', () => {
                 reanalyzeCooldownMs={0}
             />
         );
-        expect(screen.getByText(/AI 분석 데이터가 오래되었습니다/)).toBeInTheDocument();
+        expect(
+            screen.getByText(/AI 분석 데이터가 오래되었습니다/)
+        ).toBeInTheDocument();
         fireEvent.click(screen.getByRole('button', { name: /재분석/ }));
         expect(onReanalyze).toHaveBeenCalledTimes(1);
     });

--- a/src/__tests__/domain/analysis/staleThreshold.test.ts
+++ b/src/__tests__/domain/analysis/staleThreshold.test.ts
@@ -1,0 +1,38 @@
+import { isAnalysisStale, getStaleThresholdMs } from '@/domain/analysis/staleThreshold';
+import type { Timeframe } from '@y0ngha/siglens-core';
+
+describe('getStaleThresholdMs', () => {
+    it.each<[Timeframe, number]>([
+        ['5Min', 5 * 60 * 1000],
+        ['15Min', 5 * 60 * 1000],
+        ['30Min', 5 * 60 * 1000],
+        ['1Hour', 30 * 60 * 1000],
+        ['4Hour', 30 * 60 * 1000],
+        ['1Day', 4 * 60 * 60 * 1000],
+    ])('returns the expected threshold for %s', (timeframe, expected) => {
+        expect(getStaleThresholdMs(timeframe)).toBe(expected);
+    });
+});
+
+describe('isAnalysisStale', () => {
+    const now = new Date('2026-05-22T12:00:00.000Z');
+
+    it('returns false when analyzed within threshold (1Day, 3h ago)', () => {
+        const analyzedAt = new Date('2026-05-22T09:00:00.000Z').toISOString();
+        expect(isAnalysisStale(analyzedAt, '1Day', now)).toBe(false);
+    });
+
+    it('returns true when analyzed beyond threshold (1Day, 5h ago)', () => {
+        const analyzedAt = new Date('2026-05-22T07:00:00.000Z').toISOString();
+        expect(isAnalysisStale(analyzedAt, '1Day', now)).toBe(true);
+    });
+
+    it('returns true when analyzed beyond threshold (5Min, 10min ago)', () => {
+        const analyzedAt = new Date('2026-05-22T11:50:00.000Z').toISOString();
+        expect(isAnalysisStale(analyzedAt, '5Min', now)).toBe(true);
+    });
+
+    it('returns false for invalid ISO input', () => {
+        expect(isAnalysisStale('not-a-date', '1Day', now)).toBe(false);
+    });
+});

--- a/src/__tests__/domain/analysis/staleThreshold.test.ts
+++ b/src/__tests__/domain/analysis/staleThreshold.test.ts
@@ -1,5 +1,8 @@
-import { isAnalysisStale } from '@/domain/analysis/staleThreshold';
-import { MS_PER_HOUR } from '@/domain/constants/time';
+import {
+    isAnalysisStale,
+    STALE_THRESHOLD_MS,
+} from '@/domain/analysis/staleThreshold';
+import { MS_PER_MINUTE } from '@/domain/constants/time';
 
 describe('isAnalysisStale', () => {
     const now = new Date('2026-05-22T12:00:00.000Z');
@@ -14,11 +17,25 @@ describe('isAnalysisStale', () => {
         expect(isAnalysisStale(analyzedAt, '1Day', now)).toBe(true);
     });
 
-    it('returns false at the exact boundary (1Day, 4h ago — strict >)', () => {
+    it('returns false at the exact boundary (1Day — strict >)', () => {
         const analyzedAt = new Date(
-            now.getTime() - 4 * MS_PER_HOUR
+            now.getTime() - STALE_THRESHOLD_MS['1Day']
         ).toISOString();
         expect(isAnalysisStale(analyzedAt, '1Day', now)).toBe(false);
+    });
+
+    it('returns false when analyzed within threshold (1Hour, 29min ago)', () => {
+        const analyzedAt = new Date(
+            now.getTime() - STALE_THRESHOLD_MS['1Hour'] + MS_PER_MINUTE
+        ).toISOString();
+        expect(isAnalysisStale(analyzedAt, '1Hour', now)).toBe(false);
+    });
+
+    it('returns true when analyzed beyond threshold (4Hour, boundary + 1min)', () => {
+        const analyzedAt = new Date(
+            now.getTime() - STALE_THRESHOLD_MS['4Hour'] - MS_PER_MINUTE
+        ).toISOString();
+        expect(isAnalysisStale(analyzedAt, '4Hour', now)).toBe(true);
     });
 
     it('returns true when analyzed beyond threshold (5Min, 10min ago)', () => {

--- a/src/__tests__/domain/analysis/staleThreshold.test.ts
+++ b/src/__tests__/domain/analysis/staleThreshold.test.ts
@@ -1,18 +1,5 @@
-import { isAnalysisStale, getStaleThresholdMs } from '@/domain/analysis/staleThreshold';
-import type { Timeframe } from '@y0ngha/siglens-core';
-
-describe('getStaleThresholdMs', () => {
-    it.each<[Timeframe, number]>([
-        ['5Min', 5 * 60 * 1000],
-        ['15Min', 5 * 60 * 1000],
-        ['30Min', 5 * 60 * 1000],
-        ['1Hour', 30 * 60 * 1000],
-        ['4Hour', 30 * 60 * 1000],
-        ['1Day', 4 * 60 * 60 * 1000],
-    ])('returns the expected threshold for %s', (timeframe, expected) => {
-        expect(getStaleThresholdMs(timeframe)).toBe(expected);
-    });
-});
+import { isAnalysisStale } from '@/domain/analysis/staleThreshold';
+import { MS_PER_HOUR } from '@/domain/constants/time';
 
 describe('isAnalysisStale', () => {
     const now = new Date('2026-05-22T12:00:00.000Z');
@@ -25,6 +12,11 @@ describe('isAnalysisStale', () => {
     it('returns true when analyzed beyond threshold (1Day, 5h ago)', () => {
         const analyzedAt = new Date('2026-05-22T07:00:00.000Z').toISOString();
         expect(isAnalysisStale(analyzedAt, '1Day', now)).toBe(true);
+    });
+
+    it('returns false at the exact boundary (1Day, 4h ago — strict >)', () => {
+        const analyzedAt = new Date(now.getTime() - 4 * MS_PER_HOUR).toISOString();
+        expect(isAnalysisStale(analyzedAt, '1Day', now)).toBe(false);
     });
 
     it('returns true when analyzed beyond threshold (5Min, 10min ago)', () => {

--- a/src/__tests__/domain/analysis/staleThreshold.test.ts
+++ b/src/__tests__/domain/analysis/staleThreshold.test.ts
@@ -43,6 +43,20 @@ describe('isAnalysisStale', () => {
         expect(isAnalysisStale(analyzedAt, '5Min', now)).toBe(true);
     });
 
+    it('returns true when analyzed beyond threshold (15Min, boundary + 1min)', () => {
+        const analyzedAt = new Date(
+            now.getTime() - STALE_THRESHOLD_MS['15Min'] - MS_PER_MINUTE
+        ).toISOString();
+        expect(isAnalysisStale(analyzedAt, '15Min', now)).toBe(true);
+    });
+
+    it('returns false when analyzed within threshold (30Min, boundary - 1min)', () => {
+        const analyzedAt = new Date(
+            now.getTime() - STALE_THRESHOLD_MS['30Min'] + MS_PER_MINUTE
+        ).toISOString();
+        expect(isAnalysisStale(analyzedAt, '30Min', now)).toBe(false);
+    });
+
     it('returns false for invalid ISO input', () => {
         expect(isAnalysisStale('not-a-date', '1Day', now)).toBe(false);
     });

--- a/src/__tests__/domain/analysis/staleThreshold.test.ts
+++ b/src/__tests__/domain/analysis/staleThreshold.test.ts
@@ -15,7 +15,9 @@ describe('isAnalysisStale', () => {
     });
 
     it('returns false at the exact boundary (1Day, 4h ago — strict >)', () => {
-        const analyzedAt = new Date(now.getTime() - 4 * MS_PER_HOUR).toISOString();
+        const analyzedAt = new Date(
+            now.getTime() - 4 * MS_PER_HOUR
+        ).toISOString();
         expect(isAnalysisStale(analyzedAt, '1Day', now)).toBe(false);
     });
 

--- a/src/__tests__/lib/formatAnalyzedAt.test.ts
+++ b/src/__tests__/lib/formatAnalyzedAt.test.ts
@@ -1,0 +1,14 @@
+import { formatAnalyzedAt } from '@/lib/formatAnalyzedAt';
+
+describe('formatAnalyzedAt', () => {
+    it('formats ISO timestamp into a human-readable Korean string', () => {
+        const result = formatAnalyzedAt('2026-05-22T05:30:00.000Z');
+        expect(result).toMatch(/2026/);
+        expect(result).toMatch(/05|5월/);
+    });
+
+    it('returns a fallback when the input is not a valid ISO string', () => {
+        const result = formatAnalyzedAt('not-a-date');
+        expect(typeof result).toBe('string');
+    });
+});

--- a/src/__tests__/lib/formatAnalyzedAt.test.ts
+++ b/src/__tests__/lib/formatAnalyzedAt.test.ts
@@ -1,14 +1,11 @@
 import { formatAnalyzedAt } from '@/lib/formatAnalyzedAt';
 
 describe('formatAnalyzedAt', () => {
-    it('formats ISO timestamp into a human-readable Korean string', () => {
-        const result = formatAnalyzedAt('2026-05-22T05:30:00.000Z');
-        expect(result).toMatch(/2026/);
-        expect(result).toMatch(/05|5월/);
+    it('replaces the "T" separator with a space and truncates to minute precision', () => {
+        expect(formatAnalyzedAt('2026-05-22T05:30:00.000Z')).toBe('2026-05-22 05:30');
     });
 
-    it('returns a fallback when the input is not a valid ISO string', () => {
-        const result = formatAnalyzedAt('not-a-date');
-        expect(typeof result).toBe('string');
+    it('passes input through unchanged when shorter than 16 characters', () => {
+        expect(formatAnalyzedAt('not-a-date')).toBe('not-a-date');
     });
 });

--- a/src/__tests__/lib/formatAnalyzedAt.test.ts
+++ b/src/__tests__/lib/formatAnalyzedAt.test.ts
@@ -2,7 +2,9 @@ import { formatAnalyzedAt } from '@/lib/formatAnalyzedAt';
 
 describe('formatAnalyzedAt', () => {
     it('replaces the "T" separator with a space and truncates to minute precision', () => {
-        expect(formatAnalyzedAt('2026-05-22T05:30:00.000Z')).toBe('2026-05-22 05:30');
+        expect(formatAnalyzedAt('2026-05-22T05:30:00.000Z')).toBe(
+            '2026-05-22 05:30'
+        );
     });
 
     it('passes input through unchanged when shorter than 16 characters', () => {

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -795,29 +795,6 @@ export function AnalysisPanel({
         r => r.indicatorName !== '' && !patternSkillNames.has(r.indicatorName)
     );
 
-    useEffect(() => {
-        return () => {
-            if (copyTimeoutRef.current !== null) {
-                clearTimeout(copyTimeoutRef.current);
-            }
-        };
-    }, []);
-
-    // SSR/hydration mismatch 회피 — 서버에서는 `now`가 null, 클라이언트
-    // mount 직후에만 현재 시각을 캡쳐한다. setState를 useEffect 본문에서 직접
-    // 호출하는 대신 useEffectEvent로 감싸 React 19 canonical 패턴을 따르고,
-    // 본문은 startTransition으로 격리해 lint rule을 만족시킨다
-    // (MISTAKES.md §10).
-    const captureNow = useEffectEvent((): void => {
-        startTransition(() => {
-            setNow(new Date());
-        });
-    });
-
-    useEffect(() => {
-        captureNow();
-    }, [analysis.analyzedAt]);
-
     // stale 여부는 render 시점에만 평가한다 — 인터벌 타이머를 두지 않으므로
     // 사용자 인터랙션 / 신규 분석 / 라우트 변경 등으로 다음 render가 일어나야
     // 배너가 갱신된다. 로딩 상태(isAnalyzing/showProgress)에서는 곧 새 분석으로
@@ -831,6 +808,29 @@ export function AnalysisPanel({
         onReanalyze !== undefined &&
         now !== null &&
         isAnalysisStale(analysis.analyzedAt, timeframe, now);
+
+    // SSR/hydration mismatch 회피 — 서버에서는 `now`가 null, 클라이언트
+    // mount 직후에만 현재 시각을 캡쳐한다. setState를 useEffect 본문에서 직접
+    // 호출하는 대신 useEffectEvent로 감싸 React 19 canonical 패턴을 따르고,
+    // 본문은 startTransition으로 격리해 lint rule을 만족시킨다
+    // (MISTAKES.md §10).
+    const captureNow = useEffectEvent((): void => {
+        startTransition(() => {
+            setNow(new Date());
+        });
+    });
+
+    useEffect(() => {
+        return () => {
+            if (copyTimeoutRef.current !== null) {
+                clearTimeout(copyTimeoutRef.current);
+            }
+        };
+    }, []);
+
+    useEffect(() => {
+        captureNow();
+    }, [analysis.analyzedAt]);
 
     return (
         <div className="bg-secondary-800 relative flex flex-col gap-4 rounded-lg p-4">
@@ -861,7 +861,6 @@ export function AnalysisPanel({
                     {analysis.analyzedAt && (
                         <time
                             dateTime={analysis.analyzedAt}
-                            aria-label="분석 완료 시각"
                             className="text-secondary-500 text-xs"
                         >
                             {formatAnalyzedAt(analysis.analyzedAt)}

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -17,6 +17,7 @@ import type {
     PriceScenario,
     RiskLevel,
     StrategyResult,
+    Timeframe,
     Trend,
     Trendline,
     TrendlineDirection,
@@ -42,6 +43,8 @@ import { TRENDLINE_DIRECTION_LABEL } from '@/components/trendline/constants';
 import { MS_PER_SECOND, SECONDS_PER_MINUTE } from '@/domain/constants/time';
 import { DEFAULT_RESET_MS as COPY_RESET_MS } from '@/components/hooks/useCopyToClipboard';
 import { formatAnalyzedAt } from '@/lib/formatAnalyzedAt';
+import { isAnalysisStale } from '@/domain/analysis/staleThreshold';
+import { StaleAnalysisBanner } from '@/components/analysis/StaleAnalysisBanner';
 
 function formatCooldown(ms: number): string {
     const totalSec = Math.ceil(ms / MS_PER_SECOND);
@@ -685,6 +688,8 @@ interface AnalysisPanelProps {
     symbol: string;
     analysis: AnalysisResponse;
     keyLevels: ClusteredKeyLevels;
+    /** 분석 대상 타임프레임. stale 판정 임계값 산정에 사용된다. */
+    timeframe: Timeframe;
     isAnalyzing?: boolean;
     /** 마무리 애니메이션을 포함해 "사용자에게 분석이 진행 중인 것처럼 보이는" 상태.
      *  AnalysisProgress 표시·본문 섹션 숨김에 사용된다. ChartContent가 소유한다. */
@@ -709,6 +714,7 @@ export function AnalysisPanel({
     symbol,
     analysis,
     keyLevels,
+    timeframe,
     isAnalyzing = false,
     showProgress = false,
     progressPhaseIndex = 0,
@@ -787,8 +793,19 @@ export function AnalysisPanel({
         };
     }, []);
 
+    const showStaleBanner =
+        analysis.analyzedAt !== undefined &&
+        onReanalyze !== undefined &&
+        isAnalysisStale(analysis.analyzedAt, timeframe);
+
     return (
         <div className="bg-secondary-800 relative flex flex-col gap-4 rounded-lg p-4">
+            {showStaleBanner && onReanalyze !== undefined && (
+                <StaleAnalysisBanner
+                    onReanalyze={onReanalyze}
+                    reanalyzeCooldownMs={reanalyzeCooldownMs ?? 0}
+                />
+            )}
             <AnalysisToast
                 key={cooldownNotice?.nonce}
                 notice={cooldownNotice}

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -730,6 +730,10 @@ export function AnalysisPanel({
     const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>(
         'idle'
     );
+    // SSR/hydration mismatch 방지 — 서버 렌더링 시점의 `new Date()`와
+    // 클라이언트 hydration 시점의 시각이 다를 수 있어 stale 평가는 client mount
+    // 이후로 미룬다. `now`가 null인 동안에는 배너가 표시되지 않는다.
+    const [now, setNow] = useState<Date | null>(null);
     const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const resetCopyStateLater = (): void => {
@@ -793,16 +797,28 @@ export function AnalysisPanel({
         };
     }, []);
 
+    useEffect(() => {
+        // SSR/hydration mismatch 회피 — 서버에서는 `now`가 null, 클라이언트
+        // mount 직후에만 현재 시각을 캡쳐한다. analyzedAt 변경 시(=신규 분석
+        // 완료) 다시 캡쳐해 stale 판정을 갱신한다. effect dep이 분석 ISO 문자열
+        // 한 개라 cascading render 위험은 없다.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setNow(new Date());
+    }, [analysis.analyzedAt]);
+
     // stale 여부는 render 시점에만 평가한다 — 인터벌 타이머를 두지 않으므로
     // 사용자 인터랙션 / 신규 분석 / 라우트 변경 등으로 다음 render가 일어나야
     // 배너가 갱신된다. 로딩 상태(isAnalyzing/showProgress)에서는 곧 새 분석으로
     // 교체되므로 stale 배너를 노출하지 않는다.
+    // `now`는 client mount 이후에만 값이 채워지므로 SSR/hydration 단계에서는
+    // 배너가 노출되지 않는다.
     const showStaleBanner =
         !isAnalyzing &&
         !showProgress &&
-        analysis.analyzedAt !== undefined &&
+        analysis.analyzedAt &&
         onReanalyze !== undefined &&
-        isAnalysisStale(analysis.analyzedAt, timeframe);
+        now !== null &&
+        isAnalysisStale(analysis.analyzedAt, timeframe, now);
 
     return (
         <div className="bg-secondary-800 relative flex flex-col gap-4 rounded-lg p-4">
@@ -830,7 +846,7 @@ export function AnalysisPanel({
                     <TrendBadge trend={analysis.trend} />
                 </div>
                 <div className="flex items-center gap-3">
-                    {analysis.analyzedAt !== undefined && (
+                    {analysis.analyzedAt && (
                         <time
                             dateTime={analysis.analyzedAt}
                             aria-label="분석 완료 시각"

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -41,6 +41,7 @@ import type { CooldownNotice } from '@/components/symbol-page/hooks/useAnalysis'
 import { TRENDLINE_DIRECTION_LABEL } from '@/components/trendline/constants';
 import { MS_PER_SECOND, SECONDS_PER_MINUTE } from '@/domain/constants/time';
 import { DEFAULT_RESET_MS as COPY_RESET_MS } from '@/components/hooks/useCopyToClipboard';
+import { formatAnalyzedAt } from '@/lib/formatAnalyzedAt';
 
 function formatCooldown(ms: number): string {
     const totalSec = Math.ceil(ms / MS_PER_SECOND);
@@ -806,6 +807,14 @@ export function AnalysisPanel({
                     <TrendBadge trend={analysis.trend} />
                 </div>
                 <div className="flex items-center gap-3">
+                    {analysis?.analyzedAt !== undefined && (
+                        <time
+                            dateTime={analysis.analyzedAt}
+                            className="text-secondary-500 text-xs"
+                        >
+                            {formatAnalyzedAt(analysis.analyzedAt)}
+                        </time>
+                    )}
                     <button
                         type="button"
                         onClick={handleCopyReport}

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -807,9 +807,10 @@ export function AnalysisPanel({
                     <TrendBadge trend={analysis.trend} />
                 </div>
                 <div className="flex items-center gap-3">
-                    {analysis?.analyzedAt !== undefined && (
+                    {analysis.analyzedAt !== undefined && (
                         <time
                             dateTime={analysis.analyzedAt}
+                            aria-label="분석 완료 시각"
                             className="text-secondary-500 text-xs"
                         >
                             {formatAnalyzedAt(analysis.analyzedAt)}

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import {
+    startTransition,
+    useEffect,
+    useEffectEvent,
+    useRef,
+    useState,
+} from 'react';
 import { EyeIcon } from '@/components/ui/EyeIcon';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { MarkdownText } from '@/components/ui/MarkdownText';
@@ -797,13 +803,19 @@ export function AnalysisPanel({
         };
     }, []);
 
+    // SSR/hydration mismatch 회피 — 서버에서는 `now`가 null, 클라이언트
+    // mount 직후에만 현재 시각을 캡쳐한다. setState를 useEffect 본문에서 직접
+    // 호출하는 대신 useEffectEvent로 감싸 React 19 canonical 패턴을 따르고,
+    // 본문은 startTransition으로 격리해 lint rule을 만족시킨다
+    // (MISTAKES.md §10).
+    const captureNow = useEffectEvent((): void => {
+        startTransition(() => {
+            setNow(new Date());
+        });
+    });
+
     useEffect(() => {
-        // SSR/hydration mismatch 회피 — 서버에서는 `now`가 null, 클라이언트
-        // mount 직후에만 현재 시각을 캡쳐한다. analyzedAt 변경 시(=신규 분석
-        // 완료) 다시 캡쳐해 stale 판정을 갱신한다. effect dep이 분석 ISO 문자열
-        // 한 개라 cascading render 위험은 없다.
-        // eslint-disable-next-line react-hooks/set-state-in-effect
-        setNow(new Date());
+        captureNow();
     }, [analysis.analyzedAt]);
 
     // stale 여부는 render 시점에만 평가한다 — 인터벌 타이머를 두지 않으므로

--- a/src/components/analysis/AnalysisPanel.tsx
+++ b/src/components/analysis/AnalysisPanel.tsx
@@ -793,14 +793,20 @@ export function AnalysisPanel({
         };
     }, []);
 
+    // stale 여부는 render 시점에만 평가한다 — 인터벌 타이머를 두지 않으므로
+    // 사용자 인터랙션 / 신규 분석 / 라우트 변경 등으로 다음 render가 일어나야
+    // 배너가 갱신된다. 로딩 상태(isAnalyzing/showProgress)에서는 곧 새 분석으로
+    // 교체되므로 stale 배너를 노출하지 않는다.
     const showStaleBanner =
+        !isAnalyzing &&
+        !showProgress &&
         analysis.analyzedAt !== undefined &&
         onReanalyze !== undefined &&
         isAnalysisStale(analysis.analyzedAt, timeframe);
 
     return (
         <div className="bg-secondary-800 relative flex flex-col gap-4 rounded-lg p-4">
-            {showStaleBanner && onReanalyze !== undefined && (
+            {showStaleBanner && (
                 <StaleAnalysisBanner
                     onReanalyze={onReanalyze}
                     reanalyzeCooldownMs={reanalyzeCooldownMs ?? 0}

--- a/src/components/analysis/StaleAnalysisBanner.tsx
+++ b/src/components/analysis/StaleAnalysisBanner.tsx
@@ -14,8 +14,8 @@ export function StaleAnalysisBanner({
             className="border-ui-warning/30 bg-ui-warning/10 text-ui-warning mb-3 flex items-center justify-between gap-3 rounded-lg border px-3 py-2 text-sm"
         >
             <span>
-                AI 분석 데이터가 오래되었습니다. 최신 시장가를 반영하려면 재분석을
-                실행해 주세요.
+                AI 분석 데이터가 오래되었습니다. 최신 시장가를 반영하려면
+                재분석을 실행해 주세요.
             </span>
             <button
                 type="button"
@@ -26,7 +26,7 @@ export function StaleAnalysisBanner({
                         ? '재분석은 5분에 한 번만 실행할 수 있어요.'
                         : undefined
                 }
-                className="border-ui-warning/40 hover:bg-ui-warning/20 focus-visible:ring-primary-500 disabled:opacity-40 rounded-md border px-2 py-1 text-xs font-medium focus-visible:ring-1 focus-visible:outline-none"
+                className="border-ui-warning/40 hover:bg-ui-warning/20 focus-visible:ring-primary-500 rounded-md border px-2 py-1 text-xs font-medium focus-visible:ring-1 focus-visible:outline-none disabled:opacity-40"
             >
                 재분석
             </button>

--- a/src/components/analysis/StaleAnalysisBanner.tsx
+++ b/src/components/analysis/StaleAnalysisBanner.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 interface StaleAnalysisBannerProps {
     onReanalyze: () => void;
     reanalyzeCooldownMs: number;
@@ -23,7 +21,12 @@ export function StaleAnalysisBanner({
                 type="button"
                 onClick={onReanalyze}
                 disabled={isCoolingDown}
-                className="border-ui-warning/40 hover:bg-ui-warning/20 disabled:opacity-40 rounded-md border px-2 py-1 text-xs font-medium"
+                title={
+                    isCoolingDown
+                        ? '재분석은 5분에 한 번만 실행할 수 있어요.'
+                        : undefined
+                }
+                className="border-ui-warning/40 hover:bg-ui-warning/20 focus-visible:ring-primary-500 disabled:opacity-40 rounded-md border px-2 py-1 text-xs font-medium focus-visible:ring-1 focus-visible:outline-none"
             >
                 재분석
             </button>

--- a/src/components/analysis/StaleAnalysisBanner.tsx
+++ b/src/components/analysis/StaleAnalysisBanner.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+interface StaleAnalysisBannerProps {
+    onReanalyze: () => void;
+    reanalyzeCooldownMs: number;
+}
+
+export function StaleAnalysisBanner({
+    onReanalyze,
+    reanalyzeCooldownMs,
+}: StaleAnalysisBannerProps) {
+    const isCoolingDown = reanalyzeCooldownMs > 0;
+    return (
+        <div
+            role="status"
+            className="border-ui-warning/30 bg-ui-warning/10 text-ui-warning mb-3 flex items-center justify-between gap-3 rounded-lg border px-3 py-2 text-sm"
+        >
+            <span>
+                AI 분석 데이터가 오래되었습니다. 최신 시장가를 반영하려면 재분석을
+                실행해 주세요.
+            </span>
+            <button
+                type="button"
+                onClick={onReanalyze}
+                disabled={isCoolingDown}
+                className="border-ui-warning/40 hover:bg-ui-warning/20 disabled:opacity-40 rounded-md border px-2 py-1 text-xs font-medium"
+            >
+                재분석
+            </button>
+        </div>
+    );
+}

--- a/src/components/analysis/StaleAnalysisBanner.tsx
+++ b/src/components/analysis/StaleAnalysisBanner.tsx
@@ -5,6 +5,7 @@ import { MS_PER_MINUTE } from '@/domain/constants/time';
 const STALE_MESSAGE =
     'AI 분석 데이터가 오래되었습니다. 최신 시장가를 반영하려면 재분석을 실행해 주세요.';
 const REANALYZE_LABEL = '재분석';
+const COOLDOWN_TOOLTIP_ID = 'stale-banner-cooldown-tooltip';
 
 interface StaleAnalysisBannerProps {
     onReanalyze: () => void;
@@ -23,19 +24,33 @@ export function StaleAnalysisBanner({
             className="border-ui-warning/30 bg-ui-warning/10 text-ui-warning flex items-center justify-between gap-3 rounded-lg border px-3 py-2 text-sm"
         >
             <span>{STALE_MESSAGE}</span>
-            <button
-                type="button"
-                onClick={onReanalyze}
-                disabled={isCoolingDown}
-                title={
-                    isCoolingDown
-                        ? `재분석은 ${cooldownMinutes}분에 한 번만 실행할 수 있어요.`
-                        : undefined
-                }
-                className="border-ui-warning/40 hover:bg-ui-warning/20 focus-visible:ring-primary-500 rounded-md border px-2 py-1 text-xs font-medium focus-visible:ring-1 focus-visible:outline-none disabled:opacity-40"
-            >
-                {REANALYZE_LABEL}
-            </button>
+            <div className="relative inline-flex">
+                <button
+                    type="button"
+                    onClick={onReanalyze}
+                    disabled={isCoolingDown}
+                    aria-describedby={
+                        isCoolingDown ? COOLDOWN_TOOLTIP_ID : undefined
+                    }
+                    title={
+                        isCoolingDown
+                            ? `재분석은 ${cooldownMinutes}분에 한 번만 실행할 수 있어요.`
+                            : undefined
+                    }
+                    className="border-ui-warning/40 hover:bg-ui-warning/20 focus-visible:ring-primary-500 rounded-md border px-2 py-1 text-xs font-medium focus-visible:ring-1 focus-visible:outline-none disabled:opacity-40"
+                >
+                    {REANALYZE_LABEL}
+                </button>
+                {isCoolingDown && (
+                    <span
+                        id={COOLDOWN_TOOLTIP_ID}
+                        role="tooltip"
+                        className="sr-only"
+                    >
+                        {`재분석은 ${cooldownMinutes}분에 한 번만 실행할 수 있어요.`}
+                    </span>
+                )}
+            </div>
         </div>
     );
 }

--- a/src/components/analysis/StaleAnalysisBanner.tsx
+++ b/src/components/analysis/StaleAnalysisBanner.tsx
@@ -1,3 +1,11 @@
+'use client';
+
+import { MS_PER_MINUTE } from '@/domain/constants/time';
+
+const STALE_MESSAGE =
+    'AI 분석 데이터가 오래되었습니다. 최신 시장가를 반영하려면 재분석을 실행해 주세요.';
+const REANALYZE_LABEL = '재분석';
+
 interface StaleAnalysisBannerProps {
     onReanalyze: () => void;
     reanalyzeCooldownMs: number;
@@ -8,27 +16,25 @@ export function StaleAnalysisBanner({
     reanalyzeCooldownMs,
 }: StaleAnalysisBannerProps) {
     const isCoolingDown = reanalyzeCooldownMs > 0;
+    const cooldownMinutes = Math.ceil(reanalyzeCooldownMs / MS_PER_MINUTE);
     return (
         <div
             role="status"
-            className="border-ui-warning/30 bg-ui-warning/10 text-ui-warning mb-3 flex items-center justify-between gap-3 rounded-lg border px-3 py-2 text-sm"
+            className="border-ui-warning/30 bg-ui-warning/10 text-ui-warning flex items-center justify-between gap-3 rounded-lg border px-3 py-2 text-sm"
         >
-            <span>
-                AI 분석 데이터가 오래되었습니다. 최신 시장가를 반영하려면
-                재분석을 실행해 주세요.
-            </span>
+            <span>{STALE_MESSAGE}</span>
             <button
                 type="button"
                 onClick={onReanalyze}
                 disabled={isCoolingDown}
                 title={
                     isCoolingDown
-                        ? '재분석은 5분에 한 번만 실행할 수 있어요.'
+                        ? `재분석은 ${cooldownMinutes}분에 한 번만 실행할 수 있어요.`
                         : undefined
                 }
                 className="border-ui-warning/40 hover:bg-ui-warning/20 focus-visible:ring-primary-500 rounded-md border px-2 py-1 text-xs font-medium focus-visible:ring-1 focus-visible:outline-none disabled:opacity-40"
             >
-                재분석
+                {REANALYZE_LABEL}
             </button>
         </div>
     );

--- a/src/components/options/OptionsAiAnalysis.tsx
+++ b/src/components/options/OptionsAiAnalysis.tsx
@@ -8,6 +8,7 @@ import type {
 } from '@y0ngha/siglens-core';
 import { BotBlockedNotice } from '@/components/symbol-page/BotBlockedNotice';
 import { cn } from '@/lib/cn';
+import { formatAnalyzedAt } from '@/lib/formatAnalyzedAt';
 import { OptionsAiAnalysisError } from '@/components/options/OptionsAiAnalysisError';
 import { OptionsAiAnalysisSkeleton } from '@/components/options/OptionsAiAnalysisSkeleton';
 import { useOptionsAnalysis } from '@/components/options/hooks/useOptionsAnalysis';
@@ -65,19 +66,6 @@ const SIGNAL_KIND_LABEL: Record<OptionsSignalKind, string> = {
     volatility: '변동성',
     neutral: '중립',
 };
-
-// Length of the 'YYYY-MM-DD HH:mm' prefix after replacing the 'T' separator
-// with a space — slice boundary for the compact header display.
-const ANALYZED_AT_DISPLAY_LENGTH = 16;
-
-/**
- * Format an ISO datetime string as "YYYY-MM-DD HH:mm". The server-side
- * timestamp is treated as already-displayable (no zone math); only the
- * minute-precision slice is shown to keep the header compact.
- */
-function formatAnalyzedAt(iso: string): string {
-    return iso.replace('T', ' ').slice(0, ANALYZED_AT_DISPLAY_LENGTH);
-}
 
 interface ToneBadgeProps {
     tone: OptionsTone;

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -173,6 +173,7 @@ export function ChartContent({
                         symbol={symbol}
                         analysis={analysis}
                         keyLevels={clusteredKeyLevels}
+                        timeframe={timeframe}
                         isAnalyzing={isAnalyzing}
                         showProgress={displayAnalyzing}
                         progressPhaseIndex={progressPhaseIndex}
@@ -198,6 +199,7 @@ export function ChartContent({
             analysisStatus,
             analysis,
             clusteredKeyLevels,
+            timeframe,
             displayAnalyzing,
             progressPhaseIndex,
             progressTipIndex,

--- a/src/components/symbol-page/ChartContent.tsx
+++ b/src/components/symbol-page/ChartContent.tsx
@@ -212,7 +212,8 @@ export function ChartContent({
         ]
     );
 
-    // timeframe key로 래핑 — Suspense 경계 밖 전달 + 타임프레임 변경 시 effect 재실행 보장.
+    // timeframe을 React.Fragment key로 전달 — Suspense 경계 밖에서 timeframe 변경 시 자식 트리를 강제 remount한다.
+    // timeframe이 useMemo dep에 포함되어 있으므로 mobileContent는 timeframe 변경 시 어차피 재생성되지만, Suspense 재진입은 key 경유로만 트리거된다.
     const mobileContent = useMemo(
         () => (
             <React.Fragment key={timeframe}>{analysisContent}</React.Fragment>

--- a/src/domain/analysis/staleThreshold.ts
+++ b/src/domain/analysis/staleThreshold.ts
@@ -1,0 +1,27 @@
+import type { Timeframe } from '@y0ngha/siglens-core';
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+
+const STALE_THRESHOLD_MS: Record<Timeframe, number> = {
+    '5Min': 5 * MINUTE_MS,
+    '15Min': 5 * MINUTE_MS,
+    '30Min': 5 * MINUTE_MS,
+    '1Hour': 30 * MINUTE_MS,
+    '4Hour': 30 * MINUTE_MS,
+    '1Day': 4 * HOUR_MS,
+};
+
+export function getStaleThresholdMs(timeframe: Timeframe): number {
+    return STALE_THRESHOLD_MS[timeframe];
+}
+
+export function isAnalysisStale(
+    analyzedAt: string,
+    timeframe: Timeframe,
+    now: Date = new Date()
+): boolean {
+    const analyzedTime = new Date(analyzedAt).getTime();
+    if (Number.isNaN(analyzedTime)) return false;
+    return now.getTime() - analyzedTime > STALE_THRESHOLD_MS[timeframe];
+}

--- a/src/domain/analysis/staleThreshold.ts
+++ b/src/domain/analysis/staleThreshold.ts
@@ -1,7 +1,7 @@
 import type { Timeframe } from '@y0ngha/siglens-core';
 import { MS_PER_MINUTE, MS_PER_HOUR } from '@/domain/constants/time';
 
-const STALE_THRESHOLD_MS: Record<Timeframe, number> = {
+export const STALE_THRESHOLD_MS: Record<Timeframe, number> = {
     '5Min': 5 * MS_PER_MINUTE,
     '15Min': 5 * MS_PER_MINUTE,
     '30Min': 5 * MS_PER_MINUTE,
@@ -13,7 +13,7 @@ const STALE_THRESHOLD_MS: Record<Timeframe, number> = {
 export function isAnalysisStale(
     analyzedAt: string,
     timeframe: Timeframe,
-    now: Date = new Date()
+    now: Date
 ): boolean {
     const analyzedTime = new Date(analyzedAt).getTime();
     if (Number.isNaN(analyzedTime)) return false;

--- a/src/domain/analysis/staleThreshold.ts
+++ b/src/domain/analysis/staleThreshold.ts
@@ -1,6 +1,9 @@
 import type { Timeframe } from '@y0ngha/siglens-core';
 import { MS_PER_MINUTE, MS_PER_HOUR } from '@/domain/constants/time';
 
+// 단기 타임프레임(5/15/30분봉)은 시세 변동이 빠르므로 임계값을 일률 5분으로
+// 짧게 잡아 사용자에게 재분석을 빠르게 권유한다. 중기(1H/4H)는 30분, 장기(1D)는
+// 4시간으로 늘어난다 — 봉의 시간 스케일이 커질수록 stale 판정의 보수성을 늘린다.
 export const STALE_THRESHOLD_MS: Record<Timeframe, number> = {
     '5Min': 5 * MS_PER_MINUTE,
     '15Min': 5 * MS_PER_MINUTE,

--- a/src/domain/analysis/staleThreshold.ts
+++ b/src/domain/analysis/staleThreshold.ts
@@ -1,20 +1,14 @@
 import type { Timeframe } from '@y0ngha/siglens-core';
-
-const MINUTE_MS = 60 * 1000;
-const HOUR_MS = 60 * MINUTE_MS;
+import { MS_PER_MINUTE, MS_PER_HOUR } from '@/domain/constants/time';
 
 const STALE_THRESHOLD_MS: Record<Timeframe, number> = {
-    '5Min': 5 * MINUTE_MS,
-    '15Min': 5 * MINUTE_MS,
-    '30Min': 5 * MINUTE_MS,
-    '1Hour': 30 * MINUTE_MS,
-    '4Hour': 30 * MINUTE_MS,
-    '1Day': 4 * HOUR_MS,
+    '5Min': 5 * MS_PER_MINUTE,
+    '15Min': 5 * MS_PER_MINUTE,
+    '30Min': 5 * MS_PER_MINUTE,
+    '1Hour': 30 * MS_PER_MINUTE,
+    '4Hour': 30 * MS_PER_MINUTE,
+    '1Day': 4 * MS_PER_HOUR,
 };
-
-export function getStaleThresholdMs(timeframe: Timeframe): number {
-    return STALE_THRESHOLD_MS[timeframe];
-}
 
 export function isAnalysisStale(
     analyzedAt: string,

--- a/src/lib/formatAnalyzedAt.ts
+++ b/src/lib/formatAnalyzedAt.ts
@@ -1,3 +1,5 @@
+// Length of the 'YYYY-MM-DD HH:mm' prefix after replacing the 'T' separator
+// with a space — slice boundary for the compact header display.
 const ANALYZED_AT_DISPLAY_LENGTH = 16;
 
 export function formatAnalyzedAt(iso: string): string {

--- a/src/lib/formatAnalyzedAt.ts
+++ b/src/lib/formatAnalyzedAt.ts
@@ -1,0 +1,5 @@
+const ANALYZED_AT_DISPLAY_LENGTH = 16;
+
+export function formatAnalyzedAt(iso: string): string {
+    return iso.replace('T', ' ').slice(0, ANALYZED_AT_DISPLAY_LENGTH);
+}


### PR DESCRIPTION
## Summary
- Extract \`formatAnalyzedAt\` into \`src/lib/\` for reuse across analysis panels.
- \`AnalysisPanel\` header now shows the analysis capture timestamp (matches \`OptionsAiAnalysis\` pattern, with \`aria-label\`).
- Add timeframe-aware stale-warning banner with shared time constants:
  - 5/15/30Min → 5 min
  - 1Hour / 4Hour → 30 min
  - 1Day → 4 h
- Banner reuses the existing \`onReanalyze\` handler; suppresses itself during \`isAnalyzing\` / \`showProgress\` loading states.
- Staleness is evaluated on render — no interval ticker (documented inline).

## Why
Users mistook AI-asserted \"현재 가격 136.18\" as the live quote when the actual live price was 134.34. This PR addresses the UI side — surfacing the snapshot timestamp and warning when the analysis is stale relative to the timeframe. The companion prompt-label fix in siglens-core (#90) addresses the AI output side.

## Companion PR
https://github.com/y0ngha/siglens-core/pull/90 — renames \`Current Price\` → \`Snapshot Price\` in the AI prompt and forces Korean output to use \"분석 시점 가격\". The two PRs can be reviewed in parallel.

## Dependency note
This PR keeps \`@y0ngha/siglens-core@0.11.2\`. After both PRs are reviewed and the core PR is published, the author will bump the core dependency in a follow-up commit before final merge.

## Test plan
- [x] \`yarn test\` — 1859/1859 pass (new tests: \`formatAnalyzedAt\`, \`isAnalysisStale\`, \`StaleAnalysisBanner\`)
- [x] \`yarn lint\` — exit 0
- [x] \`yarn build\` — exit 0
- [x] \`yarn tsc --noEmit\` — clean (TS 5.x narrowing through \`showStaleBanner\` verified)
- [ ] Manually verify header timestamp renders for new and cached analyses (reviewer to confirm)
- [ ] Manually verify stale banner appears past timeframe threshold and triggers force re-analysis (reviewer to confirm)