### PR TITLE
test(widgets/symbol-page): add tests for hooks, components, utils

### DIFF
--- a/src/widgets/symbol-page/__tests__/ChartContent.test.tsx
+++ b/src/widgets/symbol-page/__tests__/ChartContent.test.tsx
@@ -1,0 +1,192 @@
+import { render, screen } from '@testing-library/react';
+import type { AnalysisResponse, Timeframe } from '@y0ngha/siglens-core';
+import { ChartContent } from '@/widgets/symbol-page/ChartContent';
+
+vi.mock('next/dynamic', () => ({
+    default: (loader: () => Promise<{ default: React.FC }>) => {
+        const Component = (props: Record<string, unknown>) => (
+            <div data-testid="dynamic-component" />
+        );
+        Component.displayName = 'DynamicMock';
+        return Component;
+    },
+}));
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/widgets/chart', () => ({
+    ChartSkeleton: () => <div data-testid="chart-skeleton" />,
+    useChartSync: () => ({
+        handleStockChartReady: vi.fn(),
+        handleStockChartRemove: vi.fn(),
+        handleVolumeChartReady: vi.fn(),
+        handleVolumeChartRemove: vi.fn(),
+    }),
+}));
+
+vi.mock('@/widgets/analysis', () => ({
+    AnalysisPanel: (props: Record<string, unknown>) => (
+        <div data-testid="analysis-panel" />
+    ),
+}));
+
+vi.mock('@/shared/ui/BotBlockedNotice', () => ({
+    BotBlockedNotice: () => <div data-testid="bot-blocked-notice" />,
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/useBars', () => ({
+    useBars: vi.fn(() => ({
+        bars: [
+            { time: 1, open: 100, high: 110, low: 90, close: 105, volume: 500 },
+        ],
+        indicators: { buySellVolume: [] },
+    })),
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/useAnalysis', () => ({
+    useAnalysis: vi.fn(() => ({
+        analysis: {} as AnalysisResponse,
+        analysisResult: null,
+        isAnalyzing: false,
+        analysisError: null,
+        isBotBlocked: false,
+        handleReanalyze: vi.fn(),
+        reanalyzeCooldownMs: 0,
+        cooldownNotice: null,
+    })),
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/useAnalysisDerivedData', () => ({
+    useAnalysisDerivedData: vi.fn(() => ({
+        clusteredKeyLevels: { support: [], resistance: [], poc: undefined },
+        validatedActionPrices: undefined,
+        reconciledActionLines: undefined,
+    })),
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/useAnalysisDisplay', () => ({
+    useAnalysisDisplay: vi.fn(() => ({
+        displayAnalyzing: false,
+        handleProgressFinished: vi.fn(),
+    })),
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/useActionPricesVisibility', () => ({
+    useActionPricesVisibility: vi.fn(() => ({
+        actionPricesVisible: true,
+        setActionPricesVisible: vi.fn(),
+    })),
+}));
+
+vi.mock('@/widgets/symbol-page/SymbolModelContext', () => ({
+    useSymbolModel: vi.fn(() => ({
+        modelId: 'gemini-2.5-flash-lite',
+        isHydrated: true,
+    })),
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/usePanelResize', () => ({
+    usePanelResize: vi.fn(() => ({
+        panelWidth: 640,
+        isDragging: false,
+        handleDragStart: vi.fn(),
+        handleKeyDown: vi.fn(),
+    })),
+    PANEL_MIN_WIDTH: 240,
+    PANEL_MAX_WIDTH: 640,
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/useAnalysisProgress', () => ({
+    useAnalysisProgress: vi.fn(() => ({
+        phaseIndex: 0,
+        tipIndex: 0,
+    })),
+}));
+
+vi.mock('@/features/symbol-chat', () => ({
+    usePublishSymbolChat: vi.fn(),
+}));
+
+vi.mock('@/widgets/symbol-page/utils/buildChatState', () => ({
+    buildChatState: vi.fn(() => ({
+        context: null,
+        timeframe: '1Day',
+        isAnalysisReady: false,
+    })),
+}));
+
+vi.mock('@/shared/lib/pwaEvents', () => ({
+    PWA_TRIGGER_EVENT: 'pwa-trigger',
+}));
+
+vi.mock('@/widgets/symbol-page/FearGreedCardMounted', () => ({
+    FearGreedCardMounted: () => <div data-testid="fear-greed-card" />,
+}));
+
+describe('ChartContent', () => {
+    const defaultProps = {
+        symbol: 'AAPL',
+        companyName: 'Apple Inc.',
+        timeframe: '1Day' as Timeframe,
+        timeframeChangeCount: 0,
+        initialAnalysis: {} as AnalysisResponse,
+        initialAnalysisFailed: false,
+        onMobileSheetContent: vi.fn(),
+    };
+
+    it('renders without crashing', () => {
+        const { container } = render(<ChartContent {...defaultProps} />);
+        expect(container.firstElementChild).toBeDefined();
+    });
+
+    it('renders the drag handle separator', () => {
+        render(<ChartContent {...defaultProps} />);
+        const separator = screen.getByRole('separator');
+        expect(separator.getAttribute('aria-label')).toBe('패널 너비 조절');
+    });
+
+    it('renders the disclaimer text', () => {
+        render(<ChartContent {...defaultProps} />);
+        expect(
+            screen.getByText(
+                /차트는 Pre-market, After-market 주가를 반영하지 않습니다/
+            )
+        ).toBeDefined();
+    });
+
+    it('renders analysis panel in aside', () => {
+        render(<ChartContent {...defaultProps} />);
+        expect(screen.getByTestId('analysis-panel')).toBeDefined();
+    });
+
+    it('renders bot blocked notice when bot is blocked', async () => {
+        const { useAnalysis } =
+            await import('@/widgets/symbol-page/hooks/useAnalysis');
+        (useAnalysis as ReturnType<typeof vi.fn>).mockReturnValue({
+            analysis: {} as AnalysisResponse,
+            analysisResult: null,
+            isAnalyzing: false,
+            analysisError: null,
+            isBotBlocked: true,
+            handleReanalyze: vi.fn(),
+            reanalyzeCooldownMs: 0,
+            cooldownNotice: null,
+        });
+
+        render(<ChartContent {...defaultProps} />);
+        expect(screen.getByTestId('bot-blocked-notice')).toBeDefined();
+
+        (useAnalysis as ReturnType<typeof vi.fn>).mockReturnValue({
+            analysis: {} as AnalysisResponse,
+            analysisResult: null,
+            isAnalyzing: false,
+            analysisError: null,
+            isBotBlocked: false,
+            handleReanalyze: vi.fn(),
+            reanalyzeCooldownMs: 0,
+            cooldownNotice: null,
+        });
+    });
+});

--- a/src/widgets/symbol-page/__tests__/ChartContent.test.tsx
+++ b/src/widgets/symbol-page/__tests__/ChartContent.test.tsx
@@ -126,6 +126,10 @@ vi.mock('@/widgets/symbol-page/FearGreedCardMounted', () => ({
 }));
 
 describe('ChartContent', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
     const defaultProps = {
         symbol: 'AAPL',
         companyName: 'Apple Inc.',

--- a/src/widgets/symbol-page/__tests__/CrossLinkCards.test.tsx
+++ b/src/widgets/symbol-page/__tests__/CrossLinkCards.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import { CrossLinkCards } from '@/widgets/symbol-page/CrossLinkCards';
+
+vi.mock('next/link', () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+        [key: string]: unknown;
+    }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+describe('CrossLinkCards', () => {
+    it('renders a section with accessible label', () => {
+        render(<CrossLinkCards symbol="AAPL" current="chart" />);
+        const section = screen.getByRole('region', { name: '다른 분석 탭' });
+        expect(section).toBeDefined();
+    });
+
+    it('renders 6 cards (all pages)', () => {
+        const { container } = render(
+            <CrossLinkCards symbol="AAPL" current="chart" />
+        );
+        const children = container.querySelector('section')!.children;
+        expect(children).toHaveLength(6);
+    });
+
+    it('marks the current page card with aria-current="page"', () => {
+        render(<CrossLinkCards symbol="AAPL" current="chart" />);
+        const current = screen.getByText('차트 분석').closest('[aria-current]');
+        expect(current?.getAttribute('aria-current')).toBe('page');
+    });
+
+    it('renders the current page label text', () => {
+        render(<CrossLinkCards symbol="AAPL" current="chart" />);
+        expect(screen.getByText('지금 보는 페이지예요')).toBeDefined();
+    });
+
+    it('renders non-current pages as links', () => {
+        render(<CrossLinkCards symbol="AAPL" current="chart" />);
+        const newsLink = screen.getByText('뉴스 분석').closest('a');
+        expect(newsLink).not.toBeNull();
+        expect(newsLink!.getAttribute('href')).toBe('/AAPL/news');
+    });
+
+    it('does not render current page as a link', () => {
+        render(<CrossLinkCards symbol="AAPL" current="chart" />);
+        const chartEl = screen.getByText('차트 분석').closest('a');
+        expect(chartEl).toBeNull();
+    });
+
+    it('builds correct hrefs for all non-current pages', () => {
+        render(<CrossLinkCards symbol="TSLA" current="news" />);
+        const chartLink = screen.getByText('차트 분석').closest('a');
+        expect(chartLink!.getAttribute('href')).toBe('/TSLA');
+
+        const fundamentalLink = screen.getByText('펀더멘털 분석').closest('a');
+        expect(fundamentalLink!.getAttribute('href')).toBe('/TSLA/fundamental');
+    });
+
+    it('renders descriptions for all pages', () => {
+        render(<CrossLinkCards symbol="AAPL" current="chart" />);
+        expect(screen.getByText('기술적 지표 + AI 종합 리포트')).toBeDefined();
+        expect(
+            screen.getByText('실시간 뉴스 + 애널리스트 의견 분석')
+        ).toBeDefined();
+    });
+});

--- a/src/widgets/symbol-page/__tests__/MobileAnalysisSheet.test.tsx
+++ b/src/widgets/symbol-page/__tests__/MobileAnalysisSheet.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react';
+import { MobileAnalysisSheet } from '@/widgets/symbol-page/MobileAnalysisSheet';
+import { SNAP_HALF } from '@/widgets/symbol-page/constants/mobileSheet';
+
+vi.mock('vaul', () => {
+    const DrawerRoot = ({
+        children,
+        ...rest
+    }: {
+        children: React.ReactNode;
+        [key: string]: unknown;
+    }) => <div data-testid="drawer-root">{children}</div>;
+
+    const DrawerPortal = ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="drawer-portal">{children}</div>
+    );
+
+    const DrawerContent = ({
+        children,
+        ...rest
+    }: {
+        children: React.ReactNode;
+        [key: string]: unknown;
+    }) => (
+        <div data-testid="drawer-content" aria-live="polite">
+            {children}
+        </div>
+    );
+
+    const DrawerHandle = (props: Record<string, unknown>) => (
+        <div
+            data-testid="drawer-handle"
+            aria-label={props['aria-label'] as string}
+        />
+    );
+
+    const DrawerTitle = ({ children }: { children: React.ReactNode }) => (
+        <h2 data-testid="drawer-title">{children}</h2>
+    );
+
+    const DrawerDescription = ({ children }: { children: React.ReactNode }) => (
+        <p data-testid="drawer-description">{children}</p>
+    );
+
+    return {
+        Drawer: {
+            Root: DrawerRoot,
+            Portal: DrawerPortal,
+            Content: DrawerContent,
+            Handle: DrawerHandle,
+            Title: DrawerTitle,
+            Description: DrawerDescription,
+        },
+    };
+});
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/useMobileAnalysisSheet', () => ({
+    useMobileAnalysisSheet: vi.fn(() => ({
+        isOpen: true,
+        isFullSnap: false,
+        contentRef: { current: null },
+        drawerContentRef: { current: null },
+        handleOpenChange: vi.fn(),
+    })),
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/useMobileSheetDrag', () => ({
+    useMobileSheetDrag: vi.fn(),
+}));
+
+describe('MobileAnalysisSheet', () => {
+    it('renders children inside the drawer', () => {
+        render(
+            <MobileAnalysisSheet
+                activeSnap={SNAP_HALF}
+                onActiveSnapChange={vi.fn()}
+            >
+                <span data-testid="child">analysis content</span>
+            </MobileAnalysisSheet>
+        );
+
+        expect(screen.getByTestId('child')).toBeDefined();
+    });
+
+    it('renders accessible title and description', () => {
+        render(
+            <MobileAnalysisSheet
+                activeSnap={SNAP_HALF}
+                onActiveSnapChange={vi.fn()}
+            >
+                <span>content</span>
+            </MobileAnalysisSheet>
+        );
+
+        expect(screen.getByText('AI 분석 패널')).toBeDefined();
+        expect(
+            screen.getByText('위로 드래그하여 분석 내용을 확인하세요')
+        ).toBeDefined();
+    });
+
+    it('renders the drag handle', () => {
+        render(
+            <MobileAnalysisSheet
+                activeSnap={SNAP_HALF}
+                onActiveSnapChange={vi.fn()}
+            >
+                <span>content</span>
+            </MobileAnalysisSheet>
+        );
+
+        expect(screen.getByTestId('drawer-handle')).toBeDefined();
+    });
+});

