### PR TITLE
test(app): add tests for pages, routes, OG images, special files

### DIFF
--- a/src/app/[symbol]/__tests__/SymbolLayoutClient.test.tsx
+++ b/src/app/[symbol]/__tests__/SymbolLayoutClient.test.tsx
@@ -1,0 +1,43 @@
+vi.mock('@/widgets/chat/FloatingChatButton', () => ({
+    FloatingChatButton: ({ symbol }: { symbol: string }) => (
+        <button data-testid="chat-button">{symbol}</button>
+    ),
+}));
+vi.mock('@/features/symbol-chat', () => ({
+    SymbolChatProvider: ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="chat-provider">{children}</div>
+    ),
+}));
+vi.mock('@/widgets/symbol-page/SymbolModelContext', () => ({
+    SymbolModelProvider: ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="model-provider">{children}</div>
+    ),
+}));
+
+import { render, screen } from '@testing-library/react';
+import {
+    SymbolLayoutProviders,
+    SymbolLayoutFloatingChat,
+} from '@/app/[symbol]/SymbolLayoutClient';
+
+describe('SymbolLayoutProviders', () => {
+    it('renders children inside SymbolChatProvider and SymbolModelProvider', () => {
+        render(
+            <SymbolLayoutProviders>
+                <div data-testid="child">content</div>
+            </SymbolLayoutProviders>
+        );
+
+        expect(screen.getByTestId('chat-provider')).toBeInTheDocument();
+        expect(screen.getByTestId('model-provider')).toBeInTheDocument();
+        expect(screen.getByTestId('child')).toBeInTheDocument();
+    });
+});
+
+describe('SymbolLayoutFloatingChat', () => {
+    it('renders FloatingChatButton with the given symbol', () => {
+        render(<SymbolLayoutFloatingChat symbol="AAPL" />);
+
+        expect(screen.getByTestId('chat-button')).toHaveTextContent('AAPL');
+    });
+});

--- a/src/app/[symbol]/__tests__/loading.test.tsx
+++ b/src/app/[symbol]/__tests__/loading.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import SymbolLoading from '@/app/[symbol]/loading';
+
+describe('SymbolLoading', () => {
+    it('renders a loading message', () => {
+        render(<SymbolLoading />);
+
+        expect(screen.getByText('데이터 로딩 중…')).toBeInTheDocument();
+    });
+});

--- a/src/app/[symbol]/__tests__/og-images.test.ts
+++ b/src/app/[symbol]/__tests__/og-images.test.ts
@@ -1,0 +1,61 @@
+vi.mock('@/shared/lib/og', () => ({
+    OG_IMAGE_WIDTH: 1200,
+    OG_IMAGE_HEIGHT: 630,
+}));
+vi.mock('@/entities/og-image', () => ({
+    buildSymbolOgImage: vi.fn().mockResolvedValue(new Response('image')),
+}));
+
+import OgImage, {
+    size,
+    contentType,
+    alt,
+} from '@/app/[symbol]/opengraph-image';
+import { buildSymbolOgImage } from '@/entities/og-image';
+import type { MockedFunction } from 'vitest';
+
+const mockBuildSymbolOgImage = buildSymbolOgImage as MockedFunction<
+    typeof buildSymbolOgImage
+>;
+
+describe('[symbol] OG images', () => {
+    describe('opengraph-image', () => {
+        it('exports correct size', () => {
+            expect(size).toEqual({ width: 1200, height: 630 });
+        });
+
+        it('exports correct contentType', () => {
+            expect(contentType).toBe('image/png');
+        });
+
+        it('exports alt text', () => {
+            expect(alt).toBeDefined();
+            expect(typeof alt).toBe('string');
+        });
+
+        it('calls buildSymbolOgImage with uppercased ticker and label', async () => {
+            await OgImage({ params: Promise.resolve({ symbol: 'aapl' }) });
+
+            expect(mockBuildSymbolOgImage).toHaveBeenCalledWith({
+                ticker: 'AAPL',
+                label: '차트 분석',
+            });
+        });
+
+        it('returns a Response', async () => {
+            const result = await OgImage({
+                params: Promise.resolve({ symbol: 'TSLA' }),
+            });
+            expect(result).toBeInstanceOf(Response);
+        });
+    });
+
+    describe('twitter-image (re-export)', () => {
+        it('re-exports same size/contentType/alt from opengraph-image', async () => {
+            const twitter = await import('@/app/[symbol]/twitter-image');
+            expect(twitter.size).toEqual(size);
+            expect(twitter.contentType).toBe(contentType);
+            expect(twitter.alt).toBe(alt);
+        });
+    });
+});

