### PR TITLE
refactor(arch): Phase 0 — FSD migration config setup

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,6 +7,18 @@ Layered Architecture를 기반으로 한다.
 
 ---
 
+## ⚠️ FSD 마이그레이션 진행 중
+
+본 프로젝트는 현재 Layered Architecture에서 **Feature-Sliced Design (FSD) 6-layer**로 단계적 마이그레이션 중이다.
+Phase 0~9 동안 아래 기술된 옛 레이어(domain/infrastructure/lib/components/app)와 새 FSD 레이어(pages/widgets/features/entities/shared)가 공존한다.
+
+FSD 의존 방향 및 상세 설계: `docs/superpowers/specs/2026-05-24-fsd-migration-design.md`
+CLAUDE.md의 "Layer Dependency Rules" 섹션도 함께 참고.
+
+Phase 9 완료 시 본 문서를 FSD 기준으로 전면 재작성한다.
+
+---
+
 ## 레이어 구조
 
 ```

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -499,6 +499,28 @@ import { calculateRSI } from '@/domain/indicators/rsi';
 import { calculateRSI } from '../../../domain/indicators/rsi';
 ```
 
+### FSD Slice Internal Imports
+
+FSD 슬라이스 내부에서 다른 segment를 참조할 때(예: `features/auth/ui/LoginForm.tsx` → `features/auth/model/types.ts`):
+- **relative import 허용** (`../model/types` 형태)
+- `no-restricted-imports`는 **다른 슬라이스**의 internal path만 차단하므로, 같은 슬라이스 내부 참조는 자동으로 허용됨
+- 슬라이스 root barrel(`@/features/auth`)을 통한 import도 가능하지만, 같은 슬라이스 내부에서는 필수 아님
+
+```typescript
+// ✅ 같은 slice 내 — relative import 허용
+// src/features/auth/ui/LoginForm.tsx
+import { AuthFormState } from '../model/types';
+
+// ✅ 같은 slice 내 — path alias도 가능 (비필수)
+import { AuthFormState } from '@/features/auth/model/types';
+
+// ❌ 다른 slice의 internal path — no-restricted-imports 위반
+// src/features/auth/ui/LoginForm.tsx
+import { ChatState } from '@/features/symbol-chat/model/types'; // 차단됨
+```
+
+> 기존 §7.6 ("All imports must use path aliases") 규칙은 **cross-module** import 기준이며, FSD 같은 슬라이스 내부 segment 간 참조에는 적용되지 않는다.
+
 ---
 
 ## useEffect Side Effect Isolation

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -414,14 +414,20 @@ src/__tests__/infrastructure/market/alpaca.test.ts
 ### Coverage Targets
 
 ```
-domain/         100% (필수)
-infrastructure/ 100% (필수)
+domain/         90% (필수, legacy — Phase 4에서 entities로 이동)
+infrastructure/ 90% (필수, legacy — Phase 2~3에서 entities로 이동)
+entities/       90% (필수)
+features/lib/   90% (필수)
+features/api/   90% (필수)
+shared/lib/     90% (필수)
 components/     optional
+widgets/        optional
+pages/          optional
 app/            optional
 ```
 
-`domain/` and `infrastructure/` require 100% coverage.
-`components/` and `app/` are not required to have tests, but writing tests for them is allowed.
+`domain/`, `infrastructure/`, `entities/`, `features/lib/`, `features/api/`, `shared/lib/` require 90% coverage.
+`components/`, `widgets/`, `pages/`, `app/` are not required to have tests, but writing tests for them is allowed.
 Pure utility functions and other units that benefit from testing may be freely tested.
 
 ### Test Structure
@@ -502,24 +508,28 @@ import { calculateRSI } from '../../../domain/indicators/rsi';
 ### FSD Slice Internal Imports
 
 FSD 슬라이스 내부에서 다른 segment를 참조할 때(예: `features/auth/ui/LoginForm.tsx` → `features/auth/model/types.ts`):
