### PR TITLE
test(shared): add tests for 7 config + 5 db + 1 api files

### DIFF
--- a/src/shared/api/fmp/__tests__/httpClient.test.ts
+++ b/src/shared/api/fmp/__tests__/httpClient.test.ts
@@ -28,7 +28,6 @@ describe('fmpGet', () => {
         global.fetch = originalFetch;
     });
 
-    /** Helper — resolve fetch with a JSON body. */
     function mockOk(body: unknown): void {
         mockFetch.mockResolvedValueOnce({
             ok: true,
@@ -36,7 +35,6 @@ describe('fmpGet', () => {
         });
     }
 
-    /** Helper — resolve fetch with a non-2xx status. */
     function mockError(status: number): void {
         mockFetch.mockResolvedValueOnce({ ok: false, status });
     }

--- a/src/shared/api/fmp/__tests__/httpClient.test.ts
+++ b/src/shared/api/fmp/__tests__/httpClient.test.ts
@@ -1,0 +1,110 @@
+vi.mock('@y0ngha/siglens-core', () => ({
+    readFmpConfig: vi.fn(() => ({ apiKey: 'test-fmp-key' })),
+}));
+
+import { readFmpConfig } from '@y0ngha/siglens-core';
+import { FMP_STABLE_BASE, fmpGet } from '@/shared/api/fmp/httpClient';
+
+const mockFetch = vi.fn();
+
+describe('FMP_STABLE_BASE', () => {
+    it('FMP stable base URL이 정의되어 있다', () => {
+        expect(FMP_STABLE_BASE).toBe(
+            'https://financialmodelingprep.com/stable'
+        );
+    });
+});
+
+describe('fmpGet', () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+        global.fetch = mockFetch as unknown as typeof fetch;
+        mockFetch.mockReset();
+        vi.mocked(readFmpConfig).mockReturnValue({ apiKey: 'test-fmp-key' });
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+    });
+
+    /** Helper — resolve fetch with a JSON body. */
+    function mockOk(body: unknown): void {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => body,
+        });
+    }
+
+    /** Helper — resolve fetch with a non-2xx status. */
+    function mockError(status: number): void {
+        mockFetch.mockResolvedValueOnce({ ok: false, status });
+    }
+
+    it('올바른 URL과 쿼리 파라미터로 fetch를 호출한다', async () => {
+        mockOk({ data: 'test' });
+        await fmpGet('profile', { symbol: 'AAPL' });
+
+        const calledUrl = mockFetch.mock.calls[0]![0] as string;
+        expect(calledUrl).toContain(FMP_STABLE_BASE + '/profile');
+        expect(calledUrl).toContain('apikey=test-fmp-key');
+        expect(calledUrl).toContain('symbol=AAPL');
+    });
+
+    it('query 파라미터 없이도 동작한다', async () => {
+        mockOk([]);
+        await fmpGet('stock-list');
+
+        const calledUrl = mockFetch.mock.calls[0]![0] as string;
+        expect(calledUrl).toContain(FMP_STABLE_BASE + '/stock-list');
+        expect(calledUrl).toContain('apikey=test-fmp-key');
+    });
+
+    it('응답 JSON을 파싱해서 반환한다', async () => {
+        const body = { symbol: 'AAPL', price: 150 };
+        mockOk(body);
+
+        const result = await fmpGet<typeof body>('profile');
+        expect(result).toEqual(body);
+    });
+
+    it('cache: no-store 옵션을 사용한다', async () => {
+        mockOk({});
+        await fmpGet('profile');
+
+        const options = mockFetch.mock.calls[0]![1] as RequestInit;
+        expect(options.cache).toBe('no-store');
+    });
+
+    it('AbortSignal timeout을 설정한다', async () => {
+        mockOk({});
+        await fmpGet('profile');
+
+        const options = mockFetch.mock.calls[0]![1] as RequestInit;
+        expect(options.signal).toBeDefined();
+    });
+
+    describe('에러 처리', () => {
+        it('4xx 응답 시 에러를 던진다', async () => {
+            mockError(404);
+            await expect(fmpGet('profile')).rejects.toThrow('FMP profile 404');
+        });
+
+        it('5xx 응답 시 에러를 던진다', async () => {
+            mockError(500);
+            await expect(fmpGet('profile')).rejects.toThrow('FMP profile 500');
+        });
+
+        it('FMP_API_KEY가 없으면 readFmpConfig에서 에러를 던진다', async () => {
+            vi.mocked(readFmpConfig).mockImplementation(() => {
+                throw new Error('FMP_API_KEY is required');
+            });
+            await expect(fmpGet('profile')).rejects.toThrow('FMP_API_KEY');
+        });
+
+        it('fetch가 네트워크 에러를 던지면 전파된다', async () => {
+            mockFetch.mockRejectedValueOnce(new TypeError('fetch failed'));
+            await expect(fmpGet('profile')).rejects.toThrow('fetch failed');
+        });
+    });
+});

--- a/src/shared/config/__tests__/contact.test.ts
+++ b/src/shared/config/__tests__/contact.test.ts
@@ -1,0 +1,34 @@
+import {
+    CONTACT_CONTENT_MAX_LENGTH,
+    CONTACT_TITLE_MAX_LENGTH,
+} from '@/shared/config/contact';
+
+describe('CONTACT_TITLE_MAX_LENGTH', () => {
+    it('양의 정수이다', () => {
+        expect(typeof CONTACT_TITLE_MAX_LENGTH).toBe('number');
+        expect(Number.isInteger(CONTACT_TITLE_MAX_LENGTH)).toBe(true);
+        expect(CONTACT_TITLE_MAX_LENGTH).toBeGreaterThan(0);
+    });
+
+    it('120으로 설정되어 있다', () => {
+        expect(CONTACT_TITLE_MAX_LENGTH).toBe(120);
+    });
+});
+
+describe('CONTACT_CONTENT_MAX_LENGTH', () => {
+    it('양의 정수이다', () => {
+        expect(typeof CONTACT_CONTENT_MAX_LENGTH).toBe('number');
+        expect(Number.isInteger(CONTACT_CONTENT_MAX_LENGTH)).toBe(true);
+        expect(CONTACT_CONTENT_MAX_LENGTH).toBeGreaterThan(0);
+    });
+
+    it('2000으로 설정되어 있다', () => {
+        expect(CONTACT_CONTENT_MAX_LENGTH).toBe(2000);
+    });
+
+    it('TITLE보다 크다', () => {
+        expect(CONTACT_CONTENT_MAX_LENGTH).toBeGreaterThan(
+            CONTACT_TITLE_MAX_LENGTH
+        );
+    });
+});