--- a/src/app/[symbol]/__tests__/page.test.ts
+++ b/src/app/[symbol]/__tests__/page.test.ts
@@ -1,0 +1,133 @@
+vi.mock('@/widgets/symbol-page/SymbolPageClient', () => ({
+    SymbolPageClient: () => null,
+}));
+vi.mock('@/shared/ui/JsonLd', () => ({ JsonLd: () => null }));
+vi.mock('@/entities/chat-message', () => ({
+    FALLBACK_ANALYSIS: { summary: 'fallback' },
+}));
+vi.mock('@/shared/config/market', () => ({
+    DEFAULT_TIMEFRAME: '1Day',
+    isValidTimeframe: vi.fn().mockReturnValue(false),
+    VALID_TICKER_RE: /^[A-Z]{1,5}$/,
+}));
+vi.mock('@/entities/ticker', () => ({
+    buildAssetAboutNode: vi.fn().mockReturnValue(undefined),
+    buildDisplayName: vi.fn().mockReturnValue('Apple Inc.'),
+    getAssetInfoCached: vi.fn(),
+}));
+vi.mock('@/entities/bars/actions', () => ({
+    getBarsAction: vi.fn().mockResolvedValue({ bars: [] }),
+}));
+vi.mock('@/entities/skill', () => ({
+    countSkillFiles: vi.fn().mockResolvedValue({
+        indicators: 13,
+        candlesticks: 30,
+        patterns: 5,
+        strategies: 4,
+        supportResistance: 3,
+    }),
+}));
+vi.mock('@/shared/config/queryConfig', () => ({
+    QUERY_KEYS: {
+        assetInfo: (s: string) => ['assetInfo', s],
+        bars: (s: string, t: string) => ['bars', s, t],
+    },
+    QUERY_STALE_TIME_MS: 5000,
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    buildBreadcrumbJsonLd: vi.fn().mockReturnValue({}),
+    buildSymbolSeoContent: vi.fn().mockReturnValue({
+        title: 'AAPL 차트',
+        fullTitle: 'AAPL 차트 | Siglens',
+        description: 'desc',
+        url: 'https://siglens.io/AAPL',
+        keywords: ['AAPL'],
+    }),
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+vi.mock('@tanstack/react-query', () => ({
+    dehydrate: vi.fn().mockReturnValue({}),
+    HydrationBoundary: () => null,
+    QueryClient: vi.fn().mockImplementation(() => ({
+        setQueryData: vi.fn(),
+        prefetchQuery: vi.fn(),
+    })),
+}));
+vi.mock('next/navigation', () => ({
+    notFound: vi.fn(),
+}));
+
+import { generateMetadata } from '@/app/[symbol]/page';
+import { getAssetInfoCached } from '@/entities/ticker';
+import type { MockedFunction } from 'vitest';
+
+const mockGetAssetInfoCached = getAssetInfoCached as MockedFunction<
+    typeof getAssetInfoCached
+>;
+
+describe('Symbol page', () => {
+    describe('generateMetadata', () => {
+        beforeEach(() => {
+            vi.clearAllMocks();
+        });
+
+        it('returns noindex for invalid ticker', async () => {
+            const metadata = await generateMetadata({
+                params: Promise.resolve({ symbol: '!!!invalid' }),
+                searchParams: Promise.resolve({}),
+            });
+
+            expect(metadata.robots).toEqual(
+                expect.objectContaining({ index: false })
+            );
+        });
+
+        it('returns metadata with title for valid ticker', async () => {
+            mockGetAssetInfoCached.mockResolvedValue({
+                name: 'Apple Inc.',
+                koreanName: '애플',
+                fmpSymbol: 'AAPL',
+            } as never);
+
+            const metadata = await generateMetadata({
+                params: Promise.resolve({ symbol: 'aapl' }),
+                searchParams: Promise.resolve({}),
+            });
+
+            expect(metadata.title).toBe('AAPL 차트');
+        });
+
+        it('adds noindex when tf query param is present', async () => {
+            mockGetAssetInfoCached.mockResolvedValue({
+                name: 'Apple Inc.',
+                koreanName: '애플',
+                fmpSymbol: 'AAPL',
+            } as never);
+
+            const metadata = await generateMetadata({
+                params: Promise.resolve({ symbol: 'aapl' }),
+                searchParams: Promise.resolve({ tf: '1Hour' }),
+            });
+
+            expect(metadata.robots).toEqual(
+                expect.objectContaining({ index: false })
+            );
+        });
+
+        it('does not add noindex when no tf param', async () => {
+            mockGetAssetInfoCached.mockResolvedValue({
+                name: 'Apple Inc.',
+                koreanName: '애플',
+                fmpSymbol: 'AAPL',
+            } as never);
+
+            const metadata = await generateMetadata({
+                params: Promise.resolve({ symbol: 'aapl' }),
+                searchParams: Promise.resolve({}),
+            });
+
+            expect(metadata.robots).toBeUndefined();
+        });
+    });
+});

--- a/src/app/[symbol]/fear-greed/__tests__/og-images.test.ts
+++ b/src/app/[symbol]/fear-greed/__tests__/og-images.test.ts
@@ -1,0 +1,54 @@
+vi.mock('@/shared/lib/og', () => ({
+    OG_IMAGE_WIDTH: 1200,
+    OG_IMAGE_HEIGHT: 630,
+}));
+vi.mock('@/entities/og-image', () => ({
+    buildSymbolOgImage: vi.fn().mockResolvedValue(new Response('image')),
+}));
+
+import OgImage, {
+    size,
+    contentType,
+    alt,
+} from '@/app/[symbol]/fear-greed/opengraph-image';
+import { buildSymbolOgImage } from '@/entities/og-image';
+import type { MockedFunction } from 'vitest';
+
+const mockBuildSymbolOgImage = buildSymbolOgImage as MockedFunction<
+    typeof buildSymbolOgImage
+>;
+
+describe('[symbol]/fear-greed OG images', () => {
+    describe('opengraph-image', () => {
+        it('exports correct size', () => {
+            expect(size).toEqual({ width: 1200, height: 630 });
+        });
+
+        it('exports correct contentType', () => {
+            expect(contentType).toBe('image/png');
+        });
+
+        it('exports alt text containing fear-greed', () => {
+            expect(alt).toContain('공포 탐욕 지수');
+        });
+
+        it('calls buildSymbolOgImage with ticker and fear-greed label', async () => {
+            await OgImage({ params: Promise.resolve({ symbol: 'amzn' }) });
+
+            expect(mockBuildSymbolOgImage).toHaveBeenCalledWith({
+                ticker: 'AMZN',
+                label: '공포 탐욕 지수',
+            });
+        });
+    });
+
+    describe('twitter-image (re-export)', () => {
+        it('re-exports same exports from opengraph-image', async () => {
+            const twitter =
+                await import('@/app/[symbol]/fear-greed/twitter-image');
+            expect(twitter.size).toEqual(size);
+            expect(twitter.contentType).toBe(contentType);
+            expect(twitter.alt).toBe(alt);
+        });
+    });
+});

--- a/src/app/[symbol]/fundamental/__tests__/fundamentalData.test.ts
+++ b/src/app/[symbol]/fundamental/__tests__/fundamentalData.test.ts
@@ -1,0 +1,105 @@
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: vi.fn().mockReturnValue({ db: {} }),
+}));
+vi.mock('@/entities/ticker', () => ({
+    DrizzleProfileDescriptionTranslationRepository: vi
+        .fn()
+        .mockImplementation(() => ({
+            findBySymbol: vi.fn().mockResolvedValue(null),
+            upsert: vi.fn().mockResolvedValue(undefined),
+        })),
+    translateCompanyDescription: vi.fn().mockResolvedValue('translated desc'),
+}));
+vi.mock('@/shared/api/fmp/fundamentalClient', () => ({
+    FmpFundamentalClient: class MockFmpFundamentalClient {
+        getProfile = vi.fn().mockResolvedValue(null);
+        getStockPeers = vi.fn().mockResolvedValue([]);
+        getKeyMetricsTtm = vi.fn().mockResolvedValue(null);
+        getRatiosTtm = vi.fn().mockResolvedValue(null);
+        getIncomeStatementGrowth = vi.fn().mockResolvedValue(null);
+        getFinancialScores = vi.fn().mockResolvedValue(null);
+        getCashFlowStatement = vi.fn().mockResolvedValue(null);
+        getAnalystEstimates = vi.fn().mockResolvedValue(null);
+        getGradesConsensus = vi.fn().mockResolvedValue(null);
+        getPriceTargetConsensus = vi.fn().mockResolvedValue(null);
+        getPriceTargetSummary = vi.fn().mockResolvedValue(null);
+    },
+}));
+vi.mock('react', async () => {
+    const actual = await vi.importActual<typeof import('react')>('react');
+    return {
+        ...actual,
+        cache: <T extends (...args: unknown[]) => unknown>(fn: T): T => fn,
+    };
+});
+
+import {
+    getProfile,
+    getStockPeers,
+    getKeyMetricsTtm,
+    getRatiosTtm,
+    getIncomeStatementGrowth,
+    getFinancialScores,
+    getCashFlowStatement,
+    getAnalystEstimates,
+    getGradesConsensus,
+    getPriceTargetConsensus,
+    getPriceTargetSummary,
+} from '@/app/[symbol]/fundamental/fundamentalData';
+
+describe('fundamentalData', () => {
+    it('getProfile returns null when FMP returns null', async () => {
+        const result = await getProfile('AAPL');
+        expect(result).toBeNull();
+    });
+
+    it('getStockPeers returns an empty array', async () => {
+        const result = await getStockPeers('AAPL');
+        expect(result).toEqual([]);
+    });
+
+    it('getKeyMetricsTtm returns null', async () => {
+        const result = await getKeyMetricsTtm('AAPL');
+        expect(result).toBeNull();
+    });
+
+    it('getRatiosTtm returns null', async () => {
+        const result = await getRatiosTtm('AAPL');
+        expect(result).toBeNull();
+    });
+
+    it('getIncomeStatementGrowth returns null', async () => {
+        const result = await getIncomeStatementGrowth('AAPL');
+        expect(result).toBeNull();
+    });
+
+    it('getFinancialScores returns null', async () => {
+        const result = await getFinancialScores('AAPL');
+        expect(result).toBeNull();
+    });
+
+    it('getCashFlowStatement returns null', async () => {
+        const result = await getCashFlowStatement('AAPL');
+        expect(result).toBeNull();
+    });
+
+    it('getAnalystEstimates returns null', async () => {
+        const result = await getAnalystEstimates('AAPL');
+        expect(result).toBeNull();
+    });
+
+    it('getGradesConsensus returns null', async () => {
+        const result = await getGradesConsensus('AAPL');
+        expect(result).toBeNull();
+    });
+
+    it('getPriceTargetConsensus returns null', async () => {
+        const result = await getPriceTargetConsensus('AAPL');
+        expect(result).toBeNull();
+    });
+
+    it('getPriceTargetSummary returns null', async () => {
+        const result = await getPriceTargetSummary('AAPL');
+        expect(result).toBeNull();
+    });
+});

--- a/src/app/[symbol]/fundamental/__tests__/og-images.test.ts
+++ b/src/app/[symbol]/fundamental/__tests__/og-images.test.ts
@@ -1,0 +1,54 @@
+vi.mock('@/shared/lib/og', () => ({
+    OG_IMAGE_WIDTH: 1200,
+    OG_IMAGE_HEIGHT: 630,
+}));
+vi.mock('@/entities/og-image', () => ({
+    buildSymbolOgImage: vi.fn().mockResolvedValue(new Response('image')),
+}));
+
+import OgImage, {
+    size,
+    contentType,
+    alt,
+} from '@/app/[symbol]/fundamental/opengraph-image';
+import { buildSymbolOgImage } from '@/entities/og-image';
+import type { MockedFunction } from 'vitest';
+
+const mockBuildSymbolOgImage = buildSymbolOgImage as MockedFunction<
+    typeof buildSymbolOgImage
+>;
+
+describe('[symbol]/fundamental OG images', () => {
+    describe('opengraph-image', () => {
+        it('exports correct size', () => {
+            expect(size).toEqual({ width: 1200, height: 630 });
+        });
+
+        it('exports correct contentType', () => {
+            expect(contentType).toBe('image/png');
+        });
+
+        it('exports alt text containing fundamental', () => {
+            expect(alt).toContain('펀더멘털');
+        });
+
+        it('calls buildSymbolOgImage with ticker and fundamental label', async () => {
+            await OgImage({ params: Promise.resolve({ symbol: 'nvda' }) });
+
+            expect(mockBuildSymbolOgImage).toHaveBeenCalledWith({
+                ticker: 'NVDA',
+                label: '펀더멘털',
+            });
+        });
+    });
+
+    describe('twitter-image (re-export)', () => {
+        it('re-exports same exports from opengraph-image', async () => {
+            const twitter =
+                await import('@/app/[symbol]/fundamental/twitter-image');
+            expect(twitter.size).toEqual(size);
+            expect(twitter.contentType).toBe(contentType);
+            expect(twitter.alt).toBe(alt);
+        });
+    });
+});

--- a/src/app/[symbol]/news/__tests__/loading.test.tsx
+++ b/src/app/[symbol]/news/__tests__/loading.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import NewsLoading from '@/app/[symbol]/news/loading';
+
+describe('NewsLoading', () => {
+    it('renders skeleton placeholder blocks', () => {
+        const { container } = render(<NewsLoading />);
+
+        const skeletons = container.querySelectorAll('.animate-pulse');
+        expect(skeletons.length).toBe(5);
+    });
+
+    it('marks skeleton blocks as aria-hidden', () => {
+        const { container } = render(<NewsLoading />);
+
+        const hiddenBlocks = container.querySelectorAll('[aria-hidden="true"]');
+        expect(hiddenBlocks.length).toBe(5);
+    });
+});

