### PR TITLE
test(widgets/chart): add tests for utils, components, constants

### DIFF
--- a/src/widgets/chart/__tests__/ChartErrorFallback.test.tsx
+++ b/src/widgets/chart/__tests__/ChartErrorFallback.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChartErrorFallback } from '@/widgets/chart/ChartErrorFallback';
+
+describe('ChartErrorFallback', () => {
+    it('renders the error message from an Error instance', () => {
+        const error = new Error('차트 로딩 실패');
+        render(
+            <ChartErrorFallback error={error} resetErrorBoundary={vi.fn()} />
+        );
+
+        expect(screen.getByText('차트 로딩 실패')).toBeInTheDocument();
+    });
+
+    it('renders a fallback message for non-Error values', () => {
+        render(
+            <ChartErrorFallback
+                error="string error"
+                resetErrorBoundary={vi.fn()}
+            />
+        );
+
+        expect(
+            screen.getByText('알 수 없는 오류가 발생했습니다.')
+        ).toBeInTheDocument();
+    });
+
+    it('renders the retry button', () => {
+        render(
+            <ChartErrorFallback
+                error={new Error('test')}
+                resetErrorBoundary={vi.fn()}
+            />
+        );
+
+        expect(
+            screen.getByRole('button', { name: '다시 시도' })
+        ).toBeInTheDocument();
+    });
+
+    it('calls resetErrorBoundary when retry button is clicked', async () => {
+        const user = userEvent.setup();
+        const resetErrorBoundary = vi.fn();
+        render(
+            <ChartErrorFallback
+                error={new Error('test')}
+                resetErrorBoundary={resetErrorBoundary}
+            />
+        );
+
+        await user.click(screen.getByRole('button', { name: '다시 시도' }));
+
+        expect(resetErrorBoundary).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/widgets/chart/__tests__/ChartSkeleton.test.tsx
+++ b/src/widgets/chart/__tests__/ChartSkeleton.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import { ChartSkeleton } from '@/widgets/chart/ChartSkeleton';
+
+describe('ChartSkeleton', () => {
+    it('renders the loading text', () => {
+        render(<ChartSkeleton />);
+
+        expect(screen.getByText('데이터 로딩 중…')).toBeInTheDocument();
+    });
+});

--- a/src/widgets/chart/__tests__/IndicatorToolbar.test.tsx
+++ b/src/widgets/chart/__tests__/IndicatorToolbar.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IndicatorToolbar } from '@/widgets/chart/IndicatorToolbar';
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/shared/lib/chartColors', () => ({
+    getPeriodColor: (period: number) => `#color-${period}`,
+}));
+
+const { mockIsExpanded } = vi.hoisted(() => ({
+    mockIsExpanded: { value: true },
+}));
+
+vi.mock('@/widgets/chart/hooks/useIndicatorDropdown', () => ({
+    useIndicatorDropdown: () => ({
+        isExpanded: mockIsExpanded.value,
+        openDropdown: null,
+        dropdownPosition: null,
+        toolbarRef: { current: null },
+        portalRef: { current: null },
+        buttonRefs: {
+            ma: { current: null },
+            ema: { current: null },
+        },
+        toggleExpanded: vi.fn(),
+        toggleDropdown: vi.fn(),
+    }),
+}));
+
+function makeToggleGroup(visible = false) {
+    return { visible, onToggle: vi.fn() };
+}
+
+const defaultProps = {
+    maVisiblePeriods: [] as number[],
+    maAvailablePeriods: [5, 10, 20] as const,
+    onMAToggle: vi.fn(),
+    emaVisiblePeriods: [] as number[],
+    emaAvailablePeriods: [9, 21] as const,
+    onEMAToggle: vi.fn(),
+    bollinger: makeToggleGroup(),
+    macd: makeToggleGroup(),
+    rsi: makeToggleGroup(),
+    dmi: makeToggleGroup(),
+    stochastic: makeToggleGroup(),
+    stochRsi: makeToggleGroup(),
+    cci: makeToggleGroup(),
+    volumeProfile: makeToggleGroup(),
+    ichimoku: makeToggleGroup(),
+};
+
+describe('IndicatorToolbar', () => {
+    beforeEach(() => {
+        mockIsExpanded.value = true;
+    });
+
+    it('renders all toggle indicator buttons when expanded', () => {
+        render(<IndicatorToolbar {...defaultProps} />);
+
+        expect(screen.getByText('BB')).toBeInTheDocument();
+        expect(screen.getByText('RSI')).toBeInTheDocument();
+        expect(screen.getByText('MACD')).toBeInTheDocument();
+        expect(screen.getByText('DMI')).toBeInTheDocument();
+        expect(screen.getByText('Stoch')).toBeInTheDocument();
+        expect(screen.getByText('StochRSI')).toBeInTheDocument();
+        expect(screen.getByText('CCI')).toBeInTheDocument();
+        expect(screen.getByText('VP')).toBeInTheDocument();
+        expect(screen.getByText('Ichimoku')).toBeInTheDocument();
+    });
+
+    it('renders dropdown indicator buttons (MA, EMA)', () => {
+        render(<IndicatorToolbar {...defaultProps} />);
+
+        expect(screen.getByText('MA')).toBeInTheDocument();
+        expect(screen.getByText('EMA')).toBeInTheDocument();
+    });
+
+    it('calls toggle callback when a toggle indicator button is clicked', async () => {
+        const user = userEvent.setup();
+        const bollingerToggle = vi.fn();
+        render(
+            <IndicatorToolbar
+                {...defaultProps}
+                bollinger={{ visible: false, onToggle: bollingerToggle }}
+            />
+        );
+
+        await user.click(screen.getByText('BB'));
+
+        expect(bollingerToggle).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the expand/collapse button with correct aria-label when expanded', () => {
+        render(<IndicatorToolbar {...defaultProps} />);
+
+        const collapseButton = screen.getByRole('button', {
+            name: 'Hide indicators',
+        });
+        expect(collapseButton).toBeInTheDocument();
+        expect(collapseButton).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('renders period labels when maVisiblePeriods are active', () => {
+        render(
+            <IndicatorToolbar {...defaultProps} maVisiblePeriods={[5, 20]} />
+        );
+
+        expect(screen.getByText('MA(5)')).toBeInTheDocument();
+        expect(screen.getByText('MA(20)')).toBeInTheDocument();
+    });
+
+    it('renders EMA period labels when emaVisiblePeriods are active', () => {
+        render(<IndicatorToolbar {...defaultProps} emaVisiblePeriods={[9]} />);
+
+        expect(screen.getByText('EMA(9)')).toBeInTheDocument();
+    });
+});
+
+describe('IndicatorToolbar collapsed state', () => {
+    beforeEach(() => {
+        mockIsExpanded.value = false;
+    });
+
+    it('does not render indicator buttons when collapsed', () => {
+        render(<IndicatorToolbar {...defaultProps} />);
+
+        expect(screen.queryByText('BB')).not.toBeInTheDocument();
+        expect(screen.queryByText('RSI')).not.toBeInTheDocument();
+        expect(screen.queryByText('MA')).not.toBeInTheDocument();
+    });
+
+    it('shows "Show indicators" aria-label when collapsed', () => {
+        render(<IndicatorToolbar {...defaultProps} />);
+
+        const expandButton = screen.getByRole('button', {
+            name: 'Show indicators',
+        });
+        expect(expandButton).toHaveAttribute('aria-expanded', 'false');
+    });
+});

--- a/src/widgets/chart/__tests__/OverlayLegend.test.tsx
+++ b/src/widgets/chart/__tests__/OverlayLegend.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { OverlayLegend } from '@/widgets/chart/OverlayLegend';
+import type { OverlayLegendItem } from '@/widgets/chart/types';
+import type { OverlayGroup } from '@/widgets/chart/utils/overlayLegendFormat';
+
+vi.mock('@/widgets/chart/hooks/useOverlayGroups', () => ({
+    useOverlayGroups: (items: OverlayLegendItem[]): OverlayGroup[] => {
+        if (items.length === 0) return [];
+        return [{ key: 'TestGroup', items }];
+    },
+}));
+
+vi.mock('@/widgets/chart/utils/overlayLegendFormat', async importOriginal => {
+    const original =
+        await importOriginal<
+            typeof import('@/widgets/chart/utils/overlayLegendFormat')
+        >();
+    return { ...original };
+});
+
+describe('OverlayLegend', () => {
+    it('returns null when items is empty', () => {
+        const { container } = render(<OverlayLegend items={[]} />);
+
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders item names and formatted values', () => {
+        const items: OverlayLegendItem[] = [
+            { name: 'MA(5)', color: '#ff0000', value: 100.5 },
+            { name: 'MA(20)', color: '#00ff00', value: null },
+        ];
+
+        render(<OverlayLegend items={items} />);
+
+        expect(screen.getByText(/MA\(5\)/)).toBeInTheDocument();
+        expect(screen.getByText(/100\.50/)).toBeInTheDocument();
+        expect(screen.getByText(/MA\(20\)/)).toBeInTheDocument();
+        expect(screen.getByText(/-/)).toBeInTheDocument();
+    });
+
+    it('renders the bullet character for each item', () => {
+        const items: OverlayLegendItem[] = [
+            { name: 'RSI', color: '#ff0000', value: 70 },
+        ];
+
+        render(<OverlayLegend items={items} />);
+
+        expect(screen.getByText(/●/)).toBeInTheDocument();
+    });
+});

--- a/src/widgets/chart/__tests__/StockChart.test.tsx
+++ b/src/widgets/chart/__tests__/StockChart.test.tsx
@@ -1,0 +1,317 @@
+import { render, screen } from '@testing-library/react';
+import type { Bar } from '@y0ngha/siglens-core';
+import { StockChart } from '@/widgets/chart/StockChart';
+import { INACTIVE_PANE_INDEX } from '@/widgets/chart/constants';
+
+const { mockCreateChart, mockAddSeries, mockSetData, mockFitContent } =
+    vi.hoisted(() => {
+        const mockSetData = vi.fn();
+        const mockFitContent = vi.fn();
+        const mockAddSeries = vi.fn(() => ({
+            setData: mockSetData,
+            applyOptions: vi.fn(),
+            setMarkers: vi.fn(),
+        }));
+        const mockCreateChart = vi.fn(() => ({
+            addSeries: mockAddSeries,
+            addCandlestickSeries: vi.fn(() => ({
+                setData: mockSetData,
+                applyOptions: vi.fn(),
+            })),
+            addLineSeries: vi.fn(() => ({
+                setData: vi.fn(),
+                applyOptions: vi.fn(),
+            })),
+            addHistogramSeries: vi.fn(() => ({
+                setData: vi.fn(),
+                applyOptions: vi.fn(),
+            })),
+            applyOptions: vi.fn(),
+            resize: vi.fn(),
+            remove: vi.fn(),
+            removeSeries: vi.fn(),
+            timeScale: vi.fn(() => ({
+                fitContent: mockFitContent,
+                scrollToRealTime: vi.fn(),
+            })),
+            subscribeCrosshairMove: vi.fn(),
+            priceScale: vi.fn(() => ({ applyOptions: vi.fn() })),
+        }));
+        return { mockCreateChart, mockAddSeries, mockSetData, mockFitContent };
+    });
+
+vi.mock('lightweight-charts', () => ({
+    createChart: mockCreateChart,
+    CandlestickSeries: 'CandlestickSeries',
+    LineSeries: 'LineSeries',
+    HistogramSeries: 'HistogramSeries',
+    CrosshairMode: { Normal: 0, Magnet: 1 },
+    ColorType: { Solid: 'solid' },
+    LineStyle: { Solid: 0, Dotted: 1, Dashed: 2 },
+    PriceScaleMode: { Normal: 0, Logarithmic: 1 },
+}));
+
+vi.mock('@/shared/lib/chartColors', () => ({
+    CHART_COLORS: {
+        background: '#1a1a2e',
+        text: '#a0a0b0',
+        grid: '#2a2a3e',
+        bullish: '#26a69a',
+        bearish: '#ef5350',
+        bollingerUpper: '#aaaaff',
+        bollingerMiddle: '#8888cc',
+        bollingerLower: '#6666aa',
+    },
+    getPeriodColor: (period: number) => `#color-${period}`,
+}));
+
+vi.mock('@/shared/lib/timeFormat', () => ({
+    getTimeFormatter: () => (time: number) => String(time),
+}));
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/widgets/chart/hooks/useMAOverlay', () => ({
+    useMAOverlay: () => ({
+        visiblePeriods: [],
+        togglePeriod: vi.fn(),
+    }),
+}));
+
+vi.mock('@/widgets/chart/hooks/useEMAOverlay', () => ({
+    useEMAOverlay: () => ({
+        visiblePeriods: [],
+        togglePeriod: vi.fn(),
+    }),
+}));
+
+vi.mock('@/widgets/chart/hooks/useBollingerOverlay', () => ({
+    useBollingerOverlay: () => ({
+        isVisible: false,
+        toggle: vi.fn(),
+    }),
+}));
+
+vi.mock('@/widgets/chart/hooks/useMACDChart', () => ({
+    useMACDChart: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useRSIChart', () => ({
+    useRSIChart: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useDMIChart', () => ({
+    useDMIChart: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useStochasticChart', () => ({
+    useStochasticChart: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useStochRSIChart', () => ({
+    useStochRSIChart: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useCCIChart', () => ({
+    useCCIChart: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useVolumeProfileOverlay', () => ({
+    useVolumeProfileOverlay: () => ({
+        isVisible: false,
+        toggle: vi.fn(),
+    }),
+}));
+
+vi.mock('@/widgets/chart/hooks/useIchimokuOverlay', () => ({
+    useIchimokuOverlay: () => ({
+        isVisible: false,
+        toggle: vi.fn(),
+    }),
+}));
+
+vi.mock('@/widgets/chart/hooks/useCandlePatternMarkers', () => ({
+    useCandlePatternMarkers: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useActionRecommendationOverlay', () => ({
+    useActionRecommendationOverlay: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/usePaneLabels', () => ({
+    usePaneLabels: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useOverlayLegend', () => ({
+    useOverlayLegend: () => [],
+}));
+
+vi.mock('@/widgets/chart/hooks/useIndicatorVisibility', () => ({
+    useIndicatorVisibility: () => ({
+        rsiVisible: false,
+        macdVisible: false,
+        dmiVisible: false,
+        stochasticVisible: false,
+        stochRsiVisible: false,
+        cciVisible: false,
+        toggleRSI: vi.fn(),
+        toggleMACD: vi.fn(),
+        toggleDMI: vi.fn(),
+        toggleStochastic: vi.fn(),
+        toggleStochRSI: vi.fn(),
+        toggleCCI: vi.fn(),
+        paneIndices: {
+            rsi: INACTIVE_PANE_INDEX,
+            macd: INACTIVE_PANE_INDEX,
+            dmi: INACTIVE_PANE_INDEX,
+            stochastic: INACTIVE_PANE_INDEX,
+            stochRsi: INACTIVE_PANE_INDEX,
+            cci: INACTIVE_PANE_INDEX,
+        },
+    }),
+}));
+
+vi.mock('@/widgets/chart/hooks/useIndicatorDropdown', () => ({
+    useIndicatorDropdown: () => ({
+        isExpanded: false,
+        openDropdown: null,
+        dropdownPosition: null,
+        toolbarRef: { current: null },
+        portalRef: { current: null },
+        buttonRefs: { ma: { current: null }, ema: { current: null } },
+        toggleExpanded: vi.fn(),
+        toggleDropdown: vi.fn(),
+    }),
+}));
+
+vi.mock('@/widgets/chart/utils/paneLabelUtils', () => ({
+    buildPaneLabels: () => [],
+}));
+
+vi.mock('@/widgets/chart/utils/overlayLabelUtils', () => ({
+    buildOverlayLabelConfigs: () => [],
+}));
+
+vi.mock('@y0ngha/siglens-core', () => ({
+    EMPTY_INDICATOR_RESULT: {
+        ma: {},
+        ema: {},
+        macd: [],
+        bollinger: [],
+        rsi: [],
+        cci: [],
+        dmi: [],
+        stochastic: [],
+        stochRsi: [],
+        vwap: [],
+        volumeProfile: { poc: 0, vah: 0, val: 0, profile: [] },
+        ichimoku: [],
+        atr: [],
+        obv: [],
+        parabolicSar: [],
+        williamsR: [],
+        supertrend: [],
+        mfi: [],
+        keltnerChannel: [],
+        cmf: [],
+        donchianChannel: [],
+        squeezeMomentum: [],
+        buySellVolume: [],
+        smc: {
+            orderBlocks: [],
+            fairValueGaps: [],
+            breakOfStructure: [],
+            changeOfCharacter: [],
+        },
+    },
+    MA_DEFAULT_PERIODS: [5, 10, 20, 50, 100, 200],
+    EMA_DEFAULT_PERIODS: [9, 12, 21, 26, 50, 200],
+}));
+
+const mockBars: Bar[] = [
+    { time: 100, open: 10, high: 15, low: 9, close: 12, volume: 1000 },
+    { time: 200, open: 12, high: 18, low: 11, close: 15, volume: 1200 },
+    { time: 300, open: 15, high: 20, low: 14, close: 18, volume: 1100 },
+];
+
+describe('StockChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders empty state message when bars is empty', () => {
+        render(<StockChart bars={[]} timeframe="1Day" />);
+
+        expect(screen.getByText('차트 데이터가 없습니다')).toBeInTheDocument();
+    });
+
+    it('creates a chart when bars are provided', () => {
+        render(<StockChart bars={mockBars} timeframe="1Day" />);
+
+        expect(mockCreateChart).toHaveBeenCalledTimes(1);
+    });
+
+    it('adds a candlestick series', () => {
+        render(<StockChart bars={mockBars} timeframe="1Day" />);
+
+        expect(mockAddSeries).toHaveBeenCalledWith(
+            'CandlestickSeries',
+            expect.objectContaining({
+                upColor: '#26a69a',
+                downColor: '#ef5350',
+            })
+        );
+    });
+
+    it('sets bar data on the candlestick series', () => {
+        render(<StockChart bars={mockBars} timeframe="1Day" />);
+
+        expect(mockSetData).toHaveBeenCalled();
+    });
+
+    it('fits content on the time scale', () => {
+        render(<StockChart bars={mockBars} timeframe="1Day" />);
+
+        expect(mockFitContent).toHaveBeenCalled();
+    });
+
+    it('renders chart container with role="img" and default aria-label', () => {
+        render(<StockChart bars={mockBars} timeframe="1Day" />);
+
+        expect(screen.getByRole('img')).toHaveAttribute(
+            'aria-label',
+            '가격 차트'
+        );
+    });
+
+    it('renders chart with ticker-specific aria-label when ticker is provided', () => {
+        render(<StockChart bars={mockBars} timeframe="1Day" ticker="AAPL" />);
+
+        expect(screen.getByRole('img')).toHaveAttribute(
+            'aria-label',
+            'AAPL 1Day 캔들 차트'
+        );
+    });
+
+    it('uses generic aria-label when ticker is empty string', () => {
+        render(<StockChart bars={mockBars} timeframe="1Day" ticker="" />);
+
+        expect(screen.getByRole('img')).toHaveAttribute(
+            'aria-label',
+            '가격 차트'
+        );
+    });
+
+    it('removes chart on unmount', () => {
+        const { unmount } = render(
+            <StockChart bars={mockBars} timeframe="1Day" />
+        );
+
+        unmount();
+
+        const chart = mockCreateChart.mock.results[0].value;
+        expect(chart.remove).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chart/__tests__/TimeframeSelector.test.tsx
+++ b/src/widgets/chart/__tests__/TimeframeSelector.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Timeframe } from '@y0ngha/siglens-core';
+import { TimeframeSelector } from '@/widgets/chart/TimeframeSelector';
+import { TIMEFRAMES } from '@/shared/config/market';
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+describe('TimeframeSelector', () => {
+    it('renders a button for each timeframe', () => {
+        render(<TimeframeSelector value="1Day" onChange={vi.fn()} />);
+
+        const buttons = screen.getAllByRole('button');
+        expect(buttons).toHaveLength(TIMEFRAMES.length);
+    });
+
+    it('renders Korean labels for timeframes', () => {
+        render(<TimeframeSelector value="1Day" onChange={vi.fn()} />);
+
+        expect(screen.getByText('5분')).toBeInTheDocument();
+        expect(screen.getByText('15분')).toBeInTheDocument();
+        expect(screen.getByText('30분')).toBeInTheDocument();
+        expect(screen.getByText('1시간')).toBeInTheDocument();
+        expect(screen.getByText('4시간')).toBeInTheDocument();
+        expect(screen.getByText('1일')).toBeInTheDocument();
+    });
+
+    it('calls onChange with the clicked timeframe', async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        render(<TimeframeSelector value="1Day" onChange={onChange} />);
+
+        await user.click(screen.getByText('5분'));
+
+        expect(onChange).toHaveBeenCalledWith('5Min' satisfies Timeframe);
+    });
+
+    it('calls onChange when a different timeframe is selected', async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        render(<TimeframeSelector value="1Day" onChange={onChange} />);
+
+        await user.click(screen.getByText('4시간'));
+
+        expect(onChange).toHaveBeenCalledWith('4Hour' satisfies Timeframe);
+    });
+});

