### PR TITLE
refactor(arch): Phase 0 — workflow & sub-agent path-agnostic redesign

### DIFF
--- a/.claude/agents/review-agent.md
+++ b/.claude/agents/review-agent.md
@@ -96,10 +96,13 @@ Additionally, based on changed file locations:
 
 | Condition | Also read |
 |---|---|
-| `src/domain/` changed (excluding `__tests__/` only changes) | `docs/DOMAIN.md` |
-| `src/components/*.tsx` changed | `docs/DESIGN.md` |
-| `src/infrastructure/ai/` or `src/infrastructure/market/` changed | `docs/API.md` |
-| Only `src/__tests__/` files changed, no source files | Skip all conditional docs |
+| Diff touches indicator calculations, signal logic, candle patterns, or prompt builders | `docs/DOMAIN.md` |
+| Diff touches `.tsx` files (UI components) | `docs/DESIGN.md` |
+| Diff touches AI provider calls or market data fetches | `docs/API.md` |
+| Diff touches authentication flows or session management | `docs/AUTH.md` |
+| Only test files changed, no source files | Skip all conditional docs |
+
+Determine the trigger by reading the actual file content of the diff — do NOT match on directory paths (`src/domain/`, `src/infrastructure/`). FSD migration is in progress; concrete layer paths are unstable.
 
 **Round 2+ note:** On round 2+, "changed file locations" refers to the `modified_files` list provided by the orchestrator, not the full diff.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -70,7 +70,21 @@ jobs:
                         ## Review Procedure & Agentic Flow
                         1. Run: gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "🔍 리뷰를 진행 중입니다."
                         2. Run: gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }} to analyze the changes.
-                        3. **Contextual Reading**: Based on the diff, read CLAUDE.md, /docs/MISTAKES.md, and ONLY the relevant principle documents from the list below.
+                        3. **Contextual Reading**: Always read the following core documents:
+                           - CLAUDE.md
+                           - /docs/MISTAKES.md (highest priority — known repeated patterns)
+                           - /docs/ARCHITECTURE.md
+                           - /docs/CONVENTIONS.md
+                           - /docs/FF.md
+
+                           Additionally read **only** the documents relevant to the changed files:
+                           - If the diff touches indicator calculations, signal logic, candle patterns, or prompt builders → read /docs/DOMAIN.md
+                           - If the diff touches UI components (.tsx files) → read /docs/DESIGN.md
+                           - If the diff touches external API integrations (AI providers, market data) → read /docs/API.md
+                           - If the diff touches authentication flows or session management → read /docs/AUTH.md
+                           - If the diff touches FSD layer boundaries or cross-layer imports → read the relevant src/<layer>/CLAUDE.md (if it exists)
+
+                           Do NOT use concrete directory paths (src/domain/, src/infrastructure/) as triggers — those layers are being migrated to FSD and may not exist mid-migration. Use file content / responsibility as the trigger instead.
                         4. Review the diff strictly against the loaded rules.
 
                         ## Completeness Rule (CRITICAL — Never Omit)
@@ -103,6 +117,7 @@ jobs:
                         - /docs/FF.md: Frontend principles (Readability, Predictability, Cohesion, Coupling).
                         - /docs/ARCHITECTURE.md: Layer structure, folder layout, dependency directions.
                         - /docs/DOMAIN.md: Indicator specs, domain rules, IndicatorResult structure.
+                        - /docs/AUTH.md: Authentication flows, session management.
                         - /docs/DESIGN.md: Color system, chart color constants.
 
                         ## Documentation Policy (Override — DO NOT FLAG)

--- a/docs/ISSUE_IMPL_FLOW.md
+++ b/docs/ISSUE_IMPL_FLOW.md
@@ -37,20 +37,24 @@ Use this value directly in all `gh` commands.
 Always read (targeted):
 - `docs/MISTAKES.md` — read only the sections relevant to the task scope:
 
-| Modified layer | MISTAKES.md sections to read |
+| Modified area | MISTAKES.md sections to read |
 |---|---|
