### PR TITLE
fix: v0.11.17 pre-deploy cleanup — Opus 검토 follow-up 10건

### DIFF
--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -307,6 +307,16 @@ This file contains only **recurring gotchas** that agents keep missing despite e
     → When extracting a function from a parent function scope, make all parent variables explicit parameters
     ❌ function searchAction() { function toResult(x) { ... parent var ... } }
     ✅ function toResult(x, parentVar) { ... }; function searchAction() { toResult(..., parentVar); }
+
+20.5. Substring matching on ID/code patterns instead of whole-token matching
+    → Fixed code patterns (SQLSTATE codes, error IDs, constant values) must not be matched with substring searches
+    → Substring matching produces false positives when user data or identifiers happen to contain the same digits/characters
+    → Use word-boundary regex (`\b(code1|code2|...)\b`), whole-token matching, or array membership (Set/indexOf) instead
+    ❌ `'57P01'.includes(message)` or regex without word boundary — matches false positives in user data like "user_57P01_backup"
+    ❌ const TRANSIENT_CODES = ['57P01', '08006']; ... regex `/${TRANSIENT_CODES.join('|')}/` — substring match
+    ✅ const TRANSIENT_CODES = ['57P01', '08006']; regex `/\b(${TRANSIENT_CODES.join('|')})\b/` — word boundary
+    ✅ const TRANSIENT_SQLSTATE_SET = new Set(TRANSIENT_CODES); ... TRANSIENT_SQLSTATE_SET.has(extractedCode) — exact token match
+    → Recurring: PR #456 B4 (SQLSTATE false positive on user data like `pk_constraint_53300_check`)
 ```
 
 ---

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -481,3 +481,11 @@
 - Violation: WHY 주석에 WHAT(타입 선언이 자체 표현하는 의미)이 섞임
 - Rule: MISTAKES.md §15.3 — WHAT 주석 금지 (식별자/타입이 이미 표현하면 코멘트로 반복하지 않음)
 - Context: Suggestion S-1 — round 3에서 추가한 `let cachedRedis: Redis | null | undefined` 위 주석의 후반부 "Redis 타입을 직접 쓰고 env 미설정 시 null로 fallback"이 declaration과 중복. 패턴 cross-reference(lazy-singleton) WHY만 남기고 축약.
+
+## [PR #456 Round 2 | fix/pre-deploy-cleanup-v0.11.17 | 2026-05-23]
+- S1: `src/infrastructure/utils/withRetry.ts` — 파라미터명 `totalTimeoutMs` 오해의 소지 (실제로는 backoff sleep budget만 제한; 실행 중 `fn()`은 abort 안 됨, JSDoc에 기재). `backoffBudgetMs`로 전역 rename (interface, impl, NEON_TRANSIENT_RETRY usage, test assertions).
+  - Rule: 파라미터 이름은 control-flow 결과를 정확히 반영해야 함 (MISTAKES.md Design §4.6 개념)
+  - Context: Suggestion — 함수 이름/도메인 설명과 실제 동작의 gap을 파라미터명으로 해소. 호출부에서 의도가 명확해짐.
+- S2: `src/infrastructure/options/optionsDataCache.ts` — `1 * SECONDS_PER_MINUTE` 중복 multiplier (MISTAKES.md §15 readability gradient).
+  - Rule: MISTAKES.md §15 — 상수와 표시 텍스트의 단일 source.
+  - Context: Suggestion — `SECONDS_PER_MINUTE`로 단순화.

--- a/src/__tests__/infrastructure/db/isNeonTransientError.test.ts
+++ b/src/__tests__/infrastructure/db/isNeonTransientError.test.ts
@@ -124,6 +124,6 @@ describe('NEON_TRANSIENT_RETRY', () => {
         expect(NEON_TRANSIENT_RETRY.isRetryable).toBe(isNeonTransientError);
         // 최악 시 backoff sleeps: 200+400+800 = 1.4s + 1×jitter ≈ 2.8s.
         // 5s budget은 fn() 자체 시간을 포함해도 Vercel 10s 안에 안전하게 들어간다.
-        expect(NEON_TRANSIENT_RETRY.totalTimeoutMs).toBe(5000);
+        expect(NEON_TRANSIENT_RETRY.backoffBudgetMs).toBe(5000);
     });
 });

--- a/src/__tests__/infrastructure/db/isNeonTransientError.test.ts
+++ b/src/__tests__/infrastructure/db/isNeonTransientError.test.ts
@@ -4,10 +4,11 @@ import {
     isNeonTransientError,
 } from '@/infrastructure/db/isNeonTransientError';
 
-function makeNeonError(message: string): NeonDbError {
+function makeNeonError(message: string, code?: string): NeonDbError {
     // `Error.name`은 lib 정의상 writable string이라 추가 캐스트 없이 직접 할당 가능.
-    const err = new Error(message);
+    const err = new Error(message) as Error & { code?: string };
     err.name = 'NeonDbError';
+    if (code !== undefined) err.code = code;
     // Cast to NeonDbError so callers receive the structural shape they expect.
     return err as unknown as NeonDbError;
 }
@@ -70,6 +71,38 @@ describe('isNeonTransientError', () => {
     it('cause 체인이 self-referential 이어도 무한 루프 없이 종료된다', () => {
         const err = new Error('outer') as Error & { cause?: unknown };
         err.cause = err;
+        expect(isNeonTransientError(err)).toBe(false);
+    });
+
+    it.each([
+        ['57P01', 'admin_shutdown'],
+        ['08006', 'connection_failure'],
+        ['08003', 'connection_does_not_exist'],
+        ['08001', 'sqlclient_unable_to_establish_sqlconnection'],
+        ['08004', 'sqlserver_rejected_establishment_of_sqlconnection'],
+        ['53300', 'too_many_connections'],
+    ])(
+        'NeonDbError.code=%s (%s) 면 transient 로 인식한다',
+        (code, _description) => {
+            const err = makeNeonError(
+                'Failed query: connection broken',
+                code
+            );
+            expect(isNeonTransientError(err)).toBe(true);
+        }
+    );
+
+    it('SQLSTATE가 메시지에만 박혀 있어도 transient 로 인식한다', () => {
+        // Postgres가 code 필드 없이 메시지로만 내려준 경우의 fallback.
+        const err = makeNeonError('terminating connection (code 57P01)');
+        expect(isNeonTransientError(err)).toBe(true);
+    });
+
+    it('permanent SQLSTATE(23505 unique_violation)은 transient 가 아니다', () => {
+        const err = makeNeonError(
+            'duplicate key value violates unique constraint',
+            '23505'
+        );
         expect(isNeonTransientError(err)).toBe(false);
     });
 });

--- a/src/__tests__/infrastructure/db/isNeonTransientError.test.ts
+++ b/src/__tests__/infrastructure/db/isNeonTransientError.test.ts
@@ -84,10 +84,7 @@ describe('isNeonTransientError', () => {
     ])(
         'NeonDbError.code=%s (%s) 면 transient 로 인식한다',
         (code, _description) => {
-            const err = makeNeonError(
-                'Failed query: connection broken',
-                code
-            );
+            const err = makeNeonError('Failed query: connection broken', code);
             expect(isNeonTransientError(err)).toBe(true);
         }
     );
@@ -105,12 +102,28 @@ describe('isNeonTransientError', () => {
         );
         expect(isNeonTransientError(err)).toBe(false);
     });
+
+    it.each([
+        ['user_id A57P01B detected', 'user 데이터/식별자에 코드 숫자 포함'],
+        [
+            'constraint pk_53300_check failed',
+            'identifier 내부에 코드 숫자 포함 (underscore-delimited)',
+        ],
+    ])('false positive 방어: %s', (message, _description) => {
+        // 메시지에 SQLSTATE 코드 숫자가 단어 경계 없이 포함되면 transient로 오인하지
+        // 않는다. .code 필드가 없고 message에만 박힌 경우의 false positive 방어.
+        const err = makeNeonError(message);
+        expect(isNeonTransientError(err)).toBe(false);
+    });
 });
 
 describe('NEON_TRANSIENT_RETRY', () => {
-    it('3회 / 200ms / isNeonTransientError 정책으로 고정되어 있다', () => {
+    it('3회 / 200ms / 5s budget / isNeonTransientError 정책으로 고정되어 있다', () => {
         expect(NEON_TRANSIENT_RETRY.maxRetries).toBe(3);
         expect(NEON_TRANSIENT_RETRY.baseDelayMs).toBe(200);
         expect(NEON_TRANSIENT_RETRY.isRetryable).toBe(isNeonTransientError);
+        // 최악 시 backoff sleeps: 200+400+800 = 1.4s + 1×jitter ≈ 2.8s.
+        // 5s budget은 fn() 자체 시간을 포함해도 Vercel 10s 안에 안전하게 들어간다.
+        expect(NEON_TRANSIENT_RETRY.totalTimeoutMs).toBe(5000);
     });
 });

--- a/src/__tests__/infrastructure/options/YahooOptionsAdapter.test.ts
+++ b/src/__tests__/infrastructure/options/YahooOptionsAdapter.test.ts
@@ -193,21 +193,26 @@ describe('YahooOptionsAdapter.fetchSnapshot', () => {
         const consoleWarnSpy = jest
             .spyOn(console, 'warn')
             .mockImplementation(() => {});
-        const fixtureNoQuote = {
-            ...FULL_FIXTURE,
-            quote: {} as { regularMarketPrice?: number },
-        };
-        mockOptionsMethod.mockResolvedValue(fixtureNoQuote);
-        const adapter = makeAdapter();
+        // try/finally — assertion 실패 시에도 console.warn spy를 반드시 복구해
+        // 후속 테스트 간 spy leak을 막는다 (formatAnalyzedAt.test.ts 패턴 일치).
+        try {
+            const fixtureNoQuote = {
+                ...FULL_FIXTURE,
+                quote: {} as { regularMarketPrice?: number },
+            };
+            mockOptionsMethod.mockResolvedValue(fixtureNoQuote);
+            const adapter = makeAdapter();
 
-        const result = await adapter.fetchSnapshot('AAPL');
+            const result = await adapter.fetchSnapshot('AAPL');
 
-        expect(result).toBeNull();
-        expect(consoleWarnSpy).toHaveBeenCalledWith(
-            '[YahooOptionsAdapter] missing underlyingPrice — treating snapshot as unavailable',
-            'AAPL'
-        );
-        consoleWarnSpy.mockRestore();
+            expect(result).toBeNull();
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                '[YahooOptionsAdapter] missing underlyingPrice — treating snapshot as unavailable',
+                'AAPL'
+            );
+        } finally {
+            consoleWarnSpy.mockRestore();
+        }
     });
 
     it('returns null when all chains are rejected by sanitizeOptionsChain', async () => {

--- a/src/__tests__/infrastructure/options/YahooOptionsAdapter.test.ts
+++ b/src/__tests__/infrastructure/options/YahooOptionsAdapter.test.ts
@@ -186,6 +186,30 @@ describe('YahooOptionsAdapter.fetchSnapshot', () => {
         expect(result).toBeNull();
     });
 
+    it('returns null when underlyingPrice is missing (regularMarketPrice undefined)', async () => {
+        // Yahoo가 quote.regularMarketPrice를 누락하면 normalize가 0으로 폴백한다.
+        // 이 경우 underlyingPrice=0 인 채로 통과되면 차트 가이드라인이 최저
+        // strike에 그려지는 등 잘못된 시각을 노출하므로 adapter에서 reject한다.
+        const consoleWarnSpy = jest
+            .spyOn(console, 'warn')
+            .mockImplementation(() => {});
+        const fixtureNoQuote = {
+            ...FULL_FIXTURE,
+            quote: {} as { regularMarketPrice?: number },
+        };
+        mockOptionsMethod.mockResolvedValue(fixtureNoQuote);
+        const adapter = makeAdapter();
+
+        const result = await adapter.fetchSnapshot('AAPL');
+
+        expect(result).toBeNull();
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+            '[YahooOptionsAdapter] missing underlyingPrice — treating snapshot as unavailable',
+            'AAPL'
+        );
+        consoleWarnSpy.mockRestore();
+    });
+
     it('returns null when all chains are rejected by sanitizeOptionsChain', async () => {
         mockOptionsMethod.mockResolvedValue(FULL_FIXTURE);
         (sanitizeOptionsChain as jest.Mock).mockReturnValue(null);

--- a/src/__tests__/infrastructure/options/optionsDataCache.test.ts
+++ b/src/__tests__/infrastructure/options/optionsDataCache.test.ts
@@ -369,9 +369,9 @@ describe('OPTIONS_SNAPSHOT_TTL_SECONDS', () => {
     it('시장 시간대별 TTL은 open < closed < weekend 순으로 늘어난다', () => {
         // freshness vs Yahoo 호출량 trade-off — 정규장 중에는 분 단위로 짧게,
         // 주말에는 시간 단위로 길게 캐시하는 정책이 invariant.
-        expect(OPTIONS_SNAPSHOT_TTL_SECONDS['options-market-open']).toBeLessThan(
-            OPTIONS_SNAPSHOT_TTL_SECONDS['options-market-closed']
-        );
+        expect(
+            OPTIONS_SNAPSHOT_TTL_SECONDS['options-market-open']
+        ).toBeLessThan(OPTIONS_SNAPSHOT_TTL_SECONDS['options-market-closed']);
         expect(
             OPTIONS_SNAPSHOT_TTL_SECONDS['options-market-closed']
         ).toBeLessThan(OPTIONS_SNAPSHOT_TTL_SECONDS['options-weekend']);

--- a/src/__tests__/infrastructure/options/optionsDataCache.test.ts
+++ b/src/__tests__/infrastructure/options/optionsDataCache.test.ts
@@ -38,6 +38,7 @@ import {
     hasOptionsMarket,
     fetchOptionsSnapshot,
     HAS_OPTIONS_MARKET_TTL_SECONDS,
+    OPTIONS_SNAPSHOT_TTL_SECONDS,
 } from '@/infrastructure/options/optionsDataCache';
 
 const ORIGINAL_REDIS_URL = process.env.UPSTASH_REDIS_REST_URL;
@@ -249,5 +250,130 @@ describe('fetchOptionsSnapshot', () => {
         const result = await fetchOptionsSnapshot('TSLA');
 
         expect(result).toBe(snapshot);
+    });
+});
+
+describe('fetchOptionsSnapshot — Redis 캐시 레이어', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const sampleSnapshot = {
+        symbol: 'AAPL',
+        underlyingPrice: 195,
+        chains: [],
+        capturedAt: '2026-05-14T16:00:00Z',
+    };
+
+    it('Redis env가 없으면 adapter로 직행한다', async () => {
+        mockFetchSnapshot.mockResolvedValue(sampleSnapshot);
+
+        const mod = await loadWithEnv({});
+        const result = await mod.fetchOptionsSnapshot('AAPL');
+
+        expect(mockRedisConstructor).not.toHaveBeenCalled();
+        expect(mockFetchSnapshot).toHaveBeenCalledWith('AAPL');
+        expect(result).toEqual(sampleSnapshot);
+    });
+
+    it('Redis cache hit 시 adapter를 호출하지 않고 캐시 값을 그대로 반환', async () => {
+        mockRedisGet.mockResolvedValue(sampleSnapshot);
+
+        const mod = await loadWithEnv({
+            url: 'https://example.upstash.io',
+            token: 'tok',
+        });
+        const result = await mod.fetchOptionsSnapshot('AAPL');
+
+        expect(mockRedisGet).toHaveBeenCalledWith('options:snapshot:AAPL');
+        expect(mockFetchSnapshot).not.toHaveBeenCalled();
+        expect(mockRedisSet).not.toHaveBeenCalled();
+        expect(result).toEqual(sampleSnapshot);
+    });
+
+    it('Redis cache miss 시 adapter 결과를 market-aware TTL로 저장', async () => {
+        mockRedisGet.mockResolvedValue(null);
+        mockFetchSnapshot.mockResolvedValue(sampleSnapshot);
+        mockRedisSet.mockResolvedValue('OK');
+
+        const mod = await loadWithEnv({
+            url: 'https://example.upstash.io',
+            token: 'tok',
+        });
+        await mod.fetchOptionsSnapshot('AAPL');
+
+        // beforeEach 위에서 getOptionsCacheLifeProfile mock이 'options-market-open' 반환
+        expect(mockRedisSet).toHaveBeenCalledWith(
+            'options:snapshot:AAPL',
+            sampleSnapshot,
+            { ex: OPTIONS_SNAPSHOT_TTL_SECONDS['options-market-open'] }
+        );
+    });
+
+    it('adapter가 null을 반환하면 negative cache를 남기지 않는다', async () => {
+        mockRedisGet.mockResolvedValue(null);
+        mockFetchSnapshot.mockResolvedValue(null);
+
+        const mod = await loadWithEnv({
+            url: 'https://example.upstash.io',
+            token: 'tok',
+        });
+        const result = await mod.fetchOptionsSnapshot('NOOPT');
+
+        expect(result).toBeNull();
+        // Yahoo 일시 장애를 TTL 동안 굳히지 않도록 null은 캐시하지 않는다.
+        expect(mockRedisSet).not.toHaveBeenCalled();
+    });
+
+    it('Redis get 예외는 흡수하고 adapter fresh로 진행', async () => {
+        const errSpy = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+        mockRedisGet.mockRejectedValue(new Error('redis down'));
+        mockFetchSnapshot.mockResolvedValue(sampleSnapshot);
+        mockRedisSet.mockResolvedValue('OK');
+
+        const mod = await loadWithEnv({
+            url: 'https://example.upstash.io',
+            token: 'tok',
+        });
+        const result = await mod.fetchOptionsSnapshot('AAPL');
+
+        expect(errSpy).toHaveBeenCalled();
+        expect(mockFetchSnapshot).toHaveBeenCalledWith('AAPL');
+        expect(result).toEqual(sampleSnapshot);
+        errSpy.mockRestore();
+    });
+
+    it('Redis set 예외는 흡수하고 fresh 값을 정상 반환', async () => {
+        const errSpy = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+        mockRedisGet.mockResolvedValue(null);
+        mockFetchSnapshot.mockResolvedValue(sampleSnapshot);
+        mockRedisSet.mockRejectedValue(new Error('redis write fail'));
+
+        const mod = await loadWithEnv({
+            url: 'https://example.upstash.io',
+            token: 'tok',
+        });
+        const result = await mod.fetchOptionsSnapshot('AAPL');
+
+        expect(errSpy).toHaveBeenCalled();
+        expect(result).toEqual(sampleSnapshot);
+        errSpy.mockRestore();
+    });
+});
+
+describe('OPTIONS_SNAPSHOT_TTL_SECONDS', () => {
+    it('시장 시간대별 TTL은 open < closed < weekend 순으로 늘어난다', () => {
+        // freshness vs Yahoo 호출량 trade-off — 정규장 중에는 분 단위로 짧게,
+        // 주말에는 시간 단위로 길게 캐시하는 정책이 invariant.
+        expect(OPTIONS_SNAPSHOT_TTL_SECONDS['options-market-open']).toBeLessThan(
+            OPTIONS_SNAPSHOT_TTL_SECONDS['options-market-closed']
+        );
+        expect(
+            OPTIONS_SNAPSHOT_TTL_SECONDS['options-market-closed']
+        ).toBeLessThan(OPTIONS_SNAPSHOT_TTL_SECONDS['options-weekend']);
     });
 });

--- a/src/__tests__/infrastructure/utils/withRetry.test.ts
+++ b/src/__tests__/infrastructure/utils/withRetry.test.ts
@@ -126,9 +126,9 @@ describe('withRetry', () => {
         expect(sleepMock).toHaveBeenCalledWith(300);
     });
 
-    it('totalTimeoutMs 초과 시 다음 sleep 호출 없이 마지막 에러를 던진다', async () => {
+    it('backoffBudgetMs 초과 시 다음 sleep 호출 없이 마지막 에러를 던진다', async () => {
         // Math.random=0 + baseDelayMs=200 ⇒ 첫 sleep=200ms.
-        // totalTimeoutMs=50으로 두면 deadline이 즉시 지나 sleep 없이 throw.
+        // backoffBudgetMs=50으로 두면 deadline이 즉시 지나 sleep 없이 throw.
         const firstError = new Error('attempt-0');
         const fn = jest.fn().mockRejectedValueOnce(firstError);
 
@@ -137,7 +137,7 @@ describe('withRetry', () => {
                 maxRetries: 3,
                 baseDelayMs: 200,
                 isRetryable: () => true,
-                totalTimeoutMs: 50,
+                backoffBudgetMs: 50,
             })
         ).rejects.toBe(firstError);
         expect(fn).toHaveBeenCalledTimes(1);
@@ -145,7 +145,7 @@ describe('withRetry', () => {
         expect(sleepMock).not.toHaveBeenCalled();
     });
 
-    it('totalTimeoutMs 가 충분하면 정상 backoff 후 성공한다', async () => {
+    it('backoffBudgetMs 가 충분하면 정상 backoff 후 성공한다', async () => {
         // 첫 실패 후 200ms sleep까지는 budget 1초 안에 충분히 들어간다.
         const fn = jest
             .fn()
@@ -156,7 +156,7 @@ describe('withRetry', () => {
             maxRetries: 3,
             baseDelayMs: 200,
             isRetryable: () => true,
-            totalTimeoutMs: 1000,
+            backoffBudgetMs: 1000,
         });
 
         expect(result).toBe('ok');

--- a/src/__tests__/infrastructure/utils/withRetry.test.ts
+++ b/src/__tests__/infrastructure/utils/withRetry.test.ts
@@ -126,6 +126,44 @@ describe('withRetry', () => {
         expect(sleepMock).toHaveBeenCalledWith(300);
     });
 
+    it('totalTimeoutMs 초과 시 다음 sleep 호출 없이 마지막 에러를 던진다', async () => {
+        // Math.random=0 + baseDelayMs=200 ⇒ 첫 sleep=200ms.
+        // totalTimeoutMs=50으로 두면 deadline이 즉시 지나 sleep 없이 throw.
+        const firstError = new Error('attempt-0');
+        const fn = jest.fn().mockRejectedValueOnce(firstError);
+
+        await expect(
+            withRetry(fn, {
+                maxRetries: 3,
+                baseDelayMs: 200,
+                isRetryable: () => true,
+                totalTimeoutMs: 50,
+            })
+        ).rejects.toBe(firstError);
+        expect(fn).toHaveBeenCalledTimes(1);
+        // budget이 잘려서 backoff sleep도 실행되지 않아야 한다.
+        expect(sleepMock).not.toHaveBeenCalled();
+    });
+
+    it('totalTimeoutMs 가 충분하면 정상 backoff 후 성공한다', async () => {
+        // 첫 실패 후 200ms sleep까지는 budget 1초 안에 충분히 들어간다.
+        const fn = jest
+            .fn()
+            .mockRejectedValueOnce(new Error('transient'))
+            .mockResolvedValueOnce('ok');
+
+        const result = await withRetry(fn, {
+            maxRetries: 3,
+            baseDelayMs: 200,
+            isRetryable: () => true,
+            totalTimeoutMs: 1000,
+        });
+
+        expect(result).toBe('ok');
+        expect(fn).toHaveBeenCalledTimes(2);
+        expect(sleepMock).toHaveBeenCalledTimes(1);
+    });
+
     it('non-retryable 판정이 중간에 발생해도 즉시 던진다', async () => {
         // 1st: transient retryable, 2nd: non-retryable.
         const transient = new Error('transient');

--- a/src/__tests__/lib/formatAnalyzedAt.test.ts
+++ b/src/__tests__/lib/formatAnalyzedAt.test.ts
@@ -1,13 +1,58 @@
 import { formatAnalyzedAt } from '@/lib/formatAnalyzedAt';
 
 describe('formatAnalyzedAt', () => {
-    it('replaces the "T" separator with a space and truncates to minute precision', () => {
+    it('UTC ISO 를 KST(+09:00) YYYY-MM-DD HH:mm 으로 환산한다', () => {
+        // 2026-05-22 05:30 UTC = 2026-05-22 14:30 KST
         expect(formatAnalyzedAt('2026-05-22T05:30:00.000Z')).toBe(
-            '2026-05-22 05:30'
+            '2026-05-22 14:30'
         );
     });
 
-    it('passes input through unchanged when shorter than 16 characters', () => {
+    it('자정 경계에서 KST 날짜가 한 칸 앞당겨진다', () => {
+        // 2026-05-21 15:00 UTC = 2026-05-22 00:00 KST
+        expect(formatAnalyzedAt('2026-05-21T15:00:00.000Z')).toBe(
+            '2026-05-22 00:00'
+        );
+    });
+
+    it('연말 23:00 UTC 는 KST 익년 08:00 으로 변환된다', () => {
+        // 2025-12-31 23:00 UTC = 2026-01-01 08:00 KST
+        expect(formatAnalyzedAt('2025-12-31T23:00:00.000Z')).toBe(
+            '2026-01-01 08:00'
+        );
+    });
+
+    it('잘못된 ISO 입력은 16자로 잘라 fallback 한다 (기존 동작 호환)', () => {
         expect(formatAnalyzedAt('not-a-date')).toBe('not-a-date');
+    });
+
+    it('빈 문자열도 안전하게 처리된다', () => {
+        expect(formatAnalyzedAt('')).toBe('');
+    });
+
+    it("ICU hour='24' edge case 를 '00' 으로 정규화한다", () => {
+        // 일부 Node/ICU 버전은 hour12:false + 자정에 '24'를 emit한다. V8 en-US 에선
+        // 직접 trigger할 수 없으므로 formatToParts 를 spy 로 가로채 '24'를 강제로
+        // 주입해 정규화 분기를 검증한다 (MISTAKES.md Tests §18).
+        const spy = jest
+            .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+            .mockReturnValueOnce([
+                { type: 'year', value: '2026' },
+                { type: 'literal', value: '-' },
+                { type: 'month', value: '05' },
+                { type: 'literal', value: '-' },
+                { type: 'day', value: '22' },
+                { type: 'literal', value: ', ' },
+                { type: 'hour', value: '24' },
+                { type: 'literal', value: ':' },
+                { type: 'minute', value: '00' },
+            ]);
+        try {
+            expect(formatAnalyzedAt('2026-05-21T15:00:00.000Z')).toBe(
+                '2026-05-22 00:00'
+            );
+        } finally {
+            spy.mockRestore();
+        }
     });
 });

--- a/src/components/options/OptionsPageClient.tsx
+++ b/src/components/options/OptionsPageClient.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import {
+    startTransition,
+    useEffect,
+    useEffectEvent,
+    useMemo,
+    useState,
+} from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { CrossLinkCards } from '@/components/symbol-page/CrossLinkCards';
 import { useSymbolModel } from '@/components/symbol-page/SymbolModelContext';
@@ -53,22 +59,39 @@ export function OptionsPageClient({
     // 각자 pickActiveChain + summarizeChainForLlm을 동일 입력으로 3번
     // 돌렸다. chip 전환 시마다 같은 계산이 세 번 반복되던 비용을 제거한다.
     const chainMetrics = useOptionsChainMetrics(snapshot, expirationDate);
-    // isOpenInterestSnapshotStale은 모든 chain × strike를 순회해 OI=0 비율을
-    // 산정하므로 chip 전환 등으로 컴포넌트가 리렌더될 때마다 다시 돌면 비용이
-    // 든다. snapshot 참조 안정성을 deps로 memoize. `new Date()`는 deps에 들어가지
-    // 않는데, 매 호출마다 다른 결과를 낼 수 있지만 사용자가 페이지에 머무는 동안
-    // 정규장 boundary를 가로지르는 케이스는 거의 없고, snapshot이 새로 들어오면
-    // 자동으로 재평가된다.
+    // oiStale 평가는 client-only.
+    //   SSR(또는 initial client render)에서 `new Date()`로 평가하면 정규장
+    //   boundary를 가로지르는 사용자에게 서버/클라이언트 결과가 어긋나
+    //   hydration mismatch 경고가 발생한다. `now`를 useState(null)로 두고
+    //   useEffect로 mount 직후 한 번만 채워 SSR 마크업은 항상 banner 없음
+    //   상태로 통일한다. snapshot 참조가 갱신되면 자동으로 재평가된다.
+    //
+    //   setNow는 useEffect 본문에서 직접 호출하면 react-hooks/set-state-in-effect
+    //   lint rule에 걸린다. AnalysisPanel.tsx의 canonical 패턴
+    //   (MISTAKES.md §10)을 따라 useEffectEvent + startTransition 으로 감싼다.
+    const [now, setNow] = useState<Date | null>(null);
+    const captureNow = useEffectEvent((): void => {
+        startTransition(() => {
+            setNow(new Date());
+        });
+    });
+    useEffect(() => {
+        captureNow();
+    }, []);
     const oiStale = useMemo(
         () =>
-            !isUsOptionsRegularSession(new Date()) &&
+            now !== null &&
+            !isUsOptionsRegularSession(now) &&
             isOpenInterestSnapshotStale(snapshot),
-        [snapshot]
+        [now, snapshot]
     );
     const nearestExpiry = snapshot.chains[0]?.expirationDate ?? '';
 
     return (
-        <main className="mx-auto max-w-5xl space-y-6 px-4 py-6">
+        // page.tsx가 이미 <main> landmark로 감싸므로 여기는 일반 컨테이너만.
+        // 중첩 <main>은 invalid HTML이고 screen reader landmark navigation을
+        // 깬다.
+        <div className="mx-auto max-w-5xl space-y-6 px-4 py-6">
             <ExpirationSelector
                 slots={validSlots}
                 value={expirationDate}
@@ -124,6 +147,6 @@ export function OptionsPageClient({
             />
 
             <CrossLinkCards symbol={symbol} current="options" />
-        </main>
+        </div>
     );
 }

--- a/src/components/options/OptionsPageClient.tsx
+++ b/src/components/options/OptionsPageClient.tsx
@@ -75,9 +75,9 @@ export function OptionsPageClient({
             setNow(new Date());
         });
     });
-    useEffect(() => {
-        captureNow();
-    }, []);
+    // 훅 선언 순서(CONVENTIONS.md / MISTAKES.md §17):
+    //   useState → 사용자 정의 훅 → useMemo/useCallback → derived → handlers → useEffect.
+    // oiStale은 useMemo이므로 useEffect 전에 선언해야 한다.
     const oiStale = useMemo(
         () =>
             now !== null &&
@@ -86,6 +86,9 @@ export function OptionsPageClient({
         [now, snapshot]
     );
     const nearestExpiry = snapshot.chains[0]?.expirationDate ?? '';
+    useEffect(() => {
+        captureNow();
+    }, []);
 
     return (
         // page.tsx가 이미 <main> landmark로 감싸므로 여기는 일반 컨테이너만.

--- a/src/components/options/OptionsPageClient.tsx
+++ b/src/components/options/OptionsPageClient.tsx
@@ -48,17 +48,14 @@ export function OptionsPageClient({
     snapshot,
     slots,
 }: OptionsPageClientProps) {
+    // 훅 선언 순서(CONVENTIONS.md / MISTAKES.md §17):
+    //   useState/useRef → 사용자 정의 훅 → useMemo/useCallback → derived → handlers → useEffect.
+    // 모든 useState 와 그에 직결된 useEffectEvent setter 를 사용자 정의 훅 호출
+    // 이전에 모아 둔다.
     const [expirationDate, setExpirationDate] =
         useState<OptionsExpirationSelector>(
             () => slots.find(isSlotMapping)?.expirationDate ?? 'all'
         );
-    const { modelId } = useSymbolModel();
-    const validSlots = useMemo(() => slots.filter(isSlotMapping), [slots]);
-    // 단일 호출로 (chain, metrics)을 산출하고 세 자식에 prop-drill 한다 —
-    // 이전엔 OptionsMetricsRow / OpenInterestChart / OptionsChainTable이
-    // 각자 pickActiveChain + summarizeChainForLlm을 동일 입력으로 3번
-    // 돌렸다. chip 전환 시마다 같은 계산이 세 번 반복되던 비용을 제거한다.
-    const chainMetrics = useOptionsChainMetrics(snapshot, expirationDate);
     // oiStale 평가는 client-only.
     //   SSR(또는 initial client render)에서 `new Date()`로 평가하면 정규장
     //   boundary를 가로지르는 사용자에게 서버/클라이언트 결과가 어긋나
@@ -75,9 +72,13 @@ export function OptionsPageClient({
             setNow(new Date());
         });
     });
-    // 훅 선언 순서(CONVENTIONS.md / MISTAKES.md §17):
-    //   useState → 사용자 정의 훅 → useMemo/useCallback → derived → handlers → useEffect.
-    // oiStale은 useMemo이므로 useEffect 전에 선언해야 한다.
+    const { modelId } = useSymbolModel();
+    const validSlots = useMemo(() => slots.filter(isSlotMapping), [slots]);
+    // 단일 호출로 (chain, metrics)을 산출하고 세 자식에 prop-drill 한다 —
+    // 이전엔 OptionsMetricsRow / OpenInterestChart / OptionsChainTable이
+    // 각자 pickActiveChain + summarizeChainForLlm을 동일 입력으로 3번
+    // 돌렸다. chip 전환 시마다 같은 계산이 세 번 반복되던 비용을 제거한다.
+    const chainMetrics = useOptionsChainMetrics(snapshot, expirationDate);
     const oiStale = useMemo(
         () =>
             now !== null &&

--- a/src/components/options/OptionsPageClient.tsx
+++ b/src/components/options/OptionsPageClient.tsx
@@ -50,8 +50,10 @@ export function OptionsPageClient({
 }: OptionsPageClientProps) {
     // 훅 선언 순서(CONVENTIONS.md / MISTAKES.md §17):
     //   useState/useRef → 사용자 정의 훅 → useMemo/useCallback → derived → handlers → useEffect.
-    // 모든 useState 와 그에 직결된 useEffectEvent setter 를 사용자 정의 훅 호출
-    // 이전에 모아 둔다.
+    // useEffectEvent 는 effect 본문의 setState 를 lint-rule(react-hooks/
+    // set-state-in-effect)을 만족시키기 위한 stable handler 이므로 "handlers"
+    // 구간(useEffect 직전)에 둔다 — `AnalysisPanel.tsx` 의 canonical 위치와
+    // 동일.
     const [expirationDate, setExpirationDate] =
         useState<OptionsExpirationSelector>(
             () => slots.find(isSlotMapping)?.expirationDate ?? 'all'
@@ -62,16 +64,7 @@ export function OptionsPageClient({
     //   hydration mismatch 경고가 발생한다. `now`를 useState(null)로 두고
     //   useEffect로 mount 직후 한 번만 채워 SSR 마크업은 항상 banner 없음
     //   상태로 통일한다. snapshot 참조가 갱신되면 자동으로 재평가된다.
-    //
-    //   setNow는 useEffect 본문에서 직접 호출하면 react-hooks/set-state-in-effect
-    //   lint rule에 걸린다. AnalysisPanel.tsx의 canonical 패턴
-    //   (MISTAKES.md §10)을 따라 useEffectEvent + startTransition 으로 감싼다.
     const [now, setNow] = useState<Date | null>(null);
-    const captureNow = useEffectEvent((): void => {
-        startTransition(() => {
-            setNow(new Date());
-        });
-    });
     const { modelId } = useSymbolModel();
     const validSlots = useMemo(() => slots.filter(isSlotMapping), [slots]);
     // 단일 호출로 (chain, metrics)을 산출하고 세 자식에 prop-drill 한다 —
@@ -87,6 +80,14 @@ export function OptionsPageClient({
         [now, snapshot]
     );
     const nearestExpiry = snapshot.chains[0]?.expirationDate ?? '';
+    // handlers — useEffectEvent 는 stable reference 이므로 deps 에 넣지 않는다
+    // (MISTAKES.md Predictability §3). 본문은 startTransition 으로 격리해
+    // react-hooks/set-state-in-effect lint rule 을 만족시킨다 (§10).
+    const captureNow = useEffectEvent((): void => {
+        startTransition(() => {
+            setNow(new Date());
+        });
+    });
     useEffect(() => {
         captureNow();
     }, []);

--- a/src/infrastructure/db/agreementRepository.ts
+++ b/src/infrastructure/db/agreementRepository.ts
@@ -1,5 +1,7 @@
+import { NEON_TRANSIENT_RETRY } from '@/infrastructure/db/isNeonTransientError';
 import { agreements } from '@/infrastructure/db/schema';
 import type { SiglensDatabase } from '@/infrastructure/db/types';
+import { withRetry } from '@/infrastructure/utils/withRetry';
 
 export interface AgreementInsertInput {
     userId: string;
@@ -20,13 +22,20 @@ export class DrizzleAgreementRepository implements AgreementRepository {
         if (inputs.length === 0) {
             throw new Error('agreement input must not be empty');
         }
-        await this.db.insert(agreements).values(
-            inputs.map(input => ({
-                userId: input.userId,
-                termsId: input.termsId,
-                agreed: input.agreed,
-                agreedAt: input.agreedAt,
-            }))
+        // 회원가입 flow에서 동의 기록 실패는 사용자에게 그대로 에러로 노출되므로
+        // transient 실패는 retry로 흡수한다. 전체 batch가 단일 INSERT문이라
+        // partial-write 우려도 없다.
+        await withRetry(
+            () =>
+                this.db.insert(agreements).values(
+                    inputs.map(input => ({
+                        userId: input.userId,
+                        termsId: input.termsId,
+                        agreed: input.agreed,
+                        agreedAt: input.agreedAt,
+                    }))
+                ),
+            NEON_TRANSIENT_RETRY
         );
     }
 }

--- a/src/infrastructure/db/contactRepository.ts
+++ b/src/infrastructure/db/contactRepository.ts
@@ -1,5 +1,7 @@
+import { NEON_TRANSIENT_RETRY } from '@/infrastructure/db/isNeonTransientError';
 import { inquiries } from '@/infrastructure/db/schema';
 import type { SiglensDatabase } from '@/infrastructure/db/types';
+import { withRetry } from '@/infrastructure/utils/withRetry';
 
 /** Input required to create a new inquiry record. */
 export interface ContactInput {
@@ -23,10 +25,16 @@ export class DrizzleContactRepository implements ContactRepository {
 
     /** Insert the inquiry record into the database. */
     async create(input: ContactInput): Promise<void> {
-        await this.db.insert(inquiries).values({
-            title: input.title,
-            content: input.content,
-            email: input.email,
-        });
+        // 문의 제출은 사용자가 명시적으로 클릭한 직후라 실패가 즉시 화면에
+        // 노출된다. transient 실패는 retry로 흡수한다.
+        await withRetry(
+            () =>
+                this.db.insert(inquiries).values({
+                    title: input.title,
+                    content: input.content,
+                    email: input.email,
+                }),
+            NEON_TRANSIENT_RETRY
+        );
     }
 }

--- a/src/infrastructure/db/isNeonTransientError.ts
+++ b/src/infrastructure/db/isNeonTransientError.ts
@@ -9,14 +9,45 @@ import type { WithRetryOptions } from '@/infrastructure/utils/withRetry';
  *   "Error connecting to database: TypeError: fetch failed"
  *   "Error connecting to database: …"
  *
+ * SQLSTATE codes are matched as substrings against the error message because
+ * Postgres surfaces them inline ("…code 57P01…"). The codes below cover the
+ * Neon connection-lifecycle and capacity-exhaustion classes:
+ *   - 57P01: admin_shutdown (Neon scales pooler down mid-request)
+ *   - 08006: connection_failure
+ *   - 08003: connection_does_not_exist
+ *   - 08001: sqlclient_unable_to_establish_sqlconnection
+ *   - 08004: sqlserver_rejected_establishment_of_sqlconnection
+ *   - 53300: too_many_connections (transient cap; safe to retry with backoff)
+ *
  * Permanent errors (constraint violations, undefined column, etc.) carry
- * different messages and are NOT matched here, so callers won't burn retries
- * on something that will fail identically next time.
+ * different codes/messages and are NOT matched here, so callers won't burn
+ * retries on something that will fail identically next time.
  */
 const TRANSIENT_MESSAGE_NEEDLES = [
     'Error connecting to database',
     'fetch failed',
+    '57P01',
+    '08006',
+    '08003',
+    '08001',
+    '08004',
+    '53300',
 ] as const;
+
+/**
+ * SQLSTATE codes treated as transient when surfaced on `NeonDbError.code`
+ * (the typed field) instead of embedded in the message. NeonDbError exposes
+ * `code?: string` for server-side errors; checking it directly avoids
+ * dependency on message formatting.
+ */
+const TRANSIENT_SQLSTATES = new Set([
+    '57P01',
+    '08006',
+    '08003',
+    '08001',
+    '08004',
+    '53300',
+]);
 
 /**
  * Upper bound on how many `cause` links we follow before giving up. Drizzle
@@ -42,6 +73,16 @@ function messageLooksTransient(error: Error): boolean {
     );
 }
 
+function codeLooksTransient(error: Error): boolean {
+    // Safe-cast 근거: NeonDbError 는 Error를 확장하면서 optional `code: string`을
+    // 노출한다(@neondatabase/serverless type 정의). 그러나 본 함수는 NeonDbError 인지
+    // 미확정 상태에서도 호출될 수 있으므로 정적 타입을 `code?: unknown` 으로 일단
+    // 넓힌 뒤 바로 아래에서 `typeof code === 'string'` 으로 좁힌다 — 런타임에
+    // code 가 없거나 비-문자열이면 false 로 떨어져 안전하다.
+    const code = (error as Error & { code?: unknown }).code;
+    return typeof code === 'string' && TRANSIENT_SQLSTATES.has(code);
+}
+
 /**
  * Walk the `cause` chain looking for a transient Neon HTTP driver error.
  * Drizzle wraps Neon errors in a generic `Failed query: …` Error and stashes
@@ -55,7 +96,10 @@ export function isNeonTransientError(error: unknown): boolean {
         depth < MAX_CAUSE_DEPTH && current instanceof Error;
         depth++
     ) {
-        if (isNeonError(current) && messageLooksTransient(current)) {
+        if (
+            isNeonError(current) &&
+            (messageLooksTransient(current) || codeLooksTransient(current))
+        ) {
             return true;
         }
         current = current.cause;

--- a/src/infrastructure/db/isNeonTransientError.ts
+++ b/src/infrastructure/db/isNeonTransientError.ts
@@ -78,12 +78,11 @@ function isNeonError(value: unknown): value is Error {
 }
 
 function messageLooksTransient(error: Error): boolean {
-    if (
-        TRANSIENT_MESSAGE_NEEDLES.some(needle => error.message.includes(needle))
-    ) {
-        return true;
-    }
-    return TRANSIENT_SQLSTATE_REGEX.test(error.message);
+    return (
+        TRANSIENT_MESSAGE_NEEDLES.some(needle =>
+            error.message.includes(needle)
+        ) || TRANSIENT_SQLSTATE_REGEX.test(error.message)
+    );
 }
 
 function codeLooksTransient(error: Error): boolean {

--- a/src/infrastructure/db/isNeonTransientError.ts
+++ b/src/infrastructure/db/isNeonTransientError.ts
@@ -2,30 +2,20 @@ import { NeonDbError } from '@neondatabase/serverless';
 import type { WithRetryOptions } from '@/infrastructure/utils/withRetry';
 
 /**
- * Substrings that indicate a Neon HTTP driver connection / network failure
- * rather than a permanent SQL-level error (schema, constraint, permission).
+ * Single source of truth for transient SQLSTATE codes — Neon connection-
+ * lifecycle and capacity-exhaustion classes. Adding a new code here
+ * propagates to both the `.code` field check and the message-substring
+ * fallback automatically; previous duplicate literal lists caused silent
+ * divergence when only one half was updated.
  *
- * Examples seen in production:
- *   "Error connecting to database: TypeError: fetch failed"
- *   "Error connecting to database: …"
- *
- * SQLSTATE codes are matched as substrings against the error message because
- * Postgres surfaces them inline ("…code 57P01…"). The codes below cover the
- * Neon connection-lifecycle and capacity-exhaustion classes:
  *   - 57P01: admin_shutdown (Neon scales pooler down mid-request)
  *   - 08006: connection_failure
  *   - 08003: connection_does_not_exist
  *   - 08001: sqlclient_unable_to_establish_sqlconnection
  *   - 08004: sqlserver_rejected_establishment_of_sqlconnection
  *   - 53300: too_many_connections (transient cap; safe to retry with backoff)
- *
- * Permanent errors (constraint violations, undefined column, etc.) carry
- * different codes/messages and are NOT matched here, so callers won't burn
- * retries on something that will fail identically next time.
  */
-const TRANSIENT_MESSAGE_NEEDLES = [
-    'Error connecting to database',
-    'fetch failed',
+const TRANSIENT_SQLSTATE_CODES = [
     '57P01',
     '08006',
     '08003',
@@ -35,19 +25,39 @@ const TRANSIENT_MESSAGE_NEEDLES = [
 ] as const;
 
 /**
- * SQLSTATE codes treated as transient when surfaced on `NeonDbError.code`
- * (the typed field) instead of embedded in the message. NeonDbError exposes
- * `code?: string` for server-side errors; checking it directly avoids
- * dependency on message formatting.
+ * Connection-lifecycle substrings the Neon HTTP driver embeds in failure
+ * messages. SQLSTATE codes are NOT bare-substring matched here — that would
+ * false-positive on user data values that happen to contain the same digits.
+ * See `TRANSIENT_SQLSTATE_REGEX` below for word-boundary matching.
+ *
+ * Examples seen in production:
+ *   "Error connecting to database: TypeError: fetch failed"
  */
-const TRANSIENT_SQLSTATES = new Set([
-    '57P01',
-    '08006',
-    '08003',
-    '08001',
-    '08004',
-    '53300',
-]);
+const TRANSIENT_MESSAGE_NEEDLES = [
+    'Error connecting to database',
+    'fetch failed',
+] as const;
+
+/**
+ * SQLSTATE codes matched against the error message with word boundaries —
+ * this catches Postgres errors that embed the code inline (e.g.
+ * "terminating connection (code 57P01)") without false-positives on user
+ * data / identifiers that happen to contain the same digit sequence
+ * ("user_57P01ABC", "pk_constraint_53300_check", etc.).
+ *
+ * The `.code` field check (`codeLooksTransient`) remains the primary path —
+ * this regex is only the fallback when `NeonDbError.code` is undefined.
+ */
+const TRANSIENT_SQLSTATE_REGEX = new RegExp(
+    `\\b(${TRANSIENT_SQLSTATE_CODES.join('|')})\\b`
+);
+
+/**
+ * SQLSTATE codes treated as transient when surfaced on `NeonDbError.code`
+ * (the typed field). NeonDbError exposes `code?: string` for server-side
+ * errors; checking it directly avoids dependency on message formatting.
+ */
+const TRANSIENT_SQLSTATES = new Set<string>(TRANSIENT_SQLSTATE_CODES);
 
 /**
  * Upper bound on how many `cause` links we follow before giving up. Drizzle
@@ -68,9 +78,12 @@ function isNeonError(value: unknown): value is Error {
 }
 
 function messageLooksTransient(error: Error): boolean {
-    return TRANSIENT_MESSAGE_NEEDLES.some(needle =>
-        error.message.includes(needle)
-    );
+    if (
+        TRANSIENT_MESSAGE_NEEDLES.some(needle => error.message.includes(needle))
+    ) {
+        return true;
+    }
+    return TRANSIENT_SQLSTATE_REGEX.test(error.message);
 }
 
 function codeLooksTransient(error: Error): boolean {
@@ -112,6 +125,12 @@ export function isNeonTransientError(error: unknown): boolean {
  * 200/400/800ms exponential backoff + jitter absorb the typical transient
  * `fetch failed` window while staying well inside serverless-function budgets.
  *
+ * `totalTimeoutMs: 5000` caps the cumulative backoff sleep budget — if `fn()`
+ * itself runs slow and the elapsed time approaches 5s, withRetry bails out
+ * rather than queueing more sleeps. Maximum sleep cap is ~2.8s (200+400+800 +
+ * up to 1× jitter), so this budget covers the worst case comfortably while
+ * leaving headroom inside Vercel serverless 10s function limits.
+ *
  * Import this constant from every `*Repository.upsert*` site so the retry
  * behavior stays uniform across repositories.
  */
@@ -119,4 +138,5 @@ export const NEON_TRANSIENT_RETRY: WithRetryOptions = {
     maxRetries: 3,
     baseDelayMs: 200,
     isRetryable: isNeonTransientError,
+    totalTimeoutMs: 5000,
 };

--- a/src/infrastructure/db/isNeonTransientError.ts
+++ b/src/infrastructure/db/isNeonTransientError.ts
@@ -125,11 +125,12 @@ export function isNeonTransientError(error: unknown): boolean {
  * 200/400/800ms exponential backoff + jitter absorb the typical transient
  * `fetch failed` window while staying well inside serverless-function budgets.
  *
- * `totalTimeoutMs: 5000` caps the cumulative backoff sleep budget — if `fn()`
- * itself runs slow and the elapsed time approaches 5s, withRetry bails out
- * rather than queueing more sleeps. Maximum sleep cap is ~2.8s (200+400+800 +
- * up to 1× jitter), so this budget covers the worst case comfortably while
- * leaving headroom inside Vercel serverless 10s function limits.
+ * `backoffBudgetMs: 5000` caps the cumulative backoff sleep budget — if
+ * `fn()` itself runs slow and the elapsed time approaches 5s, withRetry
+ * bails out rather than queueing more sleeps. Maximum sleep cap is ~2.8s
+ * (200+400+800 + up to 1× jitter), so this budget covers the worst case
+ * comfortably while leaving headroom inside Vercel serverless 10s function
+ * limits.
  *
  * Import this constant from every `*Repository.upsert*` site so the retry
  * behavior stays uniform across repositories.
@@ -138,5 +139,5 @@ export const NEON_TRANSIENT_RETRY: WithRetryOptions = {
     maxRetries: 3,
     baseDelayMs: 200,
     isRetryable: isNeonTransientError,
-    totalTimeoutMs: 5000,
+    backoffBudgetMs: 5000,
 };

--- a/src/infrastructure/db/newsRepository.ts
+++ b/src/infrastructure/db/newsRepository.ts
@@ -71,18 +71,25 @@ export class DrizzleNewsRepository {
         analysis: NewsCardAnalysis,
         analyzedAt: Date = new Date()
     ): Promise<void> {
-        await this.db
-            .update(news)
-            .set({
-                titleKo: analysis.titleKo,
-                bodyKo: analysis.bodyKo ?? null,
-                summaryKo: analysis.summaryKo,
-                sentiment: analysis.sentiment,
-                category: analysis.category,
-                priceImpact: analysis.priceImpact,
-                analyzedAt,
-            })
-            .where(eq(news.id, id));
+        // LLM 번역 결과는 비용/지연이 모두 큰 호출이라 transient `fetch failed` 한 번에
+        // 영구적으로 분실되면 다음 fetch까지 카드가 `analyzed: null` 상태로 남는다.
+        // upsertNewsItem과 동일한 retry 정책으로 자가 회복 가능하게 한다.
+        await withRetry(
+            () =>
+                this.db
+                    .update(news)
+                    .set({
+                        titleKo: analysis.titleKo,
+                        bodyKo: analysis.bodyKo ?? null,
+                        summaryKo: analysis.summaryKo,
+                        sentiment: analysis.sentiment,
+                        category: analysis.category,
+                        priceImpact: analysis.priceImpact,
+                        analyzedAt,
+                    })
+                    .where(eq(news.id, id)),
+            NEON_TRANSIENT_RETRY
+        );
     }
 
     async listBySymbol(symbol: string, sinceMs: number): Promise<NewsRow[]> {

--- a/src/infrastructure/db/sessionRepository.ts
+++ b/src/infrastructure/db/sessionRepository.ts
@@ -1,4 +1,5 @@
 import { eq, lt } from 'drizzle-orm';
+import { NEON_TRANSIENT_RETRY } from '@/infrastructure/db/isNeonTransientError';
 import { sessions } from '@/infrastructure/db/schema';
 import type { SiglensDatabase } from '@/infrastructure/db/types';
 import type {
@@ -6,6 +7,7 @@ import type {
     CreateSessionInput,
     SessionRepository,
 } from '@/infrastructure/db/types';
+import { withRetry } from '@/infrastructure/utils/withRetry';
 
 const sessionColumns = {
     id: sessions.id,
@@ -19,13 +21,19 @@ export class DrizzleSessionRepository implements SessionRepository {
     constructor(private readonly db: SiglensDatabase) {}
 
     async createSession(input: CreateSessionInput): Promise<AuthSessionRecord> {
-        const [session] = await this.db
-            .insert(sessions)
-            .values({
-                userId: input.userId,
-                expiresAt: input.expiresAt,
-            })
-            .returning(sessionColumns);
+        // 로그인 직후 세션 생성은 사용자에게 직접 노출되는 critical path —
+        // transient 실패가 그대로 노출되면 사용자가 다시 로그인해야 한다.
+        const [session] = await withRetry(
+            () =>
+                this.db
+                    .insert(sessions)
+                    .values({
+                        userId: input.userId,
+                        expiresAt: input.expiresAt,
+                    })
+                    .returning(sessionColumns),
+            NEON_TRANSIENT_RETRY
+        );
 
         return session!;
     }
@@ -41,19 +49,30 @@ export class DrizzleSessionRepository implements SessionRepository {
     }
 
     async deleteSession(sessionToken: string): Promise<boolean> {
-        const deletedSessions = await this.db
-            .delete(sessions)
-            .where(eq(sessions.id, sessionToken))
-            .returning({ id: sessions.id });
+        // 로그아웃 동작 — transient 실패가 노출되면 사용자가 다시 시도해야 한다.
+        const deletedSessions = await withRetry(
+            () =>
+                this.db
+                    .delete(sessions)
+                    .where(eq(sessions.id, sessionToken))
+                    .returning({ id: sessions.id }),
+            NEON_TRANSIENT_RETRY
+        );
 
         return deletedSessions.length > 0;
     }
 
     async deleteExpiredSessions(now: Date = new Date()): Promise<number> {
-        const deleted = await this.db
-            .delete(sessions)
-            .where(lt(sessions.expiresAt, now))
-            .returning({ id: sessions.id });
+        // 백그라운드 cleanup — transient 실패가 다음 tick에 재시도되긴 하지만,
+        // 인라인 retry로 처리해 cleanup이 한 tick 동안 누락되지 않도록 한다.
+        const deleted = await withRetry(
+            () =>
+                this.db
+                    .delete(sessions)
+                    .where(lt(sessions.expiresAt, now))
+                    .returning({ id: sessions.id }),
+            NEON_TRANSIENT_RETRY
+        );
 
         return deleted.length;
     }

--- a/src/infrastructure/db/usageLogRepository.ts
+++ b/src/infrastructure/db/usageLogRepository.ts
@@ -2,8 +2,10 @@ import type {
     CreateUsageLogInput,
     UsageLogRepository,
 } from '@y0ngha/siglens-core';
+import { NEON_TRANSIENT_RETRY } from '@/infrastructure/db/isNeonTransientError';
 import { usageLogs } from '@/infrastructure/db/schema';
 import type { SiglensDatabase } from '@/infrastructure/db/types';
+import { withRetry } from '@/infrastructure/utils/withRetry';
 
 /**
  * Drizzle ORM implementation of {@link UsageLogRepository} backed by a Neon
@@ -13,12 +15,18 @@ export class DrizzleUsageLogRepository implements UsageLogRepository {
     constructor(private readonly db: SiglensDatabase) {}
 
     async recordUsage(input: CreateUsageLogInput): Promise<void> {
-        await this.db.insert(usageLogs).values({
-            userId: input.userId,
-            ipHash: input.ipHash,
-            actionType: input.actionType,
-            modelUsed: input.modelUsed,
-            date: input.date,
-        });
+        // siglens-core 호출 경로의 usage write — analysis/chatbot 호출 직후라
+        // transient 실패가 사용자 화면 에러로 그대로 노출된다. retry로 흡수.
+        await withRetry(
+            () =>
+                this.db.insert(usageLogs).values({
+                    userId: input.userId,
+                    ipHash: input.ipHash,
+                    actionType: input.actionType,
+                    modelUsed: input.modelUsed,
+                    date: input.date,
+                }),
+            NEON_TRANSIENT_RETRY
+        );
     }
 }

--- a/src/infrastructure/db/usageRepository.ts
+++ b/src/infrastructure/db/usageRepository.ts
@@ -5,12 +5,14 @@ import {
     type UsageLogRecord,
 } from '@y0ngha/siglens-core';
 import { and, count, eq } from 'drizzle-orm';
+import { NEON_TRANSIENT_RETRY } from '@/infrastructure/db/isNeonTransientError';
 import { usageLogs } from '@/infrastructure/db/schema';
 import type { SiglensDatabase } from '@/infrastructure/db/types';
 import type {
     SiglensUsageCounts,
     SiglensUsageRepository,
 } from '@/infrastructure/db/usageCounts';
+import { withRetry } from '@/infrastructure/utils/withRetry';
 
 const EMPTY_USAGE_COUNTS: SiglensUsageCounts = {
     analysis: 0,
@@ -43,24 +45,31 @@ export class DrizzleUsageRepository implements SiglensUsageRepository {
 
     async recordUsage(input: RecordUsageInput): Promise<UsageLogRecord> {
         const occurredAt = input.occurredAt ?? new Date();
-        const [usageLog] = await this.db
-            .insert(usageLogs)
-            .values({
-                userId: input.userId ?? null,
-                ipHash: hashUsageIp(input.ipAddress, occurredAt),
-                actionType: input.actionType,
-                modelUsed: input.modelUsed,
-                date: toUtcDateString(occurredAt),
-            })
-            .returning({
-                id: usageLogs.id,
-                userId: usageLogs.userId,
-                ipHash: usageLogs.ipHash,
-                actionType: usageLogs.actionType,
-                modelUsed: usageLogs.modelUsed,
-                date: usageLogs.date,
-                createdAt: usageLogs.createdAt,
-            });
+        // Usage 로깅은 사용자에게 직접 노출되는 동작(분석/챗봇 호출 등) 직후 동기로
+        // 호출되므로 transient `fetch failed`가 그대로 에러로 노출되면 사용자가 본
+        // 작업이 실패한 것처럼 보인다. retry로 흡수해 로그가 자가 회복되게 한다.
+        const [usageLog] = await withRetry(
+            () =>
+                this.db
+                    .insert(usageLogs)
+                    .values({
+                        userId: input.userId ?? null,
+                        ipHash: hashUsageIp(input.ipAddress, occurredAt),
+                        actionType: input.actionType,
+                        modelUsed: input.modelUsed,
+                        date: toUtcDateString(occurredAt),
+                    })
+                    .returning({
+                        id: usageLogs.id,
+                        userId: usageLogs.userId,
+                        ipHash: usageLogs.ipHash,
+                        actionType: usageLogs.actionType,
+                        modelUsed: usageLogs.modelUsed,
+                        date: usageLogs.date,
+                        createdAt: usageLogs.createdAt,
+                    }),
+            NEON_TRANSIENT_RETRY
+        );
 
         return usageLog!;
     }

--- a/src/infrastructure/db/userRepository.ts
+++ b/src/infrastructure/db/userRepository.ts
@@ -81,10 +81,16 @@ export class DrizzleUserRepository
     }
 
     async deleteUser(userId: string): Promise<boolean> {
-        const deletedUsers = await this.db
-            .delete(users)
-            .where(eq(users.id, userId))
-            .returning({ id: users.id });
+        // 회원 탈퇴는 사용자 명시적 액션 — transient 실패는 retry로 흡수해
+        // 재시도 유도 없이 일관 동작.
+        const deletedUsers = await withRetry(
+            () =>
+                this.db
+                    .delete(users)
+                    .where(eq(users.id, userId))
+                    .returning({ id: users.id }),
+            NEON_TRANSIENT_RETRY
+        );
 
         return deletedUsers.length > 0;
     }
@@ -93,11 +99,16 @@ export class DrizzleUserRepository
         userId: string,
         passwordHash: string
     ): Promise<boolean> {
-        const updatedUsers = await this.db
-            .update(users)
-            .set({ passwordHash, updatedAt: sql`now()` })
-            .where(eq(users.id, userId))
-            .returning({ id: users.id });
+        // 비밀번호 변경 — 사용자가 폼 제출 직후 결과를 본다. transient retry로 흡수.
+        const updatedUsers = await withRetry(
+            () =>
+                this.db
+                    .update(users)
+                    .set({ passwordHash, updatedAt: sql`now()` })
+                    .where(eq(users.id, userId))
+                    .returning({ id: users.id }),
+            NEON_TRANSIENT_RETRY
+        );
 
         return updatedUsers.length > 0;
     }
@@ -248,11 +259,17 @@ export class DrizzleUserRepository
     }
 
     async updateUserTier(userId: string, tier: Tier): Promise<Tier | null> {
-        const [user] = await this.db
-            .update(users)
-            .set({ tier, updatedAt: sql`now()` })
-            .where(eq(users.id, userId))
-            .returning({ tier: users.tier });
+        // 결제/티어 상승 직후 호출 — transient 실패가 노출되면 결제는 됐는데
+        // 티어가 안 올라간 것처럼 보인다. retry로 흡수.
+        const [user] = await withRetry(
+            () =>
+                this.db
+                    .update(users)
+                    .set({ tier, updatedAt: sql`now()` })
+                    .where(eq(users.id, userId))
+                    .returning({ tier: users.tier }),
+            NEON_TRANSIENT_RETRY
+        );
 
         return user?.tier ?? null;
     }

--- a/src/infrastructure/market/submitOverallAnalysisAction.ts
+++ b/src/infrastructure/market/submitOverallAnalysisAction.ts
@@ -5,6 +5,7 @@ import { headers } from 'next/headers';
 import {
     submitOverallAnalysis,
     type EnrichedNewsItem,
+    type OptionsSnapshot,
     type SubmitOverallAnalysisOptions,
     type SubmitOverallAnalysisResult,
     type Timeframe,
@@ -67,26 +68,32 @@ export async function submitOverallAnalysisAction(
         const { db } = getDatabaseClient();
         const newsRepo = new DrizzleNewsRepository(db);
 
-        const [rows, next] = await Promise.all([
+        // bot 트래픽은 어차피 enqueue를 skip하므로 (`skipEnqueueIfMiss`) 옵션
+        // 스냅샷을 위해 Yahoo를 두드리지 않는다 — 크롤러가 Yahoo rate-limit을
+        // 소진시키는 시나리오 차단. 일반 유저는 fetchOptionsSnapshot의 cross-
+        // request 캐시(Upstash)로 흡수.
+        // news / earnings / options 세 fetch는 서로 독립이므로 Promise.all로
+        // 병렬화해 직렬 대기 비용 (~1-3s)을 제거한다.
+        const optionsSnapshotPromise: Promise<OptionsSnapshot | null> =
+            skipEnqueueIfMiss
+                ? Promise.resolve(null)
+                : fetchOptionsSnapshot(symbol).catch(error => {
+                      console.warn(
+                          '[submitOverallAnalysisAction] options snapshot fetch failed:',
+                          error
+                      );
+                      return null;
+                  });
+
+        const [rows, next, optionsSnapshot] = await Promise.all([
             newsRepo.listBySymbol(symbol, NEWS_ANALYSIS_LOOKBACK_MS),
             getNextEarningsReport(symbol, db),
+            optionsSnapshotPromise,
         ]);
 
         const enrichedNews: ReadonlyArray<EnrichedNewsItem> = rows
             .filter(isEnrichedRow)
             .map(toEnrichedNewsItem);
-
-        // 옵션 스냅샷 조회 실패는 4번째 axis가 graceful skip되는 시나리오로 처리한다.
-        // NoChains 종목(SPXUSD 등) 또는 Yahoo 일시 장애에도 overall 분석은 진행돼야 한다.
-        const optionsSnapshot = await fetchOptionsSnapshot(symbol).catch(
-            error => {
-                console.warn(
-                    '[submitOverallAnalysisAction] options snapshot fetch failed:',
-                    error
-                );
-                return null;
-            }
-        );
 
         // 정규장 시간대에는 OI=0 비율이 높아도 stale로 보지 않는다 — deep OTM strike
         // OI 0이 흔하므로 false positive 위험. 정규장 외에서만 stale 휴리스틱 적용.

--- a/src/infrastructure/options/YahooOptionsAdapter.ts
+++ b/src/infrastructure/options/YahooOptionsAdapter.ts
@@ -124,6 +124,19 @@ export class YahooOptionsAdapter implements OptionsDataProvider {
 
             const raw = normalizeYahooSnapshot(combined, now);
 
+            // Yahoo가 quote.regularMarketPrice를 누락하면 normalize 단에서 0으로
+            // 폴백된다. underlyingPrice=0 인 채로 그냥 통과시키면 downstream
+            // (findNearestStrike, ImpliedMove, Max Pain 가이드라인)이 최저 strike에
+            // 가이드라인을 그리는 등 시각적으로 잘못된 정보를 노출한다.
+            // 단일 경계인 adapter에서 null로 reject해 OptionsEmptyState로 떨어뜨린다.
+            if (raw.underlyingPrice <= 0) {
+                console.warn(
+                    '[YahooOptionsAdapter] missing underlyingPrice — treating snapshot as unavailable',
+                    symbol
+                );
+                return null;
+            }
+
             const sanitizedChains = raw.chains
                 .map(chain => sanitizeOptionsChain(chain))
                 .filter((chain): chain is OptionsChain => chain !== null);

--- a/src/infrastructure/options/optionsDataCache.ts
+++ b/src/infrastructure/options/optionsDataCache.ts
@@ -1,7 +1,12 @@
 import 'server-only';
 import { cache } from 'react';
 import { Redis } from '@upstash/redis';
+import { SECONDS_PER_HOUR, SECONDS_PER_MINUTE } from '@/domain/constants/time';
 import { YahooOptionsAdapter } from '@/infrastructure/options/YahooOptionsAdapter';
+import {
+    getOptionsCacheLifeProfile,
+    type OptionsCacheLifeProfile,
+} from '@/infrastructure/options/optionsCacheLife';
 import type { OptionsSnapshot } from '@y0ngha/siglens-core';
 
 const adapter = new YahooOptionsAdapter();
@@ -11,7 +16,27 @@ const adapter = new YahooOptionsAdapter();
 // rate-limit을 깨는 위험이 더 큼. 6시간이면 동일 sitemap window 안에서
 // 단 한 번만 fetch한다 (이슈 #439 참조).
 // export — 테스트가 동일 상수를 import해 silent divergence를 차단한다.
-export const HAS_OPTIONS_MARKET_TTL_SECONDS = 6 * 60 * 60;
+export const HAS_OPTIONS_MARKET_TTL_SECONDS = 6 * SECONDS_PER_HOUR;
+
+/**
+ * fetchOptionsSnapshot cross-request 캐시 TTL — 시장 시간대별로 freshness
+ * trade-off가 달라 세 단계로 분리한다.
+ *
+ * - market-open: 활성 트레이딩 중 quote/IV/volume이 실시간으로 변동하지만 옵션
+ *   페이지는 분 단위 freshness면 충분. 1분이면 인기 ticker 트래픽에서도
+ *   Yahoo 호출이 분당 1회로 수렴.
+ * - market-closed: 정규장 외(pre/post)는 OI snapshot이 다음 정규장 직전까지
+ *   거의 변하지 않는다. 30분 캐시로 충분.
+ * - weekend: 주말은 Yahoo가 갱신하지 않으므로 4시간 캐시로 호출량을 최소화.
+ */
+export const OPTIONS_SNAPSHOT_TTL_SECONDS: Record<
+    OptionsCacheLifeProfile,
+    number
+> = {
+    'options-market-open': 1 * SECONDS_PER_MINUTE,
+    'options-market-closed': 30 * SECONDS_PER_MINUTE,
+    'options-weekend': 4 * SECONDS_PER_HOUR,
+};
 
 // tokenStore.ts / pendingOAuthSignupStore.ts와 같은 lazy-singleton 패턴.
 let cachedRedis: Redis | null | undefined;
@@ -31,6 +56,10 @@ function getRedis(): Redis | null {
 
 function buildHasOptionsKey(symbol: string): string {
     return `options:has-market:${symbol.toUpperCase()}`;
+}
+
+function buildSnapshotKey(symbol: string): string {
+    return `options:snapshot:${symbol.toUpperCase()}`;
 }
 
 /**
@@ -95,9 +124,51 @@ export const hasOptionsMarket = cache(
 
 /**
  * 종목의 전체 옵션 스냅샷(모든 만기)을 가져온다. 옵션 없는 종목이면 null.
+ *
+ * 캐시 레이어:
+ *   1. React.cache — request 내 dedup (page.tsx + Server Action 같은 요청
+ *      안에서 여러 번 호출돼도 한 번만 Yahoo를 친다).
+ *   2. Upstash Redis — cross-request 캐시. 시장 시간대별 TTL(`OPTIONS_SNAPSHOT_TTL_SECONDS`)
+ *      을 적용해 활성 트레이딩 중에는 짧게, 주말은 길게 캐시한다. Redis 미설정 시
+ *      graceful fallback으로 Yahoo 직접 호출.
+ *
+ * `null` 결과(옵션 없는 ticker, Yahoo 일시 장애)는 negative cache로 저장하지 않는다 —
+ * Yahoo가 일시적으로 실패한 경우 TTL 동안 잘못된 'no data' 상태가 굳어버릴 위험이
+ * 크기 때문. `hasOptionsMarket`은 옵션 존재 여부만 묻는 가벼운 probe라 negative
+ * cache가 안전하지만, snapshot은 전체 chain을 다루므로 더 보수적으로 동작한다.
  */
 export const fetchOptionsSnapshot = cache(
     async (symbol: string): Promise<OptionsSnapshot | null> => {
-        return adapter.fetchSnapshot(symbol);
+        const key = buildSnapshotKey(symbol);
+        const redis = getRedis();
+        if (redis !== null) {
+            try {
+                const cached = await redis.get<OptionsSnapshot>(key);
+                if (cached !== null) return cached;
+            } catch (error) {
+                console.error(
+                    '[optionsDataCache] Redis get failed for',
+                    key,
+                    error
+                );
+            }
+        }
+
+        const fresh = await adapter.fetchSnapshot(symbol);
+
+        // null은 캐시하지 않음 — 위 docstring 참고.
+        if (fresh !== null && redis !== null) {
+            const ttl = OPTIONS_SNAPSHOT_TTL_SECONDS[getOptionsCacheLifeProfile()];
+            try {
+                await redis.set(key, fresh, { ex: ttl });
+            } catch (error) {
+                console.error(
+                    '[optionsDataCache] Redis set failed for',
+                    key,
+                    error
+                );
+            }
+        }
+        return fresh;
     }
 );

--- a/src/infrastructure/options/optionsDataCache.ts
+++ b/src/infrastructure/options/optionsDataCache.ts
@@ -33,7 +33,7 @@ export const OPTIONS_SNAPSHOT_TTL_SECONDS: Record<
     OptionsCacheLifeProfile,
     number
 > = {
-    'options-market-open': 1 * SECONDS_PER_MINUTE,
+    'options-market-open': SECONDS_PER_MINUTE,
     'options-market-closed': 30 * SECONDS_PER_MINUTE,
     'options-weekend': 4 * SECONDS_PER_HOUR,
 };
@@ -158,7 +158,8 @@ export const fetchOptionsSnapshot = cache(
 
         // null은 캐시하지 않음 — 위 docstring 참고.
         if (fresh !== null && redis !== null) {
-            const ttl = OPTIONS_SNAPSHOT_TTL_SECONDS[getOptionsCacheLifeProfile()];
+            const ttl =
+                OPTIONS_SNAPSHOT_TTL_SECONDS[getOptionsCacheLifeProfile()];
             try {
                 await redis.set(key, fresh, { ex: ttl });
             } catch (error) {

--- a/src/infrastructure/utils/withRetry.ts
+++ b/src/infrastructure/utils/withRetry.ts
@@ -24,6 +24,15 @@ export interface WithRetryOptions {
      * re-thrown immediately so callers see the real failure without delay.
      */
     isRetryable: (error: unknown) => boolean;
+    /**
+     * Overall budget across `fn` invocations + backoff sleeps combined,
+     * measured from the first attempt. When the next backoff sleep would push
+     * elapsed time past the deadline, `withRetry` bails out and re-throws the
+     * most recent error rather than waiting. Note this does NOT abort an
+     * in-flight `fn()` — a hanging call still blocks until it settles. Omit
+     * to disable the cap (legacy behavior).
+     */
+    totalTimeoutMs?: number;
 }
 
 /**
@@ -37,7 +46,9 @@ export async function withRetry<T>(
     fn: () => Promise<T>,
     options: WithRetryOptions
 ): Promise<T> {
-    const { maxRetries, baseDelayMs, isRetryable } = options;
+    const { maxRetries, baseDelayMs, isRetryable, totalTimeoutMs } = options;
+    const deadline =
+        totalTimeoutMs !== undefined ? Date.now() + totalTimeoutMs : Infinity;
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
         try {
             return await fn();
@@ -48,7 +59,15 @@ export async function withRetry<T>(
             }
             const exponential = baseDelayMs * 2 ** attempt;
             const jitter = Math.random() * exponential;
-            await sleep(exponential + jitter);
+            const sleepMs = exponential + jitter;
+            // 다음 backoff sleep을 마치는 시점이 deadline을 넘어서면 더 기다리지
+            // 않고 즉시 마지막 에러를 던진다. fn() 자체의 진행 중인 호출은 멈출
+            // 수 없지만, 적어도 retry sleep 으로 인한 추가 지연이 예상 예산을
+            // 초과하는 일은 막는다.
+            if (Date.now() + sleepMs >= deadline) {
+                throw error;
+            }
+            await sleep(sleepMs);
         }
     }
     // Genuinely unreachable: every iteration either returns or throws. TS

--- a/src/infrastructure/utils/withRetry.ts
+++ b/src/infrastructure/utils/withRetry.ts
@@ -25,14 +25,20 @@ export interface WithRetryOptions {
      */
     isRetryable: (error: unknown) => boolean;
     /**
-     * Budget for *backoff sleeps* (NOT individual `fn()` runtime), measured
-     * from the first attempt. When the next backoff sleep would push elapsed
-     * time past the deadline, `withRetry` bails out and re-throws the most
-     * recent error rather than waiting. A hanging in-flight `fn()` is NOT
-     * aborted — that would require an AbortSignal which we don't thread
-     * through. The name reflects this scope: it caps how long retry-related
-     * waiting can grow, not the overall function lifetime. Omit to disable
-     * the cap (legacy behavior).
+     * Wall-clock budget for backoff-related waiting, measured from the
+     * first attempt's *start*. Important semantic details:
+     *
+     *  - `fn()` runtime *does* count against the elapsed measurement (the
+     *    deadline is set before the first attempt and read between
+     *    attempts). A slow first call can consume the budget on its own.
+     *  - We check the budget only when deciding whether to *sleep before
+     *    the next retry*. An in-flight `fn()` is NEVER aborted — that
+     *    would require an AbortSignal we don't thread through.
+     *
+     * The name (`backoffBudgetMs`) reflects what callers can rely on: a
+     * cap on how long retry-related *waiting* can grow. It is NOT a hard
+     * cap on the overall withRetry call duration. Omit to disable the
+     * cap (legacy behavior).
      */
     backoffBudgetMs?: number;
 }

--- a/src/infrastructure/utils/withRetry.ts
+++ b/src/infrastructure/utils/withRetry.ts
@@ -25,14 +25,16 @@ export interface WithRetryOptions {
      */
     isRetryable: (error: unknown) => boolean;
     /**
-     * Overall budget across `fn` invocations + backoff sleeps combined,
-     * measured from the first attempt. When the next backoff sleep would push
-     * elapsed time past the deadline, `withRetry` bails out and re-throws the
-     * most recent error rather than waiting. Note this does NOT abort an
-     * in-flight `fn()` — a hanging call still blocks until it settles. Omit
-     * to disable the cap (legacy behavior).
+     * Budget for *backoff sleeps* (NOT individual `fn()` runtime), measured
+     * from the first attempt. When the next backoff sleep would push elapsed
+     * time past the deadline, `withRetry` bails out and re-throws the most
+     * recent error rather than waiting. A hanging in-flight `fn()` is NOT
+     * aborted — that would require an AbortSignal which we don't thread
+     * through. The name reflects this scope: it caps how long retry-related
+     * waiting can grow, not the overall function lifetime. Omit to disable
+     * the cap (legacy behavior).
      */
-    totalTimeoutMs?: number;
+    backoffBudgetMs?: number;
 }
 
 /**
@@ -46,9 +48,9 @@ export async function withRetry<T>(
     fn: () => Promise<T>,
     options: WithRetryOptions
 ): Promise<T> {
-    const { maxRetries, baseDelayMs, isRetryable, totalTimeoutMs } = options;
+    const { maxRetries, baseDelayMs, isRetryable, backoffBudgetMs } = options;
     const deadline =
-        totalTimeoutMs !== undefined ? Date.now() + totalTimeoutMs : Infinity;
+        backoffBudgetMs !== undefined ? Date.now() + backoffBudgetMs : Infinity;
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
         try {
             return await fn();

--- a/src/lib/formatAnalyzedAt.ts
+++ b/src/lib/formatAnalyzedAt.ts
@@ -1,7 +1,39 @@
-// Length of the 'YYYY-MM-DD HH:mm' prefix after replacing the 'T' separator
-// with a space — slice boundary for the compact header display.
+// Length of the 'YYYY-MM-DD HH:mm' prefix — used as a fallback slice boundary
+// for non-ISO inputs (e.g. malformed strings).
 const ANALYZED_AT_DISPLAY_LENGTH = 16;
 
+// 사용자 노출 시각은 KST로 표기한다. Asia/Seoul 고정 — DST가 없어 ICU/Node 버전
+// 차이로 결과가 흔들리지 않는다. en-CA 로케일은 YYYY-MM-DD 포맷을 강제하므로
+// 다른 로케일에서 발생하는 '2026. 05. 22.' 같은 문자열을 피한다.
+const KST_FORMATTER = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+});
+
+/**
+ * ISO 타임스탬프를 사용자가 즉시 환산할 수 있는 KST 표기로 변환한다.
+ *
+ * - 출력 형식: `YYYY-MM-DD HH:mm` (KST 기준)
+ * - `<time dateTime={iso}>`에는 원본 ISO가 그대로 들어가므로 SEO / 스크린리더는
+ *   영향 없음 — 본 함수는 시각적 표기만 담당한다.
+ * - 잘못된 ISO 입력은 그대로 16자 잘라 fallback (기존 동작 호환).
+ */
 export function formatAnalyzedAt(iso: string): string {
-    return iso.replace('T', ' ').slice(0, ANALYZED_AT_DISPLAY_LENGTH);
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) {
+        return iso.slice(0, ANALYZED_AT_DISPLAY_LENGTH);
+    }
+    const parts = KST_FORMATTER.formatToParts(date);
+    const get = (type: Intl.DateTimeFormatPartTypes): string =>
+        parts.find(p => p.type === type)?.value ?? '';
+    // 일부 Node/ICU 버전은 hour12:false 에서 자정에 '24'를 반환한다. KST 자정은
+    // '00:00'로 통일.
+    const rawHour = get('hour');
+    const hour = rawHour === '24' ? '00' : rawHour;
+    return `${get('year')}-${get('month')}-${get('day')} ${hour}:${get('minute')}`;
 }


### PR DESCRIPTION
## 관련 이슈

Deployment review of v0.11.16 → v0.11.17 (Opus tier internal review)

## 구현 내용

이 브랜치는 v0.11.16 → v0.11.17 배포 전 종합 검토 과정에서 식별된 10건의 후속 수정사항을 구현합니다.

### 수정 항목

**옵션 UI 계층 (B1, #8, #9)**
- B1: `OptionsPageClient.tsx` 중첩 `<main>` 회귀 제거 및 OI 스테일 상태 하이드레이션 보호
- #8: `YahooOptionsAdapter.ts` underlyingPrice=0 값 폴백 거부 로직
- #9: (B1에 포함) OI 스테일 상태 하이드레이션 가드

**옵션 데이터 계층 (B2, #4, #10)**
- B2: `optionsDataCache.ts` Upstash 크로스요청 캐시 및 시장 인식 TTL 구현
- #4: `submitOverallAnalysisAction.ts` 옵션 fetch 병렬화 + bot gate 로직
- #10: (B2에 포함) market-aware TTL 전략

**DB 레질리언스 (3, #6, #7)**
- #3: 9개 DB write 경로(newsRepository, usageRepository, usageLogRepository, agreementRepository, contactRepository, sessionRepository, userRepository)에 withRetry 확장
- #6: `withRetry.ts` totalTimeoutMs budget 옵션 추가
- #7: `isNeonTransientError.ts` SQLSTATE 코드 매칭 개선 및 safe-cast 주석

**포매팅 (5, F3)**
- #5: `formatAnalyzedAt.ts` KST 표기 변환 + const ternary 리팩터
- F3: (5에 포함) 포맷팅 개선

## 검토 및 테스트

### 내부 검토
- Round 1 (Opus): 3 required + 4 recommended 지적
- Round 2 (Opus): 모든 지적 반영 후 `approved`
- fix-log.md: 정리 완료 (신규 위반 없음, 기존 문서화된 항목만)

### 테스트 결과
- yarn lint: ✅ exit 0
- npx tsc --noEmit: ✅ exit 0
- yarn test: ✅ 229 suites / 2074 tests passed
- yarn build: ✅ exit 0

## 변경 파일 목록

### 수정
- src/components/options/OptionsPageClient.tsx
- src/infrastructure/db/*.ts (8개 Repository)
- src/infrastructure/market/submitOverallAnalysisAction.ts
- src/infrastructure/options/optionsDataCache.ts
- src/infrastructure/options/YahooOptionsAdapter.ts
- src/infrastructure/utils/withRetry.ts
- src/lib/formatAnalyzedAt.ts
- src/__tests__/**/*.test.ts (5개 테스트 파일)

## 커밋 목록

```
93b08c80 fix(options): nested <main> 회귀 제거 + oiStale 하이드레이션 가드 + underlyingPrice=0 폴백 reject
61bb91ad feat(options): fetchOptionsSnapshot Upstash 크로스요청 캐시 + market-aware TTL + 옵션 병렬화
70e6a5a6 feat(db): withRetry 9개 DB write 경로 확장 + transient error 개선 + budget 옵션
4aa90019 feat(lib): formatAnalyzedAt KST 표기 변환 + const ternary 리팩터
```

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build