--- a/src/widgets/chart/__tests__/VolumeChart.test.tsx
+++ b/src/widgets/chart/__tests__/VolumeChart.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from '@testing-library/react';
+import type { Bar, BuySellVolumeResult } from '@y0ngha/siglens-core';
+import { VolumeChart } from '@/widgets/chart/VolumeChart';
+
+const { mockCreateChart } = vi.hoisted(() => {
+    const mockCreateChart = vi.fn(() => ({
+        addSeries: vi.fn(() => ({
+            setData: vi.fn(),
+            applyOptions: vi.fn(),
+        })),
+        applyOptions: vi.fn(),
+        resize: vi.fn(),
+        remove: vi.fn(),
+        removeSeries: vi.fn(),
+        timeScale: vi.fn(() => ({
+            fitContent: vi.fn(),
+            scrollToRealTime: vi.fn(),
+        })),
+        subscribeCrosshairMove: vi.fn(),
+        priceScale: vi.fn(() => ({ applyOptions: vi.fn() })),
+    }));
+    return { mockCreateChart };
+});
+
+vi.mock('lightweight-charts', () => ({
+    createChart: mockCreateChart,
+    HistogramSeries: 'HistogramSeries',
+    LineSeries: 'LineSeries',
+    ColorType: { Solid: 'solid' },
+    LineStyle: { Solid: 0 },
+}));
+
+vi.mock('@/shared/lib/chartColors', () => ({
+    CHART_COLORS: {
+        background: '#1a1a2e',
+        text: '#a0a0b0',
+        grid: '#2a2a3e',
+        bullish: '#26a69a',
+        bearish: '#ef5350',
+        volume: '#555577',
+    },
+}));
+
+vi.mock('@/widgets/chart/hooks/usePaneLabels', () => ({
+    usePaneLabels: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useVolumeChartData', () => ({
+    useVolumeChartData: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useVolumeChartLifecycle', () => ({
+    useVolumeChartLifecycle: () => ({
+        chartRef: { current: null },
+        totalSeriesRef: { current: null },
+        buySeriesRef: { current: null },
+    }),
+}));
+
+const mockBars: Bar[] = [
+    { time: 100, open: 10, high: 15, low: 9, close: 12, volume: 1000 },
+    { time: 200, open: 12, high: 18, low: 11, close: 15, volume: 1200 },
+];
+
+const mockBuySellVolume: BuySellVolumeResult[] = [
+    { buyVolume: 600, sellVolume: 400 },
+    { buyVolume: 700, sellVolume: 500 },
+];
+
+describe('VolumeChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders the chart container', () => {
+        render(
+            <VolumeChart bars={mockBars} buySellVolume={mockBuySellVolume} />
+        );
+
+        expect(screen.getByRole('img')).toBeInTheDocument();
+    });
+
+    it('renders with default aria-label when no ticker', () => {
+        render(
+            <VolumeChart bars={mockBars} buySellVolume={mockBuySellVolume} />
+        );
+
+        expect(screen.getByRole('img')).toHaveAttribute(
+            'aria-label',
+            '거래량 차트'
+        );
+    });
+
+    it('renders with ticker-specific aria-label', () => {
+        render(
+            <VolumeChart
+                bars={mockBars}
+                buySellVolume={mockBuySellVolume}
+                ticker="TSLA"
+            />
+        );
+
+        expect(screen.getByRole('img')).toHaveAttribute(
+            'aria-label',
+            'TSLA 거래량 차트'
+        );
+    });
+
+    it('renders with generic aria-label when ticker is empty', () => {
+        render(
+            <VolumeChart
+                bars={mockBars}
+                buySellVolume={mockBuySellVolume}
+                ticker=""
+            />
+        );
+
+        expect(screen.getByRole('img')).toHaveAttribute(
+            'aria-label',
+            '거래량 차트'
+        );
+    });
+});