--- a/src/widgets/symbol-page/__tests__/SectionSkeleton.test.tsx
+++ b/src/widgets/symbol-page/__tests__/SectionSkeleton.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { SectionSkeleton } from '@/widgets/symbol-page/SectionSkeleton';
+
+describe('SectionSkeleton', () => {
+    it('renders a hidden-from-AT placeholder', () => {
+        const { container } = render(<SectionSkeleton />);
+        const el = container.firstElementChild as HTMLElement;
+        expect(el.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('applies the pulse animation class', () => {
+        const { container } = render(<SectionSkeleton />);
+        const el = container.firstElementChild as HTMLElement;
+        expect(el.className).toContain('animate-pulse');
+    });
+
+    it('respects reduced-motion preference', () => {
+        const { container } = render(<SectionSkeleton />);
+        const el = container.firstElementChild as HTMLElement;
+        expect(el.className).toContain('motion-reduce:animate-none');
+    });
+});

--- a/src/widgets/symbol-page/__tests__/SymbolLayoutHeader.test.tsx
+++ b/src/widgets/symbol-page/__tests__/SymbolLayoutHeader.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import { SymbolLayoutHeader } from '@/widgets/symbol-page/SymbolLayoutHeader';
+
+vi.mock('next/link', () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+        [key: string]: unknown;
+    }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/useAssetInfo', () => ({
+    useAssetInfo: vi.fn(() => ({
+        name: 'Apple Inc.',
+        koreanName: '애플',
+        fmpSymbol: 'AAPL',
+    })),
+}));
+
+vi.mock('@/widgets/symbol-page/SymbolModelContext', () => ({
+    useSymbolModel: vi.fn(() => ({
+        modelId: 'gemini-2.5-flash-lite',
+        allowedModels: ['gemini-2.5-flash-lite'],
+        isHydrated: true,
+        gateModal: null,
+        dismissGate: vi.fn(),
+        handleModelChange: vi.fn(),
+    })),
+}));
+
+vi.mock('@/widgets/symbol-page/SymbolTabs', () => ({
+    SymbolTabs: () => <nav data-testid="symbol-tabs">tabs</nav>,
+}));
+
+vi.mock('@/widgets/symbol-page/SymbolTabsSkeleton', () => ({
+    SymbolTabsSkeleton: () => <div data-testid="tabs-skeleton">loading</div>,
+}));
+
+vi.mock('@/widgets/analysis', () => ({
+    ModelSelector: ({
+        selectedModel,
+    }: {
+        selectedModel: string;
+        [key: string]: unknown;
+    }) => <div data-testid="model-selector">{selectedModel}</div>,
+}));
+
+vi.mock('@/widgets/symbol-page/FearGreedHeaderChipMounted', () => ({
+    FearGreedHeaderChipMounted: () => (
+        <span data-testid="fear-greed-chip">FG</span>
+    ),
+}));
+
+vi.mock('@/features/premium-gate', () => ({
+    PremiumModelGateModal: () => <div data-testid="gate-modal">modal</div>,
+}));
+
+vi.mock('@/shared/lib/llmProviderLabels', () => ({
+    LLM_PROVIDER_LABELS: { google: 'Google' },
+}));
+
+describe('SymbolLayoutHeader', () => {
+    it('renders a header element', () => {
+        render(<SymbolLayoutHeader symbol="aapl" />);
+        expect(screen.getByRole('banner')).toBeDefined();
+    });
+
+    it('renders the SIGLENS logo link', () => {
+        render(<SymbolLayoutHeader symbol="aapl" />);
+        const link = screen.getByText('SIGLENS');
+        expect(link.closest('a')?.getAttribute('href')).toBe('/');
+    });
+
+    it('renders the uppercased ticker', () => {
+        render(<SymbolLayoutHeader symbol="aapl" />);
+        expect(screen.getByText('(AAPL)')).toBeDefined();
+    });
+
+    it('renders the company name', () => {
+        render(<SymbolLayoutHeader symbol="aapl" />);
+        expect(screen.getByText('Apple Inc.')).toBeDefined();
+    });
+
+    it('renders the korean name', () => {
+        render(<SymbolLayoutHeader symbol="aapl" />);
+        expect(screen.getByText(/애플/)).toBeDefined();
+    });
+
+    it('renders the model selector', () => {
+        render(<SymbolLayoutHeader symbol="aapl" />);
+        expect(screen.getByTestId('model-selector')).toBeDefined();
+    });
+
+    it('renders AI model label text', () => {
+        render(<SymbolLayoutHeader symbol="aapl" />);
+        expect(screen.getByText('AI 분석 모델')).toBeDefined();
+    });
+});

--- a/src/widgets/symbol-page/__tests__/SymbolModelContext.test.tsx
+++ b/src/widgets/symbol-page/__tests__/SymbolModelContext.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import type { ModelId } from '@y0ngha/siglens-core';
+import {
+    SymbolModelProvider,
+    useSymbolModel,
+} from '@/widgets/symbol-page/SymbolModelContext';
+
+vi.mock('@y0ngha/siglens-core', () => ({
+    getAllowedModels: vi.fn(() => ['gemini-2.5-flash-lite'] as ModelId[]),
+    GEMINI_2_5_FLASH_LITE_MODEL: 'gemini-2.5-flash-lite',
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/useSelectedModel', () => ({
+    useSelectedModel: vi.fn(() => ['gemini-2.5-flash-lite', vi.fn(), true]),
+}));
+
+vi.mock('@/features/premium-gate', () => ({
+    useModelGate: vi.fn(({ onAllow }: { onAllow: (m: ModelId) => void }) => ({
+        gateModal: null,
+        dismissGate: vi.fn(),
+        handleModelChange: onAllow,
+    })),
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/useUserTier', () => ({
+    useUserTier: vi.fn(() => ({ tier: 'free', isLoading: false })),
+}));
+
+const queryClients: QueryClient[] = [];
+
+function makeWrapper() {
+    const client = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    queryClients.push(client);
+    return function Wrapper({ children }: { children: ReactNode }) {
+        return (
+            <QueryClientProvider client={client}>
+                <SymbolModelProvider>{children}</SymbolModelProvider>
+            </QueryClientProvider>
+        );
+    };
+}
+
+describe('SymbolModelContext', () => {
+    afterEach(() => {
+        queryClients.splice(0).forEach(c => c.clear());
+    });
+
+    it('provides modelId to consumers', () => {
+        function Consumer() {
+            const { modelId } = useSymbolModel();
+            return <span data-testid="model">{modelId}</span>;
+        }
+
+        render(<Consumer />, { wrapper: makeWrapper() });
+        expect(screen.getByTestId('model').textContent).toBe(
+            'gemini-2.5-flash-lite'
+        );
+    });
+
+    it('provides allowedModels', () => {
+        const { result } = renderHook(() => useSymbolModel(), {
+            wrapper: makeWrapper(),
+        });
+
+        expect(result.current.allowedModels).toEqual(['gemini-2.5-flash-lite']);
+    });
+
+    it('throws when used outside provider', () => {
+        const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        expect(() => {
+            renderHook(() => useSymbolModel());
+        }).toThrow('useSymbolModel must be used inside SymbolModelProvider');
+
+        spy.mockRestore();
+    });
+
+    it('provides isHydrated flag', () => {
+        const { result } = renderHook(() => useSymbolModel(), {
+            wrapper: makeWrapper(),
+        });
+
+        expect(result.current.isHydrated).toBe(true);
+    });
+});

