### PR TITLE
test(worst-case): add 27 error/edge-case tests

### DIFF
--- a/src/__tests__/worst-case/aiMalformedJsonResponse.test.ts
+++ b/src/__tests__/worst-case/aiMalformedJsonResponse.test.ts
@@ -1,0 +1,91 @@
+import {
+    parseJsonResponse,
+    stripMarkdownCodeBlock,
+} from '@/entities/llm-provider/lib/parseJsonResponse';
+
+describe('parseJsonResponse malformed JSON handling', () => {
+    it('parses valid JSON directly', () => {
+        const result = parseJsonResponse('{"key": "value"}', 'test');
+        expect(result).toEqual({ key: 'value' });
+    });
+
+    it('strips markdown code fence before parsing', () => {
+        const wrapped = '```json\n{"key": "value"}\n```';
+        const result = parseJsonResponse(wrapped, 'test');
+        expect(result).toEqual({ key: 'value' });
+    });
+
+    it('strips code fence without json language tag', () => {
+        const wrapped = '```\n{"key": "value"}\n```';
+        const result = parseJsonResponse(wrapped, 'test');
+        expect(result).toEqual({ key: 'value' });
+    });
+
+    it('repairs trailing comma via jsonrepair', () => {
+        const broken = '{"key": "value",}';
+        const result = parseJsonResponse(broken, 'test');
+        expect(result).toEqual({ key: 'value' });
+    });
+
+    it('repairs unquoted keys via jsonrepair', () => {
+        const broken = '{key: "value"}';
+        const result = parseJsonResponse(broken, 'test');
+        expect(result).toEqual({ key: 'value' });
+    });
+
+    it('throws for completely invalid non-JSON-shaped text', () => {
+        expect(() =>
+            parseJsonResponse('This is just plain text', 'test')
+        ).toThrow('Failed to parse test response as JSON');
+    });
+
+    it('throws for truncated JSON that jsonrepair cannot fix', () => {
+        expect(() => parseJsonResponse('{{{{{{{{{', 'test')).toThrow(
+            'Failed to parse test response as JSON'
+        );
+    });
+
+    it('preserves cause in thrown error', () => {
+        let caught: unknown;
+        try {
+            parseJsonResponse('not json at all!!!', 'analysis');
+        } catch (err) {
+            caught = err;
+        }
+        expect(caught).toBeInstanceOf(Error);
+        expect((caught as Error).message).toContain(
+            'Failed to parse analysis response'
+        );
+    });
+
+    it('handles empty string input', () => {
+        expect(() => parseJsonResponse('', 'test')).toThrow(
+            'Failed to parse test response'
+        );
+    });
+
+    it('parses array JSON', () => {
+        const result = parseJsonResponse('[1, 2, 3]', 'test');
+        expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('handles JSON inside markdown with extra whitespace', () => {
+        const input = '  ```json\n  {"a": 1}  \n```  ';
+        const result = parseJsonResponse(input, 'test');
+        expect(result).toEqual({ a: 1 });
+    });
+});
+
+describe('stripMarkdownCodeBlock', () => {
+    it('returns trimmed text when no code block present', () => {
+        expect(stripMarkdownCodeBlock('  hello  ')).toBe('hello');
+    });
+
+    it('extracts content from fenced block', () => {
+        expect(stripMarkdownCodeBlock('```\ninner\n```')).toBe('inner');
+    });
+
+    it('extracts content from json-tagged block', () => {
+        expect(stripMarkdownCodeBlock('```json\n{"a":1}\n```')).toBe('{"a":1}');
+    });
+});

--- a/src/__tests__/worst-case/aiRateLimit.test.ts
+++ b/src/__tests__/worst-case/aiRateLimit.test.ts
@@ -1,0 +1,100 @@
+const mockAnthropicFinalMessage = vi.fn();
+const mockOpenaiCreate = vi.fn();
+const mockGeminiGenerate = vi.fn();
+
+vi.mock('@anthropic-ai/sdk', () => ({
+    default: class MockAnthropic {
+        messages = {
+            stream: () => ({ finalMessage: mockAnthropicFinalMessage }),
+        };
+    },
+}));
+
+vi.mock('openai', () => ({
+    default: class MockOpenAI {
+        responses = { create: mockOpenaiCreate };
+    },
+}));
+
+vi.mock('@google/genai', () => ({
+    GoogleGenAI: class MockGoogleGenAI {
+        models = { generateContent: mockGeminiGenerate };
+    },
+}));
+
+vi.mock('@y0ngha/siglens-core', () => ({
+    MODEL_SPECS: {
+        'claude-haiku-4-5': {
+            apiModelId: 'claude-haiku-4-5-20251001',
+            provider: 'anthropic',
+            maxOutputTokens: 8192,
+            temperature: 1.0,
+        },
+        'gpt-4.1-mini': {
+            apiModelId: 'gpt-4.1-mini',
+            provider: 'openai',
+            maxOutputTokens: 16384,
+            temperature: 1.0,
+        },
+        'gemini-2.5-flash': {
+            apiModelId: 'gemini-2.5-flash',
+            provider: 'google',
+            maxOutputTokens: 8192,
+            temperature: 1.0,
+        },
+    },
+    getProviderForModel: (model: string) => {
+        const map: Record<string, string> = {
+            'claude-haiku-4-5': 'anthropic',
+            'gpt-4.1-mini': 'openai',
+            'gemini-2.5-flash': 'google',
+        };
+        return map[model];
+    },
+}));
+
+import { callAiProviderRouter } from '@/entities/llm-provider/api/router';
+
+const BASE = {
+    serverApiKey: 'key',
+    userApiKey: undefined,
+    contents: 'test',
+};
+
+function create429Error(provider: string): Error {
+    const err = new Error(`${provider} 429 Rate limit exceeded`);
+    (err as Error & { status: number }).status = 429;
+    return err;
+}
+
+describe('AI provider 429 rate limit errors', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('propagates 429 from Anthropic', async () => {
+        mockAnthropicFinalMessage.mockRejectedValue(
+            create429Error('Anthropic')
+        );
+
+        await expect(
+            callAiProviderRouter({ ...BASE, model: 'claude-haiku-4-5' })
+        ).rejects.toThrow('429');
+    });
+
+    it('propagates 429 from OpenAI', async () => {
+        mockOpenaiCreate.mockRejectedValue(create429Error('OpenAI'));
+
+        await expect(
+            callAiProviderRouter({ ...BASE, model: 'gpt-4.1-mini' })
+        ).rejects.toThrow('429');
+    });
+
+    it('propagates 429 from Gemini', async () => {
+        mockGeminiGenerate.mockRejectedValue(create429Error('Gemini'));
+
+        await expect(
+            callAiProviderRouter({ ...BASE, model: 'gemini-2.5-flash' })
+        ).rejects.toThrow('429');
+    });
+});

--- a/src/__tests__/worst-case/aiSlowResponse.test.ts
+++ b/src/__tests__/worst-case/aiSlowResponse.test.ts
@@ -1,0 +1,134 @@
+const mockAnthropicFinalMessage = vi.fn();
+const mockOpenaiCreate = vi.fn();
+
+vi.mock('@anthropic-ai/sdk', () => ({
+    default: class MockAnthropic {
+        messages = {
+            stream: () => ({ finalMessage: mockAnthropicFinalMessage }),
+        };
+    },
+}));
+
+vi.mock('openai', () => ({
+    default: class MockOpenAI {
+        responses = { create: mockOpenaiCreate };
+    },
+}));
+
+vi.mock('@y0ngha/siglens-core', () => ({
+    MODEL_SPECS: {
+        'claude-haiku-4-5': {
+            apiModelId: 'claude-haiku-4-5-20251001',
+            provider: 'anthropic',
+            maxOutputTokens: 8192,
+            temperature: 1.0,
+        },
+        'gpt-4.1-mini': {
+            apiModelId: 'gpt-4.1-mini',
+            provider: 'openai',
+            maxOutputTokens: 16384,
+            temperature: 1.0,
+        },
+    },
+    getProviderForModel: (model: string) => {
+        const map: Record<string, string> = {
+            'claude-haiku-4-5': 'anthropic',
+            'gpt-4.1-mini': 'openai',
+        };
+        return map[model];
+    },
+    pollAnalysis: vi.fn(),
+}));
+
+vi.mock('@vercel/functions', () => ({
+    waitUntil: vi.fn(),
+}));
+
+import { callAiProviderRouter } from '@/entities/llm-provider/api/router';
+import { pollAnalysisAction } from '@/entities/analysis/actions/pollAnalysisAction';
+import { pollAnalysis } from '@y0ngha/siglens-core';
+
+const mockPollAnalysis = pollAnalysis as ReturnType<typeof vi.fn>;
+
+describe('AI slow response and timeout handling', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('Anthropic timeout error is propagated to caller', async () => {
+        mockAnthropicFinalMessage.mockRejectedValue(
+            new Error('Request timed out after 10000ms')
+        );
+
+        await expect(
+            callAiProviderRouter({
+                serverApiKey: 'test-key',
+                userApiKey: undefined,
+                model: 'claude-haiku-4-5',
+                contents: 'Hello',
+            })
+        ).rejects.toThrow('Request timed out');
+    });
+
+    it('OpenAI timeout error is propagated to caller', async () => {
+        mockOpenaiCreate.mockRejectedValue(
+            new Error('Request timed out after 30000ms')
+        );
+
+        await expect(
+            callAiProviderRouter({
+                serverApiKey: 'test-key',
+                userApiKey: undefined,
+                model: 'gpt-4.1-mini',
+                contents: 'Hello',
+            })
+        ).rejects.toThrow('Request timed out');
+    });
+
+    it('Anthropic connection error is propagated', async () => {
+        mockAnthropicFinalMessage.mockRejectedValue(
+            new Error('Connection error')
+        );
+
+        await expect(
+            callAiProviderRouter({
+                serverApiKey: 'test-key',
+                userApiKey: undefined,
+                model: 'claude-haiku-4-5',
+                contents: 'Hello',
+            })
+        ).rejects.toThrow('Connection error');
+    });
+
+    describe('pollAnalysisAction', () => {
+        it('returns error status from core', async () => {
+            mockPollAnalysis.mockResolvedValue({
+                status: 'error',
+                message: 'Analysis failed',
+            });
+
+            const result = await pollAnalysisAction('job-123');
+
+            expect(result.status).toBe('error');
+        });
+
+        it('returns pending status while processing', async () => {
+            mockPollAnalysis.mockResolvedValue({ status: 'pending' });
+
+            const result = await pollAnalysisAction('job-456');
+
+            expect(result.status).toBe('pending');
+        });
+
+        it('returns completed result with data', async () => {
+            mockPollAnalysis.mockResolvedValue({
+                status: 'completed',
+                data: { summary: 'test' },
+            });
+
+            const result = await pollAnalysisAction('job-789');
+
+            expect(result.status).toBe('completed');
+        });
+    });
+});

--- a/src/__tests__/worst-case/analysisMissingFields.test.ts
+++ b/src/__tests__/worst-case/analysisMissingFields.test.ts
@@ -1,0 +1,95 @@
+import {
+    parseStructuredSummary,
+    MIN_STRUCTURED_SUMMARY_SECTIONS,
+} from '@/widgets/analysis/utils/parseStructuredSummary';
+
+describe('parseStructuredSummary missing fields', () => {
+    it('returns null when summary is empty string', () => {
+        expect(parseStructuredSummary('')).toBeNull();
+    });
+
+    it('returns null when summary has no structured sections', () => {
+        const plainText = 'This is just regular text without any bold labels.';
+        expect(parseStructuredSummary(plainText)).toBeNull();
+    });
+
+    it('returns null when fewer than minimum sections', () => {
+        const twoSections = '**Label1**: value1\n**Label2**: value2';
+        expect(parseStructuredSummary(twoSections)).toBeNull();
+        expect(MIN_STRUCTURED_SUMMARY_SECTIONS).toBe(3);
+    });
+
+    it('parses valid structured summary with enough sections', () => {
+        const valid = [
+            '**종합 의견**: 매수',
+            '**신뢰도**: 높음',
+            '**핵심 포인트**: 상승 추세 유지',
+        ].join('\n');
+
+        const result = parseStructuredSummary(valid);
+
+        expect(result).not.toBeNull();
+        expect(result).toHaveLength(3);
+        expect(result![0]).toEqual({ label: '종합 의견', value: '매수' });
+    });
+
+    it('filters out non-structured lines mixed with structured ones', () => {
+        const mixed = [
+            '**Label1**: value1',
+            'plain text line',
+            '**Label2**: value2',
+            '',
+            '**Label3**: value3',
+        ].join('\n');
+
+        const result = parseStructuredSummary(mixed);
+
+        expect(result).not.toBeNull();
+        expect(result).toHaveLength(3);
+    });
+
+    it('handles short value after label', () => {
+        const withShortValue = [
+            '**Label1**: a',
+            '**Label2**: value2',
+            '**Label3**: value3',
+        ].join('\n');
+
+        const result = parseStructuredSummary(withShortValue);
+
+        expect(result).not.toBeNull();
+        expect(result![0].value).toBe('a');
+    });
+
+    it('returns null when all lines are blank', () => {
+        expect(parseStructuredSummary('\n\n\n')).toBeNull();
+    });
+
+    it('handles multiline sections (only first line matched)', () => {
+        const multiline = [
+            '**Label1**: start of value',
+            'continuation of value',
+            '**Label2**: value2',
+            '**Label3**: value3',
+        ].join('\n');
+
+        const result = parseStructuredSummary(multiline);
+
+        expect(result).not.toBeNull();
+        expect(result).toHaveLength(3);
+        expect(result![0].value).toBe('start of value');
+    });
+
+    it('handles label with special characters', () => {
+        const special = [
+            '**Key Levels (지지/저항)**: $150, $175',
+            '**RSI (14)**: 65.2',
+            '**MACD**: 상승 크로스',
+        ].join('\n');
+
+        const result = parseStructuredSummary(special);
+
+        expect(result).not.toBeNull();
+        expect(result).toHaveLength(3);
+    });
+});

