### PR TITLE
test(features): add tests for 15 UI components + 2 model files

### DIFF
--- a/src/features/account-delete/__tests__/DeleteAccountConfirm.test.tsx
+++ b/src/features/account-delete/__tests__/DeleteAccountConfirm.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DeleteAccountConfirm } from '@/features/account-delete/ui/DeleteAccountConfirm';
+import { useDeleteAccountForm } from '@/features/account-delete/hooks/useDeleteAccountForm';
+import type { DeleteAccountFormState } from '@/shared/lib/auth/formTypes';
+
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: vi.fn(() => ({ db: {}, sql: () => null })),
+}));
+vi.mock('@/features/account-delete/hooks/useDeleteAccountForm');
+vi.mock('next/link', () => ({
+    default: ({
+        children,
+        ...props
+    }: {
+        children: React.ReactNode;
+        href: string;
+    }) => <a {...props}>{children}</a>,
+}));
+
+const mockFormAction = vi.fn();
+const mockUseDeleteAccountForm = vi.mocked(useDeleteAccountForm);
+
+function setFormState(state: DeleteAccountFormState) {
+    mockUseDeleteAccountForm.mockReturnValue([state, mockFormAction, false]);
+}
+
+const USER_EMAIL = 'user@example.com';
+
+describe('DeleteAccountConfirm', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        setFormState({ error: null });
+    });
+
+    it('renders user email display', () => {
+        render(<DeleteAccountConfirm userEmail={USER_EMAIL} />);
+        expect(screen.getByText(USER_EMAIL)).toBeInTheDocument();
+    });
+
+    it('renders email confirmation input', () => {
+        render(<DeleteAccountConfirm userEmail={USER_EMAIL} />);
+        expect(
+            screen.getByLabelText('계속하려면 본인 이메일을 정확히 입력하세요')
+        ).toBeInTheDocument();
+    });
+
+    it('shows default hint when input is empty', () => {
+        render(<DeleteAccountConfirm userEmail={USER_EMAIL} />);
+        expect(
+            screen.getByText('이메일이 일치해야 탈퇴 버튼이 활성화됩니다.')
+        ).toBeInTheDocument();
+    });
+
+    it('shows mismatch hint when input does not match email', async () => {
+        const user = userEvent.setup();
+        render(<DeleteAccountConfirm userEmail={USER_EMAIL} />);
+        await user.type(
+            screen.getByLabelText('계속하려면 본인 이메일을 정확히 입력하세요'),
+            'wrong@test.com'
+        );
+        expect(
+            screen.getByText('입력한 이메일이 본인 이메일과 일치하지 않습니다.')
+        ).toBeInTheDocument();
+    });
+
+    it('shows match hint and enables submit when input matches email', async () => {
+        const user = userEvent.setup();
+        render(<DeleteAccountConfirm userEmail={USER_EMAIL} />);
+        await user.type(
+            screen.getByLabelText('계속하려면 본인 이메일을 정확히 입력하세요'),
+            USER_EMAIL
+        );
+        expect(
+            screen.getByText(
+                '입력한 이메일이 일치합니다. 탈퇴 버튼이 활성화되었습니다.'
+            )
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: '계정 영구 삭제' })
+        ).toBeEnabled();
+    });
+
+    it('disables submit button when email does not match', () => {
+        render(<DeleteAccountConfirm userEmail={USER_EMAIL} />);
+        expect(
+            screen.getByRole('button', { name: '계정 영구 삭제' })
+        ).toBeDisabled();
+    });
+
+    it('renders cancel link to /account', () => {
+        render(<DeleteAccountConfirm userEmail={USER_EMAIL} />);
+        const cancelLink = screen.getByRole('link', { name: '취소' });
+        expect(cancelLink).toHaveAttribute('href', '/account');
+    });
+
+    it('shows error alert when state has error', () => {
+        setFormState({
+            error: {
+                code: 'not_authenticated',
+                message: '로그인이 필요합니다.',
+            },
+        });
+        render(<DeleteAccountConfirm userEmail={USER_EMAIL} />);
+        expect(screen.getByRole('alert')).toHaveTextContent(
+            '로그인이 필요합니다.'
+        );
+    });
+
+    it('renders warning list items', () => {
+        render(<DeleteAccountConfirm userEmail={USER_EMAIL} />);
+        expect(
+            screen.getByText(/이메일·닉네임·프로필 사진이 즉시 영구 삭제/)
+        ).toBeInTheDocument();
+    });
+
+    it('matches case-insensitively', async () => {
+        const user = userEvent.setup();
+        render(<DeleteAccountConfirm userEmail={USER_EMAIL} />);
+        await user.type(
+            screen.getByLabelText('계속하려면 본인 이메일을 정확히 입력하세요'),
+            USER_EMAIL.toUpperCase()
+        );
+        expect(
+            screen.getByRole('button', { name: '계정 영구 삭제' })
+        ).toBeEnabled();
+    });
+});

--- a/src/features/api-key-management/__tests__/ApiKeyInput.test.tsx
+++ b/src/features/api-key-management/__tests__/ApiKeyInput.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ApiKeyInput } from '@/features/api-key-management/ui/ApiKeyInput';
+
+describe('ApiKeyInput', () => {
+    it('renders password input by default', () => {
+        render(<ApiKeyInput name="apiKey" />);
+        const passwordInput = document.querySelector(
+            'input[name="apiKey"]'
+        ) as HTMLInputElement;
+        expect(passwordInput).not.toBeNull();
+        expect(passwordInput.type).toBe('password');
+    });
+
+    it('renders visibility toggle button', () => {
+        render(<ApiKeyInput name="apiKey" />);
+        expect(
+            screen.getByRole('button', { name: 'API 키 보이기' })
+        ).toBeInTheDocument();
+    });
+
+    it('toggles input type when visibility button is clicked', async () => {
+        const user = userEvent.setup();
+        render(<ApiKeyInput name="apiKey" />);
+        const input = document.querySelector(
+            'input[name="apiKey"]'
+        ) as HTMLInputElement;
+
+        await user.click(screen.getByRole('button', { name: 'API 키 보이기' }));
+        expect(input.type).toBe('text');
+        expect(
+            screen.getByRole('button', { name: 'API 키 숨기기' })
+        ).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'API 키 숨기기' }));
+        expect(input.type).toBe('password');
+    });
+
+    it('renders with placeholder', () => {
+        render(<ApiKeyInput name="apiKey" placeholder="sk-ant-..." />);
+        expect(screen.getByPlaceholderText('sk-ant-...')).toBeInTheDocument();
+    });
+
+    it('renders with aria-label', () => {
+        render(<ApiKeyInput name="apiKey" aria-label="Claude API 키" />);
+        const input = document.querySelector(
+            'input[name="apiKey"]'
+        ) as HTMLInputElement;
+        expect(input.getAttribute('aria-label')).toBe('Claude API 키');
+    });
+
+    it('renders with aria-describedby', () => {
+        render(<ApiKeyInput name="apiKey" aria-describedby="status-msg" />);
+        const input = document.querySelector(
+            'input[name="apiKey"]'
+        ) as HTMLInputElement;
+        expect(input.getAttribute('aria-describedby')).toBe('status-msg');
+    });
+
+    it('sets required attribute', () => {
+        render(<ApiKeyInput name="apiKey" />);
+        const input = document.querySelector(
+            'input[name="apiKey"]'
+        ) as HTMLInputElement;
+        expect(input.required).toBe(true);
+    });
+
+    it('updates aria-pressed on toggle button', async () => {
+        const user = userEvent.setup();
+        render(<ApiKeyInput name="apiKey" />);
+        const button = screen.getByRole('button', { name: 'API 키 보이기' });
+        expect(button).toHaveAttribute('aria-pressed', 'false');
+
+        await user.click(button);
+        expect(
+            screen.getByRole('button', { name: 'API 키 숨기기' })
+        ).toHaveAttribute('aria-pressed', 'true');
+    });
+});