--- a/src/widgets/symbol-page/__tests__/SymbolPageClient.test.tsx
+++ b/src/widgets/symbol-page/__tests__/SymbolPageClient.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from '@testing-library/react';
+import type { AnalysisResponse, Timeframe } from '@y0ngha/siglens-core';
+import { SymbolPageClient } from '@/widgets/symbol-page/SymbolPageClient';
+
+vi.mock('next/dynamic', () => ({
+    default: () => {
+        const Stub = () => <div data-testid="mobile-sheet" />;
+        Stub.displayName = 'MobileSheetStub';
+        return Stub;
+    },
+}));
+
+vi.mock('react-error-boundary', () => ({
+    ErrorBoundary: ({
+        children,
+    }: {
+        children: React.ReactNode;
+        [key: string]: unknown;
+    }) => <div data-testid="error-boundary">{children}</div>,
+}));
+
+vi.mock('@/widgets/chart', () => ({
+    ChartErrorFallback: () => <div data-testid="chart-error" />,
+    ChartSkeleton: () => <div data-testid="chart-skeleton" />,
+    TimeframeSelector: ({
+        value,
+        onChange,
+    }: {
+        value: string;
+        onChange: (v: string) => void;
+    }) => <div data-testid="timeframe-selector">{value}</div>,
+}));
+
+vi.mock('@/shared/hooks/useHydrated', () => ({
+    useHydrated: vi.fn(() => true),
+}));
+
+vi.mock('@/shared/hooks/useIsMobileViewport', () => ({
+    useIsMobileViewport: vi.fn(() => false),
+}));
+
+vi.mock('@/widgets/symbol-page/ChartContent', () => ({
+    ChartContent: (props: Record<string, unknown>) => (
+        <div data-testid="chart-content">{props.symbol as string}</div>
+    ),
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/useAssetInfo', () => ({
+    useAssetInfo: vi.fn(() => undefined),
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/useMobileSheet', () => ({
+    useMobileSheet: vi.fn(() => ({
+        sheetSnap: 0.55,
+        setSheetSnap: vi.fn(),
+        mobileSheetContent: null,
+        setMobileSheetContent: vi.fn(),
+    })),
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/useTimeframeChange', () => ({
+    useTimeframeChange: vi.fn(() => ({
+        timeframe: '1Day' as Timeframe,
+        timeframeChangeCount: 0,
+        handleTimeframeChange: vi.fn(),
+    })),
+}));
+
+vi.mock('@/widgets/symbol-page/SymbolPageContext', () => ({
+    SymbolPageProvider: ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="provider">{children}</div>
+    ),
+}));
+
+describe('SymbolPageClient', () => {
+    const defaultProps = {
+        symbol: 'AAPL',
+        companyName: 'Apple Inc.',
+        initialAnalysis: {} as AnalysisResponse,
+        initialAnalysisFailed: false,
+        indicatorCount: 20,
+    };
+
+    it('renders without crashing', () => {
+        const { container } = render(<SymbolPageClient {...defaultProps} />);
+        expect(container.firstElementChild).toBeDefined();
+    });
+
+    it('wraps content in SymbolPageProvider', () => {
+        render(<SymbolPageClient {...defaultProps} />);
+        expect(screen.getByTestId('provider')).toBeDefined();
+    });
+
+    it('renders the timeframe selector with current value', () => {
+        render(<SymbolPageClient {...defaultProps} />);
+        expect(screen.getByTestId('timeframe-selector').textContent).toBe(
+            '1Day'
+        );
+    });
+
+    it('renders ChartContent inside the error boundary', () => {
+        render(<SymbolPageClient {...defaultProps} />);
+        expect(screen.getByTestId('chart-content')).toBeDefined();
+    });
+
+    it('passes symbol to ChartContent', () => {
+        render(<SymbolPageClient {...defaultProps} />);
+        expect(screen.getByTestId('chart-content').textContent).toBe('AAPL');
+    });
+});

--- a/src/widgets/symbol-page/__tests__/SymbolPageContext.test.tsx
+++ b/src/widgets/symbol-page/__tests__/SymbolPageContext.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import {
+    SymbolPageProvider,
+    useSymbolPageContext,
+} from '@/widgets/symbol-page/SymbolPageContext';
+
+describe('SymbolPageContext', () => {
+    it('provides indicatorCount to consumers', () => {
+        function Consumer() {
+            const ctx = useSymbolPageContext();
+            return <span data-testid="count">{ctx.indicatorCount}</span>;
+        }
+
+        render(
+            <SymbolPageProvider indicatorCount={42}>
+                <Consumer />
+            </SymbolPageProvider>
+        );
+
+        expect(screen.getByTestId('count').textContent).toBe('42');
+    });
+
+    it('throws when used outside provider', () => {
+        const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        expect(() => {
+            renderHook(() => useSymbolPageContext());
+        }).toThrow(
+            'useSymbolPageContext must be used inside SymbolPageProvider'
+        );
+
+        spy.mockRestore();
+    });
+
+    it('renders children', () => {
+        render(
+            <SymbolPageProvider indicatorCount={0}>
+                <span data-testid="child">hello</span>
+            </SymbolPageProvider>
+        );
+
+        expect(screen.getByTestId('child').textContent).toBe('hello');
+    });
+});

--- a/src/widgets/symbol-page/__tests__/SymbolTabs.test.tsx
+++ b/src/widgets/symbol-page/__tests__/SymbolTabs.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import { SymbolTabs } from '@/widgets/symbol-page/SymbolTabs';
+
+vi.mock('next/navigation', () => ({
+    usePathname: vi.fn(() => '/AAPL'),
+}));
+
+vi.mock('next/link', () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+        [key: string]: unknown;
+    }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock('@/widgets/symbol-page/utils/symbolTabsConfig', () => ({
+    TABS: [
+        { key: 'chart', label: '차트', hrefBuilder: (s: string) => `/${s}` },
+        {
+            key: 'news',
+            label: '뉴스',
+            hrefBuilder: (s: string) => `/${s}/news`,
+        },
+        {
+            key: 'fundamental',
+            label: '펀더멘털',
+            hrefBuilder: (s: string) => `/${s}/fundamental`,
+        },
+    ],
+}));
+
+import { usePathname } from 'next/navigation';
+
+describe('SymbolTabs', () => {
+    beforeEach(() => {
+        (usePathname as ReturnType<typeof vi.fn>).mockReturnValue('/AAPL');
+    });
+
+    it('renders a nav with accessible label', () => {
+        render(<SymbolTabs symbol="aapl" />);
+        const nav = screen.getByRole('navigation', { name: '분석 종류' });
+        expect(nav).toBeDefined();
+    });
+
+    it('renders all tab links', () => {
+        render(<SymbolTabs symbol="aapl" />);
+        expect(screen.getByText('차트')).toBeDefined();
+        expect(screen.getByText('뉴스')).toBeDefined();
+        expect(screen.getByText('펀더멘털')).toBeDefined();
+    });
+
+    it('marks the active tab with aria-current="page"', () => {
+        render(<SymbolTabs symbol="aapl" />);
+        const chartLink = screen.getByText('차트').closest('a')!;
+        expect(chartLink.getAttribute('aria-current')).toBe('page');
+    });
+
+    it('does not mark inactive tabs with aria-current', () => {
+        render(<SymbolTabs symbol="aapl" />);
+        const newsLink = screen.getByText('뉴스').closest('a')!;
+        expect(newsLink.getAttribute('aria-current')).toBeNull();
+    });
+
+    it('uppercases the symbol for href building', () => {
+        render(<SymbolTabs symbol="aapl" />);
+        const newsLink = screen.getByText('뉴스').closest('a')!;
+        expect(newsLink.getAttribute('href')).toBe('/AAPL/news');
+    });
+
+    it('marks different tab as active based on pathname', () => {
+        (usePathname as ReturnType<typeof vi.fn>).mockReturnValue('/AAPL/news');
+
+        render(<SymbolTabs symbol="aapl" />);
+        const newsLink = screen.getByText('뉴스').closest('a')!;
+        expect(newsLink.getAttribute('aria-current')).toBe('page');
+
+        const chartLink = screen.getByText('차트').closest('a')!;
+        expect(chartLink.getAttribute('aria-current')).toBeNull();
+    });
+});

--- a/src/widgets/symbol-page/__tests__/SymbolTabs.test.tsx
+++ b/src/widgets/symbol-page/__tests__/SymbolTabs.test.tsx
@@ -1,6 +1,3 @@
-import { render, screen } from '@testing-library/react';
-import { SymbolTabs } from '@/widgets/symbol-page/SymbolTabs';
-
 vi.mock('next/navigation', () => ({
     usePathname: vi.fn(() => '/AAPL'),
 }));
@@ -37,7 +34,9 @@ vi.mock('@/widgets/symbol-page/utils/symbolTabsConfig', () => ({
     ],
 }));
 
+import { render, screen } from '@testing-library/react';
 import { usePathname } from 'next/navigation';
