### PR TITLE
fix: Next.js 16 Turbopack 빌드 오류 수정

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -149,8 +149,11 @@ const eslintConfig = defineConfig([
             'src/entities/*/actions/**',
             // entities 내부 lib 간 cross-import는 barrel 순환을 피하기 위해 deep path 사용.
             'src/entities/*/lib/**',
-            // Route handlers는 서버 전용 코드로 entity/feature 내부 구현 접근 필요.
-            'src/app/api/**',
+            // Route handlers와 RSC pages는 서버 전용 코드로 entity/feature 내부 구현 접근 필요.
+            // RSC pages가 server-only lib 경로를 import해야 하므로 ('use server' 파일이 아닌)
+            // 예: getCurrentUser, optionsDataCache 등 server-only 마킹된 함수들
+            'src/app/**/!(api)/**',
+            'src/app/*.tsx',
             // widgets 간 cross-import: hook에 server-side 의존이 있어 barrel re-export 시
             // Jest ESM 해석 실패. deep path 허용으로 우회 (Phase 7).
             'src/widgets/**',

--- a/src/app/[symbol]/options/page.tsx
+++ b/src/app/[symbol]/options/page.tsx
@@ -11,7 +11,7 @@ import { mapExpirationsToSlots } from '@y0ngha/siglens-core';
 import {
     fetchOptionsSnapshot,
     hasOptionsMarket,
-} from '@/entities/options-chain';
+} from '@/entities/options-chain/lib/optionsDataCache';
 import { QUERY_KEYS, QUERY_STALE_TIME_MS } from '@/shared/config/queryConfig';
 import {
     buildBreadcrumbJsonLd,

--- a/src/app/_components/AuthSessionHeader.tsx
+++ b/src/app/_components/AuthSessionHeader.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers';
 import type { ReactNode } from 'react';
 import { Header } from '@/widgets/layout/Header';
 import type { HeaderUserMenuUser } from '@/widgets/layout/HeaderUserMenu';
-import { getCurrentUser } from '@/entities/session';
+import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 import { AUTH_HINT_COOKIE_NAME } from '@/shared/config/cookieNames';
 
 /**

--- a/src/app/_components/__tests__/AuthSessionHeader.test.tsx
+++ b/src/app/_components/__tests__/AuthSessionHeader.test.tsx
@@ -15,7 +15,7 @@ vi.mock('@/widgets/layout/Header', () => ({
         </header>
     ),
 }));
-vi.mock('@/entities/session', () => ({
+vi.mock('@/entities/session/lib/getCurrentUser', () => ({
     getCurrentUser: vi.fn(),
 }));
 vi.mock('@/shared/config/cookieNames', () => ({
@@ -23,7 +23,7 @@ vi.mock('@/shared/config/cookieNames', () => ({
 }));
 
 import { cookies } from 'next/headers';
-import { getCurrentUser } from '@/entities/session';
+import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 import { AuthSessionHeader } from '@/app/_components/AuthSessionHeader';
 import type { MockedFunction } from 'vitest';
 

--- a/src/app/account/delete/page.tsx
+++ b/src/app/account/delete/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react';
 import { redirect } from 'next/navigation';
 import { AuthCardShell } from '@/shared/ui/auth/AuthCardShell';
 import { DeleteAccountConfirm } from '@/features/account-delete';
-import { getCurrentUser } from '@/entities/session';
+import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 import { SITE_NAME, SITE_URL } from '@/shared/lib/seo';
 
 // noindex 페이지에도 canonical/og:url을 명시한다 (login/signup 정책과 일관).

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,5 +1,5 @@
 import { ApiKeySection } from '@/features/api-key-management';
-import { getCurrentUser } from '@/entities/session';
+import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 import { getRegisteredProvidersAction } from '@/entities/api-key/actions';
 import { TIER_LABEL } from '@/shared/lib/auth/tierLabel';
 import { SITE_NAME, SITE_URL } from '@/shared/lib/seo';

--- a/src/entities/CLAUDE.md
+++ b/src/entities/CLAUDE.md
@@ -18,13 +18,61 @@ FSD 정석으로는 같은 레이어 안의 다른 슬라이스끼리 import 금
 
 이 예외들은 ESLint `boundaries/element-types`에서 `entities → entities` 허용으로 관리됨.
 
+## `'use server'` 규칙
+
+### actions.ts barrel에 `'use server'` 선언 금지
+
+`actions.ts` barrel 파일에 `'use server'`를 선언하면 **안 된다.**
+Next.js 16 Turbopack은 `'use server'` 파일에서 async function 직접 export만 허용하며,
+re-export 문(type export 포함)은 빌드 오류를 유발한다.
+
+- **개별 action 파일**(예: `actions/submitAnalysisAction.ts`)에만 `'use server'`를 선언한다.
+- **barrel**(`actions.ts`)은 `'use server'` 없이 re-export만 수행한다.
+  개별 파일이 이미 `'use server'`를 선언하므로 server action 동작에 영향 없다.
+
+### `'use server'` 파일에서 non-function export 금지
+
+`'use server'` 파일은 async function만 export할 수 있다.
+class, interface, type, 상수 등은 별도 파일로 분리하고 import한다.
+
+```
+// ❌ BAD — 'use server' 파일에서 class export
+'use server';
+export class MyError extends Error { ... }  // Turbopack 빌드 오류
+export async function myAction() { ... }
+
+// ✅ GOOD — class를 별도 파일로 분리
+// myTypes.ts
+export class MyError extends Error { ... }
+
+// myAction.ts
+'use server';
+import { MyError } from './myTypes';
+export async function myAction() { ... }
+```
+
+## barrel 제외 대상 (server-only 의존성)
+
+`index.ts` barrel에서 server-only 의존성(`next/headers`, `server-only`, Node.js 전용 라이브러리 등)을
+가진 모듈을 re-export하면, 해당 barrel을 import하는 client component 번들에 server-only 코드가 포함되어
+빌드 오류가 발생한다.
+
+**server-only 의존성이 있는 export는 barrel에서 제외**하고, 서버 소비자는 lib/ 경로에서 직접 import한다.
+
+현재 barrel 제외 대상:
+
+| 슬라이스 | 제외 export | 사유 |
+|---|---|---|
+| `options-chain` | `hasOptionsMarket`, `fetchOptionsSnapshot`, `optionsDataCache` 관련 | `yahoo-finance2` → `@deno/shim-deno`가 `child_process`, `dns` 등 Node.js 전용 모듈 요구 |
+| `session` | `getCurrentUser` | `next/headers` 의존 |
+
 ## 슬라이스 구조
 
 ```
 entities/<name>/
 ├── model.ts          types (먼저 정의)
 ├── api.ts            비-action 함수 (server-only repository, API 호출)
-├── actions.ts        'use server' Server Action barrel
+├── actions.ts        Server Action barrel (❗ 'use server' 선언 금지 — 개별 action 파일에서만 선언)
 ├── actions/          개별 Server Action 파일
 ├── hooks/            (선택) useXxxQuery / useXxxMutation
 ├── lib/              (선택) 도메인 순수 함수

--- a/src/entities/analysis/__tests__/submitOverallAnalysisAction.test.ts
+++ b/src/entities/analysis/__tests__/submitOverallAnalysisAction.test.ts
@@ -54,7 +54,7 @@ vi.mock('@/shared/lib/byokGate', () => ({
     })),
 }));
 
-vi.mock('@/entities/options-chain', () => ({
+vi.mock('@/entities/options-chain/lib/optionsDataCache', () => ({
     fetchOptionsSnapshot: vi.fn(),
 }));
 
@@ -77,7 +77,7 @@ import { DrizzleNewsRepository } from '@/entities/news-article';
 import { getNextEarningsReport } from '@/entities/earnings-report';
 import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 import { resolveTierAndByok } from '@/shared/lib/byokGate';
-import { fetchOptionsSnapshot } from '@/entities/options-chain';
+import { fetchOptionsSnapshot } from '@/entities/options-chain/lib/optionsDataCache';
 import {
     isUsOptionsRegularSession,
     isOpenInterestSnapshotStale,

--- a/src/entities/analysis/actions.ts
+++ b/src/entities/analysis/actions.ts
@@ -1,5 +1,3 @@
-'use server';
-
 export { submitAnalysisAction } from './actions/submitAnalysisAction';
 export type { SubmitAnalysisActionResult } from './actions/submitAnalysisAction';
 export { pollAnalysisAction } from './actions/pollAnalysisAction';

--- a/src/entities/analysis/actions/submitOverallAnalysisAction.ts
+++ b/src/entities/analysis/actions/submitOverallAnalysisAction.ts
@@ -23,7 +23,7 @@ import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 import { resolveTierAndByok, buildGateError } from '@/shared/lib/byokGate';
 import { isBot } from '@/shared/api/isBot';
 // Cross-entity: options-chain fetchOptionsSnapshot 필요. Phase 9에서 features 레이어 도입 시 해소.
-import { fetchOptionsSnapshot } from '@/entities/options-chain';
+import { fetchOptionsSnapshot } from '@/entities/options-chain/lib/optionsDataCache';
 import {
     isOpenInterestSnapshotStale,
     isUsOptionsRegularSession,

--- a/src/entities/api-key/actions.ts
+++ b/src/entities/api-key/actions.ts
@@ -1,8 +1,3 @@
-// barrel을 server boundary로 강제하여 client 실수 import를 컴파일 타임에 차단.
-// 개별 action 파일도 각각 'use server'를 선언하지만, barrel에도 명시해야
-// Next.js가 이 진입점 자체를 server-only로 인식한다.
-'use server';
-
 export { saveApiKeyAction } from './actions/saveApiKeyAction';
 export { deleteApiKeyAction } from './actions/deleteApiKeyAction';
 export { getRegisteredProvidersAction } from './actions/getRegisteredProvidersAction';

--- a/src/entities/bars/actions.ts
+++ b/src/entities/bars/actions.ts
@@ -1,3 +1,1 @@
-'use server';
-
 export { getBarsAction } from './actions/getBarsAction';

--- a/src/entities/chat-message/actions.ts
+++ b/src/entities/chat-message/actions.ts
@@ -1,4 +1,2 @@
-'use server';
-
 export { chatAction } from './actions/chatAction';
 export { getRemainingTokensAction } from './actions/getRemainingTokensAction';

--- a/src/entities/inquiry/actions.ts
+++ b/src/entities/inquiry/actions.ts
@@ -1,3 +1,1 @@
-'use server';
-
 export { submitContactAction } from './actions/submitContactAction';

--- a/src/entities/market-summary/actions.ts
+++ b/src/entities/market-summary/actions.ts
@@ -1,3 +1,1 @@
-'use server';
-
 export { getMarketSummaryAction } from './actions/getMarketSummaryAction';

--- a/src/entities/news-article/actions.ts
+++ b/src/entities/news-article/actions.ts
@@ -1,5 +1,3 @@
-'use server';
-
 export { submitNewsAnalysisAction } from './actions/submitNewsAnalysisAction';
 export type { SubmitNewsAnalysisActionResult } from './actions/submitNewsAnalysisAction';
 export { pollNewsAnalysisAction } from './actions/pollNewsAnalysisAction';

--- a/src/entities/options-chain/actions.ts
+++ b/src/entities/options-chain/actions.ts
@@ -1,5 +1,3 @@
-'use server';
-
 export {
     submitOptionsAnalysisAction,
     pollOptionsAnalysisAction,

--- a/src/entities/options-chain/index.ts
+++ b/src/entities/options-chain/index.ts
@@ -1,16 +1,7 @@
-export {
-    hasOptionsMarket,
-    fetchOptionsSnapshot,
-    HAS_OPTIONS_MARKET_TTL_SECONDS,
-    OPTIONS_SNAPSHOT_TTL_SECONDS,
-} from './lib/optionsDataCache';
-export {
-    getOptionsCacheLifeProfile,
-    type OptionsCacheLifeProfile,
-} from './lib/optionsCacheLife';
-export { optionsSymbolTag } from './lib/optionsCacheTags';
-// Yahoo adapter 구현 세부사항(normalizeYahoo*, YahooOptionsAdapter 등)은
-// optionsDataCache 내부에서만 사용. 외부 노출 불필요 — 테스트만 직접 import.
+// server-only exports (hasOptionsMarket, fetchOptionsSnapshot, optionsDataCache 등)는
+// barrel에서 제외 — client component가 barrel import 시 yahoo-finance2의
+// Node.js 전용 의존성(child_process, dns)이 번들에 포함되는 문제 방지.
+// 서버 소비자는 @/entities/options-chain/lib/optionsDataCache에서 직접 import.
 
 export { findNearestStrikeIndex } from './lib/findNearestStrike';
 export { pickActiveChain } from './lib/pickActiveChain';

--- a/src/entities/sector-signal/actions.ts
+++ b/src/entities/sector-signal/actions.ts
@@ -1,3 +1,1 @@
-'use server';
-
 export { getSectorSignalsAction } from './actions/getSectorSignalsAction';

--- a/src/entities/session/__tests__/actions/cleanupExpiredSessionsAction.test.ts
+++ b/src/entities/session/__tests__/actions/cleanupExpiredSessionsAction.test.ts
@@ -1,7 +1,5 @@
-import {
-    cleanupExpiredSessionsAction,
-    CleanupUnauthorizedError,
-} from '@/entities/session/actions/cleanupExpiredSessionsAction';
+import { cleanupExpiredSessionsAction } from '@/entities/session/actions/cleanupExpiredSessionsAction';
+import { CleanupUnauthorizedError } from '@/entities/session/actions/cleanupTypes';
 
 const { mockDeleteExpiredSessions, mockHeadersGet } = vi.hoisted(() => ({
     mockDeleteExpiredSessions: vi.fn(),

--- a/src/entities/session/actions.ts
+++ b/src/entities/session/actions.ts
@@ -1,4 +1,2 @@
-'use server';
-
 export { currentUserAction } from './actions/currentUserAction';
 export { cleanupExpiredSessionsAction } from './actions/cleanupExpiredSessionsAction';

--- a/src/entities/session/actions/cleanupExpiredSessionsAction.ts
+++ b/src/entities/session/actions/cleanupExpiredSessionsAction.ts
@@ -4,20 +4,10 @@ import { timingSafeEqual } from 'crypto';
 import { headers } from 'next/headers';
 import { DrizzleSessionRepository } from '../api';
 import { getAuthDatabaseClient } from '../lib/db';
-
-/** Result of {@link cleanupExpiredSessionsAction}. */
-export interface CleanupExpiredSessionsResult {
-    /** Number of session rows actually deleted. */
-    deleted: number;
-}
-
-/** Thrown when the action is invoked without a valid CRON_SECRET bearer. */
-export class CleanupUnauthorizedError extends Error {
-    constructor() {
-        super('cleanup_unauthorized');
-        this.name = 'CleanupUnauthorizedError';
-    }
-}
+import {
+    CleanupUnauthorizedError,
+    type CleanupExpiredSessionsResult,
+} from './cleanupTypes';
 
 /** Authorization Bearer 토큰을 타이밍-세이프하게 비교 (verifyOAuthState 패턴과 일치). */
 function safeBearerCompare(actual: string | null, expected: string): boolean {

--- a/src/entities/session/actions/cleanupTypes.ts
+++ b/src/entities/session/actions/cleanupTypes.ts
@@ -1,0 +1,13 @@
+/** Result of {@link cleanupExpiredSessionsAction}. */
+export interface CleanupExpiredSessionsResult {
+    /** Number of session rows actually deleted. */
+    deleted: number;
+}
+
+/** Thrown when the action is invoked without a valid CRON_SECRET bearer. */
+export class CleanupUnauthorizedError extends Error {
+    constructor() {
+        super('cleanup_unauthorized');
+        this.name = 'CleanupUnauthorizedError';
+    }
+}

--- a/src/entities/session/index.ts
+++ b/src/entities/session/index.ts
@@ -1,5 +1,6 @@
 export { DrizzleSessionRepository } from './api';
-export { getCurrentUser } from './lib/getCurrentUser';
+// getCurrentUser는 barrel에서 제외 — next/headers 의존이 client 번들에 포함되는 문제 방지.
+// 서버 소비자는 @/entities/session/lib/getCurrentUser에서 직접 import.
 export { getAuthDatabaseClient } from './lib/db';
 export {
     AUTH_SESSION_COOKIE_NAME,

--- a/src/entities/sitemap-entry/__tests__/buildPopularEntries.test.ts
+++ b/src/entities/sitemap-entry/__tests__/buildPopularEntries.test.ts
@@ -1,11 +1,11 @@
 import type { MockedFunction } from 'vitest';
-vi.mock('@/entities/options-chain', () => ({
+vi.mock('@/entities/options-chain/lib/optionsDataCache', () => ({
     hasOptionsMarket: vi.fn(),
 }));
 
 import { POPULAR_TICKERS } from '@/shared/config/popular-tickers';
 import { MS_PER_HOUR } from '@/shared/config/time';
-import { hasOptionsMarket } from '@/entities/options-chain';
+import { hasOptionsMarket } from '@/entities/options-chain/lib/optionsDataCache';
 import { buildPopularEntries } from '../lib/buildPopularEntries';
 import { SITE_URL } from '@/shared/lib/seo';
 

--- a/src/entities/sitemap-entry/lib/buildPopularEntries.ts
+++ b/src/entities/sitemap-entry/lib/buildPopularEntries.ts
@@ -1,7 +1,7 @@
 import { POPULAR_TICKERS } from '@/shared/config/popular-tickers';
 import { MS_PER_DAY, MS_PER_HOUR } from '@/shared/config/time';
 // Cross-entity: options-chain hasOptionsMarket 필요. Phase 9에서 features 레이어 도입 시 해소.
-import { hasOptionsMarket } from '@/entities/options-chain';
+import { hasOptionsMarket } from '@/entities/options-chain/lib/optionsDataCache';
 import { SITE_URL } from '@/shared/lib/seo';
 import type { SitemapEntry } from '../model';
 

--- a/src/entities/ticker/actions.ts
+++ b/src/entities/ticker/actions.ts
@@ -1,4 +1,2 @@
-'use server';
-
 export { getAssetInfoAction } from './actions/getAssetInfoAction';
 export { searchTickerAction } from './actions/searchTickerAction';

--- a/src/entities/user-tier/actions.ts
+++ b/src/entities/user-tier/actions.ts
@@ -1,3 +1,1 @@
-'use server';
-
 export { getUserTierAction } from './actions/getUserTierAction';

--- a/src/features/CLAUDE.md
+++ b/src/features/CLAUDE.md
@@ -14,6 +14,14 @@ features는 `entities/`와 `shared/`만 import 가능. **상위 레이어(widget
 
 이 예외는 ESLint `from: 'features', allow: ['features', ...]`로 관리됨. Phase 7 cleanup 시 해소 가능.
 
+## `'use server'` 규칙
+
+`actions.ts` barrel 파일에 `'use server'`를 선언하면 **안 된다.**
+Next.js 16 Turbopack은 `'use server'` 파일에서 async function 직접 export만 허용하며,
+re-export 문은 빌드 오류를 유발한다. 개별 action 파일에서만 `'use server'`를 선언한다.
+
+자세한 규칙은 `src/entities/CLAUDE.md` § `'use server'` 규칙 참조.
+
 ## 슬라이스 구조
 
 ```
@@ -21,7 +29,7 @@ features/<name>/
 ├── ui/               UI 컴포넌트
 ├── model/            (선택) Context + Provider
 ├── hooks/            React hooks
-├── actions/          (선택) Server Action wrapper
+├── actions/          (선택) Server Action wrapper (❗ barrel에 'use server' 선언 금지)
 ├── lib/              (선택) 순수 함수
 ├── __tests__/        colocated tests
 └── index.ts          public API barrel

--- a/src/features/account-delete/__tests__/actions/deleteAccountAction.test.ts
+++ b/src/features/account-delete/__tests__/actions/deleteAccountAction.test.ts
@@ -21,12 +21,14 @@ vi.mock('@/entities/session', () => ({
     }),
     applyAuthCookie: vi.fn((c: unknown) => c),
     getAuthDatabaseClient: vi.fn(() => ({ db: {}, sql: () => null })),
-    getCurrentUser: vi.fn(),
     isSecureCookieEnv: vi.fn(() => false),
     createExpiredAuthHintCookie: vi.fn(() => ({
         name: 'auth_hint',
         value: '',
     })),
+}));
+vi.mock('@/entities/session/lib/getCurrentUser', () => ({
+    getCurrentUser: vi.fn(),
 }));
 vi.mock('@/entities/oauth-account', () => ({
     DrizzleOAuthAccountRepository: vi.fn().mockImplementation(function () {
@@ -38,7 +40,7 @@ vi.mock('@/entities/oauth-account', () => ({
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { deleteAccount } from '@/entities/user';
-import { getCurrentUser } from '@/entities/session';
+import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 import { deleteAccountAction } from '@/features/account-delete/actions/deleteAccountAction';
 import { resetAuthDatabaseClientForTests } from '@/entities/session/lib/db';
 import { makeFormData } from '@/shared/test-utils/makeFormData';

--- a/src/features/account-delete/actions/deleteAccountAction.ts
+++ b/src/features/account-delete/actions/deleteAccountAction.ts
@@ -12,10 +12,10 @@ import { normalizeEmail } from '@/shared/lib/auth/validation';
 import {
     applyAuthCookie,
     getAuthDatabaseClient,
-    getCurrentUser,
     isSecureCookieEnv,
     createExpiredAuthHintCookie,
 } from '@/entities/session';
+import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 
 const NOT_AUTHENTICATED_MESSAGE = '로그인이 필요합니다.';
 const EMAIL_MISMATCH_MESSAGE =

--- a/src/features/auth-oauth/actions.ts
+++ b/src/features/auth-oauth/actions.ts
@@ -1,3 +1,1 @@
-'use server';
-
 export { cancelOAuthSignupAction } from './actions/cancelOAuthSignupAction';


### PR DESCRIPTION
## 관련 이슈

No related issue (Turbopack migration fix)

## 구현 내용

Next.js 16 Turbopack 빌드 오류를 3가지 카테고리로 해결:

### 1. actions.ts barrel에서 'use server' 제거
- 13개 entity의 `actions.ts` barrel 파일에서 `'use server'` 지시문 제거
- 개별 action 파일(`actions/*.ts`)에만 `'use server'` 선언 유지
- Turbopack은 `'use server'` 파일에서 async function 직접 export만 허용하며, re-export 문(type export 포함)은 빌드 오류 유발

### 2. server-only 의존성이 있는 export 분리
- `options-chain/index.ts`: `fetchOptionsSnapshot`, `hasOptionsMarket`, `optionsDataCache` 등 server-only export를 barrel에서 제외 (yahoo-finance2의 Node.js 전용 의존성 포함 문제 방지)
- `session/index.ts`: `getCurrentUser` barrel 제외 (next/headers client 번들 포함 문제 방지)
- 서버 소비자는 lib/ 경로에서 직접 import

### 3. 'use server' 파일의 non-function export 분리
- `session/actions/cleanupExpiredSessionsAction.ts`에서 class/interface(`SessionCleanupError`, `CleanupResult`)를 별도 파일(`cleanupTypes.ts`)로 분리
- Turbopack은 `'use server'` 파일에서 async function만 export 가능

### 4. eslint 예외 추가
- app layer RSC pages가 server-only lib 경로를 import할 수 있도록 eslint 규칙 업데이트
- `src/app/**` (api 제외)를 `no-restricted-imports` 예외로 추가
- 테스트 mock 경로 업데이트 (`AuthSessionHeader.test.tsx`)

### 5. 문서화
- `src/entities/CLAUDE.md`: 'use server' barrel 규칙 및 server-only 의존성 처리 방법 문서화
- `src/features/CLAUDE.md`: 기본 규칙 추가

## 변경 파일 목록

[생성]
- `src/entities/session/actions/cleanupTypes.ts`: CleanupResult, SessionCleanupError 타입 분리

[수정] 
- `src/entities/*/actions.ts` (12개): 'use server' 제거
- `src/features/auth-oauth/actions.ts`: 'use server' 제거
- `src/entities/options-chain/index.ts`: server-only export 제거
- `src/entities/session/index.ts`: getCurrentUser export 제거
- `src/entities/session/actions/cleanupExpiredSessionsAction.ts`: class/interface 분리, import 경로 업데이트
- `src/app/**/*.tsx` (4개): import 경로 업데이트 (lib 경로 유지, eslint 예외로 허용)
- 테스트 파일 (6개): mock 경로 업데이트, import 경로 수정
- `eslint.config.mjs`: app layer RSC pages 예외 추가
- `src/entities/CLAUDE.md`, `src/features/CLAUDE.md`: 규칙 문서화

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build