--- a/src/shared/config/__tests__/cookieNames.test.ts
+++ b/src/shared/config/__tests__/cookieNames.test.ts
@@ -1,0 +1,32 @@
+import {
+    AUTH_HINT_COOKIE_NAME,
+    AUTH_SESSION_COOKIE_NAME,
+} from '@/shared/config/cookieNames';
+
+describe('AUTH_SESSION_COOKIE_NAME', () => {
+    it('비어있지 않은 문자열이다', () => {
+        expect(typeof AUTH_SESSION_COOKIE_NAME).toBe('string');
+        expect(AUTH_SESSION_COOKIE_NAME.length).toBeGreaterThan(0);
+    });
+
+    it("'siglens_session'으로 설정되어 있다", () => {
+        expect(AUTH_SESSION_COOKIE_NAME).toBe('siglens_session');
+    });
+});
+
+describe('AUTH_HINT_COOKIE_NAME', () => {
+    it('비어있지 않은 문자열이다', () => {
+        expect(typeof AUTH_HINT_COOKIE_NAME).toBe('string');
+        expect(AUTH_HINT_COOKIE_NAME.length).toBeGreaterThan(0);
+    });
+
+    it("'siglens_auth'로 설정되어 있다", () => {
+        expect(AUTH_HINT_COOKIE_NAME).toBe('siglens_auth');
+    });
+});
+
+describe('쿠키 이름 고유성', () => {
+    it('세션 쿠키와 힌트 쿠키 이름이 서로 다르다', () => {
+        expect(AUTH_SESSION_COOKIE_NAME).not.toBe(AUTH_HINT_COOKIE_NAME);
+    });
+});