--- a/src/__tests__/worst-case/assetInfoDegradation.test.ts
+++ b/src/__tests__/worst-case/assetInfoDegradation.test.ts
@@ -1,0 +1,151 @@
+vi.mock('@vercel/functions', () => ({
+    waitUntil: vi.fn((p: Promise<unknown>) => p.catch(() => {})),
+}));
+
+const mockCacheGet = vi.fn();
+const mockCacheSet = vi.fn();
+const mockCreateCacheProvider = vi.fn();
+
+vi.mock('@y0ngha/siglens-core', () => ({
+    createCacheProvider: (...args: unknown[]) =>
+        mockCreateCacheProvider(...args),
+}));
+
+vi.mock('@/entities/ticker/lib/ticker', () => ({
+    isValidTickerFormat: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('@/entities/ticker/api', () => ({
+    DrizzleAssetTranslationRepository: vi.fn(),
+}));
+
+vi.mock('@/entities/ticker/lib/db', () => ({
+    tryGetTickerDatabaseClient: vi.fn().mockReturnValue(null),
+}));
+
+const mockSearchBySymbol = vi.fn().mockResolvedValue([]);
+const mockFilterUsExchanges = vi.fn().mockReturnValue([]);
+
+vi.mock('@/entities/ticker/lib/fmpTickerApi', () => ({
+    searchBySymbol: (...args: unknown[]) => mockSearchBySymbol(...args),
+    filterUsExchanges: (...args: unknown[]) => mockFilterUsExchanges(...args),
+}));
+
+vi.mock('@/entities/ticker/lib/koreanNameStore', () => ({
+    getKoreanNames: vi.fn().mockResolvedValue({}),
+    setKoreanTickers: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/entities/ticker/lib/koreanTranslator', () => ({
+    translateCompanyNames: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@/entities/ticker/lib/cacheKeys', () => ({
+    buildAssetInfoCacheKey: vi.fn((s: string) => `asset:${s}`),
+    ASSET_INFO_CACHE_TTL_WITH_KOREAN: 86400,
+    ASSET_INFO_CACHE_TTL_WITHOUT_KOREAN: 43200,
+}));
+
+import {
+    getAssetInfo,
+    _resetInFlightTranslationsForTest,
+} from '@/entities/ticker/lib/getAssetInfo';
+
+describe('getAssetInfo degradation chain', () => {
+    beforeEach(() => {
+        _resetInFlightTranslationsForTest();
+        mockCreateCacheProvider.mockReturnValue(null);
+        mockSearchBySymbol.mockResolvedValue([]);
+        mockFilterUsExchanges.mockReturnValue([]);
+        mockCacheGet.mockResolvedValue(null);
+        mockCacheSet.mockResolvedValue(undefined);
+    });
+
+    it('returns null when cache, DB, and FMP all return nothing', async () => {
+        const result = await getAssetInfo('AAPL');
+
+        expect(result).toBeNull();
+    });
+
+    it('returns null for invalid ticker format', async () => {
+        const { isValidTickerFormat } =
+            await import('@/entities/ticker/lib/ticker');
+        (isValidTickerFormat as ReturnType<typeof vi.fn>).mockReturnValue(
+            false
+        );
+
+        const result = await getAssetInfo('!!!');
+
+        expect(result).toBeNull();
+
+        (isValidTickerFormat as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    });
+
+    it('falls through to FMP when cache read throws', async () => {
+        mockCreateCacheProvider.mockReturnValue({
+            get: vi.fn().mockRejectedValue(new Error('Redis down')),
+            set: vi.fn().mockResolvedValue(undefined),
+        });
+        const fmpResults = [
+            {
+                symbol: 'AAPL',
+                name: 'Apple Inc.',
+                exchange: 'NASDAQ',
+                exchangeFullName: 'NASDAQ Global Select Market',
+            },
+        ];
+        mockSearchBySymbol.mockResolvedValue(fmpResults);
+        mockFilterUsExchanges.mockReturnValue(fmpResults);
+
+        const result = await getAssetInfo('AAPL');
+
+        expect(result).not.toBeNull();
+        expect(result?.symbol).toBe('AAPL');
+    });
+
+    it('logs warning when cache write fails (best-effort)', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        mockCreateCacheProvider.mockReturnValue({
+            get: vi.fn().mockResolvedValue(null),
+            set: vi.fn().mockRejectedValue(new Error('Redis write failed')),
+        });
+        const fmpResults = [
+            {
+                symbol: 'TSLA',
+                name: 'Tesla Inc.',
+                exchange: 'NASDAQ',
+                exchangeFullName: 'NASDAQ',
+            },
+        ];
+        mockSearchBySymbol.mockResolvedValue(fmpResults);
+        mockFilterUsExchanges.mockReturnValue(fmpResults);
+
+        const result = await getAssetInfo('TSLA');
+
+        expect(result).not.toBeNull();
+        await vi.waitFor(() => {
+            expect(warnSpy).toHaveBeenCalledWith(
+                '[getAssetInfo] cache write failed',
+                expect.any(Error)
+            );
+        });
+    });
+
+    it('returns cached data when available', async () => {
+        const cachedInfo = {
+            symbol: 'MSFT',
+            name: 'Microsoft Corporation',
+            koreanName: '마이크로소프트',
+        };
+        mockCreateCacheProvider.mockReturnValue({
+            get: vi.fn().mockResolvedValue(cachedInfo),
+            set: vi.fn(),
+        });
+
+        mockSearchBySymbol.mockClear();
+        const result = await getAssetInfo('MSFT');
+
+        expect(result).toEqual(cachedInfo);
+        expect(mockSearchBySymbol).not.toHaveBeenCalled();
+    });
+});

--- a/src/__tests__/worst-case/authHintCookieFailure.test.ts
+++ b/src/__tests__/worst-case/authHintCookieFailure.test.ts
@@ -1,0 +1,135 @@
+vi.mock('next/headers', () => ({
+    cookies: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+    redirect: vi.fn((url: string) => {
+        throw new Error(`NEXT_REDIRECT:${url}`);
+    }),
+}));
+
+vi.mock('@/entities/session', () => ({
+    DrizzleSessionRepository: vi.fn(),
+    bcryptPasswordVerifier: { verifyPassword: vi.fn() },
+    applyAuthCookie: vi.fn((cookie: unknown) => cookie),
+    getAuthDatabaseClient: vi.fn(() => ({ db: {} })),
+    isSecureCookieEnv: vi.fn(() => false),
+    createAuthHintCookie: vi.fn(() => ({
+        name: 'siglens_auth_hint',
+        value: '1',
+    })),
+    DEFAULT_SESSION_TTL_SECONDS: 604800,
+}));
+
+vi.mock('@/entities/user', () => ({
+    DrizzleUserRepository: vi.fn(),
+    loginUser: vi.fn(),
+}));
+
+vi.mock('@/shared/lib/auth/redirect', () => ({
+    sanitizeNextPath: vi.fn((path?: string) => path ?? '/'),
+}));
+
+vi.mock('@/shared/lib/auth/validation', () => ({
+    normalizeEmail: vi.fn((e: string) => e.toLowerCase().trim()),
+}));
+
+import { loginAction } from '@/features/auth-login/actions/loginAction';
+import { loginUser } from '@/entities/user';
+import { cookies } from 'next/headers';
+import type { LoginFormState } from '@/shared/lib/auth/formTypes';
+
+const mockLoginUser = loginUser as ReturnType<typeof vi.fn>;
+const mockCookies = cookies as ReturnType<typeof vi.fn>;
+
+const INITIAL_STATE: LoginFormState = { error: null };
+
+function createFormData(fields: Record<string, string>): FormData {
+    const fd = new FormData();
+    for (const [k, v] of Object.entries(fields)) {
+        fd.set(k, v);
+    }
+    return fd;
+}
+
+describe('loginAction auth hint cookie failure', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns error state when loginUser fails', async () => {
+        mockLoginUser.mockResolvedValue({
+            ok: false,
+            error: { code: 'invalid_credentials', message: 'Wrong password' },
+        });
+
+        const result = await loginAction(
+            INITIAL_STATE,
+            createFormData({ email: 'test@test.com', password: 'wrong' })
+        );
+
+        expect(result.error?.code).toBe('invalid_credentials');
+    });
+
+    it('catches unexpected errors and returns generic error', async () => {
+        const errorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+        mockLoginUser.mockRejectedValue(new Error('DB connection lost'));
+
+        const result = await loginAction(
+            INITIAL_STATE,
+            createFormData({ email: 'test@test.com', password: 'password' })
+        );
+
+        expect(result.error?.code).toBe('unexpected');
+        expect(errorSpy).toHaveBeenCalledWith(
+            '[loginAction] unexpected error:',
+            expect.any(Error)
+        );
+    });
+
+    it('re-throws NEXT_REDIRECT error (redirect after success)', async () => {
+        mockLoginUser.mockResolvedValue({
+            ok: true,
+            user: { id: '1' },
+            session: { id: 's1' },
+            cookie: { name: 'session', value: 'tok', httpOnly: true },
+        });
+
+        const mockSet = vi.fn();
+        mockCookies.mockResolvedValue({ set: mockSet });
+
+        await expect(
+            loginAction(
+                INITIAL_STATE,
+                createFormData({ email: 'test@test.com', password: 'pass123' })
+            )
+        ).rejects.toThrow('NEXT_REDIRECT');
+    });
+
+    it('sets both auth cookie and hint cookie on success', async () => {
+        mockLoginUser.mockResolvedValue({
+            ok: true,
+            user: { id: '1' },
+            session: { id: 's1' },
+            cookie: { name: 'session', value: 'tok', httpOnly: true },
+        });
+
+        const setCalls: unknown[] = [];
+        mockCookies.mockResolvedValue({
+            set: vi.fn((...args: unknown[]) => setCalls.push(args)),
+        });
+
+        try {
+            await loginAction(
+                INITIAL_STATE,
+                createFormData({ email: 'test@test.com', password: 'pass123' })
+            );
+        } catch {
+            // NEXT_REDIRECT expected
+        }
+
+        expect(setCalls).toHaveLength(2);
+    });
+});

--- a/src/__tests__/worst-case/authHintCookieFailure.test.ts
+++ b/src/__tests__/worst-case/authHintCookieFailure.test.ts
@@ -52,7 +52,7 @@ function createFormData(fields: Record<string, string>): FormData {
     return fd;
 }
 