-- **relative import 허용** (`../model/types` 형태)
-- `no-restricted-imports`는 **다른 슬라이스**의 internal path만 차단하므로, 같은 슬라이스 내부 참조는 자동으로 허용됨
-- 슬라이스 root barrel(`@/features/auth`)을 통한 import도 가능하지만, 같은 슬라이스 내부에서는 필수 아님
+- **relative import 사용** (`../model/types` 형태)
+- `no-restricted-imports`는 path alias 기반(`@/features/*/model/*`)으로 차단하므로, **같은 슬라이스 내에서도 `@/` 절대경로로 internal segment에 접근하면 lint 에러**
+- 같은 슬라이스 내부는 반드시 relative import 사용
 
 ```typescript
-// ✅ 같은 slice 내 — relative import 허용
+// ✅ 같은 slice 내 — relative import
 // src/features/auth/ui/LoginForm.tsx
-import { AuthFormState } from '../model/types';
+import type { AuthFormState } from '../model/types';
 
-// ✅ 같은 slice 내 — path alias도 가능 (비필수)
-import { AuthFormState } from '@/features/auth/model/types';
+// ❌ 같은 slice 내라도 절대경로 internal path — no-restricted-imports 위반
+// src/features/auth/ui/LoginForm.tsx
+import type { AuthFormState } from '@/features/auth/model/types'; // 차단됨
 
 // ❌ 다른 slice의 internal path — no-restricted-imports 위반
 // src/features/auth/ui/LoginForm.tsx
-import { ChatState } from '@/features/symbol-chat/model/types'; // 차단됨
+import type { ChatState } from '@/features/symbol-chat/model/types'; // 차단됨
+
+// ✅ 다른 slice는 public API(barrel)로만 접근
+import { useChatActions } from '@/features/symbol-chat';
 ```
 