--- a/src/app/[symbol]/news/__tests__/og-images.test.ts
+++ b/src/app/[symbol]/news/__tests__/og-images.test.ts
@@ -1,0 +1,53 @@
+vi.mock('@/shared/lib/og', () => ({
+    OG_IMAGE_WIDTH: 1200,
+    OG_IMAGE_HEIGHT: 630,
+}));
+vi.mock('@/entities/og-image', () => ({
+    buildSymbolOgImage: vi.fn().mockResolvedValue(new Response('image')),
+}));
+
+import OgImage, {
+    size,
+    contentType,
+    alt,
+} from '@/app/[symbol]/news/opengraph-image';
+import { buildSymbolOgImage } from '@/entities/og-image';
+import type { MockedFunction } from 'vitest';
+
+const mockBuildSymbolOgImage = buildSymbolOgImage as MockedFunction<
+    typeof buildSymbolOgImage
+>;
+
+describe('[symbol]/news OG images', () => {
+    describe('opengraph-image', () => {
+        it('exports correct size', () => {
+            expect(size).toEqual({ width: 1200, height: 630 });
+        });
+
+        it('exports correct contentType', () => {
+            expect(contentType).toBe('image/png');
+        });
+
+        it('exports alt text containing news', () => {
+            expect(alt).toContain('뉴스');
+        });
+
+        it('calls buildSymbolOgImage with ticker and news label', async () => {
+            await OgImage({ params: Promise.resolve({ symbol: 'tsla' }) });
+
+            expect(mockBuildSymbolOgImage).toHaveBeenCalledWith({
+                ticker: 'TSLA',
+                label: '뉴스 분석',
+            });
+        });
+    });
+
+    describe('twitter-image (re-export)', () => {
+        it('re-exports same exports from opengraph-image', async () => {
+            const twitter = await import('@/app/[symbol]/news/twitter-image');
+            expect(twitter.size).toEqual(size);
+            expect(twitter.contentType).toBe(contentType);
+            expect(twitter.alt).toBe(alt);
+        });
+    });
+});

--- a/src/app/[symbol]/options/__tests__/og-images.test.ts
+++ b/src/app/[symbol]/options/__tests__/og-images.test.ts
@@ -1,0 +1,54 @@
+vi.mock('@/shared/lib/og', () => ({
+    OG_IMAGE_WIDTH: 1200,
+    OG_IMAGE_HEIGHT: 630,
+}));
+vi.mock('@/entities/og-image', () => ({
+    buildSymbolOgImage: vi.fn().mockResolvedValue(new Response('image')),
+}));
+
+import OgImage, {
+    size,
+    contentType,
+    alt,
+} from '@/app/[symbol]/options/opengraph-image';
+import { buildSymbolOgImage } from '@/entities/og-image';
+import type { MockedFunction } from 'vitest';
+
+const mockBuildSymbolOgImage = buildSymbolOgImage as MockedFunction<
+    typeof buildSymbolOgImage
+>;
+
+describe('[symbol]/options OG images', () => {
+    describe('opengraph-image', () => {
+        it('exports correct size', () => {
+            expect(size).toEqual({ width: 1200, height: 630 });
+        });
+
+        it('exports correct contentType', () => {
+            expect(contentType).toBe('image/png');
+        });
+
+        it('exports alt text containing options', () => {
+            expect(alt).toContain('옵션');
+        });
+
+        it('calls buildSymbolOgImage with ticker and options label', async () => {
+            await OgImage({ params: Promise.resolve({ symbol: 'msft' }) });
+
+            expect(mockBuildSymbolOgImage).toHaveBeenCalledWith({
+                ticker: 'MSFT',
+                label: '옵션 분석',
+            });
+        });
+    });
+
+    describe('twitter-image (re-export)', () => {
+        it('re-exports same exports from opengraph-image', async () => {
+            const twitter =
+                await import('@/app/[symbol]/options/twitter-image');
+            expect(twitter.size).toEqual(size);
+            expect(twitter.contentType).toBe(contentType);
+            expect(twitter.alt).toBe(alt);
+        });
+    });
+});

--- a/src/app/[symbol]/overall/__tests__/og-images.test.ts
+++ b/src/app/[symbol]/overall/__tests__/og-images.test.ts
@@ -1,0 +1,54 @@
+vi.mock('@/shared/lib/og', () => ({
+    OG_IMAGE_WIDTH: 1200,
+    OG_IMAGE_HEIGHT: 630,
+}));
+vi.mock('@/entities/og-image', () => ({
+    buildSymbolOgImage: vi.fn().mockResolvedValue(new Response('image')),
+}));
+
+import OgImage, {
+    size,
+    contentType,
+    alt,
+} from '@/app/[symbol]/overall/opengraph-image';
+import { buildSymbolOgImage } from '@/entities/og-image';
+import type { MockedFunction } from 'vitest';
+
+const mockBuildSymbolOgImage = buildSymbolOgImage as MockedFunction<
+    typeof buildSymbolOgImage
+>;
+
+describe('[symbol]/overall OG images', () => {
+    describe('opengraph-image', () => {
+        it('exports correct size', () => {
+            expect(size).toEqual({ width: 1200, height: 630 });
+        });
+
+        it('exports correct contentType', () => {
+            expect(contentType).toBe('image/png');
+        });
+
+        it('exports alt text containing overall analysis', () => {
+            expect(alt).toContain('종합 분석');
+        });
+
+        it('calls buildSymbolOgImage with ticker and overall label', async () => {
+            await OgImage({ params: Promise.resolve({ symbol: 'goog' }) });
+
+            expect(mockBuildSymbolOgImage).toHaveBeenCalledWith({
+                ticker: 'GOOG',
+                label: 'AI 종합 분석',
+            });
+        });
+    });
+
+    describe('twitter-image (re-export)', () => {
+        it('re-exports same exports from opengraph-image', async () => {
+            const twitter =
+                await import('@/app/[symbol]/overall/twitter-image');
+            expect(twitter.size).toEqual(size);
+            expect(twitter.contentType).toBe(contentType);
+            expect(twitter.alt).toBe(alt);
+        });
+    });
+});

--- a/src/app/__tests__/manifest.test.ts
+++ b/src/app/__tests__/manifest.test.ts
@@ -1,0 +1,52 @@
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_NAME: 'Siglens',
+}));
+
+import manifest from '@/app/manifest';
+
+describe('manifest', () => {
+    it('returns a valid manifest object', () => {
+        const result = manifest();
+
+        expect(result).toBeDefined();
+        expect(result.name).toContain('Siglens');
+        expect(result.short_name).toBe('Siglens');
+    });
+
+    it('sets display to standalone', () => {
+        const result = manifest();
+
+        expect(result.display).toBe('standalone');
+    });
+
+    it('includes PWA icons', () => {
+        const result = manifest();
+
+        expect(result.icons).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ sizes: '192x192' }),
+                expect.objectContaining({ sizes: '512x512' }),
+            ])
+        );
+    });
+
+    it('includes shortcuts for market and search', () => {
+        const result = manifest();
+
+        expect(result.shortcuts).toHaveLength(2);
+        expect(result.shortcuts![0].url).toBe('/market');
+        expect(result.shortcuts![1].url).toBe('/?focus=search');
+    });
+
+    it('sets lang to ko-KR', () => {
+        const result = manifest();
+
+        expect(result.lang).toBe('ko-KR');
+    });
+
+    it('sets start_url to /', () => {
+        const result = manifest();
+
+        expect(result.start_url).toBe('/');
+    });
+});

--- a/src/app/__tests__/not-found.test.tsx
+++ b/src/app/__tests__/not-found.test.tsx
@@ -1,0 +1,64 @@
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_NAME: 'Siglens',
+}));
+vi.mock('@/widgets/layout/ContactDialog', () => ({
+    ContactDialog: () => <div data-testid="contact-dialog" />,
+}));
+vi.mock('@/widgets/home/TickerCategories', () => ({
+    TickerCategories: () => <div data-testid="ticker-categories" />,
+}));
+vi.mock('next/link', () => ({
+    default: ({
+        children,
+        href,
+    }: {
+        children: React.ReactNode;
+        href: string;
+    }) => <a href={href}>{children}</a>,
+}));
+
+import { render, screen } from '@testing-library/react';
+import NotFound, { metadata } from '@/app/not-found';
+
+describe('NotFound page', () => {
+    it('renders the 404 text', () => {
+        render(<NotFound />);
+
+        expect(screen.getByText('404')).toBeInTheDocument();
+    });
+
+    it('renders the main heading', () => {
+        render(<NotFound />);
+
+        expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+            '페이지를 찾을 수 없습니다'
+        );
+    });
+
+    it('renders a link back to home', () => {
+        render(<NotFound />);
+
+        const link = screen.getByRole('link', {
+            name: /홈으로 돌아가기/,
+        });
+        expect(link).toHaveAttribute('href', '/');
+    });
+
+    it('renders the contact dialog trigger', () => {
+        render(<NotFound />);
+
+        expect(screen.getByTestId('contact-dialog')).toBeInTheDocument();
+    });
+
+    it('renders TickerCategories', () => {
+        render(<NotFound />);
+
+        expect(screen.getByTestId('ticker-categories')).toBeInTheDocument();
+    });
+
+    it('exports metadata with noindex', () => {
+        expect(metadata.robots).toEqual(
+            expect.objectContaining({ index: false })
+        );
+    });
+});