-describe('loginAction auth hint cookie failure', () => {
+describe('loginAction error handling and cookie behavior', () => {
     afterEach(() => {
         vi.clearAllMocks();
     });

--- a/src/__tests__/worst-case/backgroundTranslation.test.ts
+++ b/src/__tests__/worst-case/backgroundTranslation.test.ts
@@ -1,0 +1,144 @@
+vi.mock('@/entities/llm-provider', () => ({
+    callGeminiChat: vi.fn(),
+    parseJsonResponse: vi.fn(),
+}));
+
+vi.mock('@/entities/ticker/lib/config', () => ({
+    tryReadTranslatorConfig: vi.fn(),
+}));
+
+import {
+    translateCompanyNames,
+    translateCompanyDescription,
+} from '@/entities/ticker/lib/koreanTranslator';
+import { callGeminiChat, parseJsonResponse } from '@/entities/llm-provider';
+import { tryReadTranslatorConfig } from '@/entities/ticker/lib/config';
+
+const mockCallGemini = callGeminiChat as ReturnType<typeof vi.fn>;
+const mockParseJson = parseJsonResponse as ReturnType<typeof vi.fn>;
+const mockReadConfig = tryReadTranslatorConfig as ReturnType<typeof vi.fn>;
+
+const CONFIG = {
+    apiKey: 'test-key',
+    freeApiKey: 'free-key',
+    model: 'gemini-2.5-flash',
+};
+
+describe('Background translation failure handling', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('translateCompanyNames', () => {
+        it('returns empty object when Gemini fails', async () => {
+            mockReadConfig.mockReturnValue(CONFIG);
+            mockCallGemini.mockRejectedValue(new Error('Gemini 500'));
+
+            const result = await translateCompanyNames([
+                { symbol: 'AAPL', name: 'Apple Inc.' },
+            ]);
+
+            expect(result).toEqual({});
+        });
+
+        it('returns empty object when config is unavailable', async () => {
+            mockReadConfig.mockReturnValue(null);
+
+            const result = await translateCompanyNames([
+                { symbol: 'AAPL', name: 'Apple Inc.' },
+            ]);
+
+            expect(result).toEqual({});
+        });
+
+        it('returns empty object for empty entries', async () => {
+            const result = await translateCompanyNames([]);
+
+            expect(result).toEqual({});
+        });
+
+        it('returns translations when Gemini succeeds', async () => {
+            mockReadConfig.mockReturnValue(CONFIG);
+            mockCallGemini.mockResolvedValue('{"AAPL":"애플"}');
+            mockParseJson.mockReturnValue({ AAPL: '애플' });
+
+            const result = await translateCompanyNames([
+                { symbol: 'AAPL', name: 'Apple Inc.' },
+            ]);
+
+            expect(result).toEqual({ AAPL: '애플' });
+        });
+
+        it('returns empty object when parseJsonResponse returns non-string-record', async () => {
+            mockReadConfig.mockReturnValue(CONFIG);
+            mockCallGemini.mockResolvedValue('[1,2,3]');
+            mockParseJson.mockReturnValue([1, 2, 3]);
+
+            const result = await translateCompanyNames([
+                { symbol: 'AAPL', name: 'Apple Inc.' },
+            ]);
+
+            expect(result).toEqual({});
+        });
+
+        it('falls back to primary key when free key fails', async () => {
+            mockReadConfig.mockReturnValue(CONFIG);
+            mockCallGemini
+                .mockRejectedValueOnce(new Error('Free key quota exceeded'))
+                .mockResolvedValueOnce('{"AAPL":"애플"}');
+            mockParseJson.mockReturnValue({ AAPL: '애플' });
+
+            const result = await translateCompanyNames([
+                { symbol: 'AAPL', name: 'Apple Inc.' },
+            ]);
+
+            expect(result).toEqual({ AAPL: '애플' });
+            expect(mockCallGemini).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('translateCompanyDescription', () => {
+        it('returns null when Gemini fails', async () => {
+            mockReadConfig.mockReturnValue(CONFIG);
+            mockCallGemini.mockRejectedValue(new Error('API error'));
+
+            const result = await translateCompanyDescription(
+                'Apple makes iPhones'
+            );
+
+            expect(result).toBeNull();
+        });
+
+        it('returns null when config is unavailable', async () => {
+            mockReadConfig.mockReturnValue(null);
+
+            const result = await translateCompanyDescription(
+                'Apple makes iPhones'
+            );
+
+            expect(result).toBeNull();
+        });
+
+        it('returns translated text on success', async () => {
+            mockReadConfig.mockReturnValue(CONFIG);
+            mockCallGemini.mockResolvedValue('애플은 아이폰을 만듭니다');
+
+            const result = await translateCompanyDescription(
+                'Apple makes iPhones'
+            );
+
+            expect(result).toBe('애플은 아이폰을 만듭니다');
+        });
+
+        it('returns null for empty response', async () => {
+            mockReadConfig.mockReturnValue(CONFIG);
+            mockCallGemini.mockResolvedValue('   ');
+
+            const result = await translateCompanyDescription(
+                'Apple makes iPhones'
+            );
+
+            expect(result).toBeNull();
+        });
+    });
+});

--- a/src/__tests__/worst-case/cacheWriteFailure.test.ts
+++ b/src/__tests__/worst-case/cacheWriteFailure.test.ts
@@ -1,0 +1,112 @@
+vi.mock('@vercel/functions', () => ({
+    waitUntil: vi.fn((p: Promise<unknown>) => p.catch(() => {})),
+}));
+
+vi.mock('@y0ngha/siglens-core', () => ({
+    createCacheProvider: vi.fn(),
+}));
+
+vi.mock('@/entities/ticker/lib/ticker', () => ({
+    isValidTickerFormat: vi.fn().mockReturnValue(true),
+    deduplicateResults: vi.fn((arr: unknown[]) => arr),
+    isKoreanInput: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/entities/ticker/api', () => ({
+    DrizzleAssetTranslationRepository: vi.fn(),
+}));
+
+vi.mock('@/entities/ticker/lib/db', () => ({
+    tryGetTickerDatabaseClient: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('@/entities/ticker/lib/fmpTickerApi', () => ({
+    searchBySymbol: vi.fn().mockResolvedValue([]),
+    searchByName: vi.fn().mockResolvedValue([]),
+    filterUsExchanges: vi.fn().mockReturnValue([]),
+    toTickerSearchResult: vi.fn((r: unknown) => r),
+}));
+
+vi.mock('@/entities/ticker/lib/koreanNameStore', () => ({
+    getKoreanNames: vi.fn().mockResolvedValue({}),
+    setKoreanTickers: vi.fn().mockResolvedValue(undefined),
+    searchByKoreanName: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/entities/ticker/lib/koreanTranslator', () => ({
+    translateCompanyNames: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@/entities/ticker/lib/cacheKeys', () => ({
+    buildTickerSearchCacheKey: vi.fn((q: string) => `search:${q}`),
+    TICKER_SEARCH_CACHE_TTL: 300,
+    buildAssetInfoCacheKey: vi.fn((s: string) => `asset:${s}`),
+    ASSET_INFO_CACHE_TTL_WITH_KOREAN: 86400,
+    ASSET_INFO_CACHE_TTL_WITHOUT_KOREAN: 43200,
+}));
+
+vi.mock('@/entities/ticker/lib/backgroundTask', () => ({
+    fireAndForget: vi.fn((p: Promise<unknown>) => p.catch(() => {})),
+}));
+
+import {
+    searchTicker,
+    _resetInFlightTranslationsForTest,
+} from '@/entities/ticker/lib/searchTicker';
+import { createCacheProvider } from '@y0ngha/siglens-core';
+
+const mockCreateCacheProvider = createCacheProvider as ReturnType<typeof vi.fn>;
+
+describe('Cache write failure degrades gracefully', () => {
+    beforeEach(() => {
+        _resetInFlightTranslationsForTest();
+        vi.clearAllMocks();
+    });
+
+    it('logs warning when cache set fails but still returns results', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const mockCache = {
+            get: vi.fn().mockResolvedValue(null),
+            set: vi.fn().mockRejectedValue(new Error('Redis unavailable')),
+        };
+        mockCreateCacheProvider.mockReturnValue(mockCache);
+
+        const result = await searchTicker('AAPL');
+
+        expect(result).toEqual([]);
+        await vi.waitFor(() => {
+            expect(warnSpy).toHaveBeenCalledWith(
+                '[searchTicker] cache write failed',
+                expect.any(Error)
+            );
+        });
+    });
+
+    it('returns results when cache is null (provider unavailable)', async () => {
+        mockCreateCacheProvider.mockReturnValue(null);
+
+        const result = await searchTicker('AAPL');
+
+        expect(result).toEqual([]);
+    });
+
+    it('returns cached results when cache read succeeds', async () => {
+        const cached = [
+            {
+                symbol: 'AAPL',
+                name: 'Apple Inc.',
+                exchange: 'NASDAQ',
+                exchangeFullName: 'NASDAQ',
+            },
+        ];
+        const mockCache = {
+            get: vi.fn().mockResolvedValue(cached),
+            set: vi.fn(),
+        };
+        mockCreateCacheProvider.mockReturnValue(mockCache);
+
+        const result = await searchTicker('AAPL');
+
+        expect(result).toEqual(cached);
+    });
+});

--- a/src/__tests__/worst-case/chartResizeHydration.test.tsx
+++ b/src/__tests__/worst-case/chartResizeHydration.test.tsx
@@ -1,0 +1,177 @@
+import { INACTIVE_PANE_INDEX } from '@/widgets/chart/constants';
+
+const { mockCreateChart, mockResize } = vi.hoisted(() => {
+    const mockResize = vi.fn();
+    const mockCreateChart = vi.fn(() => ({
+        addSeries: vi.fn(() => ({
+            setData: vi.fn(),
+            applyOptions: vi.fn(),
+            setMarkers: vi.fn(),
+        })),
+        applyOptions: vi.fn(),
+        resize: mockResize,
+        remove: vi.fn(),
+        removeSeries: vi.fn(),
+        timeScale: vi.fn(() => ({
+            fitContent: vi.fn(),
+            scrollToRealTime: vi.fn(),
+        })),
+        subscribeCrosshairMove: vi.fn(),
+        priceScale: vi.fn(() => ({ applyOptions: vi.fn() })),
+    }));
+    return { mockCreateChart, mockResize };
+});
+
+vi.mock('lightweight-charts', () => ({
+    createChart: mockCreateChart,
+    CandlestickSeries: 'CandlestickSeries',
+    LineSeries: 'LineSeries',
+    HistogramSeries: 'HistogramSeries',
+    CrosshairMode: { Normal: 0, Magnet: 1 },
+    ColorType: { Solid: 'solid' },
+    LineStyle: { Solid: 0, Dotted: 1, Dashed: 2 },
+    PriceScaleMode: { Normal: 0, Logarithmic: 1 },
+}));
+
+vi.mock('@/shared/lib/chartColors', () => ({
+    CHART_COLORS: {
+        background: '#131722',
+        text: '#d1d4dc',
+        grid: '#1e222d',
+        bullish: '#26a69a',
+        bearish: '#ef5350',
+    },
+    getPeriodColor: (period: number) => `#color-${period}`,
+}));
+
+vi.mock('@/shared/lib/timeFormat', () => ({
+    getTimeFormatter: () => (time: number) => String(time),
+}));
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/widgets/chart/hooks/useMAOverlay', () => ({
+    useMAOverlay: () => ({ visiblePeriods: [], togglePeriod: vi.fn() }),
+}));
+vi.mock('@/widgets/chart/hooks/useEMAOverlay', () => ({
+    useEMAOverlay: () => ({ visiblePeriods: [], togglePeriod: vi.fn() }),
+}));
+vi.mock('@/widgets/chart/hooks/useBollingerOverlay', () => ({
+    useBollingerOverlay: () => ({ isVisible: false, toggle: vi.fn() }),
+}));
+vi.mock('@/widgets/chart/hooks/useMACDChart', () => ({
+    useMACDChart: vi.fn(),
+}));
+vi.mock('@/widgets/chart/hooks/useRSIChart', () => ({ useRSIChart: vi.fn() }));
+vi.mock('@/widgets/chart/hooks/useDMIChart', () => ({ useDMIChart: vi.fn() }));
+vi.mock('@/widgets/chart/hooks/useStochasticChart', () => ({
+    useStochasticChart: vi.fn(),
+}));
+vi.mock('@/widgets/chart/hooks/useStochRSIChart', () => ({
+    useStochRSIChart: vi.fn(),
+}));
+vi.mock('@/widgets/chart/hooks/useCCIChart', () => ({ useCCIChart: vi.fn() }));
+vi.mock('@/widgets/chart/hooks/useVolumeProfileOverlay', () => ({
+    useVolumeProfileOverlay: () => ({ isVisible: false, toggle: vi.fn() }),
+}));
+vi.mock('@/widgets/chart/hooks/useIchimokuOverlay', () => ({
+    useIchimokuOverlay: () => ({ isVisible: false, toggle: vi.fn() }),
+}));
+vi.mock('@/widgets/chart/hooks/useCandlePatternMarkers', () => ({
+    useCandlePatternMarkers: vi.fn(),
+}));
+vi.mock('@/widgets/chart/hooks/useActionRecommendationOverlay', () => ({
+    useActionRecommendationOverlay: vi.fn(),
+}));
+vi.mock('@/widgets/chart/hooks/usePaneLabels', () => ({
+    usePaneLabels: vi.fn(),
+}));
+vi.mock('@/widgets/chart/hooks/useOverlayLegend', () => ({
+    useOverlayLegend: () => [],
+}));
+vi.mock('@/widgets/chart/hooks/useIndicatorVisibility', () => ({
+    useIndicatorVisibility: () => ({
+        rsiVisible: false,
+        macdVisible: false,
+        dmiVisible: false,
+        stochasticVisible: false,
+        stochRsiVisible: false,
+        cciVisible: false,
+        toggleRSI: vi.fn(),
+        toggleMACD: vi.fn(),
+        toggleDMI: vi.fn(),
+        toggleStochastic: vi.fn(),
+        toggleStochRSI: vi.fn(),
+        toggleCCI: vi.fn(),
+        paneIndices: {
+            rsi: INACTIVE_PANE_INDEX,
+            macd: INACTIVE_PANE_INDEX,
+            dmi: INACTIVE_PANE_INDEX,
+            stochastic: INACTIVE_PANE_INDEX,
+            stochRsi: INACTIVE_PANE_INDEX,
+            cci: INACTIVE_PANE_INDEX,
+        },
+    }),
+}));
+vi.mock('@/widgets/chart/hooks/useIndicatorDropdown', () => ({
+    useIndicatorDropdown: () => ({
+        isExpanded: false,
+        openDropdown: null,
+        dropdownPosition: null,
+        toolbarRef: { current: null },
+        portalRef: { current: null },
+        buttonRefs: { ma: { current: null }, ema: { current: null } },
+        toggleExpanded: vi.fn(),
+        toggleDropdown: vi.fn(),
+    }),
+}));
+vi.mock('@/widgets/chart/utils/paneLabelUtils', () => ({
+    buildPaneLabels: () => [],
+}));
+vi.mock('@/widgets/chart/utils/overlayLabelUtils', () => ({
+    buildOverlayLabelConfigs: () => [],
+}));
+
+vi.mock('@y0ngha/siglens-core', () => ({
+    EMPTY_INDICATOR_RESULT: { ma: {}, ema: {} },
+    MA_DEFAULT_PERIODS: [5, 10, 20, 50, 100, 200],
+    EMA_DEFAULT_PERIODS: [9, 12, 21, 26, 50, 200],
+}));
+
+import { render } from '@testing-library/react';
+import { StockChart } from '@/widgets/chart/StockChart';
+
+describe('StockChart resize hydration behavior', () => {
+    const bars = [
+        {
+            time: 1700000000,
+            open: 100,
+            high: 110,
+            low: 90,
+            close: 105,
+            volume: 1000,
+        },
+        {
+            time: 1700086400,
+            open: 105,
+            high: 115,
+            low: 95,
+            close: 110,
+            volume: 1200,
+        },
+    ];
+
+    it('does not call resize on first mount (hydration guard)', () => {
+        render(<StockChart bars={bars} timeframe="1Day" />);
+        expect(mockResize).not.toHaveBeenCalled();
+    });
+
+    it('does not crash with empty bars on mount', () => {
+        const { container } = render(<StockChart bars={[]} timeframe="1Day" />);
+        expect(container.querySelector('p')).toHaveTextContent(
+            '차트 데이터가 없습니다'
+        );
+    });
+});

--- a/src/__tests__/worst-case/databaseRetryExhaustion.test.ts
+++ b/src/__tests__/worst-case/databaseRetryExhaustion.test.ts
@@ -1,0 +1,169 @@
+vi.mock('@/shared/lib/sleep', () => ({
+    sleep: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { withRetry } from '@/shared/lib/withRetry';
+import {
+    isNeonTransientError,
+    NEON_TRANSIENT_RETRY,
+} from '@/shared/db/isNeonTransientError';
+import { NeonDbError } from '@neondatabase/serverless';
+
+function createNeonError(code: string, message: string): NeonDbError {
+    const err = new NeonDbError(message);
+    (err as NeonDbError & { code: string }).code = code;
+    return err;
+}
+
+describe('Database retry and transient error detection', () => {
+    describe('isNeonTransientError', () => {
+        it('detects admin_shutdown (57P01) via code field', () => {
+            const err = createNeonError('57P01', 'admin shutdown');
+            expect(isNeonTransientError(err)).toBe(true);
+        });
+
+        it('detects connection_failure (08006) via code field', () => {
+            const err = createNeonError('08006', 'connection failure');
+            expect(isNeonTransientError(err)).toBe(true);
+        });
+
+        it('detects too_many_connections (53300) via code field', () => {
+            const err = createNeonError('53300', 'too many connections');
+            expect(isNeonTransientError(err)).toBe(true);
+        });
+
+        it('detects transient error via message needle (fetch failed)', () => {
+            const err = new NeonDbError(
+                'Error connecting to database: TypeError: fetch failed'
+            );
+            expect(isNeonTransientError(err)).toBe(true);
+        });
+
+        it('detects transient error in cause chain (Drizzle wrapping)', () => {
+            const inner = createNeonError('57P01', 'admin_shutdown');
+            const outer = new Error('Failed query: SELECT ...', {
+                cause: inner,
+            });
+            expect(isNeonTransientError(outer)).toBe(true);
+        });
+
+        it('returns false for non-retryable error (23505 unique violation)', () => {
+            const err = createNeonError(
+                '23505',
+                'duplicate key value violates unique constraint'
+            );
+            expect(isNeonTransientError(err)).toBe(false);
+        });
+
+        it('returns false for plain Error without NeonDbError in chain', () => {
+            const err = new Error('something else');
+            expect(isNeonTransientError(err)).toBe(false);
+        });
+
+        it('returns false for non-Error values', () => {
+            expect(isNeonTransientError('string error')).toBe(false);
+            expect(isNeonTransientError(42)).toBe(false);
+            expect(isNeonTransientError(null)).toBe(false);
+        });
+
+        it('handles deeply nested cause chain up to MAX_CAUSE_DEPTH', () => {
+            let current: Error = createNeonError(
+                '57P01',
+                'buried transient error'
+            );
+            for (let i = 0; i < 7; i++) {
+                current = new Error(`wrapper-${i}`, { cause: current });
+            }
+            expect(isNeonTransientError(current)).toBe(true);
+        });
+
+        it('does not match SQLSTATE code embedded in user data (no word boundary)', () => {
+            const err = new NeonDbError('user_57P01ABC_check');
+            expect(isNeonTransientError(err)).toBe(false);
+        });
+    });
+
+    describe('withRetry exhaustion', () => {
+        it('throws after all retries are exhausted', async () => {
+            const transientError = createNeonError('57P01', 'shutdown');
+            let callCount = 0;
+            const fn = vi.fn().mockImplementation(() => {
+                callCount++;
+                return Promise.reject(transientError);
+            });
+
+            await expect(
+                withRetry(fn, {
+                    maxRetries: 2,
+                    baseDelayMs: 10,
+                    isRetryable: isNeonTransientError,
+                })
+            ).rejects.toThrow('shutdown');
+
+            expect(callCount).toBe(3);
+        });
+
+        it('does not retry non-retryable errors', async () => {
+            const uniqueViolation = createNeonError(
+                '23505',
+                'unique violation'
+            );
+            const fn = vi.fn().mockRejectedValue(uniqueViolation);
+
+            await expect(
+                withRetry(fn, {
+                    maxRetries: 3,
+                    baseDelayMs: 10,
+                    isRetryable: isNeonTransientError,
+                })
+            ).rejects.toThrow('unique violation');
+
+            expect(fn).toHaveBeenCalledTimes(1);
+        });
+
+        it('succeeds on retry after transient failure', async () => {
+            const transientError = createNeonError(
+                '08006',
+                'connection_failure'
+            );
+            const fn = vi
+                .fn()
+                .mockRejectedValueOnce(transientError)
+                .mockResolvedValueOnce('success');
+
+            const result = await withRetry(fn, {
+                maxRetries: 2,
+                baseDelayMs: 10,
+                isRetryable: isNeonTransientError,
+            });
+
+            expect(result).toBe('success');
+            expect(fn).toHaveBeenCalledTimes(2);
+        });
+
+        it('respects backoff budget and throws early', async () => {
+            const transientError = createNeonError('57P01', 'shutdown');
+            const fn = vi.fn().mockRejectedValue(transientError);
+
+            await expect(
+                withRetry(fn, {
+                    maxRetries: 10,
+                    baseDelayMs: 1000,
+                    isRetryable: isNeonTransientError,
+                    backoffBudgetMs: 1,
+                })
+            ).rejects.toThrow('shutdown');
+
+            expect(fn.mock.calls.length).toBeLessThan(11);
+        });
+    });
+
+    describe('NEON_TRANSIENT_RETRY preset', () => {
+        it('has expected configuration', () => {
+            expect(NEON_TRANSIENT_RETRY.maxRetries).toBe(3);
+            expect(NEON_TRANSIENT_RETRY.baseDelayMs).toBe(200);
+            expect(NEON_TRANSIENT_RETRY.backoffBudgetMs).toBe(5000);
+            expect(NEON_TRANSIENT_RETRY.isRetryable).toBe(isNeonTransientError);
+        });
+    });
+});

--- a/src/__tests__/worst-case/emailVerificationEdgeCases.test.ts
+++ b/src/__tests__/worst-case/emailVerificationEdgeCases.test.ts
@@ -1,0 +1,105 @@
+import { verifyEmail } from '@/entities/user/lib/verifyEmail';
+import { hashEmailToken } from '@/entities/session/lib/tokenUtils';
+import type { VerifyEmailDependencies } from '@/entities/user/lib/authUseCaseTypes';
+
+function createMockEmailTokens(
+    overrides: Partial<VerifyEmailDependencies['emailTokens']> = {}
+): VerifyEmailDependencies['emailTokens'] {
+    return {
+        get: vi.fn().mockResolvedValue(null),
+        set: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        consume: vi.fn().mockResolvedValue(null),
+        ...overrides,
+    } as unknown as VerifyEmailDependencies['emailTokens'];
+}
+
+describe('Email verification edge cases', () => {
+    it('returns expired error when no token stored', async () => {
+        const emailTokens = createMockEmailTokens({
+            get: vi.fn().mockResolvedValue(null),
+        });
+
+        const result = await verifyEmail(
+            { email: 'test@example.com', code: '123456' },
+            { emailTokens }
+        );
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error.code).toBe('expired_verification_code');
+        }
+    });
+
+    it('returns invalid error when wrong code submitted', async () => {
+        const correctCode = '654321';
+        const emailTokens = createMockEmailTokens({
+            get: vi.fn().mockResolvedValue({
+                status: 'pending',
+                tokenHash: hashEmailToken(correctCode),
+            }),
+        });
+
+        const result = await verifyEmail(
+            { email: 'test@example.com', code: '111111' },
+            { emailTokens }
+        );
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error.code).toBe('invalid_verification_code');
+        }
+    });
+
+    it('returns ok: true when already verified', async () => {
+        const emailTokens = createMockEmailTokens({
+            get: vi.fn().mockResolvedValue({
+                status: 'verified',
+            }),
+        });
+
+        const result = await verifyEmail(
+            { email: 'test@example.com', code: 'any-code' },
+            { emailTokens }
+        );
+
+        expect(result.ok).toBe(true);
+    });
+
+    it('returns ok: true and sets verified status on correct code', async () => {
+        const code = '654321';
+        const emailTokens = createMockEmailTokens({
+            get: vi.fn().mockResolvedValue({
+                status: 'pending',
+                tokenHash: hashEmailToken(code),
+            }),
+        });
+
+        const result = await verifyEmail(
+            { email: 'test@example.com', code },
+            { emailTokens }
+        );
+
+        expect(result.ok).toBe(true);
+        expect(emailTokens.set).toHaveBeenCalledWith(
+            'email_verification',
+            'test@example.com',
+            { status: 'verified' },
+            expect.any(Number)
+        );
+    });
+
+    it('returns invalid error for malformed email', async () => {
+        const emailTokens = createMockEmailTokens();
+
+        const result = await verifyEmail(
+            { email: 'not-an-email', code: '123456' },
+            { emailTokens }
+        );
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error.code).toBe('invalid_verification_code');
+        }
+    });
+});

--- a/src/__tests__/worst-case/emptyChartData.test.tsx
+++ b/src/__tests__/worst-case/emptyChartData.test.tsx
@@ -1,0 +1,212 @@
+import { INACTIVE_PANE_INDEX } from '@/widgets/chart/constants';
+
+const { mockCreateChart } = vi.hoisted(() => {
+    const mockCreateChart = vi.fn(() => ({
+        addSeries: vi.fn(() => ({
+            setData: vi.fn(),
+            applyOptions: vi.fn(),
+            setMarkers: vi.fn(),
+        })),
+        applyOptions: vi.fn(),
+        resize: vi.fn(),
+        remove: vi.fn(),
+        removeSeries: vi.fn(),
+        timeScale: vi.fn(() => ({
+            fitContent: vi.fn(),
+            scrollToRealTime: vi.fn(),
+        })),
+        subscribeCrosshairMove: vi.fn(),
+        priceScale: vi.fn(() => ({ applyOptions: vi.fn() })),
+    }));
+    return { mockCreateChart };
+});
+
+vi.mock('lightweight-charts', () => ({
+    createChart: mockCreateChart,
+    CandlestickSeries: 'CandlestickSeries',
+    LineSeries: 'LineSeries',
+    HistogramSeries: 'HistogramSeries',
+    CrosshairMode: { Normal: 0, Magnet: 1 },
+    ColorType: { Solid: 'solid' },
+    LineStyle: { Solid: 0, Dotted: 1, Dashed: 2 },
+    PriceScaleMode: { Normal: 0, Logarithmic: 1 },
+}));
+
+vi.mock('@/shared/lib/chartColors', () => ({
+    CHART_COLORS: {
+        background: '#131722',
+        text: '#d1d4dc',
+        grid: '#1e222d',
+        bullish: '#26a69a',
+        bearish: '#ef5350',
+    },
+    getPeriodColor: (period: number) => `#color-${period}`,
+}));
+
+vi.mock('@/shared/lib/timeFormat', () => ({
+    getTimeFormatter: () => (time: number) => String(time),
+}));
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/widgets/chart/hooks/useMAOverlay', () => ({
+    useMAOverlay: () => ({ visiblePeriods: [], togglePeriod: vi.fn() }),
+}));
+vi.mock('@/widgets/chart/hooks/useEMAOverlay', () => ({
+    useEMAOverlay: () => ({ visiblePeriods: [], togglePeriod: vi.fn() }),
+}));
+vi.mock('@/widgets/chart/hooks/useBollingerOverlay', () => ({
+    useBollingerOverlay: () => ({ isVisible: false, toggle: vi.fn() }),
+}));
+vi.mock('@/widgets/chart/hooks/useMACDChart', () => ({
+    useMACDChart: vi.fn(),
+}));
+vi.mock('@/widgets/chart/hooks/useRSIChart', () => ({ useRSIChart: vi.fn() }));
+vi.mock('@/widgets/chart/hooks/useDMIChart', () => ({ useDMIChart: vi.fn() }));
+vi.mock('@/widgets/chart/hooks/useStochasticChart', () => ({
+    useStochasticChart: vi.fn(),
+}));
+vi.mock('@/widgets/chart/hooks/useStochRSIChart', () => ({
+    useStochRSIChart: vi.fn(),
+}));
+vi.mock('@/widgets/chart/hooks/useCCIChart', () => ({ useCCIChart: vi.fn() }));
+vi.mock('@/widgets/chart/hooks/useVolumeProfileOverlay', () => ({
+    useVolumeProfileOverlay: () => ({ isVisible: false, toggle: vi.fn() }),
+}));
+vi.mock('@/widgets/chart/hooks/useIchimokuOverlay', () => ({
+    useIchimokuOverlay: () => ({ isVisible: false, toggle: vi.fn() }),
+}));
+vi.mock('@/widgets/chart/hooks/useCandlePatternMarkers', () => ({
+    useCandlePatternMarkers: vi.fn(),
+}));
+vi.mock('@/widgets/chart/hooks/useActionRecommendationOverlay', () => ({
+    useActionRecommendationOverlay: vi.fn(),
+}));
+vi.mock('@/widgets/chart/hooks/usePaneLabels', () => ({
+    usePaneLabels: vi.fn(),
+}));
+vi.mock('@/widgets/chart/hooks/useOverlayLegend', () => ({
+    useOverlayLegend: () => [],
+}));
+vi.mock('@/widgets/chart/hooks/useIndicatorVisibility', () => ({
+    useIndicatorVisibility: () => ({
+        rsiVisible: false,
+        macdVisible: false,
+        dmiVisible: false,
+        stochasticVisible: false,
+        stochRsiVisible: false,
+        cciVisible: false,
+        toggleRSI: vi.fn(),
+        toggleMACD: vi.fn(),
+        toggleDMI: vi.fn(),
+        toggleStochastic: vi.fn(),
+        toggleStochRSI: vi.fn(),
+        toggleCCI: vi.fn(),
+        paneIndices: {
+            rsi: INACTIVE_PANE_INDEX,
+            macd: INACTIVE_PANE_INDEX,
+            dmi: INACTIVE_PANE_INDEX,
+            stochastic: INACTIVE_PANE_INDEX,
+            stochRsi: INACTIVE_PANE_INDEX,
+            cci: INACTIVE_PANE_INDEX,
+        },
+    }),
+}));
+vi.mock('@/widgets/chart/hooks/useIndicatorDropdown', () => ({
+    useIndicatorDropdown: () => ({
+        isExpanded: false,
+        openDropdown: null,
+        dropdownPosition: null,
+        toolbarRef: { current: null },
+        portalRef: { current: null },
+        buttonRefs: { ma: { current: null }, ema: { current: null } },
+        toggleExpanded: vi.fn(),
+        toggleDropdown: vi.fn(),
+    }),
+}));
+vi.mock('@/widgets/chart/utils/paneLabelUtils', () => ({
+    buildPaneLabels: () => [],
+}));
+vi.mock('@/widgets/chart/utils/overlayLabelUtils', () => ({
+    buildOverlayLabelConfigs: () => [],
+}));
+
+vi.mock('@y0ngha/siglens-core', () => ({
+    EMPTY_INDICATOR_RESULT: { ma: {}, ema: {} },
+    MA_DEFAULT_PERIODS: [5, 10, 20, 50, 100, 200],
+    EMA_DEFAULT_PERIODS: [9, 12, 21, 26, 50, 200],
+}));
+
+import { render, screen } from '@testing-library/react';
+import { StockChart } from '@/widgets/chart/StockChart';
+
+describe('StockChart with empty/zero data', () => {
+    it('renders empty state message when bars array is empty', () => {
+        render(<StockChart bars={[]} timeframe="1Day" />);
+        expect(screen.getByText('차트 데이터가 없습니다')).toBeInTheDocument();
+    });
+
+    it('renders chart when bars have data', () => {
+        const bars = [
+            {
+                time: 1700000000,
+                open: 100,
+                high: 110,
+                low: 90,
+                close: 105,
+                volume: 1000,
+            },
+        ];
+        const { container } = render(
+            <StockChart bars={bars} timeframe="1Day" />
+        );
+        expect(container.querySelector('[role="img"]')).toBeInTheDocument();
+    });
+
+    it('renders with all-zero OHLC bars without crashing', () => {
+        const zeroBars = [
+            { time: 1700000000, open: 0, high: 0, low: 0, close: 0, volume: 0 },
+            { time: 1700086400, open: 0, high: 0, low: 0, close: 0, volume: 0 },
+        ];
+        const { container } = render(
+            <StockChart bars={zeroBars} timeframe="1Day" />
+        );
+        expect(container.querySelector('[role="img"]')).toBeInTheDocument();
+    });
+
+    it('applies correct aria-label with ticker', () => {
+        const bars = [
+            {
+                time: 1700000000,
+                open: 100,
+                high: 110,
+                low: 90,
+                close: 105,
+                volume: 1000,
+            },
+        ];
+        render(<StockChart bars={bars} timeframe="1Day" ticker="AAPL" />);
+        expect(
+            screen.getByRole('img', { name: 'AAPL 1Day 캔들 차트' })
+        ).toBeInTheDocument();
+    });
+
+    it('applies generic aria-label without ticker', () => {
+        const bars = [
+            {
+                time: 1700000000,
+                open: 100,
+                high: 110,
+                low: 90,
+                close: 105,
+                volume: 1000,
+            },
+        ];
+        render(<StockChart bars={bars} timeframe="1Day" />);
+        expect(
+            screen.getByRole('img', { name: '가격 차트' })
+        ).toBeInTheDocument();
+    });
+});

