### PR TITLE
chore(deps): upgrade siglens-core to 0.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "@tanstack/react-query": "^5.95.2",
         "@upstash/redis": "^1.37.0",
         "@vercel/functions": "^3.4.3",
-        "@y0ngha/siglens-core": "0.11.3",
+        "@y0ngha/siglens-core": "0.11.4",
         "bcryptjs": "^3.0.3",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",

--- a/src/__tests__/infrastructure/ai/gemini.test.ts
+++ b/src/__tests__/infrastructure/ai/gemini.test.ts
@@ -102,6 +102,39 @@ describe('callGeminiChat', () => {
         });
     });
 
+    describe('ConversationTurn[] contents 변환', () => {
+        it('role: assistant는 model로 변환하여 Gemini에 전달한다', async () => {
+            mockGenerateContent.mockResolvedValue({ text: 'ok' });
+
+            await callGeminiChat({
+                ...BASE_OPTIONS,
+                contents: [
+                    { role: 'user', text: 'Q' },
+                    { role: 'assistant', text: 'A' },
+                ],
+            });
+
+            expect(mockGenerateContent).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    contents: [
+                        { role: 'user', parts: [{ text: 'Q' }] },
+                        { role: 'model', parts: [{ text: 'A' }] },
+                    ],
+                })
+            );
+        });
+
+        it('빈 배열이면 빈 배열로 변환한다', async () => {
+            mockGenerateContent.mockResolvedValue({ text: 'ok' });
+
+            await callGeminiChat({ ...BASE_OPTIONS, contents: [] });
+
+            expect(mockGenerateContent).toHaveBeenCalledWith(
+                expect.objectContaining({ contents: [] })
+            );
+        });
+    });
+
     describe('thinkingBudget', () => {
         it('thinkingBudget: 0 이면 config.thinkingConfig에 포함한다', async () => {
             mockGenerateContent.mockResolvedValue({ text: 'ok' });

--- a/src/__tests__/infrastructure/ai/gemini.test.ts
+++ b/src/__tests__/infrastructure/ai/gemini.test.ts
@@ -102,6 +102,18 @@ describe('callGeminiChat', () => {
         });
     });
 
+    describe('string contents 변환', () => {
+        it('string contents는 그대로 Gemini에 전달한다', async () => {
+            mockGenerateContent.mockResolvedValue({ text: 'ok' });
+
+            await callGeminiChat({ ...BASE_OPTIONS, contents: 'Hello' });
+
+            expect(mockGenerateContent).toHaveBeenCalledWith(
+                expect.objectContaining({ contents: 'Hello' })
+            );
+        });
+    });
+
     describe('ConversationTurn[] contents 변환', () => {
         it('role: assistant는 model로 변환하여 Gemini에 전달한다', async () => {
             mockGenerateContent.mockResolvedValue({ text: 'ok' });

--- a/src/__tests__/infrastructure/ai/utils.test.ts
+++ b/src/__tests__/infrastructure/ai/utils.test.ts
@@ -16,9 +16,7 @@ describe('toProviderTurns', () => {
         });
 
         it('role이 user인 턴은 user로 그대로 매핑한다', () => {
-            const contents: ConversationTurn[] = [
-                { role: 'user', text: 'Hi' },
-            ];
+            const contents: ConversationTurn[] = [{ role: 'user', text: 'Hi' }];
             const result = toProviderTurns(contents);
             expect(result).toEqual([{ role: 'user', content: 'Hi' }]);
         });

--- a/src/__tests__/infrastructure/ai/utils.test.ts
+++ b/src/__tests__/infrastructure/ai/utils.test.ts
@@ -1,5 +1,5 @@
 import { toProviderTurns } from '@/infrastructure/ai/utils';
-import type { GeminiContent } from '@y0ngha/siglens-core';
+import type { ConversationTurn } from '@y0ngha/siglens-core';
 
 describe('toProviderTurns', () => {
     describe('string contents', () => {
@@ -9,23 +9,23 @@ describe('toProviderTurns', () => {
         });
     });
 
-    describe('GeminiContent[] contents', () => {
+    describe('ConversationTurn[] contents', () => {
         it('빈 배열이면 빈 배열을 반환한다', () => {
             const result = toProviderTurns([]);
             expect(result).toEqual([]);
         });
 
-        it('role이 user인 턴은 user로 변환한다', () => {
-            const contents: GeminiContent[] = [
-                { role: 'user', parts: [{ text: 'Hi' }] },
+        it('role이 user인 턴은 user로 그대로 매핑한다', () => {
+            const contents: ConversationTurn[] = [
+                { role: 'user', text: 'Hi' },
             ];
             const result = toProviderTurns(contents);
             expect(result).toEqual([{ role: 'user', content: 'Hi' }]);
         });
 
-        it('role이 model인 턴은 assistant로 변환한다', () => {
-            const contents: GeminiContent[] = [
-                { role: 'model', parts: [{ text: 'Hello back' }] },
+        it('role이 assistant인 턴은 assistant로 그대로 매핑한다', () => {
+            const contents: ConversationTurn[] = [
+                { role: 'assistant', text: 'Hello back' },
             ];
             const result = toProviderTurns(contents);
             expect(result).toEqual([
@@ -33,33 +33,11 @@ describe('toProviderTurns', () => {
             ]);
         });
 
-        it('복수 part의 text를 이어붙여 content를 구성한다', () => {
-            const contents: GeminiContent[] = [
-                {
-                    role: 'user',
-                    parts: [{ text: 'Hello ' }, { text: 'world' }],
-                },
-            ];
-            const result = toProviderTurns(contents);
-            expect(result).toEqual([{ role: 'user', content: 'Hello world' }]);
-        });
-
-        it('part.text가 undefined이면 빈 문자열로 처리한다', () => {
-            const contents: GeminiContent[] = [
-                {
-                    role: 'user',
-                    parts: [{ text: undefined as unknown as string }],
-                },
-            ];
-            const result = toProviderTurns(contents);
-            expect(result).toEqual([{ role: 'user', content: '' }]);
-        });
-
-        it('user/model 교대 히스토리를 순서대로 변환한다', () => {
-            const contents: GeminiContent[] = [
-                { role: 'user', parts: [{ text: 'Q1' }] },
-                { role: 'model', parts: [{ text: 'A1' }] },
-                { role: 'user', parts: [{ text: 'Q2' }] },
+        it('user/assistant 교대 히스토리를 순서대로 변환한다', () => {
+            const contents: ConversationTurn[] = [
+                { role: 'user', text: 'Q1' },
+                { role: 'assistant', text: 'A1' },
+                { role: 'user', text: 'Q2' },
             ];
             const result = toProviderTurns(contents);
             expect(result).toEqual([

--- a/src/infrastructure/ai/gemini.ts
+++ b/src/infrastructure/ai/gemini.ts
@@ -1,5 +1,9 @@
 import { GoogleGenAI } from '@google/genai';
-import type { AiContents, CallAiProviderOptions } from '@y0ngha/siglens-core';
+import type {
+    AiContents,
+    CallAiProviderOptions,
+    ConversationTurn,
+} from '@y0ngha/siglens-core';
 
 interface GeminiChatOptions extends CallAiProviderOptions {
     /**
@@ -10,16 +14,22 @@ interface GeminiChatOptions extends CallAiProviderOptions {
     thinkingBudget?: number;
 }
 
+/** Gemini SDK's native conversation-turn shape. */
+interface GeminiTurn {
+    role: 'user' | 'model';
+    parts: [{ text: string }];
+}
+
 /**
  * Convert siglens-core's provider-neutral `AiContents` to the Gemini SDK's
  * native turn shape. Gemini expects `{ role: 'user' | 'model', parts: [{ text }] }`,
  * whereas siglens-core 0.11.4 emits `{ role: 'user' | 'assistant', text }`.
  */
-function toGeminiContents(contents: AiContents) {
+function toGeminiContents(contents: AiContents): string | GeminiTurn[] {
     if (typeof contents === 'string') {
         return contents;
     }
-    return contents.map(turn => ({
+    return contents.map((turn: ConversationTurn) => ({
         role: turn.role === 'assistant' ? 'model' : 'user',
         parts: [{ text: turn.text }],
     }));

--- a/src/infrastructure/ai/gemini.ts
+++ b/src/infrastructure/ai/gemini.ts
@@ -1,5 +1,5 @@
 import { GoogleGenAI } from '@google/genai';
-import type { CallAiProviderOptions } from '@y0ngha/siglens-core';
+import type { AiContents, CallAiProviderOptions } from '@y0ngha/siglens-core';
 
 interface GeminiChatOptions extends CallAiProviderOptions {
     /**
@@ -8,6 +8,21 @@ interface GeminiChatOptions extends CallAiProviderOptions {
      * Omit to use the model's default thinking behaviour.
      */
     thinkingBudget?: number;
+}
+
+/**
+ * Convert siglens-core's provider-neutral `AiContents` to the Gemini SDK's
+ * native turn shape. Gemini expects `{ role: 'user' | 'model', parts: [{ text }] }`,
+ * whereas siglens-core 0.11.4 emits `{ role: 'user' | 'assistant', text }`.
+ */
+function toGeminiContents(contents: AiContents) {
+    if (typeof contents === 'string') {
+        return contents;
+    }
+    return contents.map(turn => ({
+        role: turn.role === 'assistant' ? 'model' : 'user',
+        parts: [{ text: turn.text }],
+    }));
 }
 
 export async function callGeminiChat({
@@ -24,7 +39,7 @@ export async function callGeminiChat({
 
     const response = await genai.models.generateContent({
         model,
-        contents,
+        contents: toGeminiContents(contents),
         ...(hasSystemInstruction || hasThinkingBudget
             ? {
                   config: {

--- a/src/infrastructure/ai/utils.ts
+++ b/src/infrastructure/ai/utils.ts
@@ -1,4 +1,4 @@
-import type { AiContents, GeminiContent } from '@y0ngha/siglens-core';
+import type { AiContents, ConversationTurn } from '@y0ngha/siglens-core';
 
 export interface ProviderTurn {
     role: 'user' | 'assistant';
@@ -9,8 +9,8 @@ export function toProviderTurns(contents: AiContents): ProviderTurn[] {
     if (typeof contents === 'string') {
         return [{ role: 'user', content: contents }];
     }
-    return contents.map((turn: GeminiContent) => ({
-        role: turn.role === 'model' ? 'assistant' : 'user',
-        content: turn.parts.map(p => p.text ?? '').join(''),
+    return contents.map((turn: ConversationTurn) => ({
+        role: turn.role,
+        content: turn.text,
     }));
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3768,14 +3768,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@y0ngha/siglens-core@npm:0.11.3":
-  version: 0.11.3
-  resolution: "@y0ngha/siglens-core@npm:0.11.3::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.11.3%2F5c203957d7265d5cdec2edcf9e1d1efa6d070a53"
+"@y0ngha/siglens-core@npm:0.11.4":
+  version: 0.11.4
+  resolution: "@y0ngha/siglens-core@npm:0.11.4::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.11.4%2F7299a9d41dd8396e216c24f88cc2fcbd054da6a4"
   dependencies:
     jsonrepair: "npm:^3.14.0"
   peerDependencies:
     "@upstash/redis": ^1.37.0
-  checksum: 10c0/3a63ee29b2517af209c0230b9db5d8c0a758fe33264f66c7660804ca0b3b42b23f3680b51d362a3d76a99a2373f9f07a3a1d40499ba6caf8cf064687ea80f244
+  checksum: 10c0/dc6922f76301bc73331554bbd7299efc4d18c75aad370ac683d3909dc404b4df9254247ae4bc73c5fc9a48c49751aff2116ae4f215c2ffc765e92567b2ce52ca
   languageName: node
   linkType: hard
 
@@ -11381,7 +11381,7 @@ __metadata:
     "@types/react-dom": "npm:^19"
     "@upstash/redis": "npm:^1.37.0"
     "@vercel/functions": "npm:^3.4.3"
-    "@y0ngha/siglens-core": "npm:0.11.3"
+    "@y0ngha/siglens-core": "npm:0.11.4"
     babel-plugin-react-compiler: "npm:^1.0.0"
     bcryptjs: "npm:^3.0.3"
     clsx: "npm:^2.1.1"


### PR DESCRIPTION
## Summary

Upgrade `@y0ngha/siglens-core` from 0.11.3 → 0.11.4 and adapt the AI provider wiring to the new provider-neutral `ConversationTurn` shape introduced in siglens-core PR #92.

## Why

siglens-core 0.11.4 finishes a 10-module Ports & Adapters migration. The AI provider contract was abstracted away from Gemini-specific shapes:

- `AiContents` payload: `{ role: 'user'|'model', parts: [{text}] }` → `{ role: 'user'|'assistant', text: string }` (= `ConversationTurn`)
- `GeminiRole`/`GeminiPart`/`GeminiContent` are kept as deprecated aliases pointing at the new neutral types, **but the shape itself changed** — `parts[…].text` access no longer compiles.

Without this PR, `yarn typecheck` fails the moment siglens-core 0.11.4 is installed.

## Changes

- **`package.json` / `yarn.lock`** — bump `@y0ngha/siglens-core` to 0.11.4.
- **`src/infrastructure/ai/utils.ts`** — `toProviderTurns` now reads `turn.text` directly. Role is already `'user' | 'assistant'`, so no remap.
- **`src/infrastructure/ai/gemini.ts`** — new `toGeminiContents()` helper translates `ConversationTurn[]` back to Gemini's native `{ role: 'user'|'model', parts: [{text}] }` shape before passing to the SDK. OpenAI / Anthropic adapters are unaffected (they go through `toProviderTurns`).
- **`src/__tests__/infrastructure/ai/utils.test.ts`** — fixtures updated to `ConversationTurn` shape. The previous "multi-part text concat" and "undefined text" cases are no longer reachable on the new flat shape and were removed.

## Non-changes (intentional)

- `src/app/page.tsx` and `src/__tests__/infrastructure/skills/loader.test.ts` still use `new FileSkillsLoader()`. siglens-core 0.11.4 added a `createSkillsProvider()` factory as the new canonical entry point, but the class export is preserved as backward-compatible. Migrating to the factory is a recommended cleanup, deferred to a separate PR to keep this one scoped to breaking changes only.
- `src/infrastructure/skills/types.ts` defines its own `SkillsProvider` interface that mirrors siglens-core's port. Adopting the core port type is also a follow-up cleanup, out of scope here.

## Test plan

- [x] `yarn typecheck` — exit 0
- [x] `yarn lint` — exit 0
- [x] `yarn format` — applied
- [x] `yarn test` — 1905 / 1905 pass (full suite via pre-push hook)
- [x] AI + chat suites specifically — 77 / 77 pass
- [x] `yarn build` — production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)