--- a/src/widgets/chart/__tests__/constants.test.ts
+++ b/src/widgets/chart/__tests__/constants.test.ts
@@ -1,0 +1,70 @@
+import {
+    DEFAULT_LINE_WIDTH,
+    INACTIVE_PANE_INDEX,
+    FIRST_INDICATOR_PANE_INDEX,
+    LABEL_SERIES_INDEX,
+    REGION_LOWER_PRICE_INDEX,
+    REGION_UPPER_PRICE_INDEX,
+    REGION_KEY_PRICE_MIN_LENGTH,
+    MARKER_POSITION,
+    MARKER_SHAPE,
+    BASE_PATTERN_SERIES_OPTIONS,
+} from '@/widgets/chart/constants';
+
+describe('chart constants', () => {
+    it('DEFAULT_LINE_WIDTH is 1', () => {
+        expect(DEFAULT_LINE_WIDTH).toBe(1);
+    });
+
+    it('INACTIVE_PANE_INDEX is -1', () => {
+        expect(INACTIVE_PANE_INDEX).toBe(-1);
+    });
+
+    it('FIRST_INDICATOR_PANE_INDEX is 1', () => {
+        expect(FIRST_INDICATOR_PANE_INDEX).toBe(1);
+    });
+
+    it('LABEL_SERIES_INDEX is 0', () => {
+        expect(LABEL_SERIES_INDEX).toBe(0);
+    });
+
+    it('REGION_LOWER_PRICE_INDEX is 0', () => {
+        expect(REGION_LOWER_PRICE_INDEX).toBe(0);
+    });
+
+    it('REGION_UPPER_PRICE_INDEX is 1', () => {
+        expect(REGION_UPPER_PRICE_INDEX).toBe(1);
+    });
+
+    it('REGION_KEY_PRICE_MIN_LENGTH equals REGION_UPPER_PRICE_INDEX + 1', () => {
+        expect(REGION_KEY_PRICE_MIN_LENGTH).toBe(REGION_UPPER_PRICE_INDEX + 1);
+    });
+
+    it('MARKER_POSITION is "aboveBar"', () => {
+        expect(MARKER_POSITION).toBe('aboveBar');
+    });
+
+    it('MARKER_SHAPE is "arrowDown"', () => {
+        expect(MARKER_SHAPE).toBe('arrowDown');
+    });
+
+    describe('BASE_PATTERN_SERIES_OPTIONS', () => {
+        it('uses DEFAULT_LINE_WIDTH for lineWidth', () => {
+            expect(BASE_PATTERN_SERIES_OPTIONS.lineWidth).toBe(
+                DEFAULT_LINE_WIDTH
+            );
+        });
+
+        it('hides price line', () => {
+            expect(BASE_PATTERN_SERIES_OPTIONS.priceLineVisible).toBe(false);
+        });
+
+        it('hides last value', () => {
+            expect(BASE_PATTERN_SERIES_OPTIONS.lastValueVisible).toBe(false);
+        });
+
+        it('has exactly three properties', () => {
+            expect(Object.keys(BASE_PATTERN_SERIES_OPTIONS)).toHaveLength(3);
+        });
+    });
+});

