### PR TITLE
refactor: [#439] Next.js 16.1.2 downgrade & cacheComponents 재활성화

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -35,14 +35,16 @@ const nextConfig: NextConfig = {
         '/**': ['./skills/**/*'],
     },
 
-    // cacheComponents (Next.js 16 PPR + 'use cache' directive)는 임시 비활성.
-    // 활성 상태에서 모든 [symbol] 라우트가 "Couldn't find all resumable slots"
-    // 에러로 client fallback rendering으로 떨어져 SEO bot이 metadata를 못 보는
-    // 문제가 발생했음(이슈 #439 참조). 표준 SSR로 임시 회귀 후 root cause
-    // 진단 + 안전한 fix가 마련되면 재활성화. 재활성화 시 options-market-open
-    // (stale 1m / revalidate 5m / expire 30m), options-market-closed
-    // (5m / 30m / 2h), options-weekend (1h / 6h / 1d) cacheLife profile도
-    // 함께 부활시킬 것.
+    // cacheComponents (Next.js 16 PPR + 'use cache' directive) 재활성화.
+    // next@16.2.x에서는 모든 [symbol] 라우트가 "Couldn't find all resumable
+    // slots" 에러로 client fallback rendering으로 떨어져 SEO bot이 metadata를
+    // 못 보는 회귀가 있어 next@16.1.2로 pin한 상태(이슈 #439). 'use cache' /
+    // cacheLife / cacheTag 지시어도 함께 복구 — cacheComponents는 opt-in
+    // 캐싱을 강제하므로 prerender 가능한 server component는 cache 지시어가
+    // 있어야 build pass. cacheLife profile(options-market-open/closed/weekend)
+    // 도입은 다음 PR로 분리. upstream resumable slots 픽스 머지 후 16.2+
+    // 재진입 가능.
+    cacheComponents: true,
 
     // Turbopack (Next.js 16 기본값이나 명시)
     turbopack: {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "gray-matter": "^4.0.3",
         "jsonrepair": "^3.14.0",
         "lightweight-charts": "^5.1.0",
-        "next": "16.2.0",
+        "next": "16.1.2",
         "openai": "^6.35.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -67,7 +67,7 @@
         "yahoo-finance2": "3.14.1"
     },
     "devDependencies": {
-        "@next/bundle-analyzer": "^16.2.0",
+        "@next/bundle-analyzer": "16.1.2",
         "@release-it/conventional-changelog": "^10.0.6",
         "@tailwindcss/postcss": "^4",
         "@testing-library/dom": "^10.4.1",
@@ -84,7 +84,7 @@
         "dotenv-cli": "^11.0.0",
         "drizzle-kit": "^0.31.10",
         "eslint": "^9",
-        "eslint-config-next": "16.2.0",
+        "eslint-config-next": "16.1.2",
         "glob": "^13.0.6",
         "husky": "^9.1.7",
         "jest": "^30.2.0",

--- a/src/app/CLAUDE.md
+++ b/src/app/CLAUDE.md
@@ -48,10 +48,14 @@ const data = await fetch(url, {
 });
 ```
 
-> **Note (cacheComponents 비활성화):** 현재 `next.config.ts`에서 `cacheComponents`는
-> 비활성화 상태다. PPR resumable slots 오류로 인한 SEO metadata placeholder 누출 때문에
-> 임시로 꺼 둔 상태이며, 추후 재활성화 시 `'use cache'` / `cacheLife` / `cacheTag` 패턴과
-> dynamic metadata 처리 방식을 함께 재설계해야 한다.
+> **Note (cacheComponents 활성화 / phase 1):** `next.config.ts`에서 `cacheComponents: true`
+> 상태이며 next 버전은 16.1.2로 pin되어 있다(16.2.x resumable slots 회귀 회피 — 이슈 #439).
+> 활성화와 동시에 `'use cache'` / `cacheLife` / `cacheTag` 지시어도 복구되었으며
+> (fundamentalData, newsData, getBarsAction, loader, CurrentYear), 이는 cacheComponents가
+> opt-in 캐싱을 강제하기 때문이다 — prerender 가능한 server component는 명시적 cache
+> 지시어 없이는 build가 실패한다. cacheLife profile(options-market-open/closed/weekend)
+> 도입은 후속 PR로 분리. Route Handler에서 `export const dynamic = 'force-dynamic'`은
+> incompatible — 제거하고 Cache-Control 헤더로 CDN cache를 제어한다.
 
 ---
 
@@ -68,9 +72,10 @@ Server Actions are defined in `infrastructure/market/` and called directly from 
 
 - Use `proxy.ts` instead of `middleware.ts` (if needed)
 - Follow App Router conventions
-- `cacheComponents` (PPR)는 현재 비활성화 — 활성화 시 dynamic route의 `generateMetadata`가
-  fake-params로 prerender되어 canonical에 `[SYMBOL]` placeholder가 박히는 문제를 다시
-  검토해야 한다.
+- `cacheComponents` (PPR)는 활성화 상태(phase 1). dynamic route의 `generateMetadata`가
+  fake-params로 prerender되어 canonical에 `[SYMBOL]` placeholder가 박히는 문제는 phase 2
+  ('use cache' 복구 + dynamic metadata 처리 재설계)에서 함께 다룬다 — Vercel preview
+  배포에서 해당 증상이 재발하면 그 시점에 다시 검토.
 
 ---
 

--- a/src/app/[symbol]/fundamental/fundamentalData.ts
+++ b/src/app/[symbol]/fundamental/fundamentalData.ts
@@ -1,8 +1,10 @@
+import { cacheLife, cacheTag } from 'next/cache';
 import { cache } from 'react';
 import { getDatabaseClient } from '@/infrastructure/db/client';
 import { DrizzleProfileDescriptionTranslationRepository } from '@/infrastructure/db/tickerRepository';
 import { FmpFundamentalClient } from '@/infrastructure/fmp/fundamentalClient';
 import { translateCompanyDescription } from '@/infrastructure/ticker/koreanTranslator';
+import { TTL_T4_30D, TTL_T3_7D, TTL_T2_24H } from '@/lib/fundamental/cacheTtl';
 import type {
     FundamentalProfile,
     FundamentalPeerInput,
@@ -17,17 +19,16 @@ import type {
     FundamentalPriceTargetSummaryInput,
 } from '@y0ngha/siglens-core';
 
-// cacheComponents 비활성 기간 동안 'use cache' / cacheLife / cacheTag를 모두 제거.
-// 동일 요청 내 중복 호출은 React.cache로 per-request memoization을 적용해
-// FMP HTTP 호출 중복을 막는다. cross-request 캐싱은 손실 — PPR 재활성화 또는
-// unstable_cache 도입 시 복원할 것 (이슈 #439 참조).
 const fundamentalClient = new FmpFundamentalClient();
 
-export const getProfile = cache(
-    async (symbol: string): Promise<FundamentalProfile | null> => {
-        return fundamentalClient.getProfile(symbol);
-    }
-);
+export async function getProfile(
+    symbol: string
+): Promise<FundamentalProfile | null> {
+    'use cache';
+    cacheLife({ revalidate: TTL_T4_30D });
+    cacheTag(`fundamental:profile:${symbol}`);
+    return fundamentalClient.getProfile(symbol);
+}
 
 /**
  * Returns the Korean translation of the company description, storing it in
@@ -36,10 +37,11 @@ export const getProfile = cache(
  * Read path: DB lookup (instant on cache hit).
  * Write path: Gemini translation → DB upsert (first visit per symbol only).
  *
- * Nested `cache()` 호출 의도: 이 함수와 내부에서 호출하는 `getProfile`이 둘 다
- * 별도 per-request memoization을 갖는다. 같은 요청에서 description-Ko 미스이지만
- * profile은 이미 다른 호출자가 캐싱한 경우, 내부 `getProfile(symbol)`이 추가 FMP
- * 호출을 발생시키지 않는다.
+ * `'use cache'` 대신 React.cache를 쓰는 이유: 함수가 DB upsert + 외부 Gemini
+ * 호출이라는 side effect를 갖는다. Next.js 'use cache'는 pure read에 적합하고
+ * 첫 write 이후의 cache invalidation 보장이 까다로워, per-request dedup만으로
+ * 충분한 이 함수는 React.cache로 처리한다. 내부에서 호출하는 `getProfile`은
+ * 'use cache'가 적용되어 cross-request memoization이 그대로 동작한다.
  */
 export const getProfileDescriptionKo = cache(
     async (symbol: string): Promise<string | null> => {
@@ -62,66 +64,92 @@ export const getProfileDescriptionKo = cache(
     }
 );
 
-export const getStockPeers = cache(
-    async (symbol: string): Promise<FundamentalPeerInput[]> => {
-        return fundamentalClient.getStockPeers(symbol);
-    }
-);
+export async function getStockPeers(
+    symbol: string
+): Promise<FundamentalPeerInput[]> {
+    'use cache';
+    cacheLife({ revalidate: TTL_T4_30D });
+    cacheTag(`fundamental:stock-peers:${symbol}`);
+    return fundamentalClient.getStockPeers(symbol);
+}
 
-export const getKeyMetricsTtm = cache(
-    async (symbol: string): Promise<FundamentalValuationMetrics | null> => {
-        return fundamentalClient.getKeyMetricsTtm(symbol);
-    }
-);
+export async function getKeyMetricsTtm(
+    symbol: string
+): Promise<FundamentalValuationMetrics | null> {
+    'use cache';
+    cacheLife({ revalidate: TTL_T3_7D });
+    cacheTag(`fundamental:key-metrics-ttm:${symbol}`);
+    return fundamentalClient.getKeyMetricsTtm(symbol);
+}
 
-export const getRatiosTtm = cache(
-    async (symbol: string): Promise<FundamentalRatiosInput | null> => {
-        return fundamentalClient.getRatiosTtm(symbol);
-    }
-);
+export async function getRatiosTtm(
+    symbol: string
+): Promise<FundamentalRatiosInput | null> {
+    'use cache';
+    cacheLife({ revalidate: TTL_T3_7D });
+    cacheTag(`fundamental:ratios-ttm:${symbol}`);
+    return fundamentalClient.getRatiosTtm(symbol);
+}
 
-export const getIncomeStatementGrowth = cache(
-    async (symbol: string): Promise<FundamentalGrowthInput | null> => {
-        return fundamentalClient.getIncomeStatementGrowth(symbol);
-    }
-);
+export async function getIncomeStatementGrowth(
+    symbol: string
+): Promise<FundamentalGrowthInput | null> {
+    'use cache';
+    cacheLife({ revalidate: TTL_T3_7D });
+    cacheTag(`fundamental:income-statement-growth:${symbol}`);
+    return fundamentalClient.getIncomeStatementGrowth(symbol);
+}
 
-export const getFinancialScores = cache(
-    async (symbol: string): Promise<FundamentalFinancialScoresInput | null> => {
-        return fundamentalClient.getFinancialScores(symbol);
-    }
-);
+export async function getFinancialScores(
+    symbol: string
+): Promise<FundamentalFinancialScoresInput | null> {
+    'use cache';
+    cacheLife({ revalidate: TTL_T3_7D });
+    cacheTag(`fundamental:financial-scores:${symbol}`);
+    return fundamentalClient.getFinancialScores(symbol);
+}
 
-export const getCashFlowStatement = cache(
-    async (symbol: string): Promise<FundamentalCashFlowInput | null> => {
-        return fundamentalClient.getCashFlowStatement(symbol);
-    }
-);
+export async function getCashFlowStatement(
+    symbol: string
+): Promise<FundamentalCashFlowInput | null> {
+    'use cache';
+    cacheLife({ revalidate: TTL_T3_7D });
+    cacheTag(`fundamental:cash-flow-statement:${symbol}`);
+    return fundamentalClient.getCashFlowStatement(symbol);
+}
 
-export const getAnalystEstimates = cache(
-    async (symbol: string): Promise<FundamentalAnalystEstimateInput | null> => {
-        return fundamentalClient.getAnalystEstimates(symbol);
-    }
-);
+export async function getAnalystEstimates(
+    symbol: string
+): Promise<FundamentalAnalystEstimateInput | null> {
+    'use cache';
+    cacheLife({ revalidate: TTL_T2_24H });
+    cacheTag(`fundamental:analyst-estimates:${symbol}`);
+    return fundamentalClient.getAnalystEstimates(symbol);
+}
 
-export const getGradesConsensus = cache(
-    async (symbol: string): Promise<FundamentalGradesConsensusInput | null> => {
-        return fundamentalClient.getGradesConsensus(symbol);
-    }
-);
+export async function getGradesConsensus(
+    symbol: string
+): Promise<FundamentalGradesConsensusInput | null> {
+    'use cache';
+    cacheLife({ revalidate: TTL_T2_24H });
+    cacheTag(`fundamental:grades-consensus:${symbol}`);
+    return fundamentalClient.getGradesConsensus(symbol);
+}
 
-export const getPriceTargetConsensus = cache(
-    async (
-        symbol: string
-    ): Promise<FundamentalPriceTargetConsensusInput | null> => {
-        return fundamentalClient.getPriceTargetConsensus(symbol);
-    }
-);
+export async function getPriceTargetConsensus(
+    symbol: string
+): Promise<FundamentalPriceTargetConsensusInput | null> {
+    'use cache';
+    cacheLife({ revalidate: TTL_T2_24H });
+    cacheTag(`fundamental:price-target-consensus:${symbol}`);
+    return fundamentalClient.getPriceTargetConsensus(symbol);
+}
 
-export const getPriceTargetSummary = cache(
-    async (
-        symbol: string
-    ): Promise<FundamentalPriceTargetSummaryInput | null> => {
-        return fundamentalClient.getPriceTargetSummary(symbol);
-    }
-);
+export async function getPriceTargetSummary(
+    symbol: string
+): Promise<FundamentalPriceTargetSummaryInput | null> {
+    'use cache';
+    cacheLife({ revalidate: TTL_T2_24H });
+    cacheTag(`fundamental:price-target-summary:${symbol}`);
+    return fundamentalClient.getPriceTargetSummary(symbol);
+}

--- a/src/app/[symbol]/news/newsData.ts
+++ b/src/app/[symbol]/news/newsData.ts
@@ -1,4 +1,4 @@
-import { cache } from 'react';
+import { cacheLife, cacheTag } from 'next/cache';
 import { getDatabaseClient } from '@/infrastructure/db/client';
 import { DrizzleNewsRepository } from '@/infrastructure/db/newsRepository';
 import { DrizzleEarningsReportsRepository } from '@/infrastructure/db/earningsReportsRepository';
@@ -8,27 +8,35 @@ import { NEWS_LOOKBACK_MS } from '@/infrastructure/market/newsLookback';
 import type { NewsRow } from '@/infrastructure/db/newsRepository';
 import type { GradesEvent } from '@y0ngha/siglens-core';
 import type { EarningsReportComparisonItem } from '@/domain/types';
+import { NEWS_GRADES_TTL_S, NEWS_LIST_TTL_S } from '@/lib/news/cacheTtl';
 
-// cacheComponents 비활성 기간 동안 'use cache' / cacheLife / cacheTag 모두 제거.
-// 동일 요청 내 중복 호출(예: NewsPage 본문 + NewsListSection 내부)은 React.cache로
-// per-request memoization을 적용해 DB/FMP 중복 조회를 막는다. cross-request 캐싱은
-// 손실 — 이슈 #439 참조.
 const fundamentalClient = new FmpFundamentalClient();
 const EARNINGS_REPORT_FMP_LIMIT = 5;
 const EARNINGS_REPORT_STALE_MS = MS_PER_DAY;
 
-export const getNewsList = cache(async (symbol: string): Promise<NewsRow[]> => {
+export async function getNewsList(symbol: string): Promise<NewsRow[]> {
+    'use cache';
+    cacheLife({ revalidate: NEWS_LIST_TTL_S });
+    cacheTag(`news:list:${symbol}`);
+
     const { db } = getDatabaseClient();
     const repo = new DrizzleNewsRepository(db);
     return repo.listBySymbol(symbol, NEWS_LOOKBACK_MS);
-});
+}
 
-export const getGradeEvents = cache(
-    async (symbol: string): Promise<GradesEvent[]> => {
-        return fundamentalClient.getGrades(symbol);
-    }
-);
+export async function getGradeEvents(symbol: string): Promise<GradesEvent[]> {
+    'use cache';
+    cacheLife({ revalidate: NEWS_GRADES_TTL_S });
+    cacheTag(`news:grades:${symbol}`);
 
+    return fundamentalClient.getGrades(symbol);
+}
+
+/**
+ * `'use cache'` 미지정 — DB 쿼리 + 조건부 외부 FMP 호출 + DB upsert로 side
+ * effect가 있고, refresh 조건이 `Date.now()` 기반 stale 판정을 매번 평가해야
+ * 한다. cross-request 캐싱 대상이 아니라 의도적으로 per-request 동작.
+ */
 export async function getEarningsReportComparison(
     symbol: string,
     today: string

--- a/src/app/api/sitemap/longtail/[page]/route.ts
+++ b/src/app/api/sitemap/longtail/[page]/route.ts
@@ -5,9 +5,6 @@ import type { SitemapEntry } from '@/infrastructure/sitemap/types';
 import { toUrlSetXml } from '@/infrastructure/sitemap/xml';
 import { SITE_BUILD_DATE, SITE_URL } from '@/lib/seo';
 
-// DB 의존(no-store fetch)이라 force-dynamic. trafic 보호는 CDN cache에 위임.
-export const dynamic = 'force-dynamic';
-
 interface RouteContext {
     params: Promise<{ page: string }>;
 }

--- a/src/app/api/sitemap/popular/route.ts
+++ b/src/app/api/sitemap/popular/route.ts
@@ -2,10 +2,6 @@ import { NextResponse } from 'next/server';
 import { buildPopularEntries } from '@/infrastructure/sitemap/buildPopularEntries';
 import { toUrlSetXml } from '@/infrastructure/sitemap/xml';
 
-// hasOptionsMarket probe(Yahoo Finance) + 슬라이딩 lastmod 때문에 빌드 시점
-// prerender 불가. force-dynamic + CDN 1h max-age로 처리.
-export const dynamic = 'force-dynamic';
-
 export async function GET(): Promise<Response> {
     const xml = toUrlSetXml(await buildPopularEntries(new Date()));
     return new NextResponse(xml, {

--- a/src/app/api/sitemap/route.ts
+++ b/src/app/api/sitemap/route.ts
@@ -5,10 +5,6 @@ import { SITEMAP_MAX_URLS_PER_FILE } from '@/infrastructure/sitemap/types';
 import { toSitemapIndexXml } from '@/infrastructure/sitemap/xml';
 import { SITE_BUILD_DATE, SITE_URL } from '@/lib/seo';
 
-// loadLongTailTickers는 DB 조회(no-store fetch)라 빌드 시점 prerender 불가.
-// force-dynamic + CDN 1h cache로 처리.
-export const dynamic = 'force-dynamic';
-
 /**
  * 메인 sitemap은 sitemapindex로 동작한다 — sub-sitemap 여러 개를 가리키는
  * 메타 파일. 단일 urlset에 모든 URL을 박는 기존 방식은 sitemap.org 50,000개

--- a/src/app/api/sitemap/static/route.ts
+++ b/src/app/api/sitemap/static/route.ts
@@ -2,10 +2,6 @@ import { NextResponse } from 'next/server';
 import { buildStaticEntries } from '@/infrastructure/sitemap/buildStaticEntries';
 import { toUrlSetXml } from '@/infrastructure/sitemap/xml';
 
-// /market 엔트리의 1시간 슬라이딩 lastmod 때문에 빌드 시점 prerender 불가.
-// CDN max-age 1h + SWR 1h로 trafic 보호.
-export const dynamic = 'force-dynamic';
-
 export async function GET(): Promise<Response> {
     const xml = toUrlSetXml(buildStaticEntries(new Date()));
     return new NextResponse(xml, {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -69,6 +69,7 @@
 
     /* Brand — Social login */
     --color-brand-kakao: #fee500;
+
     /* font stack 순서: Geist(라틴)가 한글 글리프를 못 가지므로 자동으로
        다음 폰트(Pretendard, self-host)로 fallback된다. next/font/local이
        --font-pretendard CSS 변수를 주입하고 size-adjust를 자동 측정해
@@ -77,7 +78,7 @@
        디바이스마다 typography가 달라지고 CLS도 발생했다. */
     --font-sans:
         var(--font-geist-sans), var(--font-pretendard), -apple-system,
-        BlinkMacSystemFont, system-ui, 'Helvetica Neue', Arial, sans-serif;
+        blinkmacsystemfont, system-ui, 'Helvetica Neue', arial, sans-serif;
     --font-mono: var(--font-geist-mono);
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -147,7 +147,11 @@ export default function RootLayout({ children }: RootLayoutProps) {
                     >
                         <AuthSessionHeader />
                     </Suspense>
-                    {children}
+                    {/* cacheComponents 모드: 페이지가 uncached data(searchParams,
+                        cookies 등)를 await할 때 부모 Suspense가 없으면 build fail.
+                        children boundary에서 page-level dynamic content를 stream
+                        가능한 형태로 분리한다. */}
+                    <Suspense>{children}</Suspense>
                     {/* Footer를 root layout에 두는 이유: home/404/legal 페이지
                         에만 footer가 있어 /market, /backtesting, /[symbol]/* 등
                         대부분 라우트에 내부 링크가 누수됐다. 차트 페이지

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -150,8 +150,11 @@ export default function RootLayout({ children }: RootLayoutProps) {
                     {/* cacheComponents 모드: 페이지가 uncached data(searchParams,
                         cookies 등)를 await할 때 부모 Suspense가 없으면 build fail.
                         children boundary에서 page-level dynamic content를 stream
-                        가능한 형태로 분리한다. */}
-                    <Suspense>{children}</Suspense>
+                        가능한 형태로 분리한다. fallback={null}은 의도적 — 페이지
+                        내부에서 자체 Suspense + skeleton을 두는 패턴이며, 여기에
+                        layout-level skeleton을 추가하면 페이지 자체 skeleton과
+                        이중 표시되어 layout shift를 유발한다. */}
+                    <Suspense fallback={null}>{children}</Suspense>
                     {/* Footer를 root layout에 두는 이유: home/404/legal 페이지
                         에만 footer가 있어 /market, /backtesting, /[symbol]/* 등
                         대부분 라우트에 내부 링크가 누수됐다. 차트 페이지

--- a/src/components/layout/CurrentYear.tsx
+++ b/src/components/layout/CurrentYear.tsx
@@ -1,6 +1,11 @@
-// cacheComponents 비활성 기간 동안 'use cache' directive 제거. 단순 동기 렌더로
-// 충분(year는 매 요청마다 server time으로 평가, 비용 무시할 수준).
+import { cacheLife } from 'next/cache';
 
-export function CurrentYear() {
+// 'use cache' 안에서 new Date()를 호출하지만 cacheLife('days')로 캐시 기간을
+// 일 단위로 묶어두면 재검증 시점에만 year가 다시 평가되어 결정적으로 동작한다.
+// year는 연 1회만 바뀌므로 일 단위 revalidate면 cross-year boundary도 24시간
+// 이내에 자동 반영된다. cacheComponents non-determinism 경고를 피하는 의도.
+export async function CurrentYear() {
+    'use cache';
+    cacheLife('days');
     return <>{new Date().getFullYear()}</>;
 }

--- a/src/infrastructure/market/getBarsAction.ts
+++ b/src/infrastructure/market/getBarsAction.ts
@@ -1,23 +1,27 @@
 'use server';
 
+import { cacheLife, cacheTag } from 'next/cache';
 import {
     type BarsData,
     type Timeframe,
     fetchBarsWithIndicators,
 } from '@y0ngha/siglens-core';
 
-// cacheComponents 비활성 기간 동안 'use cache' / cacheLife / cacheTag 제거.
-// bars API 호출은 매 요청마다 fresh — 캐싱 손실은 일시적이며 향후 PPR 재활성화
-// 또는 unstable_cache 도입 시 복원할 것 (이슈 #439 참조).
-//
-// fundamentalData/newsData와 달리 React.cache로 감싸지 않는 이유:
-// `'use server'` Server Action은 클라이언트에서 호출될 때 별도 RPC 경로로 실행되어
-// RSC render 컨텍스트의 per-request memoization을 공유하지 못한다. RSC에서
-// `prefetchQuery`로 호출되는 경로(layout.tsx)도 단일 호출이라 dedup 이득이 없다.
 export async function getBarsAction(
     symbol: string,
     timeframe: Timeframe,
     fmpSymbol?: string
 ): Promise<BarsData> {
+    return getBarsCached(symbol, timeframe, fmpSymbol);
+}
+
+async function getBarsCached(
+    symbol: string,
+    timeframe: Timeframe,
+    fmpSymbol?: string
+): Promise<BarsData> {
+    'use cache';
+    cacheLife('minutes');
+    cacheTag(`bars:${fmpSymbol ?? symbol}:${timeframe}`);
     return fetchBarsWithIndicators(symbol, timeframe, fmpSymbol);
 }

--- a/src/infrastructure/skills/loader.ts
+++ b/src/infrastructure/skills/loader.ts
@@ -211,9 +211,8 @@ const countMdFiles = async (subdir: string): Promise<number> => {
     return files.length;
 };
 
-// cacheComponents 비활성 기간 동안 'use cache' 제거.
-// skills 디렉토리는 빌드 산출물이라 매 요청 fs.readdir이 사실상 OS page cache hit.
 export async function countSkillFiles(): Promise<SkillCounts> {
+    'use cache';
     const [
         indicators,
         candlesticks,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2222,83 +2222,83 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/bundle-analyzer@npm:^16.2.0":
-  version: 16.2.6
-  resolution: "@next/bundle-analyzer@npm:16.2.6"
+"@next/bundle-analyzer@npm:16.1.2":
+  version: 16.1.2
+  resolution: "@next/bundle-analyzer@npm:16.1.2"
   dependencies:
     webpack-bundle-analyzer: "npm:4.10.1"
-  checksum: 10c0/701b2a08f9666dccbcf1630fdcab3aed9a7bf270a10bb87d1ea9117e708c1ec314271714484b70390e232efa1056d3c5271e5cd22198ba8759246f414d705f94
+  checksum: 10c0/7fef2dcd4da374a4965933e74adfe3de8be9793d0c170c8edbc7a9e57a3ee86f4616f8bee28d3b1c85b6f4a075c18b86fbe52152780cc6954e2d55bed4039d20
   languageName: node
   linkType: hard
 
-"@next/env@npm:16.2.0":
-  version: 16.2.0
-  resolution: "@next/env@npm:16.2.0"
-  checksum: 10c0/5d7e9276f7ad828d495e8d4de9b0f661fa3ed7ffb21c872c1144dbc9e5ff2aa40ee42868a2c09d694607546bea3ddbc66ea6334db487693ba90402eaae2a932f
+"@next/env@npm:16.1.2":
+  version: 16.1.2
+  resolution: "@next/env@npm:16.1.2"
+  checksum: 10c0/d73c2cdf060fd8b4b4a93fcb4463eab04a266e9cc3cae73d467cd380801d50a499be6ef432c1f6586e3b37602820f3be80ec706e273ee100cd49f9852f3edc13
   languageName: node
   linkType: hard
 
-"@next/eslint-plugin-next@npm:16.2.0":
-  version: 16.2.0
-  resolution: "@next/eslint-plugin-next@npm:16.2.0"
+"@next/eslint-plugin-next@npm:16.1.2":
+  version: 16.1.2
+  resolution: "@next/eslint-plugin-next@npm:16.1.2"
   dependencies:
     fast-glob: "npm:3.3.1"
-  checksum: 10c0/3fffb10df80052ad88b4429b5a67c86270b881a1df2d90e2f9f368d036e1963abbbfbe3b4c139749759d959f881af85ba57b9983a8f4abef63b103f518f9801c
+  checksum: 10c0/58b628a5bc06c35d13fc7592cdb206bb9200d996adef4bd0cafcec3ef8060b0e2b59781f7af473ba5fb737da85d2b049a602f560775f4f8ffc60839f8a3a1ba0
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:16.2.0":
-  version: 16.2.0
-  resolution: "@next/swc-darwin-arm64@npm:16.2.0"
+"@next/swc-darwin-arm64@npm:16.1.2":
+  version: 16.1.2
+  resolution: "@next/swc-darwin-arm64@npm:16.1.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:16.2.0":
-  version: 16.2.0
-  resolution: "@next/swc-darwin-x64@npm:16.2.0"
+"@next/swc-darwin-x64@npm:16.1.2":
+  version: 16.1.2
+  resolution: "@next/swc-darwin-x64@npm:16.1.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:16.2.0":
-  version: 16.2.0
-  resolution: "@next/swc-linux-arm64-gnu@npm:16.2.0"
+"@next/swc-linux-arm64-gnu@npm:16.1.2":
+  version: 16.1.2
+  resolution: "@next/swc-linux-arm64-gnu@npm:16.1.2"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:16.2.0":
-  version: 16.2.0
-  resolution: "@next/swc-linux-arm64-musl@npm:16.2.0"
+"@next/swc-linux-arm64-musl@npm:16.1.2":
+  version: 16.1.2
+  resolution: "@next/swc-linux-arm64-musl@npm:16.1.2"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:16.2.0":
-  version: 16.2.0
-  resolution: "@next/swc-linux-x64-gnu@npm:16.2.0"
+"@next/swc-linux-x64-gnu@npm:16.1.2":
+  version: 16.1.2
+  resolution: "@next/swc-linux-x64-gnu@npm:16.1.2"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:16.2.0":
-  version: 16.2.0
-  resolution: "@next/swc-linux-x64-musl@npm:16.2.0"
+"@next/swc-linux-x64-musl@npm:16.1.2":
+  version: 16.1.2
+  resolution: "@next/swc-linux-x64-musl@npm:16.1.2"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:16.2.0":
-  version: 16.2.0
-  resolution: "@next/swc-win32-arm64-msvc@npm:16.2.0"
+"@next/swc-win32-arm64-msvc@npm:16.1.2":
+  version: 16.1.2
+  resolution: "@next/swc-win32-arm64-msvc@npm:16.1.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:16.2.0":
-  version: 16.2.0
-  resolution: "@next/swc-win32-x64-msvc@npm:16.2.0"
+"@next/swc-win32-x64-msvc@npm:16.1.2":
+  version: 16.1.2
+  resolution: "@next/swc-win32-x64-msvc@npm:16.1.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -4293,12 +4293,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"baseline-browser-mapping@npm:^2.10.12, baseline-browser-mapping@npm:^2.9.19":
+"baseline-browser-mapping@npm:^2.10.12":
   version: 2.10.25
   resolution: "baseline-browser-mapping@npm:2.10.25"
   bin:
     baseline-browser-mapping: dist/cli.cjs
   checksum: 10c0/3955a01d1ca9487b23805b89250465911c0aa7aa1bd7b6207ab64257c945ad50e37d2d6d33b559e47e20cf1d3b1930fc15115bfbc340e84fd33c238a01bdebb6
+  languageName: node
+  linkType: hard
+
+"baseline-browser-mapping@npm:^2.8.3":
+  version: 2.10.32
+  resolution: "baseline-browser-mapping@npm:2.10.32"
+  bin:
+    baseline-browser-mapping: dist/cli.cjs
+  checksum: 10c0/408c93245bdf1e92ab0f891ebf9283ec60dbabfaac81bdc9a20d371565a2a496b0fb8028f7d628c3f66f90ee142670a81575cf1cbd5229f7b4b0d350db911085
   languageName: node
   linkType: hard
 
@@ -5919,11 +5928,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-next@npm:16.2.0":
-  version: 16.2.0
-  resolution: "eslint-config-next@npm:16.2.0"
+"eslint-config-next@npm:16.1.2":
+  version: 16.1.2
+  resolution: "eslint-config-next@npm:16.1.2"
   dependencies:
-    "@next/eslint-plugin-next": "npm:16.2.0"
+    "@next/eslint-plugin-next": "npm:16.1.2"
     eslint-import-resolver-node: "npm:^0.3.6"
     eslint-import-resolver-typescript: "npm:^3.5.2"
     eslint-plugin-import: "npm:^2.32.0"
@@ -5938,7 +5947,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/461e9f878425e0d3a1ddaa2282062dbf7f9e5fc128de27ca2504cdaf1c96fabe85bf2f60d94d66709a08252ccf53da78952e3ff2cdfc1577c0a0edc4fbc6fe81
+  checksum: 10c0/8ba6ea43cbbf661e4682d9300f08f87f07889d6aca1ed07199fa6e2ea9b74720da6f69d388a28cca459e40c236e65d615a7c86f79df86b3f9e3dbec13b8f477a
   languageName: node
   linkType: hard
 
@@ -9756,24 +9765,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:16.2.0":
-  version: 16.2.0
-  resolution: "next@npm:16.2.0"
+"next@npm:16.1.2":
+  version: 16.1.2
+  resolution: "next@npm:16.1.2"
   dependencies:
-    "@next/env": "npm:16.2.0"
-    "@next/swc-darwin-arm64": "npm:16.2.0"
-    "@next/swc-darwin-x64": "npm:16.2.0"
-    "@next/swc-linux-arm64-gnu": "npm:16.2.0"
-    "@next/swc-linux-arm64-musl": "npm:16.2.0"
-    "@next/swc-linux-x64-gnu": "npm:16.2.0"
-    "@next/swc-linux-x64-musl": "npm:16.2.0"
-    "@next/swc-win32-arm64-msvc": "npm:16.2.0"
-    "@next/swc-win32-x64-msvc": "npm:16.2.0"
+    "@next/env": "npm:16.1.2"
+    "@next/swc-darwin-arm64": "npm:16.1.2"
+    "@next/swc-darwin-x64": "npm:16.1.2"
+    "@next/swc-linux-arm64-gnu": "npm:16.1.2"
+    "@next/swc-linux-arm64-musl": "npm:16.1.2"
+    "@next/swc-linux-x64-gnu": "npm:16.1.2"
+    "@next/swc-linux-x64-musl": "npm:16.1.2"
+    "@next/swc-win32-arm64-msvc": "npm:16.1.2"
+    "@next/swc-win32-x64-msvc": "npm:16.1.2"
     "@swc/helpers": "npm:0.5.15"
-    baseline-browser-mapping: "npm:^2.9.19"
+    baseline-browser-mapping: "npm:^2.8.3"
     caniuse-lite: "npm:^1.0.30001579"
     postcss: "npm:8.4.31"
-    sharp: "npm:^0.34.5"
+    sharp: "npm:^0.34.4"
     styled-jsx: "npm:5.1.6"
   peerDependencies:
     "@opentelemetry/api": ^1.1.0
@@ -9812,7 +9821,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10c0/cd1adeee535e1e9cca1efeca704b0fda2e09992c1f8889ed75d54635b803a3875748bbfecefedb20d9dd70c2cb8f974ffeeda8bffa2a6ac902ffe968a012f795
+  checksum: 10c0/9e6737d65a373c7fbea8cfef91408dce0147f1c60462d3a6838410513ec205d63d1f8075a02a5035010538f16d6f3dde0b24c3dd0f72c778a54c8e616d8c47ee
   languageName: node
   linkType: hard
 
@@ -11322,7 +11331,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sharp@npm:^0.34.5":
+"sharp@npm:^0.34.4":
   version: 0.34.5
   resolution: "sharp@npm:0.34.5"
   dependencies:
@@ -11477,7 +11486,7 @@ __metadata:
     "@anthropic-ai/sdk": "npm:^0.92.0"
     "@google/genai": "npm:^1.50.1"
     "@neondatabase/serverless": "npm:^1.1.0"
-    "@next/bundle-analyzer": "npm:^16.2.0"
+    "@next/bundle-analyzer": "npm:16.1.2"
     "@release-it/conventional-changelog": "npm:^10.0.6"
     "@tailwindcss/postcss": "npm:^4"
     "@tanstack/react-query": "npm:^5.95.2"
@@ -11502,7 +11511,7 @@ __metadata:
     drizzle-kit: "npm:^0.31.10"
     drizzle-orm: "npm:^0.45.2"
     eslint: "npm:^9"
-    eslint-config-next: "npm:16.2.0"
+    eslint-config-next: "npm:16.1.2"
     glob: "npm:^13.0.6"
     gray-matter: "npm:^4.0.3"
     husky: "npm:^9.1.7"
@@ -11510,7 +11519,7 @@ __metadata:
     jest-environment-jsdom: "npm:^30.3.0"
     jsonrepair: "npm:^3.14.0"
     lightweight-charts: "npm:^5.1.0"
-    next: "npm:16.2.0"
+    next: "npm:16.1.2"
     openai: "npm:^6.35.0"
     postgres: "npm:^3.4.9"
     prettier: "npm:^3.7.4"


### PR DESCRIPTION
## 관련 이슈

closes #439

## 구현 내용

### 배경
Next.js 16.2.0에서 "Couldn't find all resumable slots" 회귀가 발생했으며, 이로 인해 모든 [symbol] 라우트에서 렌더링 오류가 발생함. 여러 사용자가 16.1.2 다운그레이드로 해결됨을 확인함 (vercel/next.js#63210 — nikolaf994, laurentlaporte).

### 변경 사항

**Version Downgrade:**
- Next.js 16.2.0 → 16.1.2
- next, eslint-config-next, @next/bundle-analyzer 모두 16.1.2로 exact-pin (caret 제거)
- 향후 의도하지 않은 16.2.x 재상향 방지

**cacheComponents 재활성화:**
- `next.config.ts`에서 `cacheComponents: true` 재활성화
- `'use cache'` / `cacheLife` / `cacheTag` 지시문 복원 (commit 95f06977 제거분 되돌림):
  - `src/app/[symbol]/fundamental/fundamentalData.ts`
  - `src/app/[symbol]/news/newsData.ts`
  - `src/infrastructure/market/getBarsAction.ts`
  - `src/app/layout.tsx`
  - `src/components/layout/CurrentYear.tsx`

**예외 처리:**
- `getProfileDescriptionKo`: React.cache 래핑 유지 (write path — DB upsert + Gemini 호출로 'use cache' 의미론 부적절)

**동적 라우팅 정리:**
- 4개 sitemap 라우트핸들러에서 `export const dynamic = 'force-dynamic'` 제거
- cacheComponents와 비호환성 제거
- 행동 변경 없음: cacheComponents 하에서 라우트는 기본 동적이며, opt-in 캐싱 모델 적용
- CDN 캐싱은 Cache-Control 헤더로 제어됨

**스트리밍 지원:**
- 루트 layout의 `{children}`을 Suspense로 래핑 — cacheComponents에서 페이지 레벨의 캐시되지 않은 데이터(searchParams, cookies 등) 스트리밍 필수

**CurrentYear 캐싱:**
- 명시적 `cacheLife('days')` 추가로 캐시 지속 시간 결정론적 보장

### 향후 작업 (Phase 2 이후)
- cacheLife profile config in next.config.ts (`options-market-open` / `options-market-closed` / `options-weekend`)
- 16.2+ 재진입 (upstream resumable-slots 수정 후)

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수
- [x] 설정 + 지시문 변경 (테스트 파일 수정 없음)
- [x] yarn build 통과 (모든 [symbol] 라우트 ◐ Partial Prerender)
- [x] yarn lint 통과
- [x] yarn format 통과

## 변경 파일 목록

[수정]
- next.config.ts — cacheComponents: true 재활성화
- package.json — Next.js dependencies 16.1.2로 pinning
- src/app/[symbol]/fundamental/fundamentalData.ts — 'use cache' 복원
- src/app/[symbol]/news/newsData.ts — 'use cache' 복원
- src/app/layout.tsx — Suspense 래핑, 'use cache' 복원
- src/components/layout/CurrentYear.tsx — cacheLife('days') 추가
- src/app/api/sitemap/route.ts — dynamic export 제거
- src/app/api/sitemap/static/route.ts — dynamic export 제거
- src/app/api/sitemap/popular/route.ts — dynamic export 제거
- src/app/api/sitemap/longtail/[page]/route.ts — dynamic export 제거
- src/infrastructure/market/getBarsAction.ts — 'use cache' 복원
- src/infrastructure/skills/loader.ts — 'use cache' 복원
- src/app/CLAUDE.md — 문서 업데이트
- src/app/globals.css — 스타일 정리

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn build
- [x] pre-push hooks (모두 통과)