--- a/src/features/api-key-management/__tests__/ApiKeySection.test.tsx
+++ b/src/features/api-key-management/__tests__/ApiKeySection.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ApiKeySection } from '@/features/api-key-management/ui/ApiKeySection';
+import { useApiKeyForms } from '@/features/api-key-management/hooks/useApiKeyForms';
+import type { ApiKeyActionState } from '@/shared/lib/types';
+
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: vi.fn(() => ({ db: {}, sql: () => null })),
+}));
+vi.mock('@/features/api-key-management/hooks/useApiKeyForms');
+
+const mockUseApiKeyForms = vi.mocked(useApiKeyForms);
+
+const IDLE_STATE: ApiKeyActionState = { status: 'idle', message: null };
+
+function setApiKeyForms(
+    saveState: ApiKeyActionState = IDLE_STATE,
+    deleteState: ApiKeyActionState = IDLE_STATE
+) {
+    mockUseApiKeyForms.mockReturnValue({
+        saveState,
+        saveFormAction: vi.fn(),
+        deleteState,
+        deleteFormAction: vi.fn(),
+    });
+}
+
+describe('ApiKeySection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        setApiKeyForms();
+    });
+
+    it('renders section heading', () => {
+        render(<ApiKeySection registeredProviders={[]} />);
+        expect(
+            screen.getByRole('heading', { name: 'AI 모델 API 키' })
+        ).toBeInTheDocument();
+    });
+
+    it('renders all three provider cards', () => {
+        render(<ApiKeySection registeredProviders={[]} />);
+        expect(screen.getByText('Claude (Anthropic)')).toBeInTheDocument();
+        expect(screen.getByText('Gemini (Google)')).toBeInTheDocument();
+        expect(screen.getByText('ChatGPT (OpenAI)')).toBeInTheDocument();
+    });
+
+    it('shows "미등록" badge for unregistered providers', () => {
+        render(<ApiKeySection registeredProviders={[]} />);
+        const badges = screen.getAllByText('미등록');
+        expect(badges).toHaveLength(3);
+    });
+
+    it('shows "등록됨" badge for registered providers', () => {
+        render(<ApiKeySection registeredProviders={['anthropic']} />);
+        expect(screen.getByText('등록됨')).toBeInTheDocument();
+        expect(screen.getAllByText('미등록')).toHaveLength(2);
+    });
+
+    it('shows save input for unregistered providers', () => {
+        render(<ApiKeySection registeredProviders={[]} />);
+        const saveButtons = screen.getAllByRole('button', { name: '저장' });
+        expect(saveButtons.length).toBeGreaterThan(0);
+    });
+
+    it('shows 재등록 and 삭제 buttons for registered providers', () => {
+        render(<ApiKeySection registeredProviders={['anthropic', 'google']} />);
+        const reRegisterButtons = screen.getAllByRole('button', {
+            name: '재등록',
+        });
+        expect(reRegisterButtons).toHaveLength(2);
+        const deleteButtons = screen.getAllByRole('button', { name: '삭제' });
+        expect(deleteButtons).toHaveLength(2);
+    });
+
+    it('opens save input when 재등록 is clicked', async () => {
+        const user = userEvent.setup();
+        render(
+            <ApiKeySection
+                registeredProviders={['anthropic', 'google', 'openai']}
+            />
+        );
+
+        // All providers start with 재등록 + 삭제 (no save inputs visible)
+        expect(screen.queryByRole('button', { name: '저장' })).toBeNull();
+
+        const reRegisterButtons = screen.getAllByRole('button', {
+            name: '재등록',
+        });
+        await user.click(reRegisterButtons[0]);
+
+        expect(
+            screen.getByRole('button', { name: '저장' })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: '취소' })
+        ).toBeInTheDocument();
+    });
+
+    it('shows success status message for save', () => {
+        setApiKeyForms(
+            { status: 'success', message: 'API 키가 저장되었습니다.' },
+            IDLE_STATE
+        );
+        render(<ApiKeySection registeredProviders={[]} />);
+        expect(
+            screen.getAllByText('API 키가 저장되었습니다.').length
+        ).toBeGreaterThan(0);
+    });
+
+    it('shows error status message for save', () => {
+        setApiKeyForms(
+            {
+                status: 'error',
+                message: '저장에 실패했습니다.',
+                code: 'unknown',
+            },
+            IDLE_STATE
+        );
+        render(<ApiKeySection registeredProviders={[]} />);
+        expect(
+            screen.getAllByText('저장에 실패했습니다.').length
+        ).toBeGreaterThan(0);
+    });
+
+    it('renders description text', () => {
+        render(<ApiKeySection registeredProviders={[]} />);
+        expect(
+            screen.getByText(
+                '등록한 키는 계정에만 저장되며 안전한 방식으로 암호화됩니다.'
+            )
+        ).toBeInTheDocument();
+    });
+});

--- a/src/features/auth-login/__tests__/LoginForm.test.tsx
+++ b/src/features/auth-login/__tests__/LoginForm.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LoginForm } from '@/features/auth-login/ui/LoginForm';
+import { useLoginForm } from '@/features/auth-login/hooks/useLoginForm';
+import type { LoginFormState } from '@/shared/lib/auth/formTypes';
+
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: vi.fn(() => ({ db: {}, sql: () => null })),
+}));
+vi.mock('@/features/auth-login/hooks/useLoginForm');
+
+const mockFormAction = vi.fn();
+const mockUseLoginForm = vi.mocked(useLoginForm);
+
+function setLoginFormState(state: LoginFormState) {
+    mockUseLoginForm.mockReturnValue([state, mockFormAction, false]);
+}
+
+describe('LoginForm', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        setLoginFormState({ error: null });
+    });
+
+    it('renders email and password fields', () => {
+        render(<LoginForm />);
+        expect(screen.getByLabelText('이메일')).toBeInTheDocument();
+        expect(screen.getByLabelText('비밀번호')).toBeInTheDocument();
+    });
+
+    it('renders submit button with login label', () => {
+        render(<LoginForm />);
+        expect(
+            screen.getByRole('button', { name: '로그인' })
+        ).toBeInTheDocument();
+    });
+
+    it('shows error alert for invalid_credentials', () => {
+        setLoginFormState({
+            error: { code: 'invalid_credentials', message: '' },
+        });
+        render(<LoginForm />);
+        expect(screen.getByRole('alert')).toHaveTextContent(
+            '이메일 또는 비밀번호가 올바르지 않습니다.'
+        );
+    });
+
+    it('shows server error message when code is not invalid_credentials', () => {
+        setLoginFormState({
+            error: { code: 'unexpected', message: '서버 오류가 발생했습니다.' },
+        });
+        render(<LoginForm />);
+        expect(screen.getByRole('alert')).toHaveTextContent(
+            '서버 오류가 발생했습니다.'
+        );
+    });
+
+    it('shows initialError when no state error exists', () => {
+        render(<LoginForm initialError="세션이 만료되었습니다." />);
+        expect(screen.getByRole('alert')).toHaveTextContent(
+            '세션이 만료되었습니다.'
+        );
+    });
+
+    it('does not show error when state and initialError are both absent', () => {
+        render(<LoginForm />);
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('renders hidden next input when next prop is provided', () => {
+        render(<LoginForm next="/dashboard" />);
+        const hidden = document.querySelector(
+            'input[type="hidden"][name="next"]'
+        ) as HTMLInputElement;
+        expect(hidden).not.toBeNull();
+        expect(hidden.value).toBe('/dashboard');
+    });
+
+    it('does not render hidden next input when next prop is absent', () => {
+        render(<LoginForm />);
+        expect(
+            document.querySelector('input[type="hidden"][name="next"]')
+        ).toBeNull();
+    });
+
+    it('allows typing in email field', async () => {
+        const user = userEvent.setup();
+        render(<LoginForm />);
+        await user.type(screen.getByLabelText('이메일'), 'test@example.com');
+        expect(screen.getByLabelText('이메일')).toHaveValue('test@example.com');
+    });
+
+    it('allows typing in password field', async () => {
+        const user = userEvent.setup();
+        render(<LoginForm />);
+        await user.type(screen.getByLabelText('비밀번호'), 'secret123');
+        expect(screen.getByLabelText('비밀번호')).toHaveValue('secret123');
+    });
+});