--- a/src/__tests__/worst-case/fmpLargeResponse.test.ts
+++ b/src/__tests__/worst-case/fmpLargeResponse.test.ts
@@ -15,7 +15,16 @@ import { fmpGet } from '@/shared/api/fmp/httpClient';
 
 const mockFmpGet = fmpGet as ReturnType<typeof vi.fn>;
 
-function makeRawNews(count: number, baseTime = Date.now()) {
+interface RawNewsStub {
+    symbol: string;
+    site: string;
+    url: string;
+    publishedDate: string;
+    title: string;
+    text: string;
+}
+
+function makeRawNews(count: number, baseTime = Date.now()): RawNewsStub[] {
     return Array.from({ length: count }, (_, i) => ({
         symbol: 'AAPL',
         site: `Source${i}`,

--- a/src/__tests__/worst-case/fmpLargeResponse.test.ts
+++ b/src/__tests__/worst-case/fmpLargeResponse.test.ts
@@ -1,0 +1,113 @@
+vi.mock('@y0ngha/siglens-core', () => ({
+    createCacheProvider: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('@/shared/api/fmp/httpClient', () => ({
+    fmpGet: vi.fn(),
+}));
+
+vi.mock('@/shared/config/time', () => ({
+    MS_PER_HOUR: 3600000,
+}));
+
+import { FmpNewsClient } from '@/entities/news-article/lib/fmpNewsClient';
+import { fmpGet } from '@/shared/api/fmp/httpClient';
+
+const mockFmpGet = fmpGet as ReturnType<typeof vi.fn>;
+
+function makeRawNews(count: number, baseTime = Date.now()) {
+    return Array.from({ length: count }, (_, i) => ({
+        symbol: 'AAPL',
+        site: `Source${i}`,
+        url: `https://example.com/article/${i}`,
+        publishedDate: new Date(baseTime - i * 60000)
+            .toISOString()
+            .replace('T', ' ')
+            .slice(0, 19),
+        title: `Article ${i}`,
+        text: `Body of article ${i}`,
+    }));
+}
+
+describe('FMP large response handling', () => {
+    const client = new FmpNewsClient();
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('handles 1000+ news items without error', async () => {
+        const largeResponse = makeRawNews(1200);
+        mockFmpGet.mockResolvedValue(largeResponse);
+
+        const result = await client.fetchNewsForPeriod(
+            'AAPL',
+            7 * 24 * 3600000
+        );
+
+        expect(result.length).toBeGreaterThan(0);
+        expect(result.length).toBeLessThanOrEqual(1200);
+    });
+
+    it('handles empty array from FMP', async () => {
+        mockFmpGet.mockResolvedValue([]);
+
+        const result = await client.fetchNews('AAPL', '24h');
+
+        expect(result).toEqual([]);
+    });
+
+    it('filters old articles beyond cutoff', async () => {
+        const oldArticle = {
+            symbol: 'AAPL',
+            site: 'OldSource',
+            url: 'https://example.com/old',
+            publishedDate: '2020-01-01 00:00:00',
+            title: 'Old Article',
+            text: 'Old body',
+        };
+        const recentArticle = {
+            symbol: 'AAPL',
+            site: 'NewSource',
+            url: 'https://example.com/new',
+            publishedDate: new Date()
+                .toISOString()
+                .replace('T', ' ')
+                .slice(0, 19),
+            title: 'New Article',
+            text: 'New body',
+        };
+        mockFmpGet.mockResolvedValue([oldArticle, recentArticle]);
+
+        const result = await client.fetchNews('AAPL', '24h');
+
+        const urls = result.map(r => r.url);
+        expect(urls).not.toContain('https://example.com/old');
+    });
+
+    it('handles items with missing optional fields', async () => {
+        mockFmpGet.mockResolvedValue([
+            {
+                symbol: 'AAPL',
+                site: 'Source',
+                url: 'https://example.com/minimal',
+                publishedDate: new Date()
+                    .toISOString()
+                    .replace('T', ' ')
+                    .slice(0, 19),
+                title: 'Minimal',
+                text: '',
+            },
+        ]);
+
+        const result = await client.fetchNews('AAPL', '24h');
+
+        expect(result.length).toBeLessThanOrEqual(1);
+    });
+
+    it('propagates FMP 500 error', async () => {
+        mockFmpGet.mockRejectedValue(new Error('FMP news/stock 500'));
+
+        await expect(client.fetchNews('AAPL', '30d')).rejects.toThrow('500');
+    });
+});

--- a/src/__tests__/worst-case/fmpRateLimit.test.ts
+++ b/src/__tests__/worst-case/fmpRateLimit.test.ts
@@ -1,0 +1,65 @@
+vi.mock('@y0ngha/siglens-core', () => ({
+    readFmpConfig: vi.fn(() => ({ apiKey: 'test-key' })),
+}));
+
+import { fmpGet, FMP_STABLE_BASE } from '@/shared/api/fmp/httpClient';
+
+describe('FMP API error responses', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('throws on 429 rate limit', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(null, { status: 429, statusText: 'Too Many Requests' })
+        );
+
+        await expect(fmpGet('news/stock', { symbols: 'AAPL' })).rejects.toThrow(
+            'FMP news/stock 429'
+        );
+    });
+
+    it('throws on 500 internal server error', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(null, { status: 500 })
+        );
+
+        await expect(fmpGet('earnings', { symbol: 'AAPL' })).rejects.toThrow(
+            'FMP earnings 500'
+        );
+    });
+
+    it('throws on network timeout (AbortSignal)', async () => {
+        vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+            new DOMException('The operation was aborted', 'AbortError')
+        );
+
+        await expect(fmpGet('news/stock')).rejects.toThrow('aborted');
+    });
+
+    it('constructs correct URL with params', async () => {
+        const fetchSpy = vi
+            .spyOn(globalThis, 'fetch')
+            .mockResolvedValue(
+                new Response(JSON.stringify([]), { status: 200 })
+            );
+
+        await fmpGet('news/stock', { symbols: 'AAPL', limit: '30' });
+
+        const calledUrl = fetchSpy.mock.calls[0][0] as string;
+        expect(calledUrl).toContain(`${FMP_STABLE_BASE}/news/stock?`);
+        expect(calledUrl).toContain('symbols=AAPL');
+        expect(calledUrl).toContain('limit=30');
+        expect(calledUrl).toContain('apikey=test-key');
+    });
+
+    it('parses JSON response on success', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(JSON.stringify([{ id: 1 }]), { status: 200 })
+        );
+
+        const result = await fmpGet<{ id: number }[]>('test');
+
+        expect(result).toEqual([{ id: 1 }]);
+    });
+});