+import { SymbolTabs } from '@/widgets/symbol-page/SymbolTabs';
 
 describe('SymbolTabs', () => {
     beforeEach(() => {

--- a/src/widgets/symbol-page/__tests__/SymbolTabsSkeleton.test.tsx
+++ b/src/widgets/symbol-page/__tests__/SymbolTabsSkeleton.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { SymbolTabsSkeleton } from '@/widgets/symbol-page/SymbolTabsSkeleton';
+
+vi.mock('@/widgets/symbol-page/utils/symbolTabsConfig', () => ({
+    TABS: [
+        { key: 'chart', label: '차트', hrefBuilder: (s: string) => `/${s}` },
+        {
+            key: 'news',
+            label: '뉴스',
+            hrefBuilder: (s: string) => `/${s}/news`,
+        },
+    ],
+}));
+
+describe('SymbolTabsSkeleton', () => {
+    it('renders a nav element with aria-hidden', () => {
+        render(<SymbolTabsSkeleton />);
+        const nav = screen.getByRole('navigation', { hidden: true });
+        expect(nav.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('renders labels for each tab', () => {
+        render(<SymbolTabsSkeleton />);
+        expect(screen.getByText('차트')).toBeDefined();
+        expect(screen.getByText('뉴스')).toBeDefined();
+    });
+
+    it('renders spans (not links)', () => {
+        const { container } = render(<SymbolTabsSkeleton />);
+        const links = container.querySelectorAll('a');
+        expect(links).toHaveLength(0);
+
+        const spans = container.querySelectorAll('span');
+        expect(spans.length).toBe(2);
+    });
+});

--- a/src/widgets/symbol-page/__tests__/constants/mobileSheet.test.ts
+++ b/src/widgets/symbol-page/__tests__/constants/mobileSheet.test.ts
@@ -1,0 +1,60 @@
+import {
+    SNAP_PEEK,
+    SNAP_HALF,
+    SNAP_FULL,
+    MOBILE_SNAP_POINTS,
+    SNAP_POINTS_MUTABLE,
+    VAUL_EASING,
+    DRAG_RESISTANCE,
+    DRAG_THRESHOLD_PX,
+    DRAG_TO_PEEK_THRESHOLD,
+    DRAG_TO_HALF_THRESHOLD,
+    SNAP_BACK_DURATION,
+} from '@/widgets/symbol-page/constants/mobileSheet';
+
+describe('mobileSheet constants', () => {
+    it('snap points are ordered from smallest to largest', () => {
+        expect(SNAP_PEEK).toBeLessThan(SNAP_HALF);
+        expect(SNAP_HALF).toBeLessThan(SNAP_FULL);
+    });
+
+    it('snap points are between 0 and 1 (viewport fractions)', () => {
+        for (const snap of [SNAP_PEEK, SNAP_HALF, SNAP_FULL]) {
+            expect(snap).toBeGreaterThan(0);
+            expect(snap).toBeLessThanOrEqual(1);
+        }
+    });
+
+    it('MOBILE_SNAP_POINTS contains all three snap points in order', () => {
+        expect(MOBILE_SNAP_POINTS).toEqual([SNAP_PEEK, SNAP_HALF, SNAP_FULL]);
+    });
+
+    it('SNAP_POINTS_MUTABLE is a mutable copy of MOBILE_SNAP_POINTS', () => {
+        expect(SNAP_POINTS_MUTABLE).toEqual([...MOBILE_SNAP_POINTS]);
+        SNAP_POINTS_MUTABLE.push(0.99);
+        expect(SNAP_POINTS_MUTABLE).toHaveLength(4);
+        SNAP_POINTS_MUTABLE.pop();
+    });
+
+    it('VAUL_EASING is a valid CSS cubic-bezier string', () => {
+        expect(VAUL_EASING).toMatch(/^cubic-bezier\(.+\)$/);
+    });
+
+    it('DRAG_RESISTANCE is between 0 and 1', () => {
+        expect(DRAG_RESISTANCE).toBeGreaterThan(0);
+        expect(DRAG_RESISTANCE).toBeLessThanOrEqual(1);
+    });
+
+    it('DRAG_THRESHOLD_PX is a positive integer', () => {
+        expect(DRAG_THRESHOLD_PX).toBeGreaterThan(0);
+        expect(Number.isInteger(DRAG_THRESHOLD_PX)).toBe(true);
+    });
+
+    it('DRAG_TO_PEEK_THRESHOLD is greater than DRAG_TO_HALF_THRESHOLD', () => {
+        expect(DRAG_TO_PEEK_THRESHOLD).toBeGreaterThan(DRAG_TO_HALF_THRESHOLD);
+    });
+
+    it('SNAP_BACK_DURATION is a valid CSS time string', () => {
+        expect(SNAP_BACK_DURATION).toMatch(/^\d+(\.\d+)?(s|ms)$/);
+    });
+});

--- a/src/widgets/symbol-page/__tests__/constants/mobileSheet.test.ts
+++ b/src/widgets/symbol-page/__tests__/constants/mobileSheet.test.ts
@@ -31,9 +31,10 @@ describe('mobileSheet constants', () => {
 
     it('SNAP_POINTS_MUTABLE is a mutable copy of MOBILE_SNAP_POINTS', () => {
         expect(SNAP_POINTS_MUTABLE).toEqual([...MOBILE_SNAP_POINTS]);
-        SNAP_POINTS_MUTABLE.push(0.99);
-        expect(SNAP_POINTS_MUTABLE).toHaveLength(4);
-        SNAP_POINTS_MUTABLE.pop();
+        const copy = [...SNAP_POINTS_MUTABLE];
+        copy.push(0.99);
+        expect(copy).toHaveLength(MOBILE_SNAP_POINTS.length + 1);
+        expect(SNAP_POINTS_MUTABLE).toHaveLength(MOBILE_SNAP_POINTS.length);
     });
 
     it('VAUL_EASING is a valid CSS cubic-bezier string', () => {

--- a/src/widgets/symbol-page/__tests__/exceptions/BotBlockedError.test.ts
+++ b/src/widgets/symbol-page/__tests__/exceptions/BotBlockedError.test.ts
@@ -1,0 +1,32 @@
+import { BotBlockedError } from '@/widgets/symbol-page/exceptions/BotBlockedError';
+
+describe('BotBlockedError', () => {
+    it('extends Error', () => {
+        const error = new BotBlockedError();
+        expect(error).toBeInstanceOf(Error);
+    });
+
+    it('has name "BotBlockedError"', () => {
+        const error = new BotBlockedError();
+        expect(error.name).toBe('BotBlockedError');
+    });
+
+    it('has message "bot_blocked"', () => {
+        const error = new BotBlockedError();
+        expect(error.message).toBe('bot_blocked');
+    });
+
+    it('has isBotBlocked set to true', () => {
+        const error = new BotBlockedError();
+        expect(error.isBotBlocked).toBe(true);
+    });
+
+    it('can be caught with instanceof check', () => {
+        try {
+            throw new BotBlockedError();
+        } catch (e) {
+            expect(e).toBeInstanceOf(BotBlockedError);
+            expect((e as BotBlockedError).isBotBlocked).toBe(true);
+        }
+    });
+});

--- a/src/widgets/symbol-page/__tests__/hooks/useActionPricesVisibility.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/useActionPricesVisibility.test.tsx
@@ -1,0 +1,42 @@
+import { renderHook, act } from '@testing-library/react';
+import { useActionPricesVisibility } from '@/widgets/symbol-page/hooks/useActionPricesVisibility';
+
+describe('useActionPricesVisibility', () => {
+    it('defaults to visible (true)', () => {
+        const { result } = renderHook(() => useActionPricesVisibility());
+        expect(result.current.actionPricesVisible).toBe(true);
+    });
+
+    it('toggles visibility to false', () => {
+        const { result } = renderHook(() => useActionPricesVisibility());
+
+        act(() => {
+            result.current.setActionPricesVisible(false);
+        });
+
+        expect(result.current.actionPricesVisible).toBe(false);
+    });
+
+    it('toggles back to true', () => {
+        const { result } = renderHook(() => useActionPricesVisibility());
+
+        act(() => {
+            result.current.setActionPricesVisible(false);
+        });
+        act(() => {
+            result.current.setActionPricesVisible(true);
+        });
+
+        expect(result.current.actionPricesVisible).toBe(true);
+    });
+
+    it('supports functional updater', () => {
+        const { result } = renderHook(() => useActionPricesVisibility());
+
+        act(() => {
+            result.current.setActionPricesVisible(prev => !prev);
+        });
+
+        expect(result.current.actionPricesVisible).toBe(false);
+    });
+});

--- a/src/widgets/symbol-page/__tests__/hooks/useAnalysisDerivedData.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/useAnalysisDerivedData.test.tsx
@@ -1,0 +1,101 @@
+import { renderHook } from '@testing-library/react';
+import { useAnalysisDerivedData } from '@/widgets/symbol-page/hooks/useAnalysisDerivedData';
+import type {
+    AnalysisResponse,
+    Bar,
+    ClusteredKeyLevels,
+    ReconciledActionLineData,
+    ValidatedActionPrices,
+} from '@y0ngha/siglens-core';
+
+vi.mock('@y0ngha/siglens-core', () => ({
+    validateKeyLevels: vi.fn((kl: unknown) => kl ?? []),
+    clusterKeyLevels: vi.fn(
+        (_validated: unknown, _close: unknown) =>
+            ({
+                support: [{ price: 100, strength: 2 }],
+                resistance: [{ price: 200, strength: 3 }],
+                poc: undefined,
+            }) as unknown as ClusteredKeyLevels
+    ),
+    validateActionPrices: vi.fn(
+        (ar: unknown) =>
+            (ar ? { entry: 150 } : undefined) as unknown as
+                | ValidatedActionPrices
+                | undefined
+    ),
+    extractReconciledActionLines: vi.fn(
+        (ar: unknown) =>
+            (ar ? { lines: [] } : undefined) as unknown as
+                | ReconciledActionLineData
+                | undefined
+    ),
+}));
+
+const makeBars = (count: number): Bar[] =>
+    Array.from({ length: count }, (_, i) => ({
+        time: 1000 + i,
+        open: 100 + i,
+        high: 110 + i,
+        low: 90 + i,
+        close: 105 + i,
+        volume: 1000,
+    })) as unknown as Bar[];
+
+const ANALYSIS = {
+    keyLevels: [{ price: 100 }],
+    actionRecommendation: { entry: 150 },
+} as unknown as AnalysisResponse;
+
+describe('useAnalysisDerivedData', () => {
+    it('returns clustered key levels from bars', () => {
+        const bars = makeBars(3);
+        const { result } = renderHook(() =>
+            useAnalysisDerivedData(ANALYSIS, bars)
+        );
+
+        expect(result.current.clusteredKeyLevels.support).toHaveLength(1);
+        expect(result.current.clusteredKeyLevels.resistance).toHaveLength(1);
+    });
+
+    it('returns empty key levels when bars are empty', () => {
+        const { result } = renderHook(() =>
+            useAnalysisDerivedData(ANALYSIS, [])
+        );
+
+        expect(result.current.clusteredKeyLevels.support).toEqual([]);
+        expect(result.current.clusteredKeyLevels.resistance).toEqual([]);
+        expect(result.current.clusteredKeyLevels.poc).toBeUndefined();
+    });
+
+    it('returns validated action prices', () => {
+        const bars = makeBars(1);
+        const { result } = renderHook(() =>
+            useAnalysisDerivedData(ANALYSIS, bars)
+        );
+
+        expect(result.current.validatedActionPrices).toEqual({ entry: 150 });
+    });
+
+    it('returns undefined action prices when actionRecommendation is null', () => {
+        const noAction = {
+            ...ANALYSIS,
+            actionRecommendation: null,
+        } as unknown as AnalysisResponse;
+        const bars = makeBars(1);
+        const { result } = renderHook(() =>
+            useAnalysisDerivedData(noAction, bars)
+        );
+
+        expect(result.current.validatedActionPrices).toBeUndefined();
+    });
+
+    it('returns reconciled action lines', () => {
+        const bars = makeBars(1);
+        const { result } = renderHook(() =>
+            useAnalysisDerivedData(ANALYSIS, bars)
+        );
+
+        expect(result.current.reconciledActionLines).toBeDefined();
+    });
+});

--- a/src/widgets/symbol-page/__tests__/hooks/useAnalysisDisplay.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/useAnalysisDisplay.test.tsx
@@ -1,0 +1,65 @@
+import { renderHook, act } from '@testing-library/react';
+import { useAnalysisDisplay } from '@/widgets/symbol-page/hooks/useAnalysisDisplay';
+
+describe('useAnalysisDisplay', () => {
+    it('initializes displayAnalyzing from isAnalyzing prop', () => {
+        const { result } = renderHook(() => useAnalysisDisplay(true));
+        expect(result.current.displayAnalyzing).toBe(true);
+    });
+
+    it('initializes to false when not analyzing', () => {
+        const { result } = renderHook(() => useAnalysisDisplay(false));
+        expect(result.current.displayAnalyzing).toBe(false);
+    });
+
+    it('sets displayAnalyzing to true when isAnalyzing transitions false -> true', () => {
+        const { result, rerender } = renderHook(
+            ({ isAnalyzing }) => useAnalysisDisplay(isAnalyzing),
+            { initialProps: { isAnalyzing: false } }
+        );
+
+        expect(result.current.displayAnalyzing).toBe(false);
+
+        rerender({ isAnalyzing: true });
+        expect(result.current.displayAnalyzing).toBe(true);
+    });
+
+    it('does not automatically set displayAnalyzing to false when isAnalyzing transitions true -> false', () => {
+        const { result, rerender } = renderHook(
+            ({ isAnalyzing }) => useAnalysisDisplay(isAnalyzing),
+            { initialProps: { isAnalyzing: true } }
+        );
+
+        expect(result.current.displayAnalyzing).toBe(true);
+
+        rerender({ isAnalyzing: false });
+        expect(result.current.displayAnalyzing).toBe(true);
+    });
+
+    it('sets displayAnalyzing to false only via handleProgressFinished', () => {
+        const { result, rerender } = renderHook(
+            ({ isAnalyzing }) => useAnalysisDisplay(isAnalyzing),
+            { initialProps: { isAnalyzing: true } }
+        );
+
+        rerender({ isAnalyzing: false });
+        expect(result.current.displayAnalyzing).toBe(true);
+
+        act(() => {
+            result.current.handleProgressFinished();
+        });
+
+        expect(result.current.displayAnalyzing).toBe(false);
+    });
+
+    it('handleProgressFinished is stable across renders', () => {
+        const { result, rerender } = renderHook(
+            ({ isAnalyzing }) => useAnalysisDisplay(isAnalyzing),
+            { initialProps: { isAnalyzing: false } }
+        );
+
+        const first = result.current.handleProgressFinished;
+        rerender({ isAnalyzing: true });
+        expect(result.current.handleProgressFinished).toBe(first);
+    });
+});

--- a/src/widgets/symbol-page/__tests__/hooks/useAnalysisProgress.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/useAnalysisProgress.test.tsx
@@ -1,0 +1,146 @@
+import { renderHook, act } from '@testing-library/react';
+import {
+    useAnalysisProgress,
+    ANALYSIS_PHASES,
+    ANALYSIS_TIPS,
+} from '@/widgets/symbol-page/hooks/useAnalysisProgress';
+
+describe('useAnalysisProgress', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('starts at phase 0 and tip 0', () => {
+        const { result } = renderHook(() =>
+            useAnalysisProgress({ isAnalyzing: true })
+        );
+
+        expect(result.current.phaseIndex).toBe(0);
+        expect(result.current.tipIndex).toBe(0);
+    });
+
+    it('advances phase index over time while analyzing', () => {
+        const { result } = renderHook(() =>
+            useAnalysisProgress({ isAnalyzing: true })
+        );
+
+        act(() => {
+            vi.advanceTimersByTime(60_000);
+        });
+
+        expect(result.current.phaseIndex).toBe(1);
+    });
+
+    it('advances tip index over time while analyzing', () => {
+        const { result } = renderHook(() =>
+            useAnalysisProgress({ isAnalyzing: true })
+        );
+
+        act(() => {
+            vi.advanceTimersByTime(8_000);
+        });
+
+        expect(result.current.tipIndex).toBe(1);
+    });
+
+    it('tip index wraps around', () => {
+        const { result } = renderHook(() =>
+            useAnalysisProgress({ isAnalyzing: true })
+        );
+
+        act(() => {
+            vi.advanceTimersByTime(8_000 * ANALYSIS_TIPS.length);
+        });
+
+        expect(result.current.tipIndex).toBe(0);
+    });
+
+    it('does not advance phase beyond last index while analyzing', () => {
+        const { result } = renderHook(() =>
+            useAnalysisProgress({ isAnalyzing: true })
+        );
+
+        act(() => {
+            vi.advanceTimersByTime(60_000 * (ANALYSIS_PHASES.length + 5));
+        });
+
+        expect(result.current.phaseIndex).toBe(ANALYSIS_PHASES.length - 1);
+    });
+
+    it('calls onFinished after finishing sequence completes', () => {
+        const onFinished = vi.fn();
+        const { rerender } = renderHook(
+            ({ isAnalyzing }) =>
+                useAnalysisProgress({ isAnalyzing, onFinished }),
+            { initialProps: { isAnalyzing: true } }
+        );
+
+        rerender({ isAnalyzing: false });
+
+        act(() => {
+            vi.advanceTimersByTime(
+                3_500 + 1_000 * ANALYSIS_PHASES.length + 600
+            );
+        });
+
+        expect(onFinished).toHaveBeenCalled();
+    });
+
+    it('resets state when analysis restarts', () => {
+        const { result, rerender } = renderHook(
+            ({ isAnalyzing }) => useAnalysisProgress({ isAnalyzing }),
+            { initialProps: { isAnalyzing: true } }
+        );
+
+        act(() => {
+            vi.advanceTimersByTime(60_000 * 3);
+        });
+
+        expect(result.current.phaseIndex).toBe(3);
+
+        rerender({ isAnalyzing: false });
+
+        act(() => {
+            vi.advanceTimersByTime(
+                3_500 + 1_000 * ANALYSIS_PHASES.length + 600
+            );
+        });
+
+        rerender({ isAnalyzing: true });
+
+        expect(result.current.phaseIndex).toBe(0);
+        expect(result.current.tipIndex).toBe(0);
+    });
+
+    it('does not advance while finishing', () => {
+        const { result, rerender } = renderHook(
+            ({ isAnalyzing }) => useAnalysisProgress({ isAnalyzing }),
+            { initialProps: { isAnalyzing: true } }
+        );
+
+        rerender({ isAnalyzing: false });
+
+        const phaseAtFinishingStart = result.current.phaseIndex;
+
+        act(() => {
+            vi.advanceTimersByTime(60_000);
+        });
+
+        // Phase should have advanced by the finishing sequence, not the normal interval
+        expect(result.current.phaseIndex).toBeGreaterThanOrEqual(
+            phaseAtFinishingStart
+        );
+    });
+
+    it('ANALYSIS_PHASES has expected count', () => {
+        expect(ANALYSIS_PHASES.length).toBe(6);
+    });
+
+    it('ANALYSIS_TIPS is non-empty', () => {
+        expect(ANALYSIS_TIPS.length).toBeGreaterThan(0);
+    });
+});

--- a/src/widgets/symbol-page/__tests__/hooks/useAssetInfo.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/useAssetInfo.test.tsx
@@ -1,0 +1,81 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useAssetInfo } from '@/widgets/symbol-page/hooks/useAssetInfo';
+import type { AssetInfo } from '@/shared/lib/types';
+
+vi.mock('@/entities/ticker/actions', () => ({
+    getAssetInfoAction: vi.fn(),
+}));
+
+import { getAssetInfoAction } from '@/entities/ticker/actions';
+
+const MOCK_ASSET_INFO: AssetInfo = {
+    name: 'Apple Inc.',
+    koreanName: '애플',
+    fmpSymbol: 'AAPL',
+} as AssetInfo;
+
+const queryClients: QueryClient[] = [];
+
+function makeWrapper() {
+    const client = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+        },
+    });
+    queryClients.push(client);
+    return function Wrapper({ children }: { children: ReactNode }) {
+        return (
+            <QueryClientProvider client={client}>
+                {children}
+            </QueryClientProvider>
+        );
+    };
+}
+
+describe('useAssetInfo', () => {
+    afterEach(() => {
+        queryClients.splice(0).forEach(c => c.clear());
+    });
+
+    it('returns undefined while loading', () => {
+        (getAssetInfoAction as ReturnType<typeof vi.fn>).mockImplementation(
+            () => new Promise(() => {})
+        );
+
+        const { result } = renderHook(() => useAssetInfo('AAPL'), {
+            wrapper: makeWrapper(),
+        });
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('returns asset info after fetch resolves', async () => {
+        (getAssetInfoAction as ReturnType<typeof vi.fn>).mockResolvedValue(
+            MOCK_ASSET_INFO
+        );
+
+        const { result } = renderHook(() => useAssetInfo('AAPL'), {
+            wrapper: makeWrapper(),
+        });
+
+        await waitFor(() => {
+            expect(result.current).toEqual(MOCK_ASSET_INFO);
+        });
+    });
+
+    it('returns undefined when fetch resolves with null', async () => {
+        (getAssetInfoAction as ReturnType<typeof vi.fn>).mockResolvedValue(
+            null
+        );
+
+        const { result } = renderHook(() => useAssetInfo('UNKNOWN'), {
+            wrapper: makeWrapper(),
+        });
+
+        await waitFor(() => {
+            expect(result.current).toBeUndefined();
+        });
+    });
+});

--- a/src/widgets/symbol-page/__tests__/hooks/useAssetInfo.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/useAssetInfo.test.tsx
@@ -1,14 +1,13 @@
-import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import type { ReactNode } from 'react';
-import { useAssetInfo } from '@/widgets/symbol-page/hooks/useAssetInfo';
-import type { AssetInfo } from '@/shared/lib/types';
-
 vi.mock('@/entities/ticker/actions', () => ({
     getAssetInfoAction: vi.fn(),
 }));
 
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
 import { getAssetInfoAction } from '@/entities/ticker/actions';
+import { useAssetInfo } from '@/widgets/symbol-page/hooks/useAssetInfo';
+import type { AssetInfo } from '@/shared/lib/types';
 
 const MOCK_ASSET_INFO: AssetInfo = {
     name: 'Apple Inc.',

--- a/src/widgets/symbol-page/__tests__/hooks/useBars.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/useBars.test.tsx
@@ -1,0 +1,90 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useBars } from '@/widgets/symbol-page/hooks/useBars';
+import type { BarsData, Timeframe } from '@y0ngha/siglens-core';
+
+vi.mock('@/entities/bars/actions', () => ({
+    getBarsAction: vi.fn(),
+}));
+
+import { getBarsAction } from '@/entities/bars/actions';
+
+const MOCK_BARS_DATA: BarsData = {
+    bars: [
+        { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 500 },
+    ],
+    indicators: {
+        buySellVolume: [],
+    },
+} as unknown as BarsData;
+
+const queryClients: QueryClient[] = [];
+
+function makeWrapper() {
+    const client = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+        },
+    });
+    queryClients.push(client);
+    return function Wrapper({ children }: { children: ReactNode }) {
+        return (
+            <QueryClientProvider client={client}>
+                {children}
+            </QueryClientProvider>
+        );
+    };
+}
+
+describe('useBars', () => {
+    afterEach(() => {
+        queryClients.splice(0).forEach(c => c.clear());
+    });
+
+    it('returns bars and indicators after fetch resolves', async () => {
+        (getBarsAction as ReturnType<typeof vi.fn>).mockResolvedValue(
+            MOCK_BARS_DATA
+        );
+
+        const { result } = renderHook(
+            () =>
+                useBars({
+                    symbol: 'AAPL',
+                    timeframe: '1Day' as Timeframe,
+                }),
+            { wrapper: makeWrapper() }
+        );
+
+        await waitFor(() => {
+            expect(result.current.bars).toEqual(MOCK_BARS_DATA.bars);
+            expect(result.current.indicators).toEqual(
+                MOCK_BARS_DATA.indicators
+            );
+        });
+    });
+
+    it('passes fmpSymbol to the action', async () => {
+        (getBarsAction as ReturnType<typeof vi.fn>).mockResolvedValue(
+            MOCK_BARS_DATA
+        );
+
+        renderHook(
+            () =>
+                useBars({
+                    symbol: 'AAPL',
+                    timeframe: '1Day' as Timeframe,
+                    fmpSymbol: 'AAPL.US',
+                }),
+            { wrapper: makeWrapper() }
+        );
+
+        await waitFor(() => {
+            expect(getBarsAction).toHaveBeenCalledWith(
+                'AAPL',
+                '1Day',
+                'AAPL.US'
+            );
+        });
+    });
+});

--- a/src/widgets/symbol-page/__tests__/hooks/useBars.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/useBars.test.tsx
@@ -1,14 +1,13 @@
-import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import type { ReactNode } from 'react';
-import { useBars } from '@/widgets/symbol-page/hooks/useBars';
-import type { BarsData, Timeframe } from '@y0ngha/siglens-core';
-
 vi.mock('@/entities/bars/actions', () => ({
     getBarsAction: vi.fn(),
 }));
 
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
 import { getBarsAction } from '@/entities/bars/actions';
+import { useBars } from '@/widgets/symbol-page/hooks/useBars';
+import type { BarsData, Timeframe } from '@y0ngha/siglens-core';
 
 const MOCK_BARS_DATA: BarsData = {
     bars: [

--- a/src/widgets/symbol-page/__tests__/hooks/useDefaultModelId.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/useDefaultModelId.test.tsx
@@ -1,0 +1,23 @@
+import { renderHook } from '@testing-library/react';
+import type { ModelId } from '@y0ngha/siglens-core';
+import { useDefaultModelId } from '@/widgets/symbol-page/hooks/useDefaultModelId';
+
+const MOCK_MODEL_ID = 'gemini-2.5-flash-lite' as ModelId;
+
+vi.mock('@/widgets/symbol-page/SymbolModelContext', () => ({
+    useSymbolModel: vi.fn(() => ({
+        modelId: MOCK_MODEL_ID,
+        allowedModels: [MOCK_MODEL_ID],
+        isHydrated: true,
+        gateModal: null,
+        dismissGate: vi.fn(),
+        handleModelChange: vi.fn(),
+    })),
+}));
+
+describe('useDefaultModelId', () => {
+    it('returns the modelId from SymbolModelContext', () => {
+        const { result } = renderHook(() => useDefaultModelId());
+        expect(result.current).toBe(MOCK_MODEL_ID);
+    });
+});

--- a/src/widgets/symbol-page/__tests__/hooks/useDragListener.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/useDragListener.test.tsx
@@ -1,0 +1,114 @@
+import { renderHook, act } from '@testing-library/react';
+import { useDragListener } from '@/widgets/symbol-page/hooks/useDragListener';
+import type React from 'react';
+
+describe('useDragListener', () => {
+    it('starts with isDragging false', () => {
+        const onResize = vi.fn();
+        const { result } = renderHook(() => useDragListener({ onResize }));
+        expect(result.current.isDragging).toBe(false);
+    });
+
+    it('ignores non-left-button clicks', () => {
+        const onResize = vi.fn();
+        const { result } = renderHook(() => useDragListener({ onResize }));
+
+        const event = {
+            button: 2,
+            clientX: 100,
+            preventDefault: vi.fn(),
+        } as unknown as React.MouseEvent;
+
+        act(() => {
+            result.current.handleDragStart(event);
+        });
+
+        expect(result.current.isDragging).toBe(false);
+        expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('sets isDragging to true on left-button mouse down', () => {
+        const onResize = vi.fn();
+        const { result } = renderHook(() => useDragListener({ onResize }));
+
+        const event = {
+            button: 0,
+            clientX: 100,
+            preventDefault: vi.fn(),
+        } as unknown as React.MouseEvent;
+
+        act(() => {
+            result.current.handleDragStart(event);
+        });
+
+        expect(result.current.isDragging).toBe(true);
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it('calls onResize with delta during mousemove', () => {
+        const onResize = vi.fn();
+        const { result } = renderHook(() => useDragListener({ onResize }));
+
+        act(() => {
+            result.current.handleDragStart({
+                button: 0,
+                clientX: 200,
+                preventDefault: vi.fn(),
+            } as unknown as React.MouseEvent);
+        });
+
+        act(() => {
+            document.dispatchEvent(
+                new MouseEvent('mousemove', { clientX: 250 })
+            );
+        });
+
+        expect(onResize).toHaveBeenCalledWith(50);
+    });
+
+    it('sets isDragging to false on mouseup', () => {
+        const onResize = vi.fn();
+        const { result } = renderHook(() => useDragListener({ onResize }));
+
+        act(() => {
+            result.current.handleDragStart({
+                button: 0,
+                clientX: 100,
+                preventDefault: vi.fn(),
+            } as unknown as React.MouseEvent);
+        });
+
+        expect(result.current.isDragging).toBe(true);
+
+        act(() => {
+            document.dispatchEvent(new MouseEvent('mouseup'));
+        });
+
+        expect(result.current.isDragging).toBe(false);
+    });
+
+    it('removes listeners on unmount', () => {
+        const onResize = vi.fn();
+        const removeSpy = vi.spyOn(document, 'removeEventListener');
+
+        const { result, unmount } = renderHook(() =>
+            useDragListener({ onResize })
+        );
+
+        act(() => {
+            result.current.handleDragStart({
+                button: 0,
+                clientX: 100,
+                preventDefault: vi.fn(),
+            } as unknown as React.MouseEvent);
+        });
+
+        unmount();
+
+        const removedEvents = removeSpy.mock.calls.map(c => c[0]);
+        expect(removedEvents).toContain('mousemove');
+        expect(removedEvents).toContain('mouseup');
+
+        removeSpy.mockRestore();
+    });
+});

--- a/src/widgets/symbol-page/__tests__/hooks/useMobileSheet.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/useMobileSheet.test.tsx
@@ -1,0 +1,38 @@
+import { renderHook, act } from '@testing-library/react';
+import { useMobileSheet } from '@/widgets/symbol-page/hooks/useMobileSheet';
+import {
+    SNAP_HALF,
+    SNAP_PEEK,
+} from '@/widgets/symbol-page/constants/mobileSheet';
+
+describe('useMobileSheet', () => {
+    it('defaults sheetSnap to SNAP_HALF', () => {
+        const { result } = renderHook(() => useMobileSheet());
+        expect(result.current.sheetSnap).toBe(SNAP_HALF);
+    });
+
+    it('defaults mobileSheetContent to null', () => {
+        const { result } = renderHook(() => useMobileSheet());
+        expect(result.current.mobileSheetContent).toBeNull();
+    });
+
+    it('updates sheetSnap', () => {
+        const { result } = renderHook(() => useMobileSheet());
+
+        act(() => {
+            result.current.setSheetSnap(SNAP_PEEK);
+        });
+
+        expect(result.current.sheetSnap).toBe(SNAP_PEEK);
+    });
+
+    it('updates mobileSheetContent', () => {
+        const { result } = renderHook(() => useMobileSheet());
+
+        act(() => {
+            result.current.setMobileSheetContent('test content');
+        });
+
+        expect(result.current.mobileSheetContent).toBe('test content');
+    });
+});

--- a/src/widgets/symbol-page/__tests__/hooks/useMobileSheetDrag.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/useMobileSheetDrag.test.tsx
@@ -1,0 +1,108 @@
+import { renderHook } from '@testing-library/react';
+import { useMobileSheetDrag } from '@/widgets/symbol-page/hooks/useMobileSheetDrag';
+import type { RefObject } from 'react';
+
+function createMockRef<T>(value: T | null): RefObject<T | null> {
+    return { current: value };
+}
+
+describe('useMobileSheetDrag', () => {
+    it('attaches touch listeners when isFullSnap is true', () => {
+        const scrollEl = document.createElement('div');
+        const drawerEl = document.createElement('div');
+        const addSpy = vi.spyOn(scrollEl, 'addEventListener');
+
+        renderHook(() =>
+            useMobileSheetDrag({
+                scrollElRef: createMockRef(scrollEl),
+                drawerElRef: createMockRef(drawerEl),
+                isFullSnap: true,
+                onSnapChange: vi.fn(),
+            })
+        );
+
+        const events = addSpy.mock.calls.map(c => c[0]);
+        expect(events).toContain('touchstart');
+        expect(events).toContain('touchmove');
+        expect(events).toContain('touchend');
+        expect(events).toContain('touchcancel');
+
+        addSpy.mockRestore();
+    });
+
+    it('does not attach listeners when isFullSnap is false', () => {
+        const scrollEl = document.createElement('div');
+        const drawerEl = document.createElement('div');
+        const addSpy = vi.spyOn(scrollEl, 'addEventListener');
+
+        renderHook(() =>
+            useMobileSheetDrag({
+                scrollElRef: createMockRef(scrollEl),
+                drawerElRef: createMockRef(drawerEl),
+                isFullSnap: false,
+                onSnapChange: vi.fn(),
+            })
+        );
+
+        expect(addSpy).not.toHaveBeenCalled();
+
+        addSpy.mockRestore();
+    });
+
+    it('does not attach listeners when refs are null', () => {
+        renderHook(() =>
+            useMobileSheetDrag({
+                scrollElRef: createMockRef<HTMLDivElement>(null),
+                drawerElRef: createMockRef<HTMLDivElement>(null),
+                isFullSnap: true,
+                onSnapChange: vi.fn(),
+            })
+        );
+    });
+
+    it('removes listeners on unmount', () => {
+        const scrollEl = document.createElement('div');
+        const drawerEl = document.createElement('div');
+        const removeSpy = vi.spyOn(scrollEl, 'removeEventListener');
+
+        const { unmount } = renderHook(() =>
+            useMobileSheetDrag({
+                scrollElRef: createMockRef(scrollEl),
+                drawerElRef: createMockRef(drawerEl),
+                isFullSnap: true,
+                onSnapChange: vi.fn(),
+            })
+        );
+
+        unmount();
+
+        const events = removeSpy.mock.calls.map(c => c[0]);
+        expect(events).toContain('touchstart');
+        expect(events).toContain('touchmove');
+        expect(events).toContain('touchend');
+        expect(events).toContain('touchcancel');
+
+        removeSpy.mockRestore();
+    });
+
+    it('clears drawer styles on unmount', () => {
+        const scrollEl = document.createElement('div');
+        const drawerEl = document.createElement('div');
+        drawerEl.style.transform = 'translateY(100px)';
+        drawerEl.style.transition = 'transform 0.5s';
+
+        const { unmount } = renderHook(() =>
+            useMobileSheetDrag({
+                scrollElRef: createMockRef(scrollEl),
+                drawerElRef: createMockRef(drawerEl),
+                isFullSnap: true,
+                onSnapChange: vi.fn(),
+            })
+        );
+
+        unmount();
+
+        expect(drawerEl.style.transform).toBe('');
+        expect(drawerEl.style.transition).toBe('');
+    });
+});

--- a/src/widgets/symbol-page/__tests__/hooks/usePanelResize.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/usePanelResize.test.tsx
@@ -1,0 +1,132 @@
+import { renderHook, act } from '@testing-library/react';
+import {
+    usePanelResize,
+    PANEL_MIN_WIDTH,
+    PANEL_MAX_WIDTH,
+} from '@/widgets/symbol-page/hooks/usePanelResize';
+import type React from 'react';
+
+describe('usePanelResize', () => {
+    it('defaults panelWidth to PANEL_MAX_WIDTH', () => {
+        const { result } = renderHook(() => usePanelResize());
+        expect(result.current.panelWidth).toBe(PANEL_MAX_WIDTH);
+    });
+
+    it('defaults isDragging to false', () => {
+        const { result } = renderHook(() => usePanelResize());
+        expect(result.current.isDragging).toBe(false);
+    });
+
+    it('shrinks panel when dragged rightward (positive deltaX)', () => {
+        const { result } = renderHook(() => usePanelResize());
+
+        act(() => {
+            result.current.handleDragStart({
+                button: 0,
+                clientX: 500,
+                preventDefault: vi.fn(),
+            } as unknown as React.MouseEvent);
+        });
+
+        act(() => {
+            document.dispatchEvent(
+                new MouseEvent('mousemove', { clientX: 600 })
+            );
+        });
+
+        // deltaX = 600 - 500 = 100, panelWidth = 640 - 100 = 540
+        expect(result.current.panelWidth).toBe(PANEL_MAX_WIDTH - 100);
+    });
+
+    it('clamps panel width to minimum', () => {
+        const { result } = renderHook(() => usePanelResize());
+
+        act(() => {
+            result.current.handleDragStart({
+                button: 0,
+                clientX: 100,
+                preventDefault: vi.fn(),
+            } as unknown as React.MouseEvent);
+        });
+
+        act(() => {
+            document.dispatchEvent(
+                new MouseEvent('mousemove', { clientX: 2000 })
+            );
+        });
+
+        expect(result.current.panelWidth).toBe(PANEL_MIN_WIDTH);
+    });
+
+    it('clamps panel width to maximum', () => {
+        const { result } = renderHook(() => usePanelResize());
+
+        act(() => {
+            result.current.handleDragStart({
+                button: 0,
+                clientX: 500,
+                preventDefault: vi.fn(),
+            } as unknown as React.MouseEvent);
+        });
+
+        act(() => {
+            document.dispatchEvent(
+                new MouseEvent('mousemove', { clientX: -2000 })
+            );
+        });
+
+        expect(result.current.panelWidth).toBe(PANEL_MAX_WIDTH);
+    });
+
+    it('handles ArrowLeft to shrink panel', () => {
+        const { result } = renderHook(() => usePanelResize());
+
+        act(() => {
+            result.current.handleKeyDown({
+                key: 'ArrowLeft',
+                preventDefault: vi.fn(),
+            } as unknown as React.KeyboardEvent);
+        });
+
+        expect(result.current.panelWidth).toBe(PANEL_MAX_WIDTH - 10);
+    });
+
+    it('handles ArrowRight to grow panel', () => {
+        const { result } = renderHook(() => usePanelResize());
+
+        act(() => {
+            result.current.handleKeyDown({
+                key: 'ArrowLeft',
+                preventDefault: vi.fn(),
+            } as unknown as React.KeyboardEvent);
+        });
+
+        act(() => {
+            result.current.handleKeyDown({
+                key: 'ArrowRight',
+                preventDefault: vi.fn(),
+            } as unknown as React.KeyboardEvent);
+        });
+
+        expect(result.current.panelWidth).toBe(PANEL_MAX_WIDTH);
+    });
+
+    it('ignores non-arrow keys', () => {
+        const { result } = renderHook(() => usePanelResize());
+        const preventDefault = vi.fn();
+
+        act(() => {
+            result.current.handleKeyDown({
+                key: 'Enter',
+                preventDefault,
+            } as unknown as React.KeyboardEvent);
+        });
+
+        expect(result.current.panelWidth).toBe(PANEL_MAX_WIDTH);
+        expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('PANEL_MIN_WIDTH is less than PANEL_MAX_WIDTH', () => {
+        expect(PANEL_MIN_WIDTH).toBeLessThan(PANEL_MAX_WIDTH);
+    });
+});

--- a/src/widgets/symbol-page/__tests__/hooks/useSelectedModel.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/useSelectedModel.test.tsx
@@ -1,0 +1,105 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { ModelId } from '@y0ngha/siglens-core';
+import { useSelectedModel } from '@/widgets/symbol-page/hooks/useSelectedModel';
+import { LOCAL_STORAGE_ANALYSIS_MODEL_KEY } from '@/shared/lib/storageKeys';
+
+vi.mock('@y0ngha/siglens-core', () => ({
+    GEMINI_2_5_FLASH_LITE_MODEL: 'gemini-2.5-flash-lite',
+}));
+
+const DEFAULT_MODEL = 'gemini-2.5-flash-lite' as ModelId;
+const PREMIUM_MODEL = 'gemini-2.5-pro' as ModelId;
+
+describe('useSelectedModel', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('defaults to the default model', () => {
+        const { result } = renderHook(() =>
+            useSelectedModel([DEFAULT_MODEL, PREMIUM_MODEL])
+        );
+
+        expect(result.current[0]).toBe(DEFAULT_MODEL);
+    });
+
+    it('persists model selection to localStorage', () => {
+        const { result } = renderHook(() =>
+            useSelectedModel([DEFAULT_MODEL, PREMIUM_MODEL])
+        );
+
+        act(() => {
+            result.current[1](PREMIUM_MODEL);
+        });
+
+        expect(localStorage.getItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY)).toBe(
+            PREMIUM_MODEL
+        );
+        expect(result.current[0]).toBe(PREMIUM_MODEL);
+    });
+
+    it('reads stored model from localStorage after hydration', async () => {
+        localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY, PREMIUM_MODEL);
+
+        const { result } = renderHook(() =>
+            useSelectedModel([DEFAULT_MODEL, PREMIUM_MODEL])
+        );
+
+        await waitFor(() => {
+            expect(result.current[2]).toBe(true);
+        });
+
+        expect(result.current[0]).toBe(PREMIUM_MODEL);
+    });
+
+    it('falls back to default when stored model is not in allowed list', async () => {
+        localStorage.setItem(
+            LOCAL_STORAGE_ANALYSIS_MODEL_KEY,
+            'obsolete-model'
+        );
+
+        const { result } = renderHook(() =>
+            useSelectedModel([DEFAULT_MODEL, PREMIUM_MODEL])
+        );
+
+        await waitFor(() => {
+            expect(result.current[2]).toBe(true);
+        });
+
+        expect(result.current[0]).toBe(DEFAULT_MODEL);
+    });
+
+    it('re-validates when allowedModels changes to exclude current model', async () => {
+        const { result, rerender } = renderHook(
+            ({ allowed }) => useSelectedModel(allowed),
+            {
+                initialProps: {
+                    allowed: [
+                        DEFAULT_MODEL,
+                        PREMIUM_MODEL,
+                    ] as readonly ModelId[],
+                },
+            }
+        );
+
+        act(() => {
+            result.current[1](PREMIUM_MODEL);
+        });
+
+        expect(result.current[0]).toBe(PREMIUM_MODEL);
+
+        rerender({ allowed: [DEFAULT_MODEL] as readonly ModelId[] });
+
+        await waitFor(() => {
+            expect(result.current[0]).toBe(DEFAULT_MODEL);
+        });
+    });
+
+    it('becomes hydrated after effect runs', async () => {
+        const { result } = renderHook(() => useSelectedModel([DEFAULT_MODEL]));
+
+        await waitFor(() => {
+            expect(result.current[2]).toBe(true);
+        });
+    });
+});

--- a/src/widgets/symbol-page/__tests__/hooks/useTimeframeChange.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/useTimeframeChange.test.tsx
@@ -1,0 +1,102 @@
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import type { Timeframe } from '@y0ngha/siglens-core';
+import { useTimeframeChange } from '@/widgets/symbol-page/hooks/useTimeframeChange';
+
+const mockReplace = vi.fn();
+const mockGet = vi.fn().mockReturnValue(null);
+
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({ replace: mockReplace }),
+    useSearchParams: () => ({ get: mockGet }),
+}));
+
+vi.mock('@/shared/config/market', () => ({
+    DEFAULT_TIMEFRAME: '1Day',
+    isValidTimeframe: (v: unknown) =>
+        ['1Day', '1Week', '1Month'].includes(v as string),
+}));
+
+vi.mock('@/entities/bars/actions', () => ({
+    getBarsAction: vi.fn().mockResolvedValue({ bars: [], indicators: {} }),
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/useAssetInfo', () => ({
+    useAssetInfo: vi.fn(() => undefined),
+}));
+
+const queryClients: QueryClient[] = [];
+
+function makeWrapper() {
+    const client = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    queryClients.push(client);
+    return function Wrapper({ children }: { children: ReactNode }) {
+        return (
+            <QueryClientProvider client={client}>
+                {children}
+            </QueryClientProvider>
+        );
+    };
+}
+
+describe('useTimeframeChange', () => {
+    beforeEach(() => {
+        mockReplace.mockClear();
+        mockGet.mockReturnValue(null);
+    });
+
+    afterEach(() => {
+        queryClients.splice(0).forEach(c => c.clear());
+    });
+
+    it('defaults to DEFAULT_TIMEFRAME when search param is absent', () => {
+        const { result } = renderHook(() => useTimeframeChange('AAPL'), {
+            wrapper: makeWrapper(),
+        });
+
+        expect(result.current.timeframe).toBe('1Day');
+    });
+
+    it('reads timeframe from search param', () => {
+        mockGet.mockReturnValue('1Week');
+
+        const { result } = renderHook(() => useTimeframeChange('AAPL'), {
+            wrapper: makeWrapper(),
+        });
+
+        expect(result.current.timeframe).toBe('1Week');
+    });
+
+    it('falls back to DEFAULT_TIMEFRAME for invalid search param', () => {
+        mockGet.mockReturnValue('invalid');
+
+        const { result } = renderHook(() => useTimeframeChange('AAPL'), {
+            wrapper: makeWrapper(),
+        });
+
+        expect(result.current.timeframe).toBe('1Day');
+    });
+
+    it('starts with timeframeChangeCount of 0', () => {
+        const { result } = renderHook(() => useTimeframeChange('AAPL'), {
+            wrapper: makeWrapper(),
+        });
+
+        expect(result.current.timeframeChangeCount).toBe(0);
+    });
+
+    it('skips change when next timeframe equals current', () => {
+        const { result } = renderHook(() => useTimeframeChange('AAPL'), {
+            wrapper: makeWrapper(),
+        });
+
+        act(() => {
+            result.current.handleTimeframeChange('1Day' as Timeframe);
+        });
+
+        expect(mockReplace).not.toHaveBeenCalled();
+    });
+});

--- a/src/widgets/symbol-page/__tests__/hooks/useUserTier.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/useUserTier.test.tsx
@@ -1,8 +1,3 @@
-import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import type { ReactNode } from 'react';
-import { useUserTier } from '@/widgets/symbol-page/hooks/useUserTier';
-
 vi.mock('@/entities/user-tier/actions', () => ({
     getUserTierAction: vi.fn(),
 }));
@@ -11,7 +6,11 @@ vi.mock('@y0ngha/siglens-core', () => ({
     DEFAULT_TIER: 'free',
 }));
 
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
 import { getUserTierAction } from '@/entities/user-tier/actions';
+import { useUserTier } from '@/widgets/symbol-page/hooks/useUserTier';
 
 const queryClients: QueryClient[] = [];
 

--- a/src/widgets/symbol-page/__tests__/hooks/useUserTier.test.tsx
+++ b/src/widgets/symbol-page/__tests__/hooks/useUserTier.test.tsx
@@ -1,0 +1,81 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useUserTier } from '@/widgets/symbol-page/hooks/useUserTier';
+
+vi.mock('@/entities/user-tier/actions', () => ({
+    getUserTierAction: vi.fn(),
+}));
+
+vi.mock('@y0ngha/siglens-core', () => ({
+    DEFAULT_TIER: 'free',
+}));
+
+import { getUserTierAction } from '@/entities/user-tier/actions';
+
+const queryClients: QueryClient[] = [];
+
+function makeWrapper() {
+    const client = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    queryClients.push(client);
+    return function Wrapper({ children }: { children: ReactNode }) {
+        return (
+            <QueryClientProvider client={client}>
+                {children}
+            </QueryClientProvider>
+        );
+    };
+}
+
+describe('useUserTier', () => {
+    afterEach(() => {
+        queryClients.splice(0).forEach(c => c.clear());
+    });
+
+    it('returns DEFAULT_TIER while loading', () => {
+        (getUserTierAction as ReturnType<typeof vi.fn>).mockImplementation(
+            () => new Promise(() => {})
+        );
+
+        const { result } = renderHook(() => useUserTier(), {
+            wrapper: makeWrapper(),
+        });
+
+        expect(result.current.tier).toBe('free');
+        expect(result.current.isLoading).toBe(true);
+    });
+
+    it('returns fetched tier after resolving', async () => {
+        (getUserTierAction as ReturnType<typeof vi.fn>).mockResolvedValue(
+            'premium'
+        );
+
+        const { result } = renderHook(() => useUserTier(), {
+            wrapper: makeWrapper(),
+        });
+
+        await waitFor(() => {
+            expect(result.current.tier).toBe('premium');
+        });
+
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('falls back to DEFAULT_TIER on error', async () => {
+        (getUserTierAction as ReturnType<typeof vi.fn>).mockRejectedValue(
+            new Error('fetch failed')
+        );
+
+        const { result } = renderHook(() => useUserTier(), {
+            wrapper: makeWrapper(),
+        });
+
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+        });
+
+        expect(result.current.tier).toBe('free');
+    });
+});

--- a/src/widgets/symbol-page/__tests__/utils/analysisStatus.test.ts
+++ b/src/widgets/symbol-page/__tests__/utils/analysisStatus.test.ts
@@ -1,0 +1,24 @@
+import { getAnalysisStatus } from '@/widgets/symbol-page/utils/analysisStatus';
+
+describe('getAnalysisStatus', () => {
+    it('returns analyzing when isAnalyzing is true', () => {
+        expect(getAnalysisStatus(true, null)).toEqual({ type: 'analyzing' });
+    });
+
+    it('returns analyzing even when analysisError is present', () => {
+        expect(getAnalysisStatus(true, 'some error')).toEqual({
+            type: 'analyzing',
+        });
+    });
+
+    it('returns error when isAnalyzing is false and analysisError exists', () => {
+        expect(getAnalysisStatus(false, 'timeout')).toEqual({
+            type: 'error',
+            message: 'timeout',
+        });
+    });
+
+    it('returns idle when neither analyzing nor error', () => {
+        expect(getAnalysisStatus(false, null)).toEqual({ type: 'idle' });
+    });
+});

--- a/src/widgets/symbol-page/__tests__/utils/mobileSheetDom.test.ts
+++ b/src/widgets/symbol-page/__tests__/utils/mobileSheetDom.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { captureTransformY } from '@/widgets/symbol-page/utils/mobileSheetDom';
+
+// jsdom does not implement DOMMatrix — provide a minimal stub.
+class DOMMatrixStub {
+    m42: number;
+    constructor(init?: string) {
+        if (!init || init === 'none') {
+            this.m42 = 0;
+        } else {
+            const match = init.match(
+                /^matrix\(([^,]+),\s*([^,]+),\s*([^,]+),\s*([^,]+),\s*([^,]+),\s*([^)]+)\)$/
+            );
+            this.m42 = match ? Number(match[6]) : 0;
+        }
+    }
+}
+
+beforeAll(() => {
+    (globalThis as Record<string, unknown>).DOMMatrix = DOMMatrixStub;
+});
+
+afterAll(() => {
+    delete (globalThis as Record<string, unknown>).DOMMatrix;
+});
+
+describe('captureTransformY', () => {
+    it('returns 0 when transform is "none"', () => {
+        const el = document.createElement('div');
+        document.body.appendChild(el);
+
+        const spy = vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+            transform: 'none',
+        } as unknown as CSSStyleDeclaration);
+
+        expect(captureTransformY(el as HTMLDivElement)).toBe(0);
+
+        spy.mockRestore();
+        el.remove();
+    });
+
+    it('extracts translateY from a matrix transform', () => {
+        const el = document.createElement('div');
+        document.body.appendChild(el);
+
+        const spy = vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+            transform: 'matrix(1, 0, 0, 1, 0, 42)',
+        } as unknown as CSSStyleDeclaration);
+
+        expect(captureTransformY(el as HTMLDivElement)).toBe(42);
+
+        spy.mockRestore();
+        el.remove();
+    });
+
+    it('returns 0 for identity matrix', () => {
+        const el = document.createElement('div');
+        document.body.appendChild(el);
+
+        const spy = vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+            transform: 'matrix(1, 0, 0, 1, 0, 0)',
+        } as unknown as CSSStyleDeclaration);
+
+        expect(captureTransformY(el as HTMLDivElement)).toBe(0);
+
+        spy.mockRestore();
+        el.remove();
+    });
+});