--- a/src/app/__tests__/page.test.ts
+++ b/src/app/__tests__/page.test.ts
@@ -1,0 +1,43 @@
+vi.mock('@/widgets/home/HeroIllustration', () => ({
+    HeroIllustration: () => null,
+}));
+vi.mock('@/widgets/home/HowItWorks', () => ({ HowItWorks: () => null }));
+vi.mock('@/widgets/home/SkillsShowcase', () => ({
+    SkillsShowcase: () => null,
+    SkillsShowcaseSkeleton: () => null,
+}));
+vi.mock('@/widgets/home/StatsBar', () => ({
+    StatsBar: () => null,
+    StatsBarSkeleton: () => null,
+}));
+vi.mock('@/widgets/home/TickerCategories', () => ({
+    TickerCategories: () => null,
+}));
+vi.mock('@/features/ticker-search', () => ({ SymbolSearchPanel: () => null }));
+vi.mock('@/shared/ui/JsonLd', () => ({ JsonLd: () => null }));
+vi.mock('@/entities/skill', () => ({
+    countSkillFiles: vi.fn().mockResolvedValue({
+        indicators: 13,
+        candlesticks: 30,
+        patterns: 5,
+        strategies: 4,
+        supportResistance: 3,
+    }),
+    FileSkillsLoader: vi.fn().mockImplementation(() => ({
+        loadSkills: vi.fn().mockResolvedValue([]),
+    })),
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_DESCRIPTION: 'test description',
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+vi.mock('next/link', () => ({ default: () => null }));
+
+import { revalidate } from '@/app/page';
+
+describe('Home page', () => {
+    it('exports revalidate as 3600 for ISR', () => {
+        expect(revalidate).toBe(3600);
+    });
+});

--- a/src/app/__tests__/providers.test.tsx
+++ b/src/app/__tests__/providers.test.tsx
@@ -1,0 +1,40 @@
+vi.mock('@/shared/config/queryConfig', () => ({
+    QUERY_STALE_TIME_MS: 5000,
+    QUERY_GC_TIME_MS: 300000,
+}));
+vi.mock('@tanstack/react-query', () => ({
+    QueryClient: class MockQueryClient {
+        constructor() {
+            return {};
+        }
+    },
+    QueryClientProvider: ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="query-provider">{children}</div>
+    ),
+}));
+
+import { render, screen } from '@testing-library/react';
+import { ReactQueryProvider } from '@/app/providers';
+
+describe('ReactQueryProvider', () => {
+    it('renders children inside QueryClientProvider', () => {
+        render(
+            <ReactQueryProvider>
+                <div data-testid="child">test</div>
+            </ReactQueryProvider>
+        );
+
+        expect(screen.getByTestId('query-provider')).toBeInTheDocument();
+        expect(screen.getByTestId('child')).toBeInTheDocument();
+    });
+
+    it('renders children text correctly', () => {
+        render(
+            <ReactQueryProvider>
+                <span>Hello World</span>
+            </ReactQueryProvider>
+        );
+
+        expect(screen.getByText('Hello World')).toBeInTheDocument();
+    });
+});

--- a/src/app/__tests__/robots.test.ts
+++ b/src/app/__tests__/robots.test.ts
@@ -1,0 +1,41 @@
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_URL: 'https://siglens.io',
+}));
+
+import robots from '@/app/robots';
+
+describe('robots', () => {
+    it('returns a valid robots config', () => {
+        const result = robots();
+
+        expect(result).toBeDefined();
+        expect(result.rules).toBeDefined();
+    });
+
+    it('allows all paths for all user agents', () => {
+        const result = robots();
+
+        expect(result.rules).toEqual(
+            expect.objectContaining({
+                userAgent: '*',
+                allow: '/',
+            })
+        );
+    });
+
+    it('disallows /api/ routes', () => {
+        const result = robots();
+
+        expect(result.rules).toEqual(
+            expect.objectContaining({
+                disallow: ['/api/'],
+            })
+        );
+    });
+
+    it('points sitemap to the correct URL', () => {
+        const result = robots();
+
+        expect(result.sitemap).toBe('https://siglens.io/sitemap.xml');
+    });
+});

--- a/src/app/_components/__tests__/AuthSessionHeader.test.tsx
+++ b/src/app/_components/__tests__/AuthSessionHeader.test.tsx
@@ -1,0 +1,67 @@
+vi.mock('next/headers', () => ({
+    cookies: vi.fn(),
+}));
+vi.mock('@/widgets/layout/Header', () => ({
+    Header: ({
+        currentUser,
+        loadingUserMenu,
+    }: {
+        currentUser: unknown;
+        loadingUserMenu?: boolean;
+    }) => (
+        <header data-testid="header">
+            {currentUser ? 'logged-in' : 'guest'}
+            {loadingUserMenu ? '-loading' : ''}
+        </header>
+    ),
+}));
+vi.mock('@/entities/session', () => ({
+    getCurrentUser: vi.fn(),
+}));
+vi.mock('@/shared/config/cookieNames', () => ({
+    AUTH_HINT_COOKIE_NAME: 'auth_hint',
+}));
+
+import { cookies } from 'next/headers';
+import { getCurrentUser } from '@/entities/session';
+import { AuthSessionHeader } from '@/app/_components/AuthSessionHeader';
+import type { MockedFunction } from 'vitest';
+
+const mockCookies = cookies as MockedFunction<typeof cookies>;
+const mockGetCurrentUser = getCurrentUser as MockedFunction<
+    typeof getCurrentUser
+>;
+
+describe('AuthSessionHeader', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns a valid ReactNode when no session hint cookie exists', async () => {
+        mockCookies.mockResolvedValue({
+            get: vi.fn().mockReturnValue(undefined),
+        } as never);
+        mockGetCurrentUser.mockResolvedValue(null);
+
+        const result = await AuthSessionHeader();
+
+        expect(result).toBeDefined();
+    });
+
+    it('returns a valid ReactNode when session hint cookie exists', async () => {
+        mockCookies.mockResolvedValue({
+            get: vi.fn().mockReturnValue({ value: '1' }),
+        } as never);
+        mockGetCurrentUser.mockResolvedValue({
+            id: '1',
+            email: 'test@test.com',
+            name: 'Test',
+            tier: 'free',
+            avatarUrl: null,
+        } as never);
+
+        const result = await AuthSessionHeader();
+
+        expect(result).toBeDefined();
+    });
+});