--- a/src/__tests__/worst-case/jobCancelPartialFailure.test.ts
+++ b/src/__tests__/worst-case/jobCancelPartialFailure.test.ts
@@ -1,0 +1,96 @@
+vi.mock('@y0ngha/siglens-core', () => ({
+    cancelAnalysisJob: vi.fn(),
+    cancelFundamentalAnalysisJob: vi.fn(),
+    cancelNewsAnalysisJob: vi.fn(),
+    cancelJob: vi.fn(),
+    cancelOverallAnalysisJob: vi.fn(),
+}));
+
+import { POST } from '@/app/api/jobs/cancel/route';
+import {
+    cancelAnalysisJob,
+    cancelFundamentalAnalysisJob,
+    cancelOverallAnalysisJob,
+} from '@y0ngha/siglens-core';
+
+const mockCancelAnalysis = cancelAnalysisJob as ReturnType<typeof vi.fn>;
+const mockCancelFundamental = cancelFundamentalAnalysisJob as ReturnType<
+    typeof vi.fn
+>;
+const mockCancelOverall = cancelOverallAnalysisJob as ReturnType<typeof vi.fn>;
+
+function createJsonRequest(body: unknown): Request {
+    return new Request('http://localhost/api/jobs/cancel', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+}
+
+describe('Job cancel partial failure behavior', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns 204 when some cancellations succeed and some fail', async () => {
+        mockCancelAnalysis.mockResolvedValue(undefined);
+        mockCancelFundamental.mockRejectedValue(new Error('Redis timeout'));
+        mockCancelOverall.mockResolvedValue(undefined);
+
+        const req = createJsonRequest({
+            jobs: [
+                { jobId: 'j1', type: 'analysis' },
+                { jobId: 'j2', type: 'fundamental' },
+                { jobId: 'j3', type: 'overall' },
+            ],
+        });
+
+        const res = await POST(req);
+
+        expect(res.status).toBe(204);
+    });
+
+    it('returns 204 when all cancellations fail', async () => {
+        mockCancelAnalysis.mockRejectedValue(new Error('fail'));
+        mockCancelFundamental.mockRejectedValue(new Error('fail'));
+
+        const req = createJsonRequest({
+            jobs: [
+                { jobId: 'j1', type: 'analysis' },
+                { jobId: 'j2', type: 'fundamental' },
+            ],
+        });
+
+        const res = await POST(req);
+
+        expect(res.status).toBe(204);
+    });
+
+    it('returns 204 for empty jobs array (valid but no-op)', async () => {
+        const req = createJsonRequest({ jobs: [] });
+
+        const res = await POST(req);
+
+        expect(res.status).toBe(204);
+    });
+
+    it('calls correct cancel function for each job type', async () => {
+        mockCancelAnalysis.mockResolvedValue(undefined);
+        mockCancelFundamental.mockResolvedValue(undefined);
+        mockCancelOverall.mockResolvedValue(undefined);
+
+        const req = createJsonRequest({
+            jobs: [
+                { jobId: 'a1', type: 'analysis' },
+                { jobId: 'f1', type: 'fundamental' },
+                { jobId: 'o1', type: 'overall' },
+            ],
+        });
+
+        await POST(req);
+
+        expect(mockCancelAnalysis).toHaveBeenCalledWith('a1');
+        expect(mockCancelFundamental).toHaveBeenCalledWith('f1');
+        expect(mockCancelOverall).toHaveBeenCalledWith('o1');
+    });
+});

--- a/src/__tests__/worst-case/jobCancelPartialFailure.test.ts
+++ b/src/__tests__/worst-case/jobCancelPartialFailure.test.ts
@@ -32,40 +32,6 @@ describe('Job cancel partial failure behavior', () => {
         vi.clearAllMocks();
     });
 
