### PR TITLE
perf(infra): browserslist + bundle-analyzer 인프라 추가

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -489,3 +489,14 @@
 - S2: `src/infrastructure/options/optionsDataCache.ts` — `1 * SECONDS_PER_MINUTE` 중복 multiplier (MISTAKES.md §15 readability gradient).
   - Rule: MISTAKES.md §15 — 상수와 표시 텍스트의 단일 source.
   - Context: Suggestion — `SECONDS_PER_MINUTE`로 단순화.
+
+## [PR #457 | worktree-agent-a43a5be58b9f76809 | 2026-05-23]
+- Violation: `@next/bundle-analyzer` (^16.2.6) version drifted from `next` (16.2.0)
+- Rule: Next.js convention — `@next/*` packages should match `next` version
+- Context: Added bundle-analyzer with `yarn add` which picked latest 16.2.x; should have constrained to project's pinned next major.minor
+- Violation: `browserslist` missing `last 2 ChromeAndroid versions` despite PR targeting mobile LCP
+- Rule: Config completeness — declared user-base coverage must align with PR's stated optimization goal
+- Context: Browserslist had Chrome/Firefox/Safari/Edge + iOS but no Android Chrome line; siglens.io's mobile users include Android, so SWC transpile target was unintentionally excluding them
+- Violation: `analyze` script missing from package.json scripts after wiring bundle-analyzer
+- Rule: Tool integration — when wiring a tool that needs env-prefixed invocation, expose a script entrypoint so it's discoverable and CI-friendly
+- Context: bundle-analyzer is gated on ANALYZE=true env; without a script, users have to remember the magic command

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,10 @@
 import type { NextConfig } from 'next';
+import bundleAnalyzer from '@next/bundle-analyzer';
+
+// ANALYZE=true 시에만 활성화. 일반 dev/build에는 영향 없음.
+const withBundleAnalyzer = bundleAnalyzer({
+    enabled: process.env.ANALYZE === 'true',
+});
 
 const nextConfig: NextConfig = {
     allowedDevOrigins: ['172.30.1.26'],
@@ -86,4 +92,4 @@ const nextConfig: NextConfig = {
     ],
 };
 
-export default nextConfig;
+export default withBundleAnalyzer(nextConfig);

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from 'next';
 import bundleAnalyzer from '@next/bundle-analyzer';
 
-// ANALYZE=true 시에만 활성화. 일반 dev/build에는 영향 없음.
 const withBundleAnalyzer = bundleAnalyzer({
     enabled: process.env.ANALYZE === 'true',
 });

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "yahoo-finance2": "3.14.1"
     },
     "devDependencies": {
+        "@next/bundle-analyzer": "^16.2.6",
         "@release-it/conventional-changelog": "^10.0.6",
         "@tailwindcss/postcss": "^4",
         "@testing-library/dom": "^10.4.1",
@@ -98,5 +99,13 @@
         "ts-jest": "^29.4.6",
         "typescript": "^5"
     },