--- a/src/widgets/chart/__tests__/utils/ichimokuUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/ichimokuUtils.test.ts
@@ -1,0 +1,248 @@
+import type { Bar } from '@y0ngha/siglens-core';
+import type { UTCTimestamp } from 'lightweight-charts';
+import {
+    buildCloudData,
+    extendWithFutureCloud,
+    type FutureCloudBase,
+    type IchimokuCloudPoint,
+} from '@/widgets/chart/utils/ichimokuUtils';
+
+const mockBars: Bar[] = [
+    { time: 100, open: 10, high: 15, low: 9, close: 12, volume: 1000 },
+    { time: 200, open: 12, high: 18, low: 11, close: 15, volume: 1200 },
+    { time: 300, open: 15, high: 20, low: 14, close: 18, volume: 1100 },
+];
+
+describe('buildCloudData', () => {
+    it('returns bullish cloud when senkouA >= senkouB', () => {
+        const input = [{ senkouA: 110, senkouB: 100 }];
+
+        const result = buildCloudData(input);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].senkouA).toBe(110);
+        expect(result[0].senkouB).toBe(100);
+        expect(result[0].cloudBullishUpper).toBe(110);
+        expect(result[0].cloudBearishUpper).toBeNull();
+    });
+
+    it('returns bearish cloud when senkouA < senkouB', () => {
+        const input = [{ senkouA: 90, senkouB: 100 }];
+
+        const result = buildCloudData(input);
+
+        expect(result[0].cloudBullishUpper).toBeNull();
+        expect(result[0].cloudBearishUpper).toBe(100);
+    });
+
+    it('returns null cloud values when senkouA is null', () => {
+        const input = [{ senkouA: null, senkouB: 100 }];
+
+        const result = buildCloudData(input);
+
+        expect(result[0].cloudBullishUpper).toBeNull();
+        expect(result[0].cloudBearishUpper).toBeNull();
+    });
+
+    it('returns null cloud values when senkouB is null', () => {
+        const input = [{ senkouA: 100, senkouB: null }];
+
+        const result = buildCloudData(input);
+
+        expect(result[0].cloudBullishUpper).toBeNull();
+        expect(result[0].cloudBearishUpper).toBeNull();
+    });
+
+    it('maps tenkan, kijun, chikou with defaults when absent', () => {
+        const input = [{ senkouA: 100, senkouB: 90 }];
+
+        const result = buildCloudData(input);
+
+        expect(result[0].tenkan).toBeNull();
+        expect(result[0].kijun).toBeNull();
+        expect(result[0].chikou).toBeNull();
+    });
+
+    it('preserves tenkan, kijun, chikou when provided', () => {
+        const input = [
+            {
+                senkouA: 100,
+                senkouB: 90,
+                tenkan: 95,
+                kijun: 98,
+                chikou: 88,
+            },
+        ];
+
+        const result = buildCloudData(input);
+
+        expect(result[0].tenkan).toBe(95);
+        expect(result[0].kijun).toBe(98);
+        expect(result[0].chikou).toBe(88);
+    });
+
+    it('returns equal cloud when senkouA equals senkouB (treated as bullish)', () => {
+        const input = [{ senkouA: 100, senkouB: 100 }];
+
+        const result = buildCloudData(input);
+
+        expect(result[0].cloudBullishUpper).toBe(100);
+        expect(result[0].cloudBearishUpper).toBeNull();
+    });
+
+    it('handles empty array', () => {
+        expect(buildCloudData([])).toEqual([]);
+    });
+
+    it('processes multiple points', () => {
+        const input = [
+            { senkouA: 110, senkouB: 100 },
+            { senkouA: 90, senkouB: 100 },
+            { senkouA: null, senkouB: null },
+        ];
+
+        const result = buildCloudData(input);
+
+        expect(result).toHaveLength(3);
+        expect(result[0].cloudBullishUpper).toBe(110);
+        expect(result[1].cloudBearishUpper).toBe(100);
+        expect(result[2].cloudBullishUpper).toBeNull();
+        expect(result[2].cloudBearishUpper).toBeNull();
+    });
+});
+
+describe('extendWithFutureCloud', () => {
+    const emptyBase: FutureCloudBase = {
+        senkouAData: [],
+        senkouBData: [],
+        cloudBullishData: [],
+        cloudBearishData: [],
+    };
+
+    it('appends future cloud points with correct timestamps', () => {
+        const futureCloud: IchimokuCloudPoint[] = [
+            {
+                tenkan: null,
+                kijun: null,
+                senkouA: 105,
+                senkouB: 100,
+                cloudBullishUpper: 105,
+                cloudBearishUpper: null,
+                chikou: null,
+            },
+        ];
+
+        const result = extendWithFutureCloud(mockBars, futureCloud, emptyBase);
+
+        const expectedTime = (300 + 100) as UTCTimestamp;
+        expect(result.finalSenkouA).toEqual([
+            { time: expectedTime, value: 105 },
+        ]);
+        expect(result.finalSenkouB).toEqual([
+            { time: expectedTime, value: 100 },
+        ]);
+        expect(result.finalCloudBullish).toEqual([
+            { time: expectedTime, value: 105 },
+        ]);
+        expect(result.finalCloudBearish).toEqual([{ time: expectedTime }]);
+    });
+
+    it('preserves base data when extending', () => {
+        const base: FutureCloudBase = {
+            senkouAData: [{ time: 100 as UTCTimestamp, value: 50 }],
+            senkouBData: [{ time: 100 as UTCTimestamp, value: 45 }],
+            cloudBullishData: [{ time: 100 as UTCTimestamp, value: 50 }],
+            cloudBearishData: [],
+        };
+        const futureCloud: IchimokuCloudPoint[] = [
+            {
+                tenkan: null,
+                kijun: null,
+                senkouA: 60,
+                senkouB: 55,
+                cloudBullishUpper: 60,
+                cloudBearishUpper: null,
+                chikou: null,
+            },
+        ];
+
+        const result = extendWithFutureCloud(mockBars, futureCloud, base);
+
+        expect(result.finalSenkouA).toHaveLength(2);
+        expect(result.finalSenkouA[0]).toEqual({
+            time: 100 as UTCTimestamp,
+            value: 50,
+        });
+    });
+
+    it('handles null senkouA in future cloud', () => {
+        const futureCloud: IchimokuCloudPoint[] = [
+            {
+                tenkan: null,
+                kijun: null,
+                senkouA: null,
+                senkouB: 100,
+                cloudBullishUpper: null,
+                cloudBearishUpper: null,
+                chikou: null,
+            },
+        ];
+
+        const result = extendWithFutureCloud(mockBars, futureCloud, emptyBase);
+
+        expect(result.finalSenkouA[0]).toEqual({
+            time: (300 + 100) as UTCTimestamp,
+        });
+        expect(result.finalSenkouB[0]).toEqual({
+            time: (300 + 100) as UTCTimestamp,
+            value: 100,
+        });
+    });
+
+    it('uses correct interval between multiple future points', () => {
+        const futureCloud: IchimokuCloudPoint[] = [
+            {
+                tenkan: null,
+                kijun: null,
+                senkouA: 105,
+                senkouB: 100,
+                cloudBullishUpper: 105,
+                cloudBearishUpper: null,
+                chikou: null,
+            },
+            {
+                tenkan: null,
+                kijun: null,
+                senkouA: 110,
+                senkouB: 102,
+                cloudBullishUpper: 110,
+                cloudBearishUpper: null,
+                chikou: null,
+            },
+        ];
+
+        const result = extendWithFutureCloud(mockBars, futureCloud, emptyBase);
+
+        const interval = mockBars[2].time - mockBars[1].time;
+        expect(result.finalSenkouA[0].time).toBe(
+            mockBars[2].time + 1 * interval
+        );
+        expect(result.finalSenkouA[1].time).toBe(
+            mockBars[2].time + 2 * interval
+        );
+    });
+
+    it('returns base data when futureCloud is empty', () => {
+        const base: FutureCloudBase = {
+            senkouAData: [{ time: 100 as UTCTimestamp, value: 50 }],
+            senkouBData: [{ time: 100 as UTCTimestamp, value: 45 }],
+            cloudBullishData: [],
+            cloudBearishData: [],
+        };
+
+        const result = extendWithFutureCloud(mockBars, [], base);
+
+        expect(result.finalSenkouA).toEqual(base.senkouAData);
+        expect(result.finalSenkouB).toEqual(base.senkouBData);
+    });
+});