-    it('returns 204 when some cancellations succeed and some fail', async () => {
-        mockCancelAnalysis.mockResolvedValue(undefined);
-        mockCancelFundamental.mockRejectedValue(new Error('Redis timeout'));
-        mockCancelOverall.mockResolvedValue(undefined);
-
-        const req = createJsonRequest({
-            jobs: [
-                { jobId: 'j1', type: 'analysis' },
-                { jobId: 'j2', type: 'fundamental' },
-                { jobId: 'j3', type: 'overall' },
-            ],
-        });
-
-        const res = await POST(req);
-
-        expect(res.status).toBe(204);
-    });
-
-    it('returns 204 when all cancellations fail', async () => {
-        mockCancelAnalysis.mockRejectedValue(new Error('fail'));
-        mockCancelFundamental.mockRejectedValue(new Error('fail'));
-
-        const req = createJsonRequest({
-            jobs: [
-                { jobId: 'j1', type: 'analysis' },
-                { jobId: 'j2', type: 'fundamental' },
-            ],
-        });
-
-        const res = await POST(req);
-
-        expect(res.status).toBe(204);
-    });
-
     it('returns 204 for empty jobs array (valid but no-op)', async () => {
         const req = createJsonRequest({ jobs: [] });
 

--- a/src/__tests__/worst-case/llmProviderFailures.test.ts
+++ b/src/__tests__/worst-case/llmProviderFailures.test.ts
@@ -1,0 +1,188 @@
+const mockAnthropicFinalMessage = vi.fn();
+const mockOpenaiCreate = vi.fn();
+const mockGeminiGenerate = vi.fn();
+
+vi.mock('@anthropic-ai/sdk', () => ({
+    default: class MockAnthropic {
+        messages = {
+            stream: () => ({ finalMessage: mockAnthropicFinalMessage }),
+        };
+    },
+}));
+
+vi.mock('openai', () => ({
+    default: class MockOpenAI {
+        responses = { create: mockOpenaiCreate };
+    },
+}));
+
+vi.mock('@google/genai', () => ({
+    GoogleGenAI: class MockGoogleGenAI {
+        models = { generateContent: mockGeminiGenerate };
+    },
+}));
+
+vi.mock('@y0ngha/siglens-core', () => ({
+    MODEL_SPECS: {
+        'claude-haiku-4-5': {
+            apiModelId: 'claude-haiku-4-5-20251001',
+            provider: 'anthropic',
+            maxOutputTokens: 8192,
+            temperature: 1.0,
+        },
+        'gpt-4.1-mini': {
+            apiModelId: 'gpt-4.1-mini',
+            provider: 'openai',
+            maxOutputTokens: 16384,
+            temperature: 1.0,
+        },
+        'gemini-2.5-flash': {
+            apiModelId: 'gemini-2.5-flash',
+            provider: 'google',
+            maxOutputTokens: 8192,
+            temperature: 1.0,
+        },
+    },
+    getProviderForModel: (model: string) => {
+        const map: Record<string, string> = {
+            'claude-haiku-4-5': 'anthropic',
+            'gpt-4.1-mini': 'openai',
+            'gemini-2.5-flash': 'google',
+        };
+        return map[model];
+    },
+}));
+
+import { callAiProviderRouter } from '@/entities/llm-provider/api/router';
+
+const BASE_OPTIONS = {
+    serverApiKey: 'test-key',
+    userApiKey: undefined,
+    contents: 'Hello',
+    systemInstruction: undefined,
+};
+
+describe('LLM provider failure modes', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('Anthropic failures', () => {
+        it('throws when response contains no text block', async () => {
+            mockAnthropicFinalMessage.mockResolvedValue({
+                content: [{ type: 'thinking', text: 'some thought' }],
+                stop_reason: 'end_turn',
+            });
+
+            await expect(
+                callAiProviderRouter({
+                    ...BASE_OPTIONS,
+                    model: 'claude-haiku-4-5',
+                })
+            ).rejects.toThrow('Anthropic returned no text content');
+        });
+
+        it('throws when content array is empty', async () => {
+            mockAnthropicFinalMessage.mockResolvedValue({
+                content: [],
+                stop_reason: 'end_turn',
+            });
+
+            await expect(
+                callAiProviderRouter({
+                    ...BASE_OPTIONS,
+                    model: 'claude-haiku-4-5',
+                })
+            ).rejects.toThrow('Anthropic returned no text content');
+        });
+
+        it('propagates 500 error from API', async () => {
+            mockAnthropicFinalMessage.mockRejectedValue(
+                new Error('500 Internal Server Error')
+            );
+
+            await expect(
+                callAiProviderRouter({
+                    ...BASE_OPTIONS,
+                    model: 'claude-haiku-4-5',
+                })
+            ).rejects.toThrow('500 Internal Server Error');
+        });
+    });
+
+    describe('OpenAI failures', () => {
+        it('throws when output_text is null', async () => {
+            mockOpenaiCreate.mockResolvedValue({ output_text: null });
+
+            await expect(
+                callAiProviderRouter({
+                    ...BASE_OPTIONS,
+                    model: 'gpt-4.1-mini',
+                })
+            ).rejects.toThrow('Provider returned null/undefined response');
+        });
+
+        it('throws when output_text is undefined', async () => {
+            mockOpenaiCreate.mockResolvedValue({});
+
+            await expect(
+                callAiProviderRouter({
+                    ...BASE_OPTIONS,
+                    model: 'gpt-4.1-mini',
+                })
+            ).rejects.toThrow('Provider returned null/undefined response');
+        });
+
+        it('logs warning but returns empty string', async () => {
+            const warnSpy = vi
+                .spyOn(console, 'warn')
+                .mockImplementation(() => {});
+            mockOpenaiCreate.mockResolvedValue({ output_text: '' });
+
+            const result = await callAiProviderRouter({
+                ...BASE_OPTIONS,
+                model: 'gpt-4.1-mini',
+            });
+
+            expect(result).toBe('');
+            expect(warnSpy).toHaveBeenCalledWith(
+                '[openai] Provider returned empty string'
+            );
+        });
+    });
+
+    describe('Gemini failures', () => {
+        it('throws when text is null', async () => {
+            mockGeminiGenerate.mockResolvedValue({ text: null });
+
+            await expect(
+                callAiProviderRouter({
+                    ...BASE_OPTIONS,
+                    model: 'gemini-2.5-flash',
+                })
+            ).rejects.toThrow('Provider returned null/undefined response');
+        });
+
+        it('throws when text is undefined', async () => {
+            mockGeminiGenerate.mockResolvedValue({});
+
+            await expect(
+                callAiProviderRouter({
+                    ...BASE_OPTIONS,
+                    model: 'gemini-2.5-flash',
+                })
+            ).rejects.toThrow('Provider returned null/undefined response');
+        });
+    });
+
+    describe('Router-level failures', () => {
+        it('throws for unknown model ID', async () => {
+            await expect(
+                callAiProviderRouter({
+                    ...BASE_OPTIONS,
+                    model: 'nonexistent-model',
+                })
+            ).rejects.toThrow('[router] Unknown model: nonexistent-model');
+        });
+    });
+});

--- a/src/__tests__/worst-case/malformedApiRequests.test.ts
+++ b/src/__tests__/worst-case/malformedApiRequests.test.ts
@@ -58,7 +58,9 @@ describe('POST /api/jobs/cancel malformed requests', () => {
     });
 
     it('returns 400 for non-JSON body', async () => {
-        vi.spyOn(console, 'error').mockImplementation(() => {});
+        const errorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
         const req = new Request('http://localhost/api/jobs/cancel', {
             method: 'POST',
             body: 'not json',
@@ -67,6 +69,7 @@ describe('POST /api/jobs/cancel malformed requests', () => {
         const res = await POST(req);
 
         expect(res.status).toBe(400);
+        expect(errorSpy).toHaveBeenCalled();
     });
 
     it('returns 204 for valid request with mixed job types', async () => {

--- a/src/__tests__/worst-case/malformedApiRequests.test.ts
+++ b/src/__tests__/worst-case/malformedApiRequests.test.ts
@@ -1,0 +1,124 @@
+vi.mock('@y0ngha/siglens-core', () => ({
+    cancelAnalysisJob: vi.fn().mockResolvedValue(undefined),
+    cancelFundamentalAnalysisJob: vi.fn().mockResolvedValue(undefined),
+    cancelNewsAnalysisJob: vi.fn().mockResolvedValue(undefined),
+    cancelJob: vi.fn().mockResolvedValue(undefined),
+    cancelOverallAnalysisJob: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { POST } from '@/app/api/jobs/cancel/route';
+
+function createJsonRequest(body: unknown): Request {
+    return new Request('http://localhost/api/jobs/cancel', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+}
+
+describe('POST /api/jobs/cancel malformed requests', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns 400 when body has no jobs array', async () => {
+        const req = createJsonRequest({ notJobs: [] });
+
+        const res = await POST(req);
+
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when jobs is not an array', async () => {
+        const req = createJsonRequest({ jobs: 'string' });
+
+        const res = await POST(req);
+
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when a job entry has invalid type', async () => {
+        const req = createJsonRequest({
+            jobs: [{ jobId: 'j1', type: 'invalid_type' }],
+        });
+
+        const res = await POST(req);
+
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when a job entry has missing jobId', async () => {
+        const req = createJsonRequest({
+            jobs: [{ type: 'analysis' }],
+        });
+
+        const res = await POST(req);
+
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for non-JSON body', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        const req = new Request('http://localhost/api/jobs/cancel', {
+            method: 'POST',
+            body: 'not json',
+        });
+
+        const res = await POST(req);
+
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 204 for valid request with mixed job types', async () => {
+        const req = createJsonRequest({
+            jobs: [
+                { jobId: 'j1', type: 'analysis' },
+                { jobId: 'j2', type: 'fundamental' },
+                { jobId: 'j3', type: 'news' },
+            ],
+        });
+
+        const res = await POST(req);
+
+        expect(res.status).toBe(204);
+    });
+
+    it('returns 204 even when some cancel calls fail (partial failure)', async () => {
+        const { cancelAnalysisJob } = await import('@y0ngha/siglens-core');
+        (cancelAnalysisJob as ReturnType<typeof vi.fn>).mockRejectedValue(
+            new Error('Redis down')
+        );
+
+        const req = createJsonRequest({
+            jobs: [
+                { jobId: 'j1', type: 'analysis' },
+                { jobId: 'j2', type: 'fundamental' },
+            ],
+        });
+
+        const res = await POST(req);
+
+        expect(res.status).toBe(204);
+    });
+
+    it('returns 204 when all cancel calls fail', async () => {
+        const core = await import('@y0ngha/siglens-core');
+        (core.cancelAnalysisJob as ReturnType<typeof vi.fn>).mockRejectedValue(
+            new Error('fail')
+        );
+        (
+            core.cancelFundamentalAnalysisJob as ReturnType<typeof vi.fn>
+        ).mockRejectedValue(new Error('fail'));
+
+        const req = createJsonRequest({
+            jobs: [
+                { jobId: 'j1', type: 'analysis' },
+                { jobId: 'j2', type: 'fundamental' },
+            ],
+        });
+
+        const res = await POST(req);
+
+        expect(res.status).toBe(204);
+    });
+});

--- a/src/__tests__/worst-case/newsApiMalformed.test.ts
+++ b/src/__tests__/worst-case/newsApiMalformed.test.ts
@@ -1,0 +1,150 @@
+vi.mock('@y0ngha/siglens-core', () => ({
+    // unused by fmpNewsClient directly, but imported transitively
+}));
+
+vi.mock('@/shared/api/fmp/httpClient', () => ({
+    fmpGet: vi.fn(),
+}));
+
+vi.mock('@/shared/config/time', () => ({
+    MS_PER_HOUR: 3600000,
+}));
+
+import {
+    FmpNewsClient,
+    normalizeFmpPublishedDate,
+    hashUrlToId,
+} from '@/entities/news-article/lib/fmpNewsClient';
+import { fmpGet } from '@/shared/api/fmp/httpClient';
+
+const mockFmpGet = fmpGet as ReturnType<typeof vi.fn>;
+
+describe('FmpNewsClient malformed data handling', () => {
+    const client = new FmpNewsClient();
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('filters out items with unparseable publishedDate', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        mockFmpGet.mockResolvedValue([
+            {
+                symbol: 'AAPL',
+                site: 'Example',
+                url: 'https://example.com/valid',
+                publishedDate: new Date()
+                    .toISOString()
+                    .replace('T', ' ')
+                    .slice(0, 19),
+                title: 'Valid article',
+                text: 'Valid body',
+            },
+            {
+                symbol: 'AAPL',
+                site: 'Example',
+                url: 'https://example.com/bad',
+                publishedDate: 'not-a-date-at-all',
+                title: 'Bad date',
+                text: 'Body',
+            },
+        ]);
+
+        const result = await client.fetchNews('AAPL', '24h');
+
+        expect(result.length).toBeLessThanOrEqual(2);
+        const urls = result.map(r => r.url);
+        expect(urls).not.toContain('https://example.com/bad');
+        warnSpy.mockRestore();
+    });
+
+    it('returns empty array when all items have invalid dates', async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        mockFmpGet.mockResolvedValue([
+            {
+                symbol: 'AAPL',
+                site: 'Example',
+                url: 'https://example.com/1',
+                publishedDate: 'garbage',
+                title: 'A',
+                text: 'B',
+            },
+        ]);
+
+        const result = await client.fetchNews('AAPL', '24h');
+
+        expect(result).toEqual([]);
+    });
+
+    it('handles empty response array', async () => {
+        mockFmpGet.mockResolvedValue([]);
+
+        const result = await client.fetchNews('AAPL', '7d');
+
+        expect(result).toEqual([]);
+    });
+
+    it('propagates FMP 4xx/5xx errors', async () => {
+        mockFmpGet.mockRejectedValue(new Error('FMP news/stock 500'));
+
+        await expect(client.fetchNews('AAPL', '24h')).rejects.toThrow(
+            'FMP news/stock 500'
+        );
+    });
+
+    it('returns null for earnings when response is empty', async () => {
+        mockFmpGet.mockResolvedValue([]);
+
+        const result = await client.fetchEarningsReport('AAPL');
+
+        expect(result).toBeNull();
+    });
+
+    it('returns null for earnings when date fields are missing', async () => {
+        mockFmpGet.mockResolvedValue([
+            {
+                symbol: 'AAPL',
+            },
+        ]);
+
+        const result = await client.fetchEarningsReport('AAPL');
+
+        expect(result).toBeNull();
+    });
+
+    describe('normalizeFmpPublishedDate', () => {
+        it('throws for completely invalid date', () => {
+            expect(() => normalizeFmpPublishedDate('not-a-date')).toThrow(
+                'Invalid FMP publishedDate'
+            );
+        });
+
+        it('normalizes zoneless datetime to ISO', () => {
+            const result = normalizeFmpPublishedDate('2025-01-15 14:30:00');
+            expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+        });
+
+        it('passes through valid ISO dates', () => {
+            const iso = '2025-01-15T19:30:00.000Z';
+            const result = normalizeFmpPublishedDate(iso);
+            expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        });
+    });
+
+    describe('hashUrlToId', () => {
+        it('produces different IDs for URLs with same prefix but different paths', () => {
+            const id1 = hashUrlToId('https://example.com/article/123');
+            const id2 = hashUrlToId('https://example.com/article/456');
+            expect(id1).not.toBe(id2);
+        });
+
+        it('produces consistent IDs for same URL', () => {
+            const url = 'https://example.com/article/789';
+            expect(hashUrlToId(url)).toBe(hashUrlToId(url));
+        });
+
+        it('returns 32-character string', () => {
+            expect(hashUrlToId('https://example.com')).toHaveLength(32);
+        });
+    });
+});

--- a/src/__tests__/worst-case/newsApiMalformed.test.ts
+++ b/src/__tests__/worst-case/newsApiMalformed.test.ts
@@ -55,11 +55,11 @@ describe('FmpNewsClient malformed data handling', () => {
         expect(result.length).toBeLessThanOrEqual(2);
         const urls = result.map(r => r.url);
         expect(urls).not.toContain('https://example.com/bad');
+        expect(warnSpy).toHaveBeenCalled();
         warnSpy.mockRestore();
     });
 
     it('returns empty array when all items have invalid dates', async () => {
-        vi.spyOn(console, 'warn').mockImplementation(() => {});
         mockFmpGet.mockResolvedValue([
             {
                 symbol: 'AAPL',

--- a/src/__tests__/worst-case/oauthStateValidation.test.ts
+++ b/src/__tests__/worst-case/oauthStateValidation.test.ts
@@ -1,0 +1,156 @@
+import {
+    issueOAuthState,
+    verifyOAuthState,
+    OAuthStateSecretMisconfiguredError,
+    OAUTH_STATE_COOKIE_NAME,
+} from '@/features/auth-oauth/lib/state';
+
+const VALID_SECRET = 'a'.repeat(32);
+
+describe('OAuth state validation edge cases', () => {
+    afterEach(() => {
+        delete process.env.OAUTH_STATE_HMAC_SECRET;
+    });
+
+    describe('HMAC misconfiguration', () => {
+        it('throws OAuthStateSecretMisconfiguredError when secret is missing', () => {
+            delete process.env.OAUTH_STATE_HMAC_SECRET;
+
+            expect(() => issueOAuthState('google', '/')).toThrow(
+                OAuthStateSecretMisconfiguredError
+            );
+        });
+
+        it('throws when secret is too short', () => {
+            process.env.OAUTH_STATE_HMAC_SECRET = 'short';
+
+            expect(() => issueOAuthState('google', '/')).toThrow(
+                'at least 32 bytes'
+            );
+        });
+
+        it('verify also throws on missing secret', () => {
+            delete process.env.OAUTH_STATE_HMAC_SECRET;
+
+            expect(() => verifyOAuthState('google', 'state', 'cookie')).toThrow(
+                OAuthStateSecretMisconfiguredError
+            );
+        });
+    });
+
+    describe('Missing state cookie', () => {
+        it('returns ok: false when cookie value is undefined', () => {
+            process.env.OAUTH_STATE_HMAC_SECRET = VALID_SECRET;
+
+            const result = verifyOAuthState('google', 'some-state', undefined);
+
+            expect(result.ok).toBe(false);
+        });
+
+        it('returns ok: false when cookie value is empty string', () => {
+            process.env.OAUTH_STATE_HMAC_SECRET = VALID_SECRET;
+
+            const result = verifyOAuthState('google', 'state', '');
+
+            expect(result.ok).toBe(false);
+        });
+    });
+
+    describe('Tampered cookie', () => {
+        it('returns ok: false when signature is tampered', () => {
+            process.env.OAUTH_STATE_HMAC_SECRET = VALID_SECRET;
+            const { state, cookie } = issueOAuthState('google', '/dashboard');
+
+            const tampered = cookie.value.replace(/.$/, 'X');
+            const result = verifyOAuthState('google', state, tampered);
+
+            expect(result.ok).toBe(false);
+        });
+
+        it('returns ok: false when payload is tampered', () => {
+            process.env.OAUTH_STATE_HMAC_SECRET = VALID_SECRET;
+            const { state, cookie } = issueOAuthState('google', '/dashboard');
+
+            const [, sig] = cookie.value.split('.');
+            const tampered = `dGFtcGVyZWQ.${sig}`;
+            const result = verifyOAuthState('google', state, tampered);
+
+            expect(result.ok).toBe(false);
+        });
+    });
+
+    describe('Provider mismatch', () => {
+        it('returns ok: false when provider does not match', () => {
+            process.env.OAUTH_STATE_HMAC_SECRET = VALID_SECRET;
+            const { state, cookie } = issueOAuthState('google', '/');
+
+            const result = verifyOAuthState(
+                'apple' as unknown as 'google',
+                state,
+                cookie.value
+            );
+
+            expect(result.ok).toBe(false);
+        });
+    });
+
+    describe('Expired state', () => {
+        it('returns ok: false when state has expired', () => {
+            process.env.OAUTH_STATE_HMAC_SECRET = VALID_SECRET;
+            const issuedAt = new Date('2025-01-01T00:00:00Z');
+            const { state, cookie } = issueOAuthState('google', '/', issuedAt);
+
+            const verifyAt = new Date('2025-01-01T00:10:00Z');
+            const result = verifyOAuthState(
+                'google',
+                state,
+                cookie.value,
+                verifyAt
+            );
+
+            expect(result.ok).toBe(false);
+        });
+    });
+
+    describe('Valid flow', () => {
+        it('succeeds with correct state and cookie', () => {
+            process.env.OAUTH_STATE_HMAC_SECRET = VALID_SECRET;
+            const now = new Date();
+            const { state, cookie } = issueOAuthState(
+                'google',
+                '/dashboard',
+                now
+            );
+
+            const result = verifyOAuthState('google', state, cookie.value, now);
+
+            expect(result.ok).toBe(true);
+            if (result.ok) {
+                expect(result.next).toBe('/dashboard');
+            }
+        });
+
+        it('cookie has correct name', () => {
+            process.env.OAUTH_STATE_HMAC_SECRET = VALID_SECRET;
+            const { cookie } = issueOAuthState('google', '/');
+
+            expect(cookie.name).toBe(OAUTH_STATE_COOKIE_NAME);
+            expect(cookie.httpOnly).toBe(true);
+            expect(cookie.sameSite).toBe('lax');
+        });
+    });
+
+    describe('Malformed cookie format', () => {
+        it('returns ok: false when cookie has no separator', () => {
+            process.env.OAUTH_STATE_HMAC_SECRET = VALID_SECRET;
+
+            const result = verifyOAuthState(
+                'google',
+                'state',
+                'no-separator-here'
+            );
+
+            expect(result.ok).toBe(false);
+        });
+    });
+});

--- a/src/__tests__/worst-case/optionsChainMissing.test.ts
+++ b/src/__tests__/worst-case/optionsChainMissing.test.ts
@@ -1,0 +1,154 @@
+vi.mock('yahoo-finance2', () => {
+    const options = vi.fn();
+    return {
+        default: class MockYahooFinance {
+            options = (...args: unknown[]) => options(...args);
+        },
+        __mockOptions: options,
+    };
+});
+
+vi.mock('@y0ngha/siglens-core', () => ({
+    mapExpirationsToSlots: vi.fn().mockReturnValue([]),
+    sanitizeOptionsChain: vi.fn((chain: unknown) => chain),
+}));
+
+vi.mock('@/shared/config/time', () => ({
+    MS_PER_DAY: 86400000,
+}));
+
+import { YahooOptionsAdapter } from '@/entities/options-chain/lib/YahooOptionsAdapter';
+import { sanitizeOptionsChain } from '@y0ngha/siglens-core';
+
+const yahooModule = (await import('yahoo-finance2')) as Record<string, unknown>;
+const mockYahooOptions = yahooModule.__mockOptions as ReturnType<typeof vi.fn>;
+const mockSanitize = sanitizeOptionsChain as ReturnType<typeof vi.fn>;
+
+describe('YahooOptionsAdapter failure modes', () => {
+    const adapter = new YahooOptionsAdapter();
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns null when underlyingPrice is 0', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        mockYahooOptions.mockResolvedValue({
+            underlyingSymbol: 'AAPL',
+            expirationDates: [new Date('2025-07-18')],
+            strikes: [150, 155, 160],
+            hasMiniOptions: false,
+            quote: { regularMarketPrice: 0 },
+            options: [
+                {
+                    expirationDate: new Date('2025-07-18'),
+                    hasMiniOptions: false,
+                    calls: [
+                        {
+                            contractSymbol: 'AAPL250718C00150000',
+                            strike: 150,
+                            lastPrice: 5.0,
+                            change: 0,
+                            contractSize: 'REGULAR',
+                            expiration: new Date('2025-07-18'),
+                            lastTradeDate: new Date(),
+                            impliedVolatility: 0.3,
+                            inTheMoney: true,
+                        },
+                    ],
+                    puts: [],
+                },
+            ],
+        });
+
+        const result = await adapter.fetchSnapshot('AAPL');
+
+        expect(result).toBeNull();
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('missing underlyingPrice'),
+            'AAPL'
+        );
+    });
+
+    it('returns null when all chains are rejected by sanitization', async () => {
+        mockSanitize.mockReturnValue(null);
+        mockYahooOptions.mockResolvedValue({
+            underlyingSymbol: 'AAPL',
+            expirationDates: [new Date('2025-07-18')],
+            strikes: [150],
+            hasMiniOptions: false,
+            quote: { regularMarketPrice: 175 },
+            options: [
+                {
+                    expirationDate: new Date('2025-07-18'),
+                    hasMiniOptions: false,
+                    calls: [],
+                    puts: [],
+                },
+            ],
+        });
+
+        const result = await adapter.fetchSnapshot('AAPL');
+
+        expect(result).toBeNull();
+    });
+
+    it('returns null when options array is empty', async () => {
+        mockYahooOptions.mockResolvedValue({
+            underlyingSymbol: 'AAPL',
+            expirationDates: [],
+            strikes: [],
+            hasMiniOptions: false,
+            quote: { regularMarketPrice: 175 },
+            options: [],
+        });
+
+        const result = await adapter.fetchSnapshot('AAPL');
+
+        expect(result).toBeNull();
+    });
+
+    it('returns null on API error and logs it', async () => {
+        const errorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+        mockYahooOptions.mockRejectedValue(new Error('Yahoo API timeout'));
+
+        const result = await adapter.fetchSnapshot('AAPL');
+
+        expect(result).toBeNull();
+        expect(errorSpy).toHaveBeenCalledWith(
+            '[YahooOptionsAdapter] fetchSnapshot failed',
+            expect.any(Error)
+        );
+    });
+
+    describe('hasOptionsMarket', () => {
+        it('returns false on API error', async () => {
+            vi.spyOn(console, 'warn').mockImplementation(() => {});
+            mockYahooOptions.mockRejectedValue(new Error('Network error'));
+
+            const result = await adapter.hasOptionsMarket('AAPL');
+
+            expect(result).toBe(false);
+        });
+
+        it('returns false when no expiration dates', async () => {
+            mockYahooOptions.mockResolvedValue({ expirationDates: [] });
+
+            const result = await adapter.hasOptionsMarket('AAPL');
+
+            expect(result).toBe(false);
+        });
+
+        it('returns true when expirations exist', async () => {
+            mockYahooOptions.mockResolvedValue({
+                expirationDates: [new Date('2025-07-18')],
+            });
+
+            const result = await adapter.hasOptionsMarket('AAPL');
+
+            expect(result).toBe(true);
+        });
+    });
+});

--- a/src/__tests__/worst-case/optionsChainMissing.test.ts
+++ b/src/__tests__/worst-case/optionsChainMissing.test.ts
@@ -125,12 +125,15 @@ describe('YahooOptionsAdapter failure modes', () => {
 
     describe('hasOptionsMarket', () => {
         it('returns false on API error', async () => {
-            vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const warnSpy = vi
+                .spyOn(console, 'warn')
+                .mockImplementation(() => {});
             mockYahooOptions.mockRejectedValue(new Error('Network error'));
 
             const result = await adapter.hasOptionsMarket('AAPL');
 
             expect(result).toBe(false);
+            expect(warnSpy).toHaveBeenCalled();
         });
 
         it('returns false when no expiration dates', async () => {

--- a/src/__tests__/worst-case/passwordResetEdgeCases.test.ts
+++ b/src/__tests__/worst-case/passwordResetEdgeCases.test.ts
@@ -1,0 +1,190 @@
+import { confirmPasswordReset } from '@/entities/user/lib/confirmPasswordReset';
+import { hashEmailToken } from '@/entities/session/lib/tokenUtils';
+import type { ConfirmPasswordResetDependencies } from '@/entities/user/lib/authUseCaseTypes';
+
+function createMockDependencies(
+    overrides: Partial<{
+        emailTokens: Partial<ConfirmPasswordResetDependencies['emailTokens']>;
+        emailAuthUsers: Partial<
+            ConfirmPasswordResetDependencies['emailAuthUsers']
+        >;
+        users: Partial<ConfirmPasswordResetDependencies['users']>;
+        passwordHasher: Partial<
+            ConfirmPasswordResetDependencies['passwordHasher']
+        >;
+        passwordVerifier: Partial<
+            ConfirmPasswordResetDependencies['passwordVerifier']
+        >;
+    }> = {}
+): ConfirmPasswordResetDependencies {
+    return {
+        emailTokens: {
+            get: vi.fn().mockResolvedValue(null),
+            set: vi.fn().mockResolvedValue(undefined),
+            delete: vi.fn().mockResolvedValue(undefined),
+            consume: vi.fn().mockResolvedValue(null),
+            ...overrides.emailTokens,
+        } as unknown as ConfirmPasswordResetDependencies['emailTokens'],
+        emailAuthUsers: {
+            findEmailAuthUserByEmail: vi.fn().mockResolvedValue(null),
+            ...overrides.emailAuthUsers,
+        } as unknown as ConfirmPasswordResetDependencies['emailAuthUsers'],
+        users: {
+            updatePassword: vi.fn().mockResolvedValue(true),
+            ...overrides.users,
+        } as unknown as ConfirmPasswordResetDependencies['users'],
+        passwordHasher: {
+            hashPassword: vi.fn().mockResolvedValue('new-hash'),
+            ...overrides.passwordHasher,
+        } as unknown as ConfirmPasswordResetDependencies['passwordHasher'],
+        passwordVerifier: {
+            verifyPassword: vi.fn().mockResolvedValue(false),
+            ...overrides.passwordVerifier,
+        } as unknown as ConfirmPasswordResetDependencies['passwordVerifier'],
+    };
+}
+
+const VALID_TOKEN = 'valid-reset-token-abc123';
+const VALID_INPUT = {
+    email: 'test@example.com',
+    token: VALID_TOKEN,
+    newPassword: 'NewSecurePassword123!',
+};
+
+describe('Password reset edge cases', () => {
+    it('returns expired error when no token stored', async () => {
+        const deps = createMockDependencies({
+            emailTokens: {
+                get: vi.fn().mockResolvedValue(null),
+            },
+        });
+
+        const result = await confirmPasswordReset(VALID_INPUT, deps);
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error.code).toBe('expired_token');
+        }
+    });
+
+    it('returns invalid error when token hash does not match', async () => {
+        const deps = createMockDependencies({
+            emailTokens: {
+                get: vi.fn().mockResolvedValue({
+                    status: 'pending',
+                    tokenHash: hashEmailToken('different-token'),
+                }),
+            },
+        });
+
+        const result = await confirmPasswordReset(VALID_INPUT, deps);
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error.code).toBe('invalid_token');
+        }
+    });
+
+    it('returns invalid error when token status is not pending', async () => {
+        const deps = createMockDependencies({
+            emailTokens: {
+                get: vi.fn().mockResolvedValue({
+                    status: 'verified',
+                    tokenHash: hashEmailToken(VALID_TOKEN),
+                }),
+            },
+        });
+
+        const result = await confirmPasswordReset(VALID_INPUT, deps);
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error.code).toBe('invalid_token');
+        }
+    });
+
+    it('returns invalid error when user not found', async () => {
+        const deps = createMockDependencies({
+            emailTokens: {
+                get: vi.fn().mockResolvedValue({
+                    status: 'pending',
+                    tokenHash: hashEmailToken(VALID_TOKEN),
+                }),
+            },
+            emailAuthUsers: {
+                findEmailAuthUserByEmail: vi.fn().mockResolvedValue(null),
+            },
+        });
+
+        const result = await confirmPasswordReset(VALID_INPUT, deps);
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error.code).toBe('invalid_token');
+        }
+    });
+
+    it('returns same_password error when new password matches current', async () => {
+        const deps = createMockDependencies({
+            emailTokens: {
+                get: vi.fn().mockResolvedValue({
+                    status: 'pending',
+                    tokenHash: hashEmailToken(VALID_TOKEN),
+                }),
+            },
+            emailAuthUsers: {
+                findEmailAuthUserByEmail: vi.fn().mockResolvedValue({
+                    id: 'user-1',
+                    passwordHash: 'existing-hash',
+                }),
+            },
+            passwordVerifier: {
+                verifyPassword: vi.fn().mockResolvedValue(true),
+            },
+        });
+
+        const result = await confirmPasswordReset(VALID_INPUT, deps);
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error.code).toBe('same_password');
+        }
+    });
+
+    it('returns expired error when consume returns null (race condition)', async () => {
+        const deps = createMockDependencies({
+            emailTokens: {
+                get: vi.fn().mockResolvedValue({
+                    status: 'pending',
+                    tokenHash: hashEmailToken(VALID_TOKEN),
+                }),
+                consume: vi.fn().mockResolvedValue(null),
+            },
+            emailAuthUsers: {
+                findEmailAuthUserByEmail: vi.fn().mockResolvedValue({
+                    id: 'user-1',
+                    passwordHash: 'existing-hash',
+                }),
+            },
+        });
+
+        const result = await confirmPasswordReset(VALID_INPUT, deps);
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error.code).toBe('expired_token');
+        }
+    });
+
+    it('validates password format before anything else', async () => {
+        const deps = createMockDependencies();
+
+        const result = await confirmPasswordReset(
+            { ...VALID_INPUT, newPassword: '12' },
+            deps
+        );
+
+        expect(result.ok).toBe(false);
+        expect(deps.emailTokens.get).not.toHaveBeenCalled();
+    });
+});

