### PR TITLE
test(shared/lib): add tests for 18 utility files

### DIFF
--- a/src/shared/lib/__tests__/adsense.test.ts
+++ b/src/shared/lib/__tests__/adsense.test.ts
@@ -1,0 +1,71 @@
+describe('adsense', () => {
+    const originalEnv = { ...process.env };
+
+    afterEach(() => {
+        process.env = { ...originalEnv };
+        vi.resetModules();
+    });
+
+    describe('ADSENSE_PUBLISHER_ID', () => {
+        it('returns env value when NEXT_PUBLIC_ADSENSE_PUBLISHER_ID is set', async () => {
+            process.env.NEXT_PUBLIC_ADSENSE_PUBLISHER_ID = 'ca-pub-123';
+            const { ADSENSE_PUBLISHER_ID } = await import(
+                '@/shared/lib/adsense'
+            );
+            expect(ADSENSE_PUBLISHER_ID).toBe('ca-pub-123');
+        });
+
+        it('defaults to empty string when env var is not set', async () => {
+            delete process.env.NEXT_PUBLIC_ADSENSE_PUBLISHER_ID;
+            const { ADSENSE_PUBLISHER_ID } = await import(
+                '@/shared/lib/adsense'
+            );
+            expect(ADSENSE_PUBLISHER_ID).toBe('');
+        });
+    });
+
+    describe('ADSENSE_ENABLED', () => {
+        it('is true when NEXT_PUBLIC_ADSENSE_ENABLED is "true"', async () => {
+            process.env.NEXT_PUBLIC_ADSENSE_ENABLED = 'true';
+            const { ADSENSE_ENABLED } = await import('@/shared/lib/adsense');
+            expect(ADSENSE_ENABLED).toBe(true);
+        });
+
+        it('is false when NEXT_PUBLIC_ADSENSE_ENABLED is "false"', async () => {
+            process.env.NEXT_PUBLIC_ADSENSE_ENABLED = 'false';
+            const { ADSENSE_ENABLED } = await import('@/shared/lib/adsense');
+            expect(ADSENSE_ENABLED).toBe(false);
+        });
+
+        it('is false when NEXT_PUBLIC_ADSENSE_ENABLED is not set', async () => {
+            delete process.env.NEXT_PUBLIC_ADSENSE_ENABLED;
+            const { ADSENSE_ENABLED } = await import('@/shared/lib/adsense');
+            expect(ADSENSE_ENABLED).toBe(false);
+        });
+
+        it('is false for other string values', async () => {
+            process.env.NEXT_PUBLIC_ADSENSE_ENABLED = 'yes';
+            const { ADSENSE_ENABLED } = await import('@/shared/lib/adsense');
+            expect(ADSENSE_ENABLED).toBe(false);
+        });
+    });
+
+    describe('ADSENSE_SLOTS', () => {
+        it('returns env values when slot env vars are set', async () => {
+            process.env.NEXT_PUBLIC_ADSENSE_SLOT_PROGRESS = 'slot-progress-1';
+            process.env.NEXT_PUBLIC_ADSENSE_SLOT_PANEL_BOTTOM =
+                'slot-panel-bottom-1';
+            const { ADSENSE_SLOTS } = await import('@/shared/lib/adsense');
+            expect(ADSENSE_SLOTS.PROGRESS).toBe('slot-progress-1');
+            expect(ADSENSE_SLOTS.PANEL_BOTTOM).toBe('slot-panel-bottom-1');
+        });
+
+        it('defaults to empty strings when slot env vars are not set', async () => {
+            delete process.env.NEXT_PUBLIC_ADSENSE_SLOT_PROGRESS;
+            delete process.env.NEXT_PUBLIC_ADSENSE_SLOT_PANEL_BOTTOM;
+            const { ADSENSE_SLOTS } = await import('@/shared/lib/adsense');
+            expect(ADSENSE_SLOTS.PROGRESS).toBe('');
+            expect(ADSENSE_SLOTS.PANEL_BOTTOM).toBe('');
+        });
+    });
+});