--- a/src/widgets/chart/__tests__/utils/keyLevelsUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/keyLevelsUtils.test.ts
@@ -1,0 +1,75 @@
+import type { Bar } from '@y0ngha/siglens-core';
+import type { UTCTimestamp } from 'lightweight-charts';
+import {
+    buildLineData,
+    createLevelSeries,
+} from '@/widgets/chart/utils/keyLevelsUtils';
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+    LineStyle: { Dashed: 2 },
+}));
+
+const mockBars: Bar[] = [
+    { time: 100, open: 10, high: 15, low: 9, close: 12, volume: 1000 },
+    { time: 200, open: 12, high: 18, low: 11, close: 15, volume: 1200 },
+    { time: 300, open: 15, high: 20, low: 14, close: 18, volume: 1100 },
+];
+
+describe('buildLineData', () => {
+    it('returns first and last bar times with the given price', () => {
+        const result = buildLineData(mockBars, 150);
+
+        expect(result).toEqual([
+            { time: 100 as UTCTimestamp, value: 150 },
+            { time: 300 as UTCTimestamp, value: 150 },
+        ]);
+    });
+
+    it('returns empty array for empty bars', () => {
+        expect(buildLineData([], 100)).toEqual([]);
+    });
+
+    it('returns two identical-time points for single bar', () => {
+        const singleBar: Bar[] = [
+            {
+                time: 500,
+                open: 10,
+                high: 15,
+                low: 9,
+                close: 12,
+                volume: 100,
+            },
+        ];
+
+        const result = buildLineData(singleBar, 42);
+
+        expect(result).toHaveLength(2);
+        expect(result[0].time).toBe(result[1].time);
+        expect(result[0].value).toBe(42);
+    });
+});
+
+describe('createLevelSeries', () => {
+    it('calls chart.addSeries with LineSeries and correct options', () => {
+        const mockSeries = { setData: vi.fn() };
+        const mockChart = {
+            addSeries: vi.fn(() => mockSeries),
+        };
+
+        const result = createLevelSeries(
+            mockChart as never,
+            '#ff0000',
+            2 as never
+        );
+
+        expect(mockChart.addSeries).toHaveBeenCalledWith('LineSeries', {
+            color: '#ff0000',
+            lineWidth: 2,
+            lineStyle: 2,
+            priceLineVisible: false,
+            lastValueVisible: true,
+        });
+        expect(result).toBe(mockSeries);
+    });
+});