--- a/src/app/account/__tests__/page.test.ts
+++ b/src/app/account/__tests__/page.test.ts
@@ -1,0 +1,40 @@
+vi.mock('@/features/api-key-management', () => ({
+    ApiKeySection: () => null,
+}));
+vi.mock('@/entities/session', () => ({
+    getCurrentUser: vi.fn(),
+}));
+vi.mock('@/entities/api-key/actions', () => ({
+    getRegisteredProvidersAction: vi.fn(),
+}));
+vi.mock('@/shared/lib/auth/tierLabel', () => ({
+    TIER_LABEL: { free: '무료' },
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+vi.mock('next/link', () => ({ default: () => null }));
+vi.mock('next/navigation', () => ({
+    redirect: vi.fn(),
+}));
+
+import { metadata } from '@/app/account/page';
+
+describe('Account page', () => {
+    it('exports metadata with account title', () => {
+        expect(metadata.title).toBe('계정 설정');
+    });
+
+    it('sets robots to noindex, nofollow', () => {
+        expect(metadata.robots).toEqual(
+            expect.objectContaining({ index: false, follow: false })
+        );
+    });
+
+    it('includes canonical URL', () => {
+        expect(metadata.alternates?.canonical).toBe(
+            'https://siglens.io/account'
+        );
+    });
+});

--- a/src/app/account/delete/__tests__/page.test.ts
+++ b/src/app/account/delete/__tests__/page.test.ts
@@ -1,0 +1,37 @@
+vi.mock('@/shared/ui/auth/AuthCardShell', () => ({
+    AuthCardShell: () => null,
+}));
+vi.mock('@/features/account-delete', () => ({
+    DeleteAccountConfirm: () => null,
+}));
+vi.mock('@/entities/session', () => ({
+    getCurrentUser: vi.fn(),
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+vi.mock('next/link', () => ({ default: () => null }));
+vi.mock('next/navigation', () => ({
+    redirect: vi.fn(),
+}));
+
+import { metadata } from '@/app/account/delete/page';
+
+describe('Delete account page', () => {
+    it('exports metadata with delete title', () => {
+        expect(metadata.title).toBe('회원 탈퇴');
+    });
+
+    it('sets robots to noindex, nofollow', () => {
+        expect(metadata.robots).toEqual(
+            expect.objectContaining({ index: false, follow: false })
+        );
+    });
+
+    it('includes canonical URL', () => {
+        expect(metadata.alternates?.canonical).toBe(
+            'https://siglens.io/account/delete'
+        );
+    });
+});

--- a/src/app/api/auth/__tests__/start.test.ts
+++ b/src/app/api/auth/__tests__/start.test.ts
@@ -1,0 +1,120 @@
+vi.mock('@/features/auth-oauth', () => ({
+    buildOAuthRedirectUri: vi
+        .fn()
+        .mockReturnValue('https://accounts.google.com/callback'),
+    getOAuthAdapter: vi.fn().mockReturnValue({
+        authorizeUrl: vi
+            .fn()
+            .mockReturnValue(new URL('https://accounts.google.com/authorize')),
+    }),
+    isOAuthProvider: vi.fn(),
+    OAuthStateSecretMisconfiguredError: class extends Error {},
+    issueOAuthState: vi.fn(),
+}));
+vi.mock('@/shared/lib/auth/redirect', () => ({
+    sanitizeNextPath: vi.fn().mockImplementation((p: string) => p || '/'),
+}));
+
+import { NextRequest } from 'next/server';
+import { GET } from '@/app/api/auth/[provider]/start/route';
+import {
+    isOAuthProvider,
+    issueOAuthState,
+    OAuthStateSecretMisconfiguredError,
+} from '@/features/auth-oauth';
+import type { MockedFunction } from 'vitest';
+
+const mockIsOAuthProvider = isOAuthProvider as MockedFunction<
+    typeof isOAuthProvider
+>;
+const mockIssueOAuthState = issueOAuthState as MockedFunction<
+    typeof issueOAuthState
+>;
+
+function makeRequest(provider: string, next?: string): NextRequest {
+    const url = next
+        ? `http://localhost/api/auth/${provider}/start?next=${encodeURIComponent(next)}`
+        : `http://localhost/api/auth/${provider}/start`;
+    return new NextRequest(url);
+}
+
+describe('GET /api/auth/[provider]/start', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('unknown provider', () => {
+        it('redirects to /login?error=oauth_unknown', async () => {
+            mockIsOAuthProvider.mockReturnValue(false);
+
+            const res = await GET(makeRequest('unknown'), {
+                params: Promise.resolve({ provider: 'unknown' }),
+            });
+
+            expect(res.status).toBe(307);
+            const location = new URL(res.headers.get('location')!);
+            expect(location.pathname).toBe('/login');
+            expect(location.searchParams.get('error')).toBe('oauth_unknown');
+        });
+    });
+
+    describe('valid provider', () => {
+        beforeEach(() => {
+            mockIsOAuthProvider.mockReturnValue(true);
+        });
+
+        it('redirects to the authorize URL with state cookie', async () => {
+            mockIssueOAuthState.mockReturnValue({
+                state: 'test-state',
+                cookie: {
+                    name: 'oauth_state',
+                    value: 'test-cookie-value',
+                    httpOnly: true,
+                    secure: false,
+                    sameSite: 'lax' as const,
+                    maxAge: 600,
+                    path: '/',
+                    expires: new Date('2099-01-01'),
+                },
+            });
+
+            const res = await GET(makeRequest('google'), {
+                params: Promise.resolve({ provider: 'google' }),
+            });
+
+            expect(res.status).toBe(307);
+            expect(res.headers.get('location')).toContain(
+                'accounts.google.com/authorize'
+            );
+        });
+
+        it('redirects to /login?error=oauth_unknown when state secret is misconfigured', async () => {
+            mockIssueOAuthState.mockImplementation(() => {
+                throw new OAuthStateSecretMisconfiguredError(
+                    'secret not configured'
+                );
+            });
+
+            const res = await GET(makeRequest('google'), {
+                params: Promise.resolve({ provider: 'google' }),
+            });
+
+            expect(res.status).toBe(307);
+            const location = new URL(res.headers.get('location')!);
+            expect(location.pathname).toBe('/login');
+            expect(location.searchParams.get('error')).toBe('oauth_unknown');
+        });
+
+        it('rethrows unexpected errors', async () => {
+            mockIssueOAuthState.mockImplementation(() => {
+                throw new Error('unexpected');
+            });
+
+            await expect(
+                GET(makeRequest('google'), {
+                    params: Promise.resolve({ provider: 'google' }),
+                })
+            ).rejects.toThrow('unexpected');
+        });
+    });
+});

--- a/src/app/api/jobs/__tests__/cancel.test.ts
+++ b/src/app/api/jobs/__tests__/cancel.test.ts
@@ -1,0 +1,94 @@
+vi.mock('@y0ngha/siglens-core', () => ({
+    cancelAnalysisJob: vi.fn().mockResolvedValue(undefined),
+    cancelFundamentalAnalysisJob: vi.fn().mockResolvedValue(undefined),
+    cancelNewsAnalysisJob: vi.fn().mockResolvedValue(undefined),
+    cancelJob: vi.fn().mockResolvedValue(undefined),
+    cancelOverallAnalysisJob: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { constants } from 'node:http2';
+import { POST } from '@/app/api/jobs/cancel/route';
+import {
+    cancelAnalysisJob,
+    cancelFundamentalAnalysisJob,
+    cancelNewsAnalysisJob,
+    cancelJob,
+    cancelOverallAnalysisJob,
+} from '@y0ngha/siglens-core';
+
+const { HTTP_STATUS_BAD_REQUEST, HTTP_STATUS_NO_CONTENT } = constants;
+
+function makeRequest(body: unknown): Request {
+    return new Request('http://localhost/api/jobs/cancel', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+}
+
+describe('POST /api/jobs/cancel', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns 400 when body is not valid JSON', async () => {
+        const req = new Request('http://localhost/api/jobs/cancel', {
+            method: 'POST',
+            body: 'not-json',
+        });
+        const res = await POST(req);
+        expect(res.status).toBe(HTTP_STATUS_BAD_REQUEST);
+    });
+
+    it('returns 400 when jobs is not an array', async () => {
+        const res = await POST(makeRequest({ jobs: 'not-array' }));
+        expect(res.status).toBe(HTTP_STATUS_BAD_REQUEST);
+    });
+
+    it('returns 400 when a job entry has no jobId', async () => {
+        const res = await POST(makeRequest({ jobs: [{ type: 'analysis' }] }));
+        expect(res.status).toBe(HTTP_STATUS_BAD_REQUEST);
+    });
+
+    it('returns 400 when a job entry has an invalid type', async () => {
+        const res = await POST(
+            makeRequest({ jobs: [{ jobId: 'j1', type: 'invalid' }] })
+        );
+        expect(res.status).toBe(HTTP_STATUS_BAD_REQUEST);
+    });
+
+    it('returns 204 and dispatches cancel for a single analysis job', async () => {
+        const res = await POST(
+            makeRequest({ jobs: [{ jobId: 'j1', type: 'analysis' }] })
+        );
+        expect(res.status).toBe(HTTP_STATUS_NO_CONTENT);
+        expect(cancelAnalysisJob).toHaveBeenCalledWith('j1');
+    });
+
+    it('dispatches each job type to the correct cancel function', async () => {
+        const jobs = [
+            { jobId: 'a1', type: 'analysis' },
+            { jobId: 'f1', type: 'fundamental' },
+            { jobId: 'n1', type: 'news' },
+            { jobId: 'o1', type: 'options' },
+            { jobId: 'v1', type: 'overall' },
+        ];
+        const res = await POST(makeRequest({ jobs }));
+        expect(res.status).toBe(HTTP_STATUS_NO_CONTENT);
+        expect(cancelAnalysisJob).toHaveBeenCalledWith('a1');
+        expect(cancelFundamentalAnalysisJob).toHaveBeenCalledWith('f1');
+        expect(cancelNewsAnalysisJob).toHaveBeenCalledWith('n1');
+        expect(cancelJob).toHaveBeenCalledWith('o1');
+        expect(cancelOverallAnalysisJob).toHaveBeenCalledWith('v1');
+    });
+
+    it('returns 204 even when some cancel calls reject', async () => {
+        vi.mocked(cancelAnalysisJob).mockRejectedValueOnce(
+            new Error('redis down')
+        );
+        const res = await POST(
+            makeRequest({ jobs: [{ jobId: 'j1', type: 'analysis' }] })
+        );
+        expect(res.status).toBe(HTTP_STATUS_NO_CONTENT);
+    });
+});

--- a/src/app/api/sitemap/__tests__/longtail.test.ts
+++ b/src/app/api/sitemap/__tests__/longtail.test.ts
@@ -1,0 +1,98 @@
+vi.mock('next/server', async () => {
+    const actual =
+        await vi.importActual<typeof import('next/server')>('next/server');
+    return { ...actual };
+});
+vi.mock('@/entities/sitemap-entry', () => ({
+    loadLongTailTickers: vi.fn(),
+    SITEMAP_MAX_URLS_PER_FILE: 3,
+    toUrlSetXml: vi.fn().mockReturnValue('<?xml version="1.0"?><urlset/>'),
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_BUILD_DATE: new Date('2025-01-01'),
+    SITE_URL: 'https://siglens.io',
+}));
+
+import { GET } from '@/app/api/sitemap/longtail/[page]/route';
+import { loadLongTailTickers, toUrlSetXml } from '@/entities/sitemap-entry';
+import type { MockedFunction } from 'vitest';
+
+const mockLoadLongTailTickers = loadLongTailTickers as MockedFunction<
+    typeof loadLongTailTickers
+>;
+const mockToUrlSetXml = toUrlSetXml as MockedFunction<typeof toUrlSetXml>;
+
+function callGET(page: string): Promise<Response> {
+    return GET(new Request('http://localhost/api/sitemap/longtail/' + page), {
+        params: Promise.resolve({ page }),
+    });
+}
+
+describe('GET /api/sitemap/longtail/[page]', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockLoadLongTailTickers.mockResolvedValue([
+            'AAA',
+            'BBB',
+            'CCC',
+            'DDD',
+            'EEE',
+        ]);
+    });
+
+    it('returns 404 for non-numeric page', async () => {
+        const res = await callGET('abc');
+        expect(res.status).toBe(404);
+    });
+
+    it('returns 404 for page 0', async () => {
+        const res = await callGET('0');
+        expect(res.status).toBe(404);
+    });
+
+    it('returns 404 for negative page', async () => {
+        const res = await callGET('-1');
+        expect(res.status).toBe(404);
+    });
+
+    it('returns 404 when page exceeds available chunks', async () => {
+        const res = await callGET('100');
+        expect(res.status).toBe(404);
+    });
+
+    it('returns XML for a valid first page', async () => {
+        const res = await callGET('1');
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get('Content-Type')).toBe(
+            'application/xml; charset=utf-8'
+        );
+    });
+
+    it('passes correct chunk of tickers to toUrlSetXml for page 1', async () => {
+        await callGET('1');
+
+        const entries = mockToUrlSetXml.mock.calls[0][0];
+        expect(entries).toHaveLength(3);
+        expect(entries[0].url).toBe('https://siglens.io/AAA');
+        expect(entries[1].url).toBe('https://siglens.io/BBB');
+        expect(entries[2].url).toBe('https://siglens.io/CCC');
+    });
+
+    it('returns the second chunk for page 2', async () => {
+        await callGET('2');
+
+        const entries = mockToUrlSetXml.mock.calls[0][0];
+        expect(entries).toHaveLength(2);
+        expect(entries[0].url).toBe('https://siglens.io/DDD');
+        expect(entries[1].url).toBe('https://siglens.io/EEE');
+    });
+
+    it('sets changeFrequency to weekly and priority to 0.5', async () => {
+        await callGET('1');
+
+        const entries = mockToUrlSetXml.mock.calls[0][0];
+        expect(entries[0].changeFrequency).toBe('weekly');
+        expect(entries[0].priority).toBe(0.5);
+    });
+});

--- a/src/app/api/sitemap/__tests__/popular.test.ts
+++ b/src/app/api/sitemap/__tests__/popular.test.ts
@@ -1,0 +1,63 @@
+vi.mock('next/server', async () => {
+    const actual =
+        await vi.importActual<typeof import('next/server')>('next/server');
+    return { ...actual };
+});
+vi.mock('@/entities/sitemap-entry', () => ({
+    buildPopularEntries: vi.fn().mockResolvedValue([]),
+    toUrlSetXml: vi.fn().mockReturnValue('<?xml version="1.0"?><urlset/>'),
+}));
+
+import { GET } from '@/app/api/sitemap/popular/route';
+import { buildPopularEntries, toUrlSetXml } from '@/entities/sitemap-entry';
+import type { MockedFunction } from 'vitest';
+
+const mockBuildPopularEntries = buildPopularEntries as MockedFunction<
+    typeof buildPopularEntries
+>;
+const mockToUrlSetXml = toUrlSetXml as MockedFunction<typeof toUrlSetXml>;
+
+describe('GET /api/sitemap/popular', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns XML with correct content-type header', async () => {
+        const res = await GET();
+
+        expect(res.headers.get('Content-Type')).toBe(
+            'application/xml; charset=utf-8'
+        );
+    });
+
+    it('passes a Date to buildPopularEntries', async () => {
+        await GET();
+
+        expect(mockBuildPopularEntries).toHaveBeenCalledTimes(1);
+        expect(mockBuildPopularEntries.mock.calls[0][0]).toBeInstanceOf(Date);
+    });
+
+    it('passes built entries to toUrlSetXml', async () => {
+        const entries = [
+            {
+                url: 'https://siglens.io/AAPL',
+                lastModified: new Date(),
+                changeFrequency: 'daily' as const,
+                priority: 0.8,
+            },
+        ];
+        mockBuildPopularEntries.mockResolvedValue(entries);
+
+        await GET();
+
+        expect(mockToUrlSetXml).toHaveBeenCalledWith(entries);
+    });
+
+    it('includes cache-control with stale-while-revalidate', async () => {
+        const res = await GET();
+
+        expect(res.headers.get('Cache-Control')).toContain(
+            'stale-while-revalidate'
+        );
+    });
+});