-| domain/ | Coding Paradigm, TypeScript, Domain Functions, Pure Function Contracts |
-| infrastructure/ | Coding Paradigm, TypeScript |
-| components/ | Coding Paradigm, Components, Design & Cohesion |
-| components/chart/ | (above) + Lightweight Charts |
-| \_\_tests\_\_/ | Tests |
+| Indicator calculations, signal logic, candle patterns, or prompt builders | Coding Paradigm, Domain Functions |
+| UI components (.tsx) | Components |
+| TypeScript type definitions | TypeScript |
+| Test files | Tests |
+| SEO / structured data | SEO & Semantic Markup |
+| Accessibility / ARIA | Accessibility (WAI-ARIA) |
+| All other changes | Coding Paradigm (general) |
 
-Multiple layers → read the union of their sections.
+Determine the area by reading the diff content — do not match on concrete directory paths (src/domain/, src/infrastructure/). FSD migration is in progress.
+
+Multiple areas → read the union of their sections.
 
 Additional documents by scope:
-- domain/ related → `docs/DOMAIN.md` + `docs/ARCHITECTURE.md`
-- infrastructure/ → `docs/API.md` + `docs/ARCHITECTURE.md`
-- components/ → `docs/DESIGN.md` + `docs/ARCHITECTURE.md`
+- Indicator / signal / candle pattern / prompt logic → `docs/DOMAIN.md` + `docs/ARCHITECTURE.md`
+- External API integration → `docs/API.md` + `docs/ARCHITECTURE.md`
+- UI components → `docs/DESIGN.md` + `docs/ARCHITECTURE.md`
 - Layer structure check needed → `docs/ARCHITECTURE.md`
 
 Read existing similar implementations first for pattern recognition:

--- a/docs/PR_FIX_FLOW.md
+++ b/docs/PR_FIX_FLOW.md
@@ -34,20 +34,24 @@ Use this value directly in all `gh` commands.
 Always read (targeted):
 - `docs/MISTAKES.md` — read only the sections relevant to the fix scope:
 
-| Modified layer | MISTAKES.md sections to read |
+| Modified area | MISTAKES.md sections to read |
 |---|---|
-| domain/ | Coding Paradigm, TypeScript, Domain Functions, Pure Function Contracts |
-| infrastructure/ | Coding Paradigm, TypeScript |
-| components/ | Coding Paradigm, Components, Design & Cohesion |
-| components/chart/ | (above) + Lightweight Charts |
-| \_\_tests\_\_/ | Tests |
+| Indicator calculations, signal logic, candle patterns, or prompt builders | Coding Paradigm, Domain Functions |
+| UI components (.tsx) | Components |
+| TypeScript type definitions | TypeScript |
+| Test files | Tests |
+| SEO / structured data | SEO & Semantic Markup |
+| Accessibility / ARIA | Accessibility (WAI-ARIA) |
+| All other changes | Coding Paradigm (general) |
 
-Multiple layers → read the union of their sections.
+Determine the area by reading the diff content — do not match on concrete directory paths (src/domain/, src/infrastructure/). FSD migration is in progress.
+
+Multiple areas → read the union of their sections.
 
 Additional documents based on fix scope:
-- domain/ related → `docs/DOMAIN.md`
-- infrastructure/ → `docs/API.md`
-- components/ → `docs/DESIGN.md`
+- Indicator / signal / candle pattern / prompt logic → `docs/DOMAIN.md`
+- External API integration → `docs/API.md`
+- UI components → `docs/DESIGN.md`
 
 #### 1-3. Understand PR Context
 


### PR DESCRIPTION
## Summary

FSD 마이그레이션 Phase 0의 두 번째 PR. claude-code-review.yml과 sub-agent의 conditional doc loading 로직을 path-agnostic으로 일반화.

## 변경 사항

- `.github/workflows/claude-code-review.yml`: Step 3 path-agnostic 재설계, Reference Pool AUTH.md 추가
- `.claude/agents/review-agent.md`: Load Required Documents 표 path-agnostic 교체, AUTH 트리거 추가
- `docs/ISSUE_IMPL_FLOW.md`, `docs/PR_FIX_FLOW.md`: Modified layer → Modified area 표 교체

## Test plan

- [x] format:check / lint / typecheck 통과
- [x] test:quiet 228 suites / 2095 tests passed (validation run 기준)
- [x] Flaky test (useNewsAnalysis, useOverallAnalysis)는 isolated run 34/34 통과 확인, PR 2와 무관한 기존 flakiness (--no-verify 사용자 허가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)