--- a/src/features/auth-logout/__tests__/LogoutButton.test.tsx
+++ b/src/features/auth-logout/__tests__/LogoutButton.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LogoutButton } from '@/features/auth-logout/ui/LogoutButton';
+import { useLogout } from '@/features/auth-logout/hooks/useLogout';
+
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: vi.fn(() => ({ db: {}, sql: () => null })),
+}));
+vi.mock('@/features/auth-logout/hooks/useLogout');
+
+const mockUseLogout = vi.mocked(useLogout);
+
+describe('LogoutButton', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders logout text when not pending', () => {
+        mockUseLogout.mockReturnValue({ pending: false, logout: vi.fn() });
+        render(<LogoutButton />);
+        expect(
+            screen.getByRole('menuitem', { name: '로그아웃' })
+        ).toBeInTheDocument();
+    });
+
+    it('renders pending text when pending', () => {
+        mockUseLogout.mockReturnValue({ pending: true, logout: vi.fn() });
+        render(<LogoutButton />);
+        expect(
+            screen.getByRole('menuitem', { name: '로그아웃 중…' })
+        ).toBeInTheDocument();
+    });
+
+    it('is disabled when pending', () => {
+        mockUseLogout.mockReturnValue({ pending: true, logout: vi.fn() });
+        render(<LogoutButton />);
+        expect(screen.getByRole('menuitem')).toBeDisabled();
+    });
+
+    it('calls logout on click', async () => {
+        const logoutFn = vi.fn();
+        mockUseLogout.mockReturnValue({ pending: false, logout: logoutFn });
+        const user = userEvent.setup();
+        render(<LogoutButton />);
+        await user.click(screen.getByRole('menuitem'));
+        expect(logoutFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('has button type="button"', () => {
+        mockUseLogout.mockReturnValue({ pending: false, logout: vi.fn() });
+        render(<LogoutButton />);
+        expect(screen.getByRole('menuitem')).toHaveAttribute('type', 'button');
+    });
+});

--- a/src/features/auth-oauth/__tests__/SocialLoginButtons.test.tsx
+++ b/src/features/auth-oauth/__tests__/SocialLoginButtons.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { SocialLoginButtons } from '@/features/auth-oauth/ui/SocialLoginButtons';
+
+describe('SocialLoginButtons', () => {
+    it('renders Google login button', () => {
+        render(<SocialLoginButtons />);
+        expect(screen.getByText('Continue with Google')).toBeInTheDocument();
+    });
+
+    it('links to Google OAuth start endpoint', () => {
+        render(<SocialLoginButtons />);
+        const link = screen.getByText('Continue with Google').closest('a');
+        expect(link).toHaveAttribute('href', '/api/auth/google/start');
+    });
+
+    it('appends next query param when next prop is provided', () => {
+        render(<SocialLoginButtons next="/premium" />);
+        const link = screen.getByText('Continue with Google').closest('a');
+        expect(link).toHaveAttribute(
+            'href',
+            '/api/auth/google/start?next=%2Fpremium'
+        );
+    });
+
+    it('sets rel="nofollow" on provider links', () => {
+        render(<SocialLoginButtons />);
+        const link = screen.getByText('Continue with Google').closest('a');
+        expect(link).toHaveAttribute('rel', 'nofollow');
+    });
+
+    it('renders Google icon SVG', () => {
+        render(<SocialLoginButtons />);
+        const svg = document.querySelector('svg[aria-hidden]');
+        expect(svg).not.toBeNull();
+    });
+});

--- a/src/features/auth-password-reset/__tests__/ForgotPasswordForm.test.tsx
+++ b/src/features/auth-password-reset/__tests__/ForgotPasswordForm.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ForgotPasswordForm } from '@/features/auth-password-reset/ui/ForgotPasswordForm';
+import { useForgotPasswordForm } from '@/features/auth-password-reset/hooks/useForgotPasswordForm';
+import type { ForgotPasswordFormState } from '@/shared/lib/auth/formTypes';
+
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: vi.fn(() => ({ db: {}, sql: () => null })),
+}));
+vi.mock('@/features/auth-password-reset/hooks/useForgotPasswordForm');
+
+const mockFormAction = vi.fn();
+const mockUseForgotPasswordForm = vi.mocked(useForgotPasswordForm);
+
+function setFormState(state: ForgotPasswordFormState) {
+    mockUseForgotPasswordForm.mockReturnValue([state, mockFormAction, false]);
+}
+
+describe('ForgotPasswordForm', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        setFormState({ submitted: false });
+    });
+
+    it('renders email field and submit button before submission', () => {
+        render(<ForgotPasswordForm />);
+        expect(screen.getByLabelText('이메일')).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: '재설정 링크 보내기' })
+        ).toBeInTheDocument();
+    });
+
+    it('allows typing in email field', async () => {
+        const user = userEvent.setup();
+        render(<ForgotPasswordForm />);
+        await user.type(screen.getByLabelText('이메일'), 'test@example.com');
+        expect(screen.getByLabelText('이메일')).toHaveValue('test@example.com');
+    });
+
+    it('shows success message after submission', () => {
+        setFormState({ submitted: true });
+        render(<ForgotPasswordForm />);
+        expect(screen.getByRole('status')).toBeInTheDocument();
+        expect(screen.getByText('메일을 확인해 주세요')).toBeInTheDocument();
+    });
+
+    it('hides form fields after submission', () => {
+        setFormState({ submitted: true });
+        render(<ForgotPasswordForm />);
+        expect(screen.queryByLabelText('이메일')).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: '재설정 링크 보내기' })
+        ).not.toBeInTheDocument();
+    });
+});

--- a/src/features/auth-password-reset/__tests__/ResetPasswordForm.test.tsx
+++ b/src/features/auth-password-reset/__tests__/ResetPasswordForm.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ResetPasswordForm } from '@/features/auth-password-reset/ui/ResetPasswordForm';
+import { useResetPasswordForm } from '@/features/auth-password-reset/hooks/useResetPasswordForm';
+import type { ResetPasswordFormState } from '@/shared/lib/auth/formTypes';
+
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: vi.fn(() => ({ db: {}, sql: () => null })),
+}));
+vi.mock('@/features/auth-password-reset/hooks/useResetPasswordForm');
+
+const mockFormAction = vi.fn();
+const mockUseResetPasswordForm = vi.mocked(useResetPasswordForm);
+
+function setFormState(state: ResetPasswordFormState) {
+    mockUseResetPasswordForm.mockReturnValue([state, mockFormAction, false]);
+}
+
+describe('ResetPasswordForm', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        setFormState({ error: null });
+    });
+
+    it('renders new password and confirm password fields', () => {
+        render(<ResetPasswordForm email="user@test.com" token="abc123" />);
+        expect(screen.getByLabelText('새 비밀번호')).toBeInTheDocument();
+        expect(screen.getByLabelText('새 비밀번호 확인')).toBeInTheDocument();
+    });
+
+    it('renders submit button', () => {
+        render(<ResetPasswordForm email="user@test.com" token="abc123" />);
+        expect(
+            screen.getByRole('button', { name: '비밀번호 변경' })
+        ).toBeInTheDocument();
+    });
+
+    it('renders hidden email and token inputs', () => {
+        render(<ResetPasswordForm email="user@test.com" token="abc123" />);
+        const emailHidden = document.querySelector(
+            'input[type="hidden"][name="email"]'
+        ) as HTMLInputElement;
+        const tokenHidden = document.querySelector(
+            'input[type="hidden"][name="token"]'
+        ) as HTMLInputElement;
+        expect(emailHidden.value).toBe('user@test.com');
+        expect(tokenHidden.value).toBe('abc123');
+    });
+
+    it('shows invalid_token error', () => {
+        setFormState({
+            error: { code: 'invalid_token', message: '' },
+        });
+        render(<ResetPasswordForm email="user@test.com" token="abc123" />);
+        expect(screen.getByRole('alert')).toHaveTextContent(
+            '재설정 링크가 유효하지 않거나 이미 사용되었습니다'
+        );
+    });
+
+    it('shows expired_token error', () => {
+        setFormState({
+            error: { code: 'expired_token', message: '' },
+        });
+        render(<ResetPasswordForm email="user@test.com" token="abc123" />);
+        expect(screen.getByRole('alert')).toHaveTextContent(
+            '재설정 링크가 만료되었습니다'
+        );
+    });
+
+    it('shows password field error when field is password', () => {
+        setFormState({
+            error: {
+                code: 'weak_password',
+                field: 'password',
+                message: '비밀번호가 너무 짧습니다.',
+            },
+        });
+        render(<ResetPasswordForm email="user@test.com" token="abc123" />);
+        expect(screen.getByRole('alert')).toHaveTextContent(
+            '비밀번호가 너무 짧습니다.'
+        );
+    });
+
+    it('allows typing in password fields', async () => {
+        const user = userEvent.setup();
+        render(<ResetPasswordForm email="user@test.com" token="abc123" />);
+        await user.type(screen.getByLabelText('새 비밀번호'), 'newpass123');
+        await user.type(
+            screen.getByLabelText('새 비밀번호 확인'),
+            'newpass123'
+        );
+        expect(screen.getByLabelText('새 비밀번호')).toHaveValue('newpass123');
+        expect(screen.getByLabelText('새 비밀번호 확인')).toHaveValue(
+            'newpass123'
+        );
+    });
+
+    it('does not show error when state has no error', () => {
+        render(<ResetPasswordForm email="user@test.com" token="abc123" />);
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+});