--- a/src/widgets/chart/__tests__/utils/overlayLegendFormat.test.ts
+++ b/src/widgets/chart/__tests__/utils/overlayLegendFormat.test.ts
@@ -1,0 +1,149 @@
+import {
+    groupOverlayItems,
+    formatOverlayValue,
+} from '@/widgets/chart/utils/overlayLegendFormat';
+import type { OverlayLegendItem } from '@/widgets/chart/types';
+
+describe('formatOverlayValue', () => {
+    it('returns "-" for null', () => {
+        expect(formatOverlayValue(null)).toBe('-');
+    });
+
+    it('formats a number to 2 decimal places', () => {
+        expect(formatOverlayValue(100.123)).toBe('100.12');
+    });
+
+    it('pads a whole number to 2 decimal places', () => {
+        expect(formatOverlayValue(42)).toBe('42.00');
+    });
+
+    it('formats zero correctly', () => {
+        expect(formatOverlayValue(0)).toBe('0.00');
+    });
+
+    it('formats negative numbers correctly', () => {
+        expect(formatOverlayValue(-3.14159)).toBe('-3.14');
+    });
+});
+
+describe('groupOverlayItems', () => {
+    it('returns empty array for empty input', () => {
+        expect(groupOverlayItems([])).toEqual([]);
+    });
+
+    it('groups MA items under "MA" key', () => {
+        const items: OverlayLegendItem[] = [
+            { name: 'MA(5)', color: '#f00', value: 100 },
+            { name: 'MA(20)', color: '#0f0', value: 200 },
+        ];
+
+        const result = groupOverlayItems(items);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].key).toBe('MA');
+        expect(result[0].items).toHaveLength(2);
+    });
+
+    it('groups EMA items under "EMA" key', () => {
+        const items: OverlayLegendItem[] = [
+            { name: 'EMA(9)', color: '#f00', value: 100 },
+            { name: 'EMA(21)', color: '#0f0', value: 200 },
+        ];
+
+        const result = groupOverlayItems(items);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].key).toBe('EMA');
+    });
+
+    it('groups BB items under "BB" key', () => {
+        const items: OverlayLegendItem[] = [
+            { name: 'BB Upper', color: '#f00', value: 110 },
+            { name: 'BB Middle', color: '#0f0', value: 100 },
+            { name: 'BB Lower', color: '#00f', value: 90 },
+        ];
+
+        const result = groupOverlayItems(items);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].key).toBe('BB');
+        expect(result[0].items).toHaveLength(3);
+    });
+
+    it('groups Ichimoku names under "Ichimoku" key', () => {
+        const ichimokuNames = [
+            'Tenkan',
+            'Kijun',
+            'Chikou',
+            'Senkou A',
+            'Senkou B',
+        ];
+        const items: OverlayLegendItem[] = ichimokuNames.map(name => ({
+            name,
+            color: '#fff',
+            value: 100,
+        }));
+
+        const result = groupOverlayItems(items);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].key).toBe('Ichimoku');
+        expect(result[0].items).toHaveLength(5);
+    });
+
+    it('groups VP names under "VP" key', () => {
+        const items: OverlayLegendItem[] = [
+            { name: 'POC', color: '#f00', value: 100 },
+            { name: 'VAH', color: '#0f0', value: 110 },
+            { name: 'VAL', color: '#00f', value: 90 },
+        ];
+
+        const result = groupOverlayItems(items);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].key).toBe('VP');
+        expect(result[0].items).toHaveLength(3);
+    });
+
+    it('uses the item name itself as key for ungrouped items', () => {
+        const items: OverlayLegendItem[] = [
+            { name: 'CustomOverlay', color: '#f00', value: 50 },
+        ];
+
+        const result = groupOverlayItems(items);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].key).toBe('CustomOverlay');
+    });
+
+    it('preserves insertion order across different groups', () => {
+        const items: OverlayLegendItem[] = [
+            { name: 'MA(5)', color: '#f00', value: 100 },
+            { name: 'BB Upper', color: '#0f0', value: 110 },
+            { name: 'MA(20)', color: '#00f', value: 200 },
+            { name: 'BB Lower', color: '#ff0', value: 90 },
+        ];
+
+        const result = groupOverlayItems(items);
+
+        expect(result).toHaveLength(2);
+        expect(result[0].key).toBe('MA');
+        expect(result[1].key).toBe('BB');
+        expect(result[0].items).toHaveLength(2);
+        expect(result[1].items).toHaveLength(2);
+    });
+
+    it('handles mixed grouped and ungrouped items', () => {
+        const items: OverlayLegendItem[] = [
+            { name: 'MA(5)', color: '#f00', value: 100 },
+            { name: 'CustomLine', color: '#0f0', value: 50 },
+            { name: 'MA(20)', color: '#00f', value: 200 },
+        ];
+
+        const result = groupOverlayItems(items);
+
+        expect(result).toHaveLength(2);
+        expect(result[0].key).toBe('MA');
+        expect(result[1].key).toBe('CustomLine');
+    });
+});

