### PR TITLE
fix: route handlers prerender connection 및 page.tsx revalidate 제거

### DIFF
--- a/src/app/api/sitemap/longtail/[page]/route.ts
+++ b/src/app/api/sitemap/longtail/[page]/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, connection } from 'next/server';
 import { loadLongTailTickers } from '@/infrastructure/sitemap/loadLongTailTickers';
 import { SITEMAP_MAX_URLS_PER_FILE } from '@/infrastructure/sitemap/types';
 import type { SitemapEntry } from '@/infrastructure/sitemap/types';
@@ -13,6 +13,10 @@ export async function GET(
     _req: Request,
     { params }: RouteContext
 ): Promise<Response> {
+    // cacheComponents 모드의 build prerender attempt 차단 —
+    // loadLongTailTickers() DB fetch가 prerender lifetime을 넘겨
+    // HANGING_PROMISE_REJECTION으로 새지 않도록 runtime dynamic을 보장한다.
+    await connection();
     const { page } = await params;
     const pageNum = Number.parseInt(page, 10);
     if (!Number.isFinite(pageNum) || pageNum < 1) {

--- a/src/app/api/sitemap/popular/route.ts
+++ b/src/app/api/sitemap/popular/route.ts
@@ -1,8 +1,12 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, connection } from 'next/server';
 import { buildPopularEntries } from '@/infrastructure/sitemap/buildPopularEntries';
 import { toUrlSetXml } from '@/infrastructure/sitemap/xml';
 
 export async function GET(): Promise<Response> {
+    // cacheComponents 모드의 build prerender attempt 차단 — hasOptionsMarket
+    // 외부 fetch(Yahoo Finance)가 prerender lifetime을 넘겨 HANGING_PROMISE_
+    // REJECTION으로 새지 않도록 runtime dynamic을 보장한다.
+    await connection();
     const xml = toUrlSetXml(await buildPopularEntries(new Date()));
     return new NextResponse(xml, {
         headers: {

--- a/src/app/api/sitemap/route.ts
+++ b/src/app/api/sitemap/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, connection } from 'next/server';
 import { loadLongTailTickers } from '@/infrastructure/sitemap/loadLongTailTickers';
 import type { SitemapIndexEntry } from '@/infrastructure/sitemap/types';
 import { SITEMAP_MAX_URLS_PER_FILE } from '@/infrastructure/sitemap/types';
@@ -20,6 +20,11 @@ import { SITE_BUILD_DATE, SITE_URL } from '@/lib/seo';
  * (Next.js rewrite는 next.config.ts에서 /sitemap-*.xml → /api/sitemap/* 으로 매핑)
  */
 export async function GET(): Promise<Response> {
+    // cacheComponents 모드는 build 때 route를 prerender 시도하는데, Neon
+    // serverless driver의 fetch가 prerender lifetime을 넘기면 HANGING_PROMISE_
+    // REJECTION으로 새어나간다. connection()을 명시적으로 호출해 prerender
+    // attempt 자체를 차단하고 runtime dynamic만 보장한다.
+    await connection();
     const now = new Date();
     const longTailTickers = await loadLongTailTickers();
     const longTailPages = Math.ceil(

--- a/src/app/api/sitemap/static/route.ts
+++ b/src/app/api/sitemap/static/route.ts
@@ -1,8 +1,11 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, connection } from 'next/server';
 import { buildStaticEntries } from '@/infrastructure/sitemap/buildStaticEntries';
 import { toUrlSetXml } from '@/infrastructure/sitemap/xml';
 
 export async function GET(): Promise<Response> {
+    // cacheComponents 모드의 build prerender attempt 차단 — new Date() 기반
+    // 슬라이딩 lastmod가 빌드 시점에 고정되지 않도록 runtime dynamic을 보장한다.
+    await connection();
     const xml = toUrlSetXml(buildStaticEntries(new Date()));
     return new NextResponse(xml, {
         headers: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,10 +15,6 @@ import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from '@/lib/seo';
 import Link from 'next/link';
 import { cache, Suspense } from 'react';
 
-// 랜딩은 ISR 정적 페이지로 운영 — proxy.ts가 ?q= 쿼리를 처리해 redirect하므로
-// 이 페이지 자체는 dynamic 의존성이 없다. revalidate로 skills 파일 변경 반영.
-export const revalidate = 3600;
-
 const loadSkills = cache(() => new FileSkillsLoader().loadSkills());
 
 async function AsyncStatsBar() {


### PR DESCRIPTION
## 관련 이슈

Hotfix (GitHub 이슈 없음) — PR #462 빌드 로그 분석 후 ad-hoc 수정

## 구현 내용

### 배경
PR #462 (cacheComponents 재활성화) master 머지 후 Vercel 빌드 로그에서 `/api/sitemap`, `/api/sitemap/popular` 라우트의 `HANGING_PROMISE_REJECTION` 에러 발생 (Neon serverless driver fetch가 prerender 수명을 벗어남). 또한 `src/app/page.tsx`의 `export const revalidate = 3600`이 cacheComponents와 호환되지 않아 master 빌드 자체가 깨짐. PR #462 감사에서 두 가지 경우 모두 누락 (gemini-code-assist의 connection() 제안이 거짓 양성으로 잘못 거절됨, page.tsx revalidate export 미검색).

### 변경 사항

**1. 4개 sitemap route에 `connection()` 추가** (`next/server`):
   - `src/app/api/sitemap/route.ts`
   - `src/app/api/sitemap/static/route.ts`
   - `src/app/api/sitemap/popular/route.ts`
   - `src/app/api/sitemap/longtail/[page]/route.ts`

   이유: cacheComponents는 빌드 타임 prerender 시도를 통해 라우트 동적성을 분류. 자동 분류가 ƒ Dynamic이더라도 시도 자체가 실행되고, Neon의 fetch 기반 드라이버가 prerender 수명 이상으로 promise rejection을 누출. `connection()`은 prerender 시도를 전혀 건너뛰라는 표준 신호.

**2. `src/app/page.tsx`에서 `export const revalidate = 3600` 제거**

   이유: cacheComponents와 호환 불가. 사용자가 최소 제거를 명시적으로 선택 — cacheLife 기반 교체는 별도의 전담 PR에서 설계 예정.

### 감사 범위

- 7개 route handler 감사 (sitemap × 4, jobs/cancel, auth/start, auth/callback) — sitemap만 connection() 필요 (다른 4개는 POST 또는 request data 접근으로 자동 동적).
- src/app 전체 route segment 설정 감사 (`export const dynamic|revalidate|fetchCache|runtime|dynamicParams`) — page.tsx의 revalidate만 호환 불가.

### 검증

- `yarn lint` 성공
- `yarn format` 성공
- `yarn build` 성공
- 빌드 로그: HANGING_PROMISE_REJECTION 없음, 4개 sitemap route 올바르게 ƒ Dynamic으로 분류

## 변경 파일 목록

[수정]
- src/app/api/sitemap/route.ts
- src/app/api/sitemap/static/route.ts
- src/app/api/sitemap/popular/route.ts
- src/app/api/sitemap/longtail/[page]/route.ts
- src/app/page.tsx

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build