### PR TITLE
test(widgets): add tests for remaining 9 widgets

### DIFF
--- a/src/widgets/analysis/__tests__/AdBanner.test.tsx
+++ b/src/widgets/analysis/__tests__/AdBanner.test.tsx
@@ -1,0 +1,49 @@
+vi.mock('@/shared/lib/adsense', () => ({
+    ADSENSE_ENABLED: true,
+    ADSENSE_PUBLISHER_ID: 'ca-pub-1234567890',
+    ADSENSE_SLOTS: {
+        PROGRESS: 'slot-progress',
+        PANEL_BOTTOM: 'slot-panel-bottom',
+    },
+}));
+vi.mock('../hooks/useAdSensePush', () => ({
+    useAdSensePush: vi.fn(),
+}));
+
+import { render, screen } from '@testing-library/react';
+
+import { AdBanner } from '../AdBanner';
+
+describe('AdBanner', () => {
+    it('renders nothing when isFreeUser is false', () => {
+        const { container } = render(
+            <AdBanner isFreeUser={false} slot="analysis-progress" />
+        );
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('renders the ad container and support message for free users', () => {
+        render(<AdBanner isFreeUser={true} slot="analysis-progress" />);
+
+        expect(screen.getByText(/AI가 정밀 분석 중입니다/)).toBeInTheDocument();
+    });
+
+    it('renders the panel-bottom slot support message', () => {
+        render(<AdBanner isFreeUser={true} slot="analysis-panel-bottom" />);
+
+        expect(
+            screen.getByText(/분석 결과가 도움이 되셨나요/)
+        ).toBeInTheDocument();
+    });
+
+    it('renders the ins element with ad attributes', () => {
+        const { container } = render(
+            <AdBanner isFreeUser={true} slot="analysis-progress" />
+        );
+
+        const ins = container.querySelector('ins.adsbygoogle');
+        expect(ins).not.toBeNull();
+        expect(ins).toHaveAttribute('data-ad-client', 'ca-pub-1234567890');
+        expect(ins).toHaveAttribute('data-ad-slot', 'slot-progress');
+    });
+});

--- a/src/widgets/analysis/__tests__/AnalysisPanel.test.tsx
+++ b/src/widgets/analysis/__tests__/AnalysisPanel.test.tsx
@@ -51,17 +51,17 @@ vi.mock('../AdBanner', () => ({
 vi.mock('../StaleAnalysisBanner', () => ({
     StaleAnalysisBanner: () => null,
 }));
-vi.mock('./utils/parseStructuredSummary', () => ({
+vi.mock('@/widgets/analysis/utils/parseStructuredSummary', () => ({
     parseStructuredSummary: () => null,
 }));
-vi.mock('./utils/buildExpertAnalysisReport', () => ({
+vi.mock('@/widgets/analysis/utils/buildExpertAnalysisReport', () => ({
     buildExpertAnalysisReport: () => 'report text',
 }));
-vi.mock('./utils/trendUtils', () => ({
+vi.mock('@/widgets/analysis/utils/trendUtils', () => ({
     resolveTrendDisplay: (t: string | null | undefined) =>
         t === 'bullish' ? { label: '강세', color: '', bgColor: '' } : null,
 }));
-vi.mock('./utils/signalUtils', () => ({
+vi.mock('@/widgets/analysis/utils/signalUtils', () => ({
     resolveStrengthDisplay: () => null,
 }));
 

--- a/src/widgets/analysis/__tests__/AnalysisPanel.test.tsx
+++ b/src/widgets/analysis/__tests__/AnalysisPanel.test.tsx
@@ -1,0 +1,211 @@
+vi.mock('@/shared/ui/MarkdownText', () => ({
+    MarkdownText: ({ children }: { children: React.ReactNode }) => (
+        <span>{children}</span>
+    ),
+}));
+vi.mock('@/shared/ui/EyeIcon', () => ({
+    EyeIcon: () => <span data-testid="eye-icon" />,
+}));
+vi.mock('@/shared/ui/InfoTooltip', () => ({
+    InfoTooltip: ({ children }: { children: React.ReactNode }) => (
+        <span data-testid="info-tooltip">{children}</span>
+    ),
+}));
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) =>
+        args
+            .flat()
+            .filter(a => typeof a === 'string' && a.length > 0)
+            .join(' '),
+}));
+vi.mock('@/shared/lib/trendline', () => ({
+    TRENDLINE_DIRECTION_LABEL: { ascending: '상승', descending: '하강' },
+}));
+vi.mock('@/shared/config/time', () => ({
+    MS_PER_SECOND: 1000,
+    SECONDS_PER_MINUTE: 60,
+}));
+vi.mock('@/shared/hooks/useCopyToClipboard', () => ({
+    DEFAULT_RESET_MS: 2000,
+}));
+vi.mock('@/shared/lib/formatAnalyzedAt', () => ({
+    formatAnalyzedAt: () => '1시간 전',
+}));
+vi.mock('@/entities/analysis', () => ({
+    isAnalysisStale: () => false,
+}));
+vi.mock('@/widgets/symbol-page', () => ({
+    useSymbolPageContext: () => ({ indicatorCount: 25 }),
+    ANALYSIS_PHASES: ['분석 중'],
+    ANALYSIS_TIPS: ['팁'],
+}));
+vi.mock('../AnalysisProgress', () => ({
+    AnalysisProgress: () => <div data-testid="analysis-progress" />,
+}));
+vi.mock('../AnalysisToast', () => ({
+    AnalysisToast: () => null,
+}));
+vi.mock('../AdBanner', () => ({
+    AdBanner: () => null,
+}));
+vi.mock('../StaleAnalysisBanner', () => ({
+    StaleAnalysisBanner: () => null,
+}));
+vi.mock('./utils/parseStructuredSummary', () => ({
+    parseStructuredSummary: () => null,
+}));
+vi.mock('./utils/buildExpertAnalysisReport', () => ({
+    buildExpertAnalysisReport: () => 'report text',
+}));
+vi.mock('./utils/trendUtils', () => ({
+    resolveTrendDisplay: (t: string | null | undefined) =>
+        t === 'bullish' ? { label: '강세', color: '', bgColor: '' } : null,
+}));
+vi.mock('./utils/signalUtils', () => ({
+    resolveStrengthDisplay: () => null,
+}));
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type {
+    AnalysisResponse,
+    ClusteredKeyLevels,
+} from '@y0ngha/siglens-core';
+
+import { AnalysisPanel } from '../AnalysisPanel';
+
+function makeAnalysis(
+    overrides: Partial<AnalysisResponse> = {}
+): AnalysisResponse {
+    return {
+        summary: '요약 텍스트',
+        trend: 'bullish',
+        riskLevel: 'medium',
+        indicatorResults: [],
+        patternSummaries: [],
+        strategyResults: [],
+        trendlines: [],
+        priceTargets: { bullish: null, bearish: null },
+        actionRecommendation: undefined,
+        analyzedAt: '2025-01-01T00:00:00Z',
+        ...overrides,
+    } as AnalysisResponse;
+}
+
+const EMPTY_KEY_LEVELS: ClusteredKeyLevels = {
+    support: [],
+    resistance: [],
+};
+
+describe('AnalysisPanel', () => {
+    it('renders the summary text when not in progress', () => {
+        render(
+            <AnalysisPanel
+                symbol="AAPL"
+                analysis={makeAnalysis()}
+                keyLevels={EMPTY_KEY_LEVELS}
+                timeframe="1Day"
+            />
+        );
+
+        expect(screen.getByText('요약 텍스트')).toBeInTheDocument();
+    });
+
+    it('renders "AI 분석" heading', () => {
+        render(
+            <AnalysisPanel
+                symbol="AAPL"
+                analysis={makeAnalysis()}
+                keyLevels={EMPTY_KEY_LEVELS}
+                timeframe="1Day"
+            />
+        );
+
+        expect(screen.getByText('AI 분석')).toBeInTheDocument();
+    });
+
+    it('renders the risk level', () => {
+        render(
+            <AnalysisPanel
+                symbol="AAPL"
+                analysis={makeAnalysis({ riskLevel: 'high' })}
+                keyLevels={EMPTY_KEY_LEVELS}
+                timeframe="1Day"
+            />
+        );
+
+        expect(screen.getByText('높음')).toBeInTheDocument();
+    });
+
+    it('renders AnalysisProgress when showProgress is true', () => {
+        render(
+            <AnalysisPanel
+                symbol="AAPL"
+                analysis={makeAnalysis()}
+                keyLevels={EMPTY_KEY_LEVELS}
+                timeframe="1Day"
+                showProgress={true}
+            />
+        );
+
+        expect(screen.getByTestId('analysis-progress')).toBeInTheDocument();
+        expect(screen.queryByText('요약 텍스트')).not.toBeInTheDocument();
+    });
+
+    it('renders the reanalyze button when onReanalyze is provided', () => {
+        render(
+            <AnalysisPanel
+                symbol="AAPL"
+                analysis={makeAnalysis()}
+                keyLevels={EMPTY_KEY_LEVELS}
+                timeframe="1Day"
+                onReanalyze={vi.fn()}
+            />
+        );
+
+        expect(
+            screen.getByRole('button', { name: /재분석/ })
+        ).toBeInTheDocument();
+    });
+
+    it('does not render the reanalyze button when onReanalyze is not provided', () => {
+        render(
+            <AnalysisPanel
+                symbol="AAPL"
+                analysis={makeAnalysis()}
+                keyLevels={EMPTY_KEY_LEVELS}
+                timeframe="1Day"
+            />
+        );
+
+        expect(
+            screen.queryByRole('button', { name: /재분석/ })
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows "감지된 패턴 없음" when no patterns detected', () => {
+        render(
+            <AnalysisPanel
+                symbol="AAPL"
+                analysis={makeAnalysis({ patternSummaries: [] })}
+                keyLevels={EMPTY_KEY_LEVELS}
+                timeframe="1Day"
+            />
+        );
+
+        expect(screen.getByText('감지된 패턴 없음')).toBeInTheDocument();
+    });
+
+    it('shows analyzed time', () => {
+        render(
+            <AnalysisPanel
+                symbol="AAPL"
+                analysis={makeAnalysis()}
+                keyLevels={EMPTY_KEY_LEVELS}
+                timeframe="1Day"
+            />
+        );
+
+        expect(screen.getByText('1시간 전')).toBeInTheDocument();
+    });
+});

--- a/src/widgets/analysis/__tests__/AnalysisProgress.test.tsx
+++ b/src/widgets/analysis/__tests__/AnalysisProgress.test.tsx
@@ -1,0 +1,55 @@
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) =>
+        args
+            .flat()
+            .filter(a => typeof a === 'string' && a.length > 0)
+            .join(' '),
+}));
+vi.mock('@/widgets/symbol-page', () => ({
+    ANALYSIS_PHASES: ['차트 분석 중', '패턴 탐지 중', '결과 생성 중'],
+    ANALYSIS_TIPS: ['팁 하나', '팁 둘', '팁 셋'],
+}));
+vi.mock('../AdBanner', () => ({
+    AdBanner: () => <div data-testid="ad-banner" />,
+}));
+
+import { render, screen } from '@testing-library/react';
+
+import { AnalysisProgress } from '../AnalysisProgress';
+
+describe('AnalysisProgress', () => {
+    it('renders the current phase message', () => {
+        render(<AnalysisProgress phaseIndex={0} tipIndex={0} />);
+
+        expect(screen.getByText(/차트 분석 중/)).toBeInTheDocument();
+    });
+
+    it('renders the current tip', () => {
+        render(<AnalysisProgress phaseIndex={0} tipIndex={1} />);
+
+        expect(screen.getByText('팁 둘')).toBeInTheDocument();
+    });
+
+    it('renders phase dots matching the number of phases', () => {
+        const { container } = render(
+            <AnalysisProgress phaseIndex={1} tipIndex={0} />
+        );
+
+        const dots = container.querySelectorAll('.rounded-full.h-1.flex-1');
+        expect(dots).toHaveLength(3);
+    });
+
+    it('has a status role with aria-live', () => {
+        render(<AnalysisProgress phaseIndex={0} tipIndex={0} />);
+
+        const status = screen.getByRole('status');
+        expect(status).toHaveAttribute('aria-live', 'polite');
+        expect(status).toHaveAttribute('aria-label', 'AI 분석 진행 중');
+    });
+
+    it('renders the ad banner', () => {
+        render(<AnalysisProgress phaseIndex={0} tipIndex={0} />);
+
+        expect(screen.getByTestId('ad-banner')).toBeInTheDocument();
+    });
+});

--- a/src/widgets/analysis/__tests__/AnalysisToast.test.tsx
+++ b/src/widgets/analysis/__tests__/AnalysisToast.test.tsx
@@ -1,0 +1,56 @@
+vi.mock('@/shared/config/time', () => ({
+    MS_PER_SECOND: 1000,
+    SECONDS_PER_MINUTE: 60,
+}));
+
+import { render, screen, act } from '@testing-library/react';
+
+import { AnalysisToast } from '../AnalysisToast';
+
+describe('AnalysisToast', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('renders nothing when notice is null', () => {
+        const { container } = render(<AnalysisToast notice={null} />);
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('renders the cooldown message when notice is provided', () => {
+        render(<AnalysisToast notice={{ nonce: 1, remainingMs: 180000 }} />);
+
+        expect(screen.getByRole('status')).toBeInTheDocument();
+        expect(
+            screen.getByText(/재분석은 5분에 한 번만 가능해요/)
+        ).toBeInTheDocument();
+    });
+
+    it('formats remaining time correctly for minutes + seconds', () => {
+        render(<AnalysisToast notice={{ nonce: 1, remainingMs: 125000 }} />);
+
+        expect(screen.getByText(/약 2분 05초 뒤에/)).toBeInTheDocument();
+    });
+
+    it('formats remaining time as seconds-only when under 1 minute', () => {
+        render(<AnalysisToast notice={{ nonce: 1, remainingMs: 30000 }} />);
+
+        expect(screen.getByText(/약 30초 뒤에/)).toBeInTheDocument();
+    });
+
+    it('hides after the visibility timeout', () => {
+        render(<AnalysisToast notice={{ nonce: 1, remainingMs: 60000 }} />);
+
+        expect(screen.getByRole('status')).toBeInTheDocument();
+
+        act(() => {
+            vi.advanceTimersByTime(3500);
+        });
+
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+});

--- a/src/widgets/analysis/__tests__/hooks/useAdSensePush.test.ts
+++ b/src/widgets/analysis/__tests__/hooks/useAdSensePush.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { type RefObject } from 'react';
+
+import { useAdSensePush } from '../../hooks/useAdSensePush';
+
+function createMockRef(width = 300): RefObject<HTMLDivElement> {
+    const el = document.createElement('div');
+    Object.defineProperty(el, 'getBoundingClientRect', {
+        value: () => ({
+            width,
+            height: 100,
+            top: 0,
+            left: 0,
+            right: width,
+            bottom: 100,
+        }),
+    });
+    return { current: el };
+}
+
+describe('useAdSensePush', () => {
+    let originalResizeObserver: typeof ResizeObserver;
+    let mockObserve: ReturnType<typeof vi.fn>;
+    let mockDisconnect: ReturnType<typeof vi.fn>;
+    let resizeCallback: ResizeObserverCallback;
+
+    beforeEach(() => {
+        originalResizeObserver = globalThis.ResizeObserver;
+        mockObserve = vi.fn();
+        mockDisconnect = vi.fn();
+
+        class MockResizeObserver {
+            constructor(callback: ResizeObserverCallback) {
+                resizeCallback = callback;
+            }
+            observe = mockObserve;
+            unobserve = vi.fn();
+            disconnect = mockDisconnect;
+        }
+
+        globalThis.ResizeObserver =
+            MockResizeObserver as unknown as typeof ResizeObserver;
+
+        window.adsbygoogle = undefined;
+    });
+
+    afterEach(() => {
+        globalThis.ResizeObserver = originalResizeObserver;
+    });
+
+    it('does not observe when enabled is false', () => {
+        const ref = createMockRef();
+        renderHook(() => useAdSensePush(ref, false));
+
+        expect(mockObserve).not.toHaveBeenCalled();
+    });
+
+    it('observes the container when enabled', () => {
+        const ref = createMockRef();
+        renderHook(() => useAdSensePush(ref, true));
+
+        expect(mockObserve).toHaveBeenCalledWith(ref.current);
+    });
+
+    it('pushes to adsbygoogle when container has width', () => {
+        const ref = createMockRef();
+        renderHook(() => useAdSensePush(ref, true));
+
+        resizeCallback(
+            [
+                { contentRect: { width: 300 } },
+            ] as unknown as ResizeObserverEntry[],
+            {} as ResizeObserver
+        );
+
+        expect(window.adsbygoogle).toEqual([{}]);
+        expect(mockDisconnect).toHaveBeenCalled();
+    });
+
+    it('does not push when container width is 0', () => {
+        const ref = createMockRef(0);
+        renderHook(() => useAdSensePush(ref, true));
+
+        resizeCallback(
+            [{ contentRect: { width: 0 } }] as unknown as ResizeObserverEntry[],
+            {} as ResizeObserver
+        );
+
+        expect(window.adsbygoogle).toBeUndefined();
+    });
+
+    it('disconnects on unmount', () => {
+        const ref = createMockRef();
+        const { unmount } = renderHook(() => useAdSensePush(ref, true));
+
+        unmount();
+
+        expect(mockDisconnect).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/backtesting/__tests__/BacktestCaseCard.test.tsx
+++ b/src/widgets/backtesting/__tests__/BacktestCaseCard.test.tsx
@@ -1,0 +1,110 @@
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) =>
+        args
+            .flat()
+            .filter(a => typeof a === 'string' && a.length > 0)
+            .join(' '),
+}));
+vi.mock('@/shared/lib/priceFormat', () => ({
+    formatUsdCurrency: (n: number) => `$${n.toFixed(2)}`,
+}));
+
+import { render, screen } from '@testing-library/react';
+import type { BacktestCase } from '@y0ngha/siglens-core';
+
+import { BacktestCaseCard } from '../BacktestCaseCard';
+
+function makeCase(overrides: Partial<BacktestCase> = {}): BacktestCase {
+    return {
+        ticker: 'AAPL',
+        entryDate: '2024-06-15',
+        exitDate: '2024-07-01',
+        entryPrice: 190,
+        exitPrice: 200,
+        returnPct: 5.26,
+        holdingDays: 16,
+        result: 'win',
+        signalType: 'buy',
+        exitReason: 'take_profit',
+        aiResult: 'win',
+        aiTrendHit: true,
+        aiAnalysis: {
+            summary: 'AI 분석 요약',
+            tags: ['골든크로스', 'RSI 과매도'],
+            entryRecommendation: 'enter',
+            riskLevel: 'low',
+            bullishTargets: [{ price: 210, basis: '이전 고점 돌파' }],
+            stopLoss: 185,
+            takeProfit: 210,
+        },
+        ...overrides,
+    };
+}
+
+describe('BacktestCaseCard', () => {
+    it('renders the ticker badge', () => {
+        render(<BacktestCaseCard case_={makeCase()} />);
+
+        expect(screen.getByText('AAPL')).toBeInTheDocument();
+    });
+
+    it('renders the return percentage', () => {
+        render(<BacktestCaseCard case_={makeCase()} />);
+
+        expect(screen.getByText('+5.3%')).toBeInTheDocument();
+    });
+
+    it('renders the AI analysis summary', () => {
+        render(<BacktestCaseCard case_={makeCase()} />);
+
+        expect(screen.getByText('AI 분석 요약')).toBeInTheDocument();
+    });
+
+    it('renders tags', () => {
+        render(<BacktestCaseCard case_={makeCase()} />);
+
+        expect(screen.getByText('골든크로스')).toBeInTheDocument();
+        expect(screen.getByText('RSI 과매도')).toBeInTheDocument();
+    });
+
+    it('renders entry recommendation badge', () => {
+        render(<BacktestCaseCard case_={makeCase()} />);
+
+        expect(screen.getByText('AI 진입 권고')).toBeInTheDocument();
+    });
+
+    it('renders risk badge', () => {
+        render(<BacktestCaseCard case_={makeCase()} />);
+
+        expect(screen.getByText('low')).toBeInTheDocument();
+    });
+
+    it('renders formatted prices', () => {
+        render(<BacktestCaseCard case_={makeCase()} />);
+
+        expect(screen.getByText('$190.00')).toBeInTheDocument();
+        expect(screen.getByText('$200.00')).toBeInTheDocument();
+    });
+
+    it('renders loss variant for negative returns', () => {
+        render(
+            <BacktestCaseCard
+                case_={makeCase({
+                    result: 'loss',
+                    returnPct: -3.2,
+                    exitReason: 'stop_loss',
+                })}
+            />
+        );
+
+        expect(screen.getByText('-3.2%')).toBeInTheDocument();
+    });
+
+    it('has an accessible article label', () => {
+        render(<BacktestCaseCard case_={makeCase()} />);
+
+        expect(
+            screen.getByRole('article', { name: /AAPL 2024-06-15 수익/ })
+        ).toBeInTheDocument();
+    });
+});

--- a/src/widgets/backtesting/__tests__/BacktestCaseList.test.tsx
+++ b/src/widgets/backtesting/__tests__/BacktestCaseList.test.tsx
@@ -1,0 +1,65 @@
+vi.mock('../BacktestCaseCard', () => ({
+    BacktestCaseCard: ({ case_ }: { case_: { ticker: string } }) => (
+        <div data-testid={`case-${case_.ticker}`}>{case_.ticker}</div>
+    ),
+}));
+
+import { render, screen } from '@testing-library/react';
+import type { BacktestCase } from '@y0ngha/siglens-core';
+
+import { BacktestCaseList } from '../BacktestCaseList';
+
+function makeCase(ticker: string, entryDate: string): BacktestCase {
+    return {
+        ticker,
+        entryDate,
+        exitDate: '2024-07-01',
+        entryPrice: 100,
+        exitPrice: 110,
+        returnPct: 10,
+        holdingDays: 15,
+        result: 'win',
+        signalType: 'buy',
+        exitReason: 'take_profit',
+        aiTrendHit: false,
+        aiAnalysis: {
+            summary: '',
+            tags: [],
+            entryRecommendation: 'enter',
+            bullishTargets: [],
+        },
+    } as unknown as BacktestCase;
+}
+
+describe('BacktestCaseList', () => {
+    it('renders empty message when no cases', () => {
+        render(<BacktestCaseList cases={[]} />);
+
+        expect(
+            screen.getByText(/해당 종목의 케이스가 없습니다/)
+        ).toBeInTheDocument();
+    });
+
+    it('renders case cards for each item', () => {
+        const cases = [
+            makeCase('AAPL', '2024-06-15'),
+            makeCase('NVDA', '2024-06-20'),
+        ];
+        render(<BacktestCaseList cases={cases} />);
+
+        expect(screen.getByTestId('case-AAPL')).toBeInTheDocument();
+        expect(screen.getByTestId('case-NVDA')).toBeInTheDocument();
+    });
+
+    it('groups cases by month', () => {
+        const cases = [
+            makeCase('AAPL', '2024-06-15'),
+            makeCase('NVDA', '2024-06-20'),
+            makeCase('TSLA', '2024-07-01'),
+        ];
+        render(<BacktestCaseList cases={cases} />);
+
+        expect(screen.getByText('2024년 6월')).toBeInTheDocument();
+        expect(screen.getByText('2024년 7월')).toBeInTheDocument();
+    });
+});

--- a/src/widgets/backtesting/__tests__/BacktestHero.test.tsx
+++ b/src/widgets/backtesting/__tests__/BacktestHero.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import type { BacktestMeta } from '@y0ngha/siglens-core';
+
+import { BacktestHero } from '../BacktestHero';
+
+const META: BacktestMeta = {
+    period: '2023.01 ~ 2024.12',
+    winRate: 62,
+    aiWinRate: 71,
+    aiTrendHitRate: 65,
+    totalCases: 150,
+    tickerCount: 10,
+};
+
+describe('BacktestHero', () => {
+    it('renders the period', () => {
+        render(<BacktestHero meta={META} />);
+
+        expect(screen.getByText(/2023.01 ~ 2024.12/)).toBeInTheDocument();
+    });
+
+    it('renders the main heading', () => {
+        render(<BacktestHero meta={META} />);
+
+        expect(
+            screen.getByRole('heading', {
+                name: /Siglens가 얼마나 정확한가요/,
+            })
+        ).toBeInTheDocument();
+    });
+
+    it('renders stat cards with correct values', () => {
+        render(<BacktestHero meta={META} />);
+
+        expect(screen.getByText('62%')).toBeInTheDocument();
+        expect(screen.getByText('71%')).toBeInTheDocument();
+        expect(screen.getByText('150개')).toBeInTheDocument();
+        expect(screen.getByText('10종목')).toBeInTheDocument();
+    });
+
+    it('renders stat labels', () => {
+        render(<BacktestHero meta={META} />);
+
+        expect(screen.getByText('지표 신호 승률')).toBeInTheDocument();
+        expect(screen.getByText('AI 예측 승률')).toBeInTheDocument();
+        expect(screen.getByText('총 케이스')).toBeInTheDocument();
+    });
+
+    it('renders as a header element', () => {
+        render(<BacktestHero meta={META} />);
+
+        expect(screen.getByRole('banner')).toBeInTheDocument();
+    });
+});

--- a/src/widgets/backtesting/__tests__/BacktestTabs.test.tsx
+++ b/src/widgets/backtesting/__tests__/BacktestTabs.test.tsx
@@ -1,0 +1,63 @@
+vi.mock('@/shared/ui/tabs', () => ({
+    buildPanelId: (prefix: string, value: string) => `${prefix}-panel-${value}`,
+    buildTabId: (prefix: string, value: string) => `${prefix}-tab-${value}`,
+    TabsUnderline: ({
+        tabs,
+        activeTab,
+        onChange,
+    }: {
+        tabs: { value: string; label: string }[];
+        activeTab: string;
+        onChange: (v: string) => void;
+    }) => (
+        <div role="tablist">
+            {tabs.map(t => (
+                <button
+                    key={t.value}
+                    role="tab"
+                    aria-selected={activeTab === t.value}
+                    onClick={() => onChange(t.value)}
+                >
+                    {t.label}
+                </button>
+            ))}
+        </div>
+    ),
+}));
+vi.mock('@/features/backtest-filter', () => ({
+    useBacktestFilter: vi.fn(() => ({
+        tabItems: [
+            { value: 'all', label: '전체' },
+            { value: 'AAPL', label: 'AAPL' },
+        ],
+        activeTab: 'all',
+        setActiveTab: vi.fn(),
+        filtered: [],
+    })),
+}));
+vi.mock('../BacktestCaseList', () => ({
+    BacktestCaseList: ({ cases }: { cases: unknown[] }) => (
+        <div data-testid="case-list">{cases.length} cases</div>
+    ),
+}));
+
+import { render, screen } from '@testing-library/react';
+
+import { BacktestTabs } from '../BacktestTabs';
+
+describe('BacktestTabs', () => {
+    it('renders the tab list', () => {
+        render(<BacktestTabs cases={[]} tickers={['AAPL']} />);
+
+        expect(screen.getByRole('tablist')).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: /전체/ })).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: /AAPL/ })).toBeInTheDocument();
+    });
+
+    it('renders a tabpanel with BacktestCaseList', () => {
+        render(<BacktestTabs cases={[]} tickers={['AAPL']} />);
+
+        expect(screen.getByRole('tabpanel')).toBeInTheDocument();
+        expect(screen.getByTestId('case-list')).toBeInTheDocument();
+    });
+});

--- a/src/widgets/chat/__tests__/ContextSwitchSystemMessage.test.tsx
+++ b/src/widgets/chat/__tests__/ContextSwitchSystemMessage.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+
+import { ContextSwitchSystemMessage } from '../ContextSwitchSystemMessage';
+
+describe('ContextSwitchSystemMessage', () => {
+    it('renders the context switch message with the given label', () => {
+        render(<ContextSwitchSystemMessage label="뉴스 분석" />);
+
+        expect(
+            screen.getByText(/뉴스 분석 페이지로 전환되었습니다/)
+        ).toBeInTheDocument();
+    });
+
+    it('has role="status" for live-region announcements', () => {
+        render(<ContextSwitchSystemMessage label="차트" />);
+
+        expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    it('mentions that previous context no longer applies', () => {
+        render(<ContextSwitchSystemMessage label="펀더멘털" />);
+
+        expect(
+            screen.getByText(
+                /이전 페이지의 분석 컨텍스트는 더 이상 적용되지 않습니다/
+            )
+        ).toBeInTheDocument();
+    });
+});

--- a/src/widgets/chat/__tests__/FloatingChatButton.test.tsx
+++ b/src/widgets/chat/__tests__/FloatingChatButton.test.tsx
@@ -1,0 +1,79 @@
+vi.mock('@/features/symbol-chat', () => ({
+    useSymbolChat: vi.fn(() => ({ isAnalysisReady: false })),
+}));
+vi.mock('../hooks/useChatButtonState', () => ({
+    useChatButtonState: vi.fn(() => ({
+        isOpen: false,
+        showTooltip: false,
+        handleClose: vi.fn(),
+        handleButtonClick: vi.fn(),
+        dismissTooltip: vi.fn(),
+    })),
+}));
+vi.mock('../ChatPanel', () => ({
+    ChatPanel: () => <div data-testid="chat-panel" />,
+}));
+
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { FloatingChatButton } from '../FloatingChatButton';
+import { useChatButtonState } from '../hooks/useChatButtonState';
+
+describe('FloatingChatButton', () => {
+    it('renders the toggle button with "AI 채팅 열기" label when closed', () => {
+        render(<FloatingChatButton symbol="AAPL" />);
+
+        expect(
+            screen.getByRole('button', { name: /AI 채팅 열기/ })
+        ).toBeInTheDocument();
+    });
+
+    it('renders ChatPanel when isOpen is true', () => {
+        vi.mocked(useChatButtonState).mockReturnValue({
+            isOpen: true,
+            showTooltip: false,
+            handleClose: vi.fn(),
+            handleButtonClick: vi.fn(),
+            dismissTooltip: vi.fn(),
+        });
+
+        render(<FloatingChatButton symbol="AAPL" />);
+
+        expect(screen.getByTestId('chat-panel')).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /AI 채팅 닫기/ })
+        ).toBeInTheDocument();
+    });
+
+    it('renders tooltip when showTooltip is true and panel is closed', () => {
+        vi.mocked(useChatButtonState).mockReturnValue({
+            isOpen: false,
+            showTooltip: true,
+            handleClose: vi.fn(),
+            handleButtonClick: vi.fn(),
+            dismissTooltip: vi.fn(),
+        });
+
+        render(<FloatingChatButton symbol="AAPL" />);
+
+        expect(
+            screen.getByText(/분석 내용에 궁금하신 게 있다면/)
+        ).toBeInTheDocument();
+    });
+
+    it('calls handleButtonClick when the toggle button is clicked', () => {
+        const handleButtonClick = vi.fn();
+        vi.mocked(useChatButtonState).mockReturnValue({
+            isOpen: false,
+            showTooltip: false,
+            handleClose: vi.fn(),
+            handleButtonClick,
+            dismissTooltip: vi.fn(),
+        });
+
+        render(<FloatingChatButton symbol="AAPL" />);
+        fireEvent.click(screen.getByRole('button', { name: /AI 채팅 열기/ }));
+
+        expect(handleButtonClick).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/widgets/chat/__tests__/UserApiKeyRequiredModal.test.tsx
+++ b/src/widgets/chat/__tests__/UserApiKeyRequiredModal.test.tsx
@@ -1,0 +1,97 @@
+vi.mock('@/shared/hooks/useFocusTrap', () => ({
+    useFocusTrap: vi.fn(),
+}));
+vi.mock('@/shared/hooks/useEscapeKey', () => ({
+    useEscapeKey: vi.fn(),
+}));
+
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { UserApiKeyRequiredModal } from '../UserApiKeyRequiredModal';
+
+const BASE_PROPS = {
+    open: true,
+    onClose: vi.fn(),
+    provider: 'anthropic' as const,
+    loggedIn: true,
+    onSwitchToFree: vi.fn(),
+};
+
+describe('UserApiKeyRequiredModal', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders nothing when open is false', () => {
+        const { container } = render(
+            <UserApiKeyRequiredModal {...BASE_PROPS} open={false} />
+        );
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('renders the provider name in the title', () => {
+        render(
+            <UserApiKeyRequiredModal {...BASE_PROPS} provider="anthropic" />
+        );
+
+        expect(
+            screen.getByText(/Anthropic API 키 등록이 필요해요/)
+        ).toBeInTheDocument();
+    });
+
+    it('shows "API 키 등록하기" link for logged-in users', () => {
+        render(<UserApiKeyRequiredModal {...BASE_PROPS} loggedIn={true} />);
+
+        const link = screen.getByRole('link', { name: /API 키 등록하기/ });
+        expect(link).toHaveAttribute('href', '/account');
+    });
+
+    it('shows "회원가입하기" link for logged-out users', () => {
+        render(<UserApiKeyRequiredModal {...BASE_PROPS} loggedIn={false} />);
+
+        const link = screen.getByRole('link', { name: /회원가입하기/ });
+        expect(link).toHaveAttribute('href', '/signup');
+    });
+
+    it('calls onSwitchToFree when "무료 모델로 계속하기" is clicked', () => {
+        const handleSwitch = vi.fn();
+        render(
+            <UserApiKeyRequiredModal
+                {...BASE_PROPS}
+                onSwitchToFree={handleSwitch}
+            />
+        );
+
+        fireEvent.click(
+            screen.getByRole('button', { name: /무료 모델로 계속하기/ })
+        );
+
+        expect(handleSwitch).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when the close button is clicked', () => {
+        const handleClose = vi.fn();
+        render(
+            <UserApiKeyRequiredModal {...BASE_PROPS} onClose={handleClose} />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /닫기/ }));
+
+        expect(handleClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the dialog with aria-modal', () => {
+        render(<UserApiKeyRequiredModal {...BASE_PROPS} />);
+
+        const dialog = screen.getByRole('dialog');
+        expect(dialog).toHaveAttribute('aria-modal', 'true');
+    });
+
+    it('displays the google provider name correctly', () => {
+        render(<UserApiKeyRequiredModal {...BASE_PROPS} provider="google" />);
+
+        expect(
+            screen.getByText(/Google API 키 등록이 필요해요/)
+        ).toBeInTheDocument();
+    });
+});

--- a/src/widgets/chat/__tests__/hooks/useChatButtonState.test.ts
+++ b/src/widgets/chat/__tests__/hooks/useChatButtonState.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react';
+
+import { useChatButtonState } from '../../hooks/useChatButtonState';
+
+const TOOLTIP_SHOWN_KEY = 'siglens:chat-tooltip-shown';
+
+describe('useChatButtonState', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('starts with isOpen=false and showTooltip=false', () => {
+        const { result } = renderHook(() => useChatButtonState(false));
+
+        expect(result.current.isOpen).toBe(false);
+        expect(result.current.showTooltip).toBe(false);
+    });
+
+    it('toggles isOpen on handleButtonClick', () => {
+        const { result } = renderHook(() => useChatButtonState(false));
+
+        act(() => result.current.handleButtonClick());
+        expect(result.current.isOpen).toBe(true);
+
+        act(() => result.current.handleButtonClick());
+        expect(result.current.isOpen).toBe(false);
+    });
+
+    it('sets isOpen to false on handleClose', () => {
+        const { result } = renderHook(() => useChatButtonState(false));
+
+        act(() => result.current.handleButtonClick());
+        expect(result.current.isOpen).toBe(true);
+
+        act(() => result.current.handleClose());
+        expect(result.current.isOpen).toBe(false);
+    });
+
+    it('shows tooltip when analysis becomes ready and localStorage key is absent', () => {
+        const { result, rerender } = renderHook(
+            ({ ready }) => useChatButtonState(ready),
+            { initialProps: { ready: false } }
+        );
+
+        expect(result.current.showTooltip).toBe(false);
+
+        rerender({ ready: true });
+
+        expect(result.current.showTooltip).toBe(true);
+    });
+
+    it('does not show tooltip if localStorage key already set', () => {
+        localStorage.setItem(TOOLTIP_SHOWN_KEY, '1');
+
+        const { result } = renderHook(() => useChatButtonState(true));
+
+        expect(result.current.showTooltip).toBe(false);
+    });
+
+    it('sets localStorage key on dismissTooltip', () => {
+        const { result, rerender } = renderHook(
+            ({ ready }) => useChatButtonState(ready),
+            { initialProps: { ready: false } }
+        );
+
+        rerender({ ready: true });
+        expect(result.current.showTooltip).toBe(true);
+
+        act(() => result.current.dismissTooltip());
+        expect(result.current.showTooltip).toBe(false);
+        expect(localStorage.getItem(TOOLTIP_SHOWN_KEY)).toBe('1');
+    });
+
+    it('dismisses tooltip when button is clicked while tooltip is visible', () => {
+        const { result, rerender } = renderHook(
+            ({ ready }) => useChatButtonState(ready),
+            { initialProps: { ready: false } }
+        );
+
+        rerender({ ready: true });
+        expect(result.current.showTooltip).toBe(true);
+
+        act(() => result.current.handleButtonClick());
+
+        expect(result.current.showTooltip).toBe(false);
+        expect(result.current.isOpen).toBe(true);
+    });
+});

--- a/src/widgets/chat/__tests__/hooks/useChatButtonState.test.ts
+++ b/src/widgets/chat/__tests__/hooks/useChatButtonState.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import { renderHook, act } from '@testing-library/react';
 
-import { useChatButtonState } from '../../hooks/useChatButtonState';
-
-const TOOLTIP_SHOWN_KEY = 'siglens:chat-tooltip-shown';
+import {
+    useChatButtonState,
+    TOOLTIP_SHOWN_KEY,
+} from '../../hooks/useChatButtonState';
 
 describe('useChatButtonState', () => {
     beforeEach(() => {

--- a/src/widgets/chat/__tests__/hooks/useChatInput.test.ts
+++ b/src/widgets/chat/__tests__/hooks/useChatInput.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react';
+
+import { useChatInput } from '../../hooks/useChatInput';
+
+function makeOptions(
+    overrides: Partial<Parameters<typeof useChatInput>[0]> = {}
+) {
+    return {
+        messages: [],
+        loadingPhase: null,
+        isAnalysisReady: true,
+        sendMessage: vi.fn(async () => {}),
+        ...overrides,
+    };
+}
+
+describe('useChatInput', () => {
+    it('starts with empty input and not disabled', () => {
+        const { result } = renderHook(() => useChatInput(makeOptions()));
+
+        expect(result.current.inputValue).toBe('');
+        expect(result.current.isInputDisabled).toBe(false);
+    });
+
+    it('is disabled when loadingPhase is non-null', () => {
+        const { result } = renderHook(() =>
+            useChatInput(makeOptions({ loadingPhase: 'analyzing' }))
+        );
+
+        expect(result.current.isInputDisabled).toBe(true);
+    });
+
+    it('is disabled when analysis is not ready', () => {
+        const { result } = renderHook(() =>
+            useChatInput(makeOptions({ isAnalysisReady: false }))
+        );
+
+        expect(result.current.isInputDisabled).toBe(true);
+    });
+
+    it('clears input and calls sendMessage on handleSubmit', async () => {
+        const sendMessage = vi.fn(async () => {});
+        const { result } = renderHook(() =>
+            useChatInput(makeOptions({ sendMessage }))
+        );
+
+        act(() => result.current.setInputValue('질문입니다'));
+
+        await act(() => result.current.handleSubmit());
+
+        expect(sendMessage).toHaveBeenCalledWith('질문입니다');
+        expect(result.current.inputValue).toBe('');
+    });
+
+    it('does not call sendMessage when input is whitespace-only', async () => {
+        const sendMessage = vi.fn(async () => {});
+        const { result } = renderHook(() =>
+            useChatInput(makeOptions({ sendMessage }))
+        );
+
+        act(() => result.current.setInputValue('   '));
+
+        await act(() => result.current.handleSubmit());
+
+        expect(sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('does not submit when loadingPhase is active', async () => {
+        const sendMessage = vi.fn(async () => {});
+        const { result } = renderHook(() =>
+            useChatInput(
+                makeOptions({ sendMessage, loadingPhase: 'generating' })
+            )
+        );
+
+        act(() => result.current.setInputValue('hello'));
+
+        await act(() => result.current.handleSubmit());
+
+        expect(sendMessage).not.toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chat/__tests__/hooks/usePageContextLabel.test.ts
+++ b/src/widgets/chat/__tests__/hooks/usePageContextLabel.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+vi.mock('next/navigation', () => ({
+    usePathname: vi.fn(),
+}));
+vi.mock('@/entities/chat-message', () => ({
+    deriveLabel: vi.fn((pathname: string) => {
+        if (pathname.includes('/AAPL/news')) return '뉴스 분석';
+        if (pathname.includes('/AAPL')) return '차트 분석';
+        return null;
+    }),
+}));
+
+import { renderHook } from '@testing-library/react';
+import { usePathname } from 'next/navigation';
+
+import { usePageContextLabel } from '../../hooks/usePageContextLabel';
+
+describe('usePageContextLabel', () => {
+    it('returns a label for a symbol news page', () => {
+        vi.mocked(usePathname).mockReturnValue('/AAPL/news');
+        const { result } = renderHook(() => usePageContextLabel());
+
+        expect(result.current).toBe('뉴스 분석');
+    });
+
+    it('returns a label for a symbol chart page', () => {
+        vi.mocked(usePathname).mockReturnValue('/AAPL');
+        const { result } = renderHook(() => usePageContextLabel());
+
+        expect(result.current).toBe('차트 분석');
+    });
+
+    it('returns null for a non-symbol page', () => {
+        vi.mocked(usePathname).mockReturnValue('/');
+        const { result } = renderHook(() => usePageContextLabel());
+
+        expect(result.current).toBeNull();
+    });
+});

--- a/src/widgets/chat/__tests__/utils/chatStorage.test.ts
+++ b/src/widgets/chat/__tests__/utils/chatStorage.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import type { ChatMessage } from '@y0ngha/siglens-core';
+
+import {
+    buildStorageKey,
+    loadSession,
+    loadSessionFull,
+    saveSession,
+    CHAT_HISTORY_TTL_MS,
+    MAX_STORED_MESSAGES,
+} from '../../utils/chatStorage';
+
+function makeMessage(role: 'user' | 'model', content: string): ChatMessage {
+    return { role, content };
+}
+
+describe('chatStorage', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    describe('buildStorageKey', () => {
+        it('builds an uppercase key combining symbol and timeframe', () => {
+            const key = buildStorageKey('aapl', '1Day');
+            expect(key).toBe('siglens_chat_AAPL_1Day');
+        });
+    });
+
+    describe('loadSession', () => {
+        it('returns empty array when no stored data', () => {
+            expect(loadSession('nonexistent')).toEqual([]);
+        });
+
+        it('returns stored messages within TTL', () => {
+            const messages: ChatMessage[] = [
+                makeMessage('user', 'hello'),
+                makeMessage('model', 'hi'),
+            ];
+            const session = {
+                messages,
+                savedAt: Date.now(),
+            };
+            localStorage.setItem('test-key', JSON.stringify(session));
+
+            expect(loadSession('test-key')).toEqual(messages);
+        });
+
+        it('returns empty array and removes item when TTL expired', () => {
+            const session = {
+                messages: [makeMessage('user', 'old')],
+                savedAt: Date.now() - CHAT_HISTORY_TTL_MS - 1,
+            };
+            localStorage.setItem('expired-key', JSON.stringify(session));
+
+            expect(loadSession('expired-key')).toEqual([]);
+            expect(localStorage.getItem('expired-key')).toBeNull();
+        });
+
+        it('returns empty array for corrupted JSON', () => {
+            localStorage.setItem('corrupt', 'not json');
+
+            expect(loadSession('corrupt')).toEqual([]);
+        });
+    });
+
+    describe('loadSessionFull', () => {
+        it('returns messages and savedAt for valid session', () => {
+            const now = Date.now();
+            const messages: ChatMessage[] = [makeMessage('user', 'q')];
+            localStorage.setItem(
+                'full-key',
+                JSON.stringify({ messages, savedAt: now })
+            );
+
+            const result = loadSessionFull('full-key');
+            expect(result.messages).toEqual(messages);
+            expect(result.savedAt).toBe(now);
+        });
+
+        it('returns null savedAt when no data', () => {
+            const result = loadSessionFull('missing');
+            expect(result.savedAt).toBeNull();
+        });
+    });
+
+    describe('saveSession', () => {
+        it('saves messages with a savedAt timestamp', () => {
+            const messages: ChatMessage[] = [makeMessage('user', 'test')];
+            saveSession('save-key', messages);
+
+            const raw = localStorage.getItem('save-key');
+            expect(raw).not.toBeNull();
+
+            const parsed = JSON.parse(raw!);
+            expect(parsed.messages).toEqual(messages);
+            expect(typeof parsed.savedAt).toBe('number');
+        });
+
+        it('truncates messages to MAX_STORED_MESSAGES', () => {
+            const messages: ChatMessage[] = Array.from(
+                { length: MAX_STORED_MESSAGES + 10 },
+                (_, i) => makeMessage('user', `msg-${i}`)
+            );
+
+            saveSession('truncate-key', messages);
+
+            const raw = localStorage.getItem('truncate-key');
+            const parsed = JSON.parse(raw!);
+            expect(parsed.messages).toHaveLength(MAX_STORED_MESSAGES);
+            expect(parsed.messages[0].content).toBe(`msg-10`);
+        });
+    });
+});

--- a/src/widgets/chat/hooks/useChatButtonState.ts
+++ b/src/widgets/chat/hooks/useChatButtonState.ts
@@ -2,7 +2,7 @@
 
 import { startTransition, useCallback, useEffect, useState } from 'react';
 
-const TOOLTIP_SHOWN_KEY = 'siglens:chat-tooltip-shown';
+export const TOOLTIP_SHOWN_KEY = 'siglens:chat-tooltip-shown';
 
 interface UseChatButtonStateReturn {
     isOpen: boolean;

--- a/src/widgets/fear-greed/__tests__/FearGreedGauge.test.tsx
+++ b/src/widgets/fear-greed/__tests__/FearGreedGauge.test.tsx
@@ -1,0 +1,105 @@
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) =>
+        args
+            .flat()
+            .filter(a => typeof a === 'string' && a.length > 0)
+            .join(' '),
+}));
+vi.mock('@/shared/lib/fearGreedLabels', () => ({
+    SENTIMENT_LABEL_TEXT: {
+        EXTREME_FEAR: '극심한 공포',
+        FEAR: '공포',
+        NEUTRAL: '중립',
+        GREED: '탐욕',
+        EXTREME_GREED: '극심한 탐욕',
+    },
+}));
+vi.mock('@/entities/fear-greed', () => ({
+    FEAR_GREED_SCORE_BOUNDARIES: {
+        EXTREME_FEAR_MAX: 25,
+        FEAR_MAX: 40,
+        NEUTRAL_MAX: 60,
+        GREED_MAX: 75,
+    },
+}));
+vi.mock('@/shared/ui/InfoTooltip', () => ({
+    InfoTooltip: ({ children }: { children: React.ReactNode }) => (
+        <span data-testid="info-tooltip">{children}</span>
+    ),
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { FearGreedGauge } from '../FearGreedGauge';
+
+describe('FearGreedGauge', () => {
+    it('renders the score for hero size', () => {
+        render(<FearGreedGauge score={72} label="GREED" size="hero" />);
+
+        expect(screen.getByText('72')).toBeInTheDocument();
+        expect(screen.getByText('/ 100')).toBeInTheDocument();
+    });
+
+    it('renders the sentiment label for hero size', () => {
+        render(<FearGreedGauge score={15} label="EXTREME_FEAR" size="hero" />);
+
+        expect(screen.getByText('극심한 공포')).toBeInTheDocument();
+    });
+
+    it('renders the score for mini size without sentiment label', () => {
+        render(<FearGreedGauge score={50} label="NEUTRAL" size="mini" />);
+
+        expect(screen.getByText('50')).toBeInTheDocument();
+        expect(screen.queryByText('중립')).not.toBeInTheDocument();
+    });
+
+    it('renders periodLabel for mini size', () => {
+        render(
+            <FearGreedGauge
+                score={50}
+                label="NEUTRAL"
+                size="mini"
+                periodLabel="1주"
+            />
+        );
+
+        expect(screen.getByText('1주')).toBeInTheDocument();
+    });
+
+    it('renders confidence badge for hero size', () => {
+        render(
+            <FearGreedGauge
+                score={72}
+                label="GREED"
+                size="hero"
+                confidence="normal"
+            />
+        );
+
+        expect(screen.getByText('신뢰도 정상')).toBeInTheDocument();
+    });
+
+    it('renders limited confidence badge', () => {
+        render(
+            <FearGreedGauge
+                score={30}
+                label="FEAR"
+                size="hero"
+                confidence="limited"
+            />
+        );
+
+        expect(screen.getByText('신뢰도 제한')).toBeInTheDocument();
+    });
+
+    it('has an accessible SVG label', () => {
+        render(<FearGreedGauge score={72} label="GREED" size="hero" />);
+
+        const svg = screen.getByRole('img');
+        expect(svg).toHaveAttribute(
+            'aria-label',
+            expect.stringContaining('공포 탐욕 지수 72점')
+        );
+    });
+});

--- a/src/widgets/fear-greed/__tests__/FearGreedGauge.test.tsx
+++ b/src/widgets/fear-greed/__tests__/FearGreedGauge.test.tsx
@@ -17,8 +17,8 @@ vi.mock('@/shared/lib/fearGreedLabels', () => ({
 vi.mock('@/entities/fear-greed', () => ({
     FEAR_GREED_SCORE_BOUNDARIES: {
         EXTREME_FEAR_MAX: 25,
-        FEAR_MAX: 40,
-        NEUTRAL_MAX: 60,
+        FEAR_MAX: 45,
+        NEUTRAL_MAX: 55,
         GREED_MAX: 75,
     },
 }));

--- a/src/widgets/fear-greed/__tests__/hooks/useFearGreedFromSymbol.test.ts
+++ b/src/widgets/fear-greed/__tests__/hooks/useFearGreedFromSymbol.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+vi.mock('@/widgets/symbol-page/hooks/useBars', () => ({
+    useBars: vi.fn(() => ({
+        bars: [{ time: 1, open: 100, high: 110, low: 90, close: 105 }],
+        indicators: { buySellVolume: [] },
+    })),
+}));
+vi.mock('@/widgets/fear-greed/hooks/useFearGreed', () => ({
+    useFearGreed: vi.fn(() => ({
+        snapshot: { score: 55, label: 'NEUTRAL' },
+        history: [],
+    })),
+}));
+vi.mock('@/shared/config/market', () => ({
+    DEFAULT_TIMEFRAME: '1Day',
+}));
+
+import { renderHook } from '@testing-library/react';
+import { useBars } from '@/widgets/symbol-page/hooks/useBars';
+import { useFearGreed } from '@/widgets/fear-greed/hooks/useFearGreed';
+
+import { useFearGreedFromSymbol } from '../../hooks/useFearGreedFromSymbol';
+
+describe('useFearGreedFromSymbol', () => {
+    it('calls useBars with the symbol and DEFAULT_TIMEFRAME', () => {
+        renderHook(() =>
+            useFearGreedFromSymbol({ symbol: 'AAPL', fmpSymbol: 'aapl-fmp' })
+        );
+
+        expect(useBars).toHaveBeenCalledWith({
+            symbol: 'AAPL',
+            timeframe: '1Day',
+            fmpSymbol: 'aapl-fmp',
+        });
+    });
+
+    it('passes bars and buySellVolume to useFearGreed', () => {
+        renderHook(() => useFearGreedFromSymbol({ symbol: 'AAPL' }));
+
+        expect(useFearGreed).toHaveBeenCalledWith({
+            bars: [{ time: 1, open: 100, high: 110, low: 90, close: 105 }],
+            buySellVolume: [],
+        });
+    });
+
+    it('returns the useFearGreed result', () => {
+        const { result } = renderHook(() =>
+            useFearGreedFromSymbol({ symbol: 'AAPL' })
+        );
+
+        expect(result.current).toEqual({
+            snapshot: { score: 55, label: 'NEUTRAL' },
+            history: [],
+        });
+    });
+});

--- a/src/widgets/fundamental/__tests__/FundamentalAiSummary.test.tsx
+++ b/src/widgets/fundamental/__tests__/FundamentalAiSummary.test.tsx
@@ -1,0 +1,84 @@
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) =>
+        args
+            .flat()
+            .filter(a => typeof a === 'string' && a.length > 0)
+            .join(' '),
+}));
+vi.mock('@/widgets/symbol-page/hooks/useDefaultModelId', () => ({
+    useDefaultModelId: () => 'gemini-2.5-flash-lite',
+}));
+vi.mock('../hooks/useFundamentalAnalysis', () => ({
+    useFundamentalAnalysis: vi.fn(),
+}));
+vi.mock('@/features/symbol-chat', () => ({
+    usePublishSymbolChat: vi.fn(),
+}));
+vi.mock('../utils/buildChatState', () => ({
+    buildChatState: () => null,
+}));
+vi.mock('../FundamentalAiSummaryError', () => ({
+    FundamentalAiSummaryError: () => <div data-testid="error" />,
+}));
+vi.mock('../FundamentalAiSummarySkeleton', () => ({
+    FundamentalAiSummarySkeleton: () => <div data-testid="skeleton" />,
+}));
+vi.mock('@/shared/ui/BotBlockedNotice', () => ({
+    BotBlockedNotice: () => <div data-testid="bot-blocked" />,
+}));
+
+import { render, screen } from '@testing-library/react';
+
+import { FundamentalAiSummary } from '../FundamentalAiSummary';
+import { useFundamentalAnalysis } from '../hooks/useFundamentalAnalysis';
+
+describe('FundamentalAiSummary', () => {
+    it('renders skeleton during loading', () => {
+        vi.mocked(useFundamentalAnalysis).mockReturnValue({
+            status: 'loading',
+        } as ReturnType<typeof useFundamentalAnalysis>);
+
+        render(<FundamentalAiSummary symbol="AAPL" />);
+
+        expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    });
+
+    it('renders bot-blocked notice', () => {
+        vi.mocked(useFundamentalAnalysis).mockReturnValue({
+            status: 'bot_blocked',
+        } as ReturnType<typeof useFundamentalAnalysis>);
+
+        render(<FundamentalAiSummary symbol="AAPL" />);
+
+        expect(screen.getByTestId('bot-blocked')).toBeInTheDocument();
+    });
+
+    it('renders error component on error', () => {
+        vi.mocked(useFundamentalAnalysis).mockReturnValue({
+            status: 'error',
+            error: new Error('test'),
+            retry: vi.fn(),
+        } as unknown as ReturnType<typeof useFundamentalAnalysis>);
+
+        render(<FundamentalAiSummary symbol="AAPL" />);
+
+        expect(screen.getByTestId('error')).toBeInTheDocument();
+    });
+
+    it('renders the analysis result on success', () => {
+        vi.mocked(useFundamentalAnalysis).mockReturnValue({
+            status: 'done',
+            result: {
+                overallSentiment: 'bullish',
+                overallConclusionKo: '강세 전망입니다',
+                categoryAssessments: [],
+                riskFactorsKo: [],
+            },
+        } as unknown as ReturnType<typeof useFundamentalAnalysis>);
+
+        render(<FundamentalAiSummary symbol="AAPL" />);
+
+        expect(screen.getByText('강세 전망입니다')).toBeInTheDocument();
+        expect(screen.getByText('긍정')).toBeInTheDocument();
+    });
+});

--- a/src/widgets/fundamental/__tests__/FundamentalAiSummaryError.test.tsx
+++ b/src/widgets/fundamental/__tests__/FundamentalAiSummaryError.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { FundamentalAiSummaryError } from '../FundamentalAiSummaryError';
+
+describe('FundamentalAiSummaryError', () => {
+    it('renders the error message from an Error instance', () => {
+        render(
+            <FundamentalAiSummaryError
+                error={new Error('네트워크 오류')}
+                resetErrorBoundary={vi.fn()}
+            />
+        );
+
+        expect(screen.getByRole('alert')).toHaveTextContent('네트워크 오류');
+    });
+
+    it('renders a fallback message for non-Error values', () => {
+        render(
+            <FundamentalAiSummaryError
+                error="string error"
+                resetErrorBoundary={vi.fn()}
+            />
+        );
+
+        expect(screen.getByRole('alert')).toHaveTextContent(
+            '분석 중 오류가 발생했습니다.'
+        );
+    });
+
+    it('renders the heading', () => {
+        render(
+            <FundamentalAiSummaryError
+                error={new Error('err')}
+                resetErrorBoundary={vi.fn()}
+            />
+        );
+
+        expect(
+            screen.getByRole('heading', { name: /AI 펀더멘털 분석/ })
+        ).toBeInTheDocument();
+    });
+
+    it('calls resetErrorBoundary when retry button is clicked', () => {
+        const handleRetry = vi.fn();
+        render(
+            <FundamentalAiSummaryError
+                error={new Error('err')}
+                resetErrorBoundary={handleRetry}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /다시 시도/ }));
+
+        expect(handleRetry).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/widgets/fundamental/__tests__/FundamentalAiSummarySkeleton.test.tsx
+++ b/src/widgets/fundamental/__tests__/FundamentalAiSummarySkeleton.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+
+import { FundamentalAiSummarySkeleton } from '../FundamentalAiSummarySkeleton';
+
+describe('FundamentalAiSummarySkeleton', () => {
+    it('renders the heading', () => {
+        render(<FundamentalAiSummarySkeleton />);
+
+        expect(
+            screen.getByRole('heading', { name: /AI 펀더멘털 분석/ })
+        ).toBeInTheDocument();
+    });
+
+    it('sets aria-busy on the section', () => {
+        render(<FundamentalAiSummarySkeleton />);
+
+        const section = screen.getByRole('region', {
+            name: /AI 펀더멘털 분석/,
+        });
+        expect(section).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('renders a loading progress message', () => {
+        render(<FundamentalAiSummarySkeleton />);
+
+        expect(
+            screen.getByText('AI 펀더멘털 분석 진행 중…')
+        ).toBeInTheDocument();
+    });
+
+    it('renders skeleton lines', () => {
+        const { container } = render(<FundamentalAiSummarySkeleton />);
+
+        const skeletonLines = container.querySelectorAll(
+            '.animate-pulse.rounded'
+        );
+        expect(skeletonLines.length).toBeGreaterThanOrEqual(3);
+    });
+});

--- a/src/widgets/home/__tests__/HeroIllustration.test.tsx
+++ b/src/widgets/home/__tests__/HeroIllustration.test.tsx
@@ -1,0 +1,51 @@
+vi.mock('next/image', () => ({
+    default: (props: Record<string, unknown>) => (
+        <img
+            src={props.src as string}
+            alt={props.alt as string}
+            width={props.width as number}
+            height={props.height as number}
+            className={props.className as string}
+            data-priority={String(props.priority)}
+            data-fetch-priority={props.fetchPriority as string}
+        />
+    ),
+}));
+
+import { render, screen } from '@testing-library/react';
+
+import { HeroIllustration } from '../HeroIllustration';
+
+describe('HeroIllustration', () => {
+    it('renders an image with the correct src', () => {
+        render(<HeroIllustration />);
+
+        const img = screen.getByRole('img');
+        expect(img).toHaveAttribute('src', '/hero-dashboard.svg');
+    });
+
+    it('has a descriptive alt text', () => {
+        render(<HeroIllustration />);
+
+        const img = screen.getByRole('img');
+        expect(img).toHaveAttribute(
+            'alt',
+            expect.stringContaining('캔들 차트')
+        );
+    });
+
+    it('uses priority and fetchPriority for LCP optimization', () => {
+        render(<HeroIllustration />);
+
+        const img = screen.getByRole('img');
+        expect(img).toHaveAttribute('data-priority', 'true');
+        expect(img).toHaveAttribute('data-fetch-priority', 'high');
+    });
+
+    it('applies the passed className', () => {
+        render(<HeroIllustration className="custom-class" />);
+
+        const img = screen.getByRole('img');
+        expect(img).toHaveClass('custom-class');
+    });
+});

--- a/src/widgets/home/__tests__/HowItWorks.test.tsx
+++ b/src/widgets/home/__tests__/HowItWorks.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import type { SkillCounts } from '@y0ngha/siglens-core';
+
+import { HowItWorks } from '../HowItWorks';
+
+const SKILL_COUNTS: SkillCounts = {
+    indicators: 25,
+    candlesticks: 18,
+    patterns: 12,
+    strategies: 8,
+    supportResistance: 5,
+    fundamental: 3,
+    news: 2,
+};
+
+describe('HowItWorks', () => {
+    it('renders three steps', () => {
+        render(<HowItWorks skillCounts={SKILL_COUNTS} />);
+
+        expect(screen.getByText('01')).toBeInTheDocument();
+        expect(screen.getByText('02')).toBeInTheDocument();
+        expect(screen.getByText('03')).toBeInTheDocument();
+    });
+
+    it('renders the section heading', () => {
+        render(<HowItWorks skillCounts={SKILL_COUNTS} />);
+
+        expect(
+            screen.getByRole('heading', { name: /이용 방법/ })
+        ).toBeInTheDocument();
+    });
+
+    it('interpolates skill counts in step 2 description', () => {
+        render(<HowItWorks skillCounts={SKILL_COUNTS} />);
+
+        expect(
+            screen.getByText(
+                new RegExp(`보조지표 ${SKILL_COUNTS.indicators}종`)
+            )
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                new RegExp(`캔들 패턴 ${SKILL_COUNTS.candlesticks}종`)
+            )
+        ).toBeInTheDocument();
+    });
+
+    it('renders step titles', () => {
+        render(<HowItWorks skillCounts={SKILL_COUNTS} />);
+
+        expect(
+            screen.getByRole('heading', { name: /종목 입력/ })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('heading', { name: /자동 분석/ })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('heading', { name: /AI 리포트/ })
+        ).toBeInTheDocument();
+    });
+});

--- a/src/widgets/home/__tests__/SkillsShowcase.test.tsx
+++ b/src/widgets/home/__tests__/SkillsShowcase.test.tsx
@@ -1,0 +1,108 @@
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) =>
+        args
+            .flat()
+            .filter(a => typeof a === 'string' && a.length > 0)
+            .join(' '),
+}));
+vi.mock('@/shared/hooks/usePopoverToggle', () => ({
+    usePopoverToggle: () => ({ isOpen: false, toggle: vi.fn() }),
+}));
+vi.mock('@/shared/ui/tabs', () => ({
+    buildPanelId: (prefix: string, value: string) => `${prefix}-panel-${value}`,
+    buildTabId: (prefix: string, value: string) => `${prefix}-tab-${value}`,
+    TabsPill: ({
+        tabs,
+        activeTab,
+        onChange,
+    }: {
+        tabs: { value: string; label: string }[];
+        activeTab: string;
+        onChange: (v: string) => void;
+    }) => (
+        <div role="tablist">
+            {tabs.map(t => (
+                <button
+                    key={t.value}
+                    role="tab"
+                    aria-selected={activeTab === t.value}
+                    onClick={() => onChange(t.value)}
+                >
+                    {t.label}
+                </button>
+            ))}
+        </div>
+    ),
+}));
+vi.mock('../hooks/useSkillsShowcase', () => ({
+    useSkillsShowcase: () => ({
+        activeTab: 'all',
+        showAll: false,
+        baseId: 'skills',
+        handleTabSelect: vi.fn(),
+        toggleShowAll: vi.fn(),
+    }),
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { SkillShowcaseItem } from '@y0ngha/siglens-core';
+
+import { SkillsShowcase, SkillsShowcaseSkeleton } from '../SkillsShowcase';
+
+function makeSkill(
+    name: string,
+    type: SkillShowcaseItem['type'] = 'indicator_guide',
+    confidenceWeight = 0.85
+): SkillShowcaseItem {
+    return {
+        name,
+        type,
+        description: `${name} description`,
+        confidenceWeight,
+    };
+}
+
+describe('SkillsShowcase', () => {
+    it('renders the heading', () => {
+        render(<SkillsShowcase skills={[]} />);
+
+        expect(
+            screen.getByRole('heading', { name: /AI 분석 스킬/ })
+        ).toBeInTheDocument();
+    });
+
+    it('renders skill cards with names and descriptions', () => {
+        const skills = [makeSkill('RSI'), makeSkill('MACD')];
+        render(<SkillsShowcase skills={skills} />);
+
+        expect(screen.getAllByText('RSI').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByText('MACD').length).toBeGreaterThanOrEqual(1);
+        expect(
+            screen.getAllByText('RSI description').length
+        ).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders confidence percentage', () => {
+        const skills = [makeSkill('Bollinger', 'indicator_guide', 0.75)];
+        render(<SkillsShowcase skills={skills} />);
+
+        expect(screen.getAllByText('75%').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders the tab list', () => {
+        render(<SkillsShowcase skills={[]} />);
+
+        expect(screen.getByRole('tablist')).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: /전체/ })).toBeInTheDocument();
+    });
+});
+
+describe('SkillsShowcaseSkeleton', () => {
+    it('renders a loading section', () => {
+        render(<SkillsShowcaseSkeleton />);
+
+        const section = screen.getByLabelText(/AI 분석 스킬 불러오는 중/);
+        expect(section).toHaveAttribute('aria-busy', 'true');
+    });
+});

--- a/src/widgets/home/__tests__/StatsBar.test.tsx
+++ b/src/widgets/home/__tests__/StatsBar.test.tsx
@@ -1,0 +1,43 @@
+vi.mock('@/shared/ui/DotSeparator', () => ({
+    DotSeparator: () => <span aria-hidden="true">·</span>,
+}));
+vi.mock('@/shared/lib/skillStats', () => ({
+    buildSkillStats: () => [
+        { value: '25종 ', label: '보조지표' },
+        { value: '18종 ', label: '캔들 패턴' },
+    ],
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { StatsBar, StatsBarSkeleton } from '../StatsBar';
+
+describe('StatsBar', () => {
+    it('renders stats from buildSkillStats', () => {
+        render(<StatsBar skills={[]} />);
+
+        expect(screen.getByText(/25종/)).toBeInTheDocument();
+        expect(screen.getByText(/보조지표/)).toBeInTheDocument();
+        expect(screen.getByText(/18종/)).toBeInTheDocument();
+    });
+
+    it('renders an accessible list', () => {
+        render(<StatsBar skills={[]} />);
+
+        expect(
+            screen.getByRole('list', { name: /Siglens 분석 규모/ })
+        ).toBeInTheDocument();
+    });
+});
+
+describe('StatsBarSkeleton', () => {
+    it('renders skeleton bars with aria-hidden', () => {
+        const { container } = render(<StatsBarSkeleton />);
+
+        expect(container.firstElementChild).toHaveAttribute(
+            'aria-hidden',
+            'true'
+        );
+    });
+});

--- a/src/widgets/home/__tests__/TickerCategories.test.tsx
+++ b/src/widgets/home/__tests__/TickerCategories.test.tsx
@@ -1,0 +1,88 @@
+vi.mock('next/link', () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+        [key: string]: unknown;
+    }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) =>
+        args
+            .flat()
+            .filter(a => typeof a === 'string' && a.length > 0)
+            .join(' '),
+}));
+vi.mock('@/shared/config/popular-tickers', () => ({
+    TICKER_CATEGORIES: [
+        {
+            id: 'megacap',
+            label: '메가캡·지수',
+            tickers: ['AAPL', 'MSFT'],
+        },
+        {
+            id: 'ai-semiconductor',
+            label: 'AI·반도체',
+            tickers: ['NVDA'],
+        },
+    ],
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { TickerCategories } from '../TickerCategories';
+
+describe('TickerCategories', () => {
+    it('renders category headings', () => {
+        render(<TickerCategories />);
+
+        expect(
+            screen.getByRole('heading', { name: /메가캡·지수/ })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('heading', { name: /AI·반도체/ })
+        ).toBeInTheDocument();
+    });
+
+    it('renders ticker links with correct hrefs', () => {
+        render(<TickerCategories />);
+
+        const aaplLink = screen.getByRole('link', { name: /AAPL/ });
+        expect(aaplLink).toHaveAttribute('href', '/AAPL');
+
+        const nvdaLink = screen.getByRole('link', { name: /NVDA/ });
+        expect(nvdaLink).toHaveAttribute('href', '/NVDA');
+    });
+
+    it('renders the section heading', () => {
+        render(<TickerCategories />);
+
+        expect(
+            screen.getByRole('heading', { name: /섹터별 인기 종목/ })
+        ).toBeInTheDocument();
+    });
+
+    it('has a navigation landmark', () => {
+        render(<TickerCategories />);
+
+        expect(
+            screen.getByRole('navigation', { name: /섹터별 인기 종목 탐색/ })
+        ).toBeInTheDocument();
+    });
+
+    it('renders ticker lists with aria-labels', () => {
+        render(<TickerCategories />);
+
+        expect(
+            screen.getByRole('list', { name: /메가캡·지수 섹터 종목 목록/ })
+        ).toBeInTheDocument();
+    });
+});

--- a/src/widgets/home/__tests__/hooks/useSkillsShowcase.test.ts
+++ b/src/widgets/home/__tests__/hooks/useSkillsShowcase.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react';
+
+import { useSkillsShowcase } from '../../hooks/useSkillsShowcase';
+
+describe('useSkillsShowcase', () => {
+    it('initializes with "all" tab and showAll=false', () => {
+        const { result } = renderHook(() => useSkillsShowcase());
+
+        expect(result.current.activeTab).toBe('all');
+        expect(result.current.showAll).toBe(false);
+    });
+
+    it('changes the active tab on handleTabSelect', () => {
+        const { result } = renderHook(() => useSkillsShowcase());
+
+        act(() => result.current.handleTabSelect('pattern'));
+
+        expect(result.current.activeTab).toBe('pattern');
+    });
+
+    it('resets showAll when switching tabs', () => {
+        const { result } = renderHook(() => useSkillsShowcase());
+
+        act(() => result.current.toggleShowAll());
+        expect(result.current.showAll).toBe(true);
+
+        act(() => result.current.handleTabSelect('strategy'));
+        expect(result.current.showAll).toBe(false);
+    });
+
+    it('toggles showAll', () => {
+        const { result } = renderHook(() => useSkillsShowcase());
+
+        act(() => result.current.toggleShowAll());
+        expect(result.current.showAll).toBe(true);
+
+        act(() => result.current.toggleShowAll());
+        expect(result.current.showAll).toBe(false);
+    });
+
+    it('provides a stable baseId', () => {
+        const { result } = renderHook(() => useSkillsShowcase());
+
+        expect(typeof result.current.baseId).toBe('string');
+        expect(result.current.baseId.length).toBeGreaterThan(0);
+    });
+});

--- a/src/widgets/layout/__tests__/ContactDialog.test.tsx
+++ b/src/widgets/layout/__tests__/ContactDialog.test.tsx
@@ -1,0 +1,79 @@
+vi.mock('@/features/contact-form', () => ({
+    ContactForm: () => <div data-testid="contact-form" />,
+}));
+vi.mock('@/shared/hooks/useDialog', () => ({
+    useDialog: vi.fn(() => ({
+        isOpen: false,
+        open: vi.fn(),
+        close: vi.fn(),
+        dialogRef: { current: null },
+        triggerRef: { current: null },
+    })),
+}));
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) =>
+        args
+            .flat()
+            .filter(a => typeof a === 'string' && a.length > 0)
+            .join(' '),
+}));
+
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { ContactDialog } from '../ContactDialog';
+import { useDialog } from '@/shared/hooks/useDialog';
+
+describe('ContactDialog', () => {
+    it('renders the trigger button with default label', () => {
+        render(<ContactDialog />);
+
+        expect(
+            screen.getByRole('button', { name: /문의하기/ })
+        ).toBeInTheDocument();
+    });
+
+    it('renders the trigger button with custom label', () => {
+        render(<ContactDialog triggerLabel="커스텀 라벨" />);
+
+        expect(
+            screen.getByRole('button', { name: /커스텀 라벨/ })
+        ).toBeInTheDocument();
+    });
+
+    it('does not render the dialog when closed', () => {
+        render(<ContactDialog />);
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('renders the dialog with ContactForm when open', () => {
+        vi.mocked(useDialog).mockReturnValue({
+            isOpen: true,
+            open: vi.fn(),
+            close: vi.fn(),
+            dialogRef: { current: null },
+            triggerRef: { current: null },
+        });
+
+        render(<ContactDialog />);
+
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByTestId('contact-form')).toBeInTheDocument();
+    });
+
+    it('calls open when the trigger button is clicked', () => {
+        const openFn = vi.fn();
+        vi.mocked(useDialog).mockReturnValue({
+            isOpen: false,
+            open: openFn,
+            close: vi.fn(),
+            dialogRef: { current: null },
+            triggerRef: { current: null },
+        });
+
+        render(<ContactDialog />);
+        fireEvent.click(screen.getByRole('button', { name: /문의하기/ }));
+
+        expect(openFn).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/widgets/layout/__tests__/CurrentYear.test.tsx
+++ b/src/widgets/layout/__tests__/CurrentYear.test.tsx
@@ -3,9 +3,18 @@ import { render } from '@testing-library/react';
 import { CurrentYear } from '../CurrentYear';
 
 describe('CurrentYear', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2025-06-15'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     it('renders the current year', () => {
         const { container } = render(<CurrentYear />);
 
-        expect(container.textContent).toBe(String(new Date().getFullYear()));
+        expect(container.textContent).toBe('2025');
     });
 });

--- a/src/widgets/layout/__tests__/CurrentYear.test.tsx
+++ b/src/widgets/layout/__tests__/CurrentYear.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+
+import { CurrentYear } from '../CurrentYear';
+
+describe('CurrentYear', () => {
+    it('renders the current year', () => {
+        const { container } = render(<CurrentYear />);
+
+        expect(container.textContent).toBe(String(new Date().getFullYear()));
+    });
+});

--- a/src/widgets/layout/__tests__/Footer.test.tsx
+++ b/src/widgets/layout/__tests__/Footer.test.tsx
@@ -1,0 +1,82 @@
+vi.mock('next/link', () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+        [key: string]: unknown;
+    }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+vi.mock('../ContactDialog', () => ({
+    ContactDialog: ({ triggerLabel }: { triggerLabel: string }) => (
+        <button type="button">{triggerLabel}</button>
+    ),
+}));
+vi.mock('../CurrentYear', () => ({
+    CurrentYear: () => <>2026</>,
+}));
+vi.mock('@/shared/ui/DotSeparator', () => ({
+    DotSeparator: () => <span aria-hidden="true">·</span>,
+}));
+vi.mock('@/shared/lib/legal', () => ({
+    INVESTMENT_DISCLAIMER: '투자 면책 고지 텍스트',
+    PRIVACY_PATH: '/privacy',
+    PRIVACY_TITLE: '개인정보처리방침',
+    TERMS_PATH: '/terms',
+    TERMS_TITLE: '이용약관',
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { Footer } from '../Footer';
+
+describe('Footer', () => {
+    it('renders the investment disclaimer', () => {
+        render(<Footer />);
+
+        expect(screen.getByText('투자 면책 고지 텍스트')).toBeInTheDocument();
+    });
+
+    it('renders the copyright with year', () => {
+        render(<Footer />);
+
+        expect(screen.getByText(/© 2026 Siglens/)).toBeInTheDocument();
+    });
+
+    it('renders the privacy policy link', () => {
+        render(<Footer />);
+
+        const link = screen.getByRole('link', { name: /개인정보처리방침/ });
+        expect(link).toHaveAttribute('href', '/privacy');
+    });
+
+    it('renders the terms link', () => {
+        render(<Footer />);
+
+        const link = screen.getByRole('link', { name: /이용약관/ });
+        expect(link).toHaveAttribute('href', '/terms');
+    });
+
+    it('renders the contact dialog trigger', () => {
+        render(<Footer />);
+
+        expect(
+            screen.getByRole('button', { name: /문의하기/ })
+        ).toBeInTheDocument();
+    });
+
+    it('has a navigation landmark for site info', () => {
+        render(<Footer />);
+
+        expect(
+            screen.getByRole('navigation', { name: /사이트 정보/ })
+        ).toBeInTheDocument();
+    });
+});

--- a/src/widgets/layout/__tests__/Header.test.tsx
+++ b/src/widgets/layout/__tests__/Header.test.tsx
@@ -1,0 +1,68 @@
+vi.mock('next/link', () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+        [key: string]: unknown;
+    }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+vi.mock('next/image', () => ({
+    default: (props: Record<string, unknown>) => (
+        <img src={props.src as string} alt={props.alt as string} />
+    ),
+}));
+vi.mock('../HeaderNav', () => ({
+    HeaderNav: () => <nav data-testid="header-nav" />,
+}));
+vi.mock('../HeaderNavStatic', () => ({
+    HeaderNavStatic: () => <nav data-testid="header-nav-static" />,
+}));
+vi.mock('../HeaderUserMenu', () => ({
+    HeaderUserMenu: () => <div data-testid="user-menu" />,
+}));
+vi.mock('@/features/ticker-search', () => ({
+    TickerAutocomplete: () => <div data-testid="ticker-search" />,
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_NAME: 'Siglens',
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { Header } from '../Header';
+
+describe('Header', () => {
+    it('renders the site logo and name', () => {
+        render(<Header currentUser={null} />);
+
+        expect(screen.getByAltText('Siglens 로고')).toBeInTheDocument();
+    });
+
+    it('renders the home link', () => {
+        render(<Header currentUser={null} />);
+
+        const homeLink = screen.getByLabelText(/SIGLENS 홈/);
+        expect(homeLink).toHaveAttribute('href', '/');
+    });
+
+    it('renders ticker search and user menu', () => {
+        render(<Header currentUser={null} />);
+
+        expect(screen.getByTestId('ticker-search')).toBeInTheDocument();
+        expect(screen.getByTestId('user-menu')).toBeInTheDocument();
+    });
+
+    it('renders as a banner landmark', () => {
+        render(<Header currentUser={null} />);
+
+        expect(screen.getByRole('banner')).toBeInTheDocument();
+    });
+});

--- a/src/widgets/layout/__tests__/HeaderNav.test.tsx
+++ b/src/widgets/layout/__tests__/HeaderNav.test.tsx
@@ -1,0 +1,78 @@
+vi.mock('next/link', () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+        [key: string]: unknown;
+    }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+vi.mock('next/navigation', () => ({
+    usePathname: vi.fn(() => '/market'),
+}));
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) =>
+        args
+            .flat()
+            .filter(a => typeof a === 'string' && a.length > 0)
+            .join(' '),
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { usePathname } from 'next/navigation';
+
+import { HeaderNav } from '../HeaderNav';
+
+const NAV_ITEMS = [
+    { href: '/market', label: '시장 분석' },
+    { href: '/about', label: '소개' },
+] as const;
+
+describe('HeaderNav', () => {
+    it('renders all nav items', () => {
+        render(<HeaderNav items={NAV_ITEMS} />);
+
+        expect(
+            screen.getByRole('link', { name: /시장 분석/ })
+        ).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /소개/ })).toBeInTheDocument();
+    });
+
+    it('sets aria-current="page" on the active item', () => {
+        render(<HeaderNav items={NAV_ITEMS} />);
+
+        const activeLink = screen.getByRole('link', { name: /시장 분석/ });
+        expect(activeLink).toHaveAttribute('aria-current', 'page');
+    });
+
+    it('does not set aria-current on inactive items', () => {
+        render(<HeaderNav items={NAV_ITEMS} />);
+
+        const inactiveLink = screen.getByRole('link', { name: /소개/ });
+        expect(inactiveLink).not.toHaveAttribute('aria-current');
+    });
+
+    it('matches sub-paths for active state', () => {
+        vi.mocked(usePathname).mockReturnValue('/market/detail');
+
+        render(<HeaderNav items={NAV_ITEMS} />);
+
+        const activeLink = screen.getByRole('link', { name: /시장 분석/ });
+        expect(activeLink).toHaveAttribute('aria-current', 'page');
+    });
+
+    it('has a navigation landmark', () => {
+        render(<HeaderNav items={NAV_ITEMS} />);
+
+        expect(
+            screen.getByRole('navigation', { name: /주요 네비게이션/ })
+        ).toBeInTheDocument();
+    });
+});

--- a/src/widgets/layout/__tests__/HeaderNavStatic.test.tsx
+++ b/src/widgets/layout/__tests__/HeaderNavStatic.test.tsx
@@ -1,0 +1,46 @@
+vi.mock('next/link', () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+        [key: string]: unknown;
+    }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { HeaderNavStatic } from '../HeaderNavStatic';
+
+const NAV_ITEMS = [{ href: '/market', label: '시장 분석' }] as const;
+
+describe('HeaderNavStatic', () => {
+    it('renders all nav items as links', () => {
+        render(<HeaderNavStatic items={NAV_ITEMS} />);
+
+        const link = screen.getByRole('link', { name: /시장 분석/ });
+        expect(link).toHaveAttribute('href', '/market');
+    });
+
+    it('does not set aria-current on any item (no active state)', () => {
+        render(<HeaderNavStatic items={NAV_ITEMS} />);
+
+        const link = screen.getByRole('link', { name: /시장 분석/ });
+        expect(link).not.toHaveAttribute('aria-current');
+    });
+
+    it('has a navigation landmark', () => {
+        render(<HeaderNavStatic items={NAV_ITEMS} />);
+
+        expect(
+            screen.getByRole('navigation', { name: /주요 네비게이션/ })
+        ).toBeInTheDocument();
+    });
+});

--- a/src/widgets/layout/__tests__/SiteJsonLd.test.tsx
+++ b/src/widgets/layout/__tests__/SiteJsonLd.test.tsx
@@ -1,0 +1,60 @@
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+vi.mock('@/shared/ui/JsonLd', () => ({
+    JsonLd: ({ data }: { data: Record<string, unknown> }) => (
+        <script
+            type="application/ld+json"
+            data-testid="json-ld"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+        />
+    ),
+}));
+
+import { render, screen } from '@testing-library/react';
+
+import { SiteJsonLd } from '../SiteJsonLd';
+
+describe('SiteJsonLd', () => {
+    it('renders a JSON-LD script with WebSite type', () => {
+        render(<SiteJsonLd />);
+
+        const script = screen.getByTestId('json-ld');
+        const data = JSON.parse(script.innerHTML);
+
+        expect(data['@type']).toBe('WebSite');
+        expect(data['@context']).toBe('https://schema.org');
+    });
+
+    it('includes site name and URL', () => {
+        render(<SiteJsonLd />);
+
+        const script = screen.getByTestId('json-ld');
+        const data = JSON.parse(script.innerHTML);
+
+        expect(data.name).toBe('Siglens');
+        expect(data.url).toBe('https://siglens.io');
+    });
+
+    it('includes SearchAction with urlTemplate', () => {
+        render(<SiteJsonLd />);
+
+        const script = screen.getByTestId('json-ld');
+        const data = JSON.parse(script.innerHTML);
+
+        expect(data.potentialAction['@type']).toBe('SearchAction');
+        expect(data.potentialAction.target.urlTemplate).toContain(
+            '?q={search_term_string}'
+        );
+    });
+
+    it('includes @id for entity graph referencing', () => {
+        render(<SiteJsonLd />);
+
+        const script = screen.getByTestId('json-ld');
+        const data = JSON.parse(script.innerHTML);
+
+        expect(data['@id']).toBe('https://siglens.io#website');
+    });
+});

--- a/src/widgets/legal/__tests__/LegalBreadcrumb.test.tsx
+++ b/src/widgets/legal/__tests__/LegalBreadcrumb.test.tsx
@@ -1,0 +1,56 @@
+vi.mock('next/link', () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+        [key: string]: unknown;
+    }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_NAME: 'Siglens',
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { LegalBreadcrumb } from '../LegalBreadcrumb';
+
+describe('LegalBreadcrumb', () => {
+    it('renders a breadcrumb navigation', () => {
+        render(<LegalBreadcrumb pageTitle="개인정보처리방침" />);
+
+        expect(
+            screen.getByRole('navigation', { name: /breadcrumb/ })
+        ).toBeInTheDocument();
+    });
+
+    it('renders the site name as a link to home', () => {
+        render(<LegalBreadcrumb pageTitle="이용약관" />);
+
+        const homeLink = screen.getByRole('link', { name: /Siglens/ });
+        expect(homeLink).toHaveAttribute('href', '/');
+    });
+
+    it('renders the current page title with aria-current', () => {
+        render(<LegalBreadcrumb pageTitle="이용약관" />);
+
+        const currentItem = screen.getByText('이용약관');
+        expect(currentItem.closest('li')).toHaveAttribute(
+            'aria-current',
+            'page'
+        );
+    });
+
+    it('renders a separator between items', () => {
+        render(<LegalBreadcrumb pageTitle="개인정보처리방침" />);
+
+        expect(screen.getByText('/')).toBeInTheDocument();
+    });
+});

--- a/src/widgets/legal/__tests__/LegalPageShell.test.tsx
+++ b/src/widgets/legal/__tests__/LegalPageShell.test.tsx
@@ -1,0 +1,83 @@
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) =>
+        args.filter(a => typeof a === 'string' && a.length > 0).join(' '),
+}));
+vi.mock('../LegalBreadcrumb', () => ({
+    LegalBreadcrumb: ({ pageTitle }: { pageTitle: string }) => (
+        <nav data-testid="breadcrumb">{pageTitle}</nav>
+    ),
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { LegalPageShell } from '../LegalPageShell';
+
+const BASE_PROPS = {
+    breadcrumbTitle: '이용약관',
+    eyebrow: 'TERMS OF SERVICE',
+    title: '이용약관',
+    intro: <span>서비스 이용 조건입니다.</span>,
+    effectiveDate: '2025년 1월 1일',
+    toc: [
+        { id: 'section-1', label: '제1조 총칙' },
+        { id: 'section-2', label: '제2조 정의' },
+    ],
+    children: <p>약관 본문</p>,
+};
+
+describe('LegalPageShell', () => {
+    it('renders the breadcrumb', () => {
+        render(<LegalPageShell {...BASE_PROPS} />);
+
+        expect(screen.getByTestId('breadcrumb')).toHaveTextContent('이용약관');
+    });
+
+    it('renders the eyebrow and title', () => {
+        render(<LegalPageShell {...BASE_PROPS} />);
+
+        expect(screen.getByText('TERMS OF SERVICE')).toBeInTheDocument();
+        expect(
+            screen.getByRole('heading', { name: /이용약관/ })
+        ).toBeInTheDocument();
+    });
+
+    it('renders the effective date', () => {
+        render(<LegalPageShell {...BASE_PROPS} />);
+
+        expect(screen.getByText(/시행일: 2025년 1월 1일/)).toBeInTheDocument();
+    });
+
+    it('renders the table of contents with links', () => {
+        render(<LegalPageShell {...BASE_PROPS} />);
+
+        expect(
+            screen.getByRole('navigation', { name: /목차/ })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('link', { name: /제1조 총칙/ })
+        ).toHaveAttribute('href', '#section-1');
+        expect(
+            screen.getByRole('link', { name: /제2조 정의/ })
+        ).toHaveAttribute('href', '#section-2');
+    });
+
+    it('renders children content', () => {
+        render(<LegalPageShell {...BASE_PROPS} />);
+
+        expect(screen.getByText('약관 본문')).toBeInTheDocument();
+    });
+
+    it('renders topNotice and bottomNotice when provided', () => {
+        render(
+            <LegalPageShell
+                {...BASE_PROPS}
+                topNotice={<div data-testid="top-notice">Top</div>}
+                bottomNotice={<div data-testid="bottom-notice">Bottom</div>}
+            />
+        );
+
+        expect(screen.getByTestId('top-notice')).toBeInTheDocument();
+        expect(screen.getByTestId('bottom-notice')).toBeInTheDocument();
+    });
+});

--- a/src/widgets/legal/__tests__/PolicySection.test.tsx
+++ b/src/widgets/legal/__tests__/PolicySection.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+
+import { PolicySection } from '../PolicySection';
+
+describe('PolicySection', () => {
+    it('renders the title', () => {
+        render(
+            <PolicySection id="purpose" title="제1조 (목적)">
+                <p>본 약관은…</p>
+            </PolicySection>
+        );
+
+        expect(
+            screen.getByRole('heading', { name: /제1조 \(목적\)/ })
+        ).toBeInTheDocument();
+    });
+
+    it('renders children content', () => {
+        render(
+            <PolicySection id="purpose" title="제1조">
+                <p>약관 내용</p>
+            </PolicySection>
+        );
+
+        expect(screen.getByText('약관 내용')).toBeInTheDocument();
+    });
+
+    it('sets the section id for anchor linking', () => {
+        const { container } = render(
+            <PolicySection id="definitions" title="제2조 (정의)">
+                <p>정의 내용</p>
+            </PolicySection>
+        );
+
+        const section = container.querySelector('#definitions');
+        expect(section).not.toBeNull();
+        expect(section?.tagName.toLowerCase()).toBe('section');
+    });
+
+    it('has scroll-mt class for fixed header offset', () => {
+        const { container } = render(
+            <PolicySection id="test" title="제3조">
+                <p>내용</p>
+            </PolicySection>
+        );
+
+        const section = container.querySelector('#test');
+        expect(section).toHaveClass('scroll-mt-24');
+    });
+});

--- a/src/widgets/overall/__tests__/DependencyProgress.test.tsx
+++ b/src/widgets/overall/__tests__/DependencyProgress.test.tsx
@@ -1,0 +1,80 @@
+vi.mock('@/shared/config/time', () => ({
+    MS_PER_SECOND: 1000,
+    SECONDS_PER_MINUTE: 60,
+}));
+vi.mock('@/shared/config/pollingConfig', () => ({
+    AUGMENT_AND_OVERALL_POLL_INTERVAL_MS: 3000,
+}));
+
+import { render, screen } from '@testing-library/react';
+import type { OverallAxis } from '@y0ngha/siglens-core';
+
+import { DependencyProgress } from '../DependencyProgress';
+
+const ALL_PENDING: Record<OverallAxis, string | undefined> = {
+    technical: 'job-1',
+    news: 'job-2',
+    fundamental: 'job-3',
+    options: 'job-4',
+};
+
+const TWO_DONE: Record<OverallAxis, string | undefined> = {
+    technical: undefined,
+    news: undefined,
+    fundamental: 'job-3',
+    options: 'job-4',
+};
+
+describe('DependencyProgress', () => {
+    it('renders completed / total count', () => {
+        render(<DependencyProgress pendingJobs={TWO_DONE} retryCount={0} />);
+
+        expect(screen.getByText(/2\/4/)).toBeInTheDocument();
+    });
+
+    it('marks completed axes with the checkmark', () => {
+        render(<DependencyProgress pendingJobs={TWO_DONE} retryCount={0} />);
+
+        expect(screen.getByText(/기술적 분석/)).toBeInTheDocument();
+        expect(screen.getAllByText(/— 완료/)).toHaveLength(2);
+        expect(screen.getAllByText(/— 진행 중…/)).toHaveLength(2);
+    });
+
+    it('shows all four axis labels', () => {
+        render(<DependencyProgress pendingJobs={ALL_PENDING} retryCount={0} />);
+
+        expect(screen.getByText(/기술적 분석/)).toBeInTheDocument();
+        expect(screen.getByText(/뉴스 분석/)).toBeInTheDocument();
+        expect(screen.getByText(/펀더멘털 분석/)).toBeInTheDocument();
+        expect(screen.getByText(/옵션 시장 분석/)).toBeInTheDocument();
+    });
+
+    it('displays remaining minutes estimate', () => {
+        render(<DependencyProgress pendingJobs={ALL_PENDING} retryCount={0} />);
+
+        expect(screen.getByText(/약 \d+분 소요/)).toBeInTheDocument();
+    });
+
+    it('decreases remaining estimate as retryCount increases', () => {
+        const { rerender } = render(
+            <DependencyProgress pendingJobs={ALL_PENDING} retryCount={0} />
+        );
+        const firstText = screen.getByText(/약 \d+분 소요/).textContent;
+
+        rerender(
+            <DependencyProgress pendingJobs={ALL_PENDING} retryCount={40} />
+        );
+        const secondText = screen.getByText(/약 \d+분 소요/).textContent;
+
+        expect(firstText).not.toBe(secondText);
+    });
+
+    it('sets aria-busy on the section', () => {
+        render(<DependencyProgress pendingJobs={ALL_PENDING} retryCount={0} />);
+
+        const section = screen.getByRole('region', {
+            name: /종합 분석에 필요한 데이터 수집 중/,
+        });
+        expect(section).toHaveAttribute('aria-busy', 'true');
+    });
+});

--- a/src/widgets/overall/__tests__/OverallTriggerCta.test.tsx
+++ b/src/widgets/overall/__tests__/OverallTriggerCta.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { OverallTriggerCta } from '../OverallTriggerCta';
+
+describe('OverallTriggerCta', () => {
+    it('renders the heading and description', () => {
+        render(<OverallTriggerCta onTrigger={vi.fn()} />);
+
+        expect(
+            screen.getByRole('heading', { name: /AI 종합 분석/ })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(/차트·옵션·펀더멘털·뉴스·시장 분위기/)
+        ).toBeInTheDocument();
+    });
+
+    it('calls onTrigger when the button is clicked', () => {
+        const handleTrigger = vi.fn();
+        render(<OverallTriggerCta onTrigger={handleTrigger} />);
+
+        fireEvent.click(
+            screen.getByRole('button', { name: /AI 종합 분석 받기/ })
+        );
+
+        expect(handleTrigger).toHaveBeenCalledTimes(1);
+    });
+
+    it('has an accessible section landmark', () => {
+        render(<OverallTriggerCta onTrigger={vi.fn()} />);
+
+        expect(
+            screen.getByRole('region', { name: /AI 종합 분석/ })
+        ).toBeInTheDocument();
+    });
+});

--- a/src/widgets/overall/__tests__/sections/FundamentalSummary.test.tsx
+++ b/src/widgets/overall/__tests__/sections/FundamentalSummary.test.tsx
@@ -1,0 +1,37 @@
+vi.mock('@/shared/ui/MarkdownText', () => ({
+    MarkdownText: ({ children }: { children: React.ReactNode }) => (
+        <span>{children}</span>
+    ),
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { FundamentalSummary } from '../../sections/FundamentalSummary';
+
+describe('FundamentalSummary', () => {
+    it('renders nothing when bullets is empty', () => {
+        const { container } = render(<FundamentalSummary bullets={[]} />);
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('renders the heading and bullet items', () => {
+        const bullets = ['매출 성장 10%', '영업이익 감소'];
+        render(<FundamentalSummary bullets={bullets} />);
+
+        expect(
+            screen.getByRole('heading', { name: /펀더멘털 분석 요약/ })
+        ).toBeInTheDocument();
+        expect(screen.getByText('매출 성장 10%')).toBeInTheDocument();
+        expect(screen.getByText('영업이익 감소')).toBeInTheDocument();
+    });
+
+    it('renders a list with the correct item count', () => {
+        const bullets = ['A', 'B', 'C'];
+        render(<FundamentalSummary bullets={bullets} />);
+
+        const list = screen.getByRole('list', { name: /펀더멘털 분석 항목/ });
+        expect(list).toBeInTheDocument();
+        expect(screen.getAllByRole('listitem')).toHaveLength(bullets.length);
+    });
+});

--- a/src/widgets/overall/__tests__/sections/IntegratedConclusion.test.tsx
+++ b/src/widgets/overall/__tests__/sections/IntegratedConclusion.test.tsx
@@ -1,0 +1,33 @@
+vi.mock('@/shared/ui/MarkdownText', () => ({
+    MarkdownText: ({ children }: { children: React.ReactNode }) => (
+        <span>{children}</span>
+    ),
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { IntegratedConclusion } from '../../sections/IntegratedConclusion';
+
+describe('IntegratedConclusion', () => {
+    it('renders nothing when text is empty', () => {
+        const { container } = render(<IntegratedConclusion text="" />);
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('renders the heading and markdown text', () => {
+        render(<IntegratedConclusion text="전반적으로 강세 전망" />);
+
+        expect(
+            screen.getByRole('heading', { name: /통합 결론/ })
+        ).toBeInTheDocument();
+        expect(screen.getByText('전반적으로 강세 전망')).toBeInTheDocument();
+    });
+
+    it('has a primary-tone border section', () => {
+        render(<IntegratedConclusion text="결론 내용" />);
+
+        const section = screen.getByRole('region', { name: /통합 결론/ });
+        expect(section).toHaveClass('border-primary-500/30');
+    });
+});

--- a/src/widgets/overall/__tests__/sections/NewsSummary.test.tsx
+++ b/src/widgets/overall/__tests__/sections/NewsSummary.test.tsx
@@ -1,0 +1,37 @@
+vi.mock('@/shared/ui/MarkdownText', () => ({
+    MarkdownText: ({ children }: { children: React.ReactNode }) => (
+        <span>{children}</span>
+    ),
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { NewsSummary } from '../../sections/NewsSummary';
+
+describe('NewsSummary', () => {
+    it('renders nothing when bullets is empty', () => {
+        const { container } = render(<NewsSummary bullets={[]} />);
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('renders the heading and bullet items', () => {
+        const bullets = ['호재 뉴스 발표', '실적 상향 조정'];
+        render(<NewsSummary bullets={bullets} />);
+
+        expect(
+            screen.getByRole('heading', { name: /뉴스 분석 요약/ })
+        ).toBeInTheDocument();
+        expect(screen.getByText('호재 뉴스 발표')).toBeInTheDocument();
+        expect(screen.getByText('실적 상향 조정')).toBeInTheDocument();
+    });
+
+    it('renders a list with the correct item count', () => {
+        const bullets = ['A', 'B'];
+        render(<NewsSummary bullets={bullets} />);
+
+        const list = screen.getByRole('list', { name: /뉴스 분석 항목/ });
+        expect(list).toBeInTheDocument();
+        expect(screen.getAllByRole('listitem')).toHaveLength(bullets.length);
+    });
+});

--- a/src/widgets/overall/__tests__/sections/OverallSummary.test.tsx
+++ b/src/widgets/overall/__tests__/sections/OverallSummary.test.tsx
@@ -1,0 +1,26 @@
+vi.mock('@/shared/ui/MarkdownText', () => ({
+    MarkdownText: ({ children }: { children: React.ReactNode }) => (
+        <span>{children}</span>
+    ),
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { OverallSummary } from '../../sections/OverallSummary';
+
+describe('OverallSummary', () => {
+    it('renders nothing when headline is empty', () => {
+        const { container } = render(<OverallSummary headline="" />);
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('renders the heading and headline text', () => {
+        render(<OverallSummary headline="강세 전환 시그널 포착" />);
+
+        expect(
+            screen.getByRole('heading', { name: /종합 요약/ })
+        ).toBeInTheDocument();
+        expect(screen.getByText('강세 전환 시그널 포착')).toBeInTheDocument();
+    });
+});

--- a/src/widgets/overall/__tests__/sections/RiskFactors.test.tsx
+++ b/src/widgets/overall/__tests__/sections/RiskFactors.test.tsx
@@ -1,0 +1,37 @@
+vi.mock('@/shared/ui/MarkdownText', () => ({
+    MarkdownText: ({ children }: { children: React.ReactNode }) => (
+        <span>{children}</span>
+    ),
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { RiskFactors } from '../../sections/RiskFactors';
+
+describe('RiskFactors', () => {
+    it('renders nothing when factors is empty', () => {
+        const { container } = render(<RiskFactors factors={[]} />);
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('renders the heading and factor items', () => {
+        const factors = ['금리 인상 리스크', '지정학적 불안'];
+        render(<RiskFactors factors={factors} />);
+
+        expect(
+            screen.getByRole('heading', { name: /위험 요인/ })
+        ).toBeInTheDocument();
+        expect(screen.getByText('금리 인상 리스크')).toBeInTheDocument();
+        expect(screen.getByText('지정학적 불안')).toBeInTheDocument();
+    });
+
+    it('renders a list with the correct item count', () => {
+        const factors = ['A', 'B', 'C'];
+        render(<RiskFactors factors={factors} />);
+
+        const list = screen.getByRole('list', { name: /위험 요인 목록/ });
+        expect(list).toBeInTheDocument();
+        expect(screen.getAllByRole('listitem')).toHaveLength(factors.length);
+    });
+});

--- a/src/widgets/overall/__tests__/sections/ScenarioAnalysis.test.tsx
+++ b/src/widgets/overall/__tests__/sections/ScenarioAnalysis.test.tsx
@@ -1,0 +1,61 @@
+vi.mock('@/shared/ui/MarkdownText', () => ({
+    MarkdownText: ({ children }: { children: React.ReactNode }) => (
+        <span>{children}</span>
+    ),
+}));
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { OverallScenario } from '@y0ngha/siglens-core';
+
+import { ScenarioAnalysis } from '../../sections/ScenarioAnalysis';
+
+const SCENARIOS: OverallScenario[] = [
+    {
+        name: 'bullish',
+        triggerConditionKo: '실적 호조',
+        priceRangeKo: '$200-$220',
+    },
+    {
+        name: 'bearish',
+        triggerConditionKo: '매크로 리스크',
+        priceRangeKo: '$150-$160',
+    },
+];
+
+describe('ScenarioAnalysis', () => {
+    it('renders nothing when scenarios is empty', () => {
+        const { container } = render(<ScenarioAnalysis scenarios={[]} />);
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('renders the heading and scenario items', () => {
+        render(<ScenarioAnalysis scenarios={SCENARIOS} />);
+
+        expect(
+            screen.getByRole('heading', { name: /시나리오 분석/ })
+        ).toBeInTheDocument();
+        expect(screen.getByText('강세')).toBeInTheDocument();
+        expect(screen.getByText('약세')).toBeInTheDocument();
+    });
+
+    it('renders trigger conditions and price ranges', () => {
+        render(<ScenarioAnalysis scenarios={SCENARIOS} />);
+
+        expect(screen.getByText('실적 호조')).toBeInTheDocument();
+        expect(screen.getByText('$200-$220')).toBeInTheDocument();
+        expect(screen.getByText('매크로 리스크')).toBeInTheDocument();
+        expect(screen.getByText('$150-$160')).toBeInTheDocument();
+    });
+
+    it('renders a list with the correct item count', () => {
+        render(<ScenarioAnalysis scenarios={SCENARIOS} />);
+
+        const list = screen.getByRole('list', { name: /시나리오 목록/ });
+        expect(list).toBeInTheDocument();
+        expect(screen.getAllByRole('listitem')).toHaveLength(SCENARIOS.length);
+    });
+});

--- a/src/widgets/overall/__tests__/sections/TechnicalSummary.test.tsx
+++ b/src/widgets/overall/__tests__/sections/TechnicalSummary.test.tsx
@@ -1,0 +1,37 @@
+vi.mock('@/shared/ui/MarkdownText', () => ({
+    MarkdownText: ({ children }: { children: React.ReactNode }) => (
+        <span>{children}</span>
+    ),
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { TechnicalSummary } from '../../sections/TechnicalSummary';
+
+describe('TechnicalSummary', () => {
+    it('renders nothing when bullets is empty', () => {
+        const { container } = render(<TechnicalSummary bullets={[]} />);
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('renders the heading and bullet items', () => {
+        const bullets = ['RSI 과매수 구간', 'MACD 골든크로스'];
+        render(<TechnicalSummary bullets={bullets} />);
+
+        expect(
+            screen.getByRole('heading', { name: /기술적 분석 요약/ })
+        ).toBeInTheDocument();
+        expect(screen.getByText('RSI 과매수 구간')).toBeInTheDocument();
+        expect(screen.getByText('MACD 골든크로스')).toBeInTheDocument();
+    });
+
+    it('renders a list with the correct item count', () => {
+        const bullets = ['A', 'B', 'C'];
+        render(<TechnicalSummary bullets={bullets} />);
+
+        const list = screen.getByRole('list', { name: /기술적 분석 항목/ });
+        expect(list).toBeInTheDocument();
+        expect(screen.getAllByRole('listitem')).toHaveLength(bullets.length);
+    });
+});


### PR DESCRIPTION
## Summary
- 나머지 9개 위젯 (overall, chat, home, layout, analysis, backtesting, fundamental, fear-greed, legal) 46개 파일 테스트 작성
- **Phase 4 (widgets 레이어) 완료!**

## Breakdown
| Widget | Files | Content |
|---|---|---|
| overall | 9 | 2 components + 7 sections |
| chat | 7 | 3 components + 3 hooks + 1 util |
| home | 6 | 5 components + 1 hook |
| layout | 7 | 7 components |
| analysis | 5 | 4 components + 1 hook |
| backtesting | 4 | 4 components |
| fundamental | 3 | 3 components |
| fear-greed | 2 | 1 component + 1 hook |
| legal | 3 | 3 components |

## Test plan
- [x] `yarn test` — all suites pass
- [x] `tsc --noEmit` — 0 errors
- [x] `yarn lint` — 0 errors
- [x] `yarn format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)