--- a/src/shared/config/__tests__/dashboard-tickers.test.ts
+++ b/src/shared/config/__tests__/dashboard-tickers.test.ts
@@ -1,0 +1,186 @@
+import {
+    DASHBOARD_TIMEFRAME_LABELS,
+    DASHBOARD_TIMEFRAMES,
+    DEFAULT_DASHBOARD_TIMEFRAME,
+    MARKET_INDICES,
+    MARKET_SUMMARY_FMP_SYMBOLS,
+    SECTOR_ETFS,
+    SECTOR_GROUPS,
+    SECTOR_STOCKS,
+    SIGNAL_SECTORS,
+} from '@/shared/config/dashboard-tickers';
+
+describe('MARKET_INDICES', () => {
+    it('비어있지 않은 배열이다', () => {
+        expect(MARKET_INDICES.length).toBeGreaterThan(0);
+    });
+
+    it('각 항목이 symbol, fmpSymbol, displayName, koreanName을 가진다', () => {
+        for (const idx of MARKET_INDICES) {
+            expect(typeof idx.symbol).toBe('string');
+            expect(idx.symbol.length).toBeGreaterThan(0);
+            expect(typeof idx.fmpSymbol).toBe('string');
+            expect(idx.fmpSymbol.length).toBeGreaterThan(0);
+            expect(typeof idx.displayName).toBe('string');
+            expect(idx.displayName.length).toBeGreaterThan(0);
+            expect(typeof idx.koreanName).toBe('string');
+            expect(idx.koreanName.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('symbol 값에 중복이 없다', () => {
+        const symbols = MARKET_INDICES.map(i => i.symbol);
+        expect(new Set(symbols).size).toBe(symbols.length);
+    });
+
+    it('S&P 500, Dow Jones, NASDAQ, VIX를 포함한다', () => {
+        const symbols = MARKET_INDICES.map(i => i.symbol);
+        expect(symbols).toContain('GSPC');
+        expect(symbols).toContain('DJI');
+        expect(symbols).toContain('IXIC');
+        expect(symbols).toContain('VIX');
+    });
+});
+
+describe('SECTOR_ETFS', () => {
+    it('비어있지 않은 배열이다', () => {
+        expect(SECTOR_ETFS.length).toBeGreaterThan(0);
+    });
+
+    it('각 항목이 symbol, sectorName, koreanName을 가진다', () => {
+        for (const etf of SECTOR_ETFS) {
+            expect(typeof etf.symbol).toBe('string');
+            expect(etf.symbol.length).toBeGreaterThan(0);
+            expect(typeof etf.sectorName).toBe('string');
+            expect(etf.sectorName.length).toBeGreaterThan(0);
+            expect(typeof etf.koreanName).toBe('string');
+            expect(etf.koreanName.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('symbol 값에 중복이 없다', () => {
+        const symbols = SECTOR_ETFS.map(e => e.symbol);
+        expect(new Set(symbols).size).toBe(symbols.length);
+    });
+
+    it('11개 GICS 섹터를 포함한다', () => {
+        expect(SECTOR_ETFS).toHaveLength(11);
+    });
+});
+
+describe('SECTOR_GROUPS', () => {
+    it('비어있지 않은 배열이다', () => {
+        expect(SECTOR_GROUPS.length).toBeGreaterThan(0);
+    });
+
+    it('각 그룹이 label과 비어있지 않은 symbols 배열을 가진다', () => {
+        for (const group of SECTOR_GROUPS) {
+            expect(typeof group.label).toBe('string');
+            expect(group.label.length).toBeGreaterThan(0);
+            expect(group.symbols.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('성장, 경기민감, 방어 세 그룹으로 구성된다', () => {
+        const labels = SECTOR_GROUPS.map(g => g.label);
+        expect(labels).toEqual(['성장', '경기민감', '방어']);
+    });
+
+    it('모든 symbols가 SECTOR_ETFS에 존재하는 ETF 심볼이다', () => {
+        const etfSymbols = new Set(SECTOR_ETFS.map(e => e.symbol));
+        for (const group of SECTOR_GROUPS) {
+            for (const symbol of group.symbols) {
+                expect(etfSymbols).toContain(symbol);
+            }
+        }
+    });
+});
+
+describe('MARKET_SUMMARY_FMP_SYMBOLS', () => {
+    it('비어있지 않은 배열이다', () => {
+        expect(MARKET_SUMMARY_FMP_SYMBOLS.length).toBeGreaterThan(0);
+    });
+
+    it('MARKET_INDICES의 fmpSymbol + SECTOR_ETFS의 symbol을 모두 포함한다', () => {
+        const expected = [
+            ...MARKET_INDICES.map(i => i.fmpSymbol),
+            ...SECTOR_ETFS.map(e => e.symbol),
+        ];
+        expect([...MARKET_SUMMARY_FMP_SYMBOLS]).toEqual(expected);
+    });
+});
+
+describe('SECTOR_STOCKS', () => {
+    it('비어있지 않은 배열이다', () => {
+        expect(SECTOR_STOCKS.length).toBeGreaterThan(0);
+    });
+
+    it('각 항목이 symbol, koreanName, sectorSymbol을 가진다', () => {
+        for (const stock of SECTOR_STOCKS) {
+            expect(typeof stock.symbol).toBe('string');
+            expect(stock.symbol.length).toBeGreaterThan(0);
+            expect(typeof stock.koreanName).toBe('string');
+            expect(stock.koreanName.length).toBeGreaterThan(0);
+            expect(typeof stock.sectorSymbol).toBe('string');
+            expect(stock.sectorSymbol.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('symbol 값에 중복이 없다', () => {
+        const symbols = SECTOR_STOCKS.map(s => s.symbol);
+        expect(new Set(symbols).size).toBe(symbols.length);
+    });
+});
+
+describe('DASHBOARD_TIMEFRAMES', () => {
+    it('비어있지 않은 배열이다', () => {
+        expect(DASHBOARD_TIMEFRAMES.length).toBeGreaterThan(0);
+    });
+
+    it("'15Min', '1Hour', '1Day'를 포함한다", () => {
+        expect([...DASHBOARD_TIMEFRAMES]).toEqual(['15Min', '1Hour', '1Day']);
+    });
+});
+
+describe('DEFAULT_DASHBOARD_TIMEFRAME', () => {
+    it("'1Day'로 설정되어 있다", () => {
+        expect(DEFAULT_DASHBOARD_TIMEFRAME).toBe('1Day');
+    });
+
+    it('DASHBOARD_TIMEFRAMES에 포함된 값이다', () => {
+        expect(DASHBOARD_TIMEFRAMES).toContain(DEFAULT_DASHBOARD_TIMEFRAME);
+    });
+});
+
+describe('DASHBOARD_TIMEFRAME_LABELS', () => {
+    it('모든 DASHBOARD_TIMEFRAMES에 대한 레이블이 존재한다', () => {
+        for (const tf of DASHBOARD_TIMEFRAMES) {
+            expect(typeof DASHBOARD_TIMEFRAME_LABELS[tf]).toBe('string');
+            expect(DASHBOARD_TIMEFRAME_LABELS[tf].length).toBeGreaterThan(0);
+        }
+    });
+
+    it('한국어 레이블을 반환한다', () => {
+        expect(DASHBOARD_TIMEFRAME_LABELS['15Min']).toBe('15분');
+        expect(DASHBOARD_TIMEFRAME_LABELS['1Hour']).toBe('1시간');
+        expect(DASHBOARD_TIMEFRAME_LABELS['1Day']).toBe('1일');
+    });
+});
+
+describe('SIGNAL_SECTORS', () => {
+    it('SECTOR_ETFS보다 하나 더 많다 (Quantum 가상 섹터)', () => {
+        expect(SIGNAL_SECTORS.length).toBe(SECTOR_ETFS.length + 1);
+    });
+
+    it('모든 SECTOR_ETFS를 포함한다', () => {
+        for (const etf of SECTOR_ETFS) {
+            expect(SIGNAL_SECTORS).toContainEqual(etf);
+        }
+    });
+
+    it('Quantum 가상 섹터를 포함한다', () => {
+        const quantum = SIGNAL_SECTORS.find(s => s.symbol === 'QNTM');
+        expect(quantum).toBeDefined();
+        expect(quantum!.sectorName).toBe('Quantum');
+    });
+});

--- a/src/shared/config/__tests__/llmProviders.test.ts
+++ b/src/shared/config/__tests__/llmProviders.test.ts
@@ -1,0 +1,41 @@
+import {
+    LLM_PROVIDER_VALUES,
+    type LlmProvider,
+} from '@/shared/config/llmProviders';
+
+describe('LLM_PROVIDER_VALUES', () => {
+    it('비어있지 않은 배열이다', () => {
+        expect(LLM_PROVIDER_VALUES.length).toBeGreaterThan(0);
+    });
+
+    it('모든 항목이 비어있지 않은 문자열이다', () => {
+        for (const provider of LLM_PROVIDER_VALUES) {
+            expect(typeof provider).toBe('string');
+            expect(provider.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('중복 값이 없다', () => {
+        expect(new Set(LLM_PROVIDER_VALUES).size).toBe(
+            LLM_PROVIDER_VALUES.length
+        );
+    });
+
+    it("'anthropic', 'google', 'openai'를 포함한다", () => {
+        expect([...LLM_PROVIDER_VALUES]).toEqual(
+            expect.arrayContaining(['anthropic', 'google', 'openai'])
+        );
+    });
+
+    it('3개 프로바이더가 정의되어 있다', () => {
+        expect(LLM_PROVIDER_VALUES).toHaveLength(3);
+    });
+});
+
+describe('LlmProvider 타입', () => {
+    it('LLM_PROVIDER_VALUES의 각 값이 LlmProvider 타입으로 할당 가능하다', () => {
+        // 컴파일 타임 검증 — 타입 에러 없이 할당되면 통과.
+        const providers: LlmProvider[] = [...LLM_PROVIDER_VALUES];
+        expect(providers).toHaveLength(LLM_PROVIDER_VALUES.length);
+    });
+});

--- a/src/shared/config/__tests__/pollingConfig.test.ts
+++ b/src/shared/config/__tests__/pollingConfig.test.ts
@@ -1,0 +1,54 @@
+import {
+    ANALYSIS_POLL_INTERVAL_MS,
+    AUGMENT_AND_OVERALL_POLL_INTERVAL_MS,
+    CHART_ANALYSIS_POLL_INTERVAL_MS,
+} from '@/shared/config/pollingConfig';
+
+describe('ANALYSIS_POLL_INTERVAL_MS', () => {
+    it('양의 정수이다', () => {
+        expect(typeof ANALYSIS_POLL_INTERVAL_MS).toBe('number');
+        expect(Number.isInteger(ANALYSIS_POLL_INTERVAL_MS)).toBe(true);
+        expect(ANALYSIS_POLL_INTERVAL_MS).toBeGreaterThan(0);
+    });
+
+    it('2500ms로 설정되어 있다', () => {
+        expect(ANALYSIS_POLL_INTERVAL_MS).toBe(2500);
+    });
+});
+
+describe('AUGMENT_AND_OVERALL_POLL_INTERVAL_MS', () => {
+    it('양의 정수이다', () => {
+        expect(typeof AUGMENT_AND_OVERALL_POLL_INTERVAL_MS).toBe('number');
+        expect(Number.isInteger(AUGMENT_AND_OVERALL_POLL_INTERVAL_MS)).toBe(
+            true
+        );
+        expect(AUGMENT_AND_OVERALL_POLL_INTERVAL_MS).toBeGreaterThan(0);
+    });
+
+    it('3000ms로 설정되어 있다', () => {
+        expect(AUGMENT_AND_OVERALL_POLL_INTERVAL_MS).toBe(3000);
+    });
+});
+
+describe('CHART_ANALYSIS_POLL_INTERVAL_MS', () => {
+    it('양의 정수이다', () => {
+        expect(typeof CHART_ANALYSIS_POLL_INTERVAL_MS).toBe('number');
+        expect(Number.isInteger(CHART_ANALYSIS_POLL_INTERVAL_MS)).toBe(true);
+        expect(CHART_ANALYSIS_POLL_INTERVAL_MS).toBeGreaterThan(0);
+    });
+
+    it('10000ms로 설정되어 있다', () => {
+        expect(CHART_ANALYSIS_POLL_INTERVAL_MS).toBe(10_000);
+    });
+});
+
+describe('폴링 간격 순서', () => {
+    it('ANALYSIS < AUGMENT_AND_OVERALL < CHART_ANALYSIS 순서로 커진다', () => {
+        expect(ANALYSIS_POLL_INTERVAL_MS).toBeLessThan(
+            AUGMENT_AND_OVERALL_POLL_INTERVAL_MS
+        );
+        expect(AUGMENT_AND_OVERALL_POLL_INTERVAL_MS).toBeLessThan(
+            CHART_ANALYSIS_POLL_INTERVAL_MS
+        );
+    });
+});

--- a/src/shared/config/__tests__/popular-tickers.test.ts
+++ b/src/shared/config/__tests__/popular-tickers.test.ts
@@ -1,0 +1,78 @@
+import {
+    POPULAR_TICKERS,
+    TICKER_CATEGORIES,
+} from '@/shared/config/popular-tickers';
+
+describe('TICKER_CATEGORIES', () => {
+    it('비어있지 않은 배열이다', () => {
+        expect(TICKER_CATEGORIES.length).toBeGreaterThan(0);
+    });
+
+    it('각 카테고리가 id, label, tickers를 가진다', () => {
+        for (const category of TICKER_CATEGORIES) {
+            expect(typeof category.id).toBe('string');
+            expect(category.id.length).toBeGreaterThan(0);
+            expect(typeof category.label).toBe('string');
+            expect(category.label.length).toBeGreaterThan(0);
+            expect(category.tickers.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('카테고리 id 값에 중복이 없다', () => {
+        const ids = TICKER_CATEGORIES.map(c => c.id);
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('각 카테고리 내 ticker에 중복이 없다', () => {
+        for (const category of TICKER_CATEGORIES) {
+            expect(new Set(category.tickers).size).toBe(
+                category.tickers.length
+            );
+        }
+    });
+
+    it('모든 ticker가 비어있지 않은 문자열이다', () => {
+        for (const category of TICKER_CATEGORIES) {
+            for (const ticker of category.tickers) {
+                expect(typeof ticker).toBe('string');
+                expect(ticker.length).toBeGreaterThan(0);
+            }
+        }
+    });
+
+    it('megacap 카테고리가 존재한다', () => {
+        const megacap = TICKER_CATEGORIES.find(c => c.id === 'megacap');
+        expect(megacap).toBeDefined();
+        expect(megacap!.tickers).toContain('AAPL');
+        expect(megacap!.tickers).toContain('MSFT');
+    });
+});
+
+describe('POPULAR_TICKERS', () => {
+    it('비어있지 않은 배열이다', () => {
+        expect(POPULAR_TICKERS.length).toBeGreaterThan(0);
+    });
+
+    it('모든 항목이 비어있지 않은 문자열이다', () => {
+        for (const ticker of POPULAR_TICKERS) {
+            expect(typeof ticker).toBe('string');
+            expect(ticker.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('중복 값이 없다', () => {
+        expect(new Set(POPULAR_TICKERS).size).toBe(POPULAR_TICKERS.length);
+    });
+
+    it('대표 메가캡 티커를 포함한다', () => {
+        expect(POPULAR_TICKERS).toContain('AAPL');
+        expect(POPULAR_TICKERS).toContain('MSFT');
+        expect(POPULAR_TICKERS).toContain('NVDA');
+        expect(POPULAR_TICKERS).toContain('GOOGL');
+        expect(POPULAR_TICKERS).toContain('AMZN');
+    });
+
+    it('100개 이상의 티커를 포함한다', () => {
+        expect(POPULAR_TICKERS.length).toBeGreaterThanOrEqual(100);
+    });
+});

--- a/src/shared/config/__tests__/ticker.test.ts
+++ b/src/shared/config/__tests__/ticker.test.ts
@@ -1,0 +1,62 @@
+import { TICKER_RE } from '@/shared/config/ticker';
+
+describe('TICKER_RE', () => {
+    it('RegExp 인스턴스이다', () => {
+        expect(TICKER_RE).toBeInstanceOf(RegExp);
+    });
+
+    describe('유효한 티커를 매칭할 때', () => {
+        it.each(['AAPL', 'MSFT', 'A', 'NVDA', 'META', 'GOOGL', 'T'])(
+            "'%s'를 매칭한다",
+            ticker => {
+                expect(TICKER_RE.test(ticker)).toBe(true);
+            }
+        );
+
+        it("점(.)을 포함하는 'BRK.B'를 매칭한다", () => {
+            expect(TICKER_RE.test('BRK.B')).toBe(true);
+        });
+
+        it("하이픈(-)을 포함하는 'PBR-A'를 매칭한다", () => {
+            expect(TICKER_RE.test('PBR-A')).toBe(true);
+        });
+
+        it('8글자 티커를 매칭한다', () => {
+            expect(TICKER_RE.test('ABCDEFGH')).toBe(true);
+        });
+    });
+
+    describe('유효하지 않은 입력을 거부할 때', () => {
+        it('빈 문자열을 거부한다', () => {
+            expect(TICKER_RE.test('')).toBe(false);
+        });
+
+        it('소문자를 거부한다', () => {
+            expect(TICKER_RE.test('aapl')).toBe(false);
+        });
+
+        it('숫자를 거부한다', () => {
+            expect(TICKER_RE.test('A123')).toBe(false);
+        });
+
+        it('9글자 이상을 거부한다', () => {
+            expect(TICKER_RE.test('ABCDEFGHI')).toBe(false);
+        });
+
+        it('점(.)으로 시작하는 문자열을 거부한다', () => {
+            expect(TICKER_RE.test('.ABC')).toBe(false);
+        });
+
+        it('하이픈(-)으로 시작하는 문자열을 거부한다', () => {
+            expect(TICKER_RE.test('-ABC')).toBe(false);
+        });
+
+        it('공백을 포함하는 문자열을 거부한다', () => {
+            expect(TICKER_RE.test('A BC')).toBe(false);
+        });
+
+        it('특수문자를 거부한다', () => {
+            expect(TICKER_RE.test('A@BC')).toBe(false);
+        });
+    });
+});

--- a/src/shared/db/__tests__/client.test.ts
+++ b/src/shared/db/__tests__/client.test.ts
@@ -1,0 +1,101 @@
+vi.mock('@neondatabase/serverless', () => ({
+    neon: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('drizzle-orm/neon-http', () => ({
+    drizzle: vi.fn(() => ({})),
+}));
+
+vi.mock('@/shared/db/config', () => ({
+    readDatabaseConfig: vi.fn(() => ({ databaseUrl: 'postgres://test' })),
+    tryReadDatabaseConfig: vi.fn(() => ({ databaseUrl: 'postgres://test' })),
+}));
+
+vi.mock('@/shared/db/schema', () => ({}));
+
+import { neon } from '@neondatabase/serverless';
+import { drizzle } from 'drizzle-orm/neon-http';
+import { readDatabaseConfig, tryReadDatabaseConfig } from '@/shared/db/config';
+import {
+    createDatabaseClient,
+    getDatabaseClient,
+    resetDatabaseClientForTests,
+    tryGetDatabaseClient,
+} from '@/shared/db/client';
+
+describe('createDatabaseClient', () => {
+    beforeEach(() => {
+        vi.mocked(neon).mockReturnValue(vi.fn() as never);
+        vi.mocked(drizzle).mockReturnValue({} as never);
+    });
+
+    it('neon과 drizzle을 호출하고 db, sql 프로퍼티를 가진 객체를 반환한다', () => {
+        const mockSql = vi.fn();
+        const mockDb = { tables: true };
+        vi.mocked(neon).mockReturnValue(mockSql as never);
+        vi.mocked(drizzle).mockReturnValue(mockDb as never);
+
+        const client = createDatabaseClient({
+            databaseUrl: 'postgres://test-url',
+        });
+
+        expect(neon).toHaveBeenCalledWith('postgres://test-url');
+        expect(drizzle).toHaveBeenCalledWith(mockSql, expect.any(Object));
+        expect(client).toHaveProperty('db', mockDb);
+        expect(client).toHaveProperty('sql', mockSql);
+    });
+});
+
+describe('getDatabaseClient', () => {
+    beforeEach(() => {
+        resetDatabaseClientForTests();
+        vi.mocked(neon).mockReturnValue(vi.fn() as never);
+        vi.mocked(drizzle).mockReturnValue({} as never);
+    });
+
+    it('DatabaseClient를 반환한다', () => {
+        const client = getDatabaseClient();
+        expect(client).toHaveProperty('db');
+        expect(client).toHaveProperty('sql');
+    });
+
+    it('두 번 호출해도 같은 캐시된 인스턴스를 반환한다', () => {
+        const first = getDatabaseClient();
+        vi.mocked(readDatabaseConfig).mockClear();
+        const second = getDatabaseClient();
+        expect(first).toBe(second);
+        // 캐시 히트이므로 readDatabaseConfig가 다시 호출되지 않아야 한다.
+        expect(readDatabaseConfig).not.toHaveBeenCalled();
+    });
+
+    it('resetDatabaseClientForTests 후에는 새 인스턴스를 생성한다', () => {
+        const first = getDatabaseClient();
+        resetDatabaseClientForTests();
+        const second = getDatabaseClient();
+        expect(first).not.toBe(second);
+    });
+});
+
+describe('tryGetDatabaseClient', () => {
+    beforeEach(() => {
+        resetDatabaseClientForTests();
+        vi.mocked(neon).mockReturnValue(vi.fn() as never);
+        vi.mocked(drizzle).mockReturnValue({} as never);
+    });
+
+    it('config가 존재하면 DatabaseClient를 반환한다', () => {
+        vi.mocked(tryReadDatabaseConfig).mockReturnValue({
+            databaseUrl: 'postgres://test',
+        });
+        const client = tryGetDatabaseClient();
+        expect(client).not.toBeNull();
+        expect(client).toHaveProperty('db');
+        expect(client).toHaveProperty('sql');
+    });
+
+    it('config가 null이면 null을 반환한다', () => {
+        vi.mocked(tryReadDatabaseConfig).mockReturnValue(null);
+        const client = tryGetDatabaseClient();
+        expect(client).toBeNull();
+    });
+});

--- a/src/shared/db/__tests__/config.test.ts
+++ b/src/shared/db/__tests__/config.test.ts
@@ -1,0 +1,61 @@
+import { readDatabaseConfig, tryReadDatabaseConfig } from '@/shared/db/config';
+
+describe('readDatabaseConfig', () => {
+    const originalEnv = process.env.DATABASE_URL;
+
+    afterEach(() => {
+        if (originalEnv !== undefined) {
+            process.env.DATABASE_URL = originalEnv;
+        } else {
+            delete process.env.DATABASE_URL;
+        }
+    });
+
+    it('DATABASE_URL이 설정되어 있으면 DatabaseConfig를 반환한다', () => {
+        process.env.DATABASE_URL = 'postgres://localhost:5432/testdb';
+        const config = readDatabaseConfig();
+        expect(config).toEqual({
+            databaseUrl: 'postgres://localhost:5432/testdb',
+        });
+    });
+
+    it('DATABASE_URL이 없으면 에러를 던진다', () => {
+        delete process.env.DATABASE_URL;
+        expect(() => readDatabaseConfig()).toThrow('DATABASE_URL');
+    });
+
+    it('DATABASE_URL이 빈 문자열이면 에러를 던진다', () => {
+        process.env.DATABASE_URL = '';
+        expect(() => readDatabaseConfig()).toThrow('DATABASE_URL');
+    });
+});
+
+describe('tryReadDatabaseConfig', () => {
+    const originalEnv = process.env.DATABASE_URL;
+
+    afterEach(() => {
+        if (originalEnv !== undefined) {
+            process.env.DATABASE_URL = originalEnv;
+        } else {
+            delete process.env.DATABASE_URL;
+        }
+    });
+
+    it('DATABASE_URL이 설정되어 있으면 DatabaseConfig를 반환한다', () => {
+        process.env.DATABASE_URL = 'postgres://localhost:5432/testdb';
+        const config = tryReadDatabaseConfig();
+        expect(config).toEqual({
+            databaseUrl: 'postgres://localhost:5432/testdb',
+        });
+    });
+
+    it('DATABASE_URL이 없으면 null을 반환한다', () => {
+        delete process.env.DATABASE_URL;
+        expect(tryReadDatabaseConfig()).toBeNull();
+    });
+
+    it('DATABASE_URL이 빈 문자열이면 null을 반환한다', () => {
+        process.env.DATABASE_URL = '';
+        expect(tryReadDatabaseConfig()).toBeNull();
+    });
+});

--- a/src/shared/db/__tests__/constants.test.ts
+++ b/src/shared/db/__tests__/constants.test.ts
@@ -1,0 +1,113 @@
+import {
+    LLM_PROVIDER_VALUES,
+    OAUTH_PROVIDER_VALUES,
+    TERMS_KIND_VALUES,
+    USAGE_ACTION_TYPE_VALUES,
+    USER_TIER_VALUES,
+} from '@/shared/db/constants';
+
+describe('USER_TIER_VALUES', () => {
+    it('비어있지 않은 배열이다', () => {
+        expect(USER_TIER_VALUES.length).toBeGreaterThan(0);
+    });
+
+    it('모든 항목이 비어있지 않은 문자열이다', () => {
+        for (const tier of USER_TIER_VALUES) {
+            expect(typeof tier).toBe('string');
+            expect(tier.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('중복 값이 없다', () => {
+        expect(new Set(USER_TIER_VALUES).size).toBe(USER_TIER_VALUES.length);
+    });
+
+    it("'free', 'member', 'pro'를 포함한다", () => {
+        expect([...USER_TIER_VALUES]).toEqual(['free', 'member', 'pro']);
+    });
+});
+
+describe('USAGE_ACTION_TYPE_VALUES', () => {
+    it('비어있지 않은 배열이다', () => {
+        expect(USAGE_ACTION_TYPE_VALUES.length).toBeGreaterThan(0);
+    });
+
+    it('모든 항목이 비어있지 않은 문자열이다', () => {
+        for (const action of USAGE_ACTION_TYPE_VALUES) {
+            expect(typeof action).toBe('string');
+            expect(action.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('중복 값이 없다', () => {
+        expect(new Set(USAGE_ACTION_TYPE_VALUES).size).toBe(
+            USAGE_ACTION_TYPE_VALUES.length
+        );
+    });
+
+    it("'analysis', 'chatbot', 'premium_model'을 포함한다", () => {
+        expect([...USAGE_ACTION_TYPE_VALUES]).toEqual([
+            'analysis',
+            'chatbot',
+            'premium_model',
+        ]);
+    });
+});
+
+describe('OAUTH_PROVIDER_VALUES', () => {
+    it('비어있지 않은 배열이다', () => {
+        expect(OAUTH_PROVIDER_VALUES.length).toBeGreaterThan(0);
+    });
+
+    it('모든 항목이 비어있지 않은 문자열이다', () => {
+        for (const provider of OAUTH_PROVIDER_VALUES) {
+            expect(typeof provider).toBe('string');
+            expect(provider.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('중복 값이 없다', () => {
+        expect(new Set(OAUTH_PROVIDER_VALUES).size).toBe(
+            OAUTH_PROVIDER_VALUES.length
+        );
+    });
+
+    it("'google', 'kakao', 'apple'을 포함한다", () => {
+        expect([...OAUTH_PROVIDER_VALUES]).toEqual([
+            'google',
+            'kakao',
+            'apple',
+        ]);
+    });
+});
+
+describe('TERMS_KIND_VALUES', () => {
+    it('비어있지 않은 배열이다', () => {
+        expect(TERMS_KIND_VALUES.length).toBeGreaterThan(0);
+    });
+
+    it('모든 항목이 비어있지 않은 문자열이다', () => {
+        for (const kind of TERMS_KIND_VALUES) {
+            expect(typeof kind).toBe('string');
+            expect(kind.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('중복 값이 없다', () => {
+        expect(new Set(TERMS_KIND_VALUES).size).toBe(TERMS_KIND_VALUES.length);
+    });
+
+    it("'privacy', 'tos'를 포함한다", () => {
+        expect([...TERMS_KIND_VALUES]).toEqual(['privacy', 'tos']);
+    });
+});
+
+describe('LLM_PROVIDER_VALUES (re-export)', () => {
+    it('shared/config/llmProviders의 값과 동일하다', () => {
+        expect([...LLM_PROVIDER_VALUES]).toEqual([
+            'anthropic',
+            'google',
+            'openai',
+        ]);
+    });
+});

--- a/src/shared/db/__tests__/constants.test.ts
+++ b/src/shared/db/__tests__/constants.test.ts
@@ -5,6 +5,7 @@ import {
     USAGE_ACTION_TYPE_VALUES,
     USER_TIER_VALUES,
 } from '@/shared/db/constants';
+import { LLM_PROVIDER_VALUES as SOURCE_LLM_VALUES } from '@/shared/config/llmProviders';
 
 describe('USER_TIER_VALUES', () => {
     it('비어있지 않은 배열이다', () => {
@@ -104,10 +105,6 @@ describe('TERMS_KIND_VALUES', () => {
 
 describe('LLM_PROVIDER_VALUES (re-export)', () => {
     it('shared/config/llmProviders의 값과 동일하다', () => {
-        expect([...LLM_PROVIDER_VALUES]).toEqual([
-            'anthropic',
-            'google',
-            'openai',
-        ]);
+        expect([...LLM_PROVIDER_VALUES]).toEqual([...SOURCE_LLM_VALUES]);
     });
 });

--- a/src/shared/db/__tests__/schema.test.ts
+++ b/src/shared/db/__tests__/schema.test.ts
@@ -21,10 +21,9 @@ describe('schema 테이블 export', () => {
         expect(schema[tableName]).toBeDefined();
     });
 
-    it('각 테이블이 Drizzle Table 객체이다 (Symbol.toStringTag 또는 _ 속성)', () => {
+    it('각 테이블이 non-null 객체이다', () => {
         for (const tableName of expectedTables) {
             const table = schema[tableName];
-            // Drizzle tables expose an internal `_` descriptor or `Symbol.toStringTag`.
             expect(typeof table).toBe('object');
             expect(table).not.toBeNull();
         }

--- a/src/shared/db/__tests__/schema.test.ts
+++ b/src/shared/db/__tests__/schema.test.ts
@@ -1,0 +1,67 @@
+import * as schema from '@/shared/db/schema';
+
+describe('schema 테이블 export', () => {
+    const expectedTables = [
+        'users',
+        'sessions',
+        'usageLogs',
+        'oauthAccounts',
+        'userApiKeys',
+        'koreanTickers',
+        'profileDescriptionTranslations',
+        'assetTranslations',
+        'inquiries',
+        'news',
+        'earningsReports',
+        'terms',
+        'agreements',
+    ] as const;
+
+    it.each(expectedTables)("'%s' 테이블이 export 되어 있다", tableName => {
+        expect(schema[tableName]).toBeDefined();
+    });
+
+    it('각 테이블이 Drizzle Table 객체이다 (Symbol.toStringTag 또는 _ 속성)', () => {
+        for (const tableName of expectedTables) {
+            const table = schema[tableName];
+            // Drizzle tables expose an internal `_` descriptor or `Symbol.toStringTag`.
+            expect(typeof table).toBe('object');
+            expect(table).not.toBeNull();
+        }
+    });
+});
+
+describe('schema enum export', () => {
+    const expectedEnums = [
+        'userTierEnum',
+        'usageActionTypeEnum',
+        'oauthProviderEnum',
+        'llmProviderEnum',
+        'termsKindEnum',
+    ] as const;
+
+    it.each(expectedEnums)("'%s' enum이 export 되어 있다", enumName => {
+        expect(schema[enumName]).toBeDefined();
+    });
+});
+
+describe('users 테이블 컬럼', () => {
+    it('id, email, tier, createdAt, updatedAt 컬럼 속성이 존재한다', () => {
+        const users = schema.users;
+        expect(users.id).toBeDefined();
+        expect(users.email).toBeDefined();
+        expect(users.tier).toBeDefined();
+        expect(users.createdAt).toBeDefined();
+        expect(users.updatedAt).toBeDefined();
+    });
+});
+
+describe('sessions 테이블 컬럼', () => {
+    it('id, userId, expiresAt, createdAt 컬럼 속성이 존재한다', () => {
+        const sessions = schema.sessions;
+        expect(sessions.id).toBeDefined();
+        expect(sessions.userId).toBeDefined();
+        expect(sessions.expiresAt).toBeDefined();
+        expect(sessions.createdAt).toBeDefined();
+    });
+});

--- a/src/shared/db/__tests__/tokenEncryption.test.ts
+++ b/src/shared/db/__tests__/tokenEncryption.test.ts
@@ -1,0 +1,192 @@
+import { randomBytes } from 'node:crypto';
+import {
+    decryptToken,
+    encryptToken,
+    requireOauthTokenEncryptionKey,
+    tryReadEncryptionKey,
+    tryReadLlmApiKeyEncryptionKey,
+} from '@/shared/db/tokenEncryption';
+
+/** Generate a valid 32-byte hex key for AES-256. */
+function generateKeyHex(): string {
+    return randomBytes(32).toString('hex');
+}
+
+describe('encryptToken / decryptToken', () => {
+    const keyHex = generateKeyHex();
+
+    describe('라운드 트립', () => {
+        it('암호화 후 복호화하면 원본을 반환한다', () => {
+            const plaintext = 'my-secret-oauth-token';
+            const encrypted = encryptToken(plaintext, keyHex);
+            expect(decryptToken(encrypted, keyHex)).toBe(plaintext);
+        });
+
+        it('빈 문자열도 라운드 트립이 성공한다', () => {
+            const encrypted = encryptToken('', keyHex);
+            expect(decryptToken(encrypted, keyHex)).toBe('');
+        });
+
+        it('유니코드(한국어)도 라운드 트립이 성공한다', () => {
+            const plaintext = '안녕하세요 토큰 암호화 테스트';
+            const encrypted = encryptToken(plaintext, keyHex);
+            expect(decryptToken(encrypted, keyHex)).toBe(plaintext);
+        });
+
+        it('긴 문자열도 라운드 트립이 성공한다', () => {
+            const plaintext = 'a'.repeat(10_000);
+            const encrypted = encryptToken(plaintext, keyHex);
+            expect(decryptToken(encrypted, keyHex)).toBe(plaintext);
+        });
+    });
+
+    describe('랜덤 IV', () => {
+        it('동일한 평문을 두 번 암호화하면 서로 다른 암호문을 생성한다', () => {
+            const plaintext = 'same-text';
+            const encrypted1 = encryptToken(plaintext, keyHex);
+            const encrypted2 = encryptToken(plaintext, keyHex);
+            expect(encrypted1).not.toBe(encrypted2);
+        });
+    });
+
+    describe('암호문 형식', () => {
+        it("':'으로 구분된 3개의 base64 파트를 반환한다", () => {
+            const encrypted = encryptToken('test', keyHex);
+            const parts = encrypted.split(':');
+            expect(parts).toHaveLength(3);
+            for (const part of parts) {
+                // base64 문자만 포함하는지 확인
+                expect(part).toMatch(/^[A-Za-z0-9+/=]+$/);
+            }
+        });
+    });
+
+    describe('잘못된 입력에 대한 복호화', () => {
+        it("':'가 없는 문자열에 대해 null을 반환한다", () => {
+            expect(decryptToken('not-valid-format', keyHex)).toBeNull();
+        });
+
+        it('파트가 2개뿐인 문자열에 대해 null을 반환한다', () => {
+            expect(decryptToken('part1:part2', keyHex)).toBeNull();
+        });
+
+        it('파트가 4개인 문자열에 대해 null을 반환한다', () => {
+            expect(decryptToken('a:b:c:d', keyHex)).toBeNull();
+        });
+
+        it('손상된 암호문에 대해 null을 반환한다', () => {
+            const encrypted = encryptToken('test', keyHex);
+            const parts = encrypted.split(':');
+            // tag를 손상시킨다
+            const corrupted = [
+                parts[0],
+                parts[1],
+                'AAAAAAAAAAAAAAAAAAAAAA==',
+            ].join(':');
+            expect(decryptToken(corrupted, keyHex)).toBeNull();
+        });
+    });
+
+    describe('잘못된 키로 복호화', () => {
+        it('다른 키로 복호화하면 null을 반환한다', () => {
+            const otherKey = generateKeyHex();
+            const encrypted = encryptToken('secret', keyHex);
+            expect(decryptToken(encrypted, otherKey)).toBeNull();
+        });
+    });
+});
+
+describe('tryReadEncryptionKey', () => {
+    const originalEnv = process.env.OAUTH_TOKEN_ENCRYPTION_KEY;
+
+    afterEach(() => {
+        if (originalEnv !== undefined) {
+            process.env.OAUTH_TOKEN_ENCRYPTION_KEY = originalEnv;
+        } else {
+            delete process.env.OAUTH_TOKEN_ENCRYPTION_KEY;
+        }
+    });
+
+    it('유효한 32바이트 hex 키가 있으면 키를 반환한다', () => {
+        const validKey = generateKeyHex();
+        process.env.OAUTH_TOKEN_ENCRYPTION_KEY = validKey;
+        expect(tryReadEncryptionKey()).toBe(validKey);
+    });
+
+    it('환경변수가 없으면 null을 반환한다', () => {
+        delete process.env.OAUTH_TOKEN_ENCRYPTION_KEY;
+        expect(tryReadEncryptionKey()).toBeNull();
+    });
+
+    it('빈 문자열이면 null을 반환한다', () => {
+        process.env.OAUTH_TOKEN_ENCRYPTION_KEY = '';
+        expect(tryReadEncryptionKey()).toBeNull();
+    });
+
+    it('길이가 틀린 hex 키면 null을 반환한다', () => {
+        // 16바이트(32 hex chars) — AES-256에는 부족
+        process.env.OAUTH_TOKEN_ENCRYPTION_KEY =
+            randomBytes(16).toString('hex');
+        expect(tryReadEncryptionKey()).toBeNull();
+    });
+});
+
+describe('requireOauthTokenEncryptionKey', () => {
+    const originalEnv = process.env.OAUTH_TOKEN_ENCRYPTION_KEY;
+
+    afterEach(() => {
+        if (originalEnv !== undefined) {
+            process.env.OAUTH_TOKEN_ENCRYPTION_KEY = originalEnv;
+        } else {
+            delete process.env.OAUTH_TOKEN_ENCRYPTION_KEY;
+        }
+    });
+
+    it('유효한 키가 있으면 키를 반환한다', () => {
+        const validKey = generateKeyHex();
+        process.env.OAUTH_TOKEN_ENCRYPTION_KEY = validKey;
+        expect(requireOauthTokenEncryptionKey()).toBe(validKey);
+    });
+
+    it('키가 없으면 에러를 던진다', () => {
+        delete process.env.OAUTH_TOKEN_ENCRYPTION_KEY;
+        expect(() => requireOauthTokenEncryptionKey()).toThrow(
+            'OAUTH_TOKEN_ENCRYPTION_KEY'
+        );
+    });
+
+    it('잘못된 길이의 키면 에러를 던진다', () => {
+        process.env.OAUTH_TOKEN_ENCRYPTION_KEY = 'tooshort';
+        expect(() => requireOauthTokenEncryptionKey()).toThrow(
+            'OAUTH_TOKEN_ENCRYPTION_KEY'
+        );
+    });
+});
+
+describe('tryReadLlmApiKeyEncryptionKey', () => {
+    const originalEnv = process.env.LLM_API_KEY_ENCRYPTION_KEY;
+
+    afterEach(() => {
+        if (originalEnv !== undefined) {
+            process.env.LLM_API_KEY_ENCRYPTION_KEY = originalEnv;
+        } else {
+            delete process.env.LLM_API_KEY_ENCRYPTION_KEY;
+        }
+    });
+
+    it('유효한 32바이트 hex 키가 있으면 키를 반환한다', () => {
+        const validKey = generateKeyHex();
+        process.env.LLM_API_KEY_ENCRYPTION_KEY = validKey;
+        expect(tryReadLlmApiKeyEncryptionKey()).toBe(validKey);
+    });
+
+    it('환경변수가 없으면 null을 반환한다', () => {
+        delete process.env.LLM_API_KEY_ENCRYPTION_KEY;
+        expect(tryReadLlmApiKeyEncryptionKey()).toBeNull();
+    });
+
+    it('길이가 틀린 hex 키면 null을 반환한다', () => {
+        process.env.LLM_API_KEY_ENCRYPTION_KEY = 'abc123';
+        expect(tryReadLlmApiKeyEncryptionKey()).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- shared/config 7개 설정 파일 테스트 (구조 계약, 중복 검증, 타입 검증)
- shared/db 5개 파일 테스트 (tokenEncryption round-trip, client 캐싱, schema 구조)
- shared/api 1개 파일 테스트 (httpClient fetch mock, 에러 핸들링)
- 160개 새 테스트 케이스 추가

## Files tested
**Config:** contact, cookieNames, dashboard-tickers, llmProviders, pollingConfig, popular-tickers, ticker
**DB:** tokenEncryption, client, config, constants, schema
**API:** fmp/httpClient

## Test plan
- [x] `yarn test` — all suites pass
- [x] `tsc --noEmit` — 0 errors
- [x] `yarn lint` — 0 errors
- [x] `yarn format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)