--- a/src/features/auth-signup/__tests__/SignupForm.test.tsx
+++ b/src/features/auth-signup/__tests__/SignupForm.test.tsx
@@ -1,0 +1,279 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SignupForm } from '@/features/auth-signup/ui/SignupForm';
+import { useSignupForm } from '@/features/auth-signup/hooks/useSignupForm';
+import {
+    useRequestEmailVerification,
+    useVerifyEmail,
+} from '@/features/auth-email-verification';
+import type { RequestEmailVerificationFormState } from '@/shared/lib/auth/formTypes';
+import type { VerifyEmailFormState, SignupFormState } from '@/shared/lib/types';
+
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: vi.fn(() => ({ db: {}, sql: () => null })),
+}));
+vi.mock('@/features/auth-signup/hooks/useSignupForm');
+vi.mock('@/features/auth-email-verification');
+
+const mockUseSignupForm = vi.mocked(useSignupForm);
+const mockUseRequestEmailVerification = vi.mocked(useRequestEmailVerification);
+const mockUseVerifyEmail = vi.mocked(useVerifyEmail);
+
+const mockEmailFormAction = vi.fn();
+const mockCodeFormAction = vi.fn();
+const mockSignupFormAction = vi.fn();
+
+function setupPhase(
+    emailState: RequestEmailVerificationFormState,
+    codeState: VerifyEmailFormState,
+    signupState: SignupFormState = { error: null }
+) {
+    mockUseRequestEmailVerification.mockReturnValue([
+        emailState,
+        mockEmailFormAction,
+        false,
+    ]);
+    mockUseVerifyEmail.mockReturnValue([codeState, mockCodeFormAction, false]);
+    mockUseSignupForm.mockReturnValue([
+        signupState,
+        mockSignupFormAction,
+        false,
+    ]);
+}
+
+describe('SignupForm', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('Phase 1: email', () => {
+        beforeEach(() => {
+            setupPhase(
+                { submitted: false, error: null },
+                { verified: false, error: null }
+            );
+        });
+
+        it('renders step indicator for phase 1', () => {
+            render(<SignupForm />);
+            expect(
+                screen.getByText('1단계: 이메일 인증 요청')
+            ).toBeInTheDocument();
+        });
+
+        it('renders email input and submit button', () => {
+            render(<SignupForm />);
+            expect(screen.getByLabelText('이메일')).toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: '인증 코드 받기' })
+            ).toBeInTheDocument();
+        });
+
+        it('shows error alert when email phase has error', () => {
+            setupPhase(
+                {
+                    submitted: false,
+                    error: {
+                        code: 'invalid_email',
+                        message: '유효한 이메일을 입력하세요.',
+                    },
+                },
+                { verified: false, error: null }
+            );
+            render(<SignupForm />);
+            expect(screen.getByRole('alert')).toHaveTextContent(
+                '유효한 이메일을 입력하세요.'
+            );
+        });
+
+        it('allows typing in the email field', async () => {
+            const user = userEvent.setup();
+            render(<SignupForm />);
+            await user.type(
+                screen.getByLabelText('이메일'),
+                'test@example.com'
+            );
+            expect(screen.getByLabelText('이메일')).toHaveValue(
+                'test@example.com'
+            );
+        });
+    });
+
+    describe('Phase 2: code', () => {
+        function setupPhase2WithGuardBypass(
+            codeError?: VerifyEmailFormState['error']
+        ) {
+            let callCount = 0;
+            mockUseRequestEmailVerification.mockImplementation(() => {
+                callCount++;
+                if (callCount <= 1) {
+                    return [
+                        { submitted: false, error: null },
+                        mockEmailFormAction,
+                        false,
+                    ];
+                }
+                return [
+                    { submitted: true, error: null },
+                    mockEmailFormAction,
+                    false,
+                ];
+            });
+            mockUseVerifyEmail.mockReturnValue([
+                { verified: false, error: codeError ?? null },
+                mockCodeFormAction,
+                false,
+            ]);
+            mockUseSignupForm.mockReturnValue([
+                { error: null },
+                mockSignupFormAction,
+                false,
+            ]);
+        }
+
+        it('renders step indicator for phase 2', () => {
+            setupPhase2WithGuardBypass();
+            const { rerender } = render(<SignupForm />);
+            rerender(<SignupForm />);
+            expect(
+                screen.getByText('2단계: 인증 코드 확인')
+            ).toBeInTheDocument();
+        });
+
+        it('renders code input and submit button', () => {
+            setupPhase2WithGuardBypass();
+            const { rerender } = render(<SignupForm />);
+            rerender(<SignupForm />);
+            expect(screen.getByLabelText('인증 코드')).toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: '코드 확인' })
+            ).toBeInTheDocument();
+        });
+
+        it('renders email edit button', () => {
+            setupPhase2WithGuardBypass();
+            const { rerender } = render(<SignupForm />);
+            rerender(<SignupForm />);
+            expect(
+                screen.getByRole('button', { name: '이메일 수정' })
+            ).toBeInTheDocument();
+        });
+
+        it('shows redis_unavailable error as alert', () => {
+            setupPhase2WithGuardBypass({
+                code: 'redis_unavailable',
+                message: '서비스 오류',
+            });
+            const { rerender } = render(<SignupForm />);
+            rerender(<SignupForm />);
+            expect(screen.getByRole('alert')).toHaveTextContent('서비스 오류');
+        });
+    });
+
+    describe('Phase 3: details', () => {
+        /**
+         * SignupForm wraps SignupFormFlow with a resetKey that increments when
+         * the cache-restore guard fires (useLayoutEffect sees submitted/verified
+         * on mount). To reach phase 3, we render SignupFormFlow indirectly by
+         * making the hooks return initial state on first mount (so the guard
+         * doesn't fire), then update them to phase-3 state after the component
+         * settles. Since we can't easily do that with module-level mocks, we
+         * test SignupFormFlow's phase-3 behavior by importing it directly.
+         *
+         * Instead, we simulate a realistic flow: hooks start at phase-1 defaults,
+         * then we switch to phase-3. However SignupForm re-mounts on resetKey
+         * change, which resets the flow. The simplest approach is to verify
+         * phase-3 UI by ensuring the mock starts at initial state (no guard
+         * trigger) and then immediately returns phase-3 state on the second call.
+         */
+        function setupPhase3WithGuardBypass(
+            signupState: SignupFormState = { error: null }
+        ) {
+            // First call returns initial state (mount → no cache guard).
+            // All subsequent calls return phase-3 state.
+            let callCount = 0;
+            mockUseRequestEmailVerification.mockImplementation(() => {
+                callCount++;
+                if (callCount <= 1) {
+                    return [
+                        { submitted: false, error: null },
+                        mockEmailFormAction,
+                        false,
+                    ];
+                }
+                return [
+                    { submitted: true, error: null },
+                    mockEmailFormAction,
+                    false,
+                ];
+            });
+            mockUseVerifyEmail.mockImplementation(() => {
+                if (callCount <= 1) {
+                    return [
+                        { verified: false, error: null },
+                        mockCodeFormAction,
+                        false,
+                    ];
+                }
+                return [
+                    { verified: true, error: null },
+                    mockCodeFormAction,
+                    false,
+                ];
+            });
+            mockUseSignupForm.mockReturnValue([
+                signupState,
+                mockSignupFormAction,
+                false,
+            ]);
+        }
+
+        it('renders step indicator for phase 3', () => {
+            setupPhase3WithGuardBypass();
+            const { rerender } = render(<SignupForm />);
+            // Force re-render so subsequent hook calls return phase-3 state
+            rerender(<SignupForm />);
+            expect(
+                screen.getByText('3단계: 비밀번호 및 표시 이름 설정')
+            ).toBeInTheDocument();
+        });
+
+        it('renders name, password fields, and submit button', () => {
+            setupPhase3WithGuardBypass();
+            const { rerender } = render(<SignupForm />);
+            rerender(<SignupForm />);
+            expect(
+                screen.getByLabelText('표시 이름 (선택)')
+            ).toBeInTheDocument();
+            expect(screen.getByLabelText('비밀번호')).toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: '회원가입' })
+            ).toBeInTheDocument();
+        });
+
+        it('shows form-level error alert', () => {
+            setupPhase3WithGuardBypass({
+                error: {
+                    code: 'service_unavailable',
+                    message: '서비스 이용 불가',
+                },
+            });
+            const { rerender } = render(<SignupForm />);
+            rerender(<SignupForm />);
+            expect(screen.getByRole('alert')).toHaveTextContent(
+                '서비스 이용 불가'
+            );
+        });
+
+        it('renders hidden next input when next prop is provided', () => {
+            setupPhase3WithGuardBypass();
+            const { rerender } = render(<SignupForm next="/premium" />);
+            rerender(<SignupForm next="/premium" />);
+            const hidden = document.querySelector(
+                'input[type="hidden"][name="next"]'
+            ) as HTMLInputElement;
+            expect(hidden).not.toBeNull();
+            expect(hidden.value).toBe('/premium');
+        });
+    });
+});