-    "packageManager": "yarn@4.12.0"
+    "packageManager": "yarn@4.12.0",
+    "browserslist": [
+        "last 2 Chrome versions",
+        "last 2 Firefox versions",
+        "last 2 Safari versions",
+        "last 2 Edge versions",
+        "iOS >= 15",
+        "not dead"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "prebuild": "yarn clear:backtesting && yarn copy:backtesting",
         "dev": "yarn predev && next dev --turbopack -p 4200",
         "build": "yarn prebuild && rm -rf .next && next build",
+        "analyze": "ANALYZE=true yarn build",
         "start": "next start",
         "lint": "eslint",
         "lint:fix": "eslint --fix",
@@ -65,7 +66,7 @@
         "yahoo-finance2": "3.14.1"
     },
     "devDependencies": {
-        "@next/bundle-analyzer": "^16.2.6",
+        "@next/bundle-analyzer": "^16.2.0",
         "@release-it/conventional-changelog": "^10.0.6",
         "@tailwindcss/postcss": "^4",
         "@testing-library/dom": "^10.4.1",
@@ -102,6 +103,7 @@
     "packageManager": "yarn@4.12.0",
     "browserslist": [
         "last 2 Chrome versions",
+        "last 2 ChromeAndroid versions",
         "last 2 Firefox versions",
         "last 2 Safari versions",
         "last 2 Edge versions",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2222,7 +2222,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/bundle-analyzer@npm:^16.2.6":
+"@next/bundle-analyzer@npm:^16.2.0":
   version: 16.2.6
   resolution: "@next/bundle-analyzer@npm:16.2.6"
   dependencies:
@@ -11477,7 +11477,7 @@ __metadata:
     "@anthropic-ai/sdk": "npm:^0.92.0"
     "@google/genai": "npm:^1.50.1"
     "@neondatabase/serverless": "npm:^1.1.0"
-    "@next/bundle-analyzer": "npm:^16.2.6"
+    "@next/bundle-analyzer": "npm:^16.2.0"
     "@release-it/conventional-changelog": "npm:^10.0.6"
     "@tailwindcss/postcss": "npm:^4"
     "@tanstack/react-query": "npm:^5.95.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -601,6 +601,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@discoveryjs/json-ext@npm:0.5.7":
+  version: 0.5.7
+  resolution: "@discoveryjs/json-ext@npm:0.5.7"
+  checksum: 10c0/e10f1b02b78e4812646ddf289b7d9f2cb567d336c363b266bd50cd223cf3de7c2c74018d91cd2613041568397ef3a4a2b500aba588c6e5bd78c38374ba68f38c
+  languageName: node
+  linkType: hard
+
 "@drizzle-team/brocli@npm:^0.10.2":
   version: 0.10.2
   resolution: "@drizzle-team/brocli@npm:0.10.2"
@@ -2215,6 +2222,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/bundle-analyzer@npm:^16.2.6":
+  version: 16.2.6
+  resolution: "@next/bundle-analyzer@npm:16.2.6"
+  dependencies:
+    webpack-bundle-analyzer: "npm:4.10.1"
+  checksum: 10c0/701b2a08f9666dccbcf1630fdcab3aed9a7bf270a10bb87d1ea9117e708c1ec314271714484b70390e232efa1056d3c5271e5cd22198ba8759246f414d705f94
+  languageName: node
+  linkType: hard
+
 "@next/env@npm:16.2.0":
   version: 16.2.0
   resolution: "@next/env@npm:16.2.0"
@@ -2473,6 +2489,13 @@ __metadata:
   version: 0.2.9
   resolution: "@pkgr/core@npm:0.2.9"
   checksum: 10c0/ac8e4e8138b1a7a4ac6282873aef7389c352f1f8b577b4850778f5182e4a39a5241facbe48361fec817f56d02b51691b383010843fb08b34a8e8ea3614688fd5
+  languageName: node
+  linkType: hard
+
+"@polka/url@npm:^1.0.0-next.24":
+  version: 1.0.0-next.29
+  resolution: "@polka/url@npm:1.0.0-next.29"
+  checksum: 10c0/0d58e081844095cb029d3c19a659bfefd09d5d51a2f791bc61eba7ea826f13d6ee204a8a448c2f5a855c17df07b37517373ff916dd05801063c0568ae9937684
   languageName: node
   linkType: hard
 
@@ -3828,7 +3851,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.15.0":
+"acorn-walk@npm:^8.0.0":
+  version: 8.3.5
+  resolution: "acorn-walk@npm:8.3.5"
+  dependencies:
+    acorn: "npm:^8.11.0"
+  checksum: 10c0/e31bf5b5423ed1349437029d66d708b9fbd1b77a644b031501e2c753b028d13b56348210ed901d5b1d0d86eb3381c0a0fc0d0998511a9d546d1194936266a332
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.0.4, acorn@npm:^8.11.0, acorn@npm:^8.15.0":
   version: 8.16.0
   resolution: "acorn@npm:8.16.0"
   bin:
@@ -4695,6 +4727,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "commander@npm:7.2.0"
+  checksum: 10c0/8d690ff13b0356df7e0ebbe6c59b4712f754f4b724d4f473d3cc5b3fdcf978e3a5dc3078717858a2ceb50b0f84d0660a7f22a96cdc50fb877d0c9bb31593d23a
+  languageName: node
+  linkType: hard
+
 "compare-func@npm:^2.0.0":
   version: 2.0.0
   resolution: "compare-func@npm:2.0.0"
@@ -4977,6 +5016,13 @@ __metadata:
     es-errors: "npm:^1.3.0"
     is-data-view: "npm:^1.0.1"
   checksum: 10c0/fa7aa40078025b7810dcffc16df02c480573b7b53ef1205aa6a61533011005c1890e5ba17018c692ce7c900212b547262d33279fde801ad9843edc0863bf78c4
+  languageName: node
+  linkType: hard
+
+"debounce@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "debounce@npm:1.2.1"
+  checksum: 10c0/6c9320aa0973fc42050814621a7a8a78146c1975799b5b3cc1becf1f77ba9a5aa583987884230da0842a03f385def452fad5d60db97c3d1c8b824e38a8edf500
   languageName: node
   linkType: hard
 
@@ -5337,6 +5383,13 @@ __metadata:
     es-errors: "npm:^1.3.0"
     gopd: "npm:^1.2.0"
   checksum: 10c0/199f2a0c1c16593ca0a145dbf76a962f8033ce3129f01284d48c45ed4e14fea9bbacd7b3610b6cdc33486cef20385ac054948fefc6272fcce645c09468f93031
+  languageName: node
+  linkType: hard
+
+"duplexer@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "duplexer@npm:0.1.2"
+  checksum: 10c0/c57bcd4bdf7e623abab2df43a7b5b23d18152154529d166c1e0da6bee341d84c432d157d7e97b32fecb1bf3a8b8857dd85ed81a915789f550637ed25b8e64fc2
   languageName: node
   linkType: hard
 
@@ -6944,6 +6997,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gzip-size@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "gzip-size@npm:6.0.0"
+  dependencies:
+    duplexer: "npm:^0.1.2"
+  checksum: 10c0/4ccb924626c82125897a997d1c84f2377846a6ef57fbee38f7c0e6b41387fba4d00422274440747b58008b5d60114bac2349c2908e9aba55188345281af40a3f
+  languageName: node
+  linkType: hard
+
 "handlebars@npm:^4.7.7, handlebars@npm:^4.7.9":
   version: 4.7.9
   resolution: "handlebars@npm:4.7.9"
@@ -7133,7 +7195,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-escaper@npm:^2.0.0":
+"html-escaper@npm:^2.0.0, html-escaper@npm:^2.0.2":
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
   checksum: 10c0/208e8a12de1a6569edbb14544f4567e6ce8ecc30b9394fcaa4e7bb1e60c12a7c9a1ed27e31290817157e8626f3a4f29e76c8747030822eb84a6abb15c255f0a0
@@ -9625,6 +9687,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mrmime@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "mrmime@npm:2.0.1"
+  checksum: 10c0/af05afd95af202fdd620422f976ad67dc18e6ee29beb03dd1ce950ea6ef664de378e44197246df4c7cdd73d47f2e7143a6e26e473084b9e4aa2095c0ad1e1761
+  languageName: node
+  linkType: hard
+
 "ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
@@ -10043,6 +10112,15 @@ __metadata:
   bin:
     openai: bin/cli
   checksum: 10c0/b5be8c9c26b8991bc06e94d2de9ec046d7e8497f3828f8ff3cd7796cfd5e39e464a52afa2f4959003183e61a909c6ee261ca4380a61cb1f2e9a56629058314ed
+  languageName: node
+  linkType: hard
+
+"opener@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "opener@npm:1.5.2"
+  bin:
+    opener: bin/opener-bin.js
+  checksum: 10c0/dd56256ab0cf796585617bc28e06e058adf09211781e70b264c76a1dbe16e90f868c974e5bf5309c93469157c7d14b89c35dc53fe7293b0e40b4d2f92073bc79
   languageName: node
   linkType: hard
 
@@ -11399,6 +11477,7 @@ __metadata:
     "@anthropic-ai/sdk": "npm:^0.92.0"
     "@google/genai": "npm:^1.50.1"
     "@neondatabase/serverless": "npm:^1.1.0"
+    "@next/bundle-analyzer": "npm:^16.2.6"
     "@release-it/conventional-changelog": "npm:^10.0.6"
     "@tailwindcss/postcss": "npm:^4"
     "@tanstack/react-query": "npm:^5.95.2"
@@ -11468,6 +11547,17 @@ __metadata:
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
+  languageName: node
+  linkType: hard
+
+"sirv@npm:^2.0.3":
+  version: 2.0.4
+  resolution: "sirv@npm:2.0.4"
+  dependencies:
+    "@polka/url": "npm:^1.0.0-next.24"
+    mrmime: "npm:^2.0.0"
+    totalist: "npm:^3.0.0"
+  checksum: 10c0/68f8ee857f6a9415e9c07a1f31c7c561df8d5f1b1ba79bee3de583fa37da8718def5309f6b1c6e2c3ef77de45d74f5e49efc7959214443aa92d42e9c99180a4e
   languageName: node
   linkType: hard
 
@@ -12184,6 +12274,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"totalist@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "totalist@npm:3.0.1"
+  checksum: 10c0/4bb1fadb69c3edbef91c73ebef9d25b33bbf69afe1e37ce544d5f7d13854cda15e47132f3e0dc4cafe300ddb8578c77c50a65004d8b6e97e77934a69aa924863
+  languageName: node
+  linkType: hard
+
 "tough-cookie-file-store@npm:tough-cookie-file-store@^2.0.3":
   version: 2.0.3
   resolution: "tough-cookie-file-store@npm:2.0.3"
@@ -12855,6 +12952,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webpack-bundle-analyzer@npm:4.10.1":
+  version: 4.10.1
+  resolution: "webpack-bundle-analyzer@npm:4.10.1"
+  dependencies:
+    "@discoveryjs/json-ext": "npm:0.5.7"
+    acorn: "npm:^8.0.4"
+    acorn-walk: "npm:^8.0.0"
+    commander: "npm:^7.2.0"
+    debounce: "npm:^1.2.1"
+    escape-string-regexp: "npm:^4.0.0"
+    gzip-size: "npm:^6.0.0"
+    html-escaper: "npm:^2.0.2"
+    is-plain-object: "npm:^5.0.0"
+    opener: "npm:^1.5.2"
+    picocolors: "npm:^1.0.0"
+    sirv: "npm:^2.0.3"
+    ws: "npm:^7.3.1"
+  bin:
+    webpack-bundle-analyzer: lib/bin/analyzer.js
+  checksum: 10c0/6a94c8f6aa03296fb2eb00d6ad3b27bd5c551590fd253772bc61debf3177414d42701014079d4f85c74ba1ca685ae9f0cb4063812b58c21f294d108e9908e5cd
+  languageName: node
+  linkType: hard
+
 "whatwg-encoding@npm:^3.1.1":
   version: 3.1.1
   resolution: "whatwg-encoding@npm:3.1.1"
@@ -13072,6 +13192,21 @@ __metadata:
   dependencies:
     signal-exit: "npm:^4.0.1"
   checksum: 10c0/69cebb64945e22928a24ae7e2a55bf54438c92d6f657c1fa5e96b7c7a50f6c022e7454ab5c259079bb35f60296242f3a21234c79320d64a8ad57675b56a2098d
+  languageName: node
+  linkType: hard
+
+"ws@npm:^7.3.1":
+  version: 7.5.11
+  resolution: "ws@npm:7.5.11"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/7972670b676fb1ccba73b0899ca3c2e04e8c2075629c2614cced7f556536f96a672bbf4619fc5a06c8b8720bb839a47ca88c69c95dc14c9c61a99fbecba1c866
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 관련 이슈

Wave 1 PR-D — siglens.io 성능 베이스라인 정비 (Mobile LCP 13–20s → < 4s 목표)

## 구현 내용

성능 베이스라인 측정/타기팅을 위한 인프라 작업.

**변경**
- `package.json`: `browserslist` 필드 추가 (last 2 Chrome / Firefox / Safari / Edge, iOS >= 15)
- `package.json`: `@next/bundle-analyzer` devDep 추가
- `next.config.ts`: `withBundleAnalyzer({ enabled: process.env.ANALYZE === 'true' })` 래핑
- `yarn.lock`: devDep 갱신

## 정직한 스코프 노트 (중요)

원래 3개 항목(RSC payload slim / legacy JS polyfills / unused JS lazy split)을 목표로 했으나, 실제 빌드 결과 검증 후 다음과 같이 조정됨.

### legacy JS polyfills — 부분 완료

- `browserslist`는 정상적으로 추가되었지만, **Next.js 16 Turbopack은 `polyfill-module.js`를 하드코딩**해서 `browserslist`를 polyfill에 반영하지 않음.
- ~14 KB polyfill 바이트는 여전히 출하됨. 모던 브라우저는 조건부로 실행을 스킵하므로 런타임 비용은 미미.
- 처음 인용했던 "JS −14 KB" 절감은 Turbopack이 `browserslist`를 존중하기 전까지는 실현되지 않음.
- `browserslist`는 SWC transpile target 축소에는 여전히 유용 (작은 폭의 축소).

### RSC payload slim — SKIP

- fold 아래 컴포넌트(HowItWorks, StatsBar, SkillsShowcase, TickerCategories)는 **모두 SEO-critical**.
- `dynamic({ ssr: false })`는 크롤러에 해로움 → 적용 불가.
- 459 KB inline RSC의 dominant 요인은 SkillsShowcase가 직렬화하는 **67개 skill description**이며, 이 shape은 `@y0ngha/siglens-core` 소관 (CLAUDE.md scope guard).

### unused JS lazy split — SKIP

- 처음 인용된 `05nmpzrzrka_~.js` (53KB, 61% unused) 청크는 **현재 빌드에 존재하지 않음** (Turbopack 해시 변경).
- 현재 `/` 라우트는 40 KB + 17 KB 청크(TickerAutocomplete + SymbolSearchPanel)만 출하 → heavy lib 없음.

### 순효과

symbol 페이지(openai 200KB, lightweight-charts 180KB, react-markdown 117KB 등 heavy lib 출하 지점)에서 **향후 bundle-analyzer 사용을 위한 깔끔한 인프라**.

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만 (해당 없음 — 인프라 변경)
- [x] 반환 타입 명시 (해당 없음)
- [x] any 타입 없음

## 변경 파일 목록

[수정]
- `package.json`
- `next.config.ts`
- `yarn.lock`

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn test
- [x] pre-push hooks (format:check / lintcheck / typecheck / test) 모두 통과

## 사용 방법

```bash
ANALYZE=true yarn build
```

실행 후 `.next/analyze/` 디렉토리에서 client/server bundle treemap 확인 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)