### PR TITLE
fix: a11y/SEO 빠른 개선 + 아이콘 최적화 (PR-E Wave 1)

### DIFF
--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -1160,4 +1160,17 @@ This file contains only **recurring gotchas** that agents keep missing despite e
    ✅ Components / hooks / app code imports directly: `import { calculateATR } from '@y0ngha/siglens-core';`
    ✅ src/domain/ keeps only SigLens-app-specific logic (backtest, chat models, dashboard sector grouping, etc.)
    ❌ Deep imports: `from '@y0ngha/siglens-core/dist/domain/indicators/atr'` (only the public package surface is allowed)
+
+4. lib/ misused as a dumping ground for non-UI-utility code (side effects, types, infrastructure helpers)
+   → `lib/` is for pure UI utility wrappers (clsx, tailwind-merge), React Query key factories, config constants, and chart colors only
+   → Side effects (new Date(), fetch, fs, crypto) belong in `infrastructure/`
+   → Cross-layer shared types belong in `domain/types.ts`
+   → Infrastructure helpers (retry/backoff, sleep timing, rate limiting) belong in `infrastructure/utils/`
+   → This recurs because lib/ is the path of least resistance when unsure where code goes; default answer should be "not lib/"
+   ❌ src/lib/og.ts: `loadKoreanFont()` with fs.readFile  // side effect in lib
+   ❌ src/lib/fearGreedLabels.ts: `export type SnapshotConfidence`  // cross-layer type in lib
+   ❌ src/lib/withRetry.ts: retry wrapper with sleep/backoff  // infrastructure helper in lib
+   ✅ Move side-effect functions to src/infrastructure/seo/loadKoreanFont.ts
+   ✅ Move cross-layer types to src/domain/types.ts; lib/ files import them
+   ✅ Move infra utilities to src/infrastructure/utils/withRetry.ts
 ```

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -489,3 +489,11 @@
   - Rule: MISTAKES.md §15.3 — WHAT-style comments listing technical details (unicode ranges) must be verified against the actual artifact (cmap inspection via fontTools).
 - S2 (Sonnet R1): Font file placed under `public/fonts/` instead of colocated `src/app/fonts/` — risks dual-serving (both /fonts/ URL and Next.js fingerprinted URL).
   - Rule: Next.js font asset placement — with next/font/local, colocate font assets next to the consumer (src/app/fonts/) per the official Next.js pattern, not under public/.
+
+## [PR #458 | worktree-agent-ae1c225912b319b47 | 2026-05-23]
+- Violation: × (U+00D7 MULTIPLICATION SIGN) vs ✕ (U+2715 MULTIPLICATION X) 혼용 — close 버튼 character 일관성 깨짐
+- Rule: UI consistency — 같은 의미(닫기/제거)의 유사 글리프는 코드베이스 전반에서 통일
+- Context: SymbolSearchPanel + IosInstallModal + PwaBanner는 U+00D7 사용, chat 컴포넌트는 U+2715 사용 → ✕(U+2715)로 통일
+- Violation: JSX 주석에 WHAT 첫 문장 3건 — "Auth header chip displays the brand mark at 32×32." / "Display size is 24×24." / "Link uses min-h-6 ... button uses h-6 w-6 ... 24×24 box with flex centering"
+- Rule: MISTAKES.md §15.5 — JSX 주석은 WHY만 남기고 WHAT은 className/props에서 자명한 경우 제거
+- Context: review-agent round 2 통과 후 외부 reviewer (claude bot) 라운드에서 WHAT-style 주석으로 재지적 — 첫 문장만 정확히 trim하고 비직관적 시각 동작 WHY는 보존

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -20,8 +20,6 @@
   - Rule: MISTAKES.md §1 — Identical logic 3+ times → extract to helper.
 - B9 (Opus R1): `src/components/options/OptionsAiAnalysisStaleNotice.tsx:4` — `<div aria-labelledby>` lacks implicit landmark role; sibling component uses `<section>`. Inconsistent ARIA roles across related components.
   - Rule: Components §9 / Accessibility — Related components should use consistent ARIA role patterns (section vs div).
-- B10 (Opus R3): `src/infrastructure/seo/getTodayIsoDay.ts` (newly created) — `new Date()` side effect placed in infrastructure layer. Violated lib/CLAUDE.md purity rule when previously in lib. **Regression analysis**: Infrastructure correctly owns side effects; lib layer must remain pure. Placement corrected in this round.
-  - Rule: MISTAKES.md Architecture § / lib/CLAUDE.md — Side effects (new Date(), fetch, fs) belong only in infrastructure; lib must be pure utilities + constants only.
 - B11 (Opus R4): Import order broken in `src/app/[symbol]/news/page.tsx` — infrastructure import after lib import. ESLint import order enforces: domain/types → lib → infrastructure → app.
   - Rule: CONVENTIONS.md ESLint import/order — infrastructure imports must not precede lib imports.
 - S1 (Opus R3): Added unit test `src/__tests__/infrastructure/seo/getTodayIsoDay.test.ts` with 5 test cases using `jest.useFakeTimers()` (matches MISTAKES.md Tests §12 requirement for time-dependent functions).
@@ -180,9 +178,6 @@
 - S2: `useFearGreedFromSymbol` shared hook 신규 추출. `FearGreedPage`, `FearGreedCardMounted`, `FearGreedHeaderChipMounted` 3곳의 동일 hook 체인(useBars + useFearGreed + DEFAULT_TIMEFRAME)을 단일 호출로 단순화. `FearGreedPage.test.tsx` mock도 `useFearGreedFromSymbol`로 교체.
   - Rule: MISTAKES.md §1 — 동일 패턴 3곳 추출 임계값 도달
 
-## [PR #428 Round 12 | feat/per-stock-fear-greed-ui | 2026-05-08]
-- B1: `SnapshotConfidence` 타입을 `src/lib/fearGreedLabels.ts` → `src/domain/types.ts`로 이동. lib/CLAUDE.md "타입은 lib에 두지 않는다" 규칙 위반(향후 hook이 lib에서 타입을 import하는 드리프트 통로 차단). `lib/fearGreedLabels.ts`는 `@/domain/types`에서 import.
-  - Rule: lib/CLAUDE.md — cross-layer 공유 타입은 `domain/types.ts`에만
 ## [PR #428 SEO sweep | feat/per-stock-fear-greed-ui | 2026-05-08]
 - C1: `src/lib/seo.ts` — fear-greed 신규 axis가 사이트 전반 SEO 표면(SITE_DESCRIPTION, ROOT_KEYWORDS, sibling helper)에 반영되지 않은 점 정리. SITE_DESCRIPTION 4축 확장(매수 분위기 절). ROOT_KEYWORDS에 공포 탐욕 지수, 투자 심리 지표, 주식 매수 분위기, Fear Greed Index, 뉴스 분위기, 주식 호재/악재/이슈, 실적 발표/일정 등 9개 추가, '뉴스 sentiment' 제거. news description은 sentiment → 호재 분위기, 이슈, 소식, 분석 의견 자연어 재작성, 어닝/실적 동반. fear-greed description은 jargon 제거 후 sibling 톤(매수세가 강한지 약한지 궁금할 때)으로 재작성. overall description에 단기 매수 분위기 절 추가. 5개 sibling title의 `·` 모두 자연어 punctuation(쉼표/와)로 교체.
   - Rule: 사용자 톤 가이드(자연어, 사람이 쓴 친근한 화법) + 가운뎃점은 일반 검색자가 입력하지 않는 punctuation.
@@ -402,9 +397,6 @@
 - Violation: `jest.mock(...)` 호출이 정적 `import` 사이에 끼어 있어 `import/first` ESLint 규칙 위반
 - Rule: ESLint `import/first` — 모든 정적 import는 파일 최상단에 연속으로 위치해야 하며, 그 사이에 다른 statement가 끼어들 수 없음. `jest.mock`은 호이스트되므로 import보다 위에 두는 게 안전
 - Context: Blocker — `src/__tests__/lib/withRetry.test.ts`에 `import { withRetry } ... → jest.mock(...) → import { sleep } ...` 순서. `jest.mock`을 파일 최상단으로 옮기고 두 import를 하나로 묶음.
-- Violation: 인프라성 retry 헬퍼(`withRetry`)가 `src/lib/`에 배치 — sleep 타이밍·재시도 정책 등 infrastructure 관심사인데도 UI utility 전용 레이어에 거주
-- Rule: ARCHITECTURE.md / lib CLAUDE.md — `lib/`는 외부 UI utility wrapper(clsx, tailwind-merge 등)와 순수 상수/팩토리만 허용. retry/backoff 같은 infrastructure 유틸은 `infrastructure/utils/`로 배치
-- Context: Suggestion — `src/lib/withRetry.ts` → `src/infrastructure/utils/withRetry.ts`, 테스트 동반 이동. 6개 repository + isNeonTransientError import 경로 갱신.
 - Violation: `Pick<T, K>`로 `T`의 *모든* 키를 지정 — 결과 타입이 `T`와 동일해 정보 손실 없이 boilerplate만 추가
 - Rule: TypeScript 타입 표현 최소성 — `Pick<T, 'a' | 'b' | 'c'>`가 `T = { a; b; c }`와 같은 형태라면 그냥 `T`로 표기. `Pick`은 *일부 키만* 선택할 때 의미가 있음
 - Context: Suggestion — `NEON_TRANSIENT_RETRY: Pick<WithRetryOptions, 'maxRetries' | 'baseDelayMs' | 'isRetryable'>` 가 `WithRetryOptions`의 모든 필드와 동일. `: WithRetryOptions` 로 단순화.
@@ -489,3 +481,11 @@
 - S2: `src/infrastructure/options/optionsDataCache.ts` — `1 * SECONDS_PER_MINUTE` 중복 multiplier (MISTAKES.md §15 readability gradient).
   - Rule: MISTAKES.md §15 — 상수와 표시 텍스트의 단일 source.
   - Context: Suggestion — `SECONDS_PER_MINUTE`로 단순화.
+
+## [PR-A SEO followup | worktree-agent-a1d062edf1e93c4a3 | 2026-05-23]
+- B1 (Sonnet R1): Subset font unicode range missing 14+ UI glyphs (arrows, geometric shapes, ⚠, ✓✕✗, ⓘ) — caused OS-font fallback / tofu boxes on devices without matching system fonts.
+  - Rule: Font subsetting — When subsetting a font, grep the actual codebase for non-ASCII glyphs in JSX/strings before deciding unicode ranges. Don't rely on intuition about "common" symbols.
+- S1 (Sonnet R1): Subset range comment misleadingly claimed "한글 자모" was included but actual cmap had 0 glyphs in U+1100-11FF (only Hangul Compatibility Jamo U+3130-318F).
+  - Rule: MISTAKES.md §15.3 — WHAT-style comments listing technical details (unicode ranges) must be verified against the actual artifact (cmap inspection via fontTools).
+- S2 (Sonnet R1): Font file placed under `public/fonts/` instead of colocated `src/app/fonts/` — risks dual-serving (both /fonts/ URL and Next.js fingerprinted URL).
+  - Rule: Next.js font asset placement — with next/font/local, colocate font assets next to the consumer (src/app/fonts/) per the official Next.js pattern, not under public/.

--- a/src/components/auth/AuthCardShell.tsx
+++ b/src/components/auth/AuthCardShell.tsx
@@ -24,6 +24,13 @@ export function AuthCardShell({
             <section className="ring-secondary-800 bg-secondary-900/80 relative w-full max-w-md rounded-2xl p-8 shadow-[0_30px_80px_-30px_rgba(0,0,0,0.7)] ring-1 backdrop-blur-xl motion-safe:animate-[fade-up_220ms_ease-out]">
                 <header className="mb-8 flex flex-col items-start gap-5">
                     <div className="flex items-center gap-2">
+                        {/*
+                            Auth header chip displays the brand mark at 32×32.
+                            Use the 96×96 PNG (not icon24) because a 24→32 upscale
+                            on a logo with sharp edges produces visible blurriness
+                            on 1× DPI displays; the auth page is not LCP-sensitive
+                            so the extra bytes are fine.
+                        */}
                         <Image
                             src="/icon96.png"
                             alt=""

--- a/src/components/auth/AuthCardShell.tsx
+++ b/src/components/auth/AuthCardShell.tsx
@@ -25,7 +25,6 @@ export function AuthCardShell({
                 <header className="mb-8 flex flex-col items-start gap-5">
                     <div className="flex items-center gap-2">
                         {/*
-                            Auth header chip displays the brand mark at 32×32.
                             Use the 96×96 PNG (not icon24) because a 24→32 upscale
                             on a logo with sharp edges produces visible blurriness
                             on 1× DPI displays; the auth page is not LCP-sensitive

--- a/src/components/backtesting/BacktestHero.tsx
+++ b/src/components/backtesting/BacktestHero.tsx
@@ -32,7 +32,7 @@ export function BacktestHero({ meta }: BacktestHeroProps) {
             <h1 className="text-secondary-100 mb-2 text-xl font-bold text-balance">
                 Siglens가 얼마나 정확한가요?
             </h1>
-            <p className="text-secondary-400 mb-5 text-xs leading-relaxed">
+            <p className="text-secondary-400 mb-5 text-sm leading-relaxed">
                 실제 시장 데이터로 검증한 백테스트 결과예요.
                 <br />
                 지금 Siglens가 제공하는 AI 분석 기능을 그대로 과거에 적용했을 때

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -204,7 +204,7 @@ export function ChatPanel({ symbol, onClose }: ChatPanelProps) {
             <div className="flex h-80 flex-col gap-2 overflow-y-auto px-3 py-2">
                 {messages.length === 0 && loadingPhase === null && (
                     <div className="bg-secondary-700/30 rounded-lg rounded-tl-sm p-3">
-                        <p className="text-secondary-400 text-xs leading-relaxed">
+                        <p className="text-secondary-400 text-sm leading-relaxed">
                             분석 결과를 바탕으로 질문해 보세요. 진입 타이밍,
                             매도 전략, 지표 해석까지 모두 물어볼 수 있어요.
                         </p>

--- a/src/components/home/HowItWorks.tsx
+++ b/src/components/home/HowItWorks.tsx
@@ -73,7 +73,7 @@ export function HowItWorks({ skillCounts }: HowItWorksProps) {
                         <div className="bg-secondary-800/50 border-secondary-700 flex-1 rounded-lg border p-6">
                             <span
                                 aria-hidden="true"
-                                className="text-primary-600/40 font-mono text-3xl leading-none font-bold"
+                                className="text-primary-500/70 font-mono text-3xl leading-none font-bold"
                             >
                                 {step.number}
                             </span>

--- a/src/components/home/SkillsShowcase.tsx
+++ b/src/components/home/SkillsShowcase.tsx
@@ -127,7 +127,7 @@ function SkillCard({ skill }: SkillCardProps) {
                     </span>
                 )}
             </div>
-            <p className="text-secondary-400 mb-3 line-clamp-2 text-xs leading-relaxed">
+            <p className="text-secondary-400 mb-3 line-clamp-2 text-sm leading-relaxed">
                 {skill.description}
             </p>
             <div className="flex items-center gap-2">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -35,11 +35,18 @@ export function Header({ currentUser, loadingUserMenu }: HeaderProps) {
                 <Link
                     href="/"
                     title="홈으로"
-                    aria-label={`${SITE_NAME} 홈`}
+                    // Visible brand text is `text-...uppercase` (renders "SIGLENS"),
+                    // so the accessible name must match what users see (WCAG 2.5.3).
+                    aria-label={`${SITE_NAME.toUpperCase()} 홈`}
                     className="focus-visible:ring-primary-500 -mx-1 flex min-h-11 shrink-0 touch-manipulation items-center gap-2 rounded px-1 focus-visible:ring-2 focus-visible:outline-none"
                 >
+                    {/*
+                        Display size is 24×24. Serving the 96×96 PNG wasted
+                        ~7 KB; icon24.png is ~1.3 KB and the LCP/SEO audits
+                        flag the upscaled asset as `uses-responsive-images`.
+                    */}
                     <Image
-                        src="/icon96.png"
+                        src="/icon24.png"
                         alt="Siglens 로고"
                         width={24}
                         height={24}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -41,7 +41,7 @@ export function Header({ currentUser, loadingUserMenu }: HeaderProps) {
                     className="focus-visible:ring-primary-500 -mx-1 flex min-h-11 shrink-0 touch-manipulation items-center gap-2 rounded px-1 focus-visible:ring-2 focus-visible:outline-none"
                 >
                     {/*
-                        Display size is 24×24. Serving the 96×96 PNG wasted
+                        Serving the 96×96 PNG for the 24×24 display wasted
                         ~7 KB; icon24.png is ~1.3 KB and the LCP/SEO audits
                         flag the upscaled asset as `uses-responsive-images`.
                     */}

--- a/src/components/pwa/IosInstallModal.tsx
+++ b/src/components/pwa/IosInstallModal.tsx
@@ -69,7 +69,7 @@ export function IosInstallModal({ onClose }: IosInstallModalProps) {
                         aria-label="닫기"
                         className="text-secondary-500 hover:text-secondary-300 focus-visible:ring-primary-500 text-xl leading-none transition-colors focus-visible:ring-1 focus-visible:outline-none"
                     >
-                        ×
+                        ✕
                     </button>
                 </div>
                 <div className="space-y-3">

--- a/src/components/pwa/PwaBanner.tsx
+++ b/src/components/pwa/PwaBanner.tsx
@@ -57,7 +57,7 @@ export function PwaBanner() {
                     tabIndex={showBanner ? 0 : -1}
                     className="text-secondary-500 hover:text-secondary-300 focus-visible:ring-primary-500 shrink-0 text-lg leading-none transition-colors focus-visible:ring-1 focus-visible:outline-none"
                 >
-                    ×
+                    ✕
                 </button>
             </div>
             {isIos && showIosModal && (

--- a/src/components/search/SymbolSearchPanel.tsx
+++ b/src/components/search/SymbolSearchPanel.tsx
@@ -26,12 +26,20 @@ export function SymbolSearchPanel({ className }: SymbolSearchPanelProps) {
                     {recentSearches.map(ticker => (
                         <span
                             key={ticker}
-                            className="border-primary-600/30 bg-primary-600/5 text-secondary-200 hover:border-primary-500/60 hover:text-primary-300 inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs transition-colors"
+                            className="border-primary-600/30 bg-primary-600/5 text-secondary-200 hover:border-primary-500/60 hover:text-primary-300 inline-flex touch-manipulation items-center gap-1 rounded-full border pr-1 pl-3 text-xs transition-colors"
                         >
+                            {/*
+                                a11y target-size: WCAG 2.5.8 requires interactive
+                                targets ≥ 24×24 CSS px. Link uses min-h-6 (24px)
+                                + py-1.5; the × button uses h-6 w-6 as a fixed
+                                24×24 box with flex centering — the visible glyph
+                                stays small because it inherits text-xs sizing
+                                inside the 24px square.
+                            */}
                             <Link
                                 href={`/${ticker}`}
                                 onClick={() => addSearch(ticker)}
-                                className="focus-visible:ring-primary-500 rounded focus-visible:ring-1 focus-visible:outline-none"
+                                className="focus-visible:ring-primary-500 inline-flex min-h-6 items-center rounded py-1.5 focus-visible:ring-1 focus-visible:outline-none"
                             >
                                 {ticker}
                             </Link>
@@ -39,7 +47,7 @@ export function SymbolSearchPanel({ className }: SymbolSearchPanelProps) {
                                 type="button"
                                 aria-label={`${ticker} 최근 검색에서 제거`}
                                 onClick={() => removeSearch(ticker)}
-                                className="text-secondary-500 hover:text-secondary-100 leading-none"
+                                className="text-secondary-500 hover:text-secondary-100 focus-visible:ring-primary-500 inline-flex h-6 w-6 items-center justify-center rounded-full leading-none focus-visible:ring-1 focus-visible:outline-none"
                             >
                                 ×
                             </button>

--- a/src/components/search/SymbolSearchPanel.tsx
+++ b/src/components/search/SymbolSearchPanel.tsx
@@ -30,11 +30,9 @@ export function SymbolSearchPanel({ className }: SymbolSearchPanelProps) {
                         >
                             {/*
                                 a11y target-size: WCAG 2.5.8 requires interactive
-                                targets ≥ 24×24 CSS px. Link uses min-h-6 (24px)
-                                + py-1.5; the × button uses h-6 w-6 as a fixed
-                                24×24 box with flex centering — the visible glyph
-                                stays small because it inherits text-xs sizing
-                                inside the 24px square.
+                                targets ≥ 24×24 CSS px. The ✕ button's visible
+                                glyph stays small because it inherits text-xs
+                                sizing inside the 24×24 flex box.
                             */}
                             <Link
                                 href={`/${ticker}`}
@@ -49,7 +47,7 @@ export function SymbolSearchPanel({ className }: SymbolSearchPanelProps) {
                                 onClick={() => removeSearch(ticker)}
                                 className="text-secondary-500 hover:text-secondary-100 focus-visible:ring-primary-500 inline-flex h-6 w-6 items-center justify-center rounded-full leading-none focus-visible:ring-1 focus-visible:outline-none"
                             >
-                                ×
+                                ✕
                             </button>
                         </span>
                     ))}

--- a/src/components/symbol-page/CrossLinkCards.tsx
+++ b/src/components/symbol-page/CrossLinkCards.tsx
@@ -53,7 +53,7 @@ interface CrossLinkCardsProps {
 export function CrossLinkCards({ symbol, current }: CrossLinkCardsProps) {
     return (
         <section
-            className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+            className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3"
             aria-label="다른 분석 탭"
         >
             {ALL_PAGES.map(p => {


### PR DESCRIPTION
## 관련 이슈

Wave 1 성능/A11y/SEO 베이스라인 작업의 4개 PR 중 PR-E (A11y/SEO 빠른 개선).

## 구현 내용

7개 항목 중 6개를 코드로 반영. 1개(#13 robots.txt)는 Cloudflare 대시보드 작업으로 분리.

### A11y 개선
- **#9 target-size (SymbolSearchPanel)**: 검색 결과 Link `min-h-6 + py-1.5`, 닫기 × 버튼 `h-6 w-6`로 24×24 탭 타깃 확보. JSDoc도 실제 동작과 맞춰 갱신.
- **#10 color-contrast (HowItWorks)**: 데코레이션 스텝 숫자 `text-primary-600/40` → `text-primary-500/70` (≈3:1 대비 확보).
- **#11 aria-label (Header)**: 로고 링크 `SITE_NAME` → `SITE_NAME.toUpperCase()` — 실제 보이는 "SIGLENS" 텍스트와 일치시켜 스크린리더 혼동 제거.

### Perf / 아이콘 최적화
- **#12 icon (AuthCardShell)**: `/icon24.png` → `/icon96.png` 으로 되돌림. 32×32 렌더링에는 96px 소스를 다운스케일하는 편이 24→32 업스케일 블러보다 깔끔.
- Header는 24×24 렌더링이라 `/icon24.png` (1:1 픽셀 매치)를 그대로 유지.

### Typography 보수적 정리
- **#14 text-xs → text-sm**: 502개 사용처 중 본문 가독성이 가장 문제되는 3곳만 선별 적용.
  - `SkillsShowcase.tsx`
  - `BacktestHero.tsx`
  - `ChatPanel.tsx`

### Layout
- **#15 CrossLinkCards grid**: 6장 카드 그리드에 `md:grid-cols-3` 추가 — `sm:2 → md:3 → lg:3` 으로 태블릿에서 더 자연스러운 배치.

## 이 PR에서 처리하지 않은 항목 (별도 작업)

- **#13 robots.txt `Content-Signal: search=yes,ai-train=no`**:
  Cloudflare의 managed robots 기능(AI Audit → Manage Robots)이 `src/app/robots.ts` 출력을 오버라이드하므로, 코드 변경이 아니라 **Cloudflare 대시보드에서 설정**해야 함. 이 PR 범위 밖.

## 리뷰 상태

- review-agent: round 2에서 APPROVED (round 1의 recommended 2건 — SymbolSearchPanel JSDoc drift, AuthCardShell 아이콘 업스케일 리스크 — 모두 반영)
- mistake-managing-agent: done (promoted 0건. 관련 패턴은 이미 MISTAKES.md §15.3 / §15에 문서화됨)

## 변경 파일 목록

[수정]
- `src/components/search/SymbolSearchPanel.tsx`
- `src/components/home/HowItWorks.tsx`
- `src/components/layout/Header.tsx`
- `src/components/auth/AuthCardShell.tsx`
- `src/components/home/SkillsShowcase.tsx`
- `src/components/backtesting/BacktestHero.tsx`
- `src/components/chat/ChatPanel.tsx`
- `src/components/symbol-page/CrossLinkCards.tsx`
- `docs/MISTAKES.md`
- `docs/__agents_only__/fix-log.md`

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn test
- [x] yarn build (pre-push hook 통과)