--- a/src/shared/lib/__tests__/adsense.test.ts
+++ b/src/shared/lib/__tests__/adsense.test.ts
@@ -9,17 +9,15 @@ describe('adsense', () => {
     describe('ADSENSE_PUBLISHER_ID', () => {
         it('returns env value when NEXT_PUBLIC_ADSENSE_PUBLISHER_ID is set', async () => {
             process.env.NEXT_PUBLIC_ADSENSE_PUBLISHER_ID = 'ca-pub-123';
-            const { ADSENSE_PUBLISHER_ID } = await import(
-                '@/shared/lib/adsense'
-            );
+            const { ADSENSE_PUBLISHER_ID } =
+                await import('@/shared/lib/adsense');
             expect(ADSENSE_PUBLISHER_ID).toBe('ca-pub-123');
         });
 
         it('defaults to empty string when env var is not set', async () => {
             delete process.env.NEXT_PUBLIC_ADSENSE_PUBLISHER_ID;
-            const { ADSENSE_PUBLISHER_ID } = await import(
-                '@/shared/lib/adsense'
-            );
+            const { ADSENSE_PUBLISHER_ID } =
+                await import('@/shared/lib/adsense');
             expect(ADSENSE_PUBLISHER_ID).toBe('');
         });
     });

--- a/src/shared/lib/__tests__/auth/tierLabel.test.ts
+++ b/src/shared/lib/__tests__/auth/tierLabel.test.ts
@@ -12,8 +12,8 @@ describe('TIER_LABEL', () => {
         }
     });
 
-    it('has exactly three entries', () => {
-        expect(Object.keys(TIER_LABEL)).toHaveLength(3);
+    it('has exactly as many entries as ALL_TIERS', () => {
+        expect(Object.keys(TIER_LABEL)).toHaveLength(ALL_TIERS.length);
     });
 
     it('free tier is labeled "Free"', () => {

--- a/src/shared/lib/__tests__/auth/tierLabel.test.ts
+++ b/src/shared/lib/__tests__/auth/tierLabel.test.ts
@@ -1,0 +1,30 @@
+import { TIER_LABEL } from '@/shared/lib/auth/tierLabel';
+import type { Tier } from '@y0ngha/siglens-core';
+
+const ALL_TIERS: Tier[] = ['free', 'member', 'pro'];
+
+describe('TIER_LABEL', () => {
+    it('has a label for every Tier', () => {
+        for (const tier of ALL_TIERS) {
+            expect(TIER_LABEL[tier]).toBeDefined();
+            expect(typeof TIER_LABEL[tier]).toBe('string');
+            expect(TIER_LABEL[tier].length).toBeGreaterThan(0);
+        }
+    });
+
+    it('has exactly three entries', () => {
+        expect(Object.keys(TIER_LABEL)).toHaveLength(3);
+    });
+
+    it('free tier is labeled "Free"', () => {
+        expect(TIER_LABEL.free).toBe('Free');
+    });
+
+    it('member tier is labeled "Member"', () => {
+        expect(TIER_LABEL.member).toBe('Member');
+    });
+
+    it('pro tier is labeled "Pro"', () => {
+        expect(TIER_LABEL.pro).toBe('Pro');
+    });
+});

--- a/src/shared/lib/__tests__/cancelJobsApi.test.ts
+++ b/src/shared/lib/__tests__/cancelJobsApi.test.ts
@@ -4,8 +4,4 @@ describe('CANCEL_JOBS_API_PATH', () => {
     it('is the expected API path', () => {
         expect(CANCEL_JOBS_API_PATH).toBe('/api/jobs/cancel');
     });
-
-    it('starts with /api/', () => {
-        expect(CANCEL_JOBS_API_PATH).toMatch(/^\/api\//);
-    });
 });

--- a/src/shared/lib/__tests__/cancelJobsApi.test.ts
+++ b/src/shared/lib/__tests__/cancelJobsApi.test.ts
@@ -1,0 +1,11 @@
+import { CANCEL_JOBS_API_PATH } from '@/shared/lib/cancelJobsApi';
+
+describe('CANCEL_JOBS_API_PATH', () => {
+    it('is the expected API path', () => {
+        expect(CANCEL_JOBS_API_PATH).toBe('/api/jobs/cancel');
+    });
+
+    it('starts with /api/', () => {
+        expect(CANCEL_JOBS_API_PATH).toMatch(/^\/api\//);
+    });
+});

--- a/src/shared/lib/__tests__/cardStyles.test.ts
+++ b/src/shared/lib/__tests__/cardStyles.test.ts
@@ -1,0 +1,32 @@
+import { CARD_LINK_CLASSES } from '@/shared/lib/cardStyles';
+
+describe('CARD_LINK_CLASSES', () => {
+    it('is a non-empty string', () => {
+        expect(typeof CARD_LINK_CLASSES).toBe('string');
+        expect(CARD_LINK_CLASSES.length).toBeGreaterThan(0);
+    });
+
+    it('includes rounded-lg for card shape', () => {
+        expect(CARD_LINK_CLASSES).toContain('rounded-lg');
+    });
+
+    it('includes touch-manipulation for mobile optimization', () => {
+        expect(CARD_LINK_CLASSES).toContain('touch-manipulation');
+    });
+
+    it('includes hover styles', () => {
+        expect(CARD_LINK_CLASSES).toMatch(/hover:/);
+    });
+
+    it('includes focus-visible ring styles', () => {
+        expect(CARD_LINK_CLASSES).toMatch(/focus-visible:ring/);
+    });
+
+    it('includes motion-reduce styles', () => {
+        expect(CARD_LINK_CLASSES).toMatch(/motion-reduce:/);
+    });
+
+    it('includes transition duration', () => {
+        expect(CARD_LINK_CLASSES).toContain('duration-150');
+    });
+});

--- a/src/shared/lib/__tests__/cn.test.ts
+++ b/src/shared/lib/__tests__/cn.test.ts
@@ -1,0 +1,47 @@
+import { cn } from '@/shared/lib/cn';
+
+describe('cn', () => {
+    it('merges simple class names', () => {
+        expect(cn('foo', 'bar')).toBe('foo bar');
+    });
+
+    it('handles conditional classes via clsx', () => {
+        expect(cn('base', false && 'hidden', 'extra')).toBe('base extra');
+    });
+
+    it('handles undefined and null inputs', () => {
+        expect(cn('base', undefined, null, 'extra')).toBe('base extra');
+    });
+
+    it('handles empty string inputs', () => {
+        expect(cn('base', '', 'extra')).toBe('base extra');
+    });
+
+    it('returns empty string for no arguments', () => {
+        expect(cn()).toBe('');
+    });
+
+    it('merges conflicting Tailwind classes (last wins)', () => {
+        // tailwind-merge resolves p-2 and p-4 to p-4
+        expect(cn('p-2', 'p-4')).toBe('p-4');
+    });
+
+    it('merges conflicting text color classes', () => {
+        expect(cn('text-red-500', 'text-blue-500')).toBe('text-blue-500');
+    });
+
+    it('preserves non-conflicting classes', () => {
+        const result = cn('p-2', 'mt-4', 'text-sm');
+        expect(result).toContain('p-2');
+        expect(result).toContain('mt-4');
+        expect(result).toContain('text-sm');
+    });
+
+    it('handles array inputs', () => {
+        expect(cn(['foo', 'bar'])).toBe('foo bar');
+    });
+
+    it('handles object inputs', () => {
+        expect(cn({ foo: true, bar: false, baz: true })).toBe('foo baz');
+    });
+});

--- a/src/shared/lib/__tests__/contact.test.ts
+++ b/src/shared/lib/__tests__/contact.test.ts
@@ -4,8 +4,4 @@ describe('CONTACT_EMAIL', () => {
     it('is the expected email address', () => {
         expect(CONTACT_EMAIL).toBe('stock.siglens@gmail.com');
     });
-
-    it('is a valid email format', () => {
-        expect(CONTACT_EMAIL).toMatch(/^[^\s@]+@[^\s@]+\.[^\s@]+$/);
-    });
 });

--- a/src/shared/lib/__tests__/contact.test.ts
+++ b/src/shared/lib/__tests__/contact.test.ts
@@ -1,0 +1,11 @@
+import { CONTACT_EMAIL } from '@/shared/lib/contact';
+
+describe('CONTACT_EMAIL', () => {
+    it('is the expected email address', () => {
+        expect(CONTACT_EMAIL).toBe('stock.siglens@gmail.com');
+    });
+
+    it('is a valid email format', () => {
+        expect(CONTACT_EMAIL).toMatch(/^[^\s@]+@[^\s@]+\.[^\s@]+$/);
+    });
+});

--- a/src/shared/lib/__tests__/contactErrorMessages.test.ts
+++ b/src/shared/lib/__tests__/contactErrorMessages.test.ts
@@ -1,0 +1,52 @@
+import { CONTACT_ERROR_MESSAGES } from '@/shared/lib/contactErrorMessages';
+import {
+    CONTACT_TITLE_MAX_LENGTH,
+    CONTACT_CONTENT_MAX_LENGTH,
+} from '@/shared/config/contact';
+import type { ContactFormErrorCode } from '@/shared/lib/types';
+
+const ALL_ERROR_CODES: ContactFormErrorCode[] = [
+    'title_required',
+    'title_too_long',
+    'email_required',
+    'email_invalid',
+    'content_required',
+    'content_too_long',
+    'submission_failed',
+];
+
+describe('CONTACT_ERROR_MESSAGES', () => {
+    it('has a message for every ContactFormErrorCode', () => {
+        for (const code of ALL_ERROR_CODES) {
+            expect(CONTACT_ERROR_MESSAGES[code]).toBeDefined();
+            expect(typeof CONTACT_ERROR_MESSAGES[code]).toBe('string');
+            expect(CONTACT_ERROR_MESSAGES[code].length).toBeGreaterThan(0);
+        }
+    });
+
+    it('has exactly the right number of entries', () => {
+        expect(Object.keys(CONTACT_ERROR_MESSAGES)).toHaveLength(
+            ALL_ERROR_CODES.length
+        );
+    });
+
+    it('title_too_long message includes the max length', () => {
+        expect(CONTACT_ERROR_MESSAGES.title_too_long).toContain(
+            String(CONTACT_TITLE_MAX_LENGTH)
+        );
+    });
+
+    it('content_too_long message includes the max length', () => {
+        expect(CONTACT_ERROR_MESSAGES.content_too_long).toContain(
+            String(CONTACT_CONTENT_MAX_LENGTH)
+        );
+    });
+
+    it('email_invalid message mentions email format', () => {
+        expect(CONTACT_ERROR_MESSAGES.email_invalid).toContain('이메일');
+    });
+
+    it('submission_failed message suggests retrying', () => {
+        expect(CONTACT_ERROR_MESSAGES.submission_failed).toContain('다시');
+    });
+});

--- a/src/shared/lib/__tests__/legal.test.ts
+++ b/src/shared/lib/__tests__/legal.test.ts
@@ -1,0 +1,74 @@
+import {
+    INVESTMENT_DISCLAIMER,
+    PRIVACY_PATH,
+    TERMS_PATH,
+    PRIVACY_TITLE,
+    PRIVACY_FULL_TITLE,
+    PRIVACY_DESCRIPTION,
+    TERMS_TITLE,
+    TERMS_FULL_TITLE,
+    TERMS_DESCRIPTION,
+    formatKoreanDate,
+} from '@/shared/lib/legal';
+import { SITE_NAME } from '@/shared/lib/seo';
+
+describe('legal constants', () => {
+    it('INVESTMENT_DISCLAIMER is a non-empty Korean string', () => {
+        expect(INVESTMENT_DISCLAIMER.length).toBeGreaterThan(0);
+        expect(INVESTMENT_DISCLAIMER).toContain('투자');
+    });
+
+    it('PRIVACY_PATH is /privacy', () => {
+        expect(PRIVACY_PATH).toBe('/privacy');
+    });
+
+    it('TERMS_PATH is /terms', () => {
+        expect(TERMS_PATH).toBe('/terms');
+    });
+
+    it('PRIVACY_TITLE is Korean privacy title', () => {
+        expect(PRIVACY_TITLE).toBe('개인정보처리방침');
+    });
+
+    it('PRIVACY_FULL_TITLE includes site name', () => {
+        expect(PRIVACY_FULL_TITLE).toBe(`${PRIVACY_TITLE} | ${SITE_NAME}`);
+    });
+
+    it('PRIVACY_DESCRIPTION includes site name', () => {
+        expect(PRIVACY_DESCRIPTION).toContain(SITE_NAME);
+    });
+
+    it('TERMS_TITLE is Korean terms title', () => {
+        expect(TERMS_TITLE).toBe('이용약관');
+    });
+
+    it('TERMS_FULL_TITLE includes site name', () => {
+        expect(TERMS_FULL_TITLE).toBe(`${TERMS_TITLE} | ${SITE_NAME}`);
+    });
+
+    it('TERMS_DESCRIPTION includes site name', () => {
+        expect(TERMS_DESCRIPTION).toContain(SITE_NAME);
+    });
+});
+
+describe('formatKoreanDate', () => {
+    it('formats a date in Korean format (YYYY년 M월 D일)', () => {
+        // Use a fixed UTC date, the formatter uses Asia/Seoul timezone
+        const date = new Date('2024-03-15T00:00:00Z');
+        const result = formatKoreanDate(date);
+        // In KST (UTC+9), this is March 15
+        expect(result).toMatch(/2024년 3월 15일/);
+    });
+
+    it('handles year boundaries correctly', () => {
+        // Dec 31 UTC might be Jan 1 KST
+        const date = new Date('2024-12-31T20:00:00Z');
+        const result = formatKoreanDate(date);
+        // UTC 20:00 = KST 05:00 next day → Jan 1, 2025
+        expect(result).toMatch(/2025년 1월 1일/);
+    });
+
+    it('returns a string', () => {
+        expect(typeof formatKoreanDate(new Date())).toBe('string');
+    });
+});

--- a/src/shared/lib/__tests__/llmProviderLabels.test.ts
+++ b/src/shared/lib/__tests__/llmProviderLabels.test.ts
@@ -1,0 +1,34 @@
+import { LLM_PROVIDER_LABELS } from '@/shared/lib/llmProviderLabels';
+import { LLM_PROVIDER_VALUES } from '@/shared/config/llmProviders';
+
+describe('LLM_PROVIDER_LABELS', () => {
+    it('has a label for every provider in LLM_PROVIDER_VALUES', () => {
+        for (const provider of LLM_PROVIDER_VALUES) {
+            expect(LLM_PROVIDER_LABELS[provider]).toBeDefined();
+            expect(typeof LLM_PROVIDER_LABELS[provider]).toBe('string');
+            expect(LLM_PROVIDER_LABELS[provider].length).toBeGreaterThan(0);
+        }
+    });
+
+    it('has exactly three entries', () => {
+        expect(Object.keys(LLM_PROVIDER_LABELS)).toHaveLength(3);
+    });
+
+    it('anthropic label contains Claude', () => {
+        expect(LLM_PROVIDER_LABELS.anthropic).toContain('Claude');
+    });
+
+    it('google label contains Gemini', () => {
+        expect(LLM_PROVIDER_LABELS.google).toContain('Gemini');
+    });
+
+    it('openai label contains ChatGPT', () => {
+        expect(LLM_PROVIDER_LABELS.openai).toContain('ChatGPT');
+    });
+
+    it('each label includes the company name in parentheses', () => {
+        expect(LLM_PROVIDER_LABELS.anthropic).toMatch(/\(Anthropic\)/);
+        expect(LLM_PROVIDER_LABELS.google).toMatch(/\(Google\)/);
+        expect(LLM_PROVIDER_LABELS.openai).toMatch(/\(OpenAI\)/);
+    });
+});

--- a/src/shared/lib/__tests__/llmProviderLabels.test.ts
+++ b/src/shared/lib/__tests__/llmProviderLabels.test.ts
@@ -10,8 +10,10 @@ describe('LLM_PROVIDER_LABELS', () => {
         }
     });
 
-    it('has exactly three entries', () => {
-        expect(Object.keys(LLM_PROVIDER_LABELS)).toHaveLength(3);
+    it('has exactly as many entries as LLM_PROVIDER_VALUES', () => {
+        expect(Object.keys(LLM_PROVIDER_LABELS)).toHaveLength(
+            LLM_PROVIDER_VALUES.length
+        );
     });
 
     it('anthropic label contains Claude', () => {

--- a/src/shared/lib/__tests__/og.test.ts
+++ b/src/shared/lib/__tests__/og.test.ts
@@ -40,14 +40,6 @@ describe('OG color constants', () => {
     it('OG_MUTED is slate gray', () => {
         expect(OG_MUTED).toBe('#94a3b8');
     });
-
-    it('all color values are valid hex colors', () => {
-        const hexPattern = /^#[0-9a-f]{6}$/;
-        expect(OG_BG).toMatch(hexPattern);
-        expect(OG_FG).toMatch(hexPattern);
-        expect(OG_ACCENT).toMatch(hexPattern);
-        expect(OG_MUTED).toMatch(hexPattern);
-    });
 });
 
 describe('OG layout constants', () => {

--- a/src/shared/lib/__tests__/og.test.ts
+++ b/src/shared/lib/__tests__/og.test.ts
@@ -1,0 +1,81 @@
+import {
+    OG_IMAGE_WIDTH,
+    OG_IMAGE_HEIGHT,
+    OG_BG,
+    OG_FG,
+    OG_ACCENT,
+    OG_MUTED,
+    OG_CONTAINER_PADDING,
+    OG_TICKER_FONT_SIZE,
+    OG_LABEL_FONT_SIZE,
+    OG_SITE_NAME_FONT_SIZE,
+    OG_SITE_NAME_TOP,
+    OG_SITE_NAME_RIGHT,
+    OG_LABEL_MARGIN_TOP,
+} from '@/shared/lib/og';
+
+describe('OG image dimensions', () => {
+    it('OG_IMAGE_WIDTH is 1200 (standard OG width)', () => {
+        expect(OG_IMAGE_WIDTH).toBe(1200);
+    });
+
+    it('OG_IMAGE_HEIGHT is 630 (standard OG height)', () => {
+        expect(OG_IMAGE_HEIGHT).toBe(630);
+    });
+});
+
+describe('OG color constants', () => {
+    it('OG_BG is dark navy hex color', () => {
+        expect(OG_BG).toBe('#0f172a');
+    });
+
+    it('OG_FG is white', () => {
+        expect(OG_FG).toBe('#ffffff');
+    });
+
+    it('OG_ACCENT is blue', () => {
+        expect(OG_ACCENT).toBe('#3b82f6');
+    });
+
+    it('OG_MUTED is slate gray', () => {
+        expect(OG_MUTED).toBe('#94a3b8');
+    });
+
+    it('all color values are valid hex colors', () => {
+        const hexPattern = /^#[0-9a-f]{6}$/;
+        expect(OG_BG).toMatch(hexPattern);
+        expect(OG_FG).toMatch(hexPattern);
+        expect(OG_ACCENT).toMatch(hexPattern);
+        expect(OG_MUTED).toMatch(hexPattern);
+    });
+});
+
+describe('OG layout constants', () => {
+    it('OG_CONTAINER_PADDING is a CSS pixel value', () => {
+        expect(OG_CONTAINER_PADDING).toBe('80px');
+    });
+
+    it('OG_TICKER_FONT_SIZE is 240', () => {
+        expect(OG_TICKER_FONT_SIZE).toBe(240);
+    });
+
+    it('OG_LABEL_FONT_SIZE is 64', () => {
+        expect(OG_LABEL_FONT_SIZE).toBe(64);
+    });
+
+    it('OG_SITE_NAME_FONT_SIZE is 32', () => {
+        expect(OG_SITE_NAME_FONT_SIZE).toBe(32);
+    });
+
+    it('OG_SITE_NAME_TOP is 56', () => {
+        expect(OG_SITE_NAME_TOP).toBe(56);
+    });
+
+    it('OG_SITE_NAME_RIGHT is 72', () => {
+        expect(OG_SITE_NAME_RIGHT).toBe(72);
+    });
+
+    it('OG_LABEL_MARGIN_TOP is 32', () => {
+        expect(OG_LABEL_MARGIN_TOP).toBe(32);
+    });
+});

--- a/src/shared/lib/__tests__/pwaEvents.test.ts
+++ b/src/shared/lib/__tests__/pwaEvents.test.ts
@@ -1,0 +1,11 @@
+import { PWA_TRIGGER_EVENT } from '@/shared/lib/pwaEvents';
+
+describe('PWA_TRIGGER_EVENT', () => {
+    it('is the expected event name', () => {
+        expect(PWA_TRIGGER_EVENT).toBe('siglens:pwa-trigger');
+    });
+
+    it('uses the siglens namespace prefix', () => {
+        expect(PWA_TRIGGER_EVENT).toMatch(/^siglens:/);
+    });
+});

--- a/src/shared/lib/__tests__/pwaEvents.test.ts
+++ b/src/shared/lib/__tests__/pwaEvents.test.ts
@@ -4,8 +4,4 @@ describe('PWA_TRIGGER_EVENT', () => {
     it('is the expected event name', () => {
         expect(PWA_TRIGGER_EVENT).toBe('siglens:pwa-trigger');
     });
-
-    it('uses the siglens namespace prefix', () => {
-        expect(PWA_TRIGGER_EVENT).toMatch(/^siglens:/);
-    });
 });

--- a/src/shared/lib/__tests__/skillUtils.test.ts
+++ b/src/shared/lib/__tests__/skillUtils.test.ts
@@ -1,0 +1,65 @@
+import { countSkillsByType } from '@/shared/lib/skillUtils';
+import type { SkillShowcaseItem, SkillType } from '@y0ngha/siglens-core';
+
+function makeSkill(type: SkillType | null): SkillShowcaseItem {
+    return {
+        type: type ?? undefined,
+        name: 'test',
+        description: 'test',
+        confidenceWeight: 1,
+    } as SkillShowcaseItem;
+}
+
+describe('countSkillsByType', () => {
+    it('returns empty object for empty array', () => {
+        expect(countSkillsByType([])).toEqual({});
+    });
+
+    it('counts skills of a single type', () => {
+        const skills = [
+            makeSkill('pattern'),
+            makeSkill('pattern'),
+            makeSkill('pattern'),
+        ];
+        expect(countSkillsByType(skills)).toEqual({ pattern: 3 });
+    });
+
+    it('counts skills across multiple types', () => {
+        const skills = [
+            makeSkill('pattern'),
+            makeSkill('indicator_guide'),
+            makeSkill('pattern'),
+            makeSkill('strategy'),
+        ];
+        const result = countSkillsByType(skills);
+        expect(result).toEqual({ pattern: 2, indicator_guide: 1, strategy: 1 });
+    });
+
+    it('skips skills with null type', () => {
+        const skills = [
+            makeSkill('pattern'),
+            makeSkill(null),
+            makeSkill('pattern'),
+        ];
+        expect(countSkillsByType(skills)).toEqual({ pattern: 2 });
+    });
+
+    it('skips skills with undefined type', () => {
+        const skills = [
+            {
+                name: 'test',
+                description: 'test',
+                confidenceWeight: 1,
+            } as unknown as SkillShowcaseItem,
+            makeSkill('candlestick'),
+        ];
+        expect(countSkillsByType(skills)).toEqual({ candlestick: 1 });
+    });
+
+    it('returns Partial Record (not all SkillType keys are required)', () => {
+        const skills = [makeSkill('support_resistance')];
+        const result = countSkillsByType(skills);
+        expect(result.support_resistance).toBe(1);
+        expect(result.pattern).toBeUndefined();
+    });
+});

--- a/src/shared/lib/__tests__/skillUtils.test.ts
+++ b/src/shared/lib/__tests__/skillUtils.test.ts
@@ -35,7 +35,7 @@ describe('countSkillsByType', () => {
         expect(result).toEqual({ pattern: 2, indicator_guide: 1, strategy: 1 });
     });
 
-    it('skips skills with null type', () => {
+    it('skips skills with nullish type (null coerced to undefined by makeSkill)', () => {
         const skills = [
             makeSkill('pattern'),
             makeSkill(null),

--- a/src/shared/lib/__tests__/sleep.test.ts
+++ b/src/shared/lib/__tests__/sleep.test.ts
@@ -24,7 +24,7 @@ describe('sleep', () => {
         expect(spy).not.toHaveBeenCalled();
 
         await vi.advanceTimersByTimeAsync(1);
-        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('resolves with undefined', async () => {

--- a/src/shared/lib/__tests__/sleep.test.ts
+++ b/src/shared/lib/__tests__/sleep.test.ts
@@ -1,0 +1,41 @@
+import { sleep } from '@/shared/lib/sleep';
+
+describe('sleep', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('returns a Promise', () => {
+        const result = sleep(100);
+        expect(result).toBeInstanceOf(Promise);
+    });
+
+    it('resolves after the specified delay', async () => {
+        const spy = vi.fn();
+        sleep(1000).then(spy);
+
+        expect(spy).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(999);
+        expect(spy).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(spy).toHaveBeenCalledOnce();
+    });
+
+    it('resolves with undefined', async () => {
+        const promise = sleep(50);
+        await vi.advanceTimersByTimeAsync(50);
+        await expect(promise).resolves.toBeUndefined();
+    });
+
+    it('handles 0ms delay', async () => {
+        const promise = sleep(0);
+        await vi.advanceTimersByTimeAsync(0);
+        await expect(promise).resolves.toBeUndefined();
+    });
+});

--- a/src/shared/lib/__tests__/storageKeys.test.ts
+++ b/src/shared/lib/__tests__/storageKeys.test.ts
@@ -7,10 +7,6 @@ describe('LOCAL_STORAGE_PROVIDER_KEY', () => {
     it('is the expected key', () => {
         expect(LOCAL_STORAGE_PROVIDER_KEY).toBe('siglens:selected-provider');
     });
-
-    it('uses the siglens namespace prefix', () => {
-        expect(LOCAL_STORAGE_PROVIDER_KEY).toMatch(/^siglens:/);
-    });
 });
 
 describe('LOCAL_STORAGE_ANALYSIS_MODEL_KEY', () => {
@@ -18,9 +14,5 @@ describe('LOCAL_STORAGE_ANALYSIS_MODEL_KEY', () => {
         expect(LOCAL_STORAGE_ANALYSIS_MODEL_KEY).toBe(
             'siglens:selected-analysis-model'
         );
-    });
-
-    it('uses the siglens namespace prefix', () => {
-        expect(LOCAL_STORAGE_ANALYSIS_MODEL_KEY).toMatch(/^siglens:/);
     });
 });

--- a/src/shared/lib/__tests__/storageKeys.test.ts
+++ b/src/shared/lib/__tests__/storageKeys.test.ts
@@ -1,0 +1,26 @@
+import {
+    LOCAL_STORAGE_PROVIDER_KEY,
+    LOCAL_STORAGE_ANALYSIS_MODEL_KEY,
+} from '@/shared/lib/storageKeys';
+
+describe('LOCAL_STORAGE_PROVIDER_KEY', () => {
+    it('is the expected key', () => {
+        expect(LOCAL_STORAGE_PROVIDER_KEY).toBe('siglens:selected-provider');
+    });
+
+    it('uses the siglens namespace prefix', () => {
+        expect(LOCAL_STORAGE_PROVIDER_KEY).toMatch(/^siglens:/);
+    });
+});
+
+describe('LOCAL_STORAGE_ANALYSIS_MODEL_KEY', () => {
+    it('is the expected key', () => {
+        expect(LOCAL_STORAGE_ANALYSIS_MODEL_KEY).toBe(
+            'siglens:selected-analysis-model'
+        );
+    });
+
+    it('uses the siglens namespace prefix', () => {
+        expect(LOCAL_STORAGE_ANALYSIS_MODEL_KEY).toMatch(/^siglens:/);
+    });
+});

--- a/src/shared/lib/__tests__/tooltipPosition.test.ts
+++ b/src/shared/lib/__tests__/tooltipPosition.test.ts
@@ -67,7 +67,7 @@ describe('getTooltipPosition', () => {
             expect(top).toBe(triggerRect.bottom + TOOLTIP_GAP);
         });
 
-        it('falls back to below when trigger is at very top (aboveTop exactly at padding)', () => {
+        it('places tooltip above trigger when aboveTop equals padding exactly (boundary condition)', () => {
             // aboveTop = TOOLTIP_VIEWPORT_PADDING means it should still go above
             const tooltipHeight = 40;
             const triggerTop =

--- a/src/shared/lib/__tests__/tooltipPosition.test.ts
+++ b/src/shared/lib/__tests__/tooltipPosition.test.ts
@@ -1,0 +1,169 @@
+import {
+    getTooltipPosition,
+    TOOLTIP_GAP,
+    TOOLTIP_VIEWPORT_PADDING,
+} from '@/shared/lib/tooltipPosition';
+
+function makeDOMRect(
+    x: number,
+    y: number,
+    width: number,
+    height: number
+): DOMRect {
+    return {
+        x,
+        y,
+        width,
+        height,
+        top: y,
+        left: x,
+        right: x + width,
+        bottom: y + height,
+        toJSON: () => ({}),
+    };
+}
+
+describe('tooltipPosition constants', () => {
+    it('TOOLTIP_VIEWPORT_PADDING is 8', () => {
+        expect(TOOLTIP_VIEWPORT_PADDING).toBe(8);
+    });
+
+    it('TOOLTIP_GAP is 6', () => {
+        expect(TOOLTIP_GAP).toBe(6);
+    });
+});
+
+describe('getTooltipPosition', () => {
+    const viewportWidth = 1024;
+
+    describe('vertical positioning', () => {
+        it('places tooltip above trigger when there is enough space', () => {
+            const triggerRect = makeDOMRect(400, 200, 100, 30);
+            const tooltipRect = makeDOMRect(0, 0, 120, 40);
+
+            const { top } = getTooltipPosition(
+                triggerRect,
+                tooltipRect,
+                viewportWidth
+            );
+
+            // aboveTop = 200 - 40 - 6 = 154, which is >= 8 (padding)
+            expect(top).toBe(triggerRect.top - tooltipRect.height - TOOLTIP_GAP);
+        });
+
+        it('places tooltip below trigger when above space is insufficient', () => {
+            const triggerRect = makeDOMRect(400, 10, 100, 30);
+            const tooltipRect = makeDOMRect(0, 0, 120, 40);
+
+            const { top } = getTooltipPosition(
+                triggerRect,
+                tooltipRect,
+                viewportWidth
+            );
+
+            // aboveTop = 10 - 40 - 6 = -36, which is < 8 (padding)
+            expect(top).toBe(triggerRect.bottom + TOOLTIP_GAP);
+        });
+
+        it('falls back to below when trigger is at very top (aboveTop exactly at padding)', () => {
+            // aboveTop = TOOLTIP_VIEWPORT_PADDING means it should still go above
+            const tooltipHeight = 40;
+            const triggerTop =
+                TOOLTIP_VIEWPORT_PADDING + tooltipHeight + TOOLTIP_GAP;
+            const triggerRect = makeDOMRect(400, triggerTop, 100, 30);
+            const tooltipRect = makeDOMRect(0, 0, 120, tooltipHeight);
+
+            const { top } = getTooltipPosition(
+                triggerRect,
+                tooltipRect,
+                viewportWidth
+            );
+
+            expect(top).toBe(TOOLTIP_VIEWPORT_PADDING);
+        });
+
+        it('goes below when aboveTop is just under the padding threshold', () => {
+            const tooltipHeight = 40;
+            // Make aboveTop = TOOLTIP_VIEWPORT_PADDING - 1
+            const triggerTop =
+                TOOLTIP_VIEWPORT_PADDING + tooltipHeight + TOOLTIP_GAP - 1;
+            const triggerRect = makeDOMRect(400, triggerTop, 100, 30);
+            const tooltipRect = makeDOMRect(0, 0, 120, tooltipHeight);
+
+            const { top } = getTooltipPosition(
+                triggerRect,
+                tooltipRect,
+                viewportWidth
+            );
+
+            expect(top).toBe(triggerRect.bottom + TOOLTIP_GAP);
+        });
+    });
+
+    describe('horizontal positioning', () => {
+        it('centers tooltip horizontally on the trigger', () => {
+            const triggerRect = makeDOMRect(400, 200, 100, 30);
+            const tooltipRect = makeDOMRect(0, 0, 120, 40);
+
+            const { left } = getTooltipPosition(
+                triggerRect,
+                tooltipRect,
+                viewportWidth
+            );
+
+            // rawLeft = 400 + 50 - 60 = 390
+            // maxLeft = 1024 - 120 - 8 = 896
+            // left = max(8, min(390, 896)) = 390
+            expect(left).toBe(390);
+        });
+
+        it('clamps to left edge padding when trigger is near left viewport edge', () => {
+            const triggerRect = makeDOMRect(0, 200, 10, 30);
+            const tooltipRect = makeDOMRect(0, 0, 120, 40);
+
+            const { left } = getTooltipPosition(
+                triggerRect,
+                tooltipRect,
+                viewportWidth
+            );
+
+            // rawLeft = 0 + 5 - 60 = -55
+            // left = max(8, min(-55, ...)) = 8
+            expect(left).toBe(TOOLTIP_VIEWPORT_PADDING);
+        });
+
+        it('clamps to right edge when trigger is near right viewport edge', () => {
+            const triggerRect = makeDOMRect(990, 200, 30, 30);
+            const tooltipRect = makeDOMRect(0, 0, 200, 40);
+
+            const { left } = getTooltipPosition(
+                triggerRect,
+                tooltipRect,
+                viewportWidth
+            );
+
+            // rawLeft = 990 + 15 - 100 = 905
+            // maxLeft = 1024 - 200 - 8 = 816
+            // left = max(8, min(905, 816)) = 816
+            expect(left).toBe(viewportWidth - tooltipRect.width - TOOLTIP_VIEWPORT_PADDING);
+        });
+    });
+
+    describe('return value shape', () => {
+        it('returns an object with top and left properties', () => {
+            const triggerRect = makeDOMRect(100, 100, 50, 20);
+            const tooltipRect = makeDOMRect(0, 0, 80, 30);
+
+            const result = getTooltipPosition(
+                triggerRect,
+                tooltipRect,
+                viewportWidth
+            );
+
+            expect(result).toHaveProperty('top');
+            expect(result).toHaveProperty('left');
+            expect(typeof result.top).toBe('number');
+            expect(typeof result.left).toBe('number');
+        });
+    });
+});

--- a/src/shared/lib/__tests__/tooltipPosition.test.ts
+++ b/src/shared/lib/__tests__/tooltipPosition.test.ts
@@ -48,7 +48,9 @@ describe('getTooltipPosition', () => {
             );
 
             // aboveTop = 200 - 40 - 6 = 154, which is >= 8 (padding)
-            expect(top).toBe(triggerRect.top - tooltipRect.height - TOOLTIP_GAP);
+            expect(top).toBe(
+                triggerRect.top - tooltipRect.height - TOOLTIP_GAP
+            );
         });
 
         it('places tooltip below trigger when above space is insufficient', () => {
@@ -145,7 +147,9 @@ describe('getTooltipPosition', () => {
             // rawLeft = 990 + 15 - 100 = 905
             // maxLeft = 1024 - 200 - 8 = 816
             // left = max(8, min(905, 816)) = 816
-            expect(left).toBe(viewportWidth - tooltipRect.width - TOOLTIP_VIEWPORT_PADDING);
+            expect(left).toBe(
+                viewportWidth - tooltipRect.width - TOOLTIP_VIEWPORT_PADDING
+            );
         });
     });
 

--- a/src/shared/lib/__tests__/trendline.test.ts
+++ b/src/shared/lib/__tests__/trendline.test.ts
@@ -1,0 +1,37 @@
+import {
+    TRENDLINE_DIRECTION_LABEL,
+    TRENDLINE_DIRECTION_COLOR,
+} from '@/shared/lib/trendline';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+
+describe('TRENDLINE_DIRECTION_LABEL', () => {
+    it('maps ascending to Korean ascending label', () => {
+        expect(TRENDLINE_DIRECTION_LABEL.ascending).toBe('상승 추세선');
+    });
+
+    it('maps descending to Korean descending label', () => {
+        expect(TRENDLINE_DIRECTION_LABEL.descending).toBe('하락 추세선');
+    });
+
+    it('has exactly two entries', () => {
+        expect(Object.keys(TRENDLINE_DIRECTION_LABEL)).toHaveLength(2);
+    });
+});
+
+describe('TRENDLINE_DIRECTION_COLOR', () => {
+    it('maps ascending to CHART_COLORS.trendlineAscending', () => {
+        expect(TRENDLINE_DIRECTION_COLOR.ascending).toBe(
+            CHART_COLORS.trendlineAscending
+        );
+    });
+
+    it('maps descending to CHART_COLORS.trendlineDescending', () => {
+        expect(TRENDLINE_DIRECTION_COLOR.descending).toBe(
+            CHART_COLORS.trendlineDescending
+        );
+    });
+
+    it('has exactly two entries', () => {
+        expect(Object.keys(TRENDLINE_DIRECTION_COLOR)).toHaveLength(2);
+    });
+});

--- a/src/shared/lib/news/__tests__/periodLabels.test.ts
+++ b/src/shared/lib/news/__tests__/periodLabels.test.ts
@@ -1,0 +1,16 @@
+import {
+    NEWS_LIST_PERIOD_LABEL,
+    NEWS_ANALYSIS_PERIOD_LABEL,
+} from '@/shared/lib/news/periodLabels';
+
+describe('NEWS_LIST_PERIOD_LABEL', () => {
+    it('is the expected Korean label for 6-month period', () => {
+        expect(NEWS_LIST_PERIOD_LABEL).toBe('최근 6개월');
+    });
+});
+
+describe('NEWS_ANALYSIS_PERIOD_LABEL', () => {
+    it('is the expected Korean label for 30-day period', () => {
+        expect(NEWS_ANALYSIS_PERIOD_LABEL).toBe('최근 30일');
+    });
+});

--- a/src/shared/lib/options/__tests__/marketHoursDisplay.test.ts
+++ b/src/shared/lib/options/__tests__/marketHoursDisplay.test.ts
@@ -1,0 +1,25 @@
+import {
+    ET_MARKET_HOURS_DISPLAY,
+    KST_EDT_HOURS_DISPLAY,
+    KST_EST_HOURS_DISPLAY,
+} from '@/shared/lib/options/marketHoursDisplay';
+
+describe('ET_MARKET_HOURS_DISPLAY', () => {
+    it('shows ET regular session hours', () => {
+        expect(ET_MARKET_HOURS_DISPLAY).toBe('ET 9:30 ~ 16:00');
+    });
+});
+
+describe('KST_EDT_HOURS_DISPLAY', () => {
+    it('shows KST hours during EDT (summer time, +13h offset)', () => {
+        // EDT: open 9:30 → KST 22:30, close 16:00 → KST 05:00
+        expect(KST_EDT_HOURS_DISPLAY).toBe('22:30~05:00');
+    });
+});
+
+describe('KST_EST_HOURS_DISPLAY', () => {
+    it('shows KST hours during EST (standard time, +14h offset)', () => {
+        // EST: open 9:30 → KST 23:30, close 16:00 → KST 06:00
+        expect(KST_EST_HOURS_DISPLAY).toBe('23:30~06:00');
+    });
+});


### PR DESCRIPTION
## Summary
- shared/lib 레이어의 0% 커버리지 파일 7개 + 추가 유틸리티 11개에 대한 테스트 작성
- 105개 새 테스트 케이스 추가 (총 2198 테스트)

## Files tested
sleep, tooltipPosition, trendline, adsense, cardStyles, contact,
marketHoursDisplay, legal, cn, og, cancelJobsApi, contactErrorMessages,
llmProviderLabels, periodLabels, pwaEvents, skillUtils, storageKeys, auth/tierLabel

## Test plan
- [x] `yarn test` — 244 suites, 2198 tests pass
- [x] `tsc --noEmit` — 0 errors
- [x] `yarn lint` — 0 errors
- [x] `yarn format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)