--- a/src/__tests__/worst-case/pollAnalysisRedisError.test.ts
+++ b/src/__tests__/worst-case/pollAnalysisRedisError.test.ts
@@ -11,7 +11,7 @@ import { pollAnalysis } from '@y0ngha/siglens-core';
 
 const mockPollAnalysis = pollAnalysis as ReturnType<typeof vi.fn>;
 
-describe('pollAnalysisAction Redis/error scenarios', () => {
+describe('pollAnalysisAction error handling and edge cases', () => {
     afterEach(() => {
         vi.clearAllMocks();
     });

--- a/src/__tests__/worst-case/pollAnalysisRedisError.test.ts
+++ b/src/__tests__/worst-case/pollAnalysisRedisError.test.ts
@@ -1,0 +1,72 @@
+vi.mock('@y0ngha/siglens-core', () => ({
+    pollAnalysis: vi.fn(),
+}));
+
+vi.mock('@vercel/functions', () => ({
+    waitUntil: vi.fn(),
+}));
+
+import { pollAnalysisAction } from '@/entities/analysis/actions/pollAnalysisAction';
+import { pollAnalysis } from '@y0ngha/siglens-core';
+
+const mockPollAnalysis = pollAnalysis as ReturnType<typeof vi.fn>;
+
+describe('pollAnalysisAction Redis/error scenarios', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('propagates error when pollAnalysis throws (Redis connection fail)', async () => {
+        mockPollAnalysis.mockRejectedValue(
+            new Error('Redis connection refused')
+        );
+
+        await expect(pollAnalysisAction('job-1')).rejects.toThrow(
+            'Redis connection refused'
+        );
+    });
+
+    it('handles error status from poll result', async () => {
+        mockPollAnalysis.mockResolvedValue({
+            status: 'error',
+            message: 'LLM provider failed',
+        });
+
+        const result = await pollAnalysisAction('job-2');
+
+        expect(result.status).toBe('error');
+    });
+
+    it('handles unexpected shape from poll result', async () => {
+        mockPollAnalysis.mockResolvedValue({
+            status: 'unknown_status',
+        });
+
+        const result = await pollAnalysisAction('job-3');
+
+        expect(result.status).toBe('unknown_status');
+    });
+
+    it('handles null data in completed result', async () => {
+        mockPollAnalysis.mockResolvedValue({
+            status: 'completed',
+            data: null,
+        });
+
+        const result = await pollAnalysisAction('job-4');
+
+        expect(result.status).toBe('completed');
+        expect((result as unknown as { data: unknown }).data).toBeNull();
+    });
+
+    it('passes jobId and waitUntil correctly', async () => {
+        mockPollAnalysis.mockResolvedValue({ status: 'pending' });
+
+        await pollAnalysisAction('specific-job-id');
+
+        expect(mockPollAnalysis).toHaveBeenCalledWith(
+            'specific-job-id',
+            expect.objectContaining({ waitUntil: expect.any(Function) })
+        );
+    });
+});

--- a/src/__tests__/worst-case/registerUserCompensation.test.ts
+++ b/src/__tests__/worst-case/registerUserCompensation.test.ts
@@ -1,0 +1,152 @@
+import { registerUser } from '@/entities/user/lib/registerUser';
+import type {
+    RegisterUserDependencies,
+    RegisterUserInput,
+} from '@/entities/user/lib/authUseCaseTypes';
+
+function createMockDependencies(
+    overrides: Partial<RegisterUserDependencies> = {}
+): RegisterUserDependencies {
+    return {
+        users: {
+            findByEmail: vi.fn().mockResolvedValue(null),
+            createEmailUser: vi.fn().mockResolvedValue({
+                id: 'user-1',
+                email: 'test@example.com',
+                name: null,
+                avatarUrl: null,
+                emailVerified: true,
+                createdAt: new Date(),
+            }),
+            deleteUser: vi.fn().mockResolvedValue(true),
+            ...overrides.users,
+        } as unknown as RegisterUserDependencies['users'],
+        agreements: {
+            insertMany: vi.fn().mockResolvedValue(undefined),
+            ...overrides.agreements,
+        } as unknown as RegisterUserDependencies['agreements'],
+        passwordHasher: {
+            hashPassword: vi.fn().mockResolvedValue('hashed-password'),
+            ...overrides.passwordHasher,
+        } as unknown as RegisterUserDependencies['passwordHasher'],
+        emailTokens: {
+            get: vi.fn().mockResolvedValue({ status: 'verified' }),
+            delete: vi.fn().mockResolvedValue(undefined),
+            ...overrides.emailTokens,
+        } as unknown as RegisterUserDependencies['emailTokens'],
+    };
+}
+
+const VALID_INPUT: RegisterUserInput = {
+    email: 'Test@Example.com',
+    password: 'SecurePassword123!',
+    name: 'Test User',
+    agreedTermsIds: ['terms-v1'],
+};
+
+describe('registerUser compensating transaction', () => {
+    it('deletes user when agreements INSERT fails', async () => {
+        const agreementsError = new Error('DB constraint violation');
+        const deps = createMockDependencies({
+            agreements: {
+                insertMany: vi.fn().mockRejectedValue(agreementsError),
+            } as unknown as RegisterUserDependencies['agreements'],
+        });
+
+        await expect(registerUser(VALID_INPUT, deps)).rejects.toThrow(
+            'DB constraint violation'
+        );
+
+        expect(deps.users.deleteUser).toHaveBeenCalledWith('user-1');
+    });
+
+    it('logs warning when compensating delete also fails', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const deps = createMockDependencies({
+            agreements: {
+                insertMany: vi.fn().mockRejectedValue(new Error('insert fail')),
+            } as unknown as RegisterUserDependencies['agreements'],
+            users: {
+                findByEmail: vi.fn().mockResolvedValue(null),
+                createEmailUser: vi.fn().mockResolvedValue({
+                    id: 'user-1',
+                    email: 'test@example.com',
+                    name: null,
+                    avatarUrl: null,
+                    emailVerified: true,
+                    createdAt: new Date(),
+                }),
+                deleteUser: vi.fn().mockRejectedValue(new Error('delete fail')),
+            } as unknown as RegisterUserDependencies['users'],
+        });
+
+        await expect(registerUser(VALID_INPUT, deps)).rejects.toThrow(
+            'insert fail'
+        );
+
+        expect(warnSpy).toHaveBeenCalledWith(
+            '[registerUser] compensating delete failed — user row may be orphaned',
+            expect.any(Error)
+        );
+    });
+
+    it('returns email_already_exists when createEmailUser returns null (race)', async () => {
+        const deps = createMockDependencies({
+            users: {
+                findByEmail: vi.fn().mockResolvedValue(null),
+                createEmailUser: vi.fn().mockResolvedValue(null),
+                deleteUser: vi.fn(),
+            } as unknown as RegisterUserDependencies['users'],
+        });
+
+        const result = await registerUser(VALID_INPUT, deps);
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error.code).toBe('email_already_exists');
+        }
+    });
+
+    it('returns error for empty agreedTermsIds', async () => {
+        const deps = createMockDependencies();
+        const result = await registerUser(
+            { ...VALID_INPUT, agreedTermsIds: [] },
+            deps
+        );
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error.code).toBe('invalid_input');
+        }
+    });
+
+    it('returns error when email verification is not completed', async () => {
+        const deps = createMockDependencies({
+            emailTokens: {
+                get: vi.fn().mockResolvedValue(null),
+                delete: vi.fn(),
+            } as unknown as RegisterUserDependencies['emailTokens'],
+        });
+
+        const result = await registerUser(VALID_INPUT, deps);
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error.code).toBe('email_not_verified');
+        }
+    });
+
+    it('propagates bcrypt hashPassword failure', async () => {
+        const deps = createMockDependencies({
+            passwordHasher: {
+                hashPassword: vi
+                    .fn()
+                    .mockRejectedValue(new Error('bcrypt failed')),
+            } as unknown as RegisterUserDependencies['passwordHasher'],
+        });
+
+        await expect(registerUser(VALID_INPUT, deps)).rejects.toThrow(
+            'bcrypt failed'
+        );
+    });
+});

