### PR TITLE
refactor(arch): Phase 0 — FSD migration spec & CLAUDE.md merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,9 @@ next-env.d.ts
 /worker/dist/
 /worker/node_modules/
 /.superpowers/
-/docs/superpowers/
+/docs/superpowers/*
+!/docs/superpowers/specs/
+!/docs/superpowers/plans/
 
 # backtest batch job state
 /scripts/backtests/.batch-job.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,7 @@ app  →  pages  →  widgets  →  features  →  entities  →  shared
 
 - 각 레이어는 자기 위 레이어를 import할 수 없다 (예: entities는 features를 import할 수 없음).
 - 같은 레이어 안의 다른 슬라이스끼리 import 금지 (예: `entities/user`는 `entities/session`을 직접 import할 수 없음 — 상위 레이어를 통해 라우팅).
+  **예외: `shared` 레이어는 내부 슬라이스 간 import 허용** (예: `shared/ui` → `shared/lib` 허용 — ESLint boundaries `{ from: 'shared', allow: ['shared'] }` 정책과 일치).
 - production 코드는 슬라이스 root만 import (예: `@/widgets/stock-chart`, NOT `@/widgets/stock-chart/ui/Chart`). 테스트 파일은 예외.
 
 ### Legacy 의존 방향 (마이그레이션 동안 유지)
@@ -195,9 +196,12 @@ app  →  pages  →  widgets  →  features  →  entities  →  shared
 ```
 domain         ← No external imports. Pure TypeScript functions only.
                  Exception: @y0ngha/siglens-core may be imported.
-infrastructure ← May import from domain and lib.
+infrastructure ← May import from domain and lib (lib must be pure utilities/constants only).
+                 Handles file I/O (Skills) and API calls.
 lib            ← External UI utility wrappers. Pure functions only.
-app (RSC)      ← May import from infrastructure, domain, lib.
+                 React Query key factories (QUERY_KEYS) and config constants belong in lib/.
+                 May import types from domain (e.g. Timeframe) when needed for key factories.
+app (RSC/Route) ← May import from infrastructure, domain, lib.
 components     ← May import from domain, lib.
                Component files (.tsx): Direct imports from infrastructure are prohibited.
                Hook files (hooks/): May import fetch functions from infrastructure only
@@ -209,7 +213,7 @@ Phase 9 완료 시 legacy 섹션은 제거된다.
 
 ### siglens-core 직접 import 예외 (모든 레이어)
 
-`@y0ngha/siglens-core`는 외부 라이브러리가 아니라 외부 분석 도메인 패키지다. 모든 레이어가 직접 import 가능하다. deep import(`@y0ngha/siglens-core/dist/...`) 금지.
+`@y0ngha/siglens-core`는 외부 라이브러리가 아니라 외부 분석 도메인 패키지다. 모든 레이어가 직접 import 가능하다. deep import(`@y0ngha/siglens-core/dist/...`) 금지. 로컬 `src/domain/`은 SigLens 앱 고유 로직(backtest, chat 모델 상수, 대시보드 섹터 그룹핑 등)만 보유한다. FSD 마이그레이션 중에도 이 원칙은 유지된다.
 
 ### Server Action 예외
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ app  →  pages  →  widgets  →  features  →  entities  →  shared
 
 - 각 레이어는 자기 위 레이어를 import할 수 없다 (예: entities는 features를 import할 수 없음).
 - 같은 레이어 안의 다른 슬라이스끼리 import 금지 (예: `entities/user`는 `entities/session`을 직접 import할 수 없음 — 상위 레이어를 통해 라우팅).
-  - **예외**: `shared` 레이어는 내부 슬라이스 간 import 허용 (예: `shared/ui` → `shared/lib`). Phase 0 PR 1 완료 후 ESLint `{ from: 'shared', allow: ['shared'] }` 규칙으로 강제.
+  - **예외**: `shared` 레이어는 내부 슬라이스 간 import 허용 (예: `shared/ui` → `shared/lib`). ESLint `{ from: 'shared', allow: ['shared'] }` 규칙으로 강제.
 - production 코드는 슬라이스 root만 import (예: `@/widgets/stock-chart`, NOT `@/widgets/stock-chart/ui/Chart`). 테스트 파일은 예외.
 
 ### Legacy 의존 방향 (마이그레이션 동안 유지)
@@ -223,7 +223,7 @@ Phase 9 완료 시 legacy 섹션은 제거된다.
 
 ### ESLint 강제
 
-위 규칙은 `eslint-plugin-boundaries` + `no-restricted-imports`로 정적 검증된다 (Phase 0 PR 1에서 도입). 도입 완료 후 위반 시 PR 머지 불가. 자세한 설정은 `eslint.config.mjs`.
+위 규칙은 `eslint-plugin-boundaries` + `no-restricted-imports`로 정적 검증된다. 위반 시 PR 머지 불가. 자세한 설정은 `eslint.config.mjs`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,26 +174,50 @@ Every sub-agent ends its response with a JSON exit signal and nothing else.
 
 ## Layer Dependency Rules (Never Violate)
 
+### Migration in progress: Layered → FSD
+
+본 프로젝트는 현재 **Layered 구조에서 Feature-Sliced Design (FSD) 6-layer로 단계적으로 마이그레이션 중**이다. Phase 0~9 동안 옛 layer와 새 layer가 공존한다. 자세한 설계는 `docs/superpowers/specs/2026-05-24-fsd-migration-design.md` 참고.
+
+### FSD 의존 방향 (목표 상태)
+
+```
+app  →  pages  →  widgets  →  features  →  entities  →  shared
+                                                          ↑
+                                          @y0ngha/siglens-core (외부, 모든 레이어 직접 import 가능)
+```
+
+- 각 레이어는 자기 위 레이어를 import할 수 없다 (예: entities는 features를 import할 수 없음).
+- 같은 레이어 안의 다른 슬라이스끼리 import 금지 (예: `entities/user`는 `entities/session`을 직접 import할 수 없음 — 상위 레이어를 통해 라우팅).
+- production 코드는 슬라이스 root만 import (예: `@/widgets/stock-chart`, NOT `@/widgets/stock-chart/ui/Chart`). 테스트 파일은 예외.
+
+### Legacy 의존 방향 (마이그레이션 동안 유지)
+
 ```
 domain         ← No external imports. Pure TypeScript functions only.
-                 Exception: @y0ngha/siglens-core may be imported (see below).
-infrastructure ← May import from domain and lib (lib must be pure utilities/constants only). Handles file I/O (Skills) and API calls.
-lib            ← External UI utility wrappers (clsx, tailwind-merge, etc.). Pure functions only.
-app (RSC/Route)← May import from infrastructure, domain, lib.
+                 Exception: @y0ngha/siglens-core may be imported.
+infrastructure ← May import from domain and lib.
+lib            ← External UI utility wrappers. Pure functions only.
+app (RSC)      ← May import from infrastructure, domain, lib.
 components     ← May import from domain, lib.
                Component files (.tsx): Direct imports from infrastructure are prohibited.
                Hook files (hooks/): May import fetch functions from infrastructure only
-                 → Limited to queryFn/mutationFn connection or useActionState Server Action connection purpose
-                 → Type imports must be from @/domain/types or @y0ngha/siglens-core
-
-lib            ← External UI utility wrappers (clsx, tailwind-merge, etc.). Pure functions only.
-               May import types from domain (e.g. Timeframe) when needed for React Query key factories.
-               React Query key factories (QUERY_KEYS) and config constants belong in lib/.
+                 → Limited to queryFn/mutationFn or useActionState connection.
+                 → Type imports from @/domain/types or @y0ngha/siglens-core.
 ```
 
-**`@y0ngha/siglens-core` exception**: This package is not a third-party library — it is the externalized SigLens domain logic (indicators, candle patterns, signals, domain types). Direct import is allowed from **every layer** including `components/` and hooks. Do not create thin re-export wrappers in `domain/` — they are pure boilerplate. Deep imports (`@y0ngha/siglens-core/dist/...`) are still prohibited; use only the public package surface. Local `src/domain/` keeps only SigLens-app-specific logic (backtest, chat models, dashboard sector grouping, etc.).
+Phase 9 완료 시 legacy 섹션은 제거된다.
 
-Violations trigger ESLint errors. PRs cannot be merged.
+### siglens-core 직접 import 예외 (모든 레이어)
+
+`@y0ngha/siglens-core`는 외부 라이브러리가 아니라 외부 분석 도메인 패키지다. 모든 레이어가 직접 import 가능하다. deep import(`@y0ngha/siglens-core/dist/...`) 금지.
+
+### Server Action 예외
+
+`entities/<x>/actions.ts`(Next.js `'use server'` 파일)는 features/widgets/pages에서 import 가능하다. `entities/<x>/api.ts`는 server-only이므로 same-entity 또는 app 레이어에서만 import.
+
+### ESLint 강제
+
+위 규칙은 `eslint-plugin-boundaries` + `no-restricted-imports`로 정적 검증된다. 위반 시 PR 머지 불가. 자세한 설정은 `eslint.config.mjs`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ app  →  pages  →  widgets  →  features  →  entities  →  shared
 
 - 각 레이어는 자기 위 레이어를 import할 수 없다 (예: entities는 features를 import할 수 없음).
 - 같은 레이어 안의 다른 슬라이스끼리 import 금지 (예: `entities/user`는 `entities/session`을 직접 import할 수 없음 — 상위 레이어를 통해 라우팅).
-  **예외: `shared` 레이어는 내부 슬라이스 간 import 허용** (예: `shared/ui` → `shared/lib` 허용 — ESLint boundaries `{ from: 'shared', allow: ['shared'] }` 정책과 일치).
+  - **예외**: `shared` 레이어는 내부 슬라이스 간 import 허용 (예: `shared/ui` → `shared/lib`). Phase 0 PR 1 완료 후 ESLint `{ from: 'shared', allow: ['shared'] }` 규칙으로 강제.
 - production 코드는 슬라이스 root만 import (예: `@/widgets/stock-chart`, NOT `@/widgets/stock-chart/ui/Chart`). 테스트 파일은 예외.
 
 ### Legacy 의존 방향 (마이그레이션 동안 유지)
@@ -219,9 +219,11 @@ Phase 9 완료 시 legacy 섹션은 제거된다.
 
 `entities/<x>/actions.ts`(Next.js `'use server'` 파일)는 features/widgets/pages에서 import 가능하다. `entities/<x>/api.ts`는 server-only이므로 same-entity 또는 app 레이어에서만 import.
 
+**pages/ RSC 데이터 흐름**: `app/` 레이어(RSC entry)가 `entities/<x>/api.ts`를 호출해 `queryClient.prefetchQuery()` → `dehydrate()` → `HydrationBoundary`로 pages에 전달. pages/ 레이어는 entity의 `hooks/`(client component 안)나 `actions.ts`(Server Action)를 통해 데이터에 접근하며, `api.ts`를 직접 import하지 않는다.
+
 ### ESLint 강제
 
-위 규칙은 `eslint-plugin-boundaries` + `no-restricted-imports`로 정적 검증된다. 위반 시 PR 머지 불가. 자세한 설정은 `eslint.config.mjs`.
+위 규칙은 `eslint-plugin-boundaries` + `no-restricted-imports`로 정적 검증된다 (Phase 0 PR 1에서 도입). 도입 완료 후 위반 시 PR 머지 불가. 자세한 설정은 `eslint.config.mjs`.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-24-fsd-migration-phase-0.md
+++ b/docs/superpowers/plans/2026-05-24-fsd-migration-phase-0.md
@@ -1,0 +1,772 @@
+# FSD Migration — Phase 0 (준비) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Layered → FSD 마이그레이션의 Phase 0 (안전망 준비)을 완료한다. 이 PR들이 머지되면 Phase 1~9 동안 master 빌드/배포가 깨지지 않으며, 모든 자동화(ESLint, Jest, CI 리뷰, sub-agent)가 옛 + 새 layer를 동시에 인식한다.
+
+**Architecture:** 3개 PR로 분할 — (1) Config 변경 (ESLint boundaries + tsconfig paths + Jest coverage + no-restricted-imports), (2) Workflow/Sub-agent path-agnostic 재설계, (3) Spec + CLAUDE.md 머지. 각 PR은 독립적으로 검증되고 머지된다. 새 layer 디렉토리는 비어 있는 상태로 두어 boundaries 위반이 자연 0으로 통과한다.
+
+**Tech Stack:** ESLint 9 + eslint-plugin-boundaries, TypeScript 5 + Next.js paths, Jest 30 + ts-jest, husky pre-push hook, GitHub Actions(claude-code-action@v1), Claude Code sub-agents.
+
+**참고 spec:** `docs/superpowers/specs/2026-05-24-fsd-migration-design.md`
+
+**Scope 노트:** 본 plan은 **Phase 0만** 다룬다. Phase 1~9는 각각 별도 plan으로 작성한다 (예: `2026-05-25-fsd-migration-phase-1.md`).
+
+**Git/PR 정책:** siglens `CLAUDE.md` 정책에 따라 main orchestrator는 commit/push/PR 생성을 직접 수행하지 않는다. 각 PR의 "커밋 + PR 생성" 단계에서 `git-agent` sub-agent에 위임한다.
+
+---
+
+## PR 1 — Config 변경 묶음
+
+ESLint boundaries 도입, tsconfig paths alias 확장, jest coverage threshold 완화, no-restricted-imports 도입을 한 PR로 묶는다. 이유: 4가지 모두 root 설정 파일 변경이며 서로 의존(예: boundaries가 인식할 수 있도록 tsconfig alias가 먼저 정의되어야 함). PR 분리 시 임시로 빌드 깨지는 시점이 발생.
+
+### Task 1.1: `eslint-plugin-boundaries` devDependency 추가
+
+**Files:**
+- Modify: `package.json` (devDependencies 추가)
+
+- [ ] **Step 1: 현 devDependencies 확인**
+
+Run: `grep -n '"eslint' /Users/y0ngha/Project/siglens/package.json`
+
+Expected output:
+```
+"eslint": "^9",
+"eslint-config-next": "16.2.0",
+```
+
+- [ ] **Step 2: 패키지 설치**
+
+Run: `cd /Users/y0ngha/Project/siglens && yarn add -D eslint-plugin-boundaries`
+
+Expected output: `eslint-plugin-boundaries`가 devDependencies에 추가되고 yarn.lock 갱신.
+
+- [ ] **Step 3: 설치 확인**
+
+Run: `grep -n '"eslint-plugin-boundaries' /Users/y0ngha/Project/siglens/package.json`
+
+Expected: 한 줄 출력. 버전은 `^5` 또는 그 이상.
+
+- [ ] **Step 4: 다음 task로 진행 (커밋은 PR 1 끝에서 일괄)**
+
+---
+
+### Task 1.2: `tsconfig.json` paths alias 확장
+
+**Files:**
+- Modify: `/Users/y0ngha/Project/siglens/tsconfig.json` (paths 섹션)
+
+- [ ] **Step 1: 현 paths 섹션 확인**
+
+Read `tsconfig.json`. 현재는 `"@/*": ["./src/*"]` 만 있음.
+
+- [ ] **Step 2: paths 섹션 갱신**
+
+`paths` 객체를 다음과 같이 교체:
+
+```json
+"paths": {
+    "@/*": ["./src/*"],
+    "@/widgets/*": ["./src/widgets/*"],
+    "@/features/*": ["./src/features/*"],
+    "@/entities/*": ["./src/entities/*"],
+    "@/pages/*": ["./src/pages/*"]
+}
+```
+
+기존 `@/*`는 그대로 두고 새 4개 alias를 추가한다. `@/shared/*`는 별도 등록 불필요 — `@/*`가 `./src/*`로 매핑되므로 `@/shared/foo`는 자동으로 `./src/shared/foo`로 해석된다.
+
+- [ ] **Step 3: typecheck 통과 확인**
+
+Run: `cd /Users/y0ngha/Project/siglens && yarn typecheck`
+
+Expected: `tsc --noEmit`이 에러 0으로 완료. 새 alias가 등록되었지만 실제 디렉토리는 비어 있어 미사용 → 영향 없음.
+
+- [ ] **Step 4: 다음 task로 진행**
+
+---
+
+### Task 1.3: `eslint.config.mjs`에 boundaries + no-restricted-imports 추가
+
+**Files:**
+- Modify: `/Users/y0ngha/Project/siglens/eslint.config.mjs`
+
+- [ ] **Step 1: 현 eslint.config.mjs 확인**
+
+Read 파일. 구조 확인:
+- `defineConfig`로 export
+- `...nextVitals`, `...nextTs` 펼침
+- `globalIgnores` 사용
+- 마지막에 `'@typescript-eslint/no-unused-vars'` 규칙
+
+- [ ] **Step 2: boundaries plugin import 추가**
+
+파일 최상단 import 섹션에 추가:
+
+```js
+import boundaries from 'eslint-plugin-boundaries';
+```
+
+기존 import 3개(`defineConfig`, `nextVitals`, `nextTs`) 바로 아래.
+
+- [ ] **Step 3: boundaries 설정 블록 추가**
+
+`eslintConfig` 배열의 마지막 객체 다음(`'@typescript-eslint/no-unused-vars'` 블록 다음)에 boundaries 설정 객체를 추가:
+
+```js
+{
+    plugins: { boundaries },
+    settings: {
+        'boundaries/elements': [
+            // 새 FSD layer (현재 디렉토리 비어 있음)
+            { type: 'app', pattern: 'src/app/**' },
+            { type: 'pages', pattern: 'src/pages/*' },
+            { type: 'widgets', pattern: 'src/widgets/*' },
+            { type: 'features', pattern: 'src/features/*' },
+            { type: 'entities', pattern: 'src/entities/*' },
+            { type: 'shared', pattern: 'src/shared/**' },
+            // 옛 layer (Phase 1~9 동안 점진 제거)
+            { type: 'legacy-app', pattern: 'src/app/**' },
+            { type: 'legacy-comp', pattern: 'src/components/**' },
+            { type: 'legacy-domain', pattern: 'src/domain/**' },
+            { type: 'legacy-infra', pattern: 'src/infrastructure/**' },
+            { type: 'legacy-lib', pattern: 'src/lib/**' },
+        ],
+    },
+    rules: {
+        'boundaries/element-types': [
+            'error',
+            {
+                default: 'disallow',
+                rules: [
+                    { from: 'app', allow: ['pages', 'widgets', 'features', 'entities', 'shared', 'legacy-comp', 'legacy-domain', 'legacy-infra', 'legacy-lib'] },
+                    { from: 'pages', allow: ['widgets', 'features', 'entities', 'shared', 'legacy-comp', 'legacy-domain', 'legacy-infra', 'legacy-lib'] },
+                    { from: 'widgets', allow: ['features', 'entities', 'shared', 'legacy-comp', 'legacy-domain', 'legacy-infra', 'legacy-lib'] },
+                    { from: 'features', allow: ['entities', 'shared', 'legacy-domain', 'legacy-infra', 'legacy-lib'] },
+                    { from: 'entities', allow: ['shared', 'legacy-domain', 'legacy-infra', 'legacy-lib'] },
+                    { from: 'shared', allow: ['shared'] },
+                    // 옛 layer 간 의존: 현재 코드 그대로 허용
+                    { from: 'legacy-app', allow: ['legacy-comp', 'legacy-domain', 'legacy-infra', 'legacy-lib', 'shared'] },
+                    { from: 'legacy-comp', allow: ['legacy-domain', 'legacy-infra', 'legacy-lib', 'shared'] },
+                    { from: 'legacy-domain', allow: ['legacy-lib', 'shared'] },
+                    { from: 'legacy-infra', allow: ['legacy-domain', 'legacy-lib', 'shared'] },
+                    { from: 'legacy-lib', allow: ['legacy-domain', 'shared'] },
+                ],
+            },
+        ],
+    },
+}
+```
+
+> `legacy-app`/`app` 둘 다 `src/app/**` 패턴을 공유한다 — boundaries plugin은 동일 파일에 두 type을 허용하지 않을 수 있다. 이 경우 boundaries elements에서 `legacy-app` 행을 제거하고 `from: 'app'` 의 allow 목록에 `legacy-*` 들을 포함한 그대로 둔다 (이미 그렇게 작성됨). 검증 단계에서 `yarn lint`로 충돌 여부 확인.
+
+- [ ] **Step 4: no-restricted-imports 설정 블록 추가**
+
+위 boundaries 블록 다음에 또 다른 객체를 추가:
+
+```js
+{
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['src/**/*.test.{ts,tsx}', 'src/**/__tests__/**'],
+    rules: {
+        'no-restricted-imports': [
+            'error',
+            {
+                patterns: [
+                    '@/features/*/model/*',
+                    '@/features/*/hooks/*',
+                    '@/features/*/ui/*',
+                    '@/features/*/lib/*',
+                    '@/features/*/api/*',
+                    '@/widgets/*/ui/*',
+                    '@/widgets/*/hooks/*',
+                    '@/widgets/*/lib/*',
+                    '@/entities/*/api',
+                    '@/entities/*/api/*',
+                    '@/entities/*/model',
+                    '@/entities/*/lib',
+                    '@/entities/*/lib/*',
+                ],
+            },
+        ],
+    },
+},
+```
+
+`@/entities/*/actions`는 패턴에서 의도적으로 제외 — Next.js `'use server'` 파일은 client에서 import 가능해야 한다.
+
+- [ ] **Step 5: yarn lint 통과 확인**
+
+Run: `cd /Users/y0ngha/Project/siglens && yarn lint`
+
+Expected: 에러 0. 새 layer 디렉토리(`widgets/`, `features/`, `entities/`, `pages/`)는 비어 있어 boundaries 위반 발생하지 않음. `no-restricted-imports`는 새 layer 디렉토리가 비어 있어 매칭되는 import 0.
+
+만약 boundaries plugin이 `legacy-app`와 `app` 패턴 중복을 거부하면:
+1. boundaries elements에서 `{ type: 'legacy-app', pattern: 'src/app/**' }` 행을 삭제
+2. `{ from: 'legacy-app', ... }` 규칙 행도 함께 삭제
+3. `from: 'app'` 의 allow 목록은 그대로 유지 (이미 legacy-* 포함)
+4. 다시 `yarn lint` 실행
+
+- [ ] **Step 6: 다음 task로 진행**
+
+---
+
+### Task 1.4: `jest.config.js` 갱신
+
+**Files:**
+- Modify: `/Users/y0ngha/Project/siglens/jest.config.js`
+
+- [ ] **Step 1: 현 jest.config.js 확인**
+
+Read 파일. 현재:
+- `testMatch: ['<rootDir>/src/__tests__/**/*.+(test|spec).+(ts|tsx)']`
+- `collectCoverageFrom: ['src/domain/**/*.ts', 'src/infrastructure/**/*.ts', '!src/**/*.d.ts', '!src/**/index.ts', '!src/**/types.ts']`
+- `coverageThreshold.global: { branches: 100, functions: 100, lines: 100, statements: 100 }`
+
+- [ ] **Step 2: testMatch 확장**
+
+`testMatch` 배열을 다음과 같이 교체:
+
+```js
+testMatch: [
+    '<rootDir>/src/__tests__/**/*.+(test|spec).+(ts|tsx)',
+    '<rootDir>/src/**/__tests__/**/*.+(test|spec).+(ts|tsx)',
+],
+```
+
+옛 미러(`src/__tests__/`) + 새 colocate(`src/<layer>/<slice>/__tests__/`) 둘 다 허용. 두 번째 패턴은 첫 번째와 중첩되지만 jest는 자동으로 중복 파일을 한 번만 실행한다.
+
+- [ ] **Step 3: collectCoverageFrom 확장**
+
+`collectCoverageFrom` 배열을 다음과 같이 교체:
+
+```js
+collectCoverageFrom: [
+    'src/domain/**/*.ts',
+    'src/infrastructure/**/*.ts',
+    'src/entities/**/*.ts',
+    'src/features/**/lib/**/*.ts',
+    'src/features/**/api/**/*.ts',
+    'src/shared/lib/**/*.ts',
+    '!src/**/*.d.ts',
+    '!src/**/index.ts',
+    '!src/**/types.ts',
+],
+```
+
+옛 + 새 둘 다 매칭. 옛 디렉토리가 비어지면 자동으로 collect 대상이 0이 되므로 atomic move 진행 중 안전.
+
+- [ ] **Step 4: coverageThreshold 완화**
+
+`coverageThreshold.global` 객체를 다음과 같이 교체:
+
+```js
+coverageThreshold: {
+    global: {
+        branches: 90,
+        functions: 90,
+        lines: 90,
+        statements: 90,
+    },
+},
+```
+
+100 → 90. 비즈니스 로직에 억지 테스트 부담 감소.
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `cd /Users/y0ngha/Project/siglens && yarn test:quiet`
+
+Expected: 모든 테스트 통과. 현재 100% coverage는 90% threshold를 자연 통과. `domain/`, `infrastructure/`만 측정.
+
+만약 누락 테스트로 실패하면 그 자체가 발견이지만, 현 master는 통과하는 상태이므로 정상적으로 통과해야 함. 실패 시 jest config 변경에 오타 없는지 점검.
+
+- [ ] **Step 6: 다음 task로 진행**
+
+---
+
+### Task 1.5: PR 1 검증 + 커밋 + PR 생성
+
+**Files:** 본 PR에 포함된 모든 변경 파일 검증
+
+- [ ] **Step 1: 변경 파일 목록 확인**
+
+Run: `cd /Users/y0ngha/Project/siglens && git status -s`
+
+Expected:
+```
+M eslint.config.mjs
+M jest.config.js
+M package.json
+M tsconfig.json
+M yarn.lock
+```
+
+5개 파일.
+
+- [ ] **Step 2: 전체 검증 (husky pre-push 시뮬레이션)**
+
+병렬 실행:
+```bash
+cd /Users/y0ngha/Project/siglens
+yarn format:check &
+yarn lint &
+yarn typecheck &
+yarn test:quiet &
+wait
+```
+
+Expected: 4개 모두 exit 0.
+
+각각 실패 시:
+- `format:check` 실패 → `yarn format` 실행 후 재시도
+- `lint` 실패 → Task 1.3 Step 5 트러블슈팅 참고
+- `typecheck` 실패 → tsconfig.json paths 오타 점검
+- `test:quiet` 실패 → jest.config.js 오타 점검
+
+- [ ] **Step 3: 새 branch 생성 + 커밋 + PR 생성 (git-agent 위임)**
+
+`git-agent` sub-agent를 호출하여 다음을 수행:
+- branch 생성: `refactor/fsd-phase-0-config`
+- 변경 파일 5개 스테이지 + 커밋
+- 커밋 메시지: `refactor(arch): Phase 0 — ESLint boundaries, tsconfig paths, jest coverage 90%`
+- 커밋 body:
+  ```
+  - eslint-plugin-boundaries 도입, 옛 + 새 layer 사전 등록 (위반 0 유지)
+  - tsconfig paths alias: @/widgets, @/features, @/entities, @/pages
+  - jest coverageThreshold 100 → 90, collectCoverageFrom + testMatch 옛/새 둘 다 매칭
+  - no-restricted-imports로 slice internal path 차단, @/entities/*/actions 예외
+
+  Phase 0 of FSD migration. See docs/superpowers/specs/2026-05-24-fsd-migration-design.md
+  ```
+- push + `gh pr create`로 PR 생성
+- PR 제목: `refactor(arch): Phase 0 — FSD migration config setup`
+- PR body에 spec 링크 + 본 plan 링크 + 변경 요약 + Test plan 체크리스트
+
+- [ ] **Step 4: PR URL 확인 + 리뷰 대기**
+
+git-agent가 반환한 PR URL을 기록. claude-code-review.yml이 자동으로 PR 리뷰를 시작한다. 머지 전까지 PR 2 진행 보류 (PR 2가 PR 1의 ESLint 규칙에 의존하지는 않지만, 순차 머지로 충돌 최소화).
+
+---
+
+## PR 2 — Workflow + Sub-agent path-agnostic 재설계
+
+GitHub Actions 워크플로우와 Claude Code sub-agent들의 path 의존 conditional doc loading을 일반화한다. PR 1이 머지된 후 진행.
+
+### Task 2.1: `claude-code-review.yml` 재설계
+
+**Files:**
+- Modify: `/Users/y0ngha/Project/siglens/.github/workflows/claude-code-review.yml`
+
+- [ ] **Step 1: 현 prompt 구조 확인**
+
+파일을 다시 읽어 다음 섹션 위치 파악:
+- `## Review Procedure & Agentic Flow` (line 70 부근)
+- `3. **Contextual Reading**: Based on the diff, read CLAUDE.md, /docs/MISTAKES.md, and ONLY the relevant principle documents from the list below.` — 이 문장이 핵심
+- `## Project Principle Documents (Reference Pool)` 섹션 — docs 목록
+
+- [ ] **Step 2: Contextual Reading 단계를 path-agnostic으로 갱신**
+
+`3. **Contextual Reading**: ...` 문장을 다음으로 교체:
+
+```
+3. **Contextual Reading**: Always read the following core documents:
+   - CLAUDE.md
+   - docs/MISTAKES.md (highest priority — known repeated patterns)
+   - docs/ARCHITECTURE.md
+   - docs/CONVENTIONS.md
+   - docs/FF.md
+   
+   Additionally read **only** the documents relevant to the changed files:
+   - If the diff touches indicator calculations, signal logic, or candle patterns → read docs/DOMAIN.md
+   - If the diff touches UI components (.tsx files) → read docs/DESIGN.md
+   - If the diff touches external API integrations (AI providers, market data) → read docs/API.md
+   - If the diff touches authentication flows or session management → read docs/AUTH.md
+   - If the diff touches FSD layer boundaries or cross-layer imports → read the relevant src/<layer>/CLAUDE.md (if it exists)
+   
+   Do NOT use concrete directory paths (src/domain/, src/infrastructure/) as triggers — those layers are being migrated to FSD and may not exist mid-migration. Use file content / responsibility as the trigger instead.
+```
+
+이 표현은 layer 이름이 사라져도 review-agent가 적절한 docs를 로드할 수 있게 한다.
+
+- [ ] **Step 3: Review Focus Areas 갱신**
+
+`## Review Focus Areas` 섹션에서 layer 이름이 박힌 항목 점검:
+- "Layer dependencies: Import direction violations (ARCHITECTURE.md)" — 유지 (ARCHITECTURE.md 자체가 갱신될 것)
+- "Domain rules: Purity, null handling, return types (DOMAIN.md)" — 유지
+- 나머지는 layer 이름이 박혀 있지 않으므로 유지
+
+- [ ] **Step 4: workflow 문법 검증**
+
+`yamllint` 미설치 가능. 대신 GitHub Actions UI에 노출되는 yaml 구조가 깨지지 않았는지 시각적으로 확인 — 들여쓰기 일관성, `|` 다음 prompt block의 들여쓰기 유지.
+
+- [ ] **Step 5: 다음 task로 진행**
+
+---
+
+### Task 2.2: `.claude/agents/review-agent.md` 재설계
+
+**Files:**
+- Modify: `/Users/y0ngha/Project/siglens/.claude/agents/review-agent.md`
+
+- [ ] **Step 1: 현 review-agent.md의 "Load Required Documents" 섹션 확인**
+
+`### 2. Load Required Documents` 섹션을 찾는다. 현재:
+
+```markdown
+| Condition | Also read |
+|---|---|
+| `src/domain/` changed (excluding `__tests__/` only changes) | `docs/DOMAIN.md` |
+| `src/components/*.tsx` changed | `docs/DESIGN.md` |
+| `src/infrastructure/ai/` or `src/infrastructure/market/` changed | `docs/API.md` |
+| Only `src/__tests__/` files changed, no source files | Skip all conditional docs |
+```
+
+이 표가 path 의존.
+
+- [ ] **Step 2: 표를 path-agnostic 표현으로 교체**
+
+위 표를 다음과 같이 교체:
+
+```markdown
+| Condition | Also read |
+|---|---|
+| Diff touches indicator calculations, signal logic, candle patterns, or prompt builders | `docs/DOMAIN.md` |
+| Diff touches `.tsx` files (UI components) | `docs/DESIGN.md` |
+| Diff touches AI provider calls or market data fetches | `docs/API.md` |
+| Diff touches authentication flows or session management | `docs/AUTH.md` |
+| Only test files changed, no source files | Skip all conditional docs |
+
+Determine the trigger by reading the actual file content of the diff — do NOT match on directory paths (`src/domain/`, `src/infrastructure/`). FSD migration is in progress; concrete layer paths are unstable.
+```
+
+- [ ] **Step 3: Excluded Directories 섹션 확인**
+
+`### Excluded Directories` 섹션의 path 목록 (line 70~80 부근):
+```
+/docs/**
+/refs/**
+/public/**
+/.github/**
+/.yarn/**
+/.agents/**
+/.claude/**
+```
+
+이 목록은 path 그대로 두는 게 맞다 — 이건 "리뷰 대상에서 제외할 절대 경로" 목록이라 layer 이동과 무관. 변경 없음.
+
+- [ ] **Step 4: Siglens Rule Check (Checklist) 섹션 점검**
+
+`### Step 1. Siglens Rule Check (Checklist)` 의 항목들 점검:
+- `domain/: no external library imports (technicalindicators, lodash, etc.)` — layer 이름 박힘
+- `components/: no direct imports from infrastructure` — layer 이름 박힘
+- `Lightweight Charts is not imported outside components/chart/` — 박힘
+
+이 항목들은 옛 layer 동안 유효하므로 그대로 둠. Phase 9에서 FSD 전환 완료 시 갱신.
+
+대신 본 task의 변경은 "Load Required Documents" 표만 path-agnostic화 → checklist는 옛 layer가 살아 있는 동안 유효한 그대로.
+
+- [ ] **Step 5: 다음 task로 진행**
+
+---
+
+### Task 2.3: 나머지 sub-agent 점검 + flow docs 갱신
+
+**Files:**
+- Read+Modify: `/Users/y0ngha/Project/siglens/.claude/agents/mistake-managing-agent.md`
+- Read+Modify: `/Users/y0ngha/Project/siglens/.claude/agents/git-agent.md`
+- Read+Modify: `/Users/y0ngha/Project/siglens/.claude/agents/issue-agent.md`
+- Modify: `/Users/y0ngha/Project/siglens/docs/ISSUE_IMPL_FLOW.md`
+- Modify: `/Users/y0ngha/Project/siglens/docs/PR_FIX_FLOW.md`
+
+- [ ] **Step 1: mistake-managing-agent.md 점검**
+
+파일을 읽는다. layer-name 의존 표(`src/domain/`, `src/infrastructure/`, `src/components/` 등)가 있는지 확인.
+
+- 발견 시: 해당 표를 review-agent.md와 동일한 방식으로 path-agnostic 표현으로 교체.
+- 없으면: 변경 없음, 다음 step.
+
+- [ ] **Step 2: git-agent.md 점검**
+
+파일을 읽는다. git-agent는 commit/push/PR 생성 책임이라 path 의존이 낮음. 다만 PR body 템플릿이 layer 이름을 가정하는 경우가 있을 수 있음.
+
+- 발견 시: 일반화 표현으로 교체 ("affected layer" → "affected slice/area").
+- 없으면: 변경 없음.
+
+- [ ] **Step 3: issue-agent.md 점검**
+
+파일을 읽는다. issue 템플릿에서 layer name을 카테고리로 쓰는 경우가 있는지 확인. 
+
+- 발견 시: 갱신.
+- 없으면: 변경 없음.
+
+- [ ] **Step 4: `docs/ISSUE_IMPL_FLOW.md` "Modified layer" 표 갱신**
+
+파일에서 다음 표를 찾는다(Step 1-2 인근):
+
+```
+| Modified layer | MISTAKES.md sections to read |
+| ... |
+```
+
+이 표를 path-agnostic 매핑으로 교체:
+
+```markdown
+| Modified area | MISTAKES.md sections to read |
+|---|---|
+| Indicator calculations, signal logic, candle patterns | Coding Paradigm, Domain Functions |
+| UI components (.tsx) | Components |
+| TypeScript type definitions | TypeScript |
+| Test files | Tests |
+| SEO / structured data | SEO & Semantic Markup |
+| Accessibility / ARIA | Accessibility (WAI-ARIA) |
+| All other changes | Coding Paradigm (general) |
+
+Determine the area by reading the diff content — do not match on concrete directory paths (src/domain/, src/infrastructure/). FSD migration is in progress.
+```
+
+- [ ] **Step 5: `docs/PR_FIX_FLOW.md` 동일 점검**
+
+파일 전체를 읽고 "Modified layer" 또는 유사한 path-dependent 표가 있는지 확인. 있으면 Step 4와 동일하게 교체.
+
+- [ ] **Step 6: 다음 task로 진행**
+
+---
+
+### Task 2.4: PR 2 검증 + 커밋 + PR 생성
+
+**Files:** 본 PR에 포함된 변경 파일들
+
+- [ ] **Step 1: 변경 파일 목록 확인**
+
+Run: `cd /Users/y0ngha/Project/siglens && git status -s`
+
+Expected (예시):
+```
+M .claude/agents/git-agent.md
+M .claude/agents/issue-agent.md
+M .claude/agents/mistake-managing-agent.md
+M .claude/agents/review-agent.md
+M .github/workflows/claude-code-review.yml
+M docs/ISSUE_IMPL_FLOW.md
+M docs/PR_FIX_FLOW.md
+```
+
+7개 또는 그 이하 (각 sub-agent에서 path 의존이 없으면 변경 없음).
+
+- [ ] **Step 2: 전체 검증**
+
+병렬 실행:
+```bash
+cd /Users/y0ngha/Project/siglens
+yarn format:check &
+yarn lint &
+yarn typecheck &
+yarn test:quiet &
+wait
+```
+
+Expected: 4개 모두 exit 0.
+
+> 본 PR은 코드 변경이 없고 문서/yml만 변경되므로 lint/typecheck/test는 영향 없이 통과해야 함.
+
+- [ ] **Step 3: 새 branch + 커밋 + PR 생성 (git-agent 위임)**
+
+`git-agent` sub-agent를 호출하여:
+- branch: `refactor/fsd-phase-0-workflows`
+- base: master (PR 1이 머지된 상태 가정)
+- 커밋 메시지: `refactor(arch): Phase 0 — workflow/sub-agent path-agnostic 재설계`
+- body:
+  ```
+  - claude-code-review.yml: conditional doc loading을 file content/책임 기반으로 일반화
+  - .claude/agents/{review,mistake-managing,git,issue}-agent.md: layer-name 의존 제거
+  - docs/{ISSUE_IMPL_FLOW,PR_FIX_FLOW}.md: "Modified layer" 표 path-agnostic화
+
+  Phase 0 of FSD migration. See docs/superpowers/specs/2026-05-24-fsd-migration-design.md
+  ```
+- PR 제목: `refactor(arch): Phase 0 — workflow & sub-agent path-agnostic redesign`
+
+- [ ] **Step 4: PR URL 확인 + 리뷰 대기**
+
+PR 2의 리뷰가 자동 시작된다. 이 PR이 머지된 후 PR 3 진행.
+
+---
+
+## PR 3 — Spec + CLAUDE.md 머지
+
+본 spec(`2026-05-24-fsd-migration-design.md`)과 본 plan은 이미 작성되어 워킹 트리에 있다. `CLAUDE.md`의 Layer Dependency Rules 섹션을 FSD + legacy 공존 표현으로 갱신하고, spec/plan과 함께 한 PR로 머지한다.
+
+### Task 3.1: `CLAUDE.md` 갱신
+
+**Files:**
+- Modify: `/Users/y0ngha/Project/siglens/CLAUDE.md`
+
+- [ ] **Step 1: 현 CLAUDE.md의 Layer Dependency Rules 섹션 확인**
+
+`## Layer Dependency Rules (Never Violate)` 섹션을 찾는다. 현재:
+
+```
+domain         ← No external imports. Pure TypeScript functions only.
+                 Exception: @y0ngha/siglens-core may be imported (see below).
+infrastructure ← May import from domain and lib (lib must be pure utilities/constants only). ...
+lib            ← External UI utility wrappers (clsx, tailwind-merge, etc.). ...
+app (RSC/Route)← May import from infrastructure, domain, lib.
+components     ← May import from domain, lib.
+               Component files (.tsx): Direct imports from infrastructure are prohibited.
+               Hook files (hooks/): May import fetch functions from infrastructure only
+                 ...
+```
+
+- [ ] **Step 2: Layer Dependency Rules 섹션을 FSD + legacy 공존으로 교체**
+
+위 섹션 전체를 다음으로 교체:
+
+```markdown
+## Layer Dependency Rules (Never Violate)
+
+### Migration in progress: Layered → FSD
+
+본 프로젝트는 현재 **Layered 구조에서 Feature-Sliced Design (FSD) 6-layer로 단계적으로 마이그레이션 중**이다. Phase 0~9 동안 옛 layer와 새 layer가 공존한다. 자세한 설계는 `docs/superpowers/specs/2026-05-24-fsd-migration-design.md` 참고.
+
+### FSD 의존 방향 (목표 상태)
+
+```
+app  →  pages  →  widgets  →  features  →  entities  →  shared
+                                                          ↑
+                                          @y0ngha/siglens-core (외부, 모든 레이어 직접 import 가능)
+```
+
+- 각 레이어는 자기 위 레이어를 import할 수 없다 (예: entities는 features를 import할 수 없음).
+- 같은 레이어 안의 다른 슬라이스끼리 import 금지 (예: `entities/user`는 `entities/session`을 직접 import할 수 없음 — 상위 레이어를 통해 라우팅).
+- production 코드는 슬라이스 root만 import (예: `@/widgets/stock-chart`, NOT `@/widgets/stock-chart/ui/Chart`). 테스트 파일은 예외.
+
+### Legacy 의존 방향 (마이그레이션 동안 유지)
+
+```
+domain         ← No external imports. Pure TypeScript functions only.
+                 Exception: @y0ngha/siglens-core may be imported.
+infrastructure ← May import from domain and lib.
+lib            ← External UI utility wrappers. Pure functions only.
+app (RSC)      ← May import from infrastructure, domain, lib.
+components     ← May import from domain, lib.
+               Component files (.tsx): Direct imports from infrastructure are prohibited.
+               Hook files (hooks/): May import fetch functions from infrastructure only
+                 → Limited to queryFn/mutationFn or useActionState connection.
+                 → Type imports from @/domain/types or @y0ngha/siglens-core.
+```
+
+Phase 9 완료 시 legacy 섹션은 제거된다.
+
+### siglens-core 직접 import 예외 (모든 레이어)
+
+`@y0ngha/siglens-core`는 외부 라이브러리가 아니라 외부 분석 도메인 패키지다. 모든 레이어가 직접 import 가능하다. deep import(`@y0ngha/siglens-core/dist/...`) 금지.
+
+### Server Action 예외
+
+`entities/<x>/actions.ts`(Next.js `'use server'` 파일)는 features/widgets/pages에서 import 가능하다. `entities/<x>/api.ts`는 server-only이므로 same-entity 또는 app 레이어에서만 import.
+
+### ESLint 강제
+
+위 규칙은 `eslint-plugin-boundaries` + `no-restricted-imports`로 정적 검증된다. 위반 시 PR 머지 불가. 자세한 설정은 `eslint.config.mjs`.
+```
+
+- [ ] **Step 3: Request Routing 표 확인**
+
+`## ⛔ Request Routing` 섹션은 layer 이름과 무관하므로 변경 없음.
+
+- [ ] **Step 4: Cross-repo scope guard 섹션 확인**
+
+`## ⛔ Cross-repo scope guard` 섹션의 트리거 패턴들은 분석 도메인 변경에 관한 것이라 layer 이름과 무관. 변경 없음.
+
+- [ ] **Step 5: typecheck 통과 확인**
+
+Run: `cd /Users/y0ngha/Project/siglens && yarn typecheck`
+
+Expected: 코드 변경 없으므로 정상 통과.
+
+- [ ] **Step 6: 다음 task로 진행**
+
+---
+
+### Task 3.2: PR 3 검증 + 커밋 + PR 생성
+
+**Files:** spec, plan, CLAUDE.md 변경
+
+- [ ] **Step 1: 변경 파일 목록 확인**
+
+Run: `cd /Users/y0ngha/Project/siglens && git status -s`
+
+Expected:
+```
+M CLAUDE.md
+?? docs/superpowers/plans/2026-05-24-fsd-migration-phase-0.md
+?? docs/superpowers/specs/2026-05-24-fsd-migration-design.md
+```
+
+3개 (CLAUDE.md modified, spec/plan untracked).
+
+- [ ] **Step 2: 전체 검증**
+
+병렬 실행:
+```bash
+cd /Users/y0ngha/Project/siglens
+yarn format:check &
+yarn lint &
+yarn typecheck &
+yarn test:quiet &
+wait
+```
+
+Expected: 4개 모두 exit 0.
+
+> CLAUDE.md/docs 변경뿐이므로 영향 없이 통과.
+
+- [ ] **Step 3: 새 branch + 커밋 + PR 생성 (git-agent 위임)**
+
+`git-agent` sub-agent를 호출하여:
+- branch: `refactor/fsd-phase-0-spec-claude-md`
+- base: master (PR 2가 머지된 상태 가정)
+- 스테이지할 파일:
+  - `CLAUDE.md` (modified)
+  - `docs/superpowers/specs/2026-05-24-fsd-migration-design.md` (untracked)
+  - `docs/superpowers/plans/2026-05-24-fsd-migration-phase-0.md` (untracked)
+- 커밋 메시지: `refactor(arch): Phase 0 — FSD migration spec + CLAUDE.md 갱신`
+- body:
+  ```
+  - docs/superpowers/specs/2026-05-24-fsd-migration-design.md 머지
+  - docs/superpowers/plans/2026-05-24-fsd-migration-phase-0.md 머지
+  - CLAUDE.md Layer Dependency Rules를 FSD + legacy 공존 표현으로 갱신
+  - siglens-core import 예외, Server Action 예외 명문화
+
+  Phase 0 of FSD migration.
+  ```
+- PR 제목: `refactor(arch): Phase 0 — FSD migration spec & CLAUDE.md merge`
+
+- [ ] **Step 4: PR URL 확인 + 리뷰 대기**
+
+PR 3 머지 후 Phase 0 완료. Phase 1 plan 작성은 별도 task로 진행 (`writing-plans` 스킬 재호출).
+
+---
+
+## Phase 0 완료 기준
+
+- [ ] PR 1 (config) 머지 완료
+- [ ] PR 2 (workflows/agents) 머지 완료
+- [ ] PR 3 (spec/CLAUDE.md) 머지 완료
+- [ ] master 브랜치에서 `yarn build` 성공
+- [ ] master 브랜치에서 `yarn lint`, `yarn typecheck`, `yarn test:quiet` 모두 통과
+- [ ] Vercel master 배포 정상 (vercel.json은 변경 없으므로 자동)
+- [ ] husky pre-push 통과 (새 coverage 90% threshold + 새 testMatch)
+- [ ] ESLint boundaries 위반 0 (새 layer 디렉토리 비어 있음 + legacy 옛 의존 그대로 허용)
+- [ ] claude-code-review.yml이 path-agnostic 리뷰를 정상 수행 (Phase 1 첫 PR에서 자연 검증)
+
+---
+
+## Phase 0 이후 — 다음 단계
+
+Phase 0이 머지되면 Phase 1 plan을 작성한다:
+- 파일: `docs/superpowers/plans/2026-05-25-fsd-migration-phase-1.md` (작성 일자에 맞춰 변경)
+- 범위: shared 레이어 셋업 (spec § 9 Phase 1)
+- 예상 PR: 3개 (`shared/lib`, `shared/ui` + `shared/hooks`, `shared/db/cache/email/api` 분리)
+
+Phase 2~9도 각각 별도 plan으로 진행한다.

--- a/docs/superpowers/specs/2026-05-24-fsd-migration-design.md
+++ b/docs/superpowers/specs/2026-05-24-fsd-migration-design.md
@@ -1,0 +1,624 @@
+## Siglens — Layered → FSD 아키텍처 전환 설계 문서
+
+- 작성일: 2026-05-24
+- 작성자: y0ngha (with Claude)
+- 상태: brainstorming 완료, plan 작성 대기
+- 레퍼런스: `/Users/y0ngha/Project/whatap` (Vite SPA + FSD 6-layer)
+
+---
+
+## 1. 배경 & 목적
+
+siglens는 현재 Layered Architecture(`app/`, `components/`, `domain/`, `infrastructure/`, `lib/`)를 운영 중이다. 도메인 영역이 16개, 인프라 영역이 20개, 컴포넌트 영역이 25개에 이르며 단일 레이어 안에 cross-domain 결합이 가시화되고 있다. 본 작업은 코드베이스를 **Feature-Sliced Design(FSD) 6-layer**로 재편하여:
+
+- 도메인 단위로 응집도를 끌어올리고 (변경이 함께 일어나는 파일이 함께 위치)
+- ESLint boundaries로 의존 방향을 정적 강제 (현재는 관습 의존)
+- 슬라이스 단위 추가/삭제/이동의 비용을 낮춤
+
+`@y0ngha/siglens-core` 외부 패키지 정책(`docs/SCOPE.md`)은 그대로 유지한다 — 분석 도메인은 core가 소유하고 siglens는 어댑터/UI/일반 백엔드만 보유한다는 분담은 FSD 전환과 직교한다.
+
+---
+
+## 2. 핵심 가정 (확정된 4가지 결정)
+
+| # | 항목 | 결정 |
+|---|---|---|
+| 1 | 테스트 coverage 정책 (G1) | 전체 측정 대상 레이어 **90% threshold**. `coverageThreshold: 90`, `collectCoverageFrom`을 `src/entities/**`, `src/features/**/lib/**`, `src/features/**/api/**`, `src/shared/lib/**` 로 좁힘. UI(`widgets/`, `pages/`, `app/`) 측정 제외 (현 정책 유지) |
+| 2 | 마이그레이션 중간 상태 (G6) | **Atomic move per PR**. 각 PR에서 파일 이동 + 모든 import 갱신 + 옛 경로 삭제 동시. 옛↔새 공존 0. PR을 영역 단위로 잘게 분할 |
+| 3 | 기존 layer CLAUDE.md 처리 (G7) | **영역 이동 시 함께 교체**. Phase X가 옛 영역을 비울 때 옛 CLAUDE.md 삭제, 새 layer 채워질 때 새 CLAUDE.md 작성. Phase 0에서는 기존 6개를 건들지 않음 |
+| 4 | Workflow/Sub-agent 갱신 (G2/G3) | **Phase 0에 path-agnostic 재설계**. `.github/workflows/claude-code-review.yml`과 `.claude/agents/*` 의 layer-name 의존 conditional doc loading을 일반화 |
+
+---
+
+## 3. 최종 디렉토리 구조
+
+```
+src/
+├── app/              ← FSD app(composition root) + Next.js routing 통합
+│   ├── layout.tsx, providers.tsx
+│   ├── (routes)/     thin entry, @/pages/* 로 위임
+│   │   ├── page.tsx, [symbol]/{layout,page,overall,fundamental,news,options,fear-greed}/...
+│   │   ├── market/, account/, login/, signup/, backtesting/, forgot-password/, reset-password/
+│   │   ├── privacy/, terms/, account/delete/, signup/oauth/consent/
+│   └── api/          thin Route Handler, @/features/* 또는 @/entities/* 로 위임
+│       ├── auth/[provider]/{start,callback}/route.ts
+│       ├── jobs/cancel/route.ts
+│       └── sitemap/{static,popular,longtail/[page]}/route.ts
+│
+├── proxy.ts          (Next.js 16 표준 위치; src/app/proxy.ts 미지원 — G12)
+│
+├── pages/            ← FSD pages 레이어 (실제 RSC composition)
+│   landing, symbol, symbol-overall, symbol-fundamental, symbol-news, symbol-options,
+│   symbol-fear-greed, market, account, account-delete, login, signup,
+│   signup-oauth-consent, forgot-password, reset-password, backtesting,
+│   legal-privacy, legal-terms
+│
+├── widgets/          ← Self-contained UI (총 24개)
+│   site-header, site-footer, site-jsonld,
+│   stock-chart, analysis-panel, chat-panel,
+│   market-summary, sector-signal,
+│   news-summary, fundamental-summary, options-chain, options-summary,
+│   fear-greed-gauge, overall-analysis, backtest-case-list,
+│   landing-hero, landing-stats-bar, landing-how-it-works,
+│   landing-skills-showcase, landing-ticker-categories,
+│   symbol-header, symbol-tabs, legal-shell, pwa-install-banner
+│
+├── features/         ← User interactions (총 20개)
+│   auth-login, auth-signup, auth-email-verification, auth-password-reset,
+│   auth-oauth, auth-oauth-consent, auth-logout, account-delete,
+│   api-key-management, ticker-search, timeframe-select, analysis-trigger,
+│   llm-model-select, indicator-tracking, symbol-chat, contact-form,
+│   backtest-filter, pwa-install, premium-gate, sitemap-generation
+│
+├── entities/         ← Domain + API + Query hooks (총 23개)
+│   user, session, oauth-account, api-key, user-tier,
+│   ticker, bars, analysis, chat-message,
+│   market-summary, sector-signal, fear-greed,
+│   fundamental, news-article, earnings-report, options-chain,
+│   llm-provider, skill, inquiry, email-token, backtest-case,
+│   og-image, sitemap-entry
+│
+└── shared/           ← Framework-agnostic
+    api/      (http.ts, queryClient.ts, singleFlight.ts, fmp/client.ts)
+    db/       (client.ts, schema.ts, tokenEncryption.ts)
+    email/    (dispatcher.ts — Resend/Noop)
+    cache/    (redis.ts — Upstash)
+    ui/       (DotSeparator, EyeIcon, InfoTooltip, MarkdownText, JsonLd, Tabs/, ErrorBoundary, Skeleton, Tooltip)
+    lib/      (cn, classNames/, format/, time/, seo/, pwa/, a11y/, storage/, retry/, types/)
+    hooks/    (useHydrated, useIsMobileViewport, useDialog, usePopoverToggle, useEscapeKey, useFocusTrap, usePointerTooltip, useCopyToClipboard, useQueryParamState, usePageHideCancel, usePageShowReload)
+    config/   (constants.ts, env.ts, queryKeys.ts, pollingConfig.ts)
+```
+
+---
+
+## 4. 의존 방향 (siglens 변형)
+
+```
+app  →  pages  →  widgets  →  features  →  entities  →  shared
+                                                          ↑
+                                          @y0ngha/siglens-core (외부, 모든 레이어 직접 import 가능)
+```
+
+### siglens 고유 규칙
+
+1. **Next.js 라우팅 + composition root 통합**: `src/app/`은 Next.js App Router + FSD app 레이어 역할 합체. 실제 RSC 페이지 구성은 `src/pages/`에 위임.
+2. **Server Action 위치**: `'use server'` 함수는 해당 entity가 자기 데이터 도메인을 소유한다는 원칙에 따라 `entities/<x>/actions.ts`에 둔다. 비-action 함수는 `entities/<x>/api.ts`로 분리.
+3. **siglens-core 직접 import 예외**: 모든 레이어가 `@y0ngha/siglens-core`에서 분석 도메인을 직접 import할 수 있다. deep import(`@y0ngha/siglens-core/dist/...`) 금지.
+4. **DB schema는 shared**: Drizzle 스키마는 여러 entity가 공유하므로 `shared/db/schema.ts`. 각 entity는 자기 테이블의 repository를 보유.
+5. **Email dispatcher는 shared, 템플릿은 entity**: Resend/Noop dispatcher는 인프라성 유틸이라 shared, 템플릿(`passwordResetEmail`, `emailVerificationEmail`)은 `entities/email-token/templates/`.
+6. **Server Action ESLint 예외**: `no-restricted-imports`에서 `@/entities/<x>/actions` 경로는 허용 (`'use server'` 파일은 client에서 import). `api/`, `lib/`, `hooks/`, `model/`는 internal path로 차단.
+
+---
+
+## 5. 현재 → FSD 매핑
+
+### 5-1. `src/components/*` → widgets / features
+
+| 현 위치 | 분류 | 목적지 |
+|---|---|---|
+| `components/layout/Header*, Footer, SiteJsonLd, HeaderUserMenu, ContactDialog` | widget | `widgets/site-header/`, `widgets/site-footer/`, `widgets/site-jsonld/` |
+| `components/chart/*` | widget | `widgets/stock-chart/` |
+| `components/analysis/*` | widget + feature | `widgets/analysis-panel/` + `features/analysis-trigger/` + `features/llm-model-select/` |
+| `components/chat/*` | widget + feature | `widgets/chat-panel/` + `features/symbol-chat/` |
+| `components/dashboard/*` | widget | `widgets/market-summary/`, `widgets/sector-signal/` |
+| `components/fear-greed/*` | widget | `widgets/fear-greed-gauge/` |
+| `components/fundamental/*` | widget | `widgets/fundamental-summary/` (sections colocate) |
+| `components/home/*` | widget | `widgets/landing-*/` (hero/stats/howitworks/skills/tickers 분리) |
+| `components/legal/*` | widget | `widgets/legal-shell/` |
+| `components/news/*` | widget | `widgets/news-summary/` (sections colocate) |
+| `components/options/*` | widget | `widgets/options-chain/`, `widgets/options-summary/` |
+| `components/overall/*` | widget | `widgets/overall-analysis/` |
+| `components/pwa/*` | feature | `features/pwa-install/` |
+| `components/search/*` | feature | `features/ticker-search/` |
+| `components/symbol-page/*` | widget + feature | `widgets/symbol-header/`, `widgets/symbol-tabs/` + `features/indicator-tracking/`, `features/llm-model-select/` |
+| `components/auth/*` | feature | `features/auth-login/`, `features/auth-signup/`, `features/auth-password-reset/`, `features/auth-email-verification/`, `features/auth-oauth/`, `features/account-delete/` |
+| `components/account/*` | feature | `features/api-key-management/` |
+| `components/contact/*` | feature | `features/contact-form/` |
+| `components/backtesting/*` | widget + feature | `widgets/backtest-case-list/` + `features/backtest-filter/` |
+| `components/trendline/*` | shared | `shared/lib/chart/trendlineConstants.ts` |
+| `components/ui/*` | shared | `shared/ui/` (단, PremiumModelGateModal은 `features/premium-gate/`) |
+| `components/providers/ReactQueryProvider` | app | `src/app/providers.tsx`로 흡수 |
+| `components/hooks/*` (form/dialog/device/data) | 분산 | 폼 hook → 각 auth feature `hooks/`; useCurrentUser → `entities/user/hooks/`; useDialog/usePopoverToggle/useEscapeKey/useFocusTrap/useOnClickOutside/usePointerTooltip → `shared/hooks/`; useIsMobileViewport/useHydrated/useCopyToClipboard/useQueryParamState → `shared/hooks/`; useLogout → `features/auth-logout/`; useModelGate → `features/premium-gate/` |
+
+### 5-2. `src/domain/*` → entities + shared
+
+| 현 위치 | 목적지 |
+|---|---|
+| `domain/auth/*` (validation, passwordRules, formTypes) | `entities/user/` 또는 각 auth feature `lib/`. sanitizeNextPath는 `features/auth-oauth/lib/` |
+| `domain/analysis/{gate, staleThreshold}` | `entities/analysis/lib/` |
+| `domain/backtest/*` | `entities/backtest-case/lib/` |
+| `domain/chart/timeFormat` | `shared/lib/format/` |
+| `domain/chat/{derivePageContextLabel, fallbackAnalysis}` | `entities/chat-message/lib/` |
+| `domain/constants/*` (popular-tickers, dashboard-tickers, market, ticker, time) | `shared/config/constants.ts` 또는 entity별 분산 |
+| `domain/contact/{validation, constants}` | `entities/inquiry/lib/` |
+| `domain/fearGreed/classifier` | `entities/fear-greed/lib/` |
+| `domain/llm/{types, apiKey, constants, providerDefaults}` | `entities/llm-provider/model.ts` + `api.ts` |
+| `domain/market/session` | `shared/lib/time/marketSession.ts` |
+| `domain/options/*` | `entities/options-chain/lib/` |
+| `domain/seo/assetClassification` | `entities/ticker/lib/assetClassification.ts` |
+| `domain/signals/*` | siglens-core import 우선. 로컬 잔여분만 `entities/analysis/lib/signalQuadrants.ts` |
+| `domain/time/eastern` | `shared/lib/time/` |
+| `domain/legal/` | 빈 폴더 제거 |
+
+### 5-3. `src/infrastructure/*` → entities + shared
+
+| 현 위치 | 목적지 |
+|---|---|
+| `infrastructure/ai/{anthropic, gemini, openai, router, parseJsonResponse, utils}` | `entities/llm-provider/api.ts` + `lib/` |
+| `infrastructure/auth/use-cases/*` | `entities/user/api.ts` (register/login/logout/socialLogin/deleteAccount/findUserBySessionToken) + `entities/email-token/api.ts` (requestEmailVerification/verifyEmail/requestPasswordReset/confirmPasswordReset) |
+| `infrastructure/auth/*Action.ts` | `features/auth-*/api/` 에서 entity api 호출 |
+| `infrastructure/auth/db.ts` | `shared/db/client.ts` |
+| `infrastructure/auth/oauth/*` | `entities/oauth-account/api.ts` (provider 어댑터) + `features/auth-oauth/lib/` (state issue/verify) |
+| `infrastructure/auth/{applyAuthCookie, sessionCookieOptions, getCurrentUser}` | `entities/session/api.ts` |
+| `infrastructure/chat/*` | `entities/chat-message/api.ts` |
+| `infrastructure/contact/*` | `features/contact-form/api/` (action) + `entities/inquiry/api.ts` (use-case) |
+| `infrastructure/dashboard/{marketSummary, sectorSignals}` | `entities/market-summary/api.ts`, `entities/sector-signal/api.ts` |
+| `infrastructure/db/*` (schema, client, 8 repositories) | `shared/db/client.ts` + `shared/db/schema.ts` + 각 repository는 해당 entity api로 분산 |
+| `infrastructure/email/*` | dispatcher → `shared/email/dispatcher.ts`. tokenStore → `entities/email-token/api.ts`. 템플릿 → `entities/email-token/templates/` |
+| `infrastructure/fmp/*` | `shared/api/fmp/client.ts` + `entities/fundamental/api.ts`, `entities/news-article/api.ts` |
+| `infrastructure/http/isBot` | `shared/api/http.ts` |
+| `infrastructure/llm/*` | `features/api-key-management/api/` + `entities/api-key/api.ts` |
+| `infrastructure/market/*` | `entities/analysis/api.ts` + `entities/bars/api.ts` + `entities/news-article/api.ts` |
+| `infrastructure/og/*` | `entities/og-image/` |
+| `infrastructure/options/*` | `entities/options-chain/api.ts` + `lib/` |
+| `infrastructure/seo/getTodayIsoDay` | `shared/lib/seo/` |
+| `infrastructure/sitemap/*` | `features/sitemap-generation/lib/` + `entities/sitemap-entry/` |
+| `infrastructure/skills/*` | `entities/skill/api.ts` |
+| `infrastructure/storage/recentSearches` | `entities/ticker/api/recentSearches.ts` |
+| `infrastructure/ticker/*` | `entities/ticker/api.ts` + `lib/` |
+| `infrastructure/tier/*` | `entities/user-tier/api.ts` |
+| `infrastructure/utils/{dateKey, withRetry}` | `shared/lib/` |
+
+### 5-4. `src/lib/*` → shared
+
+거의 그대로 shared로 이동. 일부 도메인 의존성 있는 것만 entity로 분기:
+- `lib/queryConfig.ts` → `shared/config/queryKeys.ts`
+- `lib/auth/cookieNames` → `shared/config/cookies.ts`
+- `lib/auth/tierLabel` → `entities/user-tier/lib/tierLabel.ts`
+- `lib/fundamental/cacheTtl` → `entities/fundamental/lib/cacheTtl.ts`
+- `lib/news/{cacheTtl, periodLabels}` → `entities/news-article/lib/`
+- `lib/options/{marketHoursDisplay, optionsFormatters}` → `entities/options-chain/lib/`
+- `lib/pwa/detectPwaEnvironment` → `features/pwa-install/lib/`
+- 나머지(`cn, chartColors, cardStyles, priceFormat, fearGreedLabels, llmProviderLabels, pollingConfig, formatAnalyzedAt, skillStats, seo, og, adsense, sleep, storageKeys, rovingKeyboardNav, tooltipPosition, contact, contactErrorMessages, legal-toc, legal, cancelJobsApi, pwaEvents`) → `shared/lib/` 또는 `shared/config/`로 책임별 재분류
+
+### 5-5. `src/app/*` → app + pages
+
+| 현 위치 | 목적지 |
+|---|---|
+| `src/app/layout.tsx` | 유지 |
+| `src/app/page.tsx` | `<LandingPage />` (from `@/pages/landing`) 렌더 |
+| `src/app/[symbol]/{layout,page,overall,fundamental,news,options,fear-greed}.tsx` | 각각 `@/pages/symbol*` 로 위임 |
+| `src/app/_components/AuthSessionHeader` | `widgets/site-header/` 또는 page level inline |
+| `src/app/api/auth/[provider]/{start,callback}/route.ts` | thin → `@/features/auth-oauth/api/*Handler` |
+| `src/app/api/jobs/cancel/route.ts` | thin → `@/entities/analysis/api/cancelJob` |
+| `src/app/api/sitemap/*/route.ts` | thin → `@/features/sitemap-generation/api/*` |
+| `src/app/{login,signup,forgot-password,reset-password,account,backtesting,market,privacy,terms}/page.tsx` | 각 `@/pages/<name>` 위임 |
+| `src/proxy.ts` | 유지 (Next.js 16 표준 위치) |
+
+---
+
+## 6. 슬라이스 내부 구조 표준
+
+### 6-1. widgets/
+
+```
+widgets/<name>/
+├── ui/
+│   ├── Component.tsx           메인 컴포넌트 (JSX-only)
+│   └── components/             서브 컴포넌트
+├── hooks/                      (선택) React hook
+├── lib/                        (선택) 순수 함수
+├── __tests__/                  (선택) colocated tests
+└── index.ts                    public API
+```
+
+### 6-2. features/
+
+```
+features/<name>/
+├── ui/
+│   └── Component.tsx
+├── model/                      (선택) Context + Provider + types
+│   ├── <Name>Context.ts
+│   ├── <Name>Provider.tsx
+│   └── types.ts
+├── hooks/
+│   ├── use<Name>Form.ts
+│   └── use<Name>Selector.ts
+├── api/                        (siglens 고유) Server Action wrapper
+│   └── <action>.ts             'use server' — entity actions를 호출
+├── lib/                        (선택) pure helper
+├── __tests__/
+└── index.ts
+```
+
+### 6-3. entities/
+
+```
+entities/<name>/
+├── model.ts                    types (먼저 정의)
+├── api.ts                      비-action 함수 (server-only repository, AI provider 호출)
+├── actions.ts                  'use server' action 함수 (client에서 invoke)
+├── hooks/                      (선택) useXxxQuery / useXxxMutation
+├── lib/                        (선택) 도메인 순수 함수
+├── templates/                  (선택) email-token 같은 경우
+├── __tests__/
+└── index.ts
+```
+
+**Next.js Server Action 제약**: 한 파일 안에서 `'use server'` 디렉티브를 쓰면 그 파일의 모든 export가 Server Action이 된다. entity 내 `api.ts`(비-action)와 `actions.ts`(action) 파일을 강제 분리한다.
+
+### 6-4. shared/
+
+```
+shared/
+├── api/                        HTTP, query client, third-party API client wrapper
+├── db/                         Drizzle client + schema + token encryption
+├── email/                      Dispatcher
+├── cache/                      Redis
+├── ui/                         Primitive components
+├── lib/                        Pure utilities
+├── hooks/                      React-dependent generic hooks
+└── config/                     constants, env, query keys, polling
+```
+
+### 6-5. 슬라이스 경계 명문화 (whatap 표준 + siglens 사례)
+
+```
+Layer dependency strict:
+  app → pages → widgets → features → entities → shared
+
+Cross-slice within same layer: forbidden
+  - widgets/site-header ⊥ widgets/stock-chart
+  - features/auth-login ⊥ features/auth-signup
+  - entities/user ⊥ entities/session
+  → route through higher layer
+
+Public API only:
+  - production: import from slice root (@/widgets/stock-chart, NOT @/widgets/stock-chart/ui/Chart)
+  - tests: exempt from no-restricted-imports (whitebox tests)
+
+siglens-core:
+  - import from any layer
+  - public surface only (NO @y0ngha/siglens-core/dist/* deep import)
+
+Server Action 예외:
+  - @/entities/<x>/actions importable from features/widgets/pages
+  - @/entities/<x>/api server-only (no 'use server'), same-entity or app only
+```
+
+**siglens 적용 사례:**
+- `widgets/site-header` → `@/features/ticker-search` public API (검색바 임베드)
+- `widgets/chat-panel` → `@/features/symbol-chat` Context selector
+- `widgets/analysis-panel` → `@/features/analysis-trigger` + `@/features/llm-model-select` 합성
+- `widgets/fundamental-summary` → `@/features/premium-gate` hook + modal
+
+---
+
+## 7. 테스트 colocation + coverage 정책
+
+### 7-1. Colocation 전환
+
+현재 `src/__tests__/`는 source mirror 구조. FSD 전환과 함께 **슬라이스 내부 colocation**으로 변경:
+
+```
+widgets/stock-chart/
+├── ui/Component.tsx
+├── lib/projection.ts
+└── __tests__/
+    ├── Component.test.tsx
+    └── projection.test.ts
+```
+
+근거:
+- whatap도 colocated
+- FF "변경이 함께 일어나는 파일은 같은 디렉토리에" (`docs/FF.md` §3-A)
+- 슬라이스 통째 이동/삭제 시 테스트도 자동 follow
+
+### 7-2. Coverage 정책 (G1)
+
+```js
+// jest.config.js (Phase 0)
+coverageThreshold: {
+    global: { branches: 90, functions: 90, lines: 90, statements: 90 },
+},
+collectCoverageFrom: [
+    // 옛 + 새 둘 다 매칭 (atomic move 이후 자동으로 옛 디렉토리는 사라짐)
+    'src/domain/**/*.ts',
+    'src/infrastructure/**/*.ts',
+    'src/entities/**/*.ts',
+    'src/features/**/lib/**/*.ts',
+    'src/features/**/api/**/*.ts',
+    'src/shared/lib/**/*.ts',
+    '!src/**/*.d.ts',
+    '!src/**/index.ts',
+    '!src/**/types.ts',
+],
+testMatch: [
+    // 옛 미러 + 새 colocate 둘 다 허용
+    '<rootDir>/src/__tests__/**/*.+(test|spec).+(ts|tsx)',
+    '<rootDir>/src/**/__tests__/**/*.+(test|spec).+(ts|tsx)',
+],
+```
+
+- UI 레이어(`widgets/`, `pages/`, `app/`)는 측정 제외 (현 정책 유지)
+- 90% threshold로 완화하여 비즈니스 로직에 억지 테스트 부담 감소
+- husky `pre-push`의 `yarn test:quiet` 도 새 threshold로 통과 보장
+
+---
+
+## 8. ESLint Boundaries 도입
+
+### 8-1. Phase 0 도입안
+
+```js
+// eslint.config.mjs 추가
+import boundaries from 'eslint-plugin-boundaries';
+
+{
+  plugins: { boundaries },
+  settings: {
+    'boundaries/elements': [
+      { type: 'app',           pattern: 'src/app/**' },
+      { type: 'pages',         pattern: 'src/pages/*' },
+      { type: 'widgets',       pattern: 'src/widgets/*' },
+      { type: 'features',      pattern: 'src/features/*' },
+      { type: 'entities',      pattern: 'src/entities/*' },
+      { type: 'shared',        pattern: 'src/shared/**' },
+      // 옛 layer 도 등록 (atomic move 진행 중 위반 0 유지)
+      { type: 'legacy-app',    pattern: 'src/app/**' },
+      { type: 'legacy-comp',   pattern: 'src/components/**' },
+      { type: 'legacy-domain', pattern: 'src/domain/**' },
+      { type: 'legacy-infra',  pattern: 'src/infrastructure/**' },
+      { type: 'legacy-lib',    pattern: 'src/lib/**' },
+    ],
+  },
+  rules: {
+    'boundaries/element-types': ['error', {
+      default: 'disallow',
+      rules: [
+        { from: 'app',      allow: ['pages','widgets','features','entities','shared','legacy-*'] },
+        { from: 'pages',    allow: ['widgets','features','entities','shared','legacy-*'] },
+        { from: 'widgets',  allow: ['features','entities','shared','legacy-*'] },
+        { from: 'features', allow: ['entities','shared','legacy-*'] },
+        { from: 'entities', allow: ['shared','legacy-*'] },
+        { from: 'shared',   allow: ['shared'] },
+        // 옛 layer 들끼리는 현 의존 그대로 허용 (Phase 진행 중 깨지지 않게)
+        { from: 'legacy-*', allow: ['legacy-*', 'shared'] },
+      ],
+    }],
+  },
+}
+```
+
+Phase 9에서 옛 layer 항목 + legacy-* 규칙을 제거하여 최종 FSD 의존 잠금.
+
+### 8-2. Slice internal path 차단
+
+```js
+'no-restricted-imports': ['error', {
+  patterns: [
+    '@/features/*/model/*',
+    '@/features/*/hooks/*',
+    '@/features/*/ui/*',
+    '@/features/*/lib/*',
+    '@/features/*/api/*',
+    '@/widgets/*/ui/*',
+    '@/widgets/*/hooks/*',
+    '@/widgets/*/lib/*',
+    '@/entities/*/api',          // 'use server' 아닌 server-only api는 차단
+    '@/entities/*/model',
+    '@/entities/*/lib/*',
+    // 예외: @/entities/*/actions 는 client import 허용 (Next.js 'use server')
+  ],
+}]
+```
+
+- 테스트 파일은 `no-restricted-imports` 비활성 (whitebox 테스트)
+- `@/entities/*/actions` 만 client에서 import 허용
+
+---
+
+## 9. 9 Phase 마이그레이션 전략
+
+### Phase 0 — 준비 (확장됨, 2~3 PR)
+- `eslint-plugin-boundaries` + 옛 + 새 layer 사전 등록 (위반 0 확인)
+- `tsconfig.json` paths alias 확장: `@/widgets/*`, `@/features/*`, `@/entities/*`, `@/pages/*` (shared는 기존 `@/*` 매칭)
+- `jest.config.js` 갱신: `coverageThreshold: 90` + `collectCoverageFrom` 확장 + `testMatch` 옛 미러 + colocate 둘 다 허용
+- `no-restricted-imports` 설정 (Server Action actions 예외 포함)
+- `.github/workflows/claude-code-review.yml` path-agnostic 재설계
+- `.claude/agents/{review,mistake-managing,git,issue}-agent.md` 동일 갱신
+- `docs/ISSUE_IMPL_FLOW.md`, `docs/PR_FIX_FLOW.md`의 "Modified layer" 표 path-agnostic 매핑
+- 본 spec 머지 + `CLAUDE.md` 갱신(FSD 의존 규칙 + SCOPE.md 정책 둘 다)
+
+### Phase 1 — shared 레이어 셋업 (3 PR)
+- `src/lib/*` → `src/shared/` (책임별 재분류)
+- `src/infrastructure/{http,utils}/*` → `src/shared/{api,lib}`
+- `src/domain/{time/eastern, market/session, chart/timeFormat}` → `src/shared/lib/`
+- `src/components/ui/*` → `src/shared/ui/` (PremiumModelGateModal 제외 — Phase 6)
+- `src/components/hooks/*` 중 generic → `src/shared/hooks/`
+- 영역 이동과 함께 `src/lib/CLAUDE.md` 삭제, `src/shared/CLAUDE.md` 작성
+- 테스트 colocation 동시 적용 (해당 영역만)
+
+### Phase 2 — entities (DB-bound, 4 PR)
+- `infrastructure/db/{client, schema, tokenEncryption}` → `shared/db/`
+- `drizzle.config.ts` 의 schema 경로 갱신 + `yarn db:generate` dry-run diff 0 검증 (G4)
+- 8 repositories → 각 entity로 분산:
+  - `userRepository` → `entities/user/api.ts`
+  - `sessionRepository` → `entities/session/api.ts`
+  - `oauthAccountRepository` → `entities/oauth-account/api.ts`
+  - `userApiKeyRepository` → `entities/api-key/api.ts`
+  - `tickerRepository` → `entities/ticker/api.ts`
+  - `contactRepository` → `entities/inquiry/api.ts`
+  - `usageLogRepository` → `entities/analysis/api/usageLog.ts`
+  - `newsRepository`(earnings 포함) → `entities/earnings-report/api.ts` 또는 분리
+- `infrastructure/email/*`: dispatcher → `shared/email/`, tokenStore → `entities/email-token/`, 템플릿 → `entities/email-token/templates/`
+- `infrastructure/skills/*` → `entities/skill/api.ts`
+- 영역 이동과 함께 `src/infrastructure/CLAUDE.md`의 해당 섹션 삭제 + entity별 CLAUDE.md 신규 작성
+
+### Phase 3 — entities (data-fetch + AI, 5 PR)
+- `infrastructure/ai/*` → `entities/llm-provider/`
+- `infrastructure/llm/*` → `entities/api-key/` + `features/api-key-management/` 분리
+- `infrastructure/market/*` → `entities/bars/`, `entities/analysis/`, `entities/news-article/`
+- `infrastructure/fmp/*` → `shared/api/fmp/` + `entities/fundamental/`, `entities/news-article/`
+- `infrastructure/options/*` → `entities/options-chain/`
+- `infrastructure/ticker/*` → `entities/ticker/`
+- `infrastructure/tier/*` → `entities/user-tier/`
+- `infrastructure/dashboard/*` → `entities/market-summary/`, `entities/sector-signal/`
+- `infrastructure/og/*` → `entities/og-image/`
+- `infrastructure/sitemap/*` → `entities/sitemap-entry/` (모델만)
+- `infrastructure/seo/*` → `shared/lib/seo/`
+
+### Phase 4 — domain → entities lib (2 PR)
+- `src/domain/*` 잔여(순수 함수)를 해당 entity의 `lib/`로 분산
+- `domain/llm`, `domain/analysis`, `domain/backtest`, `domain/contact`, `domain/fearGreed`, `domain/options`, `domain/seo`, `domain/signals`, `domain/auth`, `domain/chat` 등 정리
+- `domain/constants` → shared/config
+- `src/domain/CLAUDE.md` 삭제
+
+### Phase 5 — features (Auth, 4 PR)
+- `src/components/auth/*` + `infrastructure/auth/*Action.ts` → 8개 feature 슬라이스로 분할:
+  - `features/auth-login`, `features/auth-signup`, `features/auth-email-verification`, `features/auth-password-reset`, `features/auth-oauth`, `features/auth-oauth-consent`, `features/auth-logout`, `features/account-delete`
+- `components/account/*` → `features/api-key-management/`
+- `src/app/api/auth/*` route handlers thin wrapper로 정리 (실제 로직은 feature/api/)
+- React Compiler 영향 검증 (G11)
+
+### Phase 6 — features (그 외, 5 PR)
+- `components/search/*` → `features/ticker-search/`
+- `components/symbol-page/{SymbolPageContext, SymbolModelContext}` → `features/indicator-tracking/`, `features/llm-model-select/`
+- `components/chat/SymbolChatContext` + 입력 폼 → `features/symbol-chat/`
+- `components/analysis/{ModelSelector, 재분석 UI}` → `features/analysis-trigger/`, `features/llm-model-select/`
+- `components/pwa/*` → `features/pwa-install/`
+- `components/contact/*` → `features/contact-form/`
+- `components/backtesting/{Tabs/필터}` → `features/backtest-filter/`
+- `infrastructure/sitemap/*` → `features/sitemap-generation/`
+- PremiumModelGateModal + useModelGate → `features/premium-gate/`
+- Timeframe(URL ?tf=) → `features/timeframe-select/` (Context-less, hook only)
+
+### Phase 7 — widgets (6 PR)
+- 남은 모든 `src/components/*` 를 widgets로 이전
+- 각 widget: `ui/` + (필요 시) `hooks/`, `lib/`, `index.ts`
+- sections/utils colocate
+- `src/components/CLAUDE.md` 삭제
+
+### Phase 8 — pages + app (3 PR)
+- `src/pages/` 생성, Next.js route → page composition 위임
+- `src/app/{layout,providers}` 정리
+- `src/app/api/*` route handlers thin wrapper로 통일
+- `next.config.ts`의 `rewrites` 갱신 (Phase 8 route handler 위치와 atomic) (G5)
+- `src/app/CLAUDE.md` 갱신 (FSD app + Next.js routing 통합 설명)
+- `src/pages/CLAUDE.md` 신규 작성
+
+### Phase 9 — 문서 + 정리 (2 PR)
+- 옛 layer + `legacy-*` ESLint 규칙 제거 → 최종 FSD 의존 잠금
+- jest.config.js의 옛 path 제거
+- `docs/ARCHITECTURE.md` 전면 재작성 (FSD)
+- `docs/CONVENTIONS.md` 부분 갱신
+- `docs/MISTAKES.md` path-dependent 항목 정리
+- `docs/AUTH.md`, `docs/ISSUE_IMPL_FLOW.md`, `docs/PR_FIX_FLOW.md` 경로 갱신
+- `src/__tests__/` 디렉토리 제거 (전부 colocate된 후)
+- `src/__tests__/CLAUDE.md` 삭제
+
+---
+
+## 10. 위험 매트릭스 (최종)
+
+| 위험 | 처리 |
+|---|---|
+| husky pre-push의 `yarn test:quiet` 깨짐 | Phase 0에서 `coverageThreshold: 90` + `collectCoverageFrom` 옛 + 새 둘 다 매칭 → 마이그레이션 도중 항상 통과 |
+| CI `claude-code-review.yml` false positive | Phase 0에서 path-agnostic 재설계로 차단 |
+| review-agent stale path 참조 | Phase 0에서 함께 갱신 |
+| Server Action `'use server'` 파일 단위 충돌 | entity 내 `api.ts`/`actions.ts` 분리 + ESLint `no-restricted-imports` 예외 |
+| Drizzle migration history 꼬임 | Phase 2 schema 이동은 파일 move only, `yarn db:generate` dry-run 검증 |
+| `next.config.ts` `rewrites` 깨짐 | Phase 8 route handler 이동과 atomic |
+| React Compiler invalidation | Phase 5 첫 form hook 이동 시 실제 빌드 검증 |
+| 마이그레이션 중 다른 작업 충돌 | 모든 PR base master, 마이그레이션 PR이 rebase 책임 |
+| 거대 PR | Phase 별로 영역 단위 분할, Phase 1~9 총 ~36 PR로 분산 |
+| ESLint boundary 위반으로 PR 머지 차단 | atomic move 원칙 + 옛/새 동시 등록으로 위반 0 유지 |
+| Phase별 deps 주입 패턴 변화 | Phase 5에서 use-case deps 객체를 entity 내부 closure로 또는 app 레이어 wire-up |
+
+---
+
+## 11. 작업 사이즈 추정
+
+| Phase | 예상 PR | 예상 변경 파일 |
+|---|---|---|
+| 0 (준비 확장됨) | 2~3 | 15 |
+| 1 (shared) | 3 | 80 |
+| 2 (entities DB) | 4 | 60 |
+| 3 (entities data/AI) | 5 | 90 |
+| 4 (domain → entities lib) | 2 | 40 |
+| 5 (features auth) | 4 | 70 |
+| 6 (features 기타) | 5 | 70 |
+| 7 (widgets) | 6 | 200+ |
+| 8 (pages + app) | 3 | 50 |
+| 9 (docs + cleanup) | 2 | 30 |
+| **합계** | **~36** | **~705** |
+
+코드 로직 변경은 거의 없음(import path + 파일 이동 위주).
+
+---
+
+## 12. Commit / PR 정책 (G15)
+
+- 마이그레이션 PR commit prefix: `refactor(arch):`
+- release-it config 변경 불필요 (`refactor`는 기본 minor 포함 안 됨)
+- CHANGELOG 노출 최소
+- PR title: `refactor(arch): Phase N — <영역>`
+- PR body에 본 spec 링크 + 영향 영역 명시
+
+---
+
+## 13. 갭 점검 결과 (G1~G18, 참고)
+
+본 spec에서 해결된 갭:
+
+| ID | 항목 | 처리 |
+|---|---|---|
+| G1 | 테스트 coverage 정책 | §2-1, §7-2: 90% threshold |
+| G2/G3 | claude-code-review.yml + sub-agent path-dependent | §2-4, §9 Phase 0: path-agnostic 재설계 |
+| G4 | drizzle.config.ts schema 경로 | §9 Phase 2: 파일 move only, generate dry-run 검증 |
+| G5 | next.config.ts rewrites | §9 Phase 8: route handler 이동과 atomic |
+| G6 | 마이그레이션 중간 상태 | §2-2, §8: Atomic move per PR + legacy-* ESLint 동시 등록 |
+| G7 | 기존 layer CLAUDE.md 처리 | §2-3, §9 각 Phase: 영역 이동 시 함께 교체 |
+| G8 | docs/MISTAKES.md path 의존 항목 | §9 Phase 9: 갱신 또는 ESLint로 흡수 후 삭제 |
+| G9 | Server Action + ESLint boundary | §4 규칙 6, §8-2: actions만 예외 |
+| G10 | 슬라이스 경계 회색지대 | §6-5: whatap 표준 + 4 사례 명문화 |
+| G11 | React Compiler 영향 | §10: Phase 5에서 build 검증 |
+| G12 | proxy.ts 위치 | §3, §10: `src/proxy.ts` 유지 |
+| G13 | ISSUE_IMPL_FLOW/PR_FIX_FLOW | §9 Phase 0: G2/G3와 함께 갱신 |
+| G14 | TODO.md / 다른 작업 충돌 | §10: 모든 PR base master, 마이그레이션 PR이 rebase 책임 |
+| G15 | Conventional commit / CHANGELOG | §12: `refactor(arch):` |
+| G16 | skills/ 디렉토리 | 영향 없음 (위치 동일) |
+| G17 | vercel.json | 영향 없음 |
+| G18 | worker/, scripts/, db/scripts/ | 영향 없음 |
+
+---
+
+## 14. 다음 단계
+
+1. 본 spec을 사용자가 리뷰 → 수정 사항 반영
+2. `writing-plans` 스킬로 전환해 Phase 0 실행 계획 작성
+3. Phase 0 PR 시작 — ESLint boundaries, tsconfig alias, jest config, workflow/agent, CLAUDE.md, 본 spec 머지
+4. 이후 Phase 1~9를 순차 진행
+
+각 Phase 종료 시 본 spec의 §9 Phase N 섹션을 갱신하고 머지 상태를 표시한다.


### PR DESCRIPTION
## Summary

FSD 마이그레이션 Phase 0의 세 번째(마지막) PR. 종합 설계서 + Phase 0 plan + CLAUDE.md Layer Dependency Rules 갱신 + .gitignore 예외 추가.

## 변경 사항

- **CLAUDE.md**: Layer Dependency Rules 섹션을 FSD 6-layer + legacy 5-layer 공존 표현으로 전면 교체
- **.gitignore**: `/docs/superpowers/*` + `!/docs/superpowers/specs/` + `!/docs/superpowers/plans/` 예외
- **spec**: `docs/superpowers/specs/2026-05-24-fsd-migration-design.md` (586줄, 9 Phase 종합 설계)
- **plan**: `docs/superpowers/plans/2026-05-24-fsd-migration-phase-0.md` (Phase 0 실행 계획서)

## Test plan

- [x] format:check / lint / typecheck 통과
- [x] .gitignore 예외 동작 검증 (git check-ignore)
- [x] CLAUDE.md 다른 섹션 변경 없음

## 참고

- Linked: #469 (PR 1 — config), #470 (PR 2 — workflows)
- Phase 0 완료 후 Phase 1 plan 별도 작성 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)