--- a/src/widgets/symbol-page/__tests__/utils/mobileSheetDom.test.ts
+++ b/src/widgets/symbol-page/__tests__/utils/mobileSheetDom.test.ts
@@ -16,15 +16,14 @@ class DOMMatrixStub {
     }
 }
 
-beforeAll(() => {
-    (globalThis as Record<string, unknown>).DOMMatrix = DOMMatrixStub;
-});
-
-afterAll(() => {
-    delete (globalThis as Record<string, unknown>).DOMMatrix;
-});
-
 describe('captureTransformY', () => {
+    beforeAll(() => {
+        (globalThis as Record<string, unknown>).DOMMatrix = DOMMatrixStub;
+    });
+
+    afterAll(() => {
+        delete (globalThis as Record<string, unknown>).DOMMatrix;
+    });
     it('returns 0 when transform is "none"', () => {
         const el = document.createElement('div');
         document.body.appendChild(el);

--- a/src/widgets/symbol-page/__tests__/utils/symbolTabsConfig.test.ts
+++ b/src/widgets/symbol-page/__tests__/utils/symbolTabsConfig.test.ts
@@ -1,0 +1,48 @@
+import { TABS } from '@/widgets/symbol-page/utils/symbolTabsConfig';
+
+describe('TABS (symbolTabsConfig)', () => {
+    it('contains all 6 analysis tabs', () => {
+        expect(TABS).toHaveLength(6);
+    });
+
+    it('has unique keys', () => {
+        const keys = TABS.map(t => t.key);
+        expect(new Set(keys).size).toBe(keys.length);
+    });
+
+    it('chart tab href is /{symbol}', () => {
+        const chart = TABS.find(t => t.key === 'chart')!;
+        expect(chart.hrefBuilder('AAPL')).toBe('/AAPL');
+    });
+
+    it('news tab href is /{symbol}/news', () => {
+        const news = TABS.find(t => t.key === 'news')!;
+        expect(news.hrefBuilder('TSLA')).toBe('/TSLA/news');
+    });
+
+    it('fundamental tab href is /{symbol}/fundamental', () => {
+        const tab = TABS.find(t => t.key === 'fundamental')!;
+        expect(tab.hrefBuilder('MSFT')).toBe('/MSFT/fundamental');
+    });
+
+    it('options tab href is /{symbol}/options', () => {
+        const tab = TABS.find(t => t.key === 'options')!;
+        expect(tab.hrefBuilder('NVDA')).toBe('/NVDA/options');
+    });
+
+    it('fear-greed tab href is /{symbol}/fear-greed', () => {
+        const tab = TABS.find(t => t.key === 'fear-greed')!;
+        expect(tab.hrefBuilder('SPY')).toBe('/SPY/fear-greed');
+    });
+
+    it('overall tab href is /{symbol}/overall', () => {
+        const tab = TABS.find(t => t.key === 'overall')!;
+        expect(tab.hrefBuilder('QQQ')).toBe('/QQQ/overall');
+    });
+
+    it('every tab has a non-empty label', () => {
+        for (const tab of TABS) {
+            expect(tab.label.length).toBeGreaterThan(0);
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- symbol-page 위젯 29개 파일 테스트 작성
- 181개 새 테스트 케이스

## Tested files
**Hooks (14):** useActionPricesVisibility, useAnalysisDerivedData, useAnalysisDisplay,
useAnalysisProgress, useAssetInfo, useBars, useDefaultModelId, useDragListener,
useMobileSheet, useMobileSheetDrag, usePanelResize, useSelectedModel,
useTimeframeChange, useUserTier

**Components (10):** ChartContent, CrossLinkCards, MobileAnalysisSheet, SectionSkeleton,
SymbolLayoutHeader, SymbolModelContext, SymbolPageClient, SymbolPageContext,
SymbolTabs, SymbolTabsSkeleton

**Utils (3):** analysisStatus, mobileSheetDom, symbolTabsConfig
**Other (2):** constants/mobileSheet, exceptions/BotBlockedError

## Test plan
- [x] `yarn test` — all suites pass (181 new tests)
- [x] `tsc --noEmit` — 0 errors
- [x] `yarn lint` — 0 errors
- [x] `yarn format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)