--- a/src/widgets/chart/__tests__/utils/patternOverlayUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/patternOverlayUtils.test.ts
@@ -1,0 +1,152 @@
+import type { PatternResult } from '@y0ngha/siglens-core';
+import {
+    isDetectedAndVisible,
+    removeHidden,
+    removeSeries,
+} from '@/widgets/chart/utils/patternOverlayUtils';
+
+function makePatternResult(
+    overrides: Partial<PatternResult> = {}
+): PatternResult {
+    return {
+        id: 'test-id',
+        patternName: 'head_and_shoulders',
+        skillName: 'test-skill',
+        detected: false,
+        trend: 'bullish',
+        summary: 'Test pattern summary',
+        confidenceWeight: 1,
+        ...overrides,
+    };
+}
+
+describe('isDetectedAndVisible', () => {
+    it('returns true when detected is true and renderConfig.show is true', () => {
+        const pattern = makePatternResult({
+            detected: true,
+            renderConfig: {
+                show: true,
+                type: 'line',
+                color: '#ff0000',
+                label: 'Test',
+            },
+        });
+
+        expect(isDetectedAndVisible(pattern)).toBe(true);
+    });
+
+    it('returns false when detected is false', () => {
+        const pattern = makePatternResult({
+            detected: false,
+            renderConfig: {
+                show: true,
+                type: 'line',
+                color: '#ff0000',
+                label: 'Test',
+            },
+        });
+
+        expect(isDetectedAndVisible(pattern)).toBe(false);
+    });
+
+    it('returns false when renderConfig.show is false', () => {
+        const pattern = makePatternResult({
+            detected: true,
+            renderConfig: {
+                show: false,
+                type: 'line',
+                color: '#ff0000',
+                label: 'Test',
+            },
+        });
+
+        expect(isDetectedAndVisible(pattern)).toBe(false);
+    });
+
+    it('returns false when renderConfig is undefined', () => {
+        const pattern = makePatternResult({
+            detected: true,
+            renderConfig: undefined,
+        });
+
+        expect(isDetectedAndVisible(pattern)).toBe(false);
+    });
+});
+
+describe('removeHidden', () => {
+    it('removes entries not in visiblePatterns set', () => {
+        const cleanup = vi.fn();
+        const map = new Map([
+            ['patternA', 'valueA'],
+            ['patternB', 'valueB'],
+            ['patternC', 'valueC'],
+        ]);
+        const visiblePatterns = new Set(['patternA', 'patternC']);
+
+        removeHidden(map, visiblePatterns, cleanup);
+
+        expect(map.size).toBe(2);
+        expect(map.has('patternB')).toBe(false);
+        expect(cleanup).toHaveBeenCalledTimes(1);
+        expect(cleanup).toHaveBeenCalledWith('valueB');
+    });
+
+    it('does nothing when all entries are visible', () => {
+        const cleanup = vi.fn();
+        const map = new Map([
+            ['patternA', 'valueA'],
+            ['patternB', 'valueB'],
+        ]);
+        const visiblePatterns = new Set(['patternA', 'patternB']);
+
+        removeHidden(map, visiblePatterns, cleanup);
+
+        expect(map.size).toBe(2);
+        expect(cleanup).not.toHaveBeenCalled();
+    });
+
+    it('removes all entries when visiblePatterns is empty', () => {
+        const cleanup = vi.fn();
+        const map = new Map([
+            ['patternA', 'valueA'],
+            ['patternB', 'valueB'],
+        ]);
+
+        removeHidden(map, new Set(), cleanup);
+
+        expect(map.size).toBe(0);
+        expect(cleanup).toHaveBeenCalledTimes(2);
+    });
+
+    it('handles empty map', () => {
+        const cleanup = vi.fn();
+        const map = new Map<string, string>();
+
+        removeHidden(map, new Set(['x']), cleanup);
+
+        expect(map.size).toBe(0);
+        expect(cleanup).not.toHaveBeenCalled();
+    });
+});
+
+describe('removeSeries', () => {
+    it('calls chart.removeSeries for each series in the list', () => {
+        const mockChart = { removeSeries: vi.fn() };
+        const series1 = { id: 1 };
+        const series2 = { id: 2 };
+
+        removeSeries(mockChart as never, [series1, series2] as never);
+
+        expect(mockChart.removeSeries).toHaveBeenCalledTimes(2);
+        expect(mockChart.removeSeries).toHaveBeenCalledWith(series1);
+        expect(mockChart.removeSeries).toHaveBeenCalledWith(series2);
+    });
+
+    it('does nothing for empty series list', () => {
+        const mockChart = { removeSeries: vi.fn() };
+
+        removeSeries(mockChart as never, []);
+
+        expect(mockChart.removeSeries).not.toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts
@@ -1,0 +1,135 @@
+import type { Bar } from '@y0ngha/siglens-core';
+import type { UTCTimestamp } from 'lightweight-charts';
+import {
+    buildSeriesData,
+    buildSeriesDataFromValues,
+} from '@/widgets/chart/utils/seriesDataUtils';
+
+const mockBars: Bar[] = [
+    { time: 100, open: 10, high: 15, low: 9, close: 12, volume: 1000 },
+    { time: 200, open: 12, high: 18, low: 11, close: 15, volume: 1200 },
+    { time: 300, open: 15, high: 20, low: 14, close: 18, volume: 1100 },
+];
+
+describe('buildSeriesData', () => {
+    it('maps indicator values to series points with time from bars', () => {
+        const indicatorData = [{ rsi: 70 }, { rsi: 65 }, { rsi: 80 }];
+
+        const result = buildSeriesData(mockBars, indicatorData, 'rsi');
+
+        expect(result).toEqual([
+            { time: 100 as UTCTimestamp, value: 70 },
+            { time: 200 as UTCTimestamp, value: 65 },
+            { time: 300 as UTCTimestamp, value: 80 },
+        ]);
+    });
+
+    it('produces WhitespaceData for null values', () => {
+        const indicatorData = [{ rsi: 70 }, { rsi: null }, { rsi: 80 }];
+
+        const result = buildSeriesData(mockBars, indicatorData, 'rsi');
+
+        expect(result[1]).toEqual({ time: 200 as UTCTimestamp });
+        expect(result[1]).not.toHaveProperty('value');
+    });
+
+    it('produces WhitespaceData for undefined values', () => {
+        const indicatorData = [{ rsi: 70 }, { rsi: undefined }, { rsi: 80 }];
+
+        const result = buildSeriesData(mockBars, indicatorData, 'rsi');
+
+        expect(result[1]).toEqual({ time: 200 as UTCTimestamp });
+    });
+
+    it('uses Math.min(bars, indicatorData) for length', () => {
+        const indicatorData = [{ rsi: 70 }];
+
+        const result = buildSeriesData(mockBars, indicatorData, 'rsi');
+
+        expect(result).toHaveLength(1);
+    });
+
+    it('returns empty array for empty bars', () => {
+        expect(buildSeriesData([], [{ rsi: 70 }], 'rsi')).toEqual([]);
+    });
+
+    it('returns empty array for empty indicator data', () => {
+        expect(buildSeriesData(mockBars, [], 'rsi')).toEqual([]);
+    });
+
+    it('applies colorFn when provided', () => {
+        const indicatorData = [{ val: 10 }, { val: -5 }];
+        const colorFn = (value: number) => (value >= 0 ? '#00ff00' : '#ff0000');
+
+        const result = buildSeriesData(mockBars, indicatorData, 'val', colorFn);
+
+        expect(result[0]).toEqual({
+            time: 100 as UTCTimestamp,
+            value: 10,
+            color: '#00ff00',
+        });
+        expect(result[1]).toEqual({
+            time: 200 as UTCTimestamp,
+            value: -5,
+            color: '#ff0000',
+        });
+    });
+
+    it('does not add color when colorFn is undefined', () => {
+        const indicatorData = [{ val: 10 }];
+
+        const result = buildSeriesData(mockBars, indicatorData, 'val');
+
+        expect(result[0]).not.toHaveProperty('color');
+    });
+});
+
+describe('buildSeriesDataFromValues', () => {
+    it('maps values array to series points with time from bars', () => {
+        const values = [100, 200, 300];
+
+        const result = buildSeriesDataFromValues(mockBars, values);
+
+        expect(result).toEqual([
+            { time: 100 as UTCTimestamp, value: 100 },
+            { time: 200 as UTCTimestamp, value: 200 },
+            { time: 300 as UTCTimestamp, value: 300 },
+        ]);
+    });
+
+    it('produces WhitespaceData for null values', () => {
+        const values = [100, null, 300];
+
+        const result = buildSeriesDataFromValues(mockBars, values);
+
+        expect(result[1]).toEqual({ time: 200 as UTCTimestamp });
+        expect(result[1]).not.toHaveProperty('value');
+    });
+
+    it('uses Math.min(bars, values) for length', () => {
+        const values = [100];
+
+        const result = buildSeriesDataFromValues(mockBars, values);
+
+        expect(result).toHaveLength(1);
+    });
+
+    it('returns empty array for empty bars', () => {
+        expect(buildSeriesDataFromValues([], [100])).toEqual([]);
+    });
+
+    it('returns empty array for empty values', () => {
+        expect(buildSeriesDataFromValues(mockBars, [])).toEqual([]);
+    });
+
+    it('handles all null values', () => {
+        const values = [null, null, null];
+
+        const result = buildSeriesDataFromValues(mockBars, values);
+
+        expect(result).toHaveLength(3);
+        result.forEach(point => {
+            expect(point).not.toHaveProperty('value');
+        });
+    });
+});

--- a/src/widgets/chart/__tests__/utils/trendlineUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/trendlineUtils.test.ts
@@ -1,0 +1,78 @@
+import type { Bar, Trendline } from '@y0ngha/siglens-core';
+import {
+    trendlineKey,
+    resolveTrendlinePrice,
+} from '@/widgets/chart/utils/trendlineUtils';
+
+describe('trendlineKey', () => {
+    it('returns a string combining direction and start/end times', () => {
+        const trendline: Trendline = {
+            direction: 'ascending',
+            start: { time: 1000, price: 100 },
+            end: { time: 2000, price: 150 },
+        };
+
+        expect(trendlineKey(trendline)).toBe('ascending:1000:2000');
+    });
+
+    it('produces different keys for different directions', () => {
+        const ascending: Trendline = {
+            direction: 'ascending',
+            start: { time: 1000, price: 100 },
+            end: { time: 2000, price: 150 },
+        };
+        const descending: Trendline = {
+            direction: 'descending',
+            start: { time: 1000, price: 100 },
+            end: { time: 2000, price: 150 },
+        };
+
+        expect(trendlineKey(ascending)).not.toBe(trendlineKey(descending));
+    });
+
+    it('produces different keys for different time ranges', () => {
+        const t1: Trendline = {
+            direction: 'ascending',
+            start: { time: 1000, price: 100 },
+            end: { time: 2000, price: 150 },
+        };
+        const t2: Trendline = {
+            direction: 'ascending',
+            start: { time: 1000, price: 100 },
+            end: { time: 3000, price: 150 },
+        };
+
+        expect(trendlineKey(t1)).not.toBe(trendlineKey(t2));
+    });
+});
+
+describe('resolveTrendlinePrice', () => {
+    const mockBar: Bar = {
+        time: 100,
+        open: 50,
+        high: 60,
+        low: 40,
+        close: 55,
+        volume: 1000,
+    };
+
+    it('returns bar.low for ascending direction', () => {
+        expect(resolveTrendlinePrice(mockBar, 'ascending', 999)).toBe(
+            mockBar.low
+        );
+    });
+
+    it('returns bar.high for descending direction', () => {
+        expect(resolveTrendlinePrice(mockBar, 'descending', 999)).toBe(
+            mockBar.high
+        );
+    });
+
+    it('returns fallback when bar is undefined', () => {
+        expect(resolveTrendlinePrice(undefined, 'ascending', 42)).toBe(42);
+    });
+
+    it('returns fallback for descending when bar is undefined', () => {
+        expect(resolveTrendlinePrice(undefined, 'descending', 77)).toBe(77);
+    });
+});


### PR DESCRIPTION
## Summary
- chart 위젯의 7개 utils + 7개 components + 1개 constants 테스트 작성
- 109개 새 테스트 케이스

## Utils tested (76 tests)
ichimokuUtils, keyLevelsUtils, overlayLegendFormat, patternOverlayUtils,
seriesDataUtils, trendlineUtils, constants

## Components tested (33 tests)
ChartErrorFallback, ChartSkeleton, IndicatorToolbar, OverlayLegend,
TimeframeSelector, StockChart, VolumeChart

## Test plan
- [x] `yarn test` — all suites pass (109 new tests)
- [x] `tsc --noEmit` — 0 errors
- [x] `yarn lint` — 0 errors
- [x] `yarn format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)