-> 기존 §7.6 ("All imports must use path aliases") 규칙은 **cross-module** import 기준이며, FSD 같은 슬라이스 내부 segment 간 참조에는 적용되지 않는다.
+> 기존 §7.6 ("All imports must use path aliases") 규칙은 **cross-slice** import 기준이며, 같은 슬라이스 내부 segment 간 참조는 relative import를 사용한다.
 
 ---
 

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -407,8 +407,14 @@ function calculateRSI(closes: number[], period = RSI_DEFAULT_PERIOD): (number | 
 ### File Locations
 
 ```
+# Legacy (마이그레이션 완료까지 유지)
 src/__tests__/domain/indicators/rsi.test.ts
 src/__tests__/infrastructure/market/alpaca.test.ts
+
+# FSD 슬라이스 colocated (Phase 1+)
+src/entities/user/__tests__/userRepository.test.ts
+src/features/auth/__tests__/loginAction.test.ts
+src/shared/lib/__tests__/cn.test.ts
 ```
 
 ### Coverage Targets

--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -127,6 +127,7 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 
 7.6. Relative import paths used instead of path aliases
    → All imports must use path aliases (@/, @y0ngha/...) instead of relative paths (./, ../)
+   → 예외: FSD 슬라이스 내부 segment 간 참조는 relative import를 사용한다 (CONVENTIONS.md §FSD Slice Internal Imports 참조)
    → Relative paths create brittle dependencies when files move and make refactoring difficult
    → Path aliases are statically resolvable and enable IDE support
    ❌ import { Component } from './'
@@ -135,6 +136,9 @@ This file contains only **recurring gotchas** that agents keep missing despite e
    ✅ import { Component } from '@/components/contact'
    ✅ import { util } from '@/utils/someUtil'
    ✅ import { type } from '@/domain/types'
+   ✅ // FSD 슬라이스 내부 (src/features/auth/ui/LoginForm.tsx)
+      import type { AuthFormState } from '../model/types';  // 슬라이스 내부 relative OK
+   ❌ import type { AuthFormState } from '@/features/auth/model/types';  // 같은 슬라이스라도 no-restricted-imports 위반
 
 8. Tight coupling between interface props and dependent files
    → Group related prop pairs into a single type (e.g. IndicatorToggleGroup { visible, onToggle })
@@ -425,12 +429,15 @@ This file contains only **recurring gotchas** that agents keep missing despite e
 
 0.1. Relative path imports instead of path aliases
    → All imports must use @/ path aliases, never relative paths (./, ../)
+   → 예외: FSD 슬라이스 내부 segment 간 참조는 relative import 허용 (CONVENTIONS.md §FSD Slice Internal Imports 참조)
    → Applies to all layers: components, domain, infrastructure, lib
    → Path aliases enable safe refactoring and improve code clarity across layers
    ❌ import { formatPrice } from '../../lib/priceFormat'
    ❌ import { validateInput } from './validation'
    ✅ import { formatPrice } from '@/lib/priceFormat'
    ✅ import { validateInput } from '@/domain/contact/validation'
+   ✅ // FSD 슬라이스 내부
+      import type { AuthFormState } from '../model/types';  // 슬라이스 내부 relative OK
 
 1. External callback prop in useEffect dependency array → infinite loops
    → Use useEffectEvent to wrap callback props

--- a/docs/MISTAKES.md
+++ b/docs/MISTAKES.md
@@ -256,8 +256,8 @@ This file contains only **recurring gotchas** that agents keep missing despite e
     ❌ const lines = []; for (const rec of reconciled) { lines.push(...extractLines(rec)); } return lines;
     ✅ const lines = reconciled.flatMap(extractLines); return lines;
 
-22. Domain functions incomplete test coverage — missing unit tests entirely or covering <100% branches
-    → Every new domain function must have dedicated unit tests with 100% branch coverage
+22. Domain functions incomplete test coverage — missing unit tests entirely or covering below the project threshold
+    → Every new domain function must have dedicated unit tests achieving the project's coverage threshold (90%)
     → Test infrastructure functions similarly; coverage checks catch missing edge cases
     ❌ callGeminiWithKeyFallback added to infrastructure/ai/gemini.ts without src/__tests__/infrastructure/ test file
     ❌ extractReconciledActionLines added to domain/analysis/ without corresponding unit tests for 8+ cases
@@ -921,7 +921,7 @@ This file contains only **recurring gotchas** that agents keep missing despite e
       Background job: cache.set(symbol, { symbol, name, koreanName })  // fmpSymbol missing
    ✅ Both paths: cache.set(symbol, { symbol, name, koreanName, fmpSymbol })
 
-2. Infrastructure functions must have 100% branch coverage
+2. Infrastructure functions must have 90% branch coverage
    → All if/else, optional chaining (?.), nullish coalescing (??) paths tested
    → Test edge cases like subsecond boundaries, zero values, Math.max guard behavior
    ❌ Math.max(1, Math.floor(diffMs / 1000)) guard that converts 0→1 untested

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -101,6 +101,7 @@ const eslintConfig = defineConfig([
                             allow: [
                                 'entities',
                                 'shared',
+                                'legacy-comp',
                                 'legacy-domain',
                                 'legacy-infra',
                                 'legacy-lib',
@@ -120,11 +121,15 @@ const eslintConfig = defineConfig([
                         {
                             from: 'legacy-app',
                             allow: [
+                                'pages',
+                                'widgets',
+                                'features',
+                                'entities',
+                                'shared',
                                 'legacy-comp',
                                 'legacy-domain',
                                 'legacy-infra',
                                 'legacy-lib',
-                                'shared',
                             ],
                         },
                         {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,8 +51,7 @@ const eslintConfig = defineConfig([
         plugins: { boundaries },
         settings: {
             'boundaries/elements': [
-                // 새 FSD layer (현재 디렉토리 비어 있음)
-                { type: 'app', pattern: 'src/app/**' },
+                // 새 FSD layer (Phase 0에서는 디렉토리가 아직 생성되지 않음)
                 { type: 'pages', pattern: 'src/pages/*' },
                 { type: 'widgets', pattern: 'src/widgets/*' },
                 { type: 'features', pattern: 'src/features/*' },
@@ -72,20 +71,6 @@ const eslintConfig = defineConfig([
                 {
                     default: 'disallow',
                     rules: [
-                        {
-                            from: 'app',
-                            allow: [
-                                'pages',
-                                'widgets',
-                                'features',
-                                'entities',
-                                'shared',
-                                'legacy-comp',
-                                'legacy-domain',
-                                'legacy-infra',
-                                'legacy-lib',
-                            ],
-                        },
                         {
                             from: 'pages',
                             allow: [
@@ -176,19 +161,33 @@ const eslintConfig = defineConfig([
                 'error',
                 {
                     patterns: [
+                        // features — barrel + deep path
+                        '@/features/*/model',
                         '@/features/*/model/*',
+                        '@/features/*/hooks',
                         '@/features/*/hooks/*',
+                        '@/features/*/ui',
                         '@/features/*/ui/*',
+                        '@/features/*/lib',
                         '@/features/*/lib/*',
+                        '@/features/*/api',
                         '@/features/*/api/*',
+                        // widgets — barrel + deep path
+                        '@/widgets/*/ui',
                         '@/widgets/*/ui/*',
+                        '@/widgets/*/hooks',
                         '@/widgets/*/hooks/*',
+                        '@/widgets/*/lib',
                         '@/widgets/*/lib/*',
+                        // entities — barrel + deep path (actions 제외: 'use server')
                         '@/entities/*/api',
                         '@/entities/*/api/*',
                         '@/entities/*/model',
+                        '@/entities/*/model/*',
                         '@/entities/*/lib',
                         '@/entities/*/lib/*',
+                        '@/entities/*/ui',
+                        '@/entities/*/ui/*',
                     ],
                 },
             ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -101,7 +101,7 @@ const eslintConfig = defineConfig([
                             allow: [
                                 'entities',
                                 'shared',
-                                'legacy-comp',
+                                'legacy-comp', // 마이그레이션 중 임시 허용: 새 feature가 아직 widgets로 이동하지 않은 legacy UI를 사용. Phase 7 완료 시 제거.
                                 'legacy-domain',
                                 'legacy-infra',
                                 'legacy-lib',
@@ -133,6 +133,8 @@ const eslintConfig = defineConfig([
                             ],
                         },
                         {
+                            // legacy-comp → legacy-infra: 옛 코드 현상 유지. components/ hooks만 infrastructure fetch 함수 import 허용 (ARCHITECTURE.md).
+                            // Phase 7 (widgets 마이그레이션) 완료 시 legacy-comp 타입 자체가 제거되므로 이 규칙도 함께 삭제.
                             from: 'legacy-comp',
                             allow: [
                                 'legacy-domain',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, globalIgnores } from 'eslint/config';
 import nextVitals from 'eslint-config-next/core-web-vitals';
 import nextTs from 'eslint-config-next/typescript';
+import boundaries from 'eslint-plugin-boundaries';
 
 const eslintConfig = defineConfig([
     ...nextVitals,
@@ -42,6 +43,153 @@ const eslintConfig = defineConfig([
                     varsIgnorePattern: '^_',
                     caughtErrorsIgnorePattern: '^_',
                     destructuredArrayIgnorePattern: '^_',
+                },
+            ],
+        },
+    },
+    {
+        plugins: { boundaries },
+        settings: {
+            'boundaries/elements': [
+                // 새 FSD layer (현재 디렉토리 비어 있음)
+                { type: 'app', pattern: 'src/app/**' },
+                { type: 'pages', pattern: 'src/pages/*' },
+                { type: 'widgets', pattern: 'src/widgets/*' },
+                { type: 'features', pattern: 'src/features/*' },
+                { type: 'entities', pattern: 'src/entities/*' },
+                { type: 'shared', pattern: 'src/shared/**' },
+                // 옛 layer (Phase 1~9 동안 점진 제거)
+                { type: 'legacy-app', pattern: 'src/app/**' },
+                { type: 'legacy-comp', pattern: 'src/components/**' },
+                { type: 'legacy-domain', pattern: 'src/domain/**' },
+                { type: 'legacy-infra', pattern: 'src/infrastructure/**' },
+                { type: 'legacy-lib', pattern: 'src/lib/**' },
+            ],
+        },
+        rules: {
+            'boundaries/element-types': [
+                'error',
+                {
+                    default: 'disallow',
+                    rules: [
+                        {
+                            from: 'app',
+                            allow: [
+                                'pages',
+                                'widgets',
+                                'features',
+                                'entities',
+                                'shared',
+                                'legacy-comp',
+                                'legacy-domain',
+                                'legacy-infra',
+                                'legacy-lib',
+                            ],
+                        },
+                        {
+                            from: 'pages',
+                            allow: [
+                                'widgets',
+                                'features',
+                                'entities',
+                                'shared',
+                                'legacy-comp',
+                                'legacy-domain',
+                                'legacy-infra',
+                                'legacy-lib',
+                            ],
+                        },
+                        {
+                            from: 'widgets',
+                            allow: [
+                                'features',
+                                'entities',
+                                'shared',
+                                'legacy-comp',
+                                'legacy-domain',
+                                'legacy-infra',
+                                'legacy-lib',
+                            ],
+                        },
+                        {
+                            from: 'features',
+                            allow: [
+                                'entities',
+                                'shared',
+                                'legacy-domain',
+                                'legacy-infra',
+                                'legacy-lib',
+                            ],
+                        },
+                        {
+                            from: 'entities',
+                            allow: [
+                                'shared',
+                                'legacy-domain',
+                                'legacy-infra',
+                                'legacy-lib',
+                            ],
+                        },
+                        { from: 'shared', allow: ['shared'] },
+                        // 옛 layer 간 의존: 현재 코드 그대로 허용
+                        {
+                            from: 'legacy-app',
+                            allow: [
+                                'legacy-comp',
+                                'legacy-domain',
+                                'legacy-infra',
+                                'legacy-lib',
+                                'shared',
+                            ],
+                        },
+                        {
+                            from: 'legacy-comp',
+                            allow: [
+                                'legacy-domain',
+                                'legacy-infra',
+                                'legacy-lib',
+                                'shared',
+                            ],
+                        },
+                        {
+                            from: 'legacy-domain',
+                            allow: ['legacy-lib', 'shared'],
+                        },
+                        {
+                            from: 'legacy-infra',
+                            allow: ['legacy-domain', 'legacy-lib', 'shared'],
+                        },
+                        {
+                            from: 'legacy-lib',
+                            allow: ['legacy-domain', 'shared'],
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+    {
+        files: ['src/**/*.{ts,tsx}'],
+        ignores: ['src/**/*.test.{ts,tsx}', 'src/**/__tests__/**'],
+        rules: {
+            'no-restricted-imports': [
+                'error',
+                {
+                    patterns: [
+                        '@/features/*/model/*',
+                        '@/features/*/hooks/*',
+                        '@/features/*/ui/*',
+                        '@/features/*/lib/*',
+                        '@/features/*/api/*',
+                        '@/widgets/*/ui/*',
+                        '@/widgets/*/hooks/*',
+                        '@/widgets/*/lib/*',
+                        '@/entities/*/api',
+                        '@/entities/*/api/*',
+                        '@/entities/*/model',
+                        '@/entities/*/lib',
+                        '@/entities/*/lib/*',
+                    ],
                 },
             ],
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -201,6 +201,9 @@ const eslintConfig = defineConfig([
                         '@/entities/*/lib/*',
                         '@/entities/*/ui',
                         '@/entities/*/ui/*',
+                        // siglens-core deep import 차단 (CLAUDE.md / ARCHITECTURE.md 정책)
+                        '@y0ngha/siglens-core/dist',
+                        '@y0ngha/siglens-core/dist/*',
                     ],
                 },
             ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,6 +52,8 @@ const eslintConfig = defineConfig([
         settings: {
             'boundaries/elements': [
                 // 새 FSD layer (Phase 0에서는 디렉토리가 아직 생성되지 않음)
+                // ⚠️ src/pages/는 FSD composition layer 용도. Next.js 라우팅은 src/app/에서만 처리.
+                // Next.js App Router 프로젝트에서 src/pages/ 파일 추가 시 Pages Router 활성화 주의.
                 { type: 'pages', pattern: 'src/pages/*' },
                 { type: 'widgets', pattern: 'src/widgets/*' },
                 { type: 'features', pattern: 'src/features/*' },
@@ -133,8 +135,10 @@ const eslintConfig = defineConfig([
                             ],
                         },
                         {
-                            // legacy-comp → legacy-infra: 옛 코드 현상 유지. components/ hooks만 infrastructure fetch 함수 import 허용 (ARCHITECTURE.md).
-                            // Phase 7 (widgets 마이그레이션) 완료 시 legacy-comp 타입 자체가 제거되므로 이 규칙도 함께 삭제.
+                            // legacy-comp → legacy-infra: 옛 코드 현상 유지 (현상 유지 허용).
+                            // .tsx 파일의 직접 infrastructure import는 ARCHITECTURE.md 규칙으로 별도 차단되며,
+                            // 이 boundaries 규칙은 hooks/와 .tsx를 구분하지 않음.
+                            // Phase 7 (widgets 마이그레이션) 완료 시 legacy-comp 타입 제거.
                             from: 'legacy-comp',
                             allow: [
                                 'legacy-domain',
@@ -186,6 +190,8 @@ const eslintConfig = defineConfig([
                         '@/widgets/*/hooks/*',
                         '@/widgets/*/lib',
                         '@/widgets/*/lib/*',
+                        '@/widgets/*/model', // widgets 설계에 model 없음, 방어적 차단
+                        '@/widgets/*/model/*',
                         // entities — barrel + deep path (actions 제외: 'use server')
                         '@/entities/*/api',
                         '@/entities/*/api/*',

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,9 @@ module.exports = {
     testEnvironment: 'node',
     setupFiles: ['<rootDir>/jest.setup.ts'],
     testMatch: [
+        // 옛 mirror 구조 (하위 호환, Phase 9까지 유지)
         '<rootDir>/src/__tests__/**/*.+(test|spec).+(ts|tsx)',
+        // FSD 슬라이스 colocated 테스트 (Phase 1+)
         '<rootDir>/src/**/__tests__/**/*.+(test|spec).+(ts|tsx)',
     ],
     transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,9 +3,7 @@ module.exports = {
     testEnvironment: 'node',
     setupFiles: ['<rootDir>/jest.setup.ts'],
     testMatch: [
-        // 옛 mirror 구조 (하위 호환, Phase 9까지 유지)
-        '<rootDir>/src/__tests__/**/*.+(test|spec).+(ts|tsx)',
-        // FSD 슬라이스 colocated 테스트 (Phase 1+)
+        // legacy mirror(src/__tests__/) + FSD colocated(src/<layer>/<slice>/__tests__/) 모두 커버
         '<rootDir>/src/**/__tests__/**/*.+(test|spec).+(ts|tsx)',
     ],
     transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,10 @@ module.exports = {
     cacheDirectory: './.jest/cache',
     testEnvironment: 'node',
     setupFiles: ['<rootDir>/jest.setup.ts'],
-    testMatch: ['<rootDir>/src/__tests__/**/*.+(test|spec).+(ts|tsx)'],
+    testMatch: [
+        '<rootDir>/src/__tests__/**/*.+(test|spec).+(ts|tsx)',
+        '<rootDir>/src/**/__tests__/**/*.+(test|spec).+(ts|tsx)',
+    ],
     transform: {
         '^.+\\.(t|j)sx?$': [
             'ts-jest',
@@ -16,20 +19,25 @@ module.exports = {
     },
     // github-slugger is ESM-only; transform it via ts-jest so Jest can consume it
     transformIgnorePatterns: ['/node_modules/(?!github-slugger)'],
-    // domain, infrastructure만 커버리지 측정
+    // 옛(domain, infrastructure) + 새 FSD layer(entities, features/lib, features/api, shared/lib) 측정.
+    // UI 레이어(widgets, pages, app)는 제외.
     collectCoverageFrom: [
         'src/domain/**/*.ts',
         'src/infrastructure/**/*.ts',
+        'src/entities/**/*.ts',
+        'src/features/**/lib/**/*.ts',
+        'src/features/**/api/**/*.ts',
+        'src/shared/lib/**/*.ts',
         '!src/**/*.d.ts',
         '!src/**/index.ts',
         '!src/**/types.ts',
     ],
     coverageThreshold: {
         global: {
-            branches: 100,
-            functions: 100,
-            lines: 100,
-            statements: 100,
+            branches: 90,
+            functions: 90,
+            lines: 90,
+            statements: 90,
         },
     },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,6 +20,7 @@ module.exports = {
     // github-slugger is ESM-only; transform it via ts-jest so Jest can consume it
     transformIgnorePatterns: ['/node_modules/(?!github-slugger)'],
     // 옛(domain, infrastructure) + 새 FSD layer(entities, features/lib, features/api, shared/lib) 측정.
+    // features/model — 주로 타입 정의이므로 의도적 제외. features/hooks — UI 훅이므로 optional.
     // UI 레이어(widgets, pages, app)는 제외.
     collectCoverageFrom: [
         'src/domain/**/*.ts',

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
         "drizzle-kit": "^0.31.10",
         "eslint": "^9",
         "eslint-config-next": "16.2.0",
+        "eslint-plugin-boundaries": "^6.0.2",
         "glob": "^13.0.6",
         "husky": "^9.1.7",
         "jest": "^30.2.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,11 +22,12 @@
         ],
         "baseUrl": ".",
         "paths": {
-            "@/*": ["./src/*"],
             "@/widgets/*": ["./src/widgets/*"],
             "@/features/*": ["./src/features/*"],
             "@/entities/*": ["./src/entities/*"],
-            "@/pages/*": ["./src/pages/*"]
+            "@/pages/*": ["./src/pages/*"],
+            "@/shared/*": ["./src/shared/*"],
+            "@/*": ["./src/*"]
         }
     },
     "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,11 @@
         ],
         "baseUrl": ".",
         "paths": {
-            "@/*": ["./src/*"]
+            "@/*": ["./src/*"],
+            "@/widgets/*": ["./src/widgets/*"],
+            "@/features/*": ["./src/features/*"],
+            "@/entities/*": ["./src/entities/*"],
+            "@/pages/*": ["./src/pages/*"]
         }
     },
     "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -431,6 +431,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@boundaries/elements@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@boundaries/elements@npm:2.0.1"
+  dependencies:
+    eslint-import-resolver-node: "npm:0.3.9"
+    eslint-module-utils: "npm:2.12.1"
+    handlebars: "npm:4.7.9"
+    is-core-module: "npm:2.16.1"
+    micromatch: "npm:4.0.8"
+  checksum: 10c0/0c38a3a9d08c8d7aa79cd29b3d98ac61608120dad69ee568dbbbc0522c944cb7b60a1d985fd2ebfcd4c4ad0fe4caf44b81e519a49a99d3af85c769fe0cdad537
+  languageName: node
+  linkType: hard
+
 "@cacheable/memory@npm:^2.0.8":
   version: 2.0.8
   resolution: "@cacheable/memory@npm:2.0.8"
@@ -4530,7 +4543,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.2":
+"chalk@npm:4.1.2, chalk@npm:^4.0.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -5942,6 +5955,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-import-resolver-node@npm:0.3.9":
+  version: 0.3.9
+  resolution: "eslint-import-resolver-node@npm:0.3.9"
+  dependencies:
+    debug: "npm:^3.2.7"
+    is-core-module: "npm:^2.13.0"
+    resolve: "npm:^1.22.4"
+  checksum: 10c0/0ea8a24a72328a51fd95aa8f660dcca74c1429806737cf10261ab90cfcaaf62fd1eff664b76a44270868e0a932711a81b250053942595bcd00a93b1c1575dd61
+  languageName: node
+  linkType: hard
+
 "eslint-import-resolver-node@npm:^0.3.6, eslint-import-resolver-node@npm:^0.3.9":
   version: 0.3.10
   resolution: "eslint-import-resolver-node@npm:0.3.10"
@@ -5977,7 +6001,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-module-utils@npm:^2.12.1":
+"eslint-module-utils@npm:2.12.1, eslint-module-utils@npm:^2.12.1":
   version: 2.12.1
   resolution: "eslint-module-utils@npm:2.12.1"
   dependencies:
@@ -5986,6 +6010,22 @@ __metadata:
     eslint:
       optional: true
   checksum: 10c0/6f4efbe7a91ae49bf67b4ab3644cb60bc5bd7db4cb5521de1b65be0847ffd3fb6bce0dd68f0995e1b312d137f768e2a1f842ee26fe73621afa05f850628fdc40
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-boundaries@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "eslint-plugin-boundaries@npm:6.0.2"
+  dependencies:
+    "@boundaries/elements": "npm:2.0.1"
+    chalk: "npm:4.1.2"
+    eslint-import-resolver-node: "npm:0.3.9"
+    eslint-module-utils: "npm:2.12.1"
+    handlebars: "npm:4.7.9"
+    micromatch: "npm:4.0.8"
+  peerDependencies:
+    eslint: ">=6.0.0"
+  checksum: 10c0/70dfc01d1a0837be8e227335f57359c85955c094437985a592cd4dd555a1b662bde7b9458d5b1e14d933dd67e66a5931686bf98e85ee607cc6d114459d29b370
   languageName: node
   linkType: hard
 
@@ -7006,7 +7046,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.7.7, handlebars@npm:^4.7.9":
+"handlebars@npm:4.7.9, handlebars@npm:^4.7.7, handlebars@npm:^4.7.9":
   version: 4.7.9
   resolution: "handlebars@npm:4.7.9"
   dependencies:
@@ -7088,7 +7128,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hasown@npm:^2.0.2":
+"hasown@npm:^2.0.2, hasown@npm:^2.0.3":
   version: 2.0.3
   resolution: "hasown@npm:2.0.3"
   dependencies:
@@ -7495,12 +7535,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.16.1":
+"is-core-module@npm:2.16.1, is-core-module@npm:^2.16.1":
   version: 2.16.1
   resolution: "is-core-module@npm:2.16.1"
   dependencies:
     hasown: "npm:^2.0.2"
   checksum: 10c0/898443c14780a577e807618aaae2b6f745c8538eca5c7bc11388a3f2dc6de82b9902bcc7eb74f07be672b11bbe82dd6a6edded44a00cb3d8f933d0459905eedd
+  languageName: node
+  linkType: hard
+
+"is-core-module@npm:^2.13.0":
+  version: 2.16.2
+  resolution: "is-core-module@npm:2.16.2"
+  dependencies:
+    hasown: "npm:^2.0.3"
+  checksum: 10c0/14b4258390283709c15476d023ec173e27458d5d014ccdb8ed39d576e551c3fa45498b7c9fe178f1529c4cb2648ddd58852a6a62107a019f6e349529f277518a
   languageName: node
   linkType: hard
 
@@ -9583,7 +9632,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.4, micromatch@npm:^4.0.8":
+"micromatch@npm:4.0.8, micromatch@npm:^4.0.4, micromatch@npm:^4.0.8":
   version: 4.0.8
   resolution: "micromatch@npm:4.0.8"
   dependencies:
@@ -11089,6 +11138,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve@npm:^1.22.4":
+  version: 1.22.12
+  resolution: "resolve@npm:1.22.12"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    is-core-module: "npm:^2.16.1"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10c0/b16dc9b537c02e8c3388f7d3dcff9741d3071625f9a97ac1c885f2b0ca51e78df22328fb6d6ef214dd9101fb7cfc19aa2836fe3410402a94f3f7b8639c7149bf
+  languageName: node
+  linkType: hard
+
 "resolve@npm:^2.0.0-next.5, resolve@npm:^2.0.0-next.6":
   version: 2.0.0-next.6
   resolution: "resolve@npm:2.0.0-next.6"
@@ -11102,6 +11165,20 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 10c0/4e44cb84aa9a3c7c82d4a98e8111879671150496160a53ca6cdbed6101bf239f19105f8b8b84e40c0b76d46b0d9626813510b19a80e01f4ae18692e9d0b47749
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
+  version: 1.22.12
+  resolution: "resolve@patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    is-core-module: "npm:^2.16.1"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10c0/fc6519984ae1f894d877c0060ba8b1f5ba3bc0e85a02f74e141929c118c23d74d9735619a9cc2965397387e514884245c65d72a40731dcb6cfc84c7bcdc8321e
   languageName: node
   linkType: hard
 
@@ -11503,6 +11580,7 @@ __metadata:
     drizzle-orm: "npm:^0.45.2"
     eslint: "npm:^9"
     eslint-config-next: "npm:16.2.0"
+    eslint-plugin-boundaries: "npm:^6.0.2"
     glob: "npm:^13.0.6"
     gray-matter: "npm:^4.0.3"
     husky: "npm:^9.1.7"


### PR DESCRIPTION
## Summary

FSD 마이그레이션 Phase 0의 첫 번째 PR. ESLint boundaries 도입, tsconfig paths alias 확장, Jest coverage threshold 완화, no-restricted-imports 차단 패턴 추가를 한 번에 적용한다. 옛 layer와 새 FSD layer가 마이그레이션 동안 공존할 수 있도록 설정.

## 변경 사항

- `package.json` + `yarn.lock`: `eslint-plugin-boundaries@^6.0.2` devDependency 추가
- `tsconfig.json`: `@/widgets/*`, `@/features/*`, `@/entities/*`, `@/pages/*` paths alias 추가 (`@/*`는 그대로 — `@/shared/*` 자연 매칭)
- `eslint.config.mjs`:
  - `boundaries/elements` — 새 FSD 6 layer + legacy 5 layer 사전 등록
  - `boundaries/element-types` — 11개 from-allow rule, atomic move per PR 지원
  - `no-restricted-imports` — slice internal path 13개 차단, `@/entities/*/actions`는 의도적 예외 (Next.js 'use server')
- `jest.config.js`:
  - `coverageThreshold`: 100 → 90 (G1 결정)
  - `collectCoverageFrom`: 옛(domain, infrastructure) + 새(entities, features/lib, features/api, shared/lib) 둘 다 매칭
  - `testMatch`: 옛 mirror + 새 colocate 둘 다 허용

## 참고

- Spec: `docs/superpowers/specs/2026-05-24-fsd-migration-design.md` (PR 3에서 머지)
- Plan: `docs/superpowers/plans/2026-05-24-fsd-migration-phase-0.md` (PR 3에서 머지)
- 사용자 결정 G1(coverage 90%), G6(atomic move), G7(CLAUDE.md 영역 이동 시 함께 교체), G2/G3(workflow path-agnostic) 반영

## Test plan

- [x] `yarn format:check` 통과
- [x] `yarn lint` 통과 (boundaries v6 deprecation warning 2건 — follow-up issue)
- [x] `yarn typecheck` 통과
- [x] `yarn test:quiet` 228 suites / 2095 tests passed
- [x] 새 layer 디렉토리(widgets/features/entities/pages) 비어 있음 → boundaries 위반 자연 0

## Follow-up Issues

- boundaries plugin v6 object-based selector + `boundaries/dependencies` rule 이름으로 마이그레이션 (Phase 9에 흡수)
- `eslint.config.mjs` `react/no-danger` 예외 파일 경로를 `src/pages/...`로 갱신 (Phase 8에 흡수)
- `node_modules/prettier/bin/prettier.cjs` 실행 권한 이슈 (`yarn format` 직접 실행 실패) — 별도 추적 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)