--- a/src/features/contact-form/__tests__/ContactSubmittedNotice.test.tsx
+++ b/src/features/contact-form/__tests__/ContactSubmittedNotice.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { ContactSubmittedNotice } from '@/features/contact-form/ui/ContactSubmittedNotice';
+
+describe('ContactSubmittedNotice', () => {
+    it('renders status region', () => {
+        render(<ContactSubmittedNotice />);
+        expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    it('renders submitted title', () => {
+        render(<ContactSubmittedNotice />);
+        expect(screen.getByText('문의가 접수되었습니다')).toBeInTheDocument();
+    });
+
+    it('renders reply message', () => {
+        render(<ContactSubmittedNotice />);
+        expect(
+            screen.getByText('확인 후 입력하신 이메일로 답변드리겠습니다.')
+        ).toBeInTheDocument();
+    });
+
+    it('renders wait message', () => {
+        render(<ContactSubmittedNotice />);
+        expect(screen.getByText('잠시만 기다려 주세요.')).toBeInTheDocument();
+    });
+
+    it('has aria-live polite', () => {
+        render(<ContactSubmittedNotice />);
+        expect(screen.getByRole('status')).toHaveAttribute(
+            'aria-live',
+            'polite'
+        );
+    });
+});

--- a/src/features/contact-form/__tests__/ContactTextField.test.tsx
+++ b/src/features/contact-form/__tests__/ContactTextField.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import { ContactTextField } from '@/features/contact-form/ui/ContactTextField';
+
+describe('ContactTextField', () => {
+    const defaultProps = {
+        id: 'test-field',
+        name: 'email',
+        label: '이메일',
+        type: 'email' as const,
+    };
+
+    it('renders label and input', () => {
+        render(<ContactTextField {...defaultProps} />);
+        expect(screen.getByLabelText('이메일')).toBeInTheDocument();
+        expect(screen.getByLabelText('이메일').tagName).toBe('INPUT');
+    });
+
+    it('sets correct input type', () => {
+        render(<ContactTextField {...defaultProps} />);
+        expect(screen.getByLabelText('이메일')).toHaveAttribute(
+            'type',
+            'email'
+        );
+    });
+
+    it('does not show error when error prop is absent', () => {
+        render(<ContactTextField {...defaultProps} />);
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('shows error alert when error prop is provided', () => {
+        render(
+            <ContactTextField {...defaultProps} error="이메일을 입력하세요" />
+        );
+        expect(screen.getByRole('alert')).toHaveTextContent(
+            '이메일을 입력하세요'
+        );
+    });
+
+    it('sets aria-invalid when error prop is provided', () => {
+        render(<ContactTextField {...defaultProps} error="에러" />);
+        expect(screen.getByLabelText('이메일')).toHaveAttribute(
+            'aria-invalid',
+            'true'
+        );
+    });
+
+    it('sets aria-invalid to false when no error', () => {
+        render(<ContactTextField {...defaultProps} />);
+        expect(screen.getByLabelText('이메일')).toHaveAttribute(
+            'aria-invalid',
+            'false'
+        );
+    });
+
+    it('renders with placeholder', () => {
+        render(
+            <ContactTextField {...defaultProps} placeholder="you@example.com" />
+        );
+        expect(
+            screen.getByPlaceholderText('you@example.com')
+        ).toBeInTheDocument();
+    });
+
+    it('renders with defaultValue', () => {
+        render(
+            <ContactTextField {...defaultProps} defaultValue="pre@filled.com" />
+        );
+        expect(screen.getByLabelText('이메일')).toHaveValue('pre@filled.com');
+    });
+
+    it('renders text type correctly', () => {
+        render(
+            <ContactTextField
+                {...defaultProps}
+                id="test-text"
+                name="title"
+                label="제목"
+                type="text"
+            />
+        );
+        expect(screen.getByLabelText('제목')).toHaveAttribute('type', 'text');
+    });
+
+    it('sets aria-describedby to error id when error exists', () => {
+        render(<ContactTextField {...defaultProps} error="에러" />);
+        expect(screen.getByLabelText('이메일')).toHaveAttribute(
+            'aria-describedby',
+            'test-field-error'
+        );
+    });
+
+    it('does not set aria-describedby when no error', () => {
+        render(<ContactTextField {...defaultProps} />);
+        expect(
+            screen.getByLabelText('이메일').getAttribute('aria-describedby')
+        ).toBeNull();
+    });
+});

--- a/src/features/contact-form/__tests__/ContactTextareaField.test.tsx
+++ b/src/features/contact-form/__tests__/ContactTextareaField.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import { ContactTextareaField } from '@/features/contact-form/ui/ContactTextareaField';
+
+describe('ContactTextareaField', () => {
+    const defaultProps = {
+        id: 'test-textarea',
+        name: 'content',
+        label: '내용',
+        maxLength: 1000,
+    };
+
+    it('renders label and textarea', () => {
+        render(<ContactTextareaField {...defaultProps} />);
+        expect(screen.getByLabelText('내용')).toBeInTheDocument();
+        expect(screen.getByLabelText('내용').tagName).toBe('TEXTAREA');
+    });
+
+    it('renders max length helper text', () => {
+        render(<ContactTextareaField {...defaultProps} />);
+        expect(screen.getByText('최대 1,000자')).toBeInTheDocument();
+    });
+
+    it('does not show error when error prop is absent', () => {
+        render(<ContactTextareaField {...defaultProps} />);
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('shows error alert when error prop is provided', () => {
+        render(
+            <ContactTextareaField {...defaultProps} error="내용을 입력하세요" />
+        );
+        expect(screen.getByRole('alert')).toHaveTextContent(
+            '내용을 입력하세요'
+        );
+    });
+
+    it('sets aria-invalid when error prop is provided', () => {
+        render(<ContactTextareaField {...defaultProps} error="에러 메시지" />);
+        expect(screen.getByLabelText('내용')).toHaveAttribute(
+            'aria-invalid',
+            'true'
+        );
+    });
+
+    it('sets aria-invalid to false when no error', () => {
+        render(<ContactTextareaField {...defaultProps} />);
+        expect(screen.getByLabelText('내용')).toHaveAttribute(
+            'aria-invalid',
+            'false'
+        );
+    });
+
+    it('renders with custom rows', () => {
+        render(<ContactTextareaField {...defaultProps} rows={10} />);
+        expect(screen.getByLabelText('내용')).toHaveAttribute('rows', '10');
+    });
+
+    it('renders with placeholder', () => {
+        render(
+            <ContactTextareaField
+                {...defaultProps}
+                placeholder="내용을 입력해 주세요"
+            />
+        );
+        expect(
+            screen.getByPlaceholderText('내용을 입력해 주세요')
+        ).toBeInTheDocument();
+    });
+
+    it('uses default rows of 6', () => {
+        render(<ContactTextareaField {...defaultProps} />);
+        expect(screen.getByLabelText('내용')).toHaveAttribute('rows', '6');
+    });
+});

--- a/src/features/premium-gate/__tests__/PremiumModelGateModal.test.tsx
+++ b/src/features/premium-gate/__tests__/PremiumModelGateModal.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PremiumModelGateModal } from '@/features/premium-gate/ui/PremiumModelGateModal';
+
+vi.mock('@/shared/hooks/useFocusTrap', () => ({
+    useFocusTrap: vi.fn(),
+}));
+vi.mock('@/shared/hooks/useEscapeKey', () => ({
+    useEscapeKey: vi.fn(),
+}));
+vi.mock('next/link', () => ({
+    default: ({
+        children,
+        ...props
+    }: {
+        children: React.ReactNode;
+        href: string;
+    }) => <a {...props}>{children}</a>,
+}));
+
+describe('PremiumModelGateModal', () => {
+    const onClose = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('auth mode', () => {
+        it('renders auth title', () => {
+            render(<PremiumModelGateModal mode="auth" onClose={onClose} />);
+            expect(
+                screen.getByText('프리미엄 모델 사용 안내')
+            ).toBeInTheDocument();
+        });
+
+        it('renders auth body text', () => {
+            render(<PremiumModelGateModal mode="auth" onClose={onClose} />);
+            expect(
+                screen.getByText(
+                    '회원가입 후 API 키를 등록하면 이 모델을 사용할 수 있어요.'
+                )
+            ).toBeInTheDocument();
+        });
+
+        it('renders signup link', () => {
+            render(<PremiumModelGateModal mode="auth" onClose={onClose} />);
+            const link = screen.getByRole('link', {
+                name: '회원가입 하러 가기',
+            });
+            expect(link).toHaveAttribute('href', '/signup');
+        });
+    });
+
+    describe('byok mode', () => {
+        it('renders byok title', () => {
+            render(<PremiumModelGateModal mode="byok" onClose={onClose} />);
+            expect(screen.getByText('API 키 등록 필요')).toBeInTheDocument();
+        });
+
+        it('renders byok body text with provider label', () => {
+            render(
+                <PremiumModelGateModal
+                    mode="byok"
+                    providerLabel="Claude (Anthropic)"
+                    onClose={onClose}
+                />
+            );
+            expect(
+                screen.getByText(
+                    'Claude (Anthropic) API 키를 등록하면 이 모델을 사용할 수 있어요.'
+                )
+            ).toBeInTheDocument();
+        });
+
+        it('renders account link', () => {
+            render(<PremiumModelGateModal mode="byok" onClose={onClose} />);
+            const link = screen.getByRole('link', {
+                name: '등록하러 가기',
+            });
+            expect(link).toHaveAttribute('href', '/account');
+        });
+    });
+
+    it('renders close button', () => {
+        render(<PremiumModelGateModal mode="auth" onClose={onClose} />);
+        expect(
+            screen.getByRole('button', { name: '닫기' })
+        ).toBeInTheDocument();
+    });
+
+    it('calls onClose when close button is clicked', async () => {
+        const user = userEvent.setup();
+        render(<PremiumModelGateModal mode="auth" onClose={onClose} />);
+        await user.click(screen.getByRole('button', { name: '닫기' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders dialog with aria-modal', () => {
+        render(<PremiumModelGateModal mode="auth" onClose={onClose} />);
+        expect(screen.getByRole('dialog')).toHaveAttribute(
+            'aria-labelledby',
+            'premium-model-gate-title'
+        );
+    });
+
+    it('calls onClose when backdrop is clicked', async () => {
+        const user = userEvent.setup();
+        render(<PremiumModelGateModal mode="auth" onClose={onClose} />);
+        const backdrop = document.querySelector('[aria-hidden="true"]');
+        expect(backdrop).not.toBeNull();
+        await user.click(backdrop!);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/features/symbol-chat/__tests__/hooks/useSymbolChat.test.tsx
+++ b/src/features/symbol-chat/__tests__/hooks/useSymbolChat.test.tsx
@@ -1,0 +1,125 @@
+import { renderHook } from '@testing-library/react';
+import {
+    useSymbolChat,
+    usePublishSymbolChat,
+} from '@/features/symbol-chat/hooks/useSymbolChat';
+import {
+    SymbolChatContext,
+    type SymbolChatContextValue,
+    type SymbolChatState,
+} from '@/features/symbol-chat/model/SymbolChatContext';
+import { createElement, type ReactNode } from 'react';
+
+const INITIAL_STATE: SymbolChatState = {
+    context: null,
+    timeframe: null,
+    isAnalysisReady: false,
+};
+
+function createWrapper(value: SymbolChatContextValue) {
+    return function Wrapper({ children }: { children: ReactNode }) {
+        return createElement(SymbolChatContext.Provider, { value }, children);
+    };
+}
+
+describe('useSymbolChat', () => {
+    it('throws when used outside provider', () => {
+        expect(() => {
+            renderHook(() => useSymbolChat());
+        }).toThrow('useSymbolChat must be used inside SymbolChatProvider');
+    });
+
+    it('returns context value when used inside provider', () => {
+        const mockValue: SymbolChatContextValue = {
+            ...INITIAL_STATE,
+            publish: vi.fn(),
+            clear: vi.fn(),
+        };
+        const { result } = renderHook(() => useSymbolChat(), {
+            wrapper: createWrapper(mockValue),
+        });
+        expect(result.current).toBe(mockValue);
+    });
+});
+
+describe('usePublishSymbolChat', () => {
+    it('calls publish with the provided state on mount', () => {
+        const publish = vi.fn();
+        const clear = vi.fn();
+        const contextValue: SymbolChatContextValue = {
+            ...INITIAL_STATE,
+            publish,
+            clear,
+        };
+
+        const state: SymbolChatState = {
+            context: null,
+            timeframe: null,
+            isAnalysisReady: true,
+        };
+
+        renderHook(() => usePublishSymbolChat(state), {
+            wrapper: createWrapper(contextValue),
+        });
+
+        expect(publish).toHaveBeenCalledWith(state);
+    });
+
+    it('calls clear on unmount', () => {
+        const publish = vi.fn();
+        const clear = vi.fn();
+        const contextValue: SymbolChatContextValue = {
+            ...INITIAL_STATE,
+            publish,
+            clear,
+        };
+
+        const state: SymbolChatState = {
+            context: null,
+            timeframe: null,
+            isAnalysisReady: true,
+        };
+
+        const { unmount } = renderHook(() => usePublishSymbolChat(state), {
+            wrapper: createWrapper(contextValue),
+        });
+
+        unmount();
+        expect(clear).toHaveBeenCalled();
+    });
+
+    it('calls publish again when state changes', () => {
+        const publish = vi.fn();
+        const clear = vi.fn();
+        const contextValue: SymbolChatContextValue = {
+            ...INITIAL_STATE,
+            publish,
+            clear,
+        };
+
+        const state1: SymbolChatState = {
+            context: null,
+            timeframe: null,
+            isAnalysisReady: false,
+        };
+        const state2: SymbolChatState = {
+            context: null,
+            timeframe: null,
+            isAnalysisReady: true,
+        };
+
+        const { rerender } = renderHook(
+            ({ state }) => usePublishSymbolChat(state),
+            {
+                wrapper: createWrapper(contextValue),
+                initialProps: { state: state1 },
+            }
+        );
+
+        expect(publish).toHaveBeenCalledWith(state1);
+        publish.mockClear();
+
+        rerender({ state: state2 });
+        expect(publish).toHaveBeenCalledWith(state2);
+    });
+});

--- a/src/features/symbol-chat/__tests__/model/SymbolChatContext.test.tsx
+++ b/src/features/symbol-chat/__tests__/model/SymbolChatContext.test.tsx
@@ -1,0 +1,122 @@
+import { renderHook, act } from '@testing-library/react';
+import {
+    SymbolChatContext,
+    SymbolChatProvider,
+    type SymbolChatState,
+} from '@/features/symbol-chat/model/SymbolChatContext';
+import { useContext, type ReactNode } from 'react';
+
+function useSymbolChatContext() {
+    return useContext(SymbolChatContext);
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+    return <SymbolChatProvider>{children}</SymbolChatProvider>;
+}
+
+describe('SymbolChatContext', () => {
+    it('returns null when used outside provider', () => {
+        const { result } = renderHook(() => useSymbolChatContext());
+        expect(result.current).toBeNull();
+    });
+});
+
+describe('SymbolChatProvider', () => {
+    it('provides initial state with null context and timeframe', () => {
+        const { result } = renderHook(() => useSymbolChatContext(), {
+            wrapper,
+        });
+        expect(result.current).not.toBeNull();
+        expect(result.current!.context).toBeNull();
+        expect(result.current!.timeframe).toBeNull();
+        expect(result.current!.isAnalysisReady).toBe(false);
+    });
+
+    it('updates state via publish', () => {
+        const { result } = renderHook(() => useSymbolChatContext(), {
+            wrapper,
+        });
+
+        const nextState: SymbolChatState = {
+            context: null,
+            timeframe: null,
+            isAnalysisReady: true,
+        };
+
+        act(() => {
+            result.current!.publish(nextState);
+        });
+
+        expect(result.current!.isAnalysisReady).toBe(true);
+    });
+
+    it('resets state via clear', () => {
+        const { result } = renderHook(() => useSymbolChatContext(), {
+            wrapper,
+        });
+
+        act(() => {
+            result.current!.publish({
+                context: null,
+                timeframe: null,
+                isAnalysisReady: true,
+            });
+        });
+
+        expect(result.current!.isAnalysisReady).toBe(true);
+
+        act(() => {
+            result.current!.clear();
+        });
+
+        expect(result.current!.context).toBeNull();
+        expect(result.current!.timeframe).toBeNull();
+        expect(result.current!.isAnalysisReady).toBe(false);
+    });
+
+    it('publish returns same reference when values are identical', () => {
+        const { result } = renderHook(() => useSymbolChatContext(), {
+            wrapper,
+        });
+
+        const before = result.current;
+
+        act(() => {
+            result.current!.publish({
+                context: null,
+                timeframe: null,
+                isAnalysisReady: false,
+            });
+        });
+
+        // State should be referentially identical since values match initial
+        expect(result.current!.context).toBe(before!.context);
+        expect(result.current!.timeframe).toBe(before!.timeframe);
+        expect(result.current!.isAnalysisReady).toBe(before!.isAnalysisReady);
+    });
+
+    it('clear returns same reference when already cleared', () => {
+        const { result } = renderHook(() => useSymbolChatContext(), {
+            wrapper,
+        });
+
+        const before = result.current;
+
+        act(() => {
+            result.current!.clear();
+        });
+
+        // Already in cleared state, should remain identical
+        expect(result.current!.context).toBe(before!.context);
+        expect(result.current!.timeframe).toBe(before!.timeframe);
+        expect(result.current!.isAnalysisReady).toBe(before!.isAnalysisReady);
+    });
+
+    it('exposes publish and clear functions', () => {
+        const { result } = renderHook(() => useSymbolChatContext(), {
+            wrapper,
+        });
+        expect(typeof result.current!.publish).toBe('function');
+        expect(typeof result.current!.clear).toBe('function');
+    });
+});

--- a/src/features/ticker-search/__tests__/SymbolSearchPanel.test.tsx
+++ b/src/features/ticker-search/__tests__/SymbolSearchPanel.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SymbolSearchPanel } from '@/features/ticker-search/ui/SymbolSearchPanel';
+import { useRecentSearches } from '@/features/ticker-search/hooks/useRecentSearches';
+
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: vi.fn(() => ({ db: {}, sql: () => null })),
+}));
+vi.mock('@/features/ticker-search/hooks/useRecentSearches');
+
+// TickerAutocomplete has deep dependencies; mock the entire component
+vi.mock('@/features/ticker-search/ui/TickerAutocomplete', () => ({
+    TickerAutocomplete: ({
+        onSelect,
+    }: {
+        size?: string;
+        onSelect?: (symbol: string) => void;
+    }) => (
+        <div data-testid="ticker-autocomplete">
+            <button
+                type="button"
+                onClick={() => onSelect?.('AAPL')}
+                data-testid="mock-select"
+            >
+                select
+            </button>
+        </div>
+    ),
+}));
+
+vi.mock('next/link', () => ({
+    default: ({
+        children,
+        ...props
+    }: {
+        children: React.ReactNode;
+        href: string;
+    }) => <a {...props}>{children}</a>,
+}));
+
+const mockUseRecentSearches = vi.mocked(useRecentSearches);
+const mockAddSearch = vi.fn();
+const mockRemoveSearch = vi.fn();
+const mockClearAll = vi.fn();
+
+function setRecentSearches(searches: string[]) {
+    mockUseRecentSearches.mockReturnValue({
+        recentSearches: searches,
+        addSearch: mockAddSearch,
+        removeSearch: mockRemoveSearch,
+        clearAll: mockClearAll,
+    });
+}
+
+describe('SymbolSearchPanel', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders TickerAutocomplete', () => {
+        setRecentSearches([]);
+        render(<SymbolSearchPanel />);
+        expect(screen.getByTestId('ticker-autocomplete')).toBeInTheDocument();
+    });
+
+    it('does not show recent searches when list is empty', () => {
+        setRecentSearches([]);
+        render(<SymbolSearchPanel />);
+        expect(screen.queryByText('최근 검색')).not.toBeInTheDocument();
+    });
+
+    it('shows recent search chips when list is not empty', () => {
+        setRecentSearches(['AAPL', 'MSFT']);
+        render(<SymbolSearchPanel />);
+        expect(screen.getByText('최근 검색')).toBeInTheDocument();
+        expect(screen.getByText('AAPL')).toBeInTheDocument();
+        expect(screen.getByText('MSFT')).toBeInTheDocument();
+    });
+
+    it('renders remove button for each recent search', () => {
+        setRecentSearches(['AAPL', 'MSFT']);
+        render(<SymbolSearchPanel />);
+        expect(
+            screen.getByRole('button', { name: 'AAPL 최근 검색에서 제거' })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'MSFT 최근 검색에서 제거' })
+        ).toBeInTheDocument();
+    });
+
+    it('calls removeSearch when remove button is clicked', async () => {
+        setRecentSearches(['AAPL']);
+        const user = userEvent.setup();
+        render(<SymbolSearchPanel />);
+        await user.click(
+            screen.getByRole('button', { name: 'AAPL 최근 검색에서 제거' })
+        );
+        expect(mockRemoveSearch).toHaveBeenCalledWith('AAPL');
+    });
+
+    it('renders clear all button when recent searches exist', () => {
+        setRecentSearches(['AAPL']);
+        render(<SymbolSearchPanel />);
+        expect(
+            screen.getByRole('button', { name: '모두 지우기' })
+        ).toBeInTheDocument();
+    });
+
+    it('calls clearAll when clear all button is clicked', async () => {
+        setRecentSearches(['AAPL', 'MSFT']);
+        const user = userEvent.setup();
+        render(<SymbolSearchPanel />);
+        await user.click(screen.getByRole('button', { name: '모두 지우기' }));
+        expect(mockClearAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls addSearch when TickerAutocomplete selects a ticker', async () => {
+        setRecentSearches([]);
+        const user = userEvent.setup();
+        render(<SymbolSearchPanel />);
+        await user.click(screen.getByTestId('mock-select'));
+        expect(mockAddSearch).toHaveBeenCalledWith('AAPL');
+    });
+
+    it('renders recent search items as links', () => {
+        setRecentSearches(['AAPL']);
+        render(<SymbolSearchPanel />);
+        const link = screen.getByRole('link', { name: 'AAPL' });
+        expect(link).toHaveAttribute('href', '/AAPL');
+    });
+});

--- a/src/features/ticker-search/__tests__/TickerAutocomplete.test.tsx
+++ b/src/features/ticker-search/__tests__/TickerAutocomplete.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TickerAutocomplete } from '@/features/ticker-search/ui/TickerAutocomplete';
+import { useAutocomplete } from '@/features/ticker-search/hooks/useAutocomplete';
+import type { TickerSearchResult } from '@/shared/lib/types';
+
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: vi.fn(() => ({ db: {}, sql: () => null })),
+}));
+vi.mock('@/features/ticker-search/hooks/useAutocomplete');
+vi.mock('@/entities/ticker', () => ({
+    isKoreanInput: vi.fn(() => false),
+}));
+
+const mockUseAutocomplete = vi.mocked(useAutocomplete);
+
+const MOCK_RESULTS: TickerSearchResult[] = [
+    {
+        symbol: 'AAPL',
+        name: 'Apple Inc.',
+        koreanName: '애플',
+        exchange: 'NASDAQ',
+        exchangeFullName: 'NASDAQ',
+    },
+    {
+        symbol: 'AMZN',
+        name: 'Amazon.com Inc.',
+        koreanName: '아마존',
+        exchange: 'NASDAQ',
+        exchangeFullName: 'NASDAQ',
+    },
+];
+
+function setupAutocomplete(
+    overrides: Partial<ReturnType<typeof useAutocomplete>> = {}
+) {
+    const defaults: ReturnType<typeof useAutocomplete> = {
+        query: '',
+        results: [],
+        isSearching: false,
+        selectedIndex: -1,
+        isOpen: false,
+        inputRef: { current: null },
+        dropdownRef: { current: null },
+        handleChange: vi.fn(),
+        handleKeyDown: vi.fn(),
+        handleFocus: vi.fn(),
+        handleSearchClick: vi.fn(),
+        navigate: vi.fn(),
+        prefetch: vi.fn(),
+    };
+    mockUseAutocomplete.mockReturnValue({ ...defaults, ...overrides });
+}
+
+describe('TickerAutocomplete', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders search input with combobox role', () => {
+        setupAutocomplete();
+        render(<TickerAutocomplete />);
+        expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
+
+    it('renders search button', () => {
+        setupAutocomplete();
+        render(<TickerAutocomplete />);
+        expect(
+            screen.getByRole('button', { name: '검색' })
+        ).toBeInTheDocument();
+    });
+
+    it('renders input with correct aria-label', () => {
+        setupAutocomplete();
+        render(<TickerAutocomplete />);
+        expect(screen.getByLabelText('종목 티커 검색')).toBeInTheDocument();
+    });
+
+    it('does not show dropdown when closed', () => {
+        setupAutocomplete({ isOpen: false });
+        render(<TickerAutocomplete />);
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('shows dropdown with results when open', () => {
+        setupAutocomplete({
+            query: 'A',
+            isOpen: true,
+            results: MOCK_RESULTS,
+        });
+        render(<TickerAutocomplete />);
+        expect(screen.getByRole('listbox')).toBeInTheDocument();
+        expect(screen.getByText('AAPL')).toBeInTheDocument();
+        expect(screen.getByText('AMZN')).toBeInTheDocument();
+    });
+
+    it('shows searching indicator', () => {
+        setupAutocomplete({ isOpen: true, isSearching: true });
+        render(<TickerAutocomplete />);
+        expect(screen.getByText('검색 중…')).toBeInTheDocument();
+    });
+
+    it('shows no results message', () => {
+        setupAutocomplete({
+            query: 'xyz',
+            isOpen: true,
+            isSearching: false,
+            results: [],
+        });
+        render(<TickerAutocomplete />);
+        expect(screen.getByText('검색 결과 없음')).toBeInTheDocument();
+    });
+
+    it('renders result items with option role', () => {
+        setupAutocomplete({
+            query: 'A',
+            isOpen: true,
+            results: MOCK_RESULTS,
+        });
+        render(<TickerAutocomplete />);
+        const options = screen.getAllByRole('option');
+        expect(options).toHaveLength(2);
+    });
+
+    it('highlights selected result', () => {
+        setupAutocomplete({
+            query: 'A',
+            isOpen: true,
+            results: MOCK_RESULTS,
+            selectedIndex: 0,
+        });
+        render(<TickerAutocomplete />);
+        const options = screen.getAllByRole('option');
+        expect(options[0]).toHaveAttribute('aria-selected', 'true');
+        expect(options[1]).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('calls handleSearchClick when search button is clicked', async () => {
+        const handleSearchClick = vi.fn();
+        setupAutocomplete({ handleSearchClick });
+        const user = userEvent.setup();
+        render(<TickerAutocomplete />);
+        await user.click(screen.getByRole('button', { name: '검색' }));
+        expect(handleSearchClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders koreanName in result item display', () => {
+        setupAutocomplete({
+            query: 'A',
+            isOpen: true,
+            results: MOCK_RESULTS,
+        });
+        render(<TickerAutocomplete />);
+        expect(screen.getByText('Apple Inc. (애플)')).toBeInTheDocument();
+    });
+
+    it('renders exchange name', () => {
+        setupAutocomplete({
+            query: 'A',
+            isOpen: true,
+            results: MOCK_RESULTS,
+        });
+        render(<TickerAutocomplete />);
+        const nasdaqElements = screen.getAllByText('NASDAQ');
+        expect(nasdaqElements.length).toBeGreaterThan(0);
+    });
+
+    it('sets aria-expanded based on isOpen', () => {
+        setupAutocomplete({ isOpen: true });
+        render(<TickerAutocomplete />);
+        expect(screen.getByRole('combobox')).toHaveAttribute(
+            'aria-expanded',
+            'true'
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- features 레이어의 15개 미테스트 UI 컴포넌트 + 2개 model 파일 테스트 작성
- 141개 새 테스트 케이스 (userEvent 인터랙션 테스트 포함)

## UI components tested
**Auth:** LoginForm, SignupForm, ForgotPasswordForm, ResetPasswordForm, SocialLoginButtons, LogoutButton, DeleteAccountConfirm

**Contact:** ContactSubmittedNotice, ContactTextareaField, ContactTextField

**API Key:** ApiKeyInput, ApiKeySection

**Other:** PremiumModelGateModal, TickerAutocomplete, SymbolSearchPanel

## Model files tested
useSymbolChat, SymbolChatContext

## Test plan
- [x] `yarn test` — all suites pass (141 new tests)
- [x] `tsc --noEmit` — 0 errors
- [x] `yarn lint` — 0 errors
- [x] `yarn format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)