### PR TITLE
test(widgets): add tests for dashboard + options + news

### DIFF
--- a/src/widgets/dashboard/__tests__/BriefingCard.test.tsx
+++ b/src/widgets/dashboard/__tests__/BriefingCard.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from '@testing-library/react';
+import type { MarketBriefingResponse } from '@y0ngha/siglens-core';
+import {
+    BriefingCard,
+    BriefingLoadingCard,
+    BriefingErrorCard,
+} from '@/widgets/dashboard/BriefingCard';
+
+const BRIEFING: MarketBriefingResponse = {
+    summary: 'Markets rallied today',
+    dominantThemes: ['AI', 'Earnings'],
+    sectorAnalysis: {
+        leadingSectors: ['XLK', 'XLF'],
+        laggingSectors: ['XLE'],
+        performanceDescription: 'Tech led the way',
+    },
+    volatilityAnalysis: { vixLevel: 14.5, description: 'Low volatility' },
+    riskSentiment: 'Risk on mode',
+};
+
+describe('BriefingCard', () => {
+    it('renders summary text', () => {
+        render(
+            <BriefingCard
+                briefing={BRIEFING}
+                generatedAt="2025-01-15T10:00:00Z"
+            />
+        );
+        expect(screen.getByText('Markets rallied today')).toBeInTheDocument();
+    });
+
+    it('renders dominant themes as badges', () => {
+        render(
+            <BriefingCard
+                briefing={BRIEFING}
+                generatedAt="2025-01-15T10:00:00Z"
+            />
+        );
+        expect(screen.getByText('AI')).toBeInTheDocument();
+        expect(screen.getByText('Earnings')).toBeInTheDocument();
+    });
+
+    it('renders leading and lagging sectors', () => {
+        render(
+            <BriefingCard
+                briefing={BRIEFING}
+                generatedAt="2025-01-15T10:00:00Z"
+            />
+        );
+        expect(screen.getByText('XLK·XLF')).toBeInTheDocument();
+        expect(screen.getByText('XLE')).toBeInTheDocument();
+    });
+
+    it('renders VIX level', () => {
+        render(
+            <BriefingCard
+                briefing={BRIEFING}
+                generatedAt="2025-01-15T10:00:00Z"
+            />
+        );
+        expect(screen.getByText(/VIX 14\.50/)).toBeInTheDocument();
+    });
+
+    it('renders risk sentiment', () => {
+        render(
+            <BriefingCard
+                briefing={BRIEFING}
+                generatedAt="2025-01-15T10:00:00Z"
+            />
+        );
+        expect(screen.getByText('Risk on mode')).toBeInTheDocument();
+    });
+
+    it('renders generated date in KST', () => {
+        render(
+            <BriefingCard
+                briefing={BRIEFING}
+                generatedAt="2025-01-15T10:00:00Z"
+            />
+        );
+        expect(screen.getByText(/기준/)).toBeInTheDocument();
+    });
+
+    it('hides summary when empty', () => {
+        const briefing: MarketBriefingResponse = {
+            ...BRIEFING,
+            summary: '',
+        };
+        render(
+            <BriefingCard
+                briefing={briefing}
+                generatedAt="2025-01-15T10:00:00Z"
+            />
+        );
+        expect(
+            screen.queryByText('Markets rallied today')
+        ).not.toBeInTheDocument();
+    });
+});
+
+describe('BriefingLoadingCard', () => {
+    it('renders loading state with status role', () => {
+        render(<BriefingLoadingCard />);
+        expect(screen.getByRole('status')).toBeInTheDocument();
+        expect(screen.getByText(/브리핑 생성 중/)).toBeInTheDocument();
+    });
+});
+
+describe('BriefingErrorCard', () => {
+    it('renders error state with alert role', () => {
+        render(<BriefingErrorCard />);
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByText(/불러오지 못했어요/)).toBeInTheDocument();
+    });
+});

