### PR TITLE
test(widgets/chart): add tests for 22 chart hooks

### DIFF
--- a/src/widgets/chart/__tests__/hooks/useActionRecommendationOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useActionRecommendationOverlay.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { ValidatedActionPrices } from '@y0ngha/siglens-core';
+import { useActionRecommendationOverlay } from '../../hooks/useActionRecommendationOverlay';
+
+const mockCreatePriceLine = vi.fn(() => ({ id: Math.random() }));
+const mockRemovePriceLine = vi.fn();
+
+vi.mock('lightweight-charts', () => ({
+    LineStyle: { Dashed: 1, LargeDashed: 2 },
+}));
+
+function makeSeries() {
+    return {
+        createPriceLine: mockCreatePriceLine,
+        removePriceLine: mockRemovePriceLine,
+    };
+}
+
+function makeSeriesRef(series: ReturnType<typeof makeSeries> | null = null) {
+    return { current: series } as Parameters<
+        typeof useActionRecommendationOverlay
+    >[0]['seriesRef'];
+}
+
+const BASE_ACTION_PRICES: ValidatedActionPrices = {
+    entryPrices: [150],
+    stopLoss: 140,
+    takeProfitPrices: [160, 170],
+};
+
+describe('useActionRecommendationOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('does nothing when seriesRef is null', () => {
+        renderHook(() =>
+            useActionRecommendationOverlay({
+                seriesRef: makeSeriesRef(null),
+                actionPrices: BASE_ACTION_PRICES,
+                isVisible: true,
+            })
+        );
+
+        expect(mockCreatePriceLine).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when isVisible is false', () => {
+        renderHook(() =>
+            useActionRecommendationOverlay({
+                seriesRef: makeSeriesRef(makeSeries()),
+                actionPrices: BASE_ACTION_PRICES,
+                isVisible: false,
+            })
+        );
+
+        expect(mockCreatePriceLine).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when actionPrices is undefined', () => {
+        renderHook(() =>
+            useActionRecommendationOverlay({
+                seriesRef: makeSeriesRef(makeSeries()),
+                actionPrices: undefined,
+                isVisible: true,
+            })
+        );
+
+        expect(mockCreatePriceLine).not.toHaveBeenCalled();
+    });
+
+    it('creates price lines for entry, stopLoss, and takeProfit', () => {
+        renderHook(() =>
+            useActionRecommendationOverlay({
+                seriesRef: makeSeriesRef(makeSeries()),
+                actionPrices: BASE_ACTION_PRICES,
+                isVisible: true,
+            })
+        );
+
+        // 1 entry + 1 stopLoss + 2 takeProfit = 4
+        expect(mockCreatePriceLine).toHaveBeenCalledTimes(4);
+    });
+
+    it('skips stopLoss line when stopLoss is undefined', () => {
+        const prices: ValidatedActionPrices = {
+            entryPrices: [150],
+            stopLoss: undefined,
+            takeProfitPrices: [160],
+        };
+
+        renderHook(() =>
+            useActionRecommendationOverlay({
+                seriesRef: makeSeriesRef(makeSeries()),
+                actionPrices: prices,
+                isVisible: true,
+            })
+        );
+
+        // 1 entry + 0 stopLoss + 1 takeProfit = 2
+        expect(mockCreatePriceLine).toHaveBeenCalledTimes(2);
+    });
+
+    it('creates reconciled price lines when reconciledPrices provided', () => {
+        renderHook(() =>
+            useActionRecommendationOverlay({
+                seriesRef: makeSeriesRef(makeSeries()),
+                actionPrices: BASE_ACTION_PRICES,
+                reconciledPrices: {
+                    stopLoss: 138,
+                    takeProfitPrices: [{ price: 162, index: 0, totalCount: 1 }],
+                },
+                isVisible: true,
+            })
+        );
+
+        // 1 entry + 1 stopLoss + 2 takeProfit + 1 reconciledSL + 1 reconciledTP = 6
+        expect(mockCreatePriceLine).toHaveBeenCalledTimes(6);
+    });
+
+    it('removes existing price lines on re-render', () => {
+        const series = makeSeries();
+        const { rerender } = renderHook(
+            ({ visible }) =>
+                useActionRecommendationOverlay({
+                    seriesRef: makeSeriesRef(series),
+                    actionPrices: BASE_ACTION_PRICES,
+                    isVisible: visible,
+                }),
+            { initialProps: { visible: true } }
+        );
+
+        rerender({ visible: false });
+
+        expect(mockRemovePriceLine).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useBollingerOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useBollingerOverlay.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useBollingerOverlay } from '../../hooks/useBollingerOverlay';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    AreaSeries: 'AreaSeries',
+    LineSeries: 'LineSeries',
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useBollingerOverlay
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = {
+    bollinger: [],
+} as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    bollinger: [{ upper: 110, middle: 100, lower: 90 }],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useBollingerOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns isVisible false initially', () => {
+        const { result } = renderHook(() =>
+            useBollingerOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('toggles isVisible when toggle is called', () => {
+        const { result } = renderHook(() =>
+            useBollingerOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+        expect(result.current.isVisible).toBe(true);
+
+        act(() => {
+            result.current.toggle();
+        });
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useBollingerOverlay({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates three series (upper, middle, lower) when visible and chart exists', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useBollingerOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockAddSeries).toHaveBeenCalledTimes(3);
+    });
+
+    it('removes series when toggled off', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useBollingerOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+
+    it('provides stable toggle function reference', () => {
+        const { result, rerender } = renderHook(() =>
+            useBollingerOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+
+        const firstToggle = result.current.toggle;
+        rerender();
+        expect(result.current.toggle).toBe(firstToggle);
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useCCIChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useCCIChart.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useCCIChart } from '../../hooks/useCCIChart';
+import { INACTIVE_PANE_INDEX } from '../../constants';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockCreatePriceLine = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+    createPriceLine: mockCreatePriceLine,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+    LineStyle: { Dashed: 1 },
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesDataFromValues: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<typeof useCCIChart>[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { cci: [] } as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    cci: [100, 50, -50, null],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useCCIChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns void (no return value)', () => {
+        const { result } = renderHook(() =>
+            useCCIChart({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useCCIChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('does not create series when isVisible is false', () => {
+        renderHook(() =>
+            useCCIChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates CCI series when visible with chart', () => {
+        renderHook(() =>
+            useCCIChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalled();
+    });
+
+    it('removes series when visibility turns off', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ visible, pane }) =>
+                useCCIChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: visible,
+                    paneIndex: pane,
+                }),
+            { initialProps: { visible: true, pane: 2 } }
+        );
+
+        rerender({ visible: false, pane: INACTIVE_PANE_INDEX });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useCandlePatternMarkers.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useCandlePatternMarkers.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import type { Bar } from '@y0ngha/siglens-core';
+import { useCandlePatternMarkers } from '../../hooks/useCandlePatternMarkers';
+
+const mockSetMarkers = vi.fn();
+const mockDetach = vi.fn();
+const mockCreateSeriesMarkers = vi.fn(
+    (_series: unknown, _markers: unknown) => ({
+        setMarkers: mockSetMarkers,
+        detach: mockDetach,
+    })
+);
+
+vi.mock('lightweight-charts', () => ({
+    createSeriesMarkers: (series: unknown, markers: unknown) =>
+        mockCreateSeriesMarkers(series, markers),
+}));
+
+vi.mock('@y0ngha/siglens-core', async () => ({
+    ...(await vi.importActual('@y0ngha/siglens-core')),
+    detectCandlePatternEntries: vi.fn(() => []),
+    getDetectionBars: vi.fn((bars: Bar[]) => bars),
+    selectLastCandlePatternEntries: vi.fn(() => []),
+    getCandlePatternLabel: vi.fn(() => 'Pattern'),
+    getMultiCandlePatternLabel: vi.fn(() => 'MultiPattern'),
+    getMultiPatternTrend: vi.fn(() => 'bullish'),
+    getSinglePatternTrend: vi.fn(() => 'bearish'),
+}));
+
+function makeSeriesRef(series: unknown = null) {
+    return { current: series } as Parameters<
+        typeof useCandlePatternMarkers
+    >[0]['seriesRef'];
+}
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+    { time: 2000, open: 105, high: 115, low: 95, close: 110, volume: 1200 },
+];
+
+describe('useCandlePatternMarkers', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns isVisible false initially', () => {
+        const { result } = renderHook(() =>
+            useCandlePatternMarkers({
+                seriesRef: makeSeriesRef(),
+                bars: [],
+            })
+        );
+
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('toggles isVisible', () => {
+        const { result } = renderHook(() =>
+            useCandlePatternMarkers({
+                seriesRef: makeSeriesRef(),
+                bars: [],
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+        expect(result.current.isVisible).toBe(true);
+    });
+
+    it('creates series markers plugin when seriesRef has value', () => {
+        renderHook(() =>
+            useCandlePatternMarkers({
+                seriesRef: makeSeriesRef({}),
+                bars: FAKE_BARS,
+            })
+        );
+
+        expect(mockCreateSeriesMarkers).toHaveBeenCalled();
+    });
+
+    it('does not create markers plugin when seriesRef is null', () => {
+        renderHook(() =>
+            useCandlePatternMarkers({
+                seriesRef: makeSeriesRef(null),
+                bars: FAKE_BARS,
+            })
+        );
+
+        expect(mockCreateSeriesMarkers).not.toHaveBeenCalled();
+    });
+
+    it('sets empty markers when not visible', () => {
+        renderHook(() =>
+            useCandlePatternMarkers({
+                seriesRef: makeSeriesRef({}),
+                bars: FAKE_BARS,
+            })
+        );
+
+        expect(mockSetMarkers).toHaveBeenCalledWith([]);
+    });
+
+    it('detaches plugin on unmount', () => {
+        const { unmount } = renderHook(() =>
+            useCandlePatternMarkers({
+                seriesRef: makeSeriesRef({}),
+                bars: FAKE_BARS,
+            })
+        );
+
+        unmount();
+
+        expect(mockDetach).toHaveBeenCalled();
+    });
+
+    it('provides stable toggle reference', () => {
+        const { result, rerender } = renderHook(() =>
+            useCandlePatternMarkers({
+                seriesRef: makeSeriesRef(),
+                bars: [],
+            })
+        );
+
+        const firstToggle = result.current.toggle;
+        rerender();
+        expect(result.current.toggle).toBe(firstToggle);
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useChartSync.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useChartSync.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { useChartSync } from '../../hooks/useChartSync';
+
+vi.mock('lightweight-charts', () => ({}));
+
+function makeMockChart() {
+    const ts = {
+        subscribeVisibleLogicalRangeChange: vi.fn(),
+        unsubscribeVisibleLogicalRangeChange: vi.fn(),
+        setVisibleLogicalRange: vi.fn(),
+    };
+    return {
+        timeScale: () => ts,
+        _timeScaleMock: ts,
+    };
+}
+
+describe('useChartSync', () => {
+    it('returns four handler functions', () => {
+        const { result } = renderHook(() => useChartSync());
+
+        expect(typeof result.current.handleStockChartReady).toBe('function');
+        expect(typeof result.current.handleStockChartRemove).toBe('function');
+        expect(typeof result.current.handleVolumeChartReady).toBe('function');
+        expect(typeof result.current.handleVolumeChartRemove).toBe('function');
+    });
+
+    it('provides stable handler references across re-renders', () => {
+        const { result, rerender } = renderHook(() => useChartSync());
+
+        const firstHandlers = { ...result.current };
+        rerender();
+
+        expect(result.current.handleStockChartReady).toBe(
+            firstHandlers.handleStockChartReady
+        );
+        expect(result.current.handleStockChartRemove).toBe(
+            firstHandlers.handleStockChartRemove
+        );
+        expect(result.current.handleVolumeChartReady).toBe(
+            firstHandlers.handleVolumeChartReady
+        );
+        expect(result.current.handleVolumeChartRemove).toBe(
+            firstHandlers.handleVolumeChartRemove
+        );
+    });
+
+    it('subscribes to visible range changes on stock chart ready', () => {
+        const { result } = renderHook(() => useChartSync());
+        const mockChart = makeMockChart();
+
+        result.current.handleStockChartReady(
+            mockChart as unknown as Parameters<
+                typeof result.current.handleStockChartReady
+            >[0]
+        );
+
+        expect(
+            mockChart._timeScaleMock.subscribeVisibleLogicalRangeChange
+        ).toHaveBeenCalled();
+    });
+
+    it('subscribes to visible range changes on volume chart ready', () => {
+        const { result } = renderHook(() => useChartSync());
+        const mockChart = makeMockChart();
+
+        result.current.handleVolumeChartReady(
+            mockChart as unknown as Parameters<
+                typeof result.current.handleVolumeChartReady
+            >[0]
+        );
+
+        expect(
+            mockChart._timeScaleMock.subscribeVisibleLogicalRangeChange
+        ).toHaveBeenCalled();
+    });
+
+    it('unsubscribes on stock chart remove', () => {
+        const { result } = renderHook(() => useChartSync());
+        const mockChart = makeMockChart();
+
+        result.current.handleStockChartReady(
+            mockChart as unknown as Parameters<
+                typeof result.current.handleStockChartReady
+            >[0]
+        );
+        result.current.handleStockChartRemove();
+
+        expect(
+            mockChart._timeScaleMock.unsubscribeVisibleLogicalRangeChange
+        ).toHaveBeenCalled();
+    });
+
+    it('unsubscribes on volume chart remove', () => {
+        const { result } = renderHook(() => useChartSync());
+        const mockChart = makeMockChart();
+
+        result.current.handleVolumeChartReady(
+            mockChart as unknown as Parameters<
+                typeof result.current.handleVolumeChartReady
+            >[0]
+        );
+        result.current.handleVolumeChartRemove();
+
+        expect(
+            mockChart._timeScaleMock.unsubscribeVisibleLogicalRangeChange
+        ).toHaveBeenCalled();
+    });
+
+    it('does not throw when removing chart before ready', () => {
+        const { result } = renderHook(() => useChartSync());
+
+        expect(() => result.current.handleStockChartRemove()).not.toThrow();
+        expect(() => result.current.handleVolumeChartRemove()).not.toThrow();
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useDMIChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useDMIChart.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useDMIChart } from '../../hooks/useDMIChart';
+import { INACTIVE_PANE_INDEX } from '../../constants';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<typeof useDMIChart>[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { dmi: [] } as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    dmi: [{ diPlus: 25, diMinus: 15, adx: 30 }],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useDMIChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns void', () => {
+        const { result } = renderHook(() =>
+            useDMIChart({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useDMIChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('does not create series when not visible', () => {
+        renderHook(() =>
+            useDMIChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates three series (+DI, -DI, ADX) when visible', () => {
+        renderHook(() =>
+            useDMIChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalledTimes(3);
+    });
+
+    it('removes series when visibility turns off', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ visible, pane }) =>
+                useDMIChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: visible,
+                    paneIndex: pane,
+                }),
+            { initialProps: { visible: true, pane: 2 } }
+        );
+
+        rerender({ visible: false, pane: INACTIVE_PANE_INDEX });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useEMAOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useEMAOverlay.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useEMAOverlay } from '../../hooks/useEMAOverlay';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+    LineStyle: { Dotted: 2, Solid: 0 },
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesDataFromValues: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useEMAOverlay
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const INDICATORS = {
+    ema: { 20: [100, 101], 50: [98, 99] },
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useEMAOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns empty visiblePeriods by default', () => {
+        const { result } = renderHook(() =>
+            useEMAOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: INDICATORS,
+            })
+        );
+
+        expect(result.current.visiblePeriods).toEqual([]);
+    });
+
+    it('returns default periods when provided', () => {
+        const { result } = renderHook(() =>
+            useEMAOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: INDICATORS,
+                defaultPeriods: [20, 50],
+            })
+        );
+
+        expect(result.current.visiblePeriods).toEqual([20, 50]);
+    });
+
+    it('toggles a period on and off', () => {
+        const { result } = renderHook(() =>
+            useEMAOverlay({
+                chartRef: makeChartRef(),
+                bars: FAKE_BARS,
+                indicators: INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.togglePeriod(20);
+        });
+        expect(result.current.visiblePeriods).toContain(20);
+
+        act(() => {
+            result.current.togglePeriod(20);
+        });
+        expect(result.current.visiblePeriods).not.toContain(20);
+    });
+
+    it('creates series for visible periods when chart exists', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useEMAOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.togglePeriod(20);
+        });
+
+        expect(mockAddSeries).toHaveBeenCalled();
+    });
+
+    it('removes series when period toggled off', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useEMAOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.togglePeriod(20);
+        });
+        act(() => {
+            result.current.togglePeriod(20);
+        });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useIchimokuOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useIchimokuOverlay.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useIchimokuOverlay } from '../../hooks/useIchimokuOverlay';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    AreaSeries: 'AreaSeries',
+    LineSeries: 'LineSeries',
+    LineStyle: { Dashed: 1 },
+}));
+
+vi.mock('@y0ngha/siglens-core', async () => ({
+    ...(await vi.importActual('@y0ngha/siglens-core')),
+    calculateIchimokuFutureCloud: vi.fn(() => []),
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesData: vi.fn(() => []),
+}));
+
+vi.mock('../../utils/ichimokuUtils', () => ({
+    buildCloudData: vi.fn(() => []),
+    extendWithFutureCloud: vi.fn((_bars, _cloud, base) => ({
+        finalSenkouA: base.senkouAData,
+        finalSenkouB: base.senkouBData,
+        finalCloudBullish: base.cloudBullishData,
+        finalCloudBearish: base.cloudBearishData,
+    })),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useIchimokuOverlay
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { ichimoku: [] } as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    ichimoku: [
+        {
+            tenkan: 100,
+            kijun: 99,
+            chikou: 98,
+            senkouA: 101,
+            senkouB: 97,
+        },
+    ],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+    { time: 2000, open: 105, high: 115, low: 95, close: 110, volume: 1200 },
+];
+
+describe('useIchimokuOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns isVisible false initially', () => {
+        const { result } = renderHook(() =>
+            useIchimokuOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('toggles visibility', () => {
+        const { result } = renderHook(() =>
+            useIchimokuOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+        expect(result.current.isVisible).toBe(true);
+
+        act(() => {
+            result.current.toggle();
+        });
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useIchimokuOverlay({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates seven series when visible (5 lines + 2 cloud areas)', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useIchimokuOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockAddSeries).toHaveBeenCalledTimes(7);
+    });
+
+    it('removes series when toggled off', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useIchimokuOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+
+    it('provides stable toggle reference', () => {
+        const { result, rerender } = renderHook(() =>
+            useIchimokuOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+
+        const firstToggle = result.current.toggle;
+        rerender();
+        expect(result.current.toggle).toBe(firstToggle);
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useIndicatorDropdown.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useIndicatorDropdown.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { useIndicatorDropdown } from '../../hooks/useIndicatorDropdown';
+
+vi.mock('@/shared/hooks/useOnClickOutside', () => ({
+    useOnClickOutside: vi.fn(),
+}));
+
+describe('useIndicatorDropdown', () => {
+    it('returns isExpanded false initially', () => {
+        const { result } = renderHook(() => useIndicatorDropdown());
+
+        expect(result.current.isExpanded).toBe(false);
+    });
+
+    it('returns openDropdown null initially', () => {
+        const { result } = renderHook(() => useIndicatorDropdown());
+
+        expect(result.current.openDropdown).toBeNull();
+    });
+
+    it('returns dropdownPosition null initially', () => {
+        const { result } = renderHook(() => useIndicatorDropdown());
+
+        expect(result.current.dropdownPosition).toBeNull();
+    });
+
+    it('provides toolbarRef, portalRef, and buttonRefs', () => {
+        const { result } = renderHook(() => useIndicatorDropdown());
+
+        expect(result.current.toolbarRef).toBeDefined();
+        expect(result.current.portalRef).toBeDefined();
+        expect(result.current.buttonRefs.ma).toBeDefined();
+        expect(result.current.buttonRefs.ema).toBeDefined();
+    });
+
+    it('toggles expanded state', () => {
+        const { result } = renderHook(() => useIndicatorDropdown());
+
+        act(() => {
+            result.current.toggleExpanded();
+        });
+        expect(result.current.isExpanded).toBe(true);
+
+        act(() => {
+            result.current.toggleExpanded();
+        });
+        expect(result.current.isExpanded).toBe(false);
+    });
+
+    it('closes open dropdown when toggling expanded', () => {
+        const { result } = renderHook(() => useIndicatorDropdown());
+
+        act(() => {
+            result.current.toggleExpanded();
+        });
+
+        // Simulate that a button rect exists by mocking getBoundingClientRect
+        const button = document.createElement('button');
+        button.getBoundingClientRect = vi.fn(() => ({
+            top: 100,
+            left: 200,
+            bottom: 120,
+            right: 280,
+            width: 80,
+            height: 20,
+            x: 200,
+            y: 100,
+            toJSON: vi.fn(),
+        }));
+        Object.defineProperty(result.current.buttonRefs.ma, 'current', {
+            value: button,
+            writable: true,
+        });
+
+        act(() => {
+            result.current.toggleDropdown('ma');
+        });
+
+        act(() => {
+            result.current.toggleExpanded();
+        });
+
+        expect(result.current.openDropdown).toBeNull();
+    });
+
+    it('returns stable buttonRefs across re-renders', () => {
+        const { result, rerender } = renderHook(() => useIndicatorDropdown());
+
+        const firstRefs = result.current.buttonRefs;
+        rerender();
+        expect(result.current.buttonRefs).toBe(firstRefs);
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useIndicatorVisibility.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useIndicatorVisibility.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { useIndicatorVisibility } from '../../hooks/useIndicatorVisibility';
+import {
+    FIRST_INDICATOR_PANE_INDEX,
+    INACTIVE_PANE_INDEX,
+} from '../../constants';
+
+describe('useIndicatorVisibility', () => {
+    it('returns all indicators hidden initially', () => {
+        const { result } = renderHook(() => useIndicatorVisibility());
+
+        expect(result.current.rsiVisible).toBe(false);
+        expect(result.current.macdVisible).toBe(false);
+        expect(result.current.dmiVisible).toBe(false);
+        expect(result.current.stochasticVisible).toBe(false);
+        expect(result.current.stochRsiVisible).toBe(false);
+        expect(result.current.cciVisible).toBe(false);
+    });
+
+    it('sets all paneIndices to inactive when no indicators visible', () => {
+        const { result } = renderHook(() => useIndicatorVisibility());
+
+        expect(result.current.paneIndices.rsi).toBe(INACTIVE_PANE_INDEX);
+        expect(result.current.paneIndices.macd).toBe(INACTIVE_PANE_INDEX);
+        expect(result.current.paneIndices.dmi).toBe(INACTIVE_PANE_INDEX);
+        expect(result.current.paneIndices.stochastic).toBe(INACTIVE_PANE_INDEX);
+        expect(result.current.paneIndices.stochRsi).toBe(INACTIVE_PANE_INDEX);
+        expect(result.current.paneIndices.cci).toBe(INACTIVE_PANE_INDEX);
+    });
+
+    it('toggles RSI and assigns first pane index', () => {
+        const { result } = renderHook(() => useIndicatorVisibility());
+
+        act(() => {
+            result.current.toggleRSI();
+        });
+
+        expect(result.current.rsiVisible).toBe(true);
+        expect(result.current.paneIndices.rsi).toBe(FIRST_INDICATOR_PANE_INDEX);
+    });
+
+    it('assigns sequential pane indices for multiple active indicators', () => {
+        const { result } = renderHook(() => useIndicatorVisibility());
+
+        act(() => {
+            result.current.toggleRSI();
+        });
+        act(() => {
+            result.current.toggleMACD();
+        });
+
+        expect(result.current.paneIndices.rsi).toBe(FIRST_INDICATOR_PANE_INDEX);
+        expect(result.current.paneIndices.macd).toBe(
+            FIRST_INDICATOR_PANE_INDEX + 1
+        );
+    });
+
+    it('recalculates pane indices when an indicator is toggled off', () => {
+        const { result } = renderHook(() => useIndicatorVisibility());
+
+        act(() => {
+            result.current.toggleRSI();
+        });
+        act(() => {
+            result.current.toggleMACD();
+        });
+        act(() => {
+            result.current.toggleDMI();
+        });
+
+        act(() => {
+            result.current.toggleRSI();
+        });
+
+        expect(result.current.paneIndices.rsi).toBe(INACTIVE_PANE_INDEX);
+        expect(result.current.paneIndices.macd).toBe(
+            FIRST_INDICATOR_PANE_INDEX
+        );
+        expect(result.current.paneIndices.dmi).toBe(
+            FIRST_INDICATOR_PANE_INDEX + 1
+        );
+    });
+
+    it('toggles all six indicators', () => {
+        const { result } = renderHook(() => useIndicatorVisibility());
+
+        act(() => {
+            result.current.toggleRSI();
+            result.current.toggleMACD();
+            result.current.toggleDMI();
+            result.current.toggleStochastic();
+            result.current.toggleStochRSI();
+            result.current.toggleCCI();
+        });
+
+        expect(result.current.rsiVisible).toBe(true);
+        expect(result.current.macdVisible).toBe(true);
+        expect(result.current.dmiVisible).toBe(true);
+        expect(result.current.stochasticVisible).toBe(true);
+        expect(result.current.stochRsiVisible).toBe(true);
+        expect(result.current.cciVisible).toBe(true);
+
+        expect(result.current.paneIndices.cci).toBe(
+            FIRST_INDICATOR_PANE_INDEX + 5
+        );
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useMACDChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useMACDChart.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useMACDChart } from '../../hooks/useMACDChart';
+import { INACTIVE_PANE_INDEX } from '../../constants';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    HistogramSeries: 'HistogramSeries',
+    LineSeries: 'LineSeries',
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<typeof useMACDChart>[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { macd: [] } as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    macd: [{ macdLine: 1.5, signalLine: 1.2, histogram: 0.3 }],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useMACDChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns void', () => {
+        const { result } = renderHook(() =>
+            useMACDChart({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useMACDChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('does not create series when not visible', () => {
+        renderHook(() =>
+            useMACDChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates three series (macdLine, signalLine, histogram) when visible', () => {
+        renderHook(() =>
+            useMACDChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalledTimes(3);
+    });
+
+    it('removes series when visibility turns off', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ visible, pane }) =>
+                useMACDChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: visible,
+                    paneIndex: pane,
+                }),
+            { initialProps: { visible: true, pane: 2 } }
+        );
+
+        rerender({ visible: false, pane: INACTIVE_PANE_INDEX });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useMAOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useMAOverlay.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useMAOverlay } from '../../hooks/useMAOverlay';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+    LineStyle: { Solid: 0, Dotted: 2 },
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesDataFromValues: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<typeof useMAOverlay>[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const INDICATORS = {
+    ma: { 20: [100, 101, 102], 50: [98, 99, 100] },
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useMAOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns empty visiblePeriods by default', () => {
+        const { result } = renderHook(() =>
+            useMAOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: INDICATORS,
+            })
+        );
+
+        expect(result.current.visiblePeriods).toEqual([]);
+    });
+
+    it('returns provided default periods', () => {
+        const { result } = renderHook(() =>
+            useMAOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: INDICATORS,
+                defaultPeriods: [20],
+            })
+        );
+
+        expect(result.current.visiblePeriods).toEqual([20]);
+    });
+
+    it('toggles a period', () => {
+        const { result } = renderHook(() =>
+            useMAOverlay({
+                chartRef: makeChartRef(),
+                bars: FAKE_BARS,
+                indicators: INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.togglePeriod(50);
+        });
+        expect(result.current.visiblePeriods).toContain(50);
+
+        act(() => {
+            result.current.togglePeriod(50);
+        });
+        expect(result.current.visiblePeriods).not.toContain(50);
+    });
+
+    it('creates series for each visible period', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useMAOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.togglePeriod(20);
+        });
+        act(() => {
+            result.current.togglePeriod(50);
+        });
+
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes series when period toggled off', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useMAOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.togglePeriod(20);
+        });
+        act(() => {
+            result.current.togglePeriod(20);
+        });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+
+    it('provides stable togglePeriod reference', () => {
+        const { result, rerender } = renderHook(() =>
+            useMAOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: INDICATORS,
+            })
+        );
+
+        const firstToggle = result.current.togglePeriod;
+        rerender();
+        expect(result.current.togglePeriod).toBe(firstToggle);
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useMovingAverageOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useMovingAverageOverlay.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import type { IndicatorDataAccessor } from '../../hooks/useMovingAverageOverlay';
+import { useMovingAverageOverlay } from '../../hooks/useMovingAverageOverlay';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+    LineStyle: { Solid: 0, Dotted: 2 },
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesDataFromValues: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useMovingAverageOverlay
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const mockAccessor: IndicatorDataAccessor = vi.fn(
+    (indicators: IndicatorResult, period: number) =>
+        (indicators.ma as Record<number, (number | null)[]>)[period]
+);
+
+const INDICATORS = {
+    ma: { 10: [50, 51], 20: [100, 101] },
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+    { time: 2000, open: 105, high: 115, low: 95, close: 110, volume: 1200 },
+];
+
+describe('useMovingAverageOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns empty visiblePeriods by default', () => {
+        const { result } = renderHook(() =>
+            useMovingAverageOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: INDICATORS,
+                lineStyle: 0,
+                getIndicatorData: mockAccessor,
+            })
+        );
+
+        expect(result.current.visiblePeriods).toEqual([]);
+    });
+
+    it('respects defaultPeriods', () => {
+        const { result } = renderHook(() =>
+            useMovingAverageOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: INDICATORS,
+                defaultPeriods: [10, 20],
+                lineStyle: 0,
+                getIndicatorData: mockAccessor,
+            })
+        );
+
+        expect(result.current.visiblePeriods).toEqual([10, 20]);
+    });
+
+    it('togglePeriod adds and removes periods', () => {
+        const { result } = renderHook(() =>
+            useMovingAverageOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: INDICATORS,
+                lineStyle: 0,
+                getIndicatorData: mockAccessor,
+            })
+        );
+
+        act(() => {
+            result.current.togglePeriod(10);
+        });
+        expect(result.current.visiblePeriods).toEqual([10]);
+
+        act(() => {
+            result.current.togglePeriod(20);
+        });
+        expect(result.current.visiblePeriods).toEqual([10, 20]);
+
+        act(() => {
+            result.current.togglePeriod(10);
+        });
+        expect(result.current.visiblePeriods).toEqual([20]);
+    });
+
+    it('creates line series for each visible period when chart exists', () => {
+        const chart = makeChart();
+        renderHook(() =>
+            useMovingAverageOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: INDICATORS,
+                defaultPeriods: [10, 20],
+                lineStyle: 0,
+                getIndicatorData: mockAccessor,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useMovingAverageOverlay({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: INDICATORS,
+                defaultPeriods: [10],
+                lineStyle: 0,
+                getIndicatorData: mockAccessor,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('removes series when period is toggled off', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useMovingAverageOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: INDICATORS,
+                defaultPeriods: [10],
+                lineStyle: 0,
+                getIndicatorData: mockAccessor,
+            })
+        );
+
+        act(() => {
+            result.current.togglePeriod(10);
+        });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+
+    it('provides stable togglePeriod reference', () => {
+        const { result, rerender } = renderHook(() =>
+            useMovingAverageOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: INDICATORS,
+                lineStyle: 0,
+                getIndicatorData: mockAccessor,
+            })
+        );
+
+        const firstToggle = result.current.togglePeriod;
+        rerender();
+        expect(result.current.togglePeriod).toBe(firstToggle);
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useOverlayGroups.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useOverlayGroups.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { OverlayLegendItem } from '../../types';
+import { useOverlayGroups } from '../../hooks/useOverlayGroups';
+
+describe('useOverlayGroups', () => {
+    it('returns empty array for empty items', () => {
+        const { result } = renderHook(() => useOverlayGroups([]));
+
+        expect(result.current).toEqual([]);
+    });
+
+    it('groups MA items together', () => {
+        const items: OverlayLegendItem[] = [
+            { name: 'MA(20)', color: '#eab308', value: 100 },
+            { name: 'MA(50)', color: '#22c55e', value: 98 },
+        ];
+
+        const { result } = renderHook(() => useOverlayGroups(items));
+
+        expect(result.current).toHaveLength(1);
+        expect(result.current[0].key).toBe('MA');
+        expect(result.current[0].items).toHaveLength(2);
+    });
+
+    it('groups EMA items together', () => {
+        const items: OverlayLegendItem[] = [
+            { name: 'EMA(20)', color: '#eab308', value: 100 },
+            { name: 'EMA(50)', color: '#22c55e', value: 99 },
+        ];
+
+        const { result } = renderHook(() => useOverlayGroups(items));
+
+        expect(result.current).toHaveLength(1);
+        expect(result.current[0].key).toBe('EMA');
+    });
+
+    it('groups Bollinger Band items together', () => {
+        const items: OverlayLegendItem[] = [
+            { name: 'BB Upper', color: '#818cf8', value: 110 },
+            { name: 'BB Middle', color: '#94a3b8', value: 100 },
+            { name: 'BB Lower', color: '#818cf8', value: 90 },
+        ];
+
+        const { result } = renderHook(() => useOverlayGroups(items));
+
+        expect(result.current).toHaveLength(1);
+        expect(result.current[0].key).toBe('BB');
+        expect(result.current[0].items).toHaveLength(3);
+    });
+
+    it('groups Ichimoku items together', () => {
+        const items: OverlayLegendItem[] = [
+            { name: 'Tenkan', color: '#f00', value: 100 },
+            { name: 'Kijun', color: '#0f0', value: 99 },
+            { name: 'Senkou A', color: '#00f', value: 101 },
+        ];
+
+        const { result } = renderHook(() => useOverlayGroups(items));
+
+        expect(result.current).toHaveLength(1);
+        expect(result.current[0].key).toBe('Ichimoku');
+    });
+
+    it('groups VP items together', () => {
+        const items: OverlayLegendItem[] = [
+            { name: 'POC', color: '#f00', value: 100 },
+            { name: 'VAH', color: '#0f0', value: 110 },
+            { name: 'VAL', color: '#00f', value: 90 },
+        ];
+
+        const { result } = renderHook(() => useOverlayGroups(items));
+
+        expect(result.current).toHaveLength(1);
+        expect(result.current[0].key).toBe('VP');
+    });
+
+    it('creates separate groups for different overlay types', () => {
+        const items: OverlayLegendItem[] = [
+            { name: 'MA(20)', color: '#eab308', value: 100 },
+            { name: 'EMA(20)', color: '#eab308', value: 101 },
+            { name: 'BB Upper', color: '#818cf8', value: 110 },
+        ];
+
+        const { result } = renderHook(() => useOverlayGroups(items));
+
+        expect(result.current).toHaveLength(3);
+        expect(result.current.map(g => g.key)).toEqual(['MA', 'EMA', 'BB']);
+    });
+
+    it('returns memoized result for same input', () => {
+        const items: OverlayLegendItem[] = [
+            { name: 'MA(20)', color: '#eab308', value: 100 },
+        ];
+
+        const { result, rerender } = renderHook(() => useOverlayGroups(items));
+
+        const firstResult = result.current;
+        rerender();
+        expect(result.current).toBe(firstResult);
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useOverlayLegend.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useOverlayLegend.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useOverlayLegend } from '../../hooks/useOverlayLegend';
+import type { OverlayLabelConfig } from '../../utils/overlayLabelUtils';
+
+const mockSubscribeCrosshairMove = vi.fn();
+const mockUnsubscribeCrosshairMove = vi.fn();
+
+vi.mock('lightweight-charts', () => ({}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useOverlayLegend
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return {
+        subscribeCrosshairMove: mockSubscribeCrosshairMove,
+        unsubscribeCrosshairMove: mockUnsubscribeCrosshairMove,
+    };
+}
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+    { time: 2000, open: 105, high: 115, low: 95, close: 110, volume: 1200 },
+];
+
+const INDICATORS = {
+    ma: { 20: [100, 101] },
+} as unknown as IndicatorResult;
+
+const LABEL_CONFIGS: OverlayLabelConfig[] = [
+    {
+        name: 'MA(20)',
+        color: '#eab308',
+        getValue: (ind: IndicatorResult, i: number): number | null =>
+            (ind.ma as Record<number, (number | null)[]>)[20]?.[i] ?? null,
+    },
+];
+
+describe('useOverlayLegend', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns legend items with null values when bars are empty', () => {
+        const { result } = renderHook(() =>
+            useOverlayLegend({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: INDICATORS,
+                labelConfigs: LABEL_CONFIGS,
+            })
+        );
+
+        expect(result.current).toHaveLength(1);
+        expect(result.current[0].value).toBeNull();
+    });
+
+    it('returns legend items with last bar values by default', () => {
+        const { result } = renderHook(() =>
+            useOverlayLegend({
+                chartRef: makeChartRef(),
+                bars: FAKE_BARS,
+                indicators: INDICATORS,
+                labelConfigs: LABEL_CONFIGS,
+            })
+        );
+
+        expect(result.current).toHaveLength(1);
+        expect(result.current[0].name).toBe('MA(20)');
+        expect(result.current[0].value).toBe(101);
+    });
+
+    it('returns empty array when no label configs provided', () => {
+        const { result } = renderHook(() =>
+            useOverlayLegend({
+                chartRef: makeChartRef(),
+                bars: FAKE_BARS,
+                indicators: INDICATORS,
+                labelConfigs: [],
+            })
+        );
+
+        expect(result.current).toEqual([]);
+    });
+
+    it('subscribes to crosshair move when chart exists', () => {
+        renderHook(() =>
+            useOverlayLegend({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: INDICATORS,
+                labelConfigs: LABEL_CONFIGS,
+            })
+        );
+
+        expect(mockSubscribeCrosshairMove).toHaveBeenCalled();
+    });
+
+    it('does not subscribe when chart is null', () => {
+        renderHook(() =>
+            useOverlayLegend({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: INDICATORS,
+                labelConfigs: LABEL_CONFIGS,
+            })
+        );
+
+        expect(mockSubscribeCrosshairMove).not.toHaveBeenCalled();
+    });
+
+    it('unsubscribes on unmount', () => {
+        const { unmount } = renderHook(() =>
+            useOverlayLegend({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: INDICATORS,
+                labelConfigs: LABEL_CONFIGS,
+            })
+        );
+
+        unmount();
+
+        expect(mockUnsubscribeCrosshairMove).toHaveBeenCalled();
+    });
+
+    it('preserves color from label config', () => {
+        const { result } = renderHook(() =>
+            useOverlayLegend({
+                chartRef: makeChartRef(),
+                bars: FAKE_BARS,
+                indicators: INDICATORS,
+                labelConfigs: LABEL_CONFIGS,
+            })
+        );
+
+        expect(result.current[0].color).toBe('#eab308');
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/usePaneLabels.test.ts
+++ b/src/widgets/chart/__tests__/hooks/usePaneLabels.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { PaneLabelConfig } from '../../types';
+import { usePaneLabels } from '../../hooks/usePaneLabels';
+
+vi.mock('lightweight-charts', () => ({}));
+
+const mockObserve = vi.fn();
+const mockDisconnect = vi.fn();
+
+class MockResizeObserver {
+    observe = mockObserve;
+    unobserve = vi.fn();
+    disconnect = mockDisconnect;
+}
+
+vi.stubGlobal('ResizeObserver', MockResizeObserver);
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof usePaneLabels
+    >[0]['chartRef'];
+}
+
+function makeContainerRef(container: HTMLDivElement | null = null) {
+    return { current: container } as Parameters<
+        typeof usePaneLabels
+    >[0]['containerRef'];
+}
+
+function makeChart() {
+    return {
+        panes: vi.fn(() => [
+            { getHeight: () => 200 },
+            { getHeight: () => 100 },
+        ]),
+    };
+}
+
+const LABELS: PaneLabelConfig[] = [
+    {
+        paneIndex: 1,
+        subLabels: [{ name: 'RSI', color: '#a78bfa' }],
+    },
+];
+
+describe('usePaneLabels', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns void', () => {
+        const { result } = renderHook(() =>
+            usePaneLabels({
+                chartRef: makeChartRef(),
+                containerRef: makeContainerRef(),
+                labels: [],
+            })
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('does nothing when container is null', () => {
+        const chart = makeChart();
+        renderHook(() =>
+            usePaneLabels({
+                chartRef: makeChartRef(chart),
+                containerRef: makeContainerRef(null),
+                labels: LABELS,
+            })
+        );
+
+        expect(chart.panes).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when chart is null', () => {
+        const container = document.createElement('div');
+        renderHook(() =>
+            usePaneLabels({
+                chartRef: makeChartRef(null),
+                containerRef: makeContainerRef(container),
+                labels: LABELS,
+            })
+        );
+
+        expect(
+            container.querySelectorAll('.pane-indicator-label')
+        ).toHaveLength(0);
+    });
+
+    it('does nothing when labels array is empty', () => {
+        const container = document.createElement('div');
+        const chart = makeChart();
+
+        renderHook(() =>
+            usePaneLabels({
+                chartRef: makeChartRef(chart),
+                containerRef: makeContainerRef(container),
+                labels: [],
+            })
+        );
+
+        expect(
+            container.querySelectorAll('.pane-indicator-label')
+        ).toHaveLength(0);
+    });
+
+    it('creates label elements in the container', () => {
+        const container = document.createElement('div');
+        const chart = makeChart();
+
+        renderHook(() =>
+            usePaneLabels({
+                chartRef: makeChartRef(chart),
+                containerRef: makeContainerRef(container),
+                labels: LABELS,
+            })
+        );
+
+        const labels = container.querySelectorAll('.pane-indicator-label');
+        expect(labels).toHaveLength(1);
+    });
+
+    it('creates sub-label spans with correct text', () => {
+        const container = document.createElement('div');
+        const chart = makeChart();
+
+        renderHook(() =>
+            usePaneLabels({
+                chartRef: makeChartRef(chart),
+                containerRef: makeContainerRef(container),
+                labels: LABELS,
+            })
+        );
+
+        const spans = container.querySelectorAll('.pane-indicator-label span');
+        expect(spans).toHaveLength(1);
+        expect(spans[0].textContent).toContain('RSI');
+    });
+
+    it('cleans up labels on unmount', () => {
+        const container = document.createElement('div');
+        const chart = makeChart();
+
+        const { unmount } = renderHook(() =>
+            usePaneLabels({
+                chartRef: makeChartRef(chart),
+                containerRef: makeContainerRef(container),
+                labels: LABELS,
+            })
+        );
+
+        unmount();
+
+        expect(
+            container.querySelectorAll('.pane-indicator-label')
+        ).toHaveLength(0);
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useRSIChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useRSIChart.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useRSIChart } from '../../hooks/useRSIChart';
+import { INACTIVE_PANE_INDEX } from '../../constants';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockCreatePriceLine = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+    createPriceLine: mockCreatePriceLine,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+    LineStyle: { Dashed: 1 },
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesDataFromValues: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<typeof useRSIChart>[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { rsi: [] } as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    rsi: [null, null, 55, 60, 70],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useRSIChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns void', () => {
+        const { result } = renderHook(() =>
+            useRSIChart({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useRSIChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('does not create series when not visible', () => {
+        renderHook(() =>
+            useRSIChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates RSI series when visible with chart', () => {
+        renderHook(() =>
+            useRSIChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalled();
+    });
+
+    it('removes series when visibility turns off', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ visible, pane }) =>
+                useRSIChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: visible,
+                    paneIndex: pane,
+                }),
+            { initialProps: { visible: true, pane: 2 } }
+        );
+
+        rerender({ visible: false, pane: INACTIVE_PANE_INDEX });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useStochRSIChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useStochRSIChart.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useStochRSIChart } from '../../hooks/useStochRSIChart';
+import { INACTIVE_PANE_INDEX } from '../../constants';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockCreatePriceLine = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+    createPriceLine: mockCreatePriceLine,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+    LineStyle: { Dashed: 1 },
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useStochRSIChart
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { stochRsi: [] } as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    stochRsi: [{ k: 0.8, d: 0.75 }],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useStochRSIChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns void', () => {
+        const { result } = renderHook(() =>
+            useStochRSIChart({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useStochRSIChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('does not create series when not visible', () => {
+        renderHook(() =>
+            useStochRSIChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates two series (K and D) when visible', () => {
+        renderHook(() =>
+            useStochRSIChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes series when visibility turns off', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ visible, pane }) =>
+                useStochRSIChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: visible,
+                    paneIndex: pane,
+                }),
+            { initialProps: { visible: true, pane: 2 } }
+        );
+
+        rerender({ visible: false, pane: INACTIVE_PANE_INDEX });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useStochasticChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useStochasticChart.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useStochasticChart } from '../../hooks/useStochasticChart';
+import { INACTIVE_PANE_INDEX } from '../../constants';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockCreatePriceLine = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+    createPriceLine: mockCreatePriceLine,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+    LineStyle: { Dashed: 1 },
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useStochasticChart
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { stochastic: [] } as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    stochastic: [{ percentK: 80, percentD: 75 }],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useStochasticChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns void', () => {
+        const { result } = renderHook(() =>
+            useStochasticChart({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useStochasticChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('does not create series when not visible', () => {
+        renderHook(() =>
+            useStochasticChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates two series (%K and %D) when visible', () => {
+        renderHook(() =>
+            useStochasticChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes series when visibility turns off', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ visible, pane }) =>
+                useStochasticChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: visible,
+                    paneIndex: pane,
+                }),
+            { initialProps: { visible: true, pane: 2 } }
+        );
+
+        rerender({ visible: false, pane: INACTIVE_PANE_INDEX });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useVolumeChartData.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useVolumeChartData.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, BuySellVolumeResult } from '@y0ngha/siglens-core';
+import { useVolumeChartData } from '../../hooks/useVolumeChartData';
+
+const mockTotalSetData = vi.fn();
+const mockBuySetData = vi.fn();
+const mockFitContent = vi.fn();
+
+vi.mock('lightweight-charts', () => ({}));
+
+function makeRefs(hasRefs: boolean) {
+    const chart = hasRefs
+        ? { timeScale: () => ({ fitContent: mockFitContent }) }
+        : null;
+    const totalSeries = hasRefs ? { setData: mockTotalSetData } : null;
+    const buySeries = hasRefs ? { setData: mockBuySetData } : null;
+
+    return {
+        chartRef: { current: chart } as Parameters<
+            typeof useVolumeChartData
+        >[0]['chartRef'],
+        totalSeriesRef: { current: totalSeries } as Parameters<
+            typeof useVolumeChartData
+        >[0]['totalSeriesRef'],
+        buySeriesRef: { current: buySeries } as Parameters<
+            typeof useVolumeChartData
+        >[0]['buySeriesRef'],
+    };
+}
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 5000 },
+    { time: 2000, open: 105, high: 115, low: 95, close: 110, volume: 6000 },
+];
+
+const FAKE_BUY_SELL: BuySellVolumeResult[] = [
+    { buyVolume: 3000, sellVolume: 2000 },
+    { buyVolume: 4000, sellVolume: 2000 },
+];
+
+describe('useVolumeChartData', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns void', () => {
+        const refs = makeRefs(false);
+        const { result } = renderHook(() =>
+            useVolumeChartData({
+                ...refs,
+                bars: [],
+                buySellVolume: [],
+            })
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('does nothing when refs are null', () => {
+        const refs = makeRefs(false);
+        renderHook(() =>
+            useVolumeChartData({
+                ...refs,
+                bars: FAKE_BARS,
+                buySellVolume: FAKE_BUY_SELL,
+            })
+        );
+
+        expect(mockTotalSetData).not.toHaveBeenCalled();
+        expect(mockBuySetData).not.toHaveBeenCalled();
+    });
+
+    it('sets empty data when bars are empty', () => {
+        const refs = makeRefs(true);
+        renderHook(() =>
+            useVolumeChartData({
+                ...refs,
+                bars: [],
+                buySellVolume: [],
+            })
+        );
+
+        expect(mockTotalSetData).toHaveBeenCalledWith([]);
+        expect(mockBuySetData).toHaveBeenCalledWith([]);
+    });
+
+    it('sets volume data and calls fitContent with valid bars', () => {
+        const refs = makeRefs(true);
+        renderHook(() =>
+            useVolumeChartData({
+                ...refs,
+                bars: FAKE_BARS,
+                buySellVolume: FAKE_BUY_SELL,
+            })
+        );
+
+        expect(mockTotalSetData).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({ time: 1000, value: 5000 }),
+            ])
+        );
+        expect(mockBuySetData).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({ time: 1000, value: 3000 }),
+            ])
+        );
+        expect(mockFitContent).toHaveBeenCalled();
+    });
+
+    it('sets empty data when buySellVolume is empty but bars exist', () => {
+        const refs = makeRefs(true);
+        renderHook(() =>
+            useVolumeChartData({
+                ...refs,
+                bars: FAKE_BARS,
+                buySellVolume: [],
+            })
+        );
+
+        expect(mockTotalSetData).toHaveBeenCalledWith([]);
+        expect(mockBuySetData).toHaveBeenCalledWith([]);
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useVolumeChartLifecycle.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useVolumeChartLifecycle.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { useVolumeChartLifecycle } from '../../hooks/useVolumeChartLifecycle';
+
+const mockAddSeries = vi.fn(() => ({}));
+const mockRemove = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockFitContent = vi.fn();
+const mockCreateChart = vi.fn((_container: unknown, _options: unknown) => ({
+    addSeries: mockAddSeries,
+    remove: mockRemove,
+    applyOptions: mockApplyOptions,
+    timeScale: () => ({ fitContent: mockFitContent }),
+}));
+
+vi.mock('lightweight-charts', () => ({
+    createChart: (container: unknown, options: unknown) =>
+        mockCreateChart(container, options),
+    HistogramSeries: 'HistogramSeries',
+}));
+
+function makeContainerRef(container: HTMLDivElement | null = null) {
+    return { current: container } as Parameters<
+        typeof useVolumeChartLifecycle
+    >[0]['containerRef'];
+}
+
+describe('useVolumeChartLifecycle', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns chartRef, totalSeriesRef, buySeriesRef', () => {
+        const { result } = renderHook(() =>
+            useVolumeChartLifecycle({
+                containerRef: makeContainerRef(),
+            })
+        );
+
+        expect(result.current.chartRef).toBeDefined();
+        expect(result.current.totalSeriesRef).toBeDefined();
+        expect(result.current.buySeriesRef).toBeDefined();
+    });
+
+    it('does not create chart when container is null', () => {
+        renderHook(() =>
+            useVolumeChartLifecycle({
+                containerRef: makeContainerRef(null),
+            })
+        );
+
+        expect(mockCreateChart).not.toHaveBeenCalled();
+    });
+
+    it('creates chart when container exists', () => {
+        const container = document.createElement('div');
+        renderHook(() =>
+            useVolumeChartLifecycle({
+                containerRef: makeContainerRef(container),
+            })
+        );
+
+        expect(mockCreateChart).toHaveBeenCalledWith(
+            container,
+            expect.any(Object)
+        );
+    });
+
+    it('adds two histogram series for total and buy volume', () => {
+        const container = document.createElement('div');
+        renderHook(() =>
+            useVolumeChartLifecycle({
+                containerRef: makeContainerRef(container),
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('calls onChartReady callback', () => {
+        const container = document.createElement('div');
+        const onReady = vi.fn();
+
+        renderHook(() =>
+            useVolumeChartLifecycle({
+                containerRef: makeContainerRef(container),
+                onChartReady: onReady,
+            })
+        );
+
+        expect(onReady).toHaveBeenCalled();
+    });
+
+    it('calls onChartRemove and removes chart on unmount', () => {
+        const container = document.createElement('div');
+        const onRemove = vi.fn();
+
+        const { unmount } = renderHook(() =>
+            useVolumeChartLifecycle({
+                containerRef: makeContainerRef(container),
+                onChartRemove: onRemove,
+            })
+        );
+
+        unmount();
+
+        expect(onRemove).toHaveBeenCalled();
+        expect(mockRemove).toHaveBeenCalled();
+    });
+
+    it('disables autoSize before removing chart on cleanup', () => {
+        const container = document.createElement('div');
+
+        const { unmount } = renderHook(() =>
+            useVolumeChartLifecycle({
+                containerRef: makeContainerRef(container),
+            })
+        );
+
+        unmount();
+
+        expect(mockApplyOptions).toHaveBeenCalledWith({ autoSize: false });
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useVolumeProfileOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useVolumeProfileOverlay.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useVolumeProfileOverlay } from '../../hooks/useVolumeProfileOverlay';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useVolumeProfileOverlay
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const NO_VP_INDICATORS = {
+    volumeProfile: null,
+} as unknown as IndicatorResult;
+
+const VP_INDICATORS = {
+    volumeProfile: { poc: 100, vah: 110, val: 90 },
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+    { time: 2000, open: 105, high: 115, low: 95, close: 110, volume: 1200 },
+];
+
+describe('useVolumeProfileOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns isVisible false initially', () => {
+        const { result } = renderHook(() =>
+            useVolumeProfileOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: NO_VP_INDICATORS,
+            })
+        );
+
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('toggles visibility', () => {
+        const { result } = renderHook(() =>
+            useVolumeProfileOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: NO_VP_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+        expect(result.current.isVisible).toBe(true);
+
+        act(() => {
+            result.current.toggle();
+        });
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useVolumeProfileOverlay({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: VP_INDICATORS,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates three series (POC, VAH, VAL) when visible', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useVolumeProfileOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: VP_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockAddSeries).toHaveBeenCalledTimes(3);
+    });
+
+    it('removes series when toggled off', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useVolumeProfileOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: VP_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+
+    it('sets empty data when volumeProfile is null', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useVolumeProfileOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: NO_VP_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockSetData).toHaveBeenCalledWith([]);
+    });
+
+    it('provides stable toggle reference', () => {
+        const { result, rerender } = renderHook(() =>
+            useVolumeProfileOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: NO_VP_INDICATORS,
+            })
+        );
+
+        const firstToggle = result.current.toggle;
+        rerender();
+        expect(result.current.toggle).toBe(firstToggle);
+    });
+});


### PR DESCRIPTION
## Summary
- chart 위젯의 22개 hooks 테스트 작성
- 135개 새 테스트 케이스

## Hooks tested
useActionRecommendationOverlay, useBollingerOverlay, useCandlePatternMarkers,
useCCIChart, useChartSync, useDMIChart, useEMAOverlay, useIchimokuOverlay,
useIndicatorDropdown, useIndicatorVisibility, useMACDChart, useMAOverlay,
useMovingAverageOverlay, useOverlayGroups, useOverlayLegend, usePaneLabels,
useRSIChart, useStochasticChart, useStochRSIChart, useVolumeChartData,
useVolumeChartLifecycle, useVolumeProfileOverlay

## Test plan
- [x] `yarn test` — all suites pass (135 new tests)
- [x] `tsc --noEmit` — 0 errors
- [x] `yarn lint` — 0 errors
- [x] `yarn format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)