--- a/src/app/api/sitemap/__tests__/route.test.ts
+++ b/src/app/api/sitemap/__tests__/route.test.ts
@@ -1,0 +1,72 @@
+vi.mock('next/server', async () => {
+    const actual =
+        await vi.importActual<typeof import('next/server')>('next/server');
+    return { ...actual };
+});
+vi.mock('@/entities/sitemap-entry', () => ({
+    loadLongTailTickers: vi.fn(),
+    SITEMAP_MAX_URLS_PER_FILE: 50000,
+    toSitemapIndexXml: vi
+        .fn()
+        .mockReturnValue('<?xml version="1.0"?><sitemapindex/>'),
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_BUILD_DATE: new Date('2025-01-01'),
+    SITE_URL: 'https://siglens.io',
+}));
+
+import { GET } from '@/app/api/sitemap/route';
+import {
+    loadLongTailTickers,
+    toSitemapIndexXml,
+} from '@/entities/sitemap-entry';
+import type { MockedFunction } from 'vitest';
+
+const mockLoadLongTailTickers = loadLongTailTickers as MockedFunction<
+    typeof loadLongTailTickers
+>;
+const mockToSitemapIndexXml = toSitemapIndexXml as MockedFunction<
+    typeof toSitemapIndexXml
+>;
+
+describe('GET /api/sitemap (index)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns XML with correct content-type and cache headers', async () => {
+        mockLoadLongTailTickers.mockResolvedValue([]);
+
+        const res = await GET();
+
+        expect(res.headers.get('Content-Type')).toBe(
+            'application/xml; charset=utf-8'
+        );
+        expect(res.headers.get('Cache-Control')).toContain('max-age=3600');
+    });
+
+    it('passes static and popular entries without long-tail pages when tickers are empty', async () => {
+        mockLoadLongTailTickers.mockResolvedValue([]);
+
+        await GET();
+
+        const entries = mockToSitemapIndexXml.mock.calls[0][0];
+        expect(entries).toHaveLength(2);
+        expect(entries[0].url).toContain('sitemap-static.xml');
+        expect(entries[1].url).toContain('sitemap-popular.xml');
+    });
+
+    it('generates long-tail sub-sitemap entries based on ticker count', async () => {
+        const tickers = Array.from({ length: 100001 }, (_, i) => `T${i}`);
+        mockLoadLongTailTickers.mockResolvedValue(tickers);
+
+        await GET();
+
+        const entries = mockToSitemapIndexXml.mock.calls[0][0];
+        // 2 (static + popular) + ceil(100001/50000) = 2 + 3 = 5
+        expect(entries).toHaveLength(5);
+        expect(entries[2].url).toContain('sitemap-longtail-1.xml');
+        expect(entries[3].url).toContain('sitemap-longtail-2.xml');
+        expect(entries[4].url).toContain('sitemap-longtail-3.xml');
+    });
+});

--- a/src/app/api/sitemap/__tests__/static.test.ts
+++ b/src/app/api/sitemap/__tests__/static.test.ts
@@ -1,0 +1,63 @@
+vi.mock('next/server', async () => {
+    const actual =
+        await vi.importActual<typeof import('next/server')>('next/server');
+    return { ...actual };
+});
+vi.mock('@/entities/sitemap-entry', () => ({
+    buildStaticEntries: vi.fn().mockReturnValue([]),
+    toUrlSetXml: vi.fn().mockReturnValue('<?xml version="1.0"?><urlset/>'),
+}));
+
+import { GET } from '@/app/api/sitemap/static/route';
+import { buildStaticEntries, toUrlSetXml } from '@/entities/sitemap-entry';
+import type { MockedFunction } from 'vitest';
+
+const mockBuildStaticEntries = buildStaticEntries as MockedFunction<
+    typeof buildStaticEntries
+>;
+const mockToUrlSetXml = toUrlSetXml as MockedFunction<typeof toUrlSetXml>;
+
+describe('GET /api/sitemap/static', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns XML with correct content-type header', async () => {
+        const res = await GET();
+
+        expect(res.headers.get('Content-Type')).toBe(
+            'application/xml; charset=utf-8'
+        );
+    });
+
+    it('passes a Date to buildStaticEntries', async () => {
+        await GET();
+
+        expect(mockBuildStaticEntries).toHaveBeenCalledTimes(1);
+        expect(mockBuildStaticEntries.mock.calls[0][0]).toBeInstanceOf(Date);
+    });
+
+    it('passes built entries to toUrlSetXml', async () => {
+        const entries = [
+            {
+                url: 'https://siglens.io/',
+                lastModified: new Date(),
+                changeFrequency: 'daily' as const,
+                priority: 1.0,
+            },
+        ];
+        mockBuildStaticEntries.mockReturnValue(entries);
+
+        await GET();
+
+        expect(mockToUrlSetXml).toHaveBeenCalledWith(entries);
+    });
+
+    it('includes cache-control header', async () => {
+        const res = await GET();
+
+        expect(res.headers.get('Cache-Control')).toContain(
+            'stale-while-revalidate'
+        );
+    });
+});