--- a/src/__tests__/worst-case/sessionSecurity.test.ts
+++ b/src/__tests__/worst-case/sessionSecurity.test.ts
@@ -1,0 +1,144 @@
+import { findUserBySessionToken } from '@/entities/user/lib/findUserBySessionToken';
+import {
+    safeCompareTokenHashes,
+    hashEmailToken,
+} from '@/entities/session/lib/tokenUtils';
+import type { FindUserBySessionTokenDependencies } from '@/entities/user/lib/authUseCaseTypes';
+
+function createMockDependencies(
+    overrides: Partial<FindUserBySessionTokenDependencies> = {}
+): FindUserBySessionTokenDependencies {
+    return {
+        sessions: {
+            findSession: vi.fn().mockResolvedValue(null),
+            ...overrides.sessions,
+        } as unknown as FindUserBySessionTokenDependencies['sessions'],
+        users: {
+            findById: vi.fn().mockResolvedValue(null),
+            ...overrides.users,
+        } as unknown as FindUserBySessionTokenDependencies['users'],
+    };
+}
+
+const MOCK_USER = {
+    id: 'user-1',
+    email: 'test@example.com',
+    name: 'Test',
+    avatarUrl: null,
+    emailVerified: true,
+    createdAt: new Date(),
+};
+
+describe('Session security edge cases', () => {
+    describe('findUserBySessionToken', () => {
+        it('returns null for expired token', async () => {
+            const pastDate = new Date('2020-01-01');
+            const deps = createMockDependencies({
+                sessions: {
+                    findSession: vi.fn().mockResolvedValue({
+                        userId: 'user-1',
+                        expiresAt: pastDate,
+                    }),
+                } as unknown as FindUserBySessionTokenDependencies['sessions'],
+            });
+
+            const result = await findUserBySessionToken('valid-token', deps, {
+                now: new Date('2025-01-01'),
+            });
+
+            expect(result).toBeNull();
+        });
+
+        it('returns null when session not found (missing cookie)', async () => {
+            const deps = createMockDependencies();
+
+            const result = await findUserBySessionToken(
+                'nonexistent-token',
+                deps
+            );
+
+            expect(result).toBeNull();
+            expect(deps.sessions.findSession).toHaveBeenCalledWith(
+                'nonexistent-token'
+            );
+        });
+
+        it('returns null when token is empty string', async () => {
+            const deps = createMockDependencies();
+
+            const result = await findUserBySessionToken('', deps);
+
+            expect(result).toBeNull();
+        });
+
+        it('returns user for valid non-expired session', async () => {
+            const futureDate = new Date('2030-01-01');
+            const deps = createMockDependencies({
+                sessions: {
+                    findSession: vi.fn().mockResolvedValue({
+                        userId: 'user-1',
+                        expiresAt: futureDate,
+                    }),
+                } as unknown as FindUserBySessionTokenDependencies['sessions'],
+                users: {
+                    findById: vi.fn().mockResolvedValue(MOCK_USER),
+                } as unknown as FindUserBySessionTokenDependencies['users'],
+            });
+
+            const result = await findUserBySessionToken('valid-token', deps, {
+                now: new Date('2025-01-01'),
+            });
+
+            expect(result).toEqual(MOCK_USER);
+        });
+
+        it('returns null when session is exactly at expiration boundary', async () => {
+            const now = new Date('2025-06-01T12:00:00Z');
+            const deps = createMockDependencies({
+                sessions: {
+                    findSession: vi.fn().mockResolvedValue({
+                        userId: 'user-1',
+                        expiresAt: now,
+                    }),
+                } as unknown as FindUserBySessionTokenDependencies['sessions'],
+            });
+
+            const result = await findUserBySessionToken('token', deps, { now });
+
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('safeCompareTokenHashes (timing-safe comparison)', () => {
+        it('returns false when first hash is not valid SHA-256 hex', () => {
+            const validHash = hashEmailToken('test');
+            expect(safeCompareTokenHashes('not-a-hash', validHash)).toBe(false);
+        });
+
+        it('returns false when second hash is not valid SHA-256 hex', () => {
+            const validHash = hashEmailToken('test');
+            expect(safeCompareTokenHashes(validHash, 'not-a-hash')).toBe(false);
+        });
+
+        it('returns false for two different valid hashes', () => {
+            const hash1 = hashEmailToken('token-a');
+            const hash2 = hashEmailToken('token-b');
+            expect(safeCompareTokenHashes(hash1, hash2)).toBe(false);
+        });
+
+        it('returns true for identical hashes', () => {
+            const hash = hashEmailToken('same-token');
+            expect(safeCompareTokenHashes(hash, hash)).toBe(true);
+        });
+
+        it('returns false for empty strings', () => {
+            expect(safeCompareTokenHashes('', '')).toBe(false);
+        });
+
+        it('returns false for uppercase hex (not valid pattern)', () => {
+            const hash = hashEmailToken('test').toUpperCase();
+            const lower = hashEmailToken('test');
+            expect(safeCompareTokenHashes(hash, lower)).toBe(false);
+        });
+    });
+});

--- a/src/__tests__/worst-case/singleFlightCollapse.test.ts
+++ b/src/__tests__/worst-case/singleFlightCollapse.test.ts
@@ -1,0 +1,95 @@
+import { createSingleFlight } from '@/entities/ticker/lib/utils/singleFlight';
+
+describe('SingleFlight collapse and failure propagation', () => {
+    it('collapses 100 concurrent calls for same key into one execution', async () => {
+        const sf = createSingleFlight<string>();
+        let callCount = 0;
+
+        const work = async (): Promise<string> => {
+            callCount++;
+            await new Promise(r => setTimeout(r, 10));
+            return 'result';
+        };
+
+        const promises = Array.from({ length: 100 }, () =>
+            sf.run('same-key', work)
+        );
+
+        const results = await Promise.all(promises);
+
+        expect(callCount).toBe(1);
+        expect(results.every(r => r === 'result')).toBe(true);
+    });
+
+    it('runs separate executions for different keys', async () => {
+        const sf = createSingleFlight<string>();
+        let callCount = 0;
+
+        const work = async (): Promise<string> => {
+            callCount++;
+            return 'result';
+        };
+
+        await Promise.all([
+            sf.run('key-a', work),
+            sf.run('key-b', work),
+            sf.run('key-c', work),
+        ]);
+
+        expect(callCount).toBe(3);
+    });
+
+    it('propagates failure to all waiting callers', async () => {
+        const sf = createSingleFlight<string>();
+        const error = new Error('Gemini API failed');
+
+        const work = async (): Promise<string> => {
+            throw error;
+        };
+
+        const promises = Array.from({ length: 5 }, () =>
+            sf.run('fail-key', work)
+        );
+
+        const results = await Promise.allSettled(promises);
+
+        expect(results.every(r => r.status === 'rejected')).toBe(true);
+    });
+
+    it('allows fresh execution after failure clears in-flight entry', async () => {
+        const sf = createSingleFlight<string>();
+        let attempt = 0;
+
+        const work = async (): Promise<string> => {
+            attempt++;
+            if (attempt === 1) throw new Error('first fail');
+            return 'success';
+        };
+
+        await expect(sf.run('retry-key', work)).rejects.toThrow('first fail');
+
+        const result = await sf.run('retry-key', work);
+        expect(result).toBe('success');
+        expect(attempt).toBe(2);
+    });
+
+    it('clears entries after _resetForTest', async () => {
+        const sf = createSingleFlight<string>();
+        let callCount = 0;
+
+        const longWork = async (): Promise<string> => {
+            callCount++;
+            await new Promise(r => setTimeout(r, 50));
+            return 'done';
+        };
+
+        const promise1 = sf.run('key', longWork);
+        sf._resetForTest();
+
+        const promise2 = sf.run('key', longWork);
+
+        await Promise.all([promise1, promise2]);
+
+        expect(callCount).toBe(2);
+    });
+});

--- a/src/__tests__/worst-case/yahooNoticeSuppression.test.ts
+++ b/src/__tests__/worst-case/yahooNoticeSuppression.test.ts
@@ -1,0 +1,37 @@
+vi.mock('@y0ngha/siglens-core', () => ({
+    mapExpirationsToSlots: vi.fn().mockReturnValue([]),
+    sanitizeOptionsChain: vi.fn((chain: unknown) => chain),
+}));
+
+vi.mock('@/shared/config/time', () => ({
+    MS_PER_DAY: 86400000,
+}));
+
+const mockConstructorArgs: unknown[] = [];
+
+vi.mock('yahoo-finance2', () => ({
+    default: class MockYahooFinance {
+        options = vi.fn().mockResolvedValue({
+            underlyingSymbol: 'AAPL',
+            expirationDates: [],
+            strikes: [],
+            hasMiniOptions: false,
+            quote: { regularMarketPrice: 175 },
+            options: [],
+        });
+
+        constructor(opts?: unknown) {
+            mockConstructorArgs.push(opts);
+        }
+    },
+}));
+
+describe('Yahoo Finance notice suppression', () => {
+    it('constructs YahooFinance with suppressNotices config', async () => {
+        await import('@/entities/options-chain/lib/YahooOptionsAdapter');
+
+        expect(mockConstructorArgs).toContainEqual({
+            suppressNotices: ['yahooSurvey'],
+        });
+    });
+});

--- a/src/__tests__/worst-case/yahooTimeout.test.ts
+++ b/src/__tests__/worst-case/yahooTimeout.test.ts
@@ -30,7 +30,9 @@ describe('Yahoo API timeout and error scenarios', () => {
     });
 
     it('returns null on network timeout', async () => {
-        vi.spyOn(console, 'error').mockImplementation(() => {});
+        const errorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
         mockYahooOptions.mockRejectedValue(
             new Error('network timeout at: https://query2.finance.yahoo.com')
         );
@@ -38,10 +40,13 @@ describe('Yahoo API timeout and error scenarios', () => {
         const result = await adapter.fetchSnapshot('AAPL');
 
         expect(result).toBeNull();
+        expect(errorSpy).toHaveBeenCalled();
     });
 
     it('returns null when Yahoo returns HTML error page', async () => {
-        vi.spyOn(console, 'error').mockImplementation(() => {});
+        const errorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
         mockYahooOptions.mockRejectedValue(
             new Error('Unexpected token < in JSON at position 0')
         );
@@ -49,10 +54,13 @@ describe('Yahoo API timeout and error scenarios', () => {
         const result = await adapter.fetchSnapshot('AAPL');
 
         expect(result).toBeNull();
+        expect(errorSpy).toHaveBeenCalled();
     });
 
     it('returns null on 429 rate limit', async () => {
-        vi.spyOn(console, 'error').mockImplementation(() => {});
+        const errorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
         const rateLimitError = new Error('Too Many Requests');
         (rateLimitError as Error & { status: number }).status = 429;
         mockYahooOptions.mockRejectedValue(rateLimitError);
@@ -60,6 +68,7 @@ describe('Yahoo API timeout and error scenarios', () => {
         const result = await adapter.fetchSnapshot('AAPL');
 
         expect(result).toBeNull();
+        expect(errorSpy).toHaveBeenCalled();
     });
 
     it('handles response with 100+ expiration dates', async () => {
@@ -103,12 +112,13 @@ describe('Yahoo API timeout and error scenarios', () => {
     });
 
     it('hasOptionsMarket returns false on timeout', async () => {
-        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
         mockYahooOptions.mockRejectedValue(new Error('Timeout'));
 
         const result = await adapter.hasOptionsMarket('AAPL');
 
         expect(result).toBe(false);
+        expect(warnSpy).toHaveBeenCalled();
     });
 
     it('warns but continues when individual expiration fetch fails', async () => {

--- a/src/__tests__/worst-case/yahooTimeout.test.ts
+++ b/src/__tests__/worst-case/yahooTimeout.test.ts
@@ -1,0 +1,163 @@
+vi.mock('yahoo-finance2', () => {
+    const options = vi.fn();
+    return {
+        default: class MockYahooFinance {
+            options = (...args: unknown[]) => options(...args);
+        },
+        __mockOptions: options,
+    };
+});
+
+vi.mock('@y0ngha/siglens-core', () => ({
+    mapExpirationsToSlots: vi.fn().mockReturnValue([]),
+    sanitizeOptionsChain: vi.fn((chain: unknown) => chain),
+}));
+
+vi.mock('@/shared/config/time', () => ({
+    MS_PER_DAY: 86400000,
+}));
+
+import { YahooOptionsAdapter } from '@/entities/options-chain/lib/YahooOptionsAdapter';
+
+const yahooModule = (await import('yahoo-finance2')) as Record<string, unknown>;
+const mockYahooOptions = yahooModule.__mockOptions as ReturnType<typeof vi.fn>;
+
+describe('Yahoo API timeout and error scenarios', () => {
+    const adapter = new YahooOptionsAdapter();
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns null on network timeout', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        mockYahooOptions.mockRejectedValue(
+            new Error('network timeout at: https://query2.finance.yahoo.com')
+        );
+
+        const result = await adapter.fetchSnapshot('AAPL');
+
+        expect(result).toBeNull();
+    });
+
+    it('returns null when Yahoo returns HTML error page', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        mockYahooOptions.mockRejectedValue(
+            new Error('Unexpected token < in JSON at position 0')
+        );
+
+        const result = await adapter.fetchSnapshot('AAPL');
+
+        expect(result).toBeNull();
+    });
+
+    it('returns null on 429 rate limit', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        const rateLimitError = new Error('Too Many Requests');
+        (rateLimitError as Error & { status: number }).status = 429;
+        mockYahooOptions.mockRejectedValue(rateLimitError);
+
+        const result = await adapter.fetchSnapshot('AAPL');
+
+        expect(result).toBeNull();
+    });
+
+    it('handles response with 100+ expiration dates', async () => {
+        const expirations = Array.from({ length: 120 }, (_, i) => {
+            const d = new Date();
+            d.setDate(d.getDate() + 7 * (i + 1));
+            return d;
+        });
+
+        mockYahooOptions.mockResolvedValue({
+            underlyingSymbol: 'SPY',
+            expirationDates: expirations,
+            strikes: [400, 410, 420],
+            hasMiniOptions: false,
+            quote: { regularMarketPrice: 415 },
+            options: [
+                {
+                    expirationDate: expirations[0],
+                    hasMiniOptions: false,
+                    calls: [
+                        {
+                            contractSymbol: 'SPY250718C00400000',
+                            strike: 400,
+                            lastPrice: 15.0,
+                            change: 0,
+                            contractSize: 'REGULAR',
+                            expiration: expirations[0],
+                            lastTradeDate: new Date(),
+                            impliedVolatility: 0.2,
+                            inTheMoney: true,
+                        },
+                    ],
+                    puts: [],
+                },
+            ],
+        });
+
+        const result = await adapter.fetchSnapshot('SPY');
+
+        expect(result).not.toBeNull();
+    });
+
+    it('hasOptionsMarket returns false on timeout', async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        mockYahooOptions.mockRejectedValue(new Error('Timeout'));
+
+        const result = await adapter.hasOptionsMarket('AAPL');
+
+        expect(result).toBe(false);
+    });
+
+    it('warns but continues when individual expiration fetch fails', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const { mapExpirationsToSlots } = await import('@y0ngha/siglens-core');
+        const mockMap = mapExpirationsToSlots as ReturnType<typeof vi.fn>;
+        mockMap.mockReturnValue([{ slot: '1M', expirationDate: '2025-08-15' }]);
+
+        mockYahooOptions
+            .mockResolvedValueOnce({
+                underlyingSymbol: 'AAPL',
+                expirationDates: [
+                    new Date('2025-07-18'),
+                    new Date('2025-08-15'),
+                ],
+                strikes: [150],
+                hasMiniOptions: false,
+                quote: { regularMarketPrice: 175 },
+                options: [
+                    {
+                        expirationDate: new Date('2025-07-18'),
+                        hasMiniOptions: false,
+                        calls: [
+                            {
+                                contractSymbol: 'AAPL250718C00150000',
+                                strike: 150,
+                                lastPrice: 25,
+                                change: 0,
+                                contractSize: 'REGULAR',
+                                expiration: new Date('2025-07-18'),
+                                lastTradeDate: new Date(),
+                                impliedVolatility: 0.3,
+                                inTheMoney: true,
+                            },
+                        ],
+                        puts: [],
+                    },
+                ],
+            })
+            .mockRejectedValueOnce(new Error('Timeout on expiration fetch'));
+
+        const result = await adapter.fetchSnapshot('AAPL');
+
+        expect(result).not.toBeNull();
+        expect(warnSpy).toHaveBeenCalledWith(
+            '[YahooOptionsAdapter] fetch expiration failed',
+            'AAPL',
+            expect.any(String),
+            expect.any(Error)
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- 27개 worst-case / error / edge-case 테스트 작성 (`src/__tests__/worst-case/`)
- 184개 새 테스트 케이스
- Critical 4 + High 6 + AI/External 6 + Medium 6 + Low 5

## Critical (데이터 손실/보안)
llmProviderFailures, registerUserCompensation, sessionSecurity, databaseRetryExhaustion

## High (UX 파괴)
assetInfoDegradation, emptyChartData, newsApiMalformed, optionsChainMissing, oauthStateValidation, authHintCookieFailure

## AI/External API
aiSlowResponse, pollAnalysisRedisError, fmpLargeResponse, yahooTimeout, aiMalformedJsonResponse, analysisMissingFields

## Medium (UX 저하)
aiRateLimit, emailVerificationEdgeCases, passwordResetEdgeCases, malformedApiRequests, fmpRateLimit, singleFlightCollapse

## Low (외관/로그)
cacheWriteFailure, chartResizeHydration, backgroundTranslation, yahooNoticeSuppression, jobCancelPartialFailure

## Test plan
- [x] `yarn test` — all suites pass (184 new tests)
- [x] `tsc --noEmit` — 0 errors
- [x] `yarn lint` — 0 errors
- [x] `yarn format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)