### PR TITLE
feat(sitemap): long-tail 서브 라우트 sitemap 추가

### DIFF
--- a/src/app/api/sitemap/__tests__/longtail.test.ts
+++ b/src/app/api/sitemap/__tests__/longtail.test.ts
@@ -3,9 +3,17 @@ vi.mock('next/server', async () => {
         await vi.importActual<typeof import('next/server')>('next/server');
     return { ...actual };
 });
+
+/**
+ * SITEMAP_MAX_URLS_PER_FILE=15, LONGTAIL_ENTRIES_PER_TICKER=5 이므로
+ * TICKERS_PER_PAGE = Math.floor(15/5) = 3.
+ * 티커 5개(AAA~EEE): page1=[AAA,BBB,CCC], page2=[DDD,EEE].
+ */
 vi.mock('@/entities/sitemap-entry', () => ({
     loadLongTailTickers: vi.fn(),
-    SITEMAP_MAX_URLS_PER_FILE: 3,
+    SITEMAP_MAX_URLS_PER_FILE: 15,
+    LONGTAIL_ENTRIES_PER_TICKER: 5,
+    buildLongTailEntries: vi.fn(),
     toUrlSetXml: vi.fn().mockReturnValue('<?xml version="1.0"?><urlset/>'),
 }));
 vi.mock('@/shared/lib/seo', () => ({
@@ -14,13 +22,29 @@ vi.mock('@/shared/lib/seo', () => ({
 }));
 
 import { GET } from '@/app/api/sitemap/longtail/[page]/route';
-import { loadLongTailTickers, toUrlSetXml } from '@/entities/sitemap-entry';
+import {
+    buildLongTailEntries,
+    loadLongTailTickers,
+    toUrlSetXml,
+} from '@/entities/sitemap-entry';
 import type { MockedFunction } from 'vitest';
 
 const mockLoadLongTailTickers = loadLongTailTickers as MockedFunction<
     typeof loadLongTailTickers
 >;
+const mockBuildLongTailEntries = buildLongTailEntries as MockedFunction<
+    typeof buildLongTailEntries
+>;
 const mockToUrlSetXml = toUrlSetXml as MockedFunction<typeof toUrlSetXml>;
+
+const FAKE_ENTRIES = [
+    {
+        url: 'https://siglens.io/AAA',
+        lastModified: new Date('2025-01-01'),
+        changeFrequency: 'weekly' as const,
+        priority: 0.5,
+    },
+];
 
 function callGET(page: string): Promise<Response> {
     return GET(new Request('http://localhost/api/sitemap/longtail/' + page), {
@@ -38,6 +62,7 @@ describe('GET /api/sitemap/longtail/[page]', () => {
             'DDD',
             'EEE',
         ]);
+        mockBuildLongTailEntries.mockReturnValue(FAKE_ENTRIES);
     });
 
     it('returns 404 for non-numeric page', async () => {
@@ -69,30 +94,27 @@ describe('GET /api/sitemap/longtail/[page]', () => {
         );
     });
 
-    it('passes correct chunk of tickers to toUrlSetXml for page 1', async () => {
+    it('calls buildLongTailEntries with the first 3-ticker chunk for page 1', async () => {
         await callGET('1');
 
-        const entries = mockToUrlSetXml.mock.calls[0][0];
-        expect(entries).toHaveLength(3);
-        expect(entries[0].url).toBe('https://siglens.io/AAA');
-        expect(entries[1].url).toBe('https://siglens.io/BBB');
-        expect(entries[2].url).toBe('https://siglens.io/CCC');
+        expect(mockBuildLongTailEntries).toHaveBeenCalledWith(
+            ['AAA', 'BBB', 'CCC'],
+            new Date('2025-01-01')
+        );
     });
 
-    it('returns the second chunk for page 2', async () => {
+    it('calls buildLongTailEntries with the remaining 2-ticker chunk for page 2', async () => {
         await callGET('2');
 
-        const entries = mockToUrlSetXml.mock.calls[0][0];
-        expect(entries).toHaveLength(2);
-        expect(entries[0].url).toBe('https://siglens.io/DDD');
-        expect(entries[1].url).toBe('https://siglens.io/EEE');
+        expect(mockBuildLongTailEntries).toHaveBeenCalledWith(
+            ['DDD', 'EEE'],
+            new Date('2025-01-01')
+        );
     });
 
-    it('sets changeFrequency to weekly and priority to 0.5', async () => {
+    it('passes buildLongTailEntries result to toUrlSetXml', async () => {
         await callGET('1');
 
-        const entries = mockToUrlSetXml.mock.calls[0][0];
-        expect(entries[0].changeFrequency).toBe('weekly');
-        expect(entries[0].priority).toBe(0.5);
+        expect(mockToUrlSetXml).toHaveBeenCalledWith(FAKE_ENTRIES);
     });
 });

--- a/src/app/api/sitemap/__tests__/longtail.test.ts
+++ b/src/app/api/sitemap/__tests__/longtail.test.ts
@@ -5,14 +5,12 @@ vi.mock('next/server', async () => {
 });
 
 /**
- * SITEMAP_MAX_URLS_PER_FILE=15, LONGTAIL_ENTRIES_PER_TICKER=5 이므로
- * TICKERS_PER_PAGE = Math.floor(15/5) = 3.
+ * LONGTAIL_TICKERS_PER_PAGE=3이므로
  * 티커 5개(AAA~EEE): page1=[AAA,BBB,CCC], page2=[DDD,EEE].
  */
 vi.mock('@/entities/sitemap-entry', () => ({
     loadLongTailTickers: vi.fn(),
-    SITEMAP_MAX_URLS_PER_FILE: 15,
-    LONGTAIL_ENTRIES_PER_TICKER: 5,
+    LONGTAIL_TICKERS_PER_PAGE: 3,
     buildLongTailEntries: vi.fn(),
     toUrlSetXml: vi.fn().mockReturnValue('<?xml version="1.0"?><urlset/>'),
 }));

--- a/src/app/api/sitemap/__tests__/route.test.ts
+++ b/src/app/api/sitemap/__tests__/route.test.ts
@@ -6,6 +6,7 @@ vi.mock('next/server', async () => {
 vi.mock('@/entities/sitemap-entry', () => ({
     loadLongTailTickers: vi.fn(),
     SITEMAP_MAX_URLS_PER_FILE: 50000,
+    LONGTAIL_ENTRIES_PER_TICKER: 5,
     toSitemapIndexXml: vi
         .fn()
         .mockReturnValue('<?xml version="1.0"?><sitemapindex/>'),
@@ -57,13 +58,14 @@ describe('GET /api/sitemap (index)', () => {
     });
 
     it('generates long-tail sub-sitemap entries based on ticker count', async () => {
-        const tickers = Array.from({ length: 100001 }, (_, i) => `T${i}`);
+        // tickersPerPage = Math.floor(50000 / 5) = 10000
+        // ceil(25001 / 10000) = 3 longtail pages → 2 + 3 = 5 total entries
+        const tickers = Array.from({ length: 25001 }, (_, i) => `T${i}`);
         mockLoadLongTailTickers.mockResolvedValue(tickers);
 
         await GET();
 
         const entries = mockToSitemapIndexXml.mock.calls[0][0];
-        // 2 (static + popular) + ceil(100001/50000) = 2 + 3 = 5
         expect(entries).toHaveLength(5);
         expect(entries[2].url).toContain('sitemap-longtail-1.xml');
         expect(entries[3].url).toContain('sitemap-longtail-2.xml');

--- a/src/app/api/sitemap/__tests__/route.test.ts
+++ b/src/app/api/sitemap/__tests__/route.test.ts
@@ -5,8 +5,7 @@ vi.mock('next/server', async () => {
 });
 vi.mock('@/entities/sitemap-entry', () => ({
     loadLongTailTickers: vi.fn(),
-    SITEMAP_MAX_URLS_PER_FILE: 50000,
-    LONGTAIL_ENTRIES_PER_TICKER: 5,
+    LONGTAIL_TICKERS_PER_PAGE: 10000,
     toSitemapIndexXml: vi
         .fn()
         .mockReturnValue('<?xml version="1.0"?><sitemapindex/>'),

--- a/src/app/api/sitemap/longtail/[page]/route.ts
+++ b/src/app/api/sitemap/longtail/[page]/route.ts
@@ -1,14 +1,23 @@
 import { NextResponse } from 'next/server';
 import {
+    buildLongTailEntries,
     loadLongTailTickers,
+    LONGTAIL_ENTRIES_PER_TICKER,
     SITEMAP_MAX_URLS_PER_FILE,
-    type SitemapEntry,
     toUrlSetXml,
 } from '@/entities/sitemap-entry';
-import { SITE_BUILD_DATE, SITE_URL } from '@/shared/lib/seo';
+import { SITE_BUILD_DATE } from '@/shared/lib/seo';
 
-// DB 의존(no-store fetch)이라 force-dynamic. trafic 보호는 CDN cache에 위임.
 export const dynamic = 'force-dynamic';
+
+/**
+ * 한 sitemap 파일에 담을 수 있는 티커 수.
+ * 티커당 LONGTAIL_ENTRIES_PER_TICKER개 URL을 생성하므로,
+ * SITEMAP_MAX_URLS_PER_FILE을 넘지 않도록 역산한다.
+ */
+const TICKERS_PER_PAGE = Math.floor(
+    SITEMAP_MAX_URLS_PER_FILE / LONGTAIL_ENTRIES_PER_TICKER
+);
 
 interface RouteContext {
     params: Promise<{ page: string }>;
@@ -25,23 +34,14 @@ export async function GET(
     }
 
     const all = await loadLongTailTickers();
-    const start = (pageNum - 1) * SITEMAP_MAX_URLS_PER_FILE;
-    const chunk = all.slice(start, start + SITEMAP_MAX_URLS_PER_FILE);
+    const start = (pageNum - 1) * TICKERS_PER_PAGE;
+    const chunk = all.slice(start, start + TICKERS_PER_PAGE);
 
-    // 빈 chunk = sitemap index가 노출한 페이지 수를 초과한 요청. 404로 명시.
     if (chunk.length === 0) {
         return new NextResponse('Page out of range', { status: 404 });
     }
 
-    // long-tail은 weekly changeFreq + 빌드 시점 lastmod로 충분. POPULAR과 달리
-    // 일·시간 단위 슬라이딩 시그널이 필요할 만큼 갱신 빈도가 높지 않다.
-    const entries: SitemapEntry[] = chunk.map(ticker => ({
-        url: `${SITE_URL}/${ticker}`,
-        lastModified: SITE_BUILD_DATE,
-        changeFrequency: 'weekly',
-        priority: 0.5,
-    }));
-
+    const entries = buildLongTailEntries(chunk, SITE_BUILD_DATE);
     const xml = toUrlSetXml(entries);
     return new NextResponse(xml, {
         headers: {

--- a/src/app/api/sitemap/longtail/[page]/route.ts
+++ b/src/app/api/sitemap/longtail/[page]/route.ts
@@ -2,22 +2,13 @@ import { NextResponse } from 'next/server';
 import {
     buildLongTailEntries,
     loadLongTailTickers,
-    LONGTAIL_ENTRIES_PER_TICKER,
-    SITEMAP_MAX_URLS_PER_FILE,
+    LONGTAIL_TICKERS_PER_PAGE,
     toUrlSetXml,
 } from '@/entities/sitemap-entry';
 import { SITE_BUILD_DATE } from '@/shared/lib/seo';
 
+// DB 의존(no-store fetch)이라 force-dynamic. traffic 보호는 CDN cache에 위임.
 export const dynamic = 'force-dynamic';
-
-/**
- * 한 sitemap 파일에 담을 수 있는 티커 수.
- * 티커당 LONGTAIL_ENTRIES_PER_TICKER개 URL을 생성하므로,
- * SITEMAP_MAX_URLS_PER_FILE을 넘지 않도록 역산한다.
- */
-const TICKERS_PER_PAGE = Math.floor(
-    SITEMAP_MAX_URLS_PER_FILE / LONGTAIL_ENTRIES_PER_TICKER
-);
 
 interface RouteContext {
     params: Promise<{ page: string }>;
@@ -34,9 +25,10 @@ export async function GET(
     }
 
     const all = await loadLongTailTickers();
-    const start = (pageNum - 1) * TICKERS_PER_PAGE;
-    const chunk = all.slice(start, start + TICKERS_PER_PAGE);
+    const start = (pageNum - 1) * LONGTAIL_TICKERS_PER_PAGE;
+    const chunk = all.slice(start, start + LONGTAIL_TICKERS_PER_PAGE);
 
+    // 빈 chunk = sitemap index가 노출한 페이지 수를 초과한 요청. 404로 명시.
     if (chunk.length === 0) {
         return new NextResponse('Page out of range', { status: 404 });
     }

--- a/src/app/api/sitemap/route.ts
+++ b/src/app/api/sitemap/route.ts
@@ -1,9 +1,8 @@
 import { NextResponse } from 'next/server';
 import {
     loadLongTailTickers,
-    LONGTAIL_ENTRIES_PER_TICKER,
+    LONGTAIL_TICKERS_PER_PAGE,
     type SitemapIndexEntry,
-    SITEMAP_MAX_URLS_PER_FILE,
     toSitemapIndexXml,
 } from '@/entities/sitemap-entry';
 import { SITE_BUILD_DATE, SITE_URL } from '@/shared/lib/seo';
@@ -29,10 +28,9 @@ export const dynamic = 'force-dynamic';
 export async function GET(): Promise<Response> {
     const now = new Date();
     const longTailTickers = await loadLongTailTickers();
-    const tickersPerPage = Math.floor(
-        SITEMAP_MAX_URLS_PER_FILE / LONGTAIL_ENTRIES_PER_TICKER
+    const longTailPages = Math.ceil(
+        longTailTickers.length / LONGTAIL_TICKERS_PER_PAGE
     );
-    const longTailPages = Math.ceil(longTailTickers.length / tickersPerPage);
 
     // long-tail이 비어 있을 수 있다(DB 미설정/실패 시 graceful fallback).
     // 그 경우 longTailPages = 0이라 sub-sitemap 항목 자체가 빠지므로,

--- a/src/app/api/sitemap/route.ts
+++ b/src/app/api/sitemap/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import {
     loadLongTailTickers,
+    LONGTAIL_ENTRIES_PER_TICKER,
     type SitemapIndexEntry,
     SITEMAP_MAX_URLS_PER_FILE,
     toSitemapIndexXml,
@@ -21,16 +22,17 @@ export const dynamic = 'force-dynamic';
  * 구성:
  *   - /sitemap-static.xml  : home/market/backtesting/legal (5 URL)
  *   - /sitemap-popular.xml : POPULAR_TICKERS × 5~6 routes (~1,000 URL)
- *   - /sitemap-longtail-{n}.xml : long-tail × 1 route, page당 50,000 URL chunk
+ *   - /sitemap-longtail-{n}.xml : long-tail × 5 routes (chart/news/fundamental/overall/fear-greed), page당 10,000 tickers
  *
  * (Next.js rewrite는 next.config.ts에서 /sitemap-*.xml → /api/sitemap/* 으로 매핑)
  */
 export async function GET(): Promise<Response> {
     const now = new Date();
     const longTailTickers = await loadLongTailTickers();
-    const longTailPages = Math.ceil(
-        longTailTickers.length / SITEMAP_MAX_URLS_PER_FILE
+    const tickersPerPage = Math.floor(
+        SITEMAP_MAX_URLS_PER_FILE / LONGTAIL_ENTRIES_PER_TICKER
     );
+    const longTailPages = Math.ceil(longTailTickers.length / tickersPerPage);
 
     // long-tail이 비어 있을 수 있다(DB 미설정/실패 시 graceful fallback).
     // 그 경우 longTailPages = 0이라 sub-sitemap 항목 자체가 빠지므로,

--- a/src/app/api/sitemap/route.ts
+++ b/src/app/api/sitemap/route.ts
@@ -21,7 +21,7 @@ export const dynamic = 'force-dynamic';
  * 구성:
  *   - /sitemap-static.xml  : home/market/backtesting/legal (5 URL)
  *   - /sitemap-popular.xml : POPULAR_TICKERS × 5~6 routes (~1,000 URL)
- *   - /sitemap-longtail-{n}.xml : long-tail × 5 routes (chart/news/fundamental/overall/fear-greed), page당 10,000 tickers
+ *   - /sitemap-longtail-{n}.xml : long-tail × LONGTAIL_ENTRIES_PER_TICKER routes (chart/news/fundamental/overall/fear-greed), page당 LONGTAIL_TICKERS_PER_PAGE tickers
  *
  * (Next.js rewrite는 next.config.ts에서 /sitemap-*.xml → /api/sitemap/* 으로 매핑)
  */

--- a/src/entities/sitemap-entry/__tests__/buildLongTailEntries.test.ts
+++ b/src/entities/sitemap-entry/__tests__/buildLongTailEntries.test.ts
@@ -3,13 +3,14 @@ vi.mock('@/shared/lib/seo', () => ({
 }));
 
 import { buildLongTailEntries } from '../lib/buildLongTailEntries';
+import { LONGTAIL_ENTRIES_PER_TICKER } from '../model';
 
 const BUILD_DATE = new Date('2026-01-15T00:00:00.000Z');
 
 describe('buildLongTailEntries', () => {
     it('티커 1개 → 5개 엔트리(chart, news, fundamental, overall, fear-greed)를 반환한다', () => {
         const entries = buildLongTailEntries(['AAPL'], BUILD_DATE);
-        expect(entries).toHaveLength(5);
+        expect(entries).toHaveLength(LONGTAIL_ENTRIES_PER_TICKER);
 
         const urls = entries.map(e => e.url);
         expect(urls).toEqual([
@@ -26,7 +27,7 @@ describe('buildLongTailEntries', () => {
             ['AAPL', 'MSFT', 'GOOG'],
             BUILD_DATE
         );
-        expect(entries).toHaveLength(15);
+        expect(entries).toHaveLength(LONGTAIL_ENTRIES_PER_TICKER * 3);
     });
 
     it('빈 배열 → 빈 배열을 반환한다', () => {

--- a/src/entities/sitemap-entry/__tests__/buildLongTailEntries.test.ts
+++ b/src/entities/sitemap-entry/__tests__/buildLongTailEntries.test.ts
@@ -1,0 +1,67 @@
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_URL: 'https://siglens.io',
+}));
+
+import { buildLongTailEntries } from '../lib/buildLongTailEntries';
+
+const BUILD_DATE = new Date('2026-01-15T00:00:00.000Z');
+
+describe('buildLongTailEntries', () => {
+    it('티커 1개 → 5개 엔트리(chart, news, fundamental, overall, fear-greed)를 반환한다', () => {
+        const entries = buildLongTailEntries(['AAPL'], BUILD_DATE);
+        expect(entries).toHaveLength(5);
+
+        const urls = entries.map(e => e.url);
+        expect(urls).toEqual([
+            'https://siglens.io/AAPL',
+            'https://siglens.io/AAPL/news',
+            'https://siglens.io/AAPL/fundamental',
+            'https://siglens.io/AAPL/overall',
+            'https://siglens.io/AAPL/fear-greed',
+        ]);
+    });
+
+    it('여러 티커에 대해 올바른 총 엔트리 수를 반환한다', () => {
+        const entries = buildLongTailEntries(
+            ['AAPL', 'MSFT', 'GOOG'],
+            BUILD_DATE
+        );
+        expect(entries).toHaveLength(15);
+    });
+
+    it('빈 배열 → 빈 배열을 반환한다', () => {
+        const entries = buildLongTailEntries([], BUILD_DATE);
+        expect(entries).toHaveLength(0);
+    });
+
+    it('chart는 priority 0.5 / weekly, 서브 라우트는 설계대로 priority와 changefreq를 설정한다', () => {
+        const entries = buildLongTailEntries(['AAPL'], BUILD_DATE);
+
+        const chart = entries.find(e => e.url.endsWith('/AAPL'))!;
+        expect(chart.priority).toBe(0.5);
+        expect(chart.changeFrequency).toBe('weekly');
+
+        const news = entries.find(e => e.url.endsWith('/news'))!;
+        expect(news.priority).toBe(0.45);
+        expect(news.changeFrequency).toBe('weekly');
+
+        const fundamental = entries.find(e => e.url.endsWith('/fundamental'))!;
+        expect(fundamental.priority).toBe(0.4);
+        expect(fundamental.changeFrequency).toBe('monthly');
+
+        const overall = entries.find(e => e.url.endsWith('/overall'))!;
+        expect(overall.priority).toBe(0.45);
+        expect(overall.changeFrequency).toBe('weekly');
+
+        const fearGreed = entries.find(e => e.url.endsWith('/fear-greed'))!;
+        expect(fearGreed.priority).toBe(0.4);
+        expect(fearGreed.changeFrequency).toBe('weekly');
+    });
+
+    it('모든 엔트리의 lastModified는 전달받은 buildDate와 같다', () => {
+        const entries = buildLongTailEntries(['AAPL'], BUILD_DATE);
+        for (const entry of entries) {
+            expect(entry.lastModified).toBe(BUILD_DATE);
+        }
+    });
+});

--- a/src/entities/sitemap-entry/__tests__/buildLongTailEntries.test.ts
+++ b/src/entities/sitemap-entry/__tests__/buildLongTailEntries.test.ts
@@ -2,7 +2,12 @@ vi.mock('@/shared/lib/seo', () => ({
     SITE_URL: 'https://siglens.io',
 }));
 
-import { buildLongTailEntries } from '../lib/buildLongTailEntries';
+import {
+    buildLongTailEntries,
+    LONGTAIL_CHART_PRIORITY,
+    LONGTAIL_LOW_PRIORITY,
+    LONGTAIL_SUB_PRIORITY,
+} from '../lib/buildLongTailEntries';
 import { LONGTAIL_ENTRIES_PER_TICKER } from '../model';
 
 const BUILD_DATE = new Date('2026-01-15T00:00:00.000Z');
@@ -39,23 +44,23 @@ describe('buildLongTailEntries', () => {
         const entries = buildLongTailEntries(['AAPL'], BUILD_DATE);
 
         const chart = entries.find(e => e.url.endsWith('/AAPL'))!;
-        expect(chart.priority).toBe(0.5);
+        expect(chart.priority).toBe(LONGTAIL_CHART_PRIORITY);
         expect(chart.changeFrequency).toBe('weekly');
 
         const news = entries.find(e => e.url.endsWith('/news'))!;
-        expect(news.priority).toBe(0.45);
+        expect(news.priority).toBe(LONGTAIL_SUB_PRIORITY);
         expect(news.changeFrequency).toBe('weekly');
 
         const fundamental = entries.find(e => e.url.endsWith('/fundamental'))!;
-        expect(fundamental.priority).toBe(0.4);
+        expect(fundamental.priority).toBe(LONGTAIL_LOW_PRIORITY);
         expect(fundamental.changeFrequency).toBe('monthly');
 
         const overall = entries.find(e => e.url.endsWith('/overall'))!;
-        expect(overall.priority).toBe(0.45);
+        expect(overall.priority).toBe(LONGTAIL_SUB_PRIORITY);
         expect(overall.changeFrequency).toBe('weekly');
 
         const fearGreed = entries.find(e => e.url.endsWith('/fear-greed'))!;
-        expect(fearGreed.priority).toBe(0.4);
+        expect(fearGreed.priority).toBe(LONGTAIL_LOW_PRIORITY);
         expect(fearGreed.changeFrequency).toBe('weekly');
     });
 

--- a/src/entities/sitemap-entry/index.ts
+++ b/src/entities/sitemap-entry/index.ts
@@ -6,6 +6,7 @@ export type {
 export {
     SITEMAP_MAX_URLS_PER_FILE,
     LONGTAIL_ENTRIES_PER_TICKER,
+    LONGTAIL_TICKERS_PER_PAGE,
 } from './model';
 
 export { toUrlSetXml, toSitemapIndexXml } from './lib/xml';

--- a/src/entities/sitemap-entry/index.ts
+++ b/src/entities/sitemap-entry/index.ts
@@ -12,3 +12,4 @@ export { toUrlSetXml, toSitemapIndexXml } from './lib/xml';
 export { buildPopularEntries } from './lib/buildPopularEntries';
 export { buildStaticEntries } from './lib/buildStaticEntries';
 export { loadLongTailTickers } from './lib/loadLongTailTickers';
+export { buildLongTailEntries } from './lib/buildLongTailEntries';

--- a/src/entities/sitemap-entry/index.ts
+++ b/src/entities/sitemap-entry/index.ts
@@ -3,7 +3,10 @@ export type {
     SitemapEntry,
     SitemapIndexEntry,
 } from './model';
-export { SITEMAP_MAX_URLS_PER_FILE } from './model';
+export {
+    SITEMAP_MAX_URLS_PER_FILE,
+    LONGTAIL_ENTRIES_PER_TICKER,
+} from './model';
 
 export { toUrlSetXml, toSitemapIndexXml } from './lib/xml';
 export { buildPopularEntries } from './lib/buildPopularEntries';

--- a/src/entities/sitemap-entry/lib/buildLongTailEntries.ts
+++ b/src/entities/sitemap-entry/lib/buildLongTailEntries.ts
@@ -4,8 +4,6 @@ import type { SitemapEntry } from '../model';
 /**
  * long-tail 티커에 대한 sitemap 엔트리를 생성한다.
  * popular과 달리 옵션 라우트 제외, 낮은 priority, 고정 lastmod(SITE_BUILD_DATE).
- *
- * 순수 함수라 테스트에서 시간/외부 의존 mock 없이 결정적 검증 가능.
  */
 export function buildLongTailEntries(
     tickers: readonly string[],

--- a/src/entities/sitemap-entry/lib/buildLongTailEntries.ts
+++ b/src/entities/sitemap-entry/lib/buildLongTailEntries.ts
@@ -1,6 +1,10 @@
 import { SITE_URL } from '@/shared/lib/seo';
 import type { SitemapEntry } from '../model';
 
+export const LONGTAIL_CHART_PRIORITY = 0.5;
+export const LONGTAIL_SUB_PRIORITY = 0.45;
+export const LONGTAIL_LOW_PRIORITY = 0.4;
+
 /**
  * long-tail 티커에 대한 sitemap 엔트리를 생성한다.
  * popular과 달리 옵션 라우트 제외, 낮은 priority, 고정 lastmod(SITE_BUILD_DATE).
@@ -14,31 +18,31 @@ export function buildLongTailEntries(
             url: `${SITE_URL}/${ticker}`,
             lastModified: buildDate,
             changeFrequency: 'weekly',
-            priority: 0.5,
+            priority: LONGTAIL_CHART_PRIORITY,
         },
         {
             url: `${SITE_URL}/${ticker}/news`,
             lastModified: buildDate,
             changeFrequency: 'weekly',
-            priority: 0.45,
+            priority: LONGTAIL_SUB_PRIORITY,
         },
         {
             url: `${SITE_URL}/${ticker}/fundamental`,
             lastModified: buildDate,
             changeFrequency: 'monthly',
-            priority: 0.4,
+            priority: LONGTAIL_LOW_PRIORITY,
         },
         {
             url: `${SITE_URL}/${ticker}/overall`,
             lastModified: buildDate,
             changeFrequency: 'weekly',
-            priority: 0.45,
+            priority: LONGTAIL_SUB_PRIORITY,
         },
         {
             url: `${SITE_URL}/${ticker}/fear-greed`,
             lastModified: buildDate,
             changeFrequency: 'weekly',
-            priority: 0.4,
+            priority: LONGTAIL_LOW_PRIORITY,
         },
     ]);
 }

--- a/src/entities/sitemap-entry/lib/buildLongTailEntries.ts
+++ b/src/entities/sitemap-entry/lib/buildLongTailEntries.ts
@@ -1,0 +1,46 @@
+import { SITE_URL } from '@/shared/lib/seo';
+import type { SitemapEntry } from '../model';
+
+/**
+ * long-tail 티커에 대한 sitemap 엔트리를 생성한다.
+ * popular과 달리 옵션 라우트 제외, 낮은 priority, 고정 lastmod(SITE_BUILD_DATE).
+ *
+ * 순수 함수라 테스트에서 시간/외부 의존 mock 없이 결정적 검증 가능.
+ */
+export function buildLongTailEntries(
+    tickers: readonly string[],
+    buildDate: Date
+): SitemapEntry[] {
+    return tickers.flatMap((ticker): SitemapEntry[] => [
+        {
+            url: `${SITE_URL}/${ticker}`,
+            lastModified: buildDate,
+            changeFrequency: 'weekly',
+            priority: 0.5,
+        },
+        {
+            url: `${SITE_URL}/${ticker}/news`,
+            lastModified: buildDate,
+            changeFrequency: 'weekly',
+            priority: 0.45,
+        },
+        {
+            url: `${SITE_URL}/${ticker}/fundamental`,
+            lastModified: buildDate,
+            changeFrequency: 'monthly',
+            priority: 0.4,
+        },
+        {
+            url: `${SITE_URL}/${ticker}/overall`,
+            lastModified: buildDate,
+            changeFrequency: 'weekly',
+            priority: 0.45,
+        },
+        {
+            url: `${SITE_URL}/${ticker}/fear-greed`,
+            lastModified: buildDate,
+            changeFrequency: 'weekly',
+            priority: 0.4,
+        },
+    ]);
+}

--- a/src/entities/sitemap-entry/model.ts
+++ b/src/entities/sitemap-entry/model.ts
@@ -29,3 +29,10 @@ export interface SitemapIndexEntry {
  * 50,000으로 잡되, 운영 중 cap에 도달하면 추후 더 작은 chunk로 분할 검토.
  */
 export const SITEMAP_MAX_URLS_PER_FILE = 50_000;
+
+/**
+ * long-tail 티커당 sitemap 엔트리 수.
+ * chart + news + fundamental + overall + fear-greed = 5.
+ * sitemap index 페이지네이션과 longtail route handler 양쪽에서 참조한다.
+ */
+export const LONGTAIL_ENTRIES_PER_TICKER = 5;

--- a/src/entities/sitemap-entry/model.ts
+++ b/src/entities/sitemap-entry/model.ts
@@ -36,3 +36,12 @@ export const SITEMAP_MAX_URLS_PER_FILE = 50_000;
  * sitemap index 페이지네이션과 longtail route handler 양쪽에서 참조한다.
  */
 export const LONGTAIL_ENTRIES_PER_TICKER = 5;
+
+/**
+ * 한 sitemap 파일에 담을 수 있는 long-tail 티커 수.
+ * 티커당 LONGTAIL_ENTRIES_PER_TICKER개 URL을 생성하므로,
+ * SITEMAP_MAX_URLS_PER_FILE을 넘지 않도록 역산한다.
+ */
+export const LONGTAIL_TICKERS_PER_PAGE = Math.floor(
+    SITEMAP_MAX_URLS_PER_FILE / LONGTAIL_ENTRIES_PER_TICKER
+);

--- a/src/entities/ticker/__tests__/lib/fmpTickerApi.test.ts
+++ b/src/entities/ticker/__tests__/lib/fmpTickerApi.test.ts
@@ -41,11 +41,11 @@ describe('filterUsExchanges', () => {
         expect(filterUsExchanges(results)).toEqual([apple]);
     });
 
-    it('NYSE/NASDAQ/AMEX/NYSEArca를 모두 인식한다', () => {
+    it('NYSE/NASDAQ/AMEX/CBOE/OTC/PNK/CNQ를 모두 인식한다', () => {
         const inputs: FmpSearchResult[] = (
-            ['NYSE', 'NASDAQ', 'AMEX', 'NYSEArca'] as const
+            ['NYSE', 'NASDAQ', 'AMEX', 'CBOE', 'OTC', 'PNK', 'CNQ'] as const
         ).map(exchange => ({ ...apple, exchange }));
-        expect(filterUsExchanges(inputs)).toHaveLength(4);
+        expect(filterUsExchanges(inputs)).toHaveLength(7);
     });
 });
 

--- a/src/entities/ticker/lib/fmpTickerApi.ts
+++ b/src/entities/ticker/lib/fmpTickerApi.ts
@@ -10,7 +10,10 @@ const US_EXCHANGES: ReadonlySet<string> = new Set([
     'NYSE',
     'NASDAQ',
     'AMEX',
-    'NYSEArca',
+    'CBOE',
+    'OTC',
+    'PNK',
+    'CNQ',
 ]);
 
 type FmpEndpoint = 'search-symbol' | 'search-name';


### PR DESCRIPTION
## Summary
- Long-tail 티커의 서브 라우트(news, fundamental, overall, fear-greed)를 sitemap에 추가
- 기존: 티커당 1개 URL (차트 페이지만) → 변경: 티커당 5개 URL
- Google Search Console에서 224개 페이지가 "사용자가 선택한 표준이 없는 중복 페이지"로 보고된 문제 해결
- /options는 hasOptionsMarket probe 비용 문제로 제외
- `US_EXCHANGES` 필터에 CBOE/OTC/PNK/CNQ 추가 (QUAL, FJAN, ARKK 등 Cboe 상장 ETF noindex 문제 해결)

## Changes

### Sitemap
- `LONGTAIL_ENTRIES_PER_TICKER = 5` 상수 추가
- `LONGTAIL_TICKERS_PER_PAGE` 파생 상수 추가 (model.ts에서 단일 정의)
- `buildLongTailEntries()` 순수 함수 신규 생성 (5개 라우트 flatMap)
- longtail route handler: `buildLongTailEntries` 호출로 대체
- sitemap index: 페이지 수 계산 5배 URL 증가분 반영

### Ticker Exchange Filter
- `US_EXCHANGES`: `NYSE/NASDAQ/AMEX/NYSEArca` → `NYSE/NASDAQ/AMEX/CBOE/OTC/PNK/CNQ`
- `NYSEArca` 제거 (FMP에서 NYSE Arca는 `AMEX`로 반환 — dead code)
- Cboe BZX 상장 ETF(QUAL, FJAN, ARKK 등)가 `getAssetInfo` null → notFound() → noindex되던 버그 수정

## Priority / changefreq
| Route | Priority | changefreq |
|---|---|---|
| /{ticker} | 0.5 | weekly |
| /{ticker}/news | 0.45 | weekly |
| /{ticker}/fundamental | 0.4 | monthly |
| /{ticker}/overall | 0.45 | weekly |
| /{ticker}/fear-greed | 0.4 | weekly |

## Test plan
- [x] `yarn test` 전체 통과 (583 파일, 4332 테스트)
- [x] `yarn lint` 에러 없음
- [ ] 배포 후 `/sitemap-longtail-1.xml` 확인하여 서브 라우트 URL 포함 여부 검증
- [ ] QUAL, FJAN 페이지 접속 시 정상 렌더링 확인
- [ ] Google Search Console에서 sitemap 재제출 후 색인 상태 모니터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)