--- a/src/app/backtesting/__tests__/page.test.ts
+++ b/src/app/backtesting/__tests__/page.test.ts
@@ -1,0 +1,65 @@
+vi.mock('@/shared/lib/seo', () => ({
+    BACKTESTING_DESCRIPTION: 'test desc',
+    BACKTESTING_KEYWORDS: ['backtest'],
+    BACKTESTING_TITLE: 'AI 백테스팅',
+    BACKTESTING_URL: 'https://siglens.io/backtesting',
+    buildBreadcrumbJsonLd: vi.fn().mockReturnValue({}),
+    SITE_BUILD_DATE: new Date('2025-01-01'),
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+vi.mock('@/shared/lib/og', () => ({
+    OG_IMAGE_WIDTH: 1200,
+    OG_IMAGE_HEIGHT: 630,
+}));
+vi.mock('@/shared/lib/legal', () => ({
+    TERMS_PATH: '/terms',
+}));
+vi.mock('@/widgets/backtesting/BacktestHero', () => ({
+    BacktestHero: () => null,
+}));
+vi.mock('@/widgets/backtesting/BacktestTabs', () => ({
+    BacktestTabs: () => null,
+}));
+vi.mock('@/shared/ui/JsonLd', () => ({ JsonLd: () => null }));
+vi.mock('@/app/backtesting/data.json', () => ({
+    default: {
+        meta: { totalCases: 10, totalTickers: 5 },
+        cases: [
+            { ticker: 'AAPL', date: '2025-01-01', signal: 'buy' },
+            { ticker: 'TSLA', date: '2025-01-01', signal: 'buy' },
+        ],
+    },
+}));
+vi.mock('@/entities/backtest-case', () => ({
+    validateBacktestData: vi.fn().mockImplementation((data: unknown) => data),
+}));
+
+import { metadata } from '@/app/backtesting/page';
+
+describe('Backtesting page', () => {
+    it('exports metadata with backtesting title', () => {
+        expect(metadata.title).toEqual(
+            expect.objectContaining({
+                absolute: expect.stringContaining('백테스팅'),
+            })
+        );
+    });
+
+    it('sets canonical to backtesting URL', () => {
+        expect(metadata.alternates?.canonical).toBe(
+            'https://siglens.io/backtesting'
+        );
+    });
+
+    it('includes openGraph metadata', () => {
+        expect(metadata.openGraph).toBeDefined();
+    });
+
+    it('includes twitter card metadata', () => {
+        expect(metadata.twitter).toBeDefined();
+        expect(metadata.twitter).toEqual(
+            expect.objectContaining({ card: 'summary_large_image' })
+        );
+    });
+});

--- a/src/app/forgot-password/__tests__/page.test.ts
+++ b/src/app/forgot-password/__tests__/page.test.ts
@@ -1,0 +1,31 @@
+vi.mock('@/shared/ui/auth/AuthCardShell', () => ({
+    AuthCardShell: () => null,
+}));
+vi.mock('@/features/auth-password-reset', () => ({
+    ForgotPasswordForm: () => null,
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+vi.mock('next/link', () => ({ default: () => null }));
+
+import { metadata } from '@/app/forgot-password/page';
+
+describe('ForgotPassword page', () => {
+    it('exports metadata with forgot-password title', () => {
+        expect(metadata.title).toBe('비밀번호 찾기');
+    });
+
+    it('sets robots to noindex', () => {
+        expect(metadata.robots).toEqual(
+            expect.objectContaining({ index: false })
+        );
+    });
+
+    it('includes canonical URL', () => {
+        expect(metadata.alternates?.canonical).toBe(
+            'https://siglens.io/forgot-password'
+        );
+    });
+});

--- a/src/app/login/__tests__/error.test.tsx
+++ b/src/app/login/__tests__/error.test.tsx
@@ -1,0 +1,54 @@
+vi.mock('next/link', () => ({
+    default: ({
+        children,
+        href,
+    }: {
+        children: React.ReactNode;
+        href: string;
+    }) => <a href={href}>{children}</a>,
+}));
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import LoginError from '@/app/login/error';
+
+describe('LoginError page', () => {
+    it('renders the error heading', () => {
+        render(
+            <LoginError
+                error={Object.assign(new Error('test'), { digest: 'abc' })}
+                reset={vi.fn()}
+            />
+        );
+
+        expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+            '로그인 페이지를 표시할 수 없어요'
+        );
+    });
+
+    it('renders a retry button that calls reset', () => {
+        const mockReset = vi.fn();
+        render(
+            <LoginError
+                error={Object.assign(new Error('test'), { digest: 'abc' })}
+                reset={mockReset}
+            />
+        );
+
+        const retryButton = screen.getByRole('button', { name: '다시 시도' });
+        fireEvent.click(retryButton);
+
+        expect(mockReset).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders a link to the home page', () => {
+        render(
+            <LoginError
+                error={Object.assign(new Error('test'), { digest: 'abc' })}
+                reset={vi.fn()}
+            />
+        );
+
+        const homeLink = screen.getByRole('link', { name: '홈으로' });
+        expect(homeLink).toHaveAttribute('href', '/');
+    });
+});

--- a/src/app/login/__tests__/page.test.ts
+++ b/src/app/login/__tests__/page.test.ts
@@ -1,0 +1,39 @@
+vi.mock('@/shared/ui/auth/AuthCardShell', () => ({
+    AuthCardShell: () => null,
+}));
+vi.mock('@/features/auth-login', () => ({ LoginForm: () => null }));
+vi.mock('@/features/auth-oauth', () => ({
+    SocialLoginButtons: () => null,
+}));
+vi.mock('@/shared/lib/auth/redirect', () => ({
+    sanitizeNextPath: vi.fn().mockReturnValue('/'),
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+vi.mock('next/link', () => ({ default: () => null }));
+
+import { metadata } from '@/app/login/page';
+
+describe('Login page', () => {
+    it('exports metadata with login title', () => {
+        expect(metadata.title).toBe('로그인');
+    });
+
+    it('sets robots to noindex', () => {
+        expect(metadata.robots).toEqual(
+            expect.objectContaining({ index: false })
+        );
+    });
+
+    it('includes canonical URL', () => {
+        expect(metadata.alternates?.canonical).toBe('https://siglens.io/login');
+    });
+
+    it('sets openGraph url', () => {
+        expect(metadata.openGraph).toEqual(
+            expect.objectContaining({ url: 'https://siglens.io/login' })
+        );
+    });
+});

--- a/src/app/market/__tests__/page.test.ts
+++ b/src/app/market/__tests__/page.test.ts
@@ -1,0 +1,91 @@
+vi.mock('@tanstack/react-query', () => ({
+    dehydrate: vi.fn(),
+    HydrationBoundary: () => null,
+    QueryClient: vi.fn().mockImplementation(() => ({
+        prefetchQuery: vi.fn(),
+    })),
+}));
+vi.mock('@/widgets/dashboard/MarketSummaryPanel', () => ({
+    MarketSummaryPanel: () => null,
+}));
+vi.mock('@/widgets/dashboard/MarketSummaryPanelSkeleton', () => ({
+    MarketSummaryPanelSkeleton: () => null,
+}));
+vi.mock('@/widgets/dashboard/SectorSignalPanel', () => ({
+    SectorSignalPanel: () => null,
+}));
+vi.mock('@/widgets/dashboard/SectorSignalPanelSkeleton', () => ({
+    SectorSignalPanelSkeleton: () => null,
+}));
+vi.mock('@/widgets/dashboard/SignalTypeGuide', () => ({
+    SignalTypeGuide: () => null,
+}));
+vi.mock('@/entities/sector-signal/actions', () => ({
+    getSectorSignalsAction: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@/entities/market-summary/actions', () => ({
+    getMarketSummaryAction: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/shared/config/dashboard-tickers', () => ({
+    DASHBOARD_TIMEFRAMES: ['1Day', '1Week'],
+    DEFAULT_DASHBOARD_TIMEFRAME: '1Day',
+    SIGNAL_SECTORS: [
+        { symbol: 'XLK', koreanName: 'AI 반도체', sectorName: 'Technology' },
+    ],
+}));
+vi.mock('@/shared/config/queryConfig', () => ({
+    QUERY_KEYS: { marketSummary: () => ['marketSummary'] },
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    buildBreadcrumbJsonLd: vi.fn().mockReturnValue({}),
+    ROOT_KEYWORDS: ['주식'],
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+vi.mock('@/shared/lib/og', () => ({
+    OG_IMAGE_WIDTH: 1200,
+    OG_IMAGE_HEIGHT: 630,
+}));
+vi.mock('@/shared/ui/JsonLd', () => ({ JsonLd: () => null }));
+
+import { generateMetadata } from '@/app/market/page';
+
+describe('Market page', () => {
+    describe('generateMetadata', () => {
+        it('returns metadata with market title', async () => {
+            const metadata = await generateMetadata({
+                searchParams: Promise.resolve({}),
+            });
+
+            expect(metadata.title).toContain('미국 주식');
+        });
+
+        it('sets canonical to /market', async () => {
+            const metadata = await generateMetadata({
+                searchParams: Promise.resolve({}),
+            });
+
+            expect(metadata.alternates?.canonical).toBe(
+                'https://siglens.io/market'
+            );
+        });
+
+        it('adds noindex for query variant pages', async () => {
+            const metadata = await generateMetadata({
+                searchParams: Promise.resolve({ sector: 'XLK' }),
+            });
+
+            expect(metadata.robots).toEqual(
+                expect.objectContaining({ index: false })
+            );
+        });
+
+        it('does not add noindex for canonical page', async () => {
+            const metadata = await generateMetadata({
+                searchParams: Promise.resolve({}),
+            });
+
+            expect(metadata.robots).toBeUndefined();
+        });
+    });
+});

--- a/src/app/privacy/__tests__/page.test.ts
+++ b/src/app/privacy/__tests__/page.test.ts
@@ -1,0 +1,73 @@
+vi.mock('@/widgets/legal/PolicyMarkdownBody', () => ({
+    PolicyMarkdownBody: () => null,
+}));
+vi.mock('@/widgets/legal/LegalPageShell', () => ({
+    LegalPageShell: () => null,
+}));
+vi.mock('@/shared/ui/JsonLd', () => ({ JsonLd: () => null }));
+vi.mock('@/shared/lib/legal', () => ({
+    formatKoreanDate: vi.fn().mockReturnValue('2025년 1월 1일'),
+    INVESTMENT_DISCLAIMER: 'disclaimer text',
+    PRIVACY_DESCRIPTION: 'privacy desc',
+    PRIVACY_FULL_TITLE: 'Privacy Full Title',
+    PRIVACY_PATH: '/privacy',
+    PRIVACY_TITLE: '개인정보처리방침',
+    TERMS_PATH: '/terms',
+    TERMS_TITLE: '이용약관',
+}));
+vi.mock('@/shared/lib/legal-toc', () => ({
+    extractToc: vi.fn().mockReturnValue([]),
+}));
+vi.mock('@/shared/lib/og', () => ({
+    OG_IMAGE_WIDTH: 1200,
+    OG_IMAGE_HEIGHT: 630,
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    buildBreadcrumbJsonLd: vi.fn().mockReturnValue({}),
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: vi.fn().mockReturnValue({ db: {} }),
+}));
+vi.mock('@/entities/terms', () => ({
+    DrizzleTermsRepository: vi.fn().mockImplementation(() => ({
+        findActive: vi.fn().mockResolvedValue(null),
+    })),
+}));
+vi.mock('next/link', () => ({ default: () => null }));
+vi.mock('next/navigation', () => ({
+    notFound: vi.fn(),
+}));
+
+import { metadata } from '@/app/privacy/page';
+
+describe('Privacy page', () => {
+    it('exports metadata with privacy title', () => {
+        expect(metadata.title).toBe('개인정보처리방침');
+    });
+
+    it('allows indexing', () => {
+        expect(metadata.robots).toEqual(
+            expect.objectContaining({ index: true })
+        );
+    });
+
+    it('includes canonical URL', () => {
+        expect(metadata.alternates?.canonical).toBe(
+            'https://siglens.io/privacy'
+        );
+    });
+
+    it('sets openGraph type to article', () => {
+        expect(metadata.openGraph).toEqual(
+            expect.objectContaining({ type: 'article' })
+        );
+    });
+
+    it('sets twitter card to summary', () => {
+        expect(metadata.twitter).toEqual(
+            expect.objectContaining({ card: 'summary' })
+        );
+    });
+});

--- a/src/app/reset-password/__tests__/page.test.ts
+++ b/src/app/reset-password/__tests__/page.test.ts
@@ -1,0 +1,31 @@
+vi.mock('@/shared/ui/auth/AuthCardShell', () => ({
+    AuthCardShell: () => null,
+}));
+vi.mock('@/features/auth-password-reset', () => ({
+    ResetPasswordForm: () => null,
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+vi.mock('next/link', () => ({ default: () => null }));
+
+import { metadata } from '@/app/reset-password/page';
+
+describe('ResetPassword page', () => {
+    it('exports metadata with reset-password title', () => {
+        expect(metadata.title).toBe('비밀번호 재설정');
+    });
+
+    it('sets robots to noindex', () => {
+        expect(metadata.robots).toEqual(
+            expect.objectContaining({ index: false })
+        );
+    });
+
+    it('includes canonical URL', () => {
+        expect(metadata.alternates?.canonical).toBe(
+            'https://siglens.io/reset-password'
+        );
+    });
+});

--- a/src/app/signup/__tests__/page.test.ts
+++ b/src/app/signup/__tests__/page.test.ts
@@ -1,0 +1,35 @@
+vi.mock('@/shared/ui/auth/AuthCardShell', () => ({
+    AuthCardShell: () => null,
+}));
+vi.mock('@/features/auth-signup', () => ({ SignupForm: () => null }));
+vi.mock('@/features/auth-oauth', () => ({
+    SocialLoginButtons: () => null,
+}));
+vi.mock('@/shared/lib/auth/redirect', () => ({
+    sanitizeNextPath: vi.fn().mockReturnValue('/'),
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+vi.mock('next/link', () => ({ default: () => null }));
+
+import { metadata } from '@/app/signup/page';
+
+describe('Signup page', () => {
+    it('exports metadata with signup title', () => {
+        expect(metadata.title).toBe('회원가입');
+    });
+
+    it('sets robots to noindex', () => {
+        expect(metadata.robots).toEqual(
+            expect.objectContaining({ index: false })
+        );
+    });
+
+    it('includes canonical URL', () => {
+        expect(metadata.alternates?.canonical).toBe(
+            'https://siglens.io/signup'
+        );
+    });
+});

--- a/src/app/signup/oauth/consent/__tests__/page.test.ts
+++ b/src/app/signup/oauth/consent/__tests__/page.test.ts
@@ -1,0 +1,46 @@
+vi.mock('@/shared/ui/auth/AuthCardShell', () => ({
+    AuthCardShell: () => null,
+}));
+vi.mock('@/features/auth-oauth-consent', () => ({
+    OAuthConsentForm: () => null,
+}));
+vi.mock('@/entities/oauth-account', () => ({
+    createPendingOAuthSignupStoreFromEnv: vi.fn(),
+}));
+vi.mock('@/features/auth-oauth/actions', () => ({
+    cancelOAuthSignupAction: vi.fn(),
+}));
+vi.mock('@/entities/session', () => ({
+    OAUTH_ERROR_REDIRECT: {
+        consentInvalid: '/login?error=oauth_consent_invalid',
+        serviceUnavailable: '/login?error=service_unavailable',
+        consentExpired: '/login?error=oauth_consent_expired',
+    },
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+vi.mock('next/navigation', () => ({
+    redirect: vi.fn(),
+}));
+
+import { metadata } from '@/app/signup/oauth/consent/page';
+
+describe('OAuth consent page', () => {
+    it('exports metadata with consent title', () => {
+        expect(metadata.title).toBe('소셜 로그인 가입 동의');
+    });
+
+    it('sets robots to noindex, nofollow', () => {
+        expect(metadata.robots).toEqual(
+            expect.objectContaining({ index: false, follow: false })
+        );
+    });
+
+    it('includes canonical URL', () => {
+        expect(metadata.alternates?.canonical).toBe(
+            'https://siglens.io/signup/oauth/consent'
+        );
+    });
+});

--- a/src/app/terms/__tests__/page.test.ts
+++ b/src/app/terms/__tests__/page.test.ts
@@ -1,0 +1,68 @@
+vi.mock('@/widgets/legal/PolicyMarkdownBody', () => ({
+    PolicyMarkdownBody: () => null,
+}));
+vi.mock('@/widgets/legal/LegalPageShell', () => ({
+    LegalPageShell: () => null,
+}));
+vi.mock('@/shared/ui/JsonLd', () => ({ JsonLd: () => null }));
+vi.mock('@/shared/lib/legal', () => ({
+    formatKoreanDate: vi.fn().mockReturnValue('2025년 1월 1일'),
+    INVESTMENT_DISCLAIMER: 'disclaimer text',
+    TERMS_DESCRIPTION: 'terms desc',
+    TERMS_FULL_TITLE: 'Terms Full Title',
+    TERMS_PATH: '/terms',
+    TERMS_TITLE: '이용약관',
+}));
+vi.mock('@/shared/lib/legal-toc', () => ({
+    extractToc: vi.fn().mockReturnValue([]),
+}));
+vi.mock('@/shared/lib/og', () => ({
+    OG_IMAGE_WIDTH: 1200,
+    OG_IMAGE_HEIGHT: 630,
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    buildBreadcrumbJsonLd: vi.fn().mockReturnValue({}),
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: vi.fn().mockReturnValue({ db: {} }),
+}));
+vi.mock('@/entities/terms', () => ({
+    DrizzleTermsRepository: vi.fn().mockImplementation(() => ({
+        findActive: vi.fn().mockResolvedValue(null),
+    })),
+}));
+vi.mock('next/navigation', () => ({
+    notFound: vi.fn(),
+}));
+
+import { metadata } from '@/app/terms/page';
+
+describe('Terms page', () => {
+    it('exports metadata with terms title', () => {
+        expect(metadata.title).toBe('이용약관');
+    });
+
+    it('allows indexing', () => {
+        expect(metadata.robots).toEqual(
+            expect.objectContaining({ index: true })
+        );
+    });
+
+    it('includes canonical URL', () => {
+        expect(metadata.alternates?.canonical).toBe('https://siglens.io/terms');
+    });
+
+    it('sets openGraph type to article', () => {
+        expect(metadata.openGraph).toEqual(
+            expect.objectContaining({ type: 'article' })
+        );
+    });
+
+    it('sets twitter card to summary', () => {
+        expect(metadata.twitter).toEqual(
+            expect.objectContaining({ card: 'summary' })
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- app 레이어 35개 파일 테스트 작성
- API route handlers, pages, OG/Twitter images, loading states, special files 커버

## Breakdown
| Category | Files |
|---|---|
| API routes | 6 (auth/start, jobs/cancel, sitemap x4) |
| Pages | 12 (home, market, backtesting, login, signup, etc.) |
| Symbol pages | 3 (page, fundamentalData, SymbolLayoutClient) |
| OG/Twitter images | 6 test files (12 image files) |
| Special files | 8 (manifest, robots, not-found, providers, etc.) |

## Test plan
- [x] `yarn test` — all suites pass
- [x] `tsc --noEmit` — 0 errors
- [x] `yarn lint` — 0 errors
- [x] `yarn format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)