### PR TITLE
fix(options): stale OI EM DASH 일원화 + 툴팁/배너 DST-aware 안내

### DIFF
--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -626,6 +626,14 @@ This file contains only **recurring gotchas** that agents keep missing despite e
     → Test assertion must explicitly check the new dependency is received and used
     ❌ deleteAccountAction(oauthAccounts, oauthRevoker) added, but test asserts deleteAccountAction called without verifying deps passed
     ✅ Assertion explicitly checks both oauthAccounts and oauthRevoker are included in the deps passed
+
+17. New threshold/conditional branch introduced without test cases covering both true and false paths
+    → When a function adds a new `if (value < THRESHOLD)` check, tests must explicitly verify the branch-taken case (value below threshold) and branch-not-taken case (value at/above threshold)
+    → Testing only the normal (non-threshold) case leaves the new branch untested and vulnerable to regression
+    → Boundary test cases: values just below and just above the threshold
+    ❌ formatImpliedMove(0.04) adds `if (pct < PERCENT_DISPLAY_FLOOR)`, but tests only verify value <= 0 case, not the 0 < value < floor case
+    ✅ Add explicit test cases: formatImpliedMove(0.0004) for below-floor, formatImpliedMove(0.05) for above-floor, plus boundary values
+    → Applies to all conditional branches (time thresholds, percentage boundaries, count limits) added in a PR
 ```
 
 ---

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -378,3 +378,12 @@
 - Context: Suggestion — `OpenInterestChart.tsx` `oiByStrike.reduce(sum, 0) === 0` 가드를 `oiByStrike.every(s => s.callOpenInterest === 0 && s.putOpenInterest === 0)` 으로 교체.
 
 
+## [PR #448 Round 2 | fix/options-stale-oi-em-dash | 2026-05-22]
+- Violation: 모듈에서 export하는 placeholder 상수(`METRIC_PLACEHOLDER`)를 테스트가 import하지 않고 리터럴 `'—'`를 하드코딩
+- Rule: MISTAKES.md §Tests §13 — Expected values from module exports must be imported, not hardcoded
+- Context: Blocker — R1에서 `optionsFormatters.ts`에 `METRIC_PLACEHOLDER` export를 도입했지만 test 파일은 이전 리터럴을 그대로 유지. value drift 시 silent pass 가능. 모든 `toBe('—')`를 `toBe(METRIC_PLACEHOLDER)`로 교체.
+- Violation: `new Date()`를 평가하는 함수 컴포넌트를 export하는 파일에 `'use client'` 누락
+- Rule: FF Cohesion — DST 평가는 client 시점에만 정확. 같은 PR에서 OptionsStaleDataBanner에 `'use client'`를 추가한 결정과 일관성 필요
+- Context: Suggestion — `optionsTooltips.tsx`의 `AtmIvTooltip`/`ImpliedMoveTooltip`가 render-time `new Date()` 평가. 현재는 client consumer만 import해 기능적 문제 없으나, RSC import 시 builds-time 평가로 잘못 안내 위험. `'use client'` directive 추가.
+
+

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -387,3 +387,12 @@
 - Context: Suggestion — `optionsTooltips.tsx`의 `AtmIvTooltip`/`ImpliedMoveTooltip`가 render-time `new Date()` 평가. 현재는 client consumer만 import해 기능적 문제 없으나, RSC import 시 builds-time 평가로 잘못 안내 위험. `'use client'` directive 추가.
 
 
+## [PR #448 Round 3 | fix/options-stale-oi-em-dash | 2026-05-22]
+- Violation: 모듈에서 export하는 상수가 자신을 참조하는 function declaration보다 아래에 위치 — 런타임은 closure로 OK지만 reader에게 "어디서 옴?" 인식 부담
+- Rule: FF Readability — single source of truth는 파일 상단에 배치해 reader가 stub 참조 전에 정의를 만나도록
+- Context: Suggestion 1 — `optionsFormatters.ts`의 `METRIC_PLACEHOLDER`/`PERCENT_DISPLAY_FLOOR`가 formatters 아래(L41~L46). 두 상수를 파일 최상단(JSDoc 직후, 모든 function 선언 이전)으로 이동.
+- Violation: 테스트 설명문/입력값이 floor 상수(`PERCENT_DISPLAY_FLOOR`) 값을 하드코딩 — 상수 변경 시 description text와 input value가 자동 갱신 안 됨
+- Rule: MISTAKES.md §Tests §4 — boundary 테스트 상수는 source에서 import; description도 상수를 interpolate해 drift 차단
+- Context: Suggestion 2 — `PERCENT_DISPLAY_FLOOR`를 export로 승격. 4개 boundary 테스트에서 입력값을 `(PERCENT_DISPLAY_FLOOR / 100) * 0.8/1.2`(formatAtmIv) 또는 `PERCENT_DISPLAY_FLOOR * 0.8/1.2`(formatImpliedMove)로 derive. description은 `${PERCENT_DISPLAY_FLOOR}` interpolation.
+
+

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -369,18 +369,6 @@
 
 
 
-## [PR #446 Round 1 | fix/options-oi-stale-fraction | 2026-05-22]
-- Violation: 비율 경계 테스트가 `puts: []` 고정 헬퍼만 사용해 calls/puts 혼합 시나리오를 커버하지 않음
-- Rule: 분기 커버리지 — 구현이 `flatMap([...calls, ...puts])`로 양쪽을 합산하므로 puts 비어있는 케이스만 검증하면 합산 분기가 회귀에 노출됨
-- Context: Suggestion 1 — `session.test.ts`에 (1) 50/50 혼합 nonstale (2) 혼합 boundary stale 2개 케이스 추가. boundary는 `Math.ceil(total * OI_STALE_FRACTION_THRESHOLD)`로 임계값에서 파생.
-- Violation: 단일 자식만 남은 컨테이너에 `gap-1` Tailwind 클래스가 남아 no-op
-- Rule: MISTAKES.md Components §4 — 사용 효과가 없는 Tailwind class 잔존 금지
-- Context: Suggestion 2 — `StrikeVolumeChart.tsx` 정상 헤더 + 빈 상태 헤더 둘 다 `<InfoTooltip>`을 범례로 옮긴 뒤 단일 자식. 외곽 `<div className="flex items-center gap-1">`을 그대로 `<span>` 하나로 치환.
-- Violation: sibling grid 셀(`OpenInterestChart` 빈 상태 vs `StrikeVolumeChart` 빈 상태)이 헤더 유무·텍스트 스타일에서 어긋남
-- Rule: FF Readability / visual consistency — `lg:grid-cols-2`로 묶인 sibling 빈 상태는 동일한 레이아웃(header + body)을 따라야 함
-- Context: Gemini Medium 권고 — OI 차트 빈 상태도 `Open Interest 분포 (Strike별)` 헤더 유지 + 본문 안내로 분리. Volume 빈 상태 본문은 `text-xs leading-relaxed`로 통일.
-
-
 ## [PR #446 Round 3 | fix/options-oi-stale-fraction | 2026-05-22]
 - Violation: 동일 값(`allContracts.length`)을 같은 함수 안에서 두 번 접근
 - Rule: MISTAKES.md §2 — Identical values queried or computed multiple times → Extract to a local const
@@ -388,3 +376,5 @@
 - Violation: `reduce`로 합산 후 `=== 0`만 확인 — sum 값이 버려져 의미가 흐려지고 short-circuit 기회를 놓침
 - Rule: 의미 정합성 — "모두 0인가" 는 합산이 아닌 `.every()`로 표현해야 의도가 직접 드러나고 첫 비-zero에서 short-circuit
 - Context: Suggestion — `OpenInterestChart.tsx` `oiByStrike.reduce(sum, 0) === 0` 가드를 `oiByStrike.every(s => s.callOpenInterest === 0 && s.putOpenInterest === 0)` 으로 교체.
+
+

--- a/src/__tests__/lib/options/optionsFormatters.test.ts
+++ b/src/__tests__/lib/options/optionsFormatters.test.ts
@@ -77,6 +77,16 @@ describe('formatAtmIv', () => {
     it('소수점 첫째 자리까지 반올림한다', () => {
         expect(formatAtmIv(0.123456)).toBe('12.3%');
     });
+
+    it('0 fraction은 em dash로 표현한다 (Yahoo가 IV를 클리어한 케이스)', () => {
+        // ATM contract의 IV가 0으로 들어오면 의미 있는 변동성이 아니므로
+        // 사용자에게 "데이터 없음"으로 안내한다.
+        expect(formatAtmIv(0)).toBe('—');
+    });
+
+    it('음수 fraction도 em dash로 표현한다 (방어적 가드)', () => {
+        expect(formatAtmIv(-0.1)).toBe('—');
+    });
 });
 
 describe('formatImpliedMove', () => {
@@ -96,7 +106,13 @@ describe('formatImpliedMove', () => {
         expect(formatImpliedMove(4.2)).toBe('±4.2%');
     });
 
-    it('0% 움직임도 정상 표시', () => {
-        expect(formatImpliedMove(0)).toBe('±0.0%');
+    it('0%는 em dash로 표현한다 (ATM IV가 0이라 기대 변동성도 0인 케이스)', () => {
+        // calculateImpliedMove(atmIv=0, ...) === 0 → "±0.0%"는 변동성이 정말
+        // 0이라는 잘못된 인상을 주므로 placeholder로 대체한다.
+        expect(formatImpliedMove(0)).toBe('—');
+    });
+
+    it('음수 implied move도 em dash로 표현한다 (방어적 가드)', () => {
+        expect(formatImpliedMove(-1)).toBe('—');
     });
 });

--- a/src/__tests__/lib/options/optionsFormatters.test.ts
+++ b/src/__tests__/lib/options/optionsFormatters.test.ts
@@ -4,6 +4,7 @@ import {
     formatMaxPain,
     formatPutCallRatio,
     METRIC_PLACEHOLDER,
+    PERCENT_DISPLAY_FLOOR,
 } from '@/lib/options/optionsFormatters';
 
 describe('formatMaxPain', () => {
@@ -89,17 +90,19 @@ describe('formatAtmIv', () => {
         expect(formatAtmIv(-0.1)).toBe(METRIC_PLACEHOLDER);
     });
 
-    it('PERCENT_DISPLAY_FLOOR(0.05%) 미만 sub-percent noise는 em dash로 표현한다', () => {
-        // value=0.0004 → pct=0.04 → pct < 0.05이므로 placeholder.
+    it(`PERCENT_DISPLAY_FLOOR(${PERCENT_DISPLAY_FLOOR}%) 미만 sub-percent noise는 em dash로 표현한다`, () => {
+        // value * 100이 floor 미만이 되도록 floor를 fraction으로 환산 후 0.8배.
         // Yahoo가 pre-market에서 ATM IV를 0 또는 sub-percent로 채워 보내는
         // 경우의 noise 컷오프.
-        expect(formatAtmIv(0.0004)).toBe(METRIC_PLACEHOLDER);
+        expect(formatAtmIv((PERCENT_DISPLAY_FLOOR / 100) * 0.8)).toBe(
+            METRIC_PLACEHOLDER
+        );
     });
 
-    it('PERCENT_DISPLAY_FLOOR(0.05%) 바로 위 값은 표시한다', () => {
-        // value=0.0006 → pct=0.06 → floor(0.05) 초과 → "0.1%"로 반올림 표시.
-        // FP 정밀도 이슈를 피해 경계값(0.0005)이 아닌 명확히 위 값으로 검증.
-        expect(formatAtmIv(0.0006)).toBe('0.1%');
+    it(`PERCENT_DISPLAY_FLOOR(${PERCENT_DISPLAY_FLOOR}%) 바로 위 값은 표시한다`, () => {
+        // value * 100이 floor 초과가 되도록 floor를 fraction으로 환산 후 1.2배.
+        // FP 정밀도 이슈를 피해 경계값이 아닌 명확히 위 값으로 검증.
+        expect(formatAtmIv((PERCENT_DISPLAY_FLOOR / 100) * 1.2)).toBe('0.1%');
     });
 });
 
@@ -130,15 +133,17 @@ describe('formatImpliedMove', () => {
         expect(formatImpliedMove(-1)).toBe(METRIC_PLACEHOLDER);
     });
 
-    it('PERCENT_DISPLAY_FLOOR(0.05) 미만 sub-percent noise는 em dash로 표현한다', () => {
-        // value=0.04 → value < 0.05이므로 placeholder.
+    it(`PERCENT_DISPLAY_FLOOR(${PERCENT_DISPLAY_FLOOR}) 미만 sub-percent noise는 em dash로 표현한다`, () => {
+        // value가 floor 미만이 되도록 floor의 0.8배로 입력.
         // ATM IV가 sub-percent일 때 implied move도 같은 구간에서 노이즈로 떨어진다.
-        expect(formatImpliedMove(0.04)).toBe(METRIC_PLACEHOLDER);
+        expect(formatImpliedMove(PERCENT_DISPLAY_FLOOR * 0.8)).toBe(
+            METRIC_PLACEHOLDER
+        );
     });
 
-    it('PERCENT_DISPLAY_FLOOR(0.05) 바로 위 값은 표시한다', () => {
-        // value=0.06 → floor(0.05) 초과 → "±0.1%"로 반올림 표시.
-        // FP 정밀도 이슈를 피해 경계값(0.05)이 아닌 명확히 위 값으로 검증.
-        expect(formatImpliedMove(0.06)).toBe('±0.1%');
+    it(`PERCENT_DISPLAY_FLOOR(${PERCENT_DISPLAY_FLOOR}) 바로 위 값은 표시한다`, () => {
+        // value가 floor 초과가 되도록 floor의 1.2배로 입력.
+        // FP 정밀도 이슈를 피해 경계값이 아닌 명확히 위 값으로 검증.
+        expect(formatImpliedMove(PERCENT_DISPLAY_FLOOR * 1.2)).toBe('±0.1%');
     });
 });

--- a/src/__tests__/lib/options/optionsFormatters.test.ts
+++ b/src/__tests__/lib/options/optionsFormatters.test.ts
@@ -87,6 +87,19 @@ describe('formatAtmIv', () => {
     it('음수 fraction도 em dash로 표현한다 (방어적 가드)', () => {
         expect(formatAtmIv(-0.1)).toBe('—');
     });
+
+    it('PERCENT_DISPLAY_FLOOR(0.05%) 미만 sub-percent noise는 em dash로 표현한다', () => {
+        // value=0.0004 → pct=0.04 → pct < 0.05이므로 placeholder.
+        // Yahoo가 pre-market에서 ATM IV를 0 또는 sub-percent로 채워 보내는
+        // 경우의 noise 컷오프.
+        expect(formatAtmIv(0.0004)).toBe('—');
+    });
+
+    it('PERCENT_DISPLAY_FLOOR(0.05%) 바로 위 값은 표시한다', () => {
+        // value=0.0006 → pct=0.06 → floor(0.05) 초과 → "0.1%"로 반올림 표시.
+        // FP 정밀도 이슈를 피해 경계값(0.0005)이 아닌 명확히 위 값으로 검증.
+        expect(formatAtmIv(0.0006)).toBe('0.1%');
+    });
 });
 
 describe('formatImpliedMove', () => {
@@ -114,5 +127,17 @@ describe('formatImpliedMove', () => {
 
     it('음수 implied move도 em dash로 표현한다 (방어적 가드)', () => {
         expect(formatImpliedMove(-1)).toBe('—');
+    });
+
+    it('PERCENT_DISPLAY_FLOOR(0.05) 미만 sub-percent noise는 em dash로 표현한다', () => {
+        // value=0.04 → value < 0.05이므로 placeholder.
+        // ATM IV가 sub-percent일 때 implied move도 같은 구간에서 노이즈로 떨어진다.
+        expect(formatImpliedMove(0.04)).toBe('—');
+    });
+
+    it('PERCENT_DISPLAY_FLOOR(0.05) 바로 위 값은 표시한다', () => {
+        // value=0.06 → floor(0.05) 초과 → "±0.1%"로 반올림 표시.
+        // FP 정밀도 이슈를 피해 경계값(0.05)이 아닌 명확히 위 값으로 검증.
+        expect(formatImpliedMove(0.06)).toBe('±0.1%');
     });
 });

--- a/src/__tests__/lib/options/optionsFormatters.test.ts
+++ b/src/__tests__/lib/options/optionsFormatters.test.ts
@@ -3,19 +3,20 @@ import {
     formatImpliedMove,
     formatMaxPain,
     formatPutCallRatio,
+    METRIC_PLACEHOLDER,
 } from '@/lib/options/optionsFormatters';
 
 describe('formatMaxPain', () => {
     it('null을 em dash로 표현한다 (siglens-core R12 이후 nullable contract)', () => {
-        expect(formatMaxPain(null)).toBe('—');
+        expect(formatMaxPain(null)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('undefined를 em dash로 표현한다', () => {
-        expect(formatMaxPain(undefined)).toBe('—');
+        expect(formatMaxPain(undefined)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('NaN을 em dash로 표현한다 (legacy 호환)', () => {
-        expect(formatMaxPain(NaN)).toBe('—');
+        expect(formatMaxPain(NaN)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('정수 strike를 천 단위 콤마와 함께 표시한다', () => {
@@ -37,15 +38,15 @@ describe('formatPutCallRatio', () => {
     });
 
     it('null을 em dash로 표현한다 (siglens-core R12 이후 nullable contract)', () => {
-        expect(formatPutCallRatio(null)).toBe('—');
+        expect(formatPutCallRatio(null)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('undefined를 em dash로 표현한다', () => {
-        expect(formatPutCallRatio(undefined)).toBe('—');
+        expect(formatPutCallRatio(undefined)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('NaN을 em dash로 표현한다 (legacy 호환)', () => {
-        expect(formatPutCallRatio(NaN)).toBe('—');
+        expect(formatPutCallRatio(NaN)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('일반 비율은 소수점 두 자리로 표시한다', () => {
@@ -59,15 +60,15 @@ describe('formatPutCallRatio', () => {
 
 describe('formatAtmIv', () => {
     it('null을 em dash로 표현한다', () => {
-        expect(formatAtmIv(null)).toBe('—');
+        expect(formatAtmIv(null)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('undefined를 em dash로 표현한다', () => {
-        expect(formatAtmIv(undefined)).toBe('—');
+        expect(formatAtmIv(undefined)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('NaN을 em dash로 표현한다', () => {
-        expect(formatAtmIv(NaN)).toBe('—');
+        expect(formatAtmIv(NaN)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('0.28 fraction을 28.0% 형식으로 표시한다', () => {
@@ -81,18 +82,18 @@ describe('formatAtmIv', () => {
     it('0 fraction은 em dash로 표현한다 (Yahoo가 IV를 클리어한 케이스)', () => {
         // ATM contract의 IV가 0으로 들어오면 의미 있는 변동성이 아니므로
         // 사용자에게 "데이터 없음"으로 안내한다.
-        expect(formatAtmIv(0)).toBe('—');
+        expect(formatAtmIv(0)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('음수 fraction도 em dash로 표현한다 (방어적 가드)', () => {
-        expect(formatAtmIv(-0.1)).toBe('—');
+        expect(formatAtmIv(-0.1)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('PERCENT_DISPLAY_FLOOR(0.05%) 미만 sub-percent noise는 em dash로 표현한다', () => {
         // value=0.0004 → pct=0.04 → pct < 0.05이므로 placeholder.
         // Yahoo가 pre-market에서 ATM IV를 0 또는 sub-percent로 채워 보내는
         // 경우의 noise 컷오프.
-        expect(formatAtmIv(0.0004)).toBe('—');
+        expect(formatAtmIv(0.0004)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('PERCENT_DISPLAY_FLOOR(0.05%) 바로 위 값은 표시한다', () => {
@@ -104,15 +105,15 @@ describe('formatAtmIv', () => {
 
 describe('formatImpliedMove', () => {
     it('null을 em dash로 표현한다', () => {
-        expect(formatImpliedMove(null)).toBe('—');
+        expect(formatImpliedMove(null)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('undefined를 em dash로 표현한다', () => {
-        expect(formatImpliedMove(undefined)).toBe('—');
+        expect(formatImpliedMove(undefined)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('NaN을 em dash로 표현한다', () => {
-        expect(formatImpliedMove(NaN)).toBe('—');
+        expect(formatImpliedMove(NaN)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('± 기호와 소수점 첫째 자리로 표시한다', () => {
@@ -122,17 +123,17 @@ describe('formatImpliedMove', () => {
     it('0%는 em dash로 표현한다 (ATM IV가 0이라 기대 변동성도 0인 케이스)', () => {
         // calculateImpliedMove(atmIv=0, ...) === 0 → "±0.0%"는 변동성이 정말
         // 0이라는 잘못된 인상을 주므로 placeholder로 대체한다.
-        expect(formatImpliedMove(0)).toBe('—');
+        expect(formatImpliedMove(0)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('음수 implied move도 em dash로 표현한다 (방어적 가드)', () => {
-        expect(formatImpliedMove(-1)).toBe('—');
+        expect(formatImpliedMove(-1)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('PERCENT_DISPLAY_FLOOR(0.05) 미만 sub-percent noise는 em dash로 표현한다', () => {
         // value=0.04 → value < 0.05이므로 placeholder.
         // ATM IV가 sub-percent일 때 implied move도 같은 구간에서 노이즈로 떨어진다.
-        expect(formatImpliedMove(0.04)).toBe('—');
+        expect(formatImpliedMove(0.04)).toBe(METRIC_PLACEHOLDER);
     });
 
     it('PERCENT_DISPLAY_FLOOR(0.05) 바로 위 값은 표시한다', () => {

--- a/src/components/options/OpenInterestChart.tsx
+++ b/src/components/options/OpenInterestChart.tsx
@@ -1,46 +1,41 @@
 'use client';
 
 import {
-    useMemo,
-    useRef,
-    useState,
-    type CSSProperties,
-    type PointerEvent,
-} from 'react';
+    CALL_LABEL_MIDLINE_OFFSET_PX,
+    PEAK_LABEL_TOP_OFFSET_PX,
+    PUT_LABEL_MIDLINE_OFFSET_PX,
+} from '@/components/options/utils/chartLabelOffsets';
 import {
-    type OptionsChain,
-    type OptionsExpirationMetrics,
-    aggregateOpenInterest,
-} from '@y0ngha/siglens-core';
-import { InfoTooltip } from '@/components/ui/InfoTooltip';
-import {
-    CallOpenInterestTooltip,
-    OpenInterestTooltip,
-    PutOpenInterestTooltip,
-} from '@/components/options/utils/optionsTooltips';
+    GUIDE_LINE_STROKE_WIDTH,
+    MIDLINE_STROKE_WIDTH,
+} from '@/components/options/utils/chartStrokeWidths';
 import {
     computeTooltipPos,
     TOOLTIP_ELEMENT_ID,
     TOOLTIP_MIN_WIDTH_PX,
     type TooltipPosition,
 } from '@/components/options/utils/computeTooltipPos';
-import { pickLabelIndices } from '@/components/options/utils/pickLabelIndices';
 import { formatCompactCount } from '@/components/options/utils/formatCompactCount';
 import {
-    PEAK_LABEL_TOP_OFFSET_PX,
-    CALL_LABEL_MIDLINE_OFFSET_PX,
-    PUT_LABEL_MIDLINE_OFFSET_PX,
-} from '@/components/options/utils/chartLabelOffsets';
-import {
-    MIDLINE_STROKE_WIDTH,
-    GUIDE_LINE_STROKE_WIDTH,
-} from '@/components/options/utils/chartStrokeWidths';
+    CallOpenInterestTooltip,
+    OpenInterestTooltip,
+    PutOpenInterestTooltip,
+} from '@/components/options/utils/optionsTooltips';
+import { pickLabelIndices } from '@/components/options/utils/pickLabelIndices';
+import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { findNearestStrikeIndex } from '@/domain/options/findNearestStrike';
 import {
-    ET_MARKET_HOURS_DISPLAY,
-    KST_EDT_HOURS_DISPLAY,
-    KST_EST_HOURS_DISPLAY,
-} from '@/lib/options/marketHoursDisplay';
+    aggregateOpenInterest,
+    type OptionsChain,
+    type OptionsExpirationMetrics,
+} from '@y0ngha/siglens-core';
+import {
+    useMemo,
+    useRef,
+    useState,
+    type CSSProperties,
+    type PointerEvent,
+} from 'react';
 
 interface OpenInterestChartProps {
     /** Spot price used to anchor the current-price guide line. */
@@ -216,11 +211,7 @@ export function OpenInterestChart({
                     Open Interest 분포 (Strike별)
                 </span>
                 <p className="text-secondary-500 text-xs leading-relaxed">
-                    이 만기에는 OI 데이터가 없어요. 미국 정규장 마감 후에는
-                    Yahoo가 Open Interest를 갱신하지 않아 비어 보일 수 있어요.
-                    정확한 수치는 미국 정규장 시간({ET_MARKET_HOURS_DISPLAY},
-                    평일, 한국 시간 EDT 기간 {KST_EDT_HOURS_DISPLAY} / EST 기간{' '}
-                    {KST_EST_HOURS_DISPLAY})에 다시 확인해 주세요.
+                    이 만기에는 OI 데이터가 없어요.
                 </p>
             </div>
         );
@@ -554,25 +545,31 @@ export function OpenInterestChart({
                 </span>
             </div>
 
-            <table className="sr-only">
-                <caption>Strike별 Open Interest 데이터</caption>
-                <thead>
-                    <tr>
-                        <th scope="col">Strike</th>
-                        <th scope="col">Call OI</th>
-                        <th scope="col">Put OI</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {oiByStrike.map(row => (
-                        <tr key={row.strike}>
-                            <td>{row.strike}</td>
-                            <td>{row.callOpenInterest}</td>
-                            <td>{row.putOpenInterest}</td>
+            {/* sr-only를 <table>이 아니라 wrapper <div>에 둔다 —
+                <table>은 `display: table`이라 `position: absolute`와 결합돼도
+                일부 환경에서 normal flow에 잔재가 남아 페이지 height에
+                영향을 준다. <div>로 감싸 absolute 컨텍스트를 분리한다. */}
+            <div className="sr-only">
+                <table>
+                    <caption>Strike별 Open Interest 데이터</caption>
+                    <thead>
+                        <tr>
+                            <th scope="col">Strike</th>
+                            <th scope="col">Call OI</th>
+                            <th scope="col">Put OI</th>
                         </tr>
-                    ))}
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                        {oiByStrike.map(row => (
+                            <tr key={row.strike}>
+                                <td>{row.strike}</td>
+                                <td>{row.callOpenInterest}</td>
+                                <td>{row.putOpenInterest}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
         </div>
     );
 }

--- a/src/components/options/OptionsMetricsRow.tsx
+++ b/src/components/options/OptionsMetricsRow.tsx
@@ -9,6 +9,7 @@ import {
     formatImpliedMove,
     formatMaxPain,
     formatPutCallRatio,
+    METRIC_PLACEHOLDER,
 } from '@/lib/options/optionsFormatters';
 import {
     AtmIvTooltip,
@@ -38,10 +39,6 @@ function MetricCard({ label, value, tooltip }: MetricCardProps) {
         </div>
     );
 }
-
-// OI snapshot이 stale일 때 metric 카드 값에 일괄 표시하는 placeholder.
-// formatters의 null/NaN 분기와 동일한 글자(`—`)를 쓴다.
-const EM_DASH = '—';
 
 interface OptionsMetricsRowProps {
     /** 'YYYY-MM-DD' or 'all'. */
@@ -74,28 +71,28 @@ export function OptionsMetricsRow({
                 {
                     label: 'Max Pain',
                     value: oiStale
-                        ? EM_DASH
+                        ? METRIC_PLACEHOLDER
                         : formatMaxPain(metrics?.maxPain ?? null),
                     tooltip: MaxPainTooltip,
                 },
                 {
                     label: 'P/C Ratio',
                     value: oiStale
-                        ? EM_DASH
+                        ? METRIC_PLACEHOLDER
                         : formatPutCallRatio(metrics?.putCallRatio ?? null),
                     tooltip: PutCallRatioTooltip,
                 },
                 {
                     label: 'ATM IV',
                     value: oiStale
-                        ? EM_DASH
+                        ? METRIC_PLACEHOLDER
                         : formatAtmIv(metrics?.atmImpliedVolatility ?? null),
                     tooltip: <AtmIvTooltip />,
                 },
                 {
                     label: 'Imp. Move',
                     value: oiStale
-                        ? EM_DASH
+                        ? METRIC_PLACEHOLDER
                         : formatImpliedMove(
                               metrics?.impliedMovePercent ?? null
                           ),

--- a/src/components/options/OptionsMetricsRow.tsx
+++ b/src/components/options/OptionsMetricsRow.tsx
@@ -39,6 +39,10 @@ function MetricCard({ label, value, tooltip }: MetricCardProps) {
     );
 }
 
+// OI snapshot이 stale일 때 metric 카드 값에 일괄 표시하는 placeholder.
+// formatters의 null/NaN 분기와 동일한 글자(`—`)를 쓴다.
+const EM_DASH = '—';
+
 interface OptionsMetricsRowProps {
     /** 'YYYY-MM-DD' or 'all'. */
     expirationDate: OptionsExpirationSelector;
@@ -46,12 +50,20 @@ interface OptionsMetricsRowProps {
     metrics: OptionsExpirationMetrics | null;
     /** First-chain expiration date for the "종합 만기" caption. */
     nearestExpiry: string;
+    /**
+     * `true`이면 OI 스냅샷이 stale 상태(Yahoo 정규장 외 quote 클리어)로 판정되어
+     * 카드의 모든 metric을 EM DASH로 표시한다. Max Pain·ATM IV·Imp. Move는
+     * OI/IV에 직접 의존하므로 stale 데이터로 계산하면 사용자에게 잘못된 숫자
+     * (예: $50, 0.0%)를 신뢰성 있게 보이도록 노출하게 된다.
+     */
+    oiStale: boolean;
 }
 
 export function OptionsMetricsRow({
     expirationDate,
     metrics,
     nearestExpiry,
+    oiStale,
 }: OptionsMetricsRowProps) {
     // siglens-core R12: maxPain / putCallRatio are now `number | null`
     // (formatters tolerate the union explicitly), so pass through directly
@@ -61,28 +73,36 @@ export function OptionsMetricsRow({
             [
                 {
                     label: 'Max Pain',
-                    value: formatMaxPain(metrics?.maxPain ?? null),
+                    value: oiStale
+                        ? EM_DASH
+                        : formatMaxPain(metrics?.maxPain ?? null),
                     tooltip: MaxPainTooltip,
                 },
                 {
                     label: 'P/C Ratio',
-                    value: formatPutCallRatio(metrics?.putCallRatio ?? null),
+                    value: oiStale
+                        ? EM_DASH
+                        : formatPutCallRatio(metrics?.putCallRatio ?? null),
                     tooltip: PutCallRatioTooltip,
                 },
                 {
                     label: 'ATM IV',
-                    value: formatAtmIv(metrics?.atmImpliedVolatility ?? null),
-                    tooltip: AtmIvTooltip,
+                    value: oiStale
+                        ? EM_DASH
+                        : formatAtmIv(metrics?.atmImpliedVolatility ?? null),
+                    tooltip: <AtmIvTooltip />,
                 },
                 {
                     label: 'Imp. Move',
-                    value: formatImpliedMove(
-                        metrics?.impliedMovePercent ?? null
-                    ),
-                    tooltip: ImpliedMoveTooltip,
+                    value: oiStale
+                        ? EM_DASH
+                        : formatImpliedMove(
+                              metrics?.impliedMovePercent ?? null
+                          ),
+                    tooltip: <ImpliedMoveTooltip />,
                 },
             ] as const,
-        [metrics]
+        [metrics, oiStale]
     );
 
     return (

--- a/src/components/options/OptionsPageClient.tsx
+++ b/src/components/options/OptionsPageClient.tsx
@@ -89,25 +89,19 @@ export function OptionsPageClient({
                 expirationDate={expirationDate}
                 metrics={chainMetrics.metrics}
                 nearestExpiry={nearestExpiry}
+                oiStale={oiStale}
             />
 
-            {/* 두 차트를 큰 화면(lg+)에서 가로로 나란히 배치해 페이지 세로
-                길이를 약 240px 절약한다 — 두 SVG(각 240px)가 sibling으로
-                연달아 쌓이면 모바일 외 환경에서 스크롤이 과도하게 길어진다.
-                모바일(<lg)은 1열 유지해 좁은 너비에서 막대가 뭉치지 않도록
-                한다. */}
-            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-                <OpenInterestChart
-                    underlyingPrice={snapshot.underlyingPrice}
-                    chain={chainMetrics.chain}
-                    metrics={chainMetrics.metrics}
-                />
+            <OpenInterestChart
+                underlyingPrice={snapshot.underlyingPrice}
+                chain={chainMetrics.chain}
+                metrics={chainMetrics.metrics}
+            />
 
-                <StrikeVolumeChart
-                    underlyingPrice={snapshot.underlyingPrice}
-                    chain={chainMetrics.chain}
-                />
-            </div>
+            <StrikeVolumeChart
+                underlyingPrice={snapshot.underlyingPrice}
+                chain={chainMetrics.chain}
+            />
 
             <OptionsChainTable
                 symbol={symbol}

--- a/src/components/options/OptionsPageClient.tsx
+++ b/src/components/options/OptionsPageClient.tsx
@@ -92,16 +92,23 @@ export function OptionsPageClient({
                 oiStale={oiStale}
             />
 
-            <OpenInterestChart
-                underlyingPrice={snapshot.underlyingPrice}
-                chain={chainMetrics.chain}
-                metrics={chainMetrics.metrics}
-            />
+            {/* 두 차트를 큰 화면(lg+)에서 가로로 나란히 배치해 페이지 세로
+                길이를 약 240px 절약한다 — 두 SVG(각 240px)가 sibling으로
+                연달아 쌓이면 모바일 외 환경에서 스크롤이 과도하게 길어진다.
+                모바일(<lg)은 1열 유지해 좁은 너비에서 막대가 뭉치지 않도록
+                한다. */}
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <OpenInterestChart
+                    underlyingPrice={snapshot.underlyingPrice}
+                    chain={chainMetrics.chain}
+                    metrics={chainMetrics.metrics}
+                />
 
-            <StrikeVolumeChart
-                underlyingPrice={snapshot.underlyingPrice}
-                chain={chainMetrics.chain}
-            />
+                <StrikeVolumeChart
+                    underlyingPrice={snapshot.underlyingPrice}
+                    chain={chainMetrics.chain}
+                />
+            </div>
 
             <OptionsChainTable
                 symbol={symbol}

--- a/src/components/options/OptionsStaleDataBanner.tsx
+++ b/src/components/options/OptionsStaleDataBanner.tsx
@@ -5,9 +5,7 @@ import {
     KST_EDT_HOURS_DISPLAY,
     KST_EST_HOURS_DISPLAY,
 } from '@/lib/options/marketHoursDisplay';
-import { getEasternOffsetHours } from '@/domain/time/eastern';
-
-const EDT_OFFSET_HOURS = -4;
+import { EDT_OFFSET_HOURS, getEasternOffsetHours } from '@/domain/time/eastern';
 
 /**
  * Surfaces a "data temporarily empty" notice when the upstream provider

--- a/src/components/options/OptionsStaleDataBanner.tsx
+++ b/src/components/options/OptionsStaleDataBanner.tsx
@@ -1,8 +1,13 @@
+'use client';
+
 import {
     ET_MARKET_HOURS_DISPLAY,
     KST_EDT_HOURS_DISPLAY,
     KST_EST_HOURS_DISPLAY,
 } from '@/lib/options/marketHoursDisplay';
+import { getEasternOffsetHours } from '@/domain/time/eastern';
+
+const EDT_OFFSET_HOURS = -4;
 
 /**
  * Surfaces a "data temporarily empty" notice when the upstream provider
@@ -16,28 +21,53 @@ import {
  * silently render an empty distribution.
  *
  * KST 시각은 EDT/EST 구간별로 한 시간씩 어긋나므로, 두 구간(EDT: 22:30~05:00,
- * EST: 23:30~06:00)을 모두 병기해 사용자가 현재 시점이 어느 구간인지와
- * 무관하게 자기 KST 시계로 환산할 수 있도록 한다.
+ * EST: 23:30~06:00)을 모두 병기하되, 현재 어느 구간인지(`isCurrentlyEdt`)도
+ * 함께 안내해 사용자가 자기 KST 시계로 바로 환산할 수 있도록 한다.
  *
- * 모든 시간 표기(ET 정규장 + KST 환산)는 `@/lib/options/marketHoursDisplay`를
- * single source of truth로 사용한다 — 같은 ET/KST 환산 문자열을 쓰는
- * `OpenInterestChart`의 빈 데이터 안내와 표기가 자동으로 일치한다.
+ * 모든 시간 표기(ET 정규장 + KST 환산 + 현재 EDT/EST 판정)는
+ * `@/lib/options/marketHoursDisplay`를 single source of truth로 사용한다 —
+ * 같은 ET/KST 환산 문자열을 쓰는 `OpenInterestChart`의 빈 데이터 안내와
+ * 표기가 자동으로 일치한다.
+ *
+ * `'use client'`: 현재 시각으로 EDT/EST를 판정해야 하므로 client 렌더링.
+ * cacheComponents 비활성 상태라 RSC로 두면 빌드/요청 시점에 한 번만
+ * 평가되어 DST 경계를 가로질러 사용자가 보는 페이지가 잘못 안내될 수 있다.
  */
 export function OptionsStaleDataBanner() {
+    // DST 판정은 도메인 SoT(`domain/time/eastern`)을 사용한다 — 같은 산술
+    // 알고리즘(2번째 일요일·3월 / 1번째 일요일·11월)을 lib에 중복 구현하지
+    // 않는다.
+    const inEdt = getEasternOffsetHours(new Date()) === EDT_OFFSET_HOURS;
+    const currentKstWindow = inEdt
+        ? KST_EDT_HOURS_DISPLAY
+        : KST_EST_HOURS_DISPLAY;
+    const currentDstLabel = inEdt ? '서머타임(EDT)' : '표준시(EST)';
+
     return (
         <div
             role="status"
             className="border-ui-warning bg-ui-warning/10 text-ui-warning rounded-lg border px-3 py-2 text-xs leading-relaxed"
         >
             <p className="font-semibold">옵션 OI 데이터가 비어 있어요</p>
-            <p className="text-ui-warning/90 mt-1">
-                미국 정규장 마감 후에는 Yahoo가 Open Interest, 호가, IV 같은
-                수치를 갱신하지 않아 일시적으로 공백이에요. 정확한 수치는 미국
-                정규장 시간({ET_MARKET_HOURS_DISPLAY}, 평일)에 다시 확인해
-                주세요 — 한국 시간으로는 서머타임(EDT) 기간이면{' '}
-                {KST_EDT_HOURS_DISPLAY}, 표준시(EST) 기간이면{' '}
-                {KST_EST_HOURS_DISPLAY}이에요.
-            </p>
+            <div className="text-ui-warning/90 mt-1 space-y-1">
+                <p>
+                    미국 정규장 마감 후에는 Yahoo가 Open Interest, 호가, IV 같은
+                    수치를 갱신하지 않아 일시적으로 공백이에요.
+                </p>
+                <p>
+                    정확한 수치는 미국 정규장 시간({ET_MARKET_HOURS_DISPLAY},
+                    평일)에 다시 확인해 주세요.
+                </p>
+                <p>
+                    한국 시간으로는 서머타임(EDT) 기간이면{' '}
+                    {KST_EDT_HOURS_DISPLAY}, 표준시(EST) 기간이면{' '}
+                    {KST_EST_HOURS_DISPLAY}이에요.
+                </p>
+                <p>
+                    지금은 {currentDstLabel} 기간이니, {currentKstWindow}에
+                    확인해 주세요.
+                </p>
+            </div>
         </div>
     );
 }

--- a/src/components/options/StrikeVolumeChart.tsx
+++ b/src/components/options/StrikeVolumeChart.tsx
@@ -450,25 +450,30 @@ export function StrikeVolumeChart({
                 </span>
             </div>
 
-            <table className="sr-only">
-                <caption>Strike별 거래량 데이터</caption>
-                <thead>
-                    <tr>
-                        <th scope="col">Strike</th>
-                        <th scope="col">Call Volume</th>
-                        <th scope="col">Put Volume</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {volumeByStrike.map(row => (
-                        <tr key={row.strike}>
-                            <td>{row.strike}</td>
-                            <td>{row.callVolume}</td>
-                            <td>{row.putVolume}</td>
+            {/* OpenInterestChart와 동일 — <table>에 sr-only를 직접 두면
+                `display: table`이 normal flow에 잔재를 남겨 페이지 height에
+                영향을 주므로 <div>로 감싼다. */}
+            <div className="sr-only">
+                <table>
+                    <caption>Strike별 거래량 데이터</caption>
+                    <thead>
+                        <tr>
+                            <th scope="col">Strike</th>
+                            <th scope="col">Call Volume</th>
+                            <th scope="col">Put Volume</th>
                         </tr>
-                    ))}
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                        {volumeByStrike.map(row => (
+                            <tr key={row.strike}>
+                                <td>{row.strike}</td>
+                                <td>{row.callVolume}</td>
+                                <td>{row.putVolume}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
         </div>
     );
 }

--- a/src/components/options/utils/optionsTooltips.tsx
+++ b/src/components/options/utils/optionsTooltips.tsx
@@ -7,9 +7,19 @@
  * must agree. Centralising the JSX here prevents silent drift when one site
  * is reworded and the others are forgotten.
  *
- * Each constant is a JSX fragment with multiple `<p>` blocks; consumers
- * render them inside `<InfoTooltip>`.
+ * 대부분 const JSX fragment로 두지만, 한국 시간/DST에 따라 본문이 달라지는
+ * 안내(ATM IV·Imp. Move)는 함수 컴포넌트로 둔다 — module-level const는 import
+ * 시점에만 평가돼 DST 경계를 가로지르는 사용자에게 잘못된 시간을 보여준다.
  */
+
+import { getEasternOffsetHours } from '@/domain/time/eastern';
+import {
+    ET_MARKET_HOURS_DISPLAY,
+    KST_EDT_HOURS_DISPLAY,
+    KST_EST_HOURS_DISPLAY,
+} from '@/lib/options/marketHoursDisplay';
+
+const EDT_OFFSET_HOURS = -4;
 
 export const MaxPainTooltip = (
     <>
@@ -29,33 +39,62 @@ export const PutCallRatioTooltip = (
             1보다 크면 풋(하락 베팅)이 더 많아 시장이 조심스럽다는 뜻이고, 1보다
             작으면 콜(상승 베팅)이 더 많다는 뜻이에요.
         </p>
-        <p>
-            너무 극단으로 치우치면 오히려 반대 신호로 해석하는 경우도 많아요 —
-            모두 두려워할 때가 바닥인 경우가 있거든요.
-        </p>
+        <p>너무 극단으로 치우치면 오히려 반대 신호로 해석하는 경우도 많아요.</p>
+        <p>모두 두려워할 때가 바닥인 경우가 있거든요.</p>
     </>
 );
 
-export const AtmIvTooltip = (
-    <>
-        <p>현재 주가에 가장 가까운 옵션이 반영하고 있는 예상 변동성이에요.</p>
-        <p>어닝 발표 직전에 보통 올라가요.</p>
-    </>
-);
+function getCurrentKstWindow(): { window: string; label: string } {
+    const inEdt = getEasternOffsetHours(new Date()) === EDT_OFFSET_HOURS;
+    return inEdt
+        ? { window: KST_EDT_HOURS_DISPLAY, label: '서머타임(EDT)' }
+        : { window: KST_EST_HOURS_DISPLAY, label: '표준시(EST)' };
+}
 
-export const ImpliedMoveTooltip = (
-    <>
-        <p>
-            옵션 시장이 &ldquo;이 주식이 앞으로 얼마나 출렁일 것 같다&rdquo;고
-            가격에 반영해놓은 폭이에요.
-        </p>
-        <p>
-            예를 들어 ±4%라면 시장은 다음 만기일까지 주가가 ±4% 정도 움직일
-            가능성이 높다고 보고 있는 거예요.
-        </p>
-        <p>어닝 같은 큰 이벤트 직전에는 이 값이 평소보다 커져요.</p>
-    </>
-);
+export function AtmIvTooltip() {
+    const { window: kstWindow, label } = getCurrentKstWindow();
+    return (
+        <>
+            <p>
+                현재 주가에 가장 가까운 옵션이 반영하고 있는 예상 변동성이에요.
+            </p>
+            <p>어닝 발표 직전에 보통 올라가요.</p>
+            <br />
+            <p>
+                <strong>&lsquo;—&rsquo;로 표시될 때</strong>: 미국 정규장 마감
+                후나 pre-market에는 Yahoo가 ATM 옵션의 IV를 0으로 클리어해
+                보내는 경우가 있어서 정확한 수치를 받을 수 없어요. 한국 시간
+                기준으로 평일 {kstWindow}(미국 정규장, {ET_MARKET_HOURS_DISPLAY}
+                ) 에 다시 확인해 주세요. 지금은 {label} 기간이에요.
+            </p>
+        </>
+    );
+}
+
+export function ImpliedMoveTooltip() {
+    const { window: kstWindow, label } = getCurrentKstWindow();
+    return (
+        <>
+            <p>
+                옵션 시장이 &ldquo;이 주식이 앞으로 얼마나 출렁일 것 같다&rdquo;
+                고 가격에 반영해놓은 폭이에요.
+            </p>
+            <p>
+                예를 들어 ±4%라면 시장은 다음 만기일까지 주가가 ±4% 정도 움직일
+                가능성이 높다고 보고 있는 거예요.
+            </p>
+            <p>어닝 같은 큰 이벤트 직전에는 이 값이 평소보다 커져요.</p>
+            <br />
+            <p>
+                <strong>&lsquo;—&rsquo;로 표시될 때</strong>: ATM IV에서
+                계산하기 때문에 ATM IV가 비어 있으면(정규장 외 시간 등) 같이
+                비워져요. 또 만기 당일이면 남은 시간이 0이라 계산이 불가능해
+                비어 보일 수 있어요. 한국 시간 기준으로 평일 {kstWindow}(미국
+                정규장)에 다시 확인해 주세요. 지금은 {label} 기간이에요.
+            </p>
+        </>
+    );
+}
 
 export const OpenInterestTooltip = (
     <>
@@ -75,8 +114,11 @@ export const CallOpenInterestTooltip = (
         </p>
         <p>
             이 가격에 콜 OI가 두텁다 = 시장 참여자들이 &ldquo;주가가 이 가격
-            위로 갈 것&rdquo;에 베팅을 많이 걸어둔 자리예요. 추세가 살아 있으면
-            저항이 깨졌을 때 빠르게 올라붙는 자석 같은 역할을 해요.
+            위로 갈 것&rdquo;에 베팅을 많이 걸어둔 자리예요.
+        </p>
+        <p>
+            추세가 살아 있으면 저항이 깨졌을 때 빠르게 올라붙는 자석 같은 역할을
+            해요.
         </p>
     </>
 );
@@ -89,9 +131,9 @@ export const PutOpenInterestTooltip = (
         </p>
         <p>
             이 가격에 풋 OI가 두텁다 = &ldquo;이 가격 아래로는 안 떨어졌으면
-            좋겠다&rdquo;는 보험성 베팅이 쌓인 자리예요. 주가가 가까이 가면
-            지지선처럼 작동하는 경우가 많아요.
+            좋겠다&rdquo;는 보험성 베팅이 쌓인 자리예요.
         </p>
+        <p>주가가 가까이 가면 지지선처럼 작동하는 경우가 많아요.</p>
     </>
 );
 

--- a/src/components/options/utils/optionsTooltips.tsx
+++ b/src/components/options/utils/optionsTooltips.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * Shared tooltip JSX for options-page metrics.
  *
@@ -10,6 +12,12 @@
  * 대부분 const JSX fragment로 두지만, 한국 시간/DST에 따라 본문이 달라지는
  * 안내(ATM IV·Imp. Move)는 함수 컴포넌트로 둔다 — module-level const는 import
  * 시점에만 평가돼 DST 경계를 가로지르는 사용자에게 잘못된 시간을 보여준다.
+ *
+ * `'use client'`: `AtmIvTooltip`/`ImpliedMoveTooltip`은 render 시점에
+ * `getEasternOffsetHours(new Date())`를 호출해 DST 윈도우를 분기한다. RSC에서
+ * import되면 build/요청 시점의 한 시점만 평가돼 DST 경계를 건너는 사용자에게
+ * 잘못된 한국 시간 안내가 굳어버리므로, OptionsStaleDataBanner와 동일하게
+ * 클라이언트에서만 렌더되도록 강제한다.
  */
 
 import { EDT_OFFSET_HOURS, getEasternOffsetHours } from '@/domain/time/eastern';

--- a/src/components/options/utils/optionsTooltips.tsx
+++ b/src/components/options/utils/optionsTooltips.tsx
@@ -12,14 +12,17 @@
  * 시점에만 평가돼 DST 경계를 가로지르는 사용자에게 잘못된 시간을 보여준다.
  */
 
-import { getEasternOffsetHours } from '@/domain/time/eastern';
+import { EDT_OFFSET_HOURS, getEasternOffsetHours } from '@/domain/time/eastern';
 import {
     ET_MARKET_HOURS_DISPLAY,
     KST_EDT_HOURS_DISPLAY,
     KST_EST_HOURS_DISPLAY,
 } from '@/lib/options/marketHoursDisplay';
 
-const EDT_OFFSET_HOURS = -4;
+interface KstWindowInfo {
+    window: string;
+    label: string;
+}
 
 export const MaxPainTooltip = (
     <>
@@ -44,7 +47,7 @@ export const PutCallRatioTooltip = (
     </>
 );
 
-function getCurrentKstWindow(): { window: string; label: string } {
+function getCurrentKstWindow(): KstWindowInfo {
     const inEdt = getEasternOffsetHours(new Date()) === EDT_OFFSET_HOURS;
     return inEdt
         ? { window: KST_EDT_HOURS_DISPLAY, label: '서머타임(EDT)' }

--- a/src/domain/time/eastern.ts
+++ b/src/domain/time/eastern.ts
@@ -11,8 +11,8 @@ const FIRST_SUNDAY = 1;
 const DST_START_UTC_HOUR = 7;
 const DST_END_UTC_HOUR = 6;
 
-const EDT_OFFSET_HOURS = -4 as const;
-const EST_OFFSET_HOURS = -5 as const;
+export const EDT_OFFSET_HOURS = -4 as const;
+export const EST_OFFSET_HOURS = -5 as const;
 
 function getNthSundayOfMonth(
     year: number,

--- a/src/lib/options/optionsFormatters.ts
+++ b/src/lib/options/optionsFormatters.ts
@@ -14,6 +14,22 @@
  * compatibility.
  */
 
+/**
+ * Shared placeholder string for metrics that can't be displayed.
+ *
+ * Exported so `OptionsMetricsRow` (stale OI 시나리오에서 metric을 일괄 대체)와
+ * formatters의 null/NaN 분기가 같은 글자를 사용함을 코드 레벨에서 강제한다
+ * (§15 drift trap). 둘 중 한 쪽 표기만 바뀌면 사용자에게는 같은 자리에 서로
+ * 다른 placeholder가 보이게 된다.
+ */
+export const METRIC_PLACEHOLDER = '—';
+
+// `toFixed(1)`이 "0.0"으로 반올림되는 경계값. 정상 시장의 IV는 보통 5% 이상이고
+// `±implied move`도 0.05% 이상이라, 이 임계 아래의 값은 noise(또는 Yahoo가 채우다
+// 만 흔적)로 보고 placeholder로 통합 안내한다.
+// export: boundary 테스트가 이 상수에서 derive하도록 (값 변경 시 테스트도 자동 갱신).
+export const PERCENT_DISPLAY_FLOOR = 0.05;
+
 /** Format a Max Pain strike. null/NaN → `'—'`, otherwise `$<rounded>` with comma grouping. */
 export function formatMaxPain(value: number | null | undefined): string {
     if (value == null || Number.isNaN(value)) return METRIC_PLACEHOLDER;
@@ -29,21 +45,6 @@ export function formatPutCallRatio(value: number | null | undefined): string {
     if (value == null || Number.isNaN(value)) return METRIC_PLACEHOLDER;
     return value.toFixed(2);
 }
-
-/**
- * Shared placeholder string for metrics that can't be displayed.
- *
- * Exported so `OptionsMetricsRow` (stale OI 시나리오에서 metric을 일괄 대체)와
- * formatters의 null/NaN 분기가 같은 글자를 사용함을 코드 레벨에서 강제한다
- * (§15 drift trap). 둘 중 한 쪽 표기만 바뀌면 사용자에게는 같은 자리에 서로
- * 다른 placeholder가 보이게 된다.
- */
-export const METRIC_PLACEHOLDER = '—';
-
-// `toFixed(1)`이 "0.0"으로 반올림되는 경계값. 정상 시장의 IV는 보통 5% 이상이고
-// `±implied move`도 0.05% 이상이라, 이 임계 아래의 값은 noise(또는 Yahoo가 채우다
-// 만 흔적)로 보고 placeholder로 통합 안내한다.
-const PERCENT_DISPLAY_FLOOR = 0.05;
 
 /**
  * Format ATM implied volatility (fraction).

--- a/src/lib/options/optionsFormatters.ts
+++ b/src/lib/options/optionsFormatters.ts
@@ -30,14 +30,37 @@ export function formatPutCallRatio(value: number | null | undefined): string {
     return value.toFixed(2);
 }
 
-/** Format ATM implied volatility (fraction). null/undefined/NaN → `'—'`, otherwise `<pct>%` with 1 decimal. */
+// `toFixed(1)`이 "0.0"으로 반올림되는 경계값. 정상 시장의 IV는 보통 5% 이상이고
+// `±implied move`도 0.05% 이상이라, 이 임계 아래의 값은 noise(또는 Yahoo가 채우다
+// 만 흔적)로 보고 placeholder로 통합 안내한다.
+const PERCENT_DISPLAY_FLOOR = 0.05;
+
+/**
+ * Format ATM implied volatility (fraction).
+ *
+ * null/undefined/NaN → `'—'`. `value <= 0`도 `'—'`로 처리하고, 추가로
+ * `value * 100 < 0.05`인 작은 양수도 `'—'`로 안내한다 — Yahoo가 pre-market /
+ * pre-pre 구간에서 ATM contract의 IV를 0 또는 sub-percent noise로 채워 보내는
+ * 경우가 있어, 그대로 `0.0%`로 표시하면 "변동성이 정말 0이다"라는 잘못된
+ * 인상을 준다.
+ */
 export function formatAtmIv(value: number | null | undefined): string {
-    if (value == null || Number.isNaN(value)) return '—';
-    return `${(value * 100).toFixed(1)}%`;
+    if (value == null || Number.isNaN(value) || value <= 0) return '—';
+    const pct = value * 100;
+    if (pct < PERCENT_DISPLAY_FLOOR) return '—';
+    return `${pct.toFixed(1)}%`;
 }
 
-/** Format implied move %. null/undefined/NaN → `'—'`, otherwise `±<pct>%` with 1 decimal. */
+/**
+ * Format implied move %.
+ *
+ * null/undefined/NaN → `'—'`. `value <= 0`도 `'—'`이고, `value < 0.05`인 작은
+ * 양수도 `'—'`로 안내한다 — core의 `calculateImpliedMove`는 `atmIv * sqrt(...)
+ * * 100`이라 ATM IV가 0이거나 sub-percent noise이면 결과가 0/근사 0으로
+ * 떨어진다 (위 ATM IV와 동일 사유).
+ */
 export function formatImpliedMove(value: number | null | undefined): string {
-    if (value == null || Number.isNaN(value)) return '—';
+    if (value == null || Number.isNaN(value) || value <= 0) return '—';
+    if (value < PERCENT_DISPLAY_FLOOR) return '—';
     return `±${value.toFixed(1)}%`;
 }

--- a/src/lib/options/optionsFormatters.ts
+++ b/src/lib/options/optionsFormatters.ts
@@ -16,7 +16,7 @@
 
 /** Format a Max Pain strike. null/NaN → `'—'`, otherwise `$<rounded>` with comma grouping. */
 export function formatMaxPain(value: number | null | undefined): string {
-    if (value == null || Number.isNaN(value)) return '—';
+    if (value == null || Number.isNaN(value)) return METRIC_PLACEHOLDER;
     return `$${Math.round(value).toLocaleString()}`;
 }
 
@@ -26,9 +26,19 @@ export function formatMaxPain(value: number | null | undefined): string {
  */
 export function formatPutCallRatio(value: number | null | undefined): string {
     if (value === Number.POSITIVE_INFINITY) return '∞';
-    if (value == null || Number.isNaN(value)) return '—';
+    if (value == null || Number.isNaN(value)) return METRIC_PLACEHOLDER;
     return value.toFixed(2);
 }
+
+/**
+ * Shared placeholder string for metrics that can't be displayed.
+ *
+ * Exported so `OptionsMetricsRow` (stale OI 시나리오에서 metric을 일괄 대체)와
+ * formatters의 null/NaN 분기가 같은 글자를 사용함을 코드 레벨에서 강제한다
+ * (§15 drift trap). 둘 중 한 쪽 표기만 바뀌면 사용자에게는 같은 자리에 서로
+ * 다른 placeholder가 보이게 된다.
+ */
+export const METRIC_PLACEHOLDER = '—';
 
 // `toFixed(1)`이 "0.0"으로 반올림되는 경계값. 정상 시장의 IV는 보통 5% 이상이고
 // `±implied move`도 0.05% 이상이라, 이 임계 아래의 값은 noise(또는 Yahoo가 채우다
@@ -45,9 +55,10 @@ const PERCENT_DISPLAY_FLOOR = 0.05;
  * 인상을 준다.
  */
 export function formatAtmIv(value: number | null | undefined): string {
-    if (value == null || Number.isNaN(value) || value <= 0) return '—';
+    if (value == null || Number.isNaN(value) || value <= 0)
+        return METRIC_PLACEHOLDER;
     const pct = value * 100;
-    if (pct < PERCENT_DISPLAY_FLOOR) return '—';
+    if (pct < PERCENT_DISPLAY_FLOOR) return METRIC_PLACEHOLDER;
     return `${pct.toFixed(1)}%`;
 }
 
@@ -60,7 +71,8 @@ export function formatAtmIv(value: number | null | undefined): string {
  * 떨어진다 (위 ATM IV와 동일 사유).
  */
 export function formatImpliedMove(value: number | null | undefined): string {
-    if (value == null || Number.isNaN(value) || value <= 0) return '—';
-    if (value < PERCENT_DISPLAY_FLOOR) return '—';
+    if (value == null || Number.isNaN(value) || value <= 0)
+        return METRIC_PLACEHOLDER;
+    if (value < PERCENT_DISPLAY_FLOOR) return METRIC_PLACEHOLDER;
     return `±${value.toFixed(1)}%`;
 }


### PR DESCRIPTION
## Summary

- Yahoo가 정규장 외에 OI/IV를 클리어해 보내는 케이스를 일관되게 처리
- `OptionsMetricsRow`: `oiStale=true`이면 Max Pain·P/C·ATM IV·Imp. Move 모두 `—`
- `OptionsStaleDataBanner` / `optionsTooltips`: `getEasternOffsetHours`로 현재 EDT/EST 판정해 사용자 KST 안내 (module-level const는 DST 경계 잘못 표시 → 함수 컴포넌트화 + `'use client'`)
- `optionsFormatters`: `PERCENT_DISPLAY_FLOOR = 0.05` 이하 양수도 `—` (Yahoo가 ATM IV를 0 또는 sub-percent noise로 채우는 케이스)
- `OptionsPageClient`: 두 차트 grid 묶음 해제 (`oiStale` prop drilling)
- `StrikeVolumeChart`: `<table className="sr-only">` → `<div><table>` 래핑 (`display:table` flow 잔재 제거)

## Test plan

- [ ] `yarn test src/__tests__/lib/options/optionsFormatters.test.ts` 통과
- [ ] 정규장 외 시간에 options 페이지 진입 → metric 4개 모두 `—` 표시
- [ ] 정규장 중 진입 → 실제 수치 정상 표시
- [ ] EDT/EST 안내 문구가 현재 시점 DST에 맞게 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)