--- a/src/widgets/dashboard/__tests__/IndexCard.test.tsx
+++ b/src/widgets/dashboard/__tests__/IndexCard.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react';
+import { IndexCard } from '@/widgets/dashboard/IndexCard';
+import type { MarketIndexData, MarketSectorData } from '@y0ngha/siglens-core';
+
+vi.mock('next/link', () => ({
+    default: ({
+        children,
+        href,
+        title,
+    }: {
+        children: React.ReactNode;
+        href: string;
+        title?: string;
+    }) => (
+        <a href={href} title={title}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock('@/shared/lib/cardStyles', () => ({
+    CARD_LINK_CLASSES: 'card-link-mock',
+}));
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/shared/lib/priceFormat', () => ({
+    formatPriceChange: (percent: number) => ({
+        sign: percent >= 0 ? '+' : '-',
+        colorClass: percent >= 0 ? 'text-green' : 'text-red',
+        arrow: percent >= 0 ? '▲' : '▼',
+        arrowLabel: percent >= 0 ? '상승' : '하락',
+    }),
+    formatUsdPrice: (price: number) => price.toFixed(2),
+}));
+
+const INDEX_DATA: MarketIndexData = {
+    symbol: 'SPY',
+    fmpSymbol: '^GSPC',
+    koreanName: 'S&P 500',
+    displayName: 'S&P 500 Index',
+    price: 5012.34,
+    changesPercentage: 1.25,
+};
+
+const SECTOR_DATA: MarketSectorData = {
+    symbol: 'XLK',
+    sectorName: 'Technology',
+    koreanName: '기술',
+    price: 200.5,
+    changesPercentage: -0.75,
+};
+
+describe('IndexCard', () => {
+    it('renders symbol and price', () => {
+        render(<IndexCard data={INDEX_DATA} />);
+        expect(screen.getByText('SPY')).toBeInTheDocument();
+        expect(screen.getByText('$5012.34')).toBeInTheDocument();
+    });
+
+    it('renders korean name', () => {
+        render(<IndexCard data={INDEX_DATA} />);
+        expect(screen.getByText('S&P 500')).toBeInTheDocument();
+    });
+
+    it('renders percentage change', () => {
+        render(<IndexCard data={INDEX_DATA} />);
+        expect(screen.getByText(/1\.25%/)).toBeInTheDocument();
+    });
+
+    it('wraps in a Link when href is provided', () => {
+        render(<IndexCard data={INDEX_DATA} href="/SPY" />);
+        const link = screen.getByRole('link');
+        expect(link).toHaveAttribute('href', '/SPY');
+        expect(link).toHaveAttribute('title', 'S&P 500 Index 분석');
+    });
+
+    it('does not wrap in a Link when href is absent', () => {
+        render(<IndexCard data={INDEX_DATA} />);
+        expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('uses sectorName as label for sector data', () => {
+        render(<IndexCard data={SECTOR_DATA} href="/XLK" />);
+        const link = screen.getByRole('link');
+        expect(link).toHaveAttribute('title', 'Technology 분석');
+    });
+});

--- a/src/widgets/dashboard/__tests__/MarketSummaryPanel.test.tsx
+++ b/src/widgets/dashboard/__tests__/MarketSummaryPanel.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import { MarketSummaryPanel } from '@/widgets/dashboard/MarketSummaryPanel';
+
+vi.mock('./hooks/useBriefing', () => ({
+    useBriefing: vi.fn(),
+}));
+
+const mockUseMarketSummary = vi.fn();
+vi.mock('@/widgets/dashboard/hooks/useMarketSummary', () => ({
+    useMarketSummary: () => mockUseMarketSummary(),
+}));
+
+vi.mock('@/widgets/dashboard/hooks/useBriefing', () => ({
+    useBriefing: vi.fn(),
+}));
+
+vi.mock('@/widgets/dashboard/MarketSummaryPanelSkeleton', () => ({
+    MarketSummaryPanelSkeleton: () => (
+        <div data-testid="skeleton">Loading...</div>
+    ),
+}));
+
+vi.mock('@/widgets/dashboard/IndexCard', () => ({
+    IndexCard: ({ data }: { data: { symbol: string } }) => (
+        <div data-testid={`index-${data.symbol}`}>{data.symbol}</div>
+    ),
+}));
+
+vi.mock('@/widgets/dashboard/BriefingCard', () => ({
+    BriefingCard: () => <div data-testid="briefing">Briefing</div>,
+    BriefingLoadingCard: () => <div data-testid="briefing-loading" />,
+    BriefingErrorCard: () => <div data-testid="briefing-error" />,
+}));
+
+vi.mock('@/shared/ui/BotBlockedNotice', () => ({
+    BotBlockedNotice: () => <div data-testid="bot-blocked" />,
+}));
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/shared/config/dashboard-tickers', () => ({
+    SECTOR_GROUPS: [
+        { label: 'Tech', symbols: ['XLK'] },
+        { label: 'Finance', symbols: ['XLF', 'XLV', 'XLI'] },
+    ],
+}));
+
+vi.mock('react-error-boundary', () => ({
+    ErrorBoundary: ({ children }: { children: React.ReactNode }) => (
+        <>{children}</>
+    ),
+}));
+
+describe('MarketSummaryPanel', () => {
+    afterEach(() => {
+        mockUseMarketSummary.mockReset();
+    });
+
+    it('renders skeleton while pending', () => {
+        mockUseMarketSummary.mockReturnValue({
+            data: undefined,
+            isPending: true,
+            sectorMap: new Map(),
+            indices: [],
+        });
+        render(<MarketSummaryPanel />);
+        expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    });
+
+    it('renders null when data has ok: false', () => {
+        mockUseMarketSummary.mockReturnValue({
+            data: { ok: false },
+            isPending: false,
+            sectorMap: new Map(),
+            indices: [],
+        });
+        const { container } = render(<MarketSummaryPanel />);
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('renders indices and section heading when data is loaded', () => {
+        mockUseMarketSummary.mockReturnValue({
+            data: {
+                summary: { indices: [], sectors: [] },
+                briefing: undefined,
+            },
+            isPending: false,
+            sectorMap: new Map(),
+            indices: [
+                {
+                    symbol: 'SPY',
+                    fmpSymbol: '^GSPC',
+                    koreanName: 'S&P 500',
+                    displayName: 'S&P 500',
+                    price: 5000,
+                    changesPercentage: 1,
+                },
+            ],
+        });
+        render(<MarketSummaryPanel />);
+        expect(screen.getByText('오늘의 미국 시장')).toBeInTheDocument();
+        expect(screen.getByTestId('index-SPY')).toBeInTheDocument();
+    });
+});

--- a/src/widgets/dashboard/__tests__/MarketSummaryPanel.test.tsx
+++ b/src/widgets/dashboard/__tests__/MarketSummaryPanel.test.tsx
@@ -1,10 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { MarketSummaryPanel } from '@/widgets/dashboard/MarketSummaryPanel';
 
-vi.mock('./hooks/useBriefing', () => ({
-    useBriefing: vi.fn(),
-}));
-
 const mockUseMarketSummary = vi.fn();
 vi.mock('@/widgets/dashboard/hooks/useMarketSummary', () => ({
     useMarketSummary: () => mockUseMarketSummary(),

--- a/src/widgets/dashboard/__tests__/MarketSummaryPanelSkeleton.test.tsx
+++ b/src/widgets/dashboard/__tests__/MarketSummaryPanelSkeleton.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { MarketSummaryPanelSkeleton } from '@/widgets/dashboard/MarketSummaryPanelSkeleton';
+
+vi.mock('@/shared/config/dashboard-tickers', () => ({
+    MARKET_INDICES: [
+        { symbol: 'SPY' },
+        { symbol: 'QQQ' },
+        { symbol: 'DIA' },
+        { symbol: 'IWM' },
+    ],
+    SECTOR_GROUPS: [
+        { label: 'Tech', symbols: ['XLK', 'XLC', 'XLY'] },
+        { label: 'Core', symbols: ['XLF', 'XLV', 'XLI', 'XLP'] },
+    ],
+}));
+
+describe('MarketSummaryPanelSkeleton', () => {
+    it('renders an aria-busy section', () => {
+        render(<MarketSummaryPanelSkeleton />);
+        const section = screen.getByLabelText('시장 현황 로딩 중');
+        expect(section).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('renders skeleton placeholders for each market index', () => {
+        const { container } = render(<MarketSummaryPanelSkeleton />);
+        const indexSkeletons = container.querySelectorAll('.grid-cols-2 > div');
+        expect(indexSkeletons).toHaveLength(4);
+    });
+});

--- a/src/widgets/dashboard/__tests__/SectorSignalPanel.test.tsx
+++ b/src/widgets/dashboard/__tests__/SectorSignalPanel.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import { SectorSignalPanel } from '@/widgets/dashboard/SectorSignalPanel';
+import type { SectorSignalsResult } from '@y0ngha/siglens-core';
+
+const mockReturn = {
+    activeSector: 'XLK',
+    activeTimeframe: '1Day' as const,
+    quadrants: {
+        bullishConfirmed: [],
+        bullishExpected: [],
+        bearishExpected: [],
+        bearishConfirmed: [],
+    },
+    mixedStocks: [],
+    handleSectorChange: vi.fn(),
+    handleTimeframeChange: vi.fn(),
+};
+
+vi.mock('@/widgets/dashboard/hooks/useSectorSignalState', () => ({
+    useSectorSignalState: () => mockReturn,
+}));
+
+vi.mock('@/widgets/dashboard/SectorTabs', () => ({
+    SectorTabs: () => <div data-testid="sector-tabs" />,
+}));
+
+vi.mock('@/widgets/dashboard/TimeframeSelector', () => ({
+    TimeframeSelector: () => <div data-testid="timeframe-selector" />,
+}));
+
+vi.mock('@/widgets/dashboard/SignalSubsection', () => ({
+    SignalSubsection: ({ title }: { title: string }) => (
+        <div data-testid={`subsection-${title}`}>{title}</div>
+    ),
+}));
+
+const DATA: SectorSignalsResult = {
+    stocks: [],
+    computedAt: '2025-01-01T00:00:00Z',
+};
+
+describe('SectorSignalPanel', () => {
+    it('renders the section heading', () => {
+        render(
+            <SectorSignalPanel
+                data={DATA}
+                initialSector="XLK"
+                initialTimeframe="1Day"
+            />
+        );
+        expect(screen.getByText('섹터별 신호 모아보기')).toBeInTheDocument();
+    });
+
+    it('renders SectorTabs and TimeframeSelector', () => {
+        render(
+            <SectorSignalPanel
+                data={DATA}
+                initialSector="XLK"
+                initialTimeframe="1Day"
+            />
+        );
+        expect(screen.getByTestId('sector-tabs')).toBeInTheDocument();
+        expect(screen.getByTestId('timeframe-selector')).toBeInTheDocument();
+    });
+
+    it('renders all five signal subsections', () => {
+        render(
+            <SectorSignalPanel
+                data={DATA}
+                initialSector="XLK"
+                initialTimeframe="1Day"
+            />
+        );
+        expect(screen.getByText('상승 신호')).toBeInTheDocument();
+        expect(screen.getByText('상승 조짐')).toBeInTheDocument();
+        expect(screen.getByText('혼재')).toBeInTheDocument();
+        expect(screen.getByText('하락 조짐')).toBeInTheDocument();
+        expect(screen.getByText('하락 신호')).toBeInTheDocument();
+    });
+
+    it('renders tabpanel with correct aria attributes', () => {
+        render(
+            <SectorSignalPanel
+                data={DATA}
+                initialSector="XLK"
+                initialTimeframe="1Day"
+            />
+        );
+        const panel = screen.getByRole('tabpanel');
+        expect(panel).toHaveAttribute('aria-labelledby', 'sector-tab-XLK');
+    });
+});

--- a/src/widgets/dashboard/__tests__/SectorSignalPanelSkeleton.test.tsx
+++ b/src/widgets/dashboard/__tests__/SectorSignalPanelSkeleton.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { SectorSignalPanelSkeleton } from '@/widgets/dashboard/SectorSignalPanelSkeleton';
+
+vi.mock('@/shared/config/dashboard-tickers', () => ({
+    SIGNAL_SECTORS: [{ symbol: 'XLK' }, { symbol: 'XLF' }, { symbol: 'XLV' }],
+}));
+
+describe('SectorSignalPanelSkeleton', () => {
+    it('renders aria-busy section', () => {
+        render(<SectorSignalPanelSkeleton />);
+        const section = screen.getByLabelText('섹터 신호 로딩 중');
+        expect(section).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('renders skeleton tabs for each sector', () => {
+        const { container } = render(<SectorSignalPanelSkeleton />);
+        const tabSkeletons = container.querySelectorAll('.border-b > div');
+        expect(tabSkeletons).toHaveLength(3);
+    });
+
+    it('hides decorative content from assistive technology', () => {
+        const { container } = render(<SectorSignalPanelSkeleton />);
+        const ariaHiddenElements = container.querySelectorAll(
+            '[aria-hidden="true"]'
+        );
+        expect(ariaHiddenElements.length).toBeGreaterThan(0);
+    });
+});

--- a/src/widgets/dashboard/__tests__/SectorTabs.test.tsx
+++ b/src/widgets/dashboard/__tests__/SectorTabs.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { SectorTabs } from '@/widgets/dashboard/SectorTabs';
+
+vi.mock('@/shared/config/dashboard-tickers', () => ({
+    SIGNAL_SECTORS: [
+        { symbol: 'XLK', koreanName: '기술' },
+        { symbol: 'XLF', koreanName: '금융' },
+    ],
+}));
+
+vi.mock('@/shared/ui/tabs', () => ({
+    TabsUnderline: ({
+        tabs,
+        activeTab,
+        ariaLabel,
+    }: {
+        tabs: Array<{ value: string; label: string }>;
+        activeTab: string;
+        ariaLabel: string;
+    }) => (
+        <div role="tablist" aria-label={ariaLabel}>
+            {tabs.map(t => (
+                <button
+                    key={t.value}
+                    role="tab"
+                    aria-selected={t.value === activeTab}
+                >
+                    {t.label}
+                </button>
+            ))}
+        </div>
+    ),
+}));
+
+describe('SectorTabs', () => {
+    it('renders tabs for each sector with correct labels', () => {
+        render(<SectorTabs activeSector="XLK" onChange={vi.fn()} />);
+        expect(screen.getByText('기술')).toBeInTheDocument();
+        expect(screen.getByText('금융')).toBeInTheDocument();
+    });
+
+    it('marks the active sector tab as selected', () => {
+        render(<SectorTabs activeSector="XLK" onChange={vi.fn()} />);
+        const tabs = screen.getAllByRole('tab');
+        expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+        expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('provides a descriptive aria-label on the tablist', () => {
+        render(<SectorTabs activeSector="XLK" onChange={vi.fn()} />);
+        expect(screen.getByRole('tablist')).toHaveAttribute(
+            'aria-label',
+            '섹터 선택'
+        );
+    });
+});

--- a/src/widgets/dashboard/__tests__/SignalBadge.test.tsx
+++ b/src/widgets/dashboard/__tests__/SignalBadge.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { SignalBadge } from '@/widgets/dashboard/SignalBadge';
+import type { SignalType } from '@y0ngha/siglens-core';
+
+describe('SignalBadge', () => {
+    it('renders RSI oversold label', () => {
+        render(<SignalBadge type={'rsi_oversold' as SignalType} />);
+        expect(screen.getByText('RSI 과매도')).toBeInTheDocument();
+    });
+
+    it('renders golden cross label', () => {
+        render(<SignalBadge type={'golden_cross' as SignalType} />);
+        expect(screen.getByText('골든크로스')).toBeInTheDocument();
+    });
+
+    it('renders death cross label', () => {
+        render(<SignalBadge type={'death_cross' as SignalType} />);
+        expect(screen.getByText('데드크로스')).toBeInTheDocument();
+    });
+
+    it('renders MACD bullish cross label', () => {
+        render(<SignalBadge type={'macd_bullish_cross' as SignalType} />);
+        expect(screen.getByText('MACD 상승교차')).toBeInTheDocument();
+    });
+
+    it('renders bollinger lower bounce label', () => {
+        render(<SignalBadge type={'bollinger_lower_bounce' as SignalType} />);
+        expect(screen.getByText('볼린저 하단 반등')).toBeInTheDocument();
+    });
+});

--- a/src/widgets/dashboard/__tests__/SignalStockCard.test.tsx
+++ b/src/widgets/dashboard/__tests__/SignalStockCard.test.tsx
@@ -51,15 +51,15 @@ const STOCK: StockWithConflict = {
     trend: 'uptrend',
     signals: [
         {
-            type: 'golden_cross' as never,
-            direction: 'bullish' as never,
-            phase: 'confirmed' as never,
+            type: 'golden_cross',
+            direction: 'bullish',
+            phase: 'confirmed',
             detectedAt: 0,
         },
         {
-            type: 'rsi_oversold' as never,
-            direction: 'bullish' as never,
-            phase: 'confirmed' as never,
+            type: 'rsi_oversold',
+            direction: 'bullish',
+            phase: 'confirmed',
             detectedAt: 0,
         },
     ],

--- a/src/widgets/dashboard/__tests__/SignalStockCard.test.tsx
+++ b/src/widgets/dashboard/__tests__/SignalStockCard.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react';
+import { SignalStockCard } from '@/widgets/dashboard/SignalStockCard';
+import type { StockWithConflict } from '@y0ngha/siglens-core';
+
+vi.mock('next/link', () => ({
+    default: ({
+        children,
+        href,
+        title,
+    }: {
+        children: React.ReactNode;
+        href: string;
+        title?: string;
+    }) => (
+        <a href={href} title={title}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock('@/shared/lib/cardStyles', () => ({
+    CARD_LINK_CLASSES: 'card-link',
+}));
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/shared/lib/priceFormat', () => ({
+    formatPriceChange: (percent: number) => ({
+        sign: percent >= 0 ? '+' : '-',
+        colorClass: percent >= 0 ? 'text-green' : 'text-red',
+        arrow: percent >= 0 ? '▲' : '▼',
+        arrowLabel: percent >= 0 ? '상승' : '하락',
+    }),
+    formatUsdPrice: (price: number) => price.toFixed(2),
+}));
+
+vi.mock('@/widgets/dashboard/SignalBadge', () => ({
+    SignalBadge: ({ type }: { type: string }) => (
+        <span data-testid={`badge-${type}`}>{type}</span>
+    ),
+}));
+
+const STOCK: StockWithConflict = {
+    symbol: 'AAPL',
+    koreanName: '애플',
+    sectorSymbol: 'XLK',
+    price: 180.25,
+    changePercent: 2.5,
+    trend: 'uptrend',
+    signals: [
+        {
+            type: 'golden_cross' as never,
+            direction: 'bullish' as never,
+            phase: 'confirmed' as never,
+            detectedAt: 0,
+        },
+        {
+            type: 'rsi_oversold' as never,
+            direction: 'bullish' as never,
+            phase: 'confirmed' as never,
+            detectedAt: 0,
+        },
+    ],
+};
+
+describe('SignalStockCard', () => {
+    it('renders symbol and korean name', () => {
+        render(<SignalStockCard data={STOCK} />);
+        expect(screen.getByText('AAPL')).toBeInTheDocument();
+        expect(screen.getByText('애플')).toBeInTheDocument();
+    });
+
+    it('renders price', () => {
+        render(<SignalStockCard data={STOCK} />);
+        expect(screen.getByText('$180.25')).toBeInTheDocument();
+    });
+
+    it('links to the symbol page', () => {
+        render(<SignalStockCard data={STOCK} />);
+        const link = screen.getByRole('link');
+        expect(link).toHaveAttribute('href', '/AAPL');
+        expect(link).toHaveAttribute('title', '애플 분석');
+    });
+
+    it('renders signal badges', () => {
+        render(<SignalStockCard data={STOCK} />);
+        expect(screen.getByTestId('badge-golden_cross')).toBeInTheDocument();
+        expect(screen.getByTestId('badge-rsi_oversold')).toBeInTheDocument();
+    });
+
+    it('renders conflict info when present', () => {
+        const stockWithConflict: StockWithConflict = {
+            ...STOCK,
+            conflict: { bullishCount: 3, bearishCount: 2 },
+        };
+        render(<SignalStockCard data={stockWithConflict} />);
+        expect(screen.getByText(/상승 3건/)).toBeInTheDocument();
+        expect(screen.getByText(/하락 2건/)).toBeInTheDocument();
+    });
+
+    it('does not render conflict info when absent', () => {
+        render(<SignalStockCard data={STOCK} />);
+        expect(screen.queryByText(/상승.*건/)).not.toBeInTheDocument();
+    });
+});

--- a/src/widgets/dashboard/__tests__/SignalSubsection.test.tsx
+++ b/src/widgets/dashboard/__tests__/SignalSubsection.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/react';
+import { SignalSubsection } from '@/widgets/dashboard/SignalSubsection';
+import type { StockWithConflict } from '@y0ngha/siglens-core';
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/shared/ui/InfoTooltip', () => ({
+    InfoTooltip: ({ children }: { children: React.ReactNode }) => (
+        <span data-testid="info-tooltip">{children}</span>
+    ),
+}));
+
+vi.mock('@/widgets/dashboard/SignalStockCard', () => ({
+    SignalStockCard: ({ data }: { data: { symbol: string } }) => (
+        <div data-testid={`stock-${data.symbol}`}>{data.symbol}</div>
+    ),
+}));
+
+const STOCK: StockWithConflict = {
+    symbol: 'AAPL',
+    koreanName: '애플',
+    sectorSymbol: 'XLK',
+    price: 180,
+    changePercent: 1,
+    trend: 'uptrend',
+    signals: [],
+};
+
+describe('SignalSubsection', () => {
+    it('renders title and marker', () => {
+        render(
+            <SignalSubsection
+                title="상승 신호"
+                marker="▲"
+                variant="confirmed"
+                stocks={[STOCK]}
+            />
+        );
+        expect(screen.getByText('상승 신호')).toBeInTheDocument();
+        expect(screen.getByText('▲')).toBeInTheDocument();
+    });
+
+    it('renders zero-padded stock count', () => {
+        render(
+            <SignalSubsection
+                title="상승 신호"
+                marker="▲"
+                variant="confirmed"
+                stocks={[STOCK]}
+            />
+        );
+        expect(screen.getByText('01')).toBeInTheDocument();
+    });
+
+    it('renders empty message when no stocks', () => {
+        render(
+            <SignalSubsection
+                title="하락 신호"
+                marker="▼"
+                variant="confirmed"
+                stocks={[]}
+            />
+        );
+        expect(
+            screen.getByText(/이 신호가 잡힌 종목이 없어요/)
+        ).toBeInTheDocument();
+    });
+
+    it('renders stock cards when stocks are present', () => {
+        render(
+            <SignalSubsection
+                title="상승 신호"
+                marker="▲"
+                variant="confirmed"
+                stocks={[STOCK]}
+            />
+        );
+        expect(screen.getByTestId('stock-AAPL')).toBeInTheDocument();
+    });
+
+    it('renders info tooltip when infoMessage is provided', () => {
+        render(
+            <SignalSubsection
+                title="혼재"
+                marker="◈"
+                variant="mixed"
+                stocks={[]}
+                infoMessage={<p>Test info</p>}
+            />
+        );
+        expect(screen.getByTestId('info-tooltip')).toBeInTheDocument();
+        expect(screen.getByText('Test info')).toBeInTheDocument();
+    });
+
+    it('does not render info tooltip when infoMessage is undefined', () => {
+        render(
+            <SignalSubsection
+                title="상승 신호"
+                marker="▲"
+                variant="confirmed"
+                stocks={[]}
+            />
+        );
+        expect(screen.queryByTestId('info-tooltip')).not.toBeInTheDocument();
+    });
+});

--- a/src/widgets/dashboard/__tests__/SignalTypeGuide.test.tsx
+++ b/src/widgets/dashboard/__tests__/SignalTypeGuide.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { SignalTypeGuide } from '@/widgets/dashboard/SignalTypeGuide';
+
+describe('SignalTypeGuide', () => {
+    it('renders the heading', () => {
+        render(<SignalTypeGuide />);
+        expect(
+            screen.getByRole('heading', { name: '신호 유형 가이드' })
+        ).toBeInTheDocument();
+    });
+
+    it('renders golden cross entry', () => {
+        render(<SignalTypeGuide />);
+        expect(screen.getByText('골든크로스')).toBeInTheDocument();
+        expect(
+            screen.getByText(/단기 이동평균선이 장기 이동평균선을 위로/)
+        ).toBeInTheDocument();
+    });
+
+    it('renders death cross entry', () => {
+        render(<SignalTypeGuide />);
+        expect(screen.getByText('데드크로스')).toBeInTheDocument();
+    });
+
+    it('renders RSI entry', () => {
+        render(<SignalTypeGuide />);
+        expect(screen.getByText('RSI 과매도/과매수')).toBeInTheDocument();
+    });
+
+    it('uses a definition list structure', () => {
+        const { container } = render(<SignalTypeGuide />);
+        const dl = container.querySelector('dl');
+        expect(dl).toBeInTheDocument();
+        const dts = container.querySelectorAll('dt');
+        expect(dts.length).toBe(8);
+    });
+
+    it('links heading via aria-labelledby', () => {
+        render(<SignalTypeGuide />);
+        const section = screen.getByRole('region', {
+            name: '신호 유형 가이드',
+        });
+        expect(section).toBeInTheDocument();
+    });
+});

--- a/src/widgets/dashboard/__tests__/TimeframeSelector.test.tsx
+++ b/src/widgets/dashboard/__tests__/TimeframeSelector.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TimeframeSelector } from '@/widgets/dashboard/TimeframeSelector';
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/shared/hooks/useRovingKeyboardNav', () => ({
+    useRovingKeyboardNav: () => vi.fn(),
+}));
+
+vi.mock('@/shared/config/dashboard-tickers', () => ({
+    DASHBOARD_TIMEFRAMES: ['1Day', '1Week'] as const,
+    DASHBOARD_TIMEFRAME_LABELS: {
+        '1Day': '1일',
+        '1Week': '1주',
+    },
+}));
+
+describe('TimeframeSelector', () => {
+    it('renders radio buttons for each timeframe', () => {
+        render(<TimeframeSelector timeframe="1Day" onChange={vi.fn()} />);
+        const radios = screen.getAllByRole('radio');
+        expect(radios).toHaveLength(2);
+    });
+
+    it('marks the active timeframe as checked', () => {
+        render(<TimeframeSelector timeframe="1Day" onChange={vi.fn()} />);
+        const radios = screen.getAllByRole('radio');
+        expect(radios[0]).toHaveAttribute('aria-checked', 'true');
+        expect(radios[1]).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('calls onChange when a radio is clicked', async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        render(<TimeframeSelector timeframe="1Day" onChange={onChange} />);
+        await user.click(screen.getAllByRole('radio')[1]!);
+        expect(onChange).toHaveBeenCalledWith('1Week');
+    });
+
+    it('renders radiogroup with label', () => {
+        render(<TimeframeSelector timeframe="1Day" onChange={vi.fn()} />);
+        expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+        expect(screen.getByText('타임프레임')).toBeInTheDocument();
+    });
+
+    it('sets tabIndex 0 for active and -1 for inactive', () => {
+        render(<TimeframeSelector timeframe="1Day" onChange={vi.fn()} />);
+        const radios = screen.getAllByRole('radio');
+        expect(radios[0]).toHaveAttribute('tabindex', '0');
+        expect(radios[1]).toHaveAttribute('tabindex', '-1');
+    });
+});

--- a/src/widgets/dashboard/__tests__/hooks/useBriefing.test.ts
+++ b/src/widgets/dashboard/__tests__/hooks/useBriefing.test.ts
@@ -69,7 +69,7 @@ describe('useBriefing', () => {
         client.clear();
     });
 
-    it('throws when poll returns error', async () => {
+    it('stays in processing when poll returns error', async () => {
         mockPoll.mockResolvedValue({
             status: 'error',
             error: 'Server failure',

--- a/src/widgets/dashboard/__tests__/hooks/useBriefing.test.ts
+++ b/src/widgets/dashboard/__tests__/hooks/useBriefing.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { useBriefing } from '@/widgets/dashboard/hooks/useBriefing';
+import { pollBriefingAction } from '@/entities/analysis/actions';
+import type { MarketBriefingResponse } from '@y0ngha/siglens-core';
+
+vi.mock('@/entities/analysis/actions', () => ({
+    pollBriefingAction: vi.fn(),
+}));
+
+const mockPoll = pollBriefingAction as ReturnType<typeof vi.fn>;
+
+const BRIEFING: MarketBriefingResponse = {
+    summary: 'Market looks bullish',
+    dominantThemes: ['AI'],
+    sectorAnalysis: {
+        leadingSectors: ['XLK'],
+        laggingSectors: [],
+        performanceDescription: '',
+    },
+    volatilityAnalysis: { vixLevel: 15, description: 'low' },
+    riskSentiment: 'risk on',
+};
+
+function makeWrapper() {
+    const client = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return {
+        client,
+        wrapper: ({ children }: { children: ReactNode }) =>
+            createElement(QueryClientProvider, { client }, children),
+    };
+}
+
+describe('useBriefing', () => {
+    afterEach(() => {
+        mockPoll.mockReset();
+    });
+
+    it('returns processing when poll returns processing', () => {
+        mockPoll.mockResolvedValue({ status: 'processing' });
+        const { client, wrapper } = makeWrapper();
+        const { result } = renderHook(() => useBriefing('job-1'), { wrapper });
+        expect(result.current.status).toBe('processing');
+        client.clear();
+    });
+
+    it('returns done with briefing when poll returns done', async () => {
+        mockPoll.mockResolvedValue({
+            status: 'done',
+            briefing: BRIEFING,
+            generatedAt: '2025-01-01T00:00:00Z',
+        });
+        const { client, wrapper } = makeWrapper();
+        const { result } = renderHook(() => useBriefing('job-1'), { wrapper });
+
+        await waitFor(() => {
+            expect(result.current.status).toBe('done');
+        });
+
+        const state = result.current;
+        if (state.status !== 'done') throw new Error('expected done');
+        expect(state.briefing).toEqual(BRIEFING);
+        expect(state.generatedAt).toBe('2025-01-01T00:00:00Z');
+        client.clear();
+    });
+
+    it('throws when poll returns error', async () => {
+        mockPoll.mockResolvedValue({
+            status: 'error',
+            error: 'Server failure',
+        });
+        const { client, wrapper } = makeWrapper();
+
+        const { result } = renderHook(() => useBriefing('job-err'), {
+            wrapper,
+        });
+
+        await waitFor(() => {
+            expect(result.current.status).toBe('processing');
+        });
+        client.clear();
+    });
+});

--- a/src/widgets/dashboard/__tests__/hooks/useMarketSummary.test.ts
+++ b/src/widgets/dashboard/__tests__/hooks/useMarketSummary.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import type { ReactNode } from 'react';
+import { useMarketSummary } from '@/widgets/dashboard/hooks/useMarketSummary';
+import { getMarketSummaryAction } from '@/entities/market-summary/actions';
+
+vi.mock('@/entities/market-summary/actions', () => ({
+    getMarketSummaryAction: vi.fn(),
+}));
+
+const mockAction = getMarketSummaryAction as ReturnType<typeof vi.fn>;
+
+function makeWrapper() {
+    const client = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return {
+        client,
+        wrapper: ({ children }: { children: ReactNode }) =>
+            createElement(QueryClientProvider, { client }, children),
+    };
+}
+
+const SUMMARY_DATA = {
+    summary: {
+        indices: [
+            {
+                symbol: 'SPY',
+                fmpSymbol: '^GSPC',
+                koreanName: 'S&P 500',
+                displayName: 'S&P 500',
+                price: 5000,
+                changesPercentage: 1.5,
+            },
+        ],
+        sectors: [
+            {
+                symbol: 'XLK',
+                sectorName: 'Technology',
+                koreanName: '기술',
+                price: 200,
+                changesPercentage: 2.0,
+            },
+        ],
+    },
+    briefing: null,
+};
+
+describe('useMarketSummary', () => {
+    afterEach(() => {
+        mockAction.mockReset();
+    });
+
+    it('returns isPending true initially', () => {
+        mockAction.mockImplementation(() => new Promise(() => {}));
+        const { client, wrapper } = makeWrapper();
+        const { result } = renderHook(() => useMarketSummary(), { wrapper });
+        expect(result.current.isPending).toBe(true);
+        client.clear();
+    });
+
+    it('returns data with sectorMap and indices when action resolves', async () => {
+        mockAction.mockResolvedValue(SUMMARY_DATA);
+        const { client, wrapper } = makeWrapper();
+        const { result } = renderHook(() => useMarketSummary(), { wrapper });
+
+        await waitFor(() => {
+            expect(result.current.isPending).toBe(false);
+        });
+
+        expect(result.current.data).toEqual(SUMMARY_DATA);
+        expect(result.current.sectorMap.get('XLK')).toBeDefined();
+        expect(result.current.indices).toHaveLength(1);
+        expect(result.current.indices[0]?.symbol).toBe('SPY');
+        client.clear();
+    });
+
+    it('returns empty sectorMap and indices when action returns error shape', async () => {
+        mockAction.mockResolvedValue({ ok: false });
+        const { client, wrapper } = makeWrapper();
+        const { result } = renderHook(() => useMarketSummary(), { wrapper });
+
+        await waitFor(() => {
+            expect(result.current.isPending).toBe(false);
+        });
+
+        expect(result.current.sectorMap.size).toBe(0);
+        expect(result.current.indices).toHaveLength(0);
+        client.clear();
+    });
+});

--- a/src/widgets/dashboard/__tests__/hooks/useSectorSignalState.test.ts
+++ b/src/widgets/dashboard/__tests__/hooks/useSectorSignalState.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react';
+import { useSectorSignalState } from '@/widgets/dashboard/hooks/useSectorSignalState';
+import type { SectorSignalsResult } from '@y0ngha/siglens-core';
+
+const mockReplace = vi.fn();
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({ replace: mockReplace }),
+    usePathname: () => '/dashboard',
+    useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('@/entities/analysis', () => ({
+    EMPTY_QUADRANTS: {
+        bullishConfirmed: [],
+        bullishExpected: [],
+        bearishExpected: [],
+        bearishConfirmed: [],
+    },
+    filterStrictAnticipation: (stocks: unknown[]) => stocks,
+    resolveConflicts: (stocks: unknown[]) => ({
+        resolved: stocks,
+        mixed: [],
+    }),
+    groupStockIntoQuadrants: (
+        acc: Record<string, unknown[]>,
+        _stock: unknown
+    ) => acc,
+}));
+
+vi.mock('@/shared/config/dashboard-tickers', () => ({
+    SIGNAL_SECTORS: [
+        { symbol: 'XLK', koreanName: '기술' },
+        { symbol: 'XLF', koreanName: '금융' },
+    ],
+    DEFAULT_DASHBOARD_TIMEFRAME: '1Day',
+}));
+
+const DATA: SectorSignalsResult = {
+    stocks: [
+        {
+            symbol: 'AAPL',
+            koreanName: 'Apple',
+            sectorSymbol: 'XLK',
+            price: 150,
+            changePercent: 1.5,
+            signals: [],
+        } as never,
+    ],
+    computedAt: '2025-01-01T00:00:00Z',
+};
+
+describe('useSectorSignalState', () => {
+    afterEach(() => {
+        mockReplace.mockClear();
+    });
+
+    it('returns initial sector and timeframe', () => {
+        const { result } = renderHook(() =>
+            useSectorSignalState({
+                data: DATA,
+                initialSector: 'XLK',
+                initialTimeframe: '1Day',
+            })
+        );
+        expect(result.current.activeSector).toBe('XLK');
+        expect(result.current.activeTimeframe).toBe('1Day');
+    });
+
+    it('handleSectorChange updates sector and calls router.replace', () => {
+        const { result } = renderHook(() =>
+            useSectorSignalState({
+                data: DATA,
+                initialSector: 'XLK',
+                initialTimeframe: '1Day',
+            })
+        );
+
+        act(() => {
+            result.current.handleSectorChange('XLF');
+        });
+
+        expect(result.current.activeSector).toBe('XLF');
+        expect(mockReplace).toHaveBeenCalledTimes(1);
+    });
+
+    it('handleTimeframeChange updates timeframe and calls router.replace', () => {
+        const { result } = renderHook(() =>
+            useSectorSignalState({
+                data: DATA,
+                initialSector: 'XLK',
+                initialTimeframe: '1Day',
+            })
+        );
+
+        act(() => {
+            result.current.handleTimeframeChange('1Hour');
+        });
+
+        expect(result.current.activeTimeframe).toBe('1Hour');
+        expect(mockReplace).toHaveBeenCalledTimes(1);
+    });
+
+    it('omits default sector and timeframe from query string', () => {
+        const { result } = renderHook(() =>
+            useSectorSignalState({
+                data: DATA,
+                initialSector: 'XLF',
+                initialTimeframe: '1Hour',
+            })
+        );
+
+        act(() => {
+            result.current.handleSectorChange('XLK');
+        });
+
+        const url = mockReplace.mock.calls[0]?.[0] as string;
+        expect(url).not.toContain('sector=');
+    });
+});

--- a/src/widgets/dashboard/__tests__/hooks/useSectorSignalState.test.ts
+++ b/src/widgets/dashboard/__tests__/hooks/useSectorSignalState.test.ts
@@ -44,8 +44,9 @@ const DATA: SectorSignalsResult = {
             sectorSymbol: 'XLK',
             price: 150,
             changePercent: 1.5,
+            trend: 'uptrend' as const,
             signals: [],
-        } as never,
+        },
     ],
     computedAt: '2025-01-01T00:00:00Z',
 };
@@ -116,5 +117,6 @@ describe('useSectorSignalState', () => {
 
         const url = mockReplace.mock.calls[0]?.[0] as string;
         expect(url).not.toContain('sector=');
+        expect(url).toContain('timeframe=1Hour');
     });
 });

--- a/src/widgets/news/__tests__/NewsAiSummary.test.tsx
+++ b/src/widgets/news/__tests__/NewsAiSummary.test.tsx
@@ -1,0 +1,173 @@
+import { render, screen } from '@testing-library/react';
+import { NewsAiSummary } from '@/widgets/news/NewsAiSummary';
+import type { NewsAnalysisResponse } from '@y0ngha/siglens-core';
+
+const mockWaitResult = vi.fn();
+const mockAnalysisResult = vi.fn();
+
+vi.mock('@/widgets/news/hooks/useWaitForNewsCards', () => ({
+    useWaitForNewsCards: () => mockWaitResult(),
+}));
+
+vi.mock('@/widgets/news/hooks/useNewsAnalysis', () => ({
+    useNewsAnalysis: () => mockAnalysisResult(),
+}));
+
+vi.mock('@/features/symbol-chat', () => ({
+    usePublishSymbolChat: vi.fn(),
+}));
+
+vi.mock('@/widgets/news/utils/buildChatState', () => ({
+    buildChatState: () => ({
+        context: null,
+        timeframe: null,
+        isAnalysisReady: false,
+    }),
+}));
+
+vi.mock('@/shared/ui/BotBlockedNotice', () => ({
+    BotBlockedNotice: () => <div data-testid="bot-blocked" />,
+}));
+
+vi.mock('@/widgets/symbol-page/hooks/useDefaultModelId', () => ({
+    useDefaultModelId: () => 'gemini-2.5-flash-lite',
+}));
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/shared/lib/news/periodLabels', () => ({
+    NEWS_ANALYSIS_PERIOD_LABEL: '최근 7일',
+}));
+
+const RESULT: NewsAnalysisResponse = {
+    overallSentiment: 'bullish' as const,
+    currentDriverKo: 'Strong earnings',
+    keyEventsKo: ['Earnings beat'],
+    upcomingEventsKo: ['Fed meeting'],
+};
+
+describe('NewsAiSummary', () => {
+    afterEach(() => {
+        mockWaitResult.mockReset();
+        mockAnalysisResult.mockReset();
+    });
+
+    it('renders fetching phase while waiting for cards', () => {
+        mockWaitResult.mockReturnValue({
+            isReady: false,
+            pollError: null,
+        });
+        mockAnalysisResult.mockReturnValue({ status: 'loading' });
+
+        render(
+            <NewsAiSummary
+                symbol="AAPL"
+                companyName="Apple"
+                hasEnrichedNews={false}
+            />
+        );
+        expect(
+            screen.getByText(/뉴스 데이터를 수집하고 있어요/)
+        ).toBeInTheDocument();
+    });
+
+    it('renders analyzing phase when cards ready but analysis loading', () => {
+        mockWaitResult.mockReturnValue({
+            isReady: true,
+            pollError: null,
+        });
+        mockAnalysisResult.mockReturnValue({ status: 'loading' });
+
+        render(
+            <NewsAiSummary
+                symbol="AAPL"
+                companyName="Apple"
+                hasEnrichedNews={true}
+            />
+        );
+        expect(screen.getByText(/AI 종합 분석 중이에요/)).toBeInTheDocument();
+    });
+
+    it('renders result view when analysis is done', () => {
+        mockWaitResult.mockReturnValue({
+            isReady: true,
+            pollError: null,
+        });
+        mockAnalysisResult.mockReturnValue({
+            status: 'done',
+            result: RESULT,
+        });
+
+        render(
+            <NewsAiSummary
+                symbol="AAPL"
+                companyName="Apple"
+                hasEnrichedNews={true}
+            />
+        );
+        expect(screen.getByText('Strong earnings')).toBeInTheDocument();
+        expect(screen.getByText('Earnings beat')).toBeInTheDocument();
+        expect(screen.getByText('Fed meeting')).toBeInTheDocument();
+    });
+
+    it('renders bot blocked notice', () => {
+        mockWaitResult.mockReturnValue({
+            isReady: true,
+            pollError: null,
+        });
+        mockAnalysisResult.mockReturnValue({ status: 'bot_blocked' });
+
+        render(
+            <NewsAiSummary
+                symbol="AAPL"
+                companyName="Apple"
+                hasEnrichedNews={true}
+            />
+        );
+        expect(screen.getByTestId('bot-blocked')).toBeInTheDocument();
+    });
+
+    it('renders error state with retry', () => {
+        mockWaitResult.mockReturnValue({
+            isReady: true,
+            pollError: null,
+        });
+        mockAnalysisResult.mockReturnValue({
+            status: 'error',
+            error: new Error('Analysis failed'),
+            retry: vi.fn(),
+        });
+
+        render(
+            <NewsAiSummary
+                symbol="AAPL"
+                companyName="Apple"
+                hasEnrichedNews={true}
+            />
+        );
+        expect(screen.getByText('Analysis failed')).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /다시 시도/ })
+        ).toBeInTheDocument();
+    });
+
+    it('throws pollError for error boundary to catch', () => {
+        mockWaitResult.mockReturnValue({
+            isReady: false,
+            pollError: new Error('Poll failure'),
+        });
+        mockAnalysisResult.mockReturnValue({ status: 'loading' });
+
+        expect(() =>
+            render(
+                <NewsAiSummary
+                    symbol="AAPL"
+                    companyName="Apple"
+                    hasEnrichedNews={false}
+                />
+            )
+        ).toThrow('Poll failure');
+    });
+});

--- a/src/widgets/news/__tests__/NewsAiSummaryError.test.tsx
+++ b/src/widgets/news/__tests__/NewsAiSummaryError.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NewsAiSummaryError } from '@/widgets/news/NewsAiSummaryError';
+
+describe('NewsAiSummaryError', () => {
+    it('renders error message from Error object', () => {
+        render(
+            <NewsAiSummaryError
+                error={new Error('뉴스 분석 실패')}
+                resetErrorBoundary={vi.fn()}
+            />
+        );
+        expect(screen.getByText('뉴스 분석 실패')).toBeInTheDocument();
+    });
+
+    it('renders default message for non-Error objects', () => {
+        render(
+            <NewsAiSummaryError
+                error={'string error' as unknown as Error}
+                resetErrorBoundary={vi.fn()}
+            />
+        );
+        expect(
+            screen.getByText('분석 중 오류가 발생했습니다.')
+        ).toBeInTheDocument();
+    });
+
+    it('renders heading', () => {
+        render(
+            <NewsAiSummaryError
+                error={new Error('test')}
+                resetErrorBoundary={vi.fn()}
+            />
+        );
+        expect(
+            screen.getByRole('heading', { name: /AI 뉴스 종합 분석/ })
+        ).toBeInTheDocument();
+    });
+
+    it('renders alert role for the error message', () => {
+        render(
+            <NewsAiSummaryError
+                error={new Error('test')}
+                resetErrorBoundary={vi.fn()}
+            />
+        );
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('calls resetErrorBoundary when retry button is clicked', async () => {
+        const user = userEvent.setup();
+        const reset = vi.fn();
+        render(
+            <NewsAiSummaryError
+                error={new Error('test')}
+                resetErrorBoundary={reset}
+            />
+        );
+        await user.click(screen.getByRole('button', { name: /다시 시도/ }));
+        expect(reset).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/widgets/news/__tests__/NewsAiSummaryErrorBoundary.test.tsx
+++ b/src/widgets/news/__tests__/NewsAiSummaryErrorBoundary.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { NewsAiSummaryErrorBoundary } from '@/widgets/news/NewsAiSummaryErrorBoundary';
+
+vi.mock('react-error-boundary', () => ({
+    ErrorBoundary: ({
+        children,
+        FallbackComponent,
+    }: {
+        children: React.ReactNode;
+        FallbackComponent: React.ComponentType<{ error: Error }>;
+    }) => {
+        void FallbackComponent;
+        return <>{children}</>;
+    },
+}));
+
+describe('NewsAiSummaryErrorBoundary', () => {
+    it('renders children when no error occurs', () => {
+        render(
+            <NewsAiSummaryErrorBoundary>
+                <div data-testid="child">Content</div>
+            </NewsAiSummaryErrorBoundary>
+        );
+        expect(screen.getByTestId('child')).toBeInTheDocument();
+    });
+
+    it('wraps children in an ErrorBoundary', () => {
+        const { container } = render(
+            <NewsAiSummaryErrorBoundary>
+                <p>Safe content</p>
+            </NewsAiSummaryErrorBoundary>
+        );
+        expect(container.textContent).toContain('Safe content');
+    });
+});

--- a/src/widgets/news/__tests__/NewsAiSummarySkeleton.test.tsx
+++ b/src/widgets/news/__tests__/NewsAiSummarySkeleton.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { NewsAiSummarySkeleton } from '@/widgets/news/NewsAiSummarySkeleton';
+
+describe('NewsAiSummarySkeleton', () => {
+    it('renders aria-busy section', () => {
+        render(<NewsAiSummarySkeleton />);
+        const section = screen.getByLabelText('AI 뉴스 종합 분석');
+        expect(section).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('renders heading', () => {
+        render(<NewsAiSummarySkeleton />);
+        expect(
+            screen.getByRole('heading', { name: 'AI 뉴스 종합 분석' })
+        ).toBeInTheDocument();
+    });
+
+    it('renders progress text', () => {
+        render(<NewsAiSummarySkeleton />);
+        expect(screen.getByText('AI 뉴스 분석 진행 중…')).toBeInTheDocument();
+    });
+
+    it('renders skeleton lines', () => {
+        const { container } = render(<NewsAiSummarySkeleton />);
+        const lines = container.querySelectorAll(
+            '[aria-hidden="true"].bg-secondary-700'
+        );
+        expect(lines).toHaveLength(3);
+    });
+
+    it('includes spinner with motion-reduce support', () => {
+        const { container } = render(<NewsAiSummarySkeleton />);
+        const spinner = container.querySelector('.animate-spin');
+        expect(spinner).toBeInTheDocument();
+    });
+});

--- a/src/widgets/news/__tests__/constants.test.ts
+++ b/src/widgets/news/__tests__/constants.test.ts
@@ -4,17 +4,8 @@ import {
 } from '@/widgets/news/constants';
 
 describe('news constants', () => {
-    it('POLL_INTERVAL_MS is a positive number', () => {
-        expect(POLL_INTERVAL_MS).toBeGreaterThan(0);
-    });
-
     it('POLL_INTERVAL_MS is 3 seconds', () => {
         expect(POLL_INTERVAL_MS).toBe(3_000);
-    });
-
-    it('MAX_CONSECUTIVE_FAILURES is a positive integer', () => {
-        expect(MAX_CONSECUTIVE_FAILURES).toBeGreaterThan(0);
-        expect(Number.isInteger(MAX_CONSECUTIVE_FAILURES)).toBe(true);
     });
 
     it('MAX_CONSECUTIVE_FAILURES is 3', () => {

--- a/src/widgets/news/__tests__/constants.test.ts
+++ b/src/widgets/news/__tests__/constants.test.ts
@@ -1,0 +1,23 @@
+import {
+    POLL_INTERVAL_MS,
+    MAX_CONSECUTIVE_FAILURES,
+} from '@/widgets/news/constants';
+
+describe('news constants', () => {
+    it('POLL_INTERVAL_MS is a positive number', () => {
+        expect(POLL_INTERVAL_MS).toBeGreaterThan(0);
+    });
+
+    it('POLL_INTERVAL_MS is 3 seconds', () => {
+        expect(POLL_INTERVAL_MS).toBe(3_000);
+    });
+
+    it('MAX_CONSECUTIVE_FAILURES is a positive integer', () => {
+        expect(MAX_CONSECUTIVE_FAILURES).toBeGreaterThan(0);
+        expect(Number.isInteger(MAX_CONSECUTIVE_FAILURES)).toBe(true);
+    });
+
+    it('MAX_CONSECUTIVE_FAILURES is 3', () => {
+        expect(MAX_CONSECUTIVE_FAILURES).toBe(3);
+    });
+});

--- a/src/widgets/news/__tests__/hooks/useNewsAnalysis.test.tsx
+++ b/src/widgets/news/__tests__/hooks/useNewsAnalysis.test.tsx
@@ -9,7 +9,7 @@ import { CANCEL_JOBS_API_PATH } from '@/shared/lib/cancelJobsApi';
 import { QUERY_KEYS } from '@/shared/config/queryConfig';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import type { NewsAnalysisResponse } from '@y0ngha/siglens-core';
+import type { ModelId, NewsAnalysisResponse } from '@y0ngha/siglens-core';
 import type { ReactNode } from 'react';
 import { renderToString } from 'react-dom/server';
 import { readBlobText } from '@/shared/test-utils/readBlobText';
@@ -302,8 +302,8 @@ describe('useNewsAnalysis', () => {
             mockPoll.mockImplementation(() => new Promise(() => {}));
 
             const { rerender } = renderHook(
-                ({ modelId }: { modelId: string }) =>
-                    useNewsAnalysis('AAPL', 'Apple Inc.', modelId as never),
+                ({ modelId }: { modelId: ModelId }) =>
+                    useNewsAnalysis('AAPL', 'Apple Inc.', modelId),
                 {
                     wrapper: makeWrapper(),
                     initialProps: { modelId: 'gemini-2.5-flash-lite' },

--- a/src/widgets/news/__tests__/hooks/useNewsPollingWithInvalidation.test.ts
+++ b/src/widgets/news/__tests__/hooks/useNewsPollingWithInvalidation.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { createElement } from 'react';
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useNewsPollingWithInvalidation } from '@/widgets/news/hooks/useNewsPollingWithInvalidation';
+import type { NewsDisplayItem } from '@/shared/lib/types';
+
+const mockUseNewsCardPolling = vi.fn();
+
+vi.mock('@/widgets/news/hooks/useNewsCardPolling', () => ({
+    useNewsCardPolling: (
+        symbol: string,
+        items: NewsDisplayItem[],
+        onComplete: (items: NewsDisplayItem[]) => void
+    ) => mockUseNewsCardPolling(symbol, items, onComplete),
+}));
+
+function makeWrapper() {
+    const client = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return {
+        client,
+        wrapper: ({ children }: { children: ReactNode }) =>
+            createElement(QueryClientProvider, { client }, children),
+    };
+}
+
+const ENRICHED_ITEM = {
+    id: '1',
+    title: 'News 1',
+    url: 'https://example.com/1',
+    publishedAt: '2025-01-01T00:00:00Z',
+    source: 'Test',
+    symbol: 'AAPL',
+    sentiment: 'bullish',
+    priceImpact: 'high',
+} as unknown as NewsDisplayItem;
+
+const PENDING_ITEM = {
+    id: '2',
+    title: 'News 2',
+    url: 'https://example.com/2',
+    publishedAt: '2025-01-01T00:00:00Z',
+    source: 'Test',
+    symbol: 'AAPL',
+    sentiment: null,
+    priceImpact: null,
+} as unknown as NewsDisplayItem;
+
+describe('useNewsPollingWithInvalidation', () => {
+    afterEach(() => {
+        mockUseNewsCardPolling.mockReset();
+    });
+
+    it('delegates to useNewsCardPolling and returns its result', () => {
+        const pollingReturn = { items: [ENRICHED_ITEM], isPolling: false };
+        mockUseNewsCardPolling.mockReturnValue(pollingReturn);
+
+        const { client, wrapper } = makeWrapper();
+        const { result } = renderHook(
+            () => useNewsPollingWithInvalidation('AAPL', [ENRICHED_ITEM]),
+            { wrapper }
+        );
+
+        expect(result.current).toBe(pollingReturn);
+        expect(mockUseNewsCardPolling).toHaveBeenCalledWith(
+            'AAPL',
+            [ENRICHED_ITEM],
+            expect.any(Function)
+        );
+        client.clear();
+    });
+
+    it('passes initial items to useNewsCardPolling', () => {
+        mockUseNewsCardPolling.mockReturnValue({
+            items: [PENDING_ITEM],
+            isPolling: true,
+        });
+
+        const { client, wrapper } = makeWrapper();
+        renderHook(
+            () => useNewsPollingWithInvalidation('AAPL', [PENDING_ITEM]),
+            { wrapper }
+        );
+
+        expect(mockUseNewsCardPolling).toHaveBeenCalledWith(
+            'AAPL',
+            [PENDING_ITEM],
+            expect.any(Function)
+        );
+        client.clear();
+    });
+});

--- a/src/widgets/news/__tests__/hooks/useWaitForNewsCards.test.ts
+++ b/src/widgets/news/__tests__/hooks/useWaitForNewsCards.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useWaitForNewsCards } from '@/widgets/news/hooks/useWaitForNewsCards';
+import { getNewsCardsAction } from '@/entities/news-article/actions';
+import type { NewsDisplayItem } from '@/shared/lib/types';
+
+vi.mock('@/entities/news-article/actions', () => ({
+    getNewsCardsAction: vi.fn(),
+}));
+
+vi.mock('@/widgets/news/constants', () => ({
+    POLL_INTERVAL_MS: 50,
+    MAX_CONSECUTIVE_FAILURES: 2,
+}));
+
+const mockGetCards = getNewsCardsAction as ReturnType<typeof vi.fn>;
+
+const ENRICHED_ITEM = {
+    id: '1',
+    title: 'News 1',
+    sentiment: 'bullish',
+    priceImpact: 'high',
+} as unknown as NewsDisplayItem;
+
+const PENDING_ITEM = {
+    id: '2',
+    title: 'News 2',
+    sentiment: null,
+    priceImpact: null,
+} as unknown as NewsDisplayItem;
+
+describe('useWaitForNewsCards', () => {
+    afterEach(() => {
+        mockGetCards.mockReset();
+        vi.restoreAllMocks();
+    });
+
+    it('returns isReady true immediately when initiallyReady is true', () => {
+        const { result } = renderHook(() => useWaitForNewsCards('AAPL', true));
+        expect(result.current.isReady).toBe(true);
+        expect(result.current.pollError).toBeNull();
+    });
+
+    it('returns isReady false initially when initiallyReady is false', () => {
+        mockGetCards.mockResolvedValue([PENDING_ITEM]);
+        const { result } = renderHook(() => useWaitForNewsCards('AAPL', false));
+        expect(result.current.isReady).toBe(false);
+    });
+
+    it('becomes ready when polling returns enriched cards', async () => {
+        mockGetCards.mockResolvedValue([ENRICHED_ITEM]);
+        const { result } = renderHook(() => useWaitForNewsCards('AAPL', false));
+
+        await waitFor(() => {
+            expect(result.current.isReady).toBe(true);
+        });
+    });
+
+    it('does not call getNewsCardsAction when initiallyReady is true', () => {
+        renderHook(() => useWaitForNewsCards('AAPL', true));
+        expect(mockGetCards).not.toHaveBeenCalled();
+    });
+
+    it('sets pollError after consecutive failures', async () => {
+        mockGetCards.mockRejectedValue(new Error('fetch failed'));
+        const { result } = renderHook(() => useWaitForNewsCards('AAPL', false));
+
+        await waitFor(() => {
+            expect(result.current.pollError).not.toBeNull();
+        });
+
+        expect(result.current.pollError?.message).toBe('fetch failed');
+    });
+});

--- a/src/widgets/news/__tests__/sections/AnalystActions.test.tsx
+++ b/src/widgets/news/__tests__/sections/AnalystActions.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AnalystActions } from '@/widgets/news/sections/AnalystActions';
+import type { GradesEvent } from '@y0ngha/siglens-core';
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+const EVENTS: GradesEvent[] = [
+    {
+        symbol: 'AAPL',
+        date: '2025-01-15',
+        action: 'upgrade' as const,
+        gradingCompany: 'Goldman Sachs',
+        previousGrade: 'Neutral',
+        newGrade: 'Buy',
+    },
+    {
+        symbol: 'AAPL',
+        date: '2025-01-10',
+        action: 'downgrade' as const,
+        gradingCompany: 'Morgan Stanley',
+        previousGrade: 'Overweight',
+        newGrade: 'Equal-weight',
+    },
+    {
+        symbol: 'AAPL',
+        date: '2025-01-05',
+        action: 'initiated' as const,
+        gradingCompany: 'JP Morgan',
+        previousGrade: null,
+        newGrade: 'Overweight',
+    },
+];
+
+describe('AnalystActions', () => {
+    it('renders empty state when no events', () => {
+        render(<AnalystActions events={[]} />);
+        expect(
+            screen.getByText(/최근 애널리스트 등급 변경이 없습니다/)
+        ).toBeInTheDocument();
+    });
+
+    it('renders heading', () => {
+        render(<AnalystActions events={EVENTS} />);
+        expect(
+            screen.getByRole('heading', { name: /애널리스트 등급 변경/ })
+        ).toBeInTheDocument();
+    });
+
+    it('renders grade events with company names', () => {
+        render(<AnalystActions events={EVENTS} />);
+        expect(screen.getByText('Goldman Sachs')).toBeInTheDocument();
+        expect(screen.getByText('Morgan Stanley')).toBeInTheDocument();
+        expect(screen.getByText('JP Morgan')).toBeInTheDocument();
+    });
+
+    it('renders action labels', () => {
+        render(<AnalystActions events={EVENTS} />);
+        expect(screen.getByText('상향')).toBeInTheDocument();
+        expect(screen.getByText('하향')).toBeInTheDocument();
+        expect(screen.getByText('신규 커버리지')).toBeInTheDocument();
+    });
+
+    it('renders grade transition for upgrade/downgrade', () => {
+        render(<AnalystActions events={EVENTS} />);
+        expect(screen.getByText('Neutral')).toBeInTheDocument();
+        expect(screen.getByText('Buy')).toBeInTheDocument();
+    });
+
+    it('renders only new grade for initiated coverage', () => {
+        render(<AnalystActions events={EVENTS} />);
+        const allOverweight = screen.getAllByText('Overweight');
+        expect(allOverweight.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('paginates and shows more button', () => {
+        const manyEvents: GradesEvent[] = Array.from({ length: 8 }, (_, i) => ({
+            symbol: 'AAPL',
+            date: `2025-01-${String(i + 1).padStart(2, '0')}`,
+            action: 'maintained' as const,
+            gradingCompany: `Firm ${i}`,
+            previousGrade: 'Hold',
+            newGrade: 'Hold',
+        }));
+
+        render(<AnalystActions events={manyEvents} />);
+        expect(screen.getByText(/더보기/)).toBeInTheDocument();
+        expect(screen.getByText(/3개 남음/)).toBeInTheDocument();
+    });
+
+    it('loads more events on button click', async () => {
+        const user = userEvent.setup();
+        const manyEvents: GradesEvent[] = Array.from({ length: 8 }, (_, i) => ({
+            symbol: 'AAPL',
+            date: `2025-01-${String(i + 1).padStart(2, '0')}`,
+            action: 'maintained' as const,
+            gradingCompany: `Firm ${i}`,
+            previousGrade: 'Hold',
+            newGrade: 'Hold',
+        }));
+
+        render(<AnalystActions events={manyEvents} />);
+        await user.click(screen.getByText(/더보기/));
+        expect(screen.queryByText(/더보기/)).not.toBeInTheDocument();
+    });
+});

--- a/src/widgets/options/__tests__/ExpirationSelector.test.tsx
+++ b/src/widgets/options/__tests__/ExpirationSelector.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ExpirationSelector } from '@/widgets/options/ExpirationSelector';
+import type { SlotMapping } from '@y0ngha/siglens-core';
+
+vi.mock('@/shared/ui/InfoTooltip', () => ({
+    InfoTooltip: ({ children }: { children: React.ReactNode }) => (
+        <span>{children}</span>
+    ),
+}));
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+const SLOTS: SlotMapping[] = [
+    {
+        slot: { key: '1W', label: '근월', targetDays: 7 },
+        expirationDate: '2025-06-20',
+    },
+    {
+        slot: { key: '1M', label: '차월', targetDays: 30 },
+        expirationDate: '2025-07-18',
+    },
+];
+
+describe('ExpirationSelector', () => {
+    it('renders tabs for each slot plus the aggregate tab', () => {
+        render(
+            <ExpirationSelector
+                slots={SLOTS}
+                value="2025-06-20"
+                onChange={vi.fn()}
+            />
+        );
+        const tabs = screen.getAllByRole('tab');
+        expect(tabs).toHaveLength(3);
+    });
+
+    it('marks the active tab as selected', () => {
+        render(
+            <ExpirationSelector
+                slots={SLOTS}
+                value="2025-06-20"
+                onChange={vi.fn()}
+            />
+        );
+        const tabs = screen.getAllByRole('tab');
+        expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+        expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
+        expect(tabs[2]).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('calls onChange with the correct value when a tab is clicked', async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        render(
+            <ExpirationSelector
+                slots={SLOTS}
+                value="2025-06-20"
+                onChange={onChange}
+            />
+        );
+        await user.click(screen.getByText('종합'));
+        expect(onChange).toHaveBeenCalledWith('all');
+    });
+
+    it('renders date substring for slot tabs', () => {
+        render(
+            <ExpirationSelector
+                slots={SLOTS}
+                value="2025-06-20"
+                onChange={vi.fn()}
+            />
+        );
+        expect(screen.getByText('06-20')).toBeInTheDocument();
+        expect(screen.getByText('07-18')).toBeInTheDocument();
+    });
+
+    it('provides tablist with aria-label', () => {
+        render(
+            <ExpirationSelector
+                slots={SLOTS}
+                value="2025-06-20"
+                onChange={vi.fn()}
+            />
+        );
+        expect(screen.getByRole('tablist')).toHaveAttribute(
+            'aria-label',
+            '옵션 만기 선택'
+        );
+    });
+
+    it('sets roving tabIndex (active=0, inactive=-1)', () => {
+        render(
+            <ExpirationSelector
+                slots={SLOTS}
+                value="2025-07-18"
+                onChange={vi.fn()}
+            />
+        );
+        const tabs = screen.getAllByRole('tab');
+        expect(tabs[0]).toHaveAttribute('tabindex', '-1');
+        expect(tabs[1]).toHaveAttribute('tabindex', '0');
+    });
+});

--- a/src/widgets/options/__tests__/OpenInterestChart.test.tsx
+++ b/src/widgets/options/__tests__/OpenInterestChart.test.tsx
@@ -1,0 +1,202 @@
+import { render, screen } from '@testing-library/react';
+import { OpenInterestChart } from '@/widgets/options/OpenInterestChart';
+import type {
+    OptionsChain,
+    OptionsExpirationMetrics,
+} from '@y0ngha/siglens-core';
+
+vi.mock('@/shared/ui/InfoTooltip', () => ({
+    InfoTooltip: ({ children }: { children: React.ReactNode }) => (
+        <span>{children}</span>
+    ),
+}));
+
+vi.mock('@y0ngha/siglens-core', async importOriginal => {
+    const mod = (await importOriginal()) as Record<string, unknown>;
+    return {
+        ...mod,
+        aggregateOpenInterest: (chain: {
+            calls: Array<{ strike: number; openInterest: number }>;
+            puts: Array<{ strike: number; openInterest: number }>;
+        }) =>
+            chain.calls.map(c => ({
+                strike: c.strike,
+                callOpenInterest: c.openInterest,
+                putOpenInterest:
+                    chain.puts.find(p => p.strike === c.strike)?.openInterest ??
+                    0,
+            })),
+    };
+});
+
+vi.mock('@/entities/options-chain', () => ({
+    findNearestStrikeIndex: (strikes: number[], target: number) => {
+        let idx = 0;
+        let minDiff = Infinity;
+        for (let i = 0; i < strikes.length; i++) {
+            const diff = Math.abs(strikes[i]! - target);
+            if (diff < minDiff) {
+                minDiff = diff;
+                idx = i;
+            }
+        }
+        return idx;
+    },
+}));
+
+vi.mock('@/widgets/options/utils/computeTooltipPos', () => ({
+    computeTooltipPos: () => ({ x: 100, y: 100 }),
+    TOOLTIP_ELEMENT_ID: 'oi-chart-tooltip',
+    TOOLTIP_MIN_WIDTH_PX: 160,
+}));
+
+vi.mock('@/widgets/options/utils/formatCompactCount', () => ({
+    formatCompactCount: (v: number) => `${v}`,
+}));
+
+vi.mock('@/widgets/options/utils/pickLabelIndices', () => ({
+    pickLabelIndices: (count: number) =>
+        new Set(Array.from({ length: count }, (_, i) => i)),
+}));
+
+vi.mock('@/widgets/options/utils/optionsTooltips', () => ({
+    OpenInterestTooltip: 'OI tooltip',
+    CallOpenInterestTooltip: 'Call OI tooltip',
+    PutOpenInterestTooltip: 'Put OI tooltip',
+}));
+
+vi.mock('@/widgets/options/utils/chartLabelOffsets', () => ({
+    PEAK_LABEL_TOP_OFFSET_PX: 4,
+    CALL_LABEL_MIDLINE_OFFSET_PX: 6,
+    PUT_LABEL_MIDLINE_OFFSET_PX: 14,
+}));
+
+vi.mock('@/widgets/options/utils/chartStrokeWidths', () => ({
+    GUIDE_LINE_STROKE_WIDTH: 1.5,
+    MIDLINE_STROKE_WIDTH: 1,
+}));
+
+const CHAIN: OptionsChain = {
+    expirationDate: '2025-06-20',
+    daysToExpiration: 30,
+    calls: [
+        {
+            strike: 140,
+            bid: 10,
+            ask: 11,
+            openInterest: 500,
+            volume: 100,
+            impliedVolatility: 0.3,
+            lastPrice: 10.5,
+            inTheMoney: true,
+            contractSymbol: 'C140',
+        },
+        {
+            strike: 150,
+            bid: 5,
+            ask: 6,
+            openInterest: 1000,
+            volume: 200,
+            impliedVolatility: 0.35,
+            lastPrice: 5.5,
+            inTheMoney: true,
+            contractSymbol: 'C150',
+        },
+    ],
+    puts: [
+        {
+            strike: 140,
+            bid: 3,
+            ask: 4,
+            openInterest: 300,
+            volume: 50,
+            impliedVolatility: 0.28,
+            lastPrice: 3.5,
+            inTheMoney: false,
+            contractSymbol: 'P140',
+        },
+        {
+            strike: 150,
+            bid: 4,
+            ask: 5,
+            openInterest: 800,
+            volume: 150,
+            impliedVolatility: 0.32,
+            lastPrice: 4.5,
+            inTheMoney: false,
+            contractSymbol: 'P150',
+        },
+    ],
+};
+
+const METRICS: OptionsExpirationMetrics = {
+    expirationDate: '2025-06-20',
+    maxPain: 150,
+    putCallRatio: 0.8,
+    atmImpliedVolatility: 0.35,
+    impliedMovePercent: 4.2,
+    topOpenInterestStrikes: [],
+    topVolumeStrikes: [],
+    topOiBidAskSummary: [],
+};
+describe('OpenInterestChart', () => {
+    it('renders empty state when chain is null', () => {
+        render(
+            <OpenInterestChart
+                underlyingPrice={150}
+                chain={null}
+                metrics={null}
+            />
+        );
+        expect(screen.getByText(/OI 데이터가 없어요/)).toBeInTheDocument();
+    });
+
+    it('renders the chart with SVG when chain has data', () => {
+        const { container } = render(
+            <OpenInterestChart
+                underlyingPrice={150}
+                chain={CHAIN}
+                metrics={METRICS}
+            />
+        );
+        const svg = container.querySelector('svg');
+        expect(svg).toBeInTheDocument();
+    });
+
+    it('renders chart title', () => {
+        render(
+            <OpenInterestChart
+                underlyingPrice={150}
+                chain={CHAIN}
+                metrics={METRICS}
+            />
+        );
+        expect(
+            screen.getByText('Open Interest 분포 (Strike별)')
+        ).toBeInTheDocument();
+    });
+
+    it('renders accessible sr-only table with strike data', () => {
+        render(
+            <OpenInterestChart
+                underlyingPrice={150}
+                chain={CHAIN}
+                metrics={METRICS}
+            />
+        );
+        const table = screen.getByRole('table', { hidden: true });
+        expect(table).toBeInTheDocument();
+    });
+
+    it('renders legend items', () => {
+        render(
+            <OpenInterestChart
+                underlyingPrice={150}
+                chain={CHAIN}
+                metrics={METRICS}
+            />
+        );
+        expect(screen.getByText('Max Pain')).toBeInTheDocument();
+        expect(screen.getByText('현재가')).toBeInTheDocument();
+    });
+});

--- a/src/widgets/options/__tests__/OpenInterestChart.test.tsx
+++ b/src/widgets/options/__tests__/OpenInterestChart.test.tsx
@@ -139,6 +139,7 @@ const METRICS: OptionsExpirationMetrics = {
     topVolumeStrikes: [],
     topOiBidAskSummary: [],
 };
+
 describe('OpenInterestChart', () => {
     it('renders empty state when chain is null', () => {
         render(

--- a/src/widgets/options/__tests__/OptionsAiAnalysis.test.tsx
+++ b/src/widgets/options/__tests__/OptionsAiAnalysis.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from '@testing-library/react';
+import { OptionsAiAnalysis } from '@/widgets/options/OptionsAiAnalysis';
+import type { OptionsAnalysisResponse } from '@y0ngha/siglens-core';
+
+const mockState = vi.fn();
+
+vi.mock('@/widgets/options/hooks/useOptionsAnalysis', () => ({
+    useOptionsAnalysis: () => mockState(),
+}));
+
+vi.mock('@/features/symbol-chat', () => ({
+    usePublishSymbolChat: vi.fn(),
+}));
+
+vi.mock('@/widgets/options/utils/buildChatState', () => ({
+    buildChatState: () => ({
+        context: null,
+        timeframe: null,
+        isAnalysisReady: false,
+    }),
+}));
+
+vi.mock('@/shared/ui/BotBlockedNotice', () => ({
+    BotBlockedNotice: () => <div data-testid="bot-blocked">Bot blocked</div>,
+}));
+
+vi.mock('@/widgets/options/OptionsAiAnalysisSkeleton', () => ({
+    OptionsAiAnalysisSkeleton: () => <div data-testid="skeleton">Loading</div>,
+}));
+
+vi.mock('@/widgets/options/OptionsAiAnalysisError', () => ({
+    OptionsAiAnalysisError: () => <div data-testid="error">Error</div>,
+}));
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/shared/lib/formatAnalyzedAt', () => ({
+    formatAnalyzedAt: (d: string) => d,
+}));
+
+const RESULT: OptionsAnalysisResponse = {
+    summary: 'Bullish options flow',
+    perExpiration: [
+        {
+            expirationDate: '2025-06-20',
+            tone: 'bullish' as const,
+            commentary: 'Heavy call buying',
+        },
+    ],
+    signals: [
+        {
+            kind: 'bullish' as const,
+            message: 'Large call sweeps detected',
+        },
+    ],
+    analyzedAt: '2025-01-15T10:00:00Z',
+};
+
+describe('OptionsAiAnalysis', () => {
+    afterEach(() => {
+        mockState.mockReset();
+    });
+
+    it('renders skeleton during loading', () => {
+        mockState.mockReturnValue({ status: 'loading' });
+        render(
+            <OptionsAiAnalysis
+                symbol="AAPL"
+                companyName="Apple"
+                expirationDate="2025-06-20"
+                modelId={'gemini-2.5-flash-lite' as never}
+            />
+        );
+        expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    });
+
+    it('renders bot blocked notice', () => {
+        mockState.mockReturnValue({ status: 'bot_blocked' });
+        render(
+            <OptionsAiAnalysis
+                symbol="AAPL"
+                companyName="Apple"
+                expirationDate="2025-06-20"
+                modelId={'gemini-2.5-flash-lite' as never}
+            />
+        );
+        expect(screen.getByTestId('bot-blocked')).toBeInTheDocument();
+    });
+
+    it('renders error state', () => {
+        mockState.mockReturnValue({
+            status: 'error',
+            error: new Error('fail'),
+            retry: vi.fn(),
+        });
+        render(
+            <OptionsAiAnalysis
+                symbol="AAPL"
+                companyName="Apple"
+                expirationDate="2025-06-20"
+                modelId={'gemini-2.5-flash-lite' as never}
+            />
+        );
+        expect(screen.getByTestId('error')).toBeInTheDocument();
+    });
+
+    it('renders analysis result with summary and signals', () => {
+        mockState.mockReturnValue({ status: 'done', result: RESULT });
+        render(
+            <OptionsAiAnalysis
+                symbol="AAPL"
+                companyName="Apple"
+                expirationDate="2025-06-20"
+                modelId={'gemini-2.5-flash-lite' as never}
+            />
+        );
+        expect(screen.getByText('Bullish options flow')).toBeInTheDocument();
+        expect(screen.getByText('Heavy call buying')).toBeInTheDocument();
+        expect(
+            screen.getByText('Large call sweeps detected')
+        ).toBeInTheDocument();
+    });
+});

--- a/src/widgets/options/__tests__/OptionsAiAnalysis.test.tsx
+++ b/src/widgets/options/__tests__/OptionsAiAnalysis.test.tsx
@@ -70,7 +70,7 @@ describe('OptionsAiAnalysis', () => {
                 symbol="AAPL"
                 companyName="Apple"
                 expirationDate="2025-06-20"
-                modelId={'gemini-2.5-flash-lite' as never}
+                modelId={'gemini-2.5-flash-lite'}
             />
         );
         expect(screen.getByTestId('skeleton')).toBeInTheDocument();
@@ -83,7 +83,7 @@ describe('OptionsAiAnalysis', () => {
                 symbol="AAPL"
                 companyName="Apple"
                 expirationDate="2025-06-20"
-                modelId={'gemini-2.5-flash-lite' as never}
+                modelId={'gemini-2.5-flash-lite'}
             />
         );
         expect(screen.getByTestId('bot-blocked')).toBeInTheDocument();
@@ -100,7 +100,7 @@ describe('OptionsAiAnalysis', () => {
                 symbol="AAPL"
                 companyName="Apple"
                 expirationDate="2025-06-20"
-                modelId={'gemini-2.5-flash-lite' as never}
+                modelId={'gemini-2.5-flash-lite'}
             />
         );
         expect(screen.getByTestId('error')).toBeInTheDocument();
@@ -113,7 +113,7 @@ describe('OptionsAiAnalysis', () => {
                 symbol="AAPL"
                 companyName="Apple"
                 expirationDate="2025-06-20"
-                modelId={'gemini-2.5-flash-lite' as never}
+                modelId={'gemini-2.5-flash-lite'}
             />
         );
         expect(screen.getByText('Bullish options flow')).toBeInTheDocument();

--- a/src/widgets/options/__tests__/OptionsAiAnalysisError.test.tsx
+++ b/src/widgets/options/__tests__/OptionsAiAnalysisError.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { OptionsAiAnalysisError } from '@/widgets/options/OptionsAiAnalysisError';
+
+describe('OptionsAiAnalysisError', () => {
+    it('renders error message', () => {
+        render(<OptionsAiAnalysisError />);
+        expect(
+            screen.getByText(/옵션 분석을 가져오지 못했어요/)
+        ).toBeInTheDocument();
+    });
+
+    it('renders with alert role', () => {
+        render(<OptionsAiAnalysisError />);
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('renders retry button when resetErrorBoundary is provided', () => {
+        render(<OptionsAiAnalysisError resetErrorBoundary={vi.fn()} />);
+        expect(
+            screen.getByRole('button', { name: /다시 시도/ })
+        ).toBeInTheDocument();
+    });
+
+    it('does not render retry button when resetErrorBoundary is absent', () => {
+        render(<OptionsAiAnalysisError />);
+        expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('calls resetErrorBoundary when retry button is clicked', async () => {
+        const user = userEvent.setup();
+        const reset = vi.fn();
+        render(<OptionsAiAnalysisError resetErrorBoundary={reset} />);
+        await user.click(screen.getByRole('button', { name: /다시 시도/ }));
+        expect(reset).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/widgets/options/__tests__/OptionsAiAnalysisSkeleton.test.tsx
+++ b/src/widgets/options/__tests__/OptionsAiAnalysisSkeleton.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { OptionsAiAnalysisSkeleton } from '@/widgets/options/OptionsAiAnalysisSkeleton';
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+describe('OptionsAiAnalysisSkeleton', () => {
+    it('renders aria-busy section', () => {
+        render(<OptionsAiAnalysisSkeleton />);
+        const section = screen.getByLabelText('AI 옵션 분석 불러오는 중');
+        expect(section).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('renders spinner and status text', () => {
+        render(<OptionsAiAnalysisSkeleton />);
+        expect(screen.getByText('AI 옵션 분석 생성 중')).toBeInTheDocument();
+    });
+
+    it('renders skeleton lines', () => {
+        const { container } = render(<OptionsAiAnalysisSkeleton />);
+        const lines = container.querySelectorAll('.animate-pulse');
+        expect(lines.length).toBe(5);
+    });
+});

--- a/src/widgets/options/__tests__/OptionsChainTable.test.tsx
+++ b/src/widgets/options/__tests__/OptionsChainTable.test.tsx
@@ -88,6 +88,7 @@ const METRICS: OptionsExpirationMetrics = {
     topVolumeStrikes: [],
     topOiBidAskSummary: [],
 };
+
 describe('OptionsChainTable', () => {
     it('renders 0 contracts when chain is null', () => {
         render(

--- a/src/widgets/options/__tests__/OptionsChainTable.test.tsx
+++ b/src/widgets/options/__tests__/OptionsChainTable.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { OptionsChainTable } from '@/widgets/options/OptionsChainTable';
+import type {
+    OptionsChain,
+    OptionsExpirationMetrics,
+} from '@y0ngha/siglens-core';
+
+vi.mock('@/shared/ui/InfoTooltip', () => ({
+    InfoTooltip: ({ children }: { children: React.ReactNode }) => (
+        <span>{children}</span>
+    ),
+}));
+
+vi.mock('@/widgets/options/utils/optionsTooltips', () => ({
+    OpenInterestTooltip: 'OI',
+}));
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('@y0ngha/siglens-core', async importOriginal => {
+    const mod = (await importOriginal()) as Record<string, unknown>;
+    return {
+        ...mod,
+        aggregateOpenInterest: (chain: {
+            calls: Array<{ strike: number; openInterest: number }>;
+            puts: Array<{ strike: number; openInterest: number }>;
+        }) =>
+            chain.calls.map(c => ({
+                strike: c.strike,
+                callOpenInterest: c.openInterest,
+                putOpenInterest:
+                    chain.puts.find(p => p.strike === c.strike)?.openInterest ??
+                    0,
+            })),
+    };
+});
+
+vi.mock('@/entities/options-chain', () => ({
+    findNearestStrikeIndex: (strikes: number[], target: number) =>
+        strikes.indexOf(
+            strikes.reduce((a, b) =>
+                Math.abs(b - target) < Math.abs(a - target) ? b : a
+            )
+        ),
+}));
+
+const CHAIN: OptionsChain = {
+    expirationDate: '2025-06-20',
+    daysToExpiration: 30,
+    calls: [
+        {
+            strike: 150,
+            bid: 5,
+            ask: 6,
+            openInterest: 1000,
+            volume: 200,
+            impliedVolatility: 0.35,
+            lastPrice: 5.5,
+            inTheMoney: true,
+            contractSymbol: 'C150',
+        },
+    ],
+    puts: [
+        {
+            strike: 150,
+            bid: 4,
+            ask: 5,
+            openInterest: 800,
+            volume: 150,
+            impliedVolatility: 0.32,
+            lastPrice: 4.5,
+            inTheMoney: false,
+            contractSymbol: 'P150',
+        },
+    ],
+};
+
+const METRICS: OptionsExpirationMetrics = {
+    expirationDate: '2025-06-20',
+    maxPain: 150,
+    putCallRatio: 0.8,
+    atmImpliedVolatility: 0.35,
+    impliedMovePercent: 4.2,
+    topOpenInterestStrikes: [],
+    topVolumeStrikes: [],
+    topOiBidAskSummary: [],
+};
+describe('OptionsChainTable', () => {
+    it('renders 0 contracts when chain is null', () => {
+        render(
+            <OptionsChainTable
+                symbol="AAPL"
+                expirationDate="2025-06-20"
+                underlyingPrice={150}
+                chain={null}
+                metrics={null}
+                nearestExpiry="2025-06-20"
+            />
+        );
+        expect(screen.getByText(/0 contracts/)).toBeInTheDocument();
+    });
+
+    it('renders the expand button with contract count', () => {
+        render(
+            <OptionsChainTable
+                symbol="AAPL"
+                expirationDate="2025-06-20"
+                underlyingPrice={150}
+                chain={CHAIN}
+                metrics={METRICS}
+                nearestExpiry="2025-06-20"
+            />
+        );
+        expect(screen.getByText(/2 contracts/)).toBeInTheDocument();
+    });
+
+    it('expands the table on button click', async () => {
+        const user = userEvent.setup();
+        render(
+            <OptionsChainTable
+                symbol="AAPL"
+                expirationDate="2025-06-20"
+                underlyingPrice={150}
+                chain={CHAIN}
+                metrics={METRICS}
+                nearestExpiry="2025-06-20"
+            />
+        );
+
+        const button = screen.getByRole('button');
+        expect(button).toHaveAttribute('aria-expanded', 'false');
+
+        await user.click(button);
+        expect(button).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('does not render aggregate note for specific expiration (collapsed)', () => {
+        render(
+            <OptionsChainTable
+                symbol="AAPL"
+                expirationDate="2025-06-20"
+                underlyingPrice={150}
+                chain={CHAIN}
+                metrics={METRICS}
+                nearestExpiry="2025-06-20"
+            />
+        );
+        expect(screen.queryByText(/전체 만기 합산/)).not.toBeInTheDocument();
+    });
+});

--- a/src/widgets/options/__tests__/OptionsEmptyState.test.tsx
+++ b/src/widgets/options/__tests__/OptionsEmptyState.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { OptionsEmptyState } from '@/widgets/options/OptionsEmptyState';
+
+vi.mock('next/link', () => ({
+    default: ({
+        children,
+        href,
+    }: {
+        children: React.ReactNode;
+        href: string;
+    }) => <a href={href}>{children}</a>,
+}));
+
+describe('OptionsEmptyState', () => {
+    it('renders the symbol in the heading', () => {
+        render(<OptionsEmptyState symbol="TSLA" />);
+        expect(
+            screen.getByRole('heading', { name: /TSLA 옵션 시장 정보 없음/ })
+        ).toBeInTheDocument();
+    });
+
+    it('renders description text', () => {
+        render(<OptionsEmptyState symbol="TSLA" />);
+        expect(
+            screen.getByText(/옵션 시장이 형성되어 있지 않습니다/)
+        ).toBeInTheDocument();
+    });
+
+    it('renders fallback navigation links', () => {
+        render(<OptionsEmptyState symbol="TSLA" />);
+        const links = screen.getAllByRole('link');
+        expect(links).toHaveLength(4);
+    });
+
+    it('creates correct hrefs for the symbol', () => {
+        render(<OptionsEmptyState symbol="AAPL" />);
+        const links = screen.getAllByRole('link');
+        const hrefs = links.map(l => l.getAttribute('href'));
+        expect(hrefs).toContain('/AAPL');
+        expect(hrefs).toContain('/AAPL/fundamental');
+        expect(hrefs).toContain('/AAPL/news');
+        expect(hrefs).toContain('/AAPL/fear-greed');
+    });
+
+    it('renders all page labels', () => {
+        render(<OptionsEmptyState symbol="AAPL" />);
+        expect(screen.getByText('차트 분석')).toBeInTheDocument();
+        expect(screen.getByText('펀더멘털 분석')).toBeInTheDocument();
+        expect(screen.getByText('뉴스 분석')).toBeInTheDocument();
+        expect(screen.getByText('공포 탐욕 지수')).toBeInTheDocument();
+    });
+});

--- a/src/widgets/options/__tests__/OptionsMetricsRow.test.tsx
+++ b/src/widgets/options/__tests__/OptionsMetricsRow.test.tsx
@@ -36,6 +36,7 @@ const METRICS: OptionsExpirationMetrics = {
     topVolumeStrikes: [],
     topOiBidAskSummary: [],
 };
+
 describe('OptionsMetricsRow', () => {
     it('renders all four metric cards', () => {
         render(

--- a/src/widgets/options/__tests__/OptionsMetricsRow.test.tsx
+++ b/src/widgets/options/__tests__/OptionsMetricsRow.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import { OptionsMetricsRow } from '@/widgets/options/OptionsMetricsRow';
+import type { OptionsExpirationMetrics } from '@y0ngha/siglens-core';
+
+vi.mock('@/shared/ui/InfoTooltip', () => ({
+    InfoTooltip: ({ children }: { children: React.ReactNode }) => (
+        <span>{children}</span>
+    ),
+}));
+
+vi.mock('@/widgets/options/utils/optionsTooltips', () => ({
+    MaxPainTooltip: 'Max Pain info',
+    PutCallRatioTooltip: 'P/C info',
+    AtmIvTooltip: () => 'ATM IV info',
+    ImpliedMoveTooltip: () => 'Imp Move info',
+}));
+
+vi.mock('@/entities/options-chain', () => ({
+    formatMaxPain: (v: number | null) =>
+        v === null ? '—' : `$${v.toFixed(0)}`,
+    formatPutCallRatio: (v: number | null) => (v === null ? '—' : v.toFixed(2)),
+    formatAtmIv: (v: number | null) =>
+        v === null ? '—' : `${(v * 100).toFixed(1)}%`,
+    formatImpliedMove: (v: number | null) =>
+        v === null ? '—' : `±${v.toFixed(1)}%`,
+    METRIC_PLACEHOLDER: '—',
+}));
+
+const METRICS: OptionsExpirationMetrics = {
+    expirationDate: '2025-06-20',
+    maxPain: 150,
+    putCallRatio: 0.8,
+    atmImpliedVolatility: 0.35,
+    impliedMovePercent: 4.2,
+    topOpenInterestStrikes: [],
+    topVolumeStrikes: [],
+    topOiBidAskSummary: [],
+};
+describe('OptionsMetricsRow', () => {
+    it('renders all four metric cards', () => {
+        render(
+            <OptionsMetricsRow
+                expirationDate="2025-06-20"
+                metrics={METRICS}
+                nearestExpiry="2025-06-20"
+                oiStale={false}
+            />
+        );
+        expect(screen.getByText('Max Pain')).toBeInTheDocument();
+        expect(screen.getByText('P/C Ratio')).toBeInTheDocument();
+        expect(screen.getByText('ATM IV')).toBeInTheDocument();
+        expect(screen.getByText('Imp. Move')).toBeInTheDocument();
+    });
+
+    it('renders formatted metric values', () => {
+        render(
+            <OptionsMetricsRow
+                expirationDate="2025-06-20"
+                metrics={METRICS}
+                nearestExpiry="2025-06-20"
+                oiStale={false}
+            />
+        );
+        expect(screen.getByText('$150')).toBeInTheDocument();
+        expect(screen.getByText('0.80')).toBeInTheDocument();
+        expect(screen.getByText('35.0%')).toBeInTheDocument();
+        expect(screen.getByText('±4.2%')).toBeInTheDocument();
+    });
+
+    it('renders placeholders when oiStale is true', () => {
+        render(
+            <OptionsMetricsRow
+                expirationDate="2025-06-20"
+                metrics={METRICS}
+                nearestExpiry="2025-06-20"
+                oiStale={true}
+            />
+        );
+        const dashes = screen.getAllByText('—');
+        expect(dashes).toHaveLength(4);
+    });
+
+    it('renders aggregate note when expirationDate is all', () => {
+        render(
+            <OptionsMetricsRow
+                expirationDate="all"
+                metrics={METRICS}
+                nearestExpiry="2025-06-20"
+                oiStale={false}
+            />
+        );
+        expect(screen.getByText(/전체 만기 합산/)).toBeInTheDocument();
+    });
+
+    it('does not render aggregate note for specific expiration', () => {
+        render(
+            <OptionsMetricsRow
+                expirationDate="2025-06-20"
+                metrics={METRICS}
+                nearestExpiry="2025-06-20"
+                oiStale={false}
+            />
+        );
+        expect(screen.queryByText(/전체 만기 합산/)).not.toBeInTheDocument();
+    });
+});

--- a/src/widgets/options/__tests__/OptionsPageClient.test.tsx
+++ b/src/widgets/options/__tests__/OptionsPageClient.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen } from '@testing-library/react';
+import { OptionsPageClient } from '@/widgets/options/OptionsPageClient';
+import type { OptionsSnapshot, SlotMapping } from '@y0ngha/siglens-core';
+
+vi.mock('react-error-boundary', () => ({
+    ErrorBoundary: ({ children }: { children: React.ReactNode }) => (
+        <>{children}</>
+    ),
+}));
+
+vi.mock('@/widgets/symbol-page', () => ({
+    CrossLinkCards: () => <div data-testid="cross-links" />,
+    useSymbolModel: () => ({ modelId: 'gemini-2.5-flash-lite' }),
+}));
+
+vi.mock('@/widgets/options/ExpirationSelector', () => ({
+    ExpirationSelector: () => <div data-testid="exp-selector" />,
+}));
+
+vi.mock('@/widgets/options/OptionsAiAnalysis', () => ({
+    OptionsAiAnalysis: () => <div data-testid="ai-analysis" />,
+}));
+
+vi.mock('@/widgets/options/OptionsAiAnalysisError', () => ({
+    OptionsAiAnalysisError: () => <div>Error</div>,
+}));
+
+vi.mock('@/widgets/options/OptionsAiAnalysisStaleNotice', () => ({
+    OptionsAiAnalysisStaleNotice: () => <div data-testid="stale-notice" />,
+}));
+
+vi.mock('@/widgets/options/OptionsChainTable', () => ({
+    OptionsChainTable: () => <div data-testid="chain-table" />,
+}));
+
+vi.mock('@/widgets/options/OpenInterestChart', () => ({
+    OpenInterestChart: () => <div data-testid="oi-chart" />,
+}));
+
+vi.mock('@/widgets/options/StrikeVolumeChart', () => ({
+    StrikeVolumeChart: () => <div data-testid="volume-chart" />,
+}));
+
+vi.mock('@/widgets/options/OptionsMetricsRow', () => ({
+    OptionsMetricsRow: () => <div data-testid="metrics-row" />,
+}));
+
+vi.mock('@/widgets/options/OptionsStaleDataBanner', () => ({
+    OptionsStaleDataBanner: () => <div data-testid="stale-banner" />,
+}));
+
+vi.mock('@/widgets/options/hooks/useOptionsChainMetrics', () => ({
+    useOptionsChainMetrics: () => ({ chain: null, metrics: null }),
+}));
+
+vi.mock('@/shared/lib/marketSession', () => ({
+    isUsOptionsRegularSession: () => true,
+    isOpenInterestSnapshotStale: () => false,
+}));
+
+const SNAPSHOT: OptionsSnapshot = {
+    symbol: 'AAPL',
+    underlyingPrice: 150,
+    capturedAt: '2025-01-15T10:00:00Z',
+    chains: [
+        {
+            expirationDate: '2025-06-20',
+            daysToExpiration: 30,
+            calls: [],
+            puts: [],
+        },
+    ],
+};
+
+const SLOTS: Array<SlotMapping | null> = [
+    {
+        slot: { key: '1W', label: '근월', targetDays: 7 },
+        expirationDate: '2025-06-20',
+    },
+    null,
+];
+
+describe('OptionsPageClient', () => {
+    it('renders ExpirationSelector', () => {
+        render(
+            <OptionsPageClient
+                symbol="AAPL"
+                companyName="Apple"
+                snapshot={SNAPSHOT}
+                slots={SLOTS}
+            />
+        );
+        expect(screen.getByTestId('exp-selector')).toBeInTheDocument();
+    });
+
+    it('renders AI analysis section', () => {
+        render(
+            <OptionsPageClient
+                symbol="AAPL"
+                companyName="Apple"
+                snapshot={SNAPSHOT}
+                slots={SLOTS}
+            />
+        );
+        expect(screen.getByTestId('ai-analysis')).toBeInTheDocument();
+    });
+
+    it('renders metrics row', () => {
+        render(
+            <OptionsPageClient
+                symbol="AAPL"
+                companyName="Apple"
+                snapshot={SNAPSHOT}
+                slots={SLOTS}
+            />
+        );
+        expect(screen.getByTestId('metrics-row')).toBeInTheDocument();
+    });
+
+    it('renders charts', () => {
+        render(
+            <OptionsPageClient
+                symbol="AAPL"
+                companyName="Apple"
+                snapshot={SNAPSHOT}
+                slots={SLOTS}
+            />
+        );
+        expect(screen.getByTestId('oi-chart')).toBeInTheDocument();
+        expect(screen.getByTestId('volume-chart')).toBeInTheDocument();
+    });
+
+    it('renders chain table and cross links', () => {
+        render(
+            <OptionsPageClient
+                symbol="AAPL"
+                companyName="Apple"
+                snapshot={SNAPSHOT}
+                slots={SLOTS}
+            />
+        );
+        expect(screen.getByTestId('chain-table')).toBeInTheDocument();
+        expect(screen.getByTestId('cross-links')).toBeInTheDocument();
+    });
+});

--- a/src/widgets/options/__tests__/OptionsStaleDataBanner.test.tsx
+++ b/src/widgets/options/__tests__/OptionsStaleDataBanner.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { OptionsStaleDataBanner } from '@/widgets/options/OptionsStaleDataBanner';
+
+vi.mock('@/shared/lib/options/marketHoursDisplay', () => ({
+    ET_MARKET_HOURS_DISPLAY: '9:30~16:00 ET',
+    KST_EDT_HOURS_DISPLAY: '22:30~05:00',
+    KST_EST_HOURS_DISPLAY: '23:30~06:00',
+}));
+
+vi.mock('@/shared/lib/eastern', () => ({
+    EDT_OFFSET_HOURS: -4,
+    getEasternOffsetHours: () => -4,
+}));
+
+describe('OptionsStaleDataBanner', () => {
+    it('renders the stale data heading', () => {
+        render(<OptionsStaleDataBanner />);
+        expect(
+            screen.getByText('옵션 OI 데이터가 비어 있어요')
+        ).toBeInTheDocument();
+    });
+
+    it('renders status role', () => {
+        render(<OptionsStaleDataBanner />);
+        expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    it('renders ET market hours', () => {
+        render(<OptionsStaleDataBanner />);
+        expect(screen.getByText(/9:30~16:00 ET/)).toBeInTheDocument();
+    });
+
+    it('renders both KST windows', () => {
+        render(<OptionsStaleDataBanner />);
+        const text = screen.getByRole('status').textContent ?? '';
+        expect(text).toContain('22:30~05:00');
+        expect(text).toContain('23:30~06:00');
+    });
+
+    it('renders current DST label', () => {
+        render(<OptionsStaleDataBanner />);
+        const text = screen.getByRole('status').textContent ?? '';
+        expect(text).toContain('서머타임(EDT)');
+    });
+});

--- a/src/widgets/options/__tests__/StrikeVolumeChart.test.tsx
+++ b/src/widgets/options/__tests__/StrikeVolumeChart.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from '@testing-library/react';
+import { StrikeVolumeChart } from '@/widgets/options/StrikeVolumeChart';
+import type { OptionsChain } from '@y0ngha/siglens-core';
+
+vi.mock('@/shared/ui/InfoTooltip', () => ({
+    InfoTooltip: ({ children }: { children: React.ReactNode }) => (
+        <span>{children}</span>
+    ),
+}));
+
+vi.mock('@/widgets/options/utils/aggregateStrikeVolume', () => ({
+    aggregateStrikeVolume: (chain: {
+        calls: Array<{ strike: number; volume: number }>;
+        puts: Array<{ strike: number; volume: number }>;
+    }) =>
+        chain.calls.map(c => ({
+            strike: c.strike,
+            callVolume: c.volume,
+            putVolume: chain.puts.find(p => p.strike === c.strike)?.volume ?? 0,
+        })),
+}));
+
+vi.mock('@/widgets/options/utils/computeTooltipPos', () => ({
+    computeTooltipPos: () => ({ x: 100, y: 100 }),
+    TOOLTIP_MIN_WIDTH_PX: 160,
+}));
+
+vi.mock('@/widgets/options/utils/formatCompactCount', () => ({
+    formatCompactCount: (v: number) => `${v}`,
+}));
+
+vi.mock('@/widgets/options/utils/pickLabelIndices', () => ({
+    pickLabelIndices: (count: number) =>
+        new Set(Array.from({ length: count }, (_, i) => i)),
+}));
+
+vi.mock('@/widgets/options/utils/optionsTooltips', () => ({
+    CallVolumeTooltip: 'Call vol',
+    PutVolumeTooltip: 'Put vol',
+}));
+
+vi.mock('@/widgets/options/utils/chartLabelOffsets', () => ({
+    PEAK_LABEL_TOP_OFFSET_PX: 4,
+    CALL_LABEL_MIDLINE_OFFSET_PX: 6,
+    PUT_LABEL_MIDLINE_OFFSET_PX: 14,
+}));
+
+vi.mock('@/widgets/options/utils/chartStrokeWidths', () => ({
+    MIDLINE_STROKE_WIDTH: 1,
+    GUIDE_LINE_STROKE_WIDTH: 1.5,
+}));
+
+vi.mock('@/entities/options-chain', () => ({
+    findNearestStrikeIndex: () => 0,
+}));
+
+const CHAIN: OptionsChain = {
+    expirationDate: '2025-06-20',
+    daysToExpiration: 30,
+    calls: [
+        {
+            strike: 150,
+            bid: 5,
+            ask: 6,
+            openInterest: 1000,
+            volume: 500,
+            impliedVolatility: 0.35,
+            lastPrice: 5.5,
+            inTheMoney: true,
+            contractSymbol: 'C150',
+        },
+    ],
+    puts: [
+        {
+            strike: 150,
+            bid: 4,
+            ask: 5,
+            openInterest: 800,
+            volume: 300,
+            impliedVolatility: 0.32,
+            lastPrice: 4.5,
+            inTheMoney: false,
+            contractSymbol: 'P150',
+        },
+    ],
+};
+
+describe('StrikeVolumeChart', () => {
+    it('renders empty state when chain is null', () => {
+        render(<StrikeVolumeChart underlyingPrice={150} chain={null} />);
+        expect(screen.getByText(/거래량 데이터가 없어요/)).toBeInTheDocument();
+    });
+
+    it('renders SVG chart with data', () => {
+        const { container } = render(
+            <StrikeVolumeChart underlyingPrice={150} chain={CHAIN} />
+        );
+        expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('renders chart title', () => {
+        render(<StrikeVolumeChart underlyingPrice={150} chain={CHAIN} />);
+        expect(screen.getByText('Volume 분포 (Strike별)')).toBeInTheDocument();
+    });
+
+    it('renders legend items', () => {
+        render(<StrikeVolumeChart underlyingPrice={150} chain={CHAIN} />);
+        expect(screen.getByText('Call Vol')).toBeInTheDocument();
+        expect(screen.getByText('Put Vol')).toBeInTheDocument();
+        expect(screen.getByText('현재가')).toBeInTheDocument();
+    });
+
+    it('renders sr-only table', () => {
+        render(<StrikeVolumeChart underlyingPrice={150} chain={CHAIN} />);
+        const table = screen.getByRole('table', { hidden: true });
+        expect(table).toBeInTheDocument();
+    });
+});

--- a/src/widgets/options/__tests__/hooks/useOptionsAnalysis.test.ts
+++ b/src/widgets/options/__tests__/hooks/useOptionsAnalysis.test.ts
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import type { ReactNode } from 'react';
+import { useOptionsAnalysis } from '@/widgets/options/hooks/useOptionsAnalysis';
+import {
+    submitOptionsAnalysisAction,
+    pollOptionsAnalysisAction,
+    cancelOptionsAnalysisJobAction,
+} from '@/entities/options-chain/actions';
+import type { OptionsAnalysisResponse } from '@y0ngha/siglens-core';
+
+vi.mock('@/entities/options-chain/actions', () => ({
+    submitOptionsAnalysisAction: vi.fn(),
+    pollOptionsAnalysisAction: vi.fn(),
+    cancelOptionsAnalysisJobAction: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/entities/analysis', () => ({
+    isGateBlockedResult: () => false,
+}));
+
+vi.mock('@/shared/lib/sleep', () => ({
+    sleep: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/shared/hooks/usePageHideCancel', () => ({
+    usePageHideCancel: vi.fn(),
+}));
+
+vi.mock('@/widgets/symbol-page', () => ({
+    BotBlockedError: class BotBlockedError extends Error {
+        constructor() {
+            super('bot_blocked');
+            this.name = 'BotBlockedError';
+        }
+    },
+}));
+
+const mockSubmit = submitOptionsAnalysisAction as ReturnType<typeof vi.fn>;
+const mockPoll = pollOptionsAnalysisAction as ReturnType<typeof vi.fn>;
+
+const RESULT: OptionsAnalysisResponse = {
+    summary: 'Bullish outlook',
+    perExpiration: [],
+    signals: [],
+    analyzedAt: '2025-01-01T00:00:00Z',
+};
+
+function makeWrapper() {
+    const client = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return {
+        client,
+        wrapper: ({ children }: { children: ReactNode }) =>
+            createElement(QueryClientProvider, { client }, children),
+    };
+}
+
+describe('useOptionsAnalysis', () => {
+    afterEach(() => {
+        mockSubmit.mockReset();
+        mockPoll.mockReset();
+    });
+
+    it('returns loading initially and auto-triggers on mount', () => {
+        mockSubmit.mockImplementation(() => new Promise(() => {}));
+        const { client, wrapper } = makeWrapper();
+        const { result } = renderHook(
+            () =>
+                useOptionsAnalysis({
+                    symbol: 'AAPL',
+                    companyName: 'Apple Inc.',
+                    expirationDate: '2025-06-20',
+                    modelId: 'gemini-2.5-flash-lite' as never,
+                }),
+            { wrapper }
+        );
+        expect(result.current.status).toBe('loading');
+        client.clear();
+    });
+
+    it('returns done when submit returns cached result', async () => {
+        mockSubmit.mockResolvedValue({
+            status: 'cached',
+            result: RESULT,
+        });
+        const { client, wrapper } = makeWrapper();
+        const { result } = renderHook(
+            () =>
+                useOptionsAnalysis({
+                    symbol: 'AAPL',
+                    companyName: 'Apple Inc.',
+                    expirationDate: '2025-06-20',
+                    modelId: 'gemini-2.5-flash-lite' as never,
+                }),
+            { wrapper }
+        );
+
+        await waitFor(() => {
+            expect(result.current.status).toBe('done');
+        });
+
+        if (result.current.status !== 'done') throw new Error('expected done');
+        expect(result.current.result).toEqual(RESULT);
+        client.clear();
+    });
+
+    it('returns error when submit returns limit_error', async () => {
+        mockSubmit.mockResolvedValue({
+            status: 'limit_error',
+            error: { message: '한도 초과' },
+        });
+        const { client, wrapper } = makeWrapper();
+        const { result } = renderHook(
+            () =>
+                useOptionsAnalysis({
+                    symbol: 'AAPL',
+                    companyName: 'Apple Inc.',
+                    expirationDate: '2025-06-20',
+                    modelId: 'gemini-2.5-flash-lite' as never,
+                }),
+            { wrapper }
+        );
+
+        await waitFor(() => {
+            expect(result.current.status).toBe('error');
+        });
+
+        if (result.current.status !== 'error')
+            throw new Error('expected error');
+        expect(result.current.error.message).toBe('한도 초과');
+        client.clear();
+    });
+
+    it('returns bot_blocked when submit returns miss_no_trigger', async () => {
+        mockSubmit.mockResolvedValue({
+            status: 'miss_no_trigger',
+        });
+        const { client, wrapper } = makeWrapper();
+        const { result } = renderHook(
+            () =>
+                useOptionsAnalysis({
+                    symbol: 'AAPL',
+                    companyName: 'Apple Inc.',
+                    expirationDate: '2025-06-20',
+                    modelId: 'gemini-2.5-flash-lite' as never,
+                }),
+            { wrapper }
+        );
+
+        await waitFor(() => {
+            expect(result.current.status).toBe('bot_blocked');
+        });
+        client.clear();
+    });
+
+    it('polls and returns done when poll resolves', async () => {
+        mockSubmit.mockResolvedValue({
+            status: 'submitted',
+            jobId: 'opt-job-1',
+        });
+        mockPoll.mockResolvedValueOnce({
+            status: 'done',
+            result: RESULT,
+        });
+
+        const { client, wrapper } = makeWrapper();
+        const { result } = renderHook(
+            () =>
+                useOptionsAnalysis({
+                    symbol: 'AAPL',
+                    companyName: 'Apple Inc.',
+                    expirationDate: '2025-06-20',
+                    modelId: 'gemini-2.5-flash-lite' as never,
+                }),
+            { wrapper }
+        );
+
+        await waitFor(() => {
+            expect(result.current.status).toBe('done');
+        });
+        client.clear();
+    });
+});

--- a/src/widgets/options/__tests__/hooks/useOptionsAnalysis.test.ts
+++ b/src/widgets/options/__tests__/hooks/useOptionsAnalysis.test.ts
@@ -74,7 +74,7 @@ describe('useOptionsAnalysis', () => {
                     symbol: 'AAPL',
                     companyName: 'Apple Inc.',
                     expirationDate: '2025-06-20',
-                    modelId: 'gemini-2.5-flash-lite' as never,
+                    modelId: 'gemini-2.5-flash-lite',
                 }),
             { wrapper }
         );
@@ -94,7 +94,7 @@ describe('useOptionsAnalysis', () => {
                     symbol: 'AAPL',
                     companyName: 'Apple Inc.',
                     expirationDate: '2025-06-20',
-                    modelId: 'gemini-2.5-flash-lite' as never,
+                    modelId: 'gemini-2.5-flash-lite',
                 }),
             { wrapper }
         );
@@ -120,7 +120,7 @@ describe('useOptionsAnalysis', () => {
                     symbol: 'AAPL',
                     companyName: 'Apple Inc.',
                     expirationDate: '2025-06-20',
-                    modelId: 'gemini-2.5-flash-lite' as never,
+                    modelId: 'gemini-2.5-flash-lite',
                 }),
             { wrapper }
         );
@@ -146,7 +146,7 @@ describe('useOptionsAnalysis', () => {
                     symbol: 'AAPL',
                     companyName: 'Apple Inc.',
                     expirationDate: '2025-06-20',
-                    modelId: 'gemini-2.5-flash-lite' as never,
+                    modelId: 'gemini-2.5-flash-lite',
                 }),
             { wrapper }
         );
@@ -174,7 +174,7 @@ describe('useOptionsAnalysis', () => {
                     symbol: 'AAPL',
                     companyName: 'Apple Inc.',
                     expirationDate: '2025-06-20',
-                    modelId: 'gemini-2.5-flash-lite' as never,
+                    modelId: 'gemini-2.5-flash-lite',
                 }),
             { wrapper }
         );

--- a/src/widgets/options/__tests__/hooks/useOptionsChainMetrics.test.ts
+++ b/src/widgets/options/__tests__/hooks/useOptionsChainMetrics.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { useOptionsChainMetrics } from '@/widgets/options/hooks/useOptionsChainMetrics';
+import type { OptionsSnapshot } from '@y0ngha/siglens-core';
+
+vi.mock('@/entities/options-chain', () => ({
+    pickActiveChain: (snapshot: OptionsSnapshot, exp: string) => {
+        if (exp === 'all') return snapshot.chains[0] ?? null;
+        return snapshot.chains.find(c => c.expirationDate === exp) ?? null;
+    },
+}));
+
+vi.mock('@y0ngha/siglens-core', async () => {
+    const actual = await vi.importActual('@y0ngha/siglens-core');
+    return {
+        ...actual,
+        summarizeChainForLlm: (_chain: unknown, _price: number) => ({
+            maxPain: 150,
+            putCallRatio: 0.8,
+            atmImpliedVolatility: 0.35,
+            impliedMovePercent: 4.2,
+        }),
+    };
+});
+
+const SNAPSHOT: OptionsSnapshot = {
+    symbol: 'AAPL',
+    underlyingPrice: 150,
+    capturedAt: '2025-01-15T10:00:00Z',
+    chains: [
+        {
+            expirationDate: '2025-06-20',
+            daysToExpiration: 30,
+            calls: [
+                {
+                    strike: 150,
+                    bid: 5,
+                    ask: 6,
+                    openInterest: 1000,
+                    volume: 200,
+                    impliedVolatility: 0.35,
+                    lastPrice: 5.5,
+                    inTheMoney: true,
+                    contractSymbol: 'AAPL250620C00150000',
+                },
+            ],
+            puts: [
+                {
+                    strike: 150,
+                    bid: 4,
+                    ask: 5,
+                    openInterest: 800,
+                    volume: 150,
+                    impliedVolatility: 0.32,
+                    lastPrice: 4.5,
+                    inTheMoney: false,
+                    contractSymbol: 'AAPL250620P00150000',
+                },
+            ],
+        },
+    ],
+};
+
+describe('useOptionsChainMetrics', () => {
+    it('returns chain and metrics for a matching expiration', () => {
+        const { result } = renderHook(() =>
+            useOptionsChainMetrics(SNAPSHOT, '2025-06-20')
+        );
+        expect(result.current.chain).toBeTruthy();
+        expect(result.current.metrics).toBeTruthy();
+        expect(result.current.metrics?.maxPain).toBe(150);
+    });
+
+    it('returns null chain and metrics for non-matching expiration', () => {
+        const { result } = renderHook(() =>
+            useOptionsChainMetrics(SNAPSHOT, '2099-01-01')
+        );
+        expect(result.current.chain).toBeNull();
+        expect(result.current.metrics).toBeNull();
+    });
+
+    it('uses first chain when "all" is selected', () => {
+        const { result } = renderHook(() =>
+            useOptionsChainMetrics(SNAPSHOT, 'all')
+        );
+        expect(result.current.chain).toBeTruthy();
+        expect(result.current.chain?.expirationDate).toBe('2025-06-20');
+    });
+
+    it('memoizes result across re-renders with same inputs', () => {
+        const { result, rerender } = renderHook(() =>
+            useOptionsChainMetrics(SNAPSHOT, '2025-06-20')
+        );
+        const first = result.current;
+        rerender();
+        expect(result.current).toBe(first);
+    });
+});

--- a/src/widgets/options/__tests__/utils/chartLabelOffsets.test.ts
+++ b/src/widgets/options/__tests__/utils/chartLabelOffsets.test.ts
@@ -1,0 +1,25 @@
+import {
+    PEAK_LABEL_TOP_OFFSET_PX,
+    CALL_LABEL_MIDLINE_OFFSET_PX,
+    PUT_LABEL_MIDLINE_OFFSET_PX,
+} from '@/widgets/options/utils/chartLabelOffsets';
+
+describe('chartLabelOffsets', () => {
+    it('exports PEAK_LABEL_TOP_OFFSET_PX as a positive number', () => {
+        expect(PEAK_LABEL_TOP_OFFSET_PX).toBeGreaterThan(0);
+    });
+
+    it('exports CALL_LABEL_MIDLINE_OFFSET_PX as a positive number', () => {
+        expect(CALL_LABEL_MIDLINE_OFFSET_PX).toBeGreaterThan(0);
+    });
+
+    it('exports PUT_LABEL_MIDLINE_OFFSET_PX as a positive number', () => {
+        expect(PUT_LABEL_MIDLINE_OFFSET_PX).toBeGreaterThan(0);
+    });
+
+    it('Put offset is larger than Call offset to avoid overlap', () => {
+        expect(PUT_LABEL_MIDLINE_OFFSET_PX).toBeGreaterThan(
+            CALL_LABEL_MIDLINE_OFFSET_PX
+        );
+    });
+});

--- a/src/widgets/options/__tests__/utils/chartStrokeWidths.test.ts
+++ b/src/widgets/options/__tests__/utils/chartStrokeWidths.test.ts
@@ -1,0 +1,20 @@
+import {
+    MIDLINE_STROKE_WIDTH,
+    GUIDE_LINE_STROKE_WIDTH,
+} from '@/widgets/options/utils/chartStrokeWidths';
+
+describe('chartStrokeWidths', () => {
+    it('MIDLINE_STROKE_WIDTH is a positive number', () => {
+        expect(MIDLINE_STROKE_WIDTH).toBeGreaterThan(0);
+    });
+
+    it('GUIDE_LINE_STROKE_WIDTH is a positive number', () => {
+        expect(GUIDE_LINE_STROKE_WIDTH).toBeGreaterThan(0);
+    });
+
+    it('guide line is thicker than midline', () => {
+        expect(GUIDE_LINE_STROKE_WIDTH).toBeGreaterThanOrEqual(
+            MIDLINE_STROKE_WIDTH
+        );
+    });
+});

--- a/src/widgets/options/__tests__/utils/formatCompactCount.test.ts
+++ b/src/widgets/options/__tests__/utils/formatCompactCount.test.ts
@@ -1,0 +1,35 @@
+import { formatCompactCount } from '@/widgets/options/utils/formatCompactCount';
+
+describe('formatCompactCount', () => {
+    it('formats millions with one decimal', () => {
+        expect(formatCompactCount(1_500_000)).toBe('1.5M');
+    });
+
+    it('formats exact million', () => {
+        expect(formatCompactCount(1_000_000)).toBe('1.0M');
+    });
+
+    it('formats thousands with one decimal', () => {
+        expect(formatCompactCount(4_500)).toBe('4.5k');
+    });
+
+    it('formats exact thousand', () => {
+        expect(formatCompactCount(1_000)).toBe('1.0k');
+    });
+
+    it('returns raw number string for values below 1000', () => {
+        expect(formatCompactCount(750)).toBe('750');
+    });
+
+    it('returns zero as string', () => {
+        expect(formatCompactCount(0)).toBe('0');
+    });
+
+    it('formats large millions', () => {
+        expect(formatCompactCount(12_300_000)).toBe('12.3M');
+    });
+
+    it('formats values just at million boundary', () => {
+        expect(formatCompactCount(999_999)).toBe('1000.0k');
+    });
+});

--- a/src/widgets/options/__tests__/utils/optionsTooltips.test.tsx
+++ b/src/widgets/options/__tests__/utils/optionsTooltips.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import {
+    MaxPainTooltip,
+    PutCallRatioTooltip,
+    AtmIvTooltip,
+    ImpliedMoveTooltip,
+    OpenInterestTooltip,
+    CallOpenInterestTooltip,
+    PutOpenInterestTooltip,
+    CallVolumeTooltip,
+    PutVolumeTooltip,
+} from '@/widgets/options/utils/optionsTooltips';
+
+vi.mock('@/shared/lib/eastern', () => ({
+    EDT_OFFSET_HOURS: -4,
+    getEasternOffsetHours: () => -4,
+}));
+
+vi.mock('@/shared/lib/options/marketHoursDisplay', () => ({
+    ET_MARKET_HOURS_DISPLAY: '9:30~16:00 ET',
+    KST_EDT_HOURS_DISPLAY: '22:30~05:00',
+    KST_EST_HOURS_DISPLAY: '23:30~06:00',
+}));
+
+describe('optionsTooltips', () => {
+    describe('MaxPainTooltip', () => {
+        it('renders Max Pain explanation', () => {
+            render(<>{MaxPainTooltip}</>);
+            expect(
+                screen.getByText(/옵션 만기일이 가까워질수록/)
+            ).toBeInTheDocument();
+        });
+    });
+
+    describe('PutCallRatioTooltip', () => {
+        it('renders P/C ratio explanation', () => {
+            render(<>{PutCallRatioTooltip}</>);
+            expect(
+                screen.getByText(/풋옵션 거래량을 콜옵션 거래량으로/)
+            ).toBeInTheDocument();
+        });
+    });
+
+    describe('AtmIvTooltip', () => {
+        it('renders ATM IV explanation with KST window', () => {
+            render(<AtmIvTooltip />);
+            expect(
+                screen.getByText(/현재 주가에 가장 가까운 옵션/)
+            ).toBeInTheDocument();
+            expect(screen.getByText(/22:30~05:00/)).toBeInTheDocument();
+        });
+    });
+
+    describe('ImpliedMoveTooltip', () => {
+        it('renders implied move explanation', () => {
+            render(<ImpliedMoveTooltip />);
+            expect(screen.getByText(/옵션 시장이/)).toBeInTheDocument();
+        });
+    });
+
+    describe('OpenInterestTooltip', () => {
+        it('renders OI explanation', () => {
+            render(<>{OpenInterestTooltip}</>);
+            expect(screen.getByText(/살아있는/)).toBeInTheDocument();
+        });
+    });
+
+    describe('Call/Put specific tooltips', () => {
+        it('renders CallOpenInterestTooltip', () => {
+            render(<>{CallOpenInterestTooltip}</>);
+            expect(
+                screen.getByText(/콜\(상승\) 옵션을 산 사람/)
+            ).toBeInTheDocument();
+        });
+
+        it('renders PutOpenInterestTooltip', () => {
+            render(<>{PutOpenInterestTooltip}</>);
+            expect(
+                screen.getByText(/풋\(하락\) 옵션을 산 사람/)
+            ).toBeInTheDocument();
+        });
+
+        it('renders CallVolumeTooltip', () => {
+            render(<>{CallVolumeTooltip}</>);
+            expect(screen.getByText(/오늘 새로 체결된 콜/)).toBeInTheDocument();
+        });
+
+        it('renders PutVolumeTooltip', () => {
+            render(<>{PutVolumeTooltip}</>);
+            expect(screen.getByText(/오늘 새로 체결된 풋/)).toBeInTheDocument();
+        });
+    });
+});

--- a/src/widgets/options/__tests__/utils/pickLabelIndices.test.ts
+++ b/src/widgets/options/__tests__/utils/pickLabelIndices.test.ts
@@ -1,0 +1,49 @@
+import { pickLabelIndices } from '@/widgets/options/utils/pickLabelIndices';
+
+describe('pickLabelIndices', () => {
+    it('returns all indices when count <= maxLabels', () => {
+        const result = pickLabelIndices(5, [], 10);
+        expect(result).toEqual(new Set([0, 1, 2, 3, 4]));
+    });
+
+    it('returns all indices when count equals maxLabels', () => {
+        const result = pickLabelIndices(10, [], 10);
+        expect(result).toEqual(new Set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
+    });
+
+    it('always includes the last index', () => {
+        const result = pickLabelIndices(20, [], 5);
+        expect(result.has(19)).toBe(true);
+    });
+
+    it('always includes valid anchor indices', () => {
+        const result = pickLabelIndices(30, [7, 15], 5);
+        expect(result.has(7)).toBe(true);
+        expect(result.has(15)).toBe(true);
+    });
+
+    it('skips invalid anchor indices (negative or out of range)', () => {
+        const result = pickLabelIndices(10, [-1, 50], 5);
+        expect(result.has(-1)).toBe(false);
+        expect(result.has(50)).toBe(false);
+    });
+
+    it('limits output size near maxLabels for large counts', () => {
+        const result = pickLabelIndices(100, [], 10);
+        expect(result.size).toBeLessThanOrEqual(15);
+    });
+
+    it('always includes index 0 via stride', () => {
+        const result = pickLabelIndices(50, [], 10);
+        expect(result.has(0)).toBe(true);
+    });
+
+    it('uses even stride spacing', () => {
+        const result = pickLabelIndices(20, [], 5);
+        expect(result.has(0)).toBe(true);
+        expect(result.has(4)).toBe(true);
+        expect(result.has(8)).toBe(true);
+        expect(result.has(12)).toBe(true);
+        expect(result.has(16)).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- dashboard, options, news 위젯 41개 파일 테스트 작성
- 247개 새 테스트 케이스

## Dashboard (15 files)
**Hooks:** useBriefing, useMarketSummary, useSectorSignalState
**Components:** BriefingCard, IndexCard, MarketSummaryPanel, MarketSummaryPanelSkeleton,
SectorSignalPanel, SectorSignalPanelSkeleton, SectorTabs, SignalBadge,
SignalStockCard, SignalSubsection, SignalTypeGuide, TimeframeSelector

## Options (18 files)
**Hooks:** useOptionsAnalysis, useOptionsChainMetrics
**Components:** ExpirationSelector, OpenInterestChart, OptionsAiAnalysis, OptionsAiAnalysisError,
OptionsAiAnalysisSkeleton, OptionsChainTable, OptionsEmptyState, OptionsMetricsRow,
OptionsPageClient, OptionsStaleDataBanner, StrikeVolumeChart
**Utils:** chartLabelOffsets, chartStrokeWidths, formatCompactCount, optionsTooltips, pickLabelIndices

## News (8 files)
**Hooks:** useNewsPollingWithInvalidation, useWaitForNewsCards
**Components:** NewsAiSummary, NewsAiSummaryError, NewsAiSummaryErrorBoundary,
NewsAiSummarySkeleton, AnalystActions
**Other:** constants

## Test plan
- [x] `yarn test` — all suites pass
- [x] `tsc --noEmit` — 0 errors
- [x] `yarn lint` — 0 errors
- [x] `yarn format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)