### PR TITLE
fix: Fear-Greed SSR 오류 및 FMP 429 재시도 로직

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,6 +1,11 @@
 
 # Fix Log
 
+## [PR #513 Round 1 | fix/fear-greed-ssr-and-fmp-retry | 2026-05-26]
+- Violation: `page.tsx` prefetch 배열에 `.push()` 사용 — 배열 직접 변이
+  - Rule: MISTAKES.md §5 — Array/object mutation via push/splice 금지
+  - Context: 차트 페이지에서 조건부 prefetch를 추가할 때 spread 대신 push를 사용. spread 패턴으로 교체
+
 ## [PR #432 Round 4 | fix/cancel-job-on-page-unload | 2026-05-09]
 - Violation: `route.ts` body validation used `!j.type` (falsy check only), allowing invalid type strings (e.g. `"unknown"`) to pass and silently return 204
   - Rule: Infrastructure Functions — validate all inputs at API boundaries; invalid values must return 400

--- a/src/__tests__/worst-case/fmpRateLimit.test.ts
+++ b/src/__tests__/worst-case/fmpRateLimit.test.ts
@@ -1,43 +1,98 @@
+// `sleep` is the only side-effect inside `withRetry`. Stubbing it prevents
+// real wall-clock delays and keeps tests synchronous.
+vi.mock('@/shared/lib/sleep', () => ({
+    sleep: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('@y0ngha/siglens-core', () => ({
     readFmpConfig: vi.fn(() => ({ apiKey: 'test-key' })),
 }));
 
 import { fmpGet, FMP_STABLE_BASE } from '@/shared/api/fmp/httpClient';
+import { FmpHttpError } from '@/shared/api/fmp/FmpHttpError';
 
 describe('FMP API error responses', () => {
+    beforeEach(() => {
+        // Deterministic jitter so delay assertions can be exact.
+        vi.spyOn(Math, 'random').mockReturnValue(0);
+    });
+
     afterEach(() => {
         vi.restoreAllMocks();
     });
 
-    it('throws on 429 rate limit', async () => {
-        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-            new Response(null, { status: 429, statusText: 'Too Many Requests' })
+    it('429 rate limit: maxRetries=3 이므로 fetch가 4번 호출된다', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(null, {
+                status: 429,
+                statusText: 'Too Many Requests',
+            })
         );
 
         await expect(fmpGet('news/stock', { symbols: 'AAPL' })).rejects.toThrow(
             'FMP news/stock 429'
         );
+
+        // initial attempt + 3 retries = 4 total
+        expect(fetchSpy).toHaveBeenCalledTimes(4);
     });
 
-    it('throws on 500 internal server error', async () => {
+    it('429 rate limit 소진 시 FmpHttpError를 던진다', async () => {
         vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-            new Response(null, { status: 500 })
+            new Response(null, {
+                status: 429,
+                statusText: 'Too Many Requests',
+            })
         );
+
+        const error = await fmpGet('news/stock', { symbols: 'AAPL' }).catch(
+            (e: unknown) => e
+        );
+        expect(error).toBeInstanceOf(FmpHttpError);
+    });
+
+    it('500 server error: fetch가 4번 호출되고 FmpHttpError를 던진다', async () => {
+        const fetchSpy = vi
+            .spyOn(globalThis, 'fetch')
+            .mockResolvedValue(new Response(null, { status: 500 }));
 
         await expect(fmpGet('earnings', { symbol: 'AAPL' })).rejects.toThrow(
             'FMP earnings 500'
         );
+
+        expect(fetchSpy).toHaveBeenCalledTimes(4);
     });
 
-    it('throws on network timeout (AbortSignal)', async () => {
+    it('network timeout (DOMException): 재시도 후 결국 던진다', async () => {
         vi.spyOn(globalThis, 'fetch').mockRejectedValue(
             new DOMException('The operation was aborted', 'AbortError')
         );
 
-        await expect(fmpGet('news/stock')).rejects.toThrow('aborted');
+        await expect(fmpGet('news/stock')).rejects.toThrow(DOMException);
     });
 
-    it('constructs correct URL with params', async () => {
+    it('429 followed by success on retry: 결과를 반환하고 fetch가 2번 호출된다', async () => {
+        const fetchSpy = vi
+            .spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(
+                new Response(null, {
+                    status: 429,
+                    statusText: 'Too Many Requests',
+                })
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify([{ id: 1 }]), { status: 200 })
+            );
+
+        const result = await fmpGet<{ id: number }[]>('news/stock', {
+            symbols: 'AAPL',
+        });
+
+        expect(result).toEqual([{ id: 1 }]);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('올바른 URL과 쿼리 파라미터로 fetch를 호출한다', async () => {
         const fetchSpy = vi
             .spyOn(globalThis, 'fetch')
             .mockResolvedValue(
@@ -53,7 +108,7 @@ describe('FMP API error responses', () => {
         expect(calledUrl).toContain('apikey=test-key');
     });
 
-    it('parses JSON response on success', async () => {
+    it('성공 응답의 JSON을 파싱해서 반환한다', async () => {
         vi.spyOn(globalThis, 'fetch').mockResolvedValue(
             new Response(JSON.stringify([{ id: 1 }]), { status: 200 })
         );

--- a/src/__tests__/worst-case/fmpRateLimit.test.ts
+++ b/src/__tests__/worst-case/fmpRateLimit.test.ts
@@ -64,11 +64,14 @@ describe('FMP API error responses', () => {
     });
 
     it('network timeout (DOMException): 재시도 후 결국 던진다', async () => {
-        vi.spyOn(globalThis, 'fetch').mockRejectedValue(
-            new DOMException('The operation was aborted', 'AbortError')
-        );
+        const fetchSpy = vi
+            .spyOn(globalThis, 'fetch')
+            .mockRejectedValue(
+                new DOMException('The operation was aborted', 'AbortError')
+            );
 
         await expect(fmpGet('news/stock')).rejects.toThrow(DOMException);
+        expect(fetchSpy).toHaveBeenCalledTimes(4);
     });
 
     it('429 followed by success on retry: 결과를 반환하고 fetch가 2번 호출된다', async () => {

--- a/src/app/[symbol]/fear-greed/page.tsx
+++ b/src/app/[symbol]/fear-greed/page.tsx
@@ -1,4 +1,6 @@
 import { FearGreedPage } from '@/widgets/fear-greed/FearGreedPage';
+import { ErrorBoundary } from 'react-error-boundary';
+import { FearGreedPageError } from '@/widgets/fear-greed/FearGreedPageError';
 import { CrossLinkCards } from '@/widgets/symbol-page';
 import { JsonLd } from '@/shared/ui/JsonLd';
 import { DEFAULT_TIMEFRAME, VALID_TICKER_RE } from '@/shared/config/market';
@@ -151,7 +153,11 @@ export default async function SymbolFearGreedPage({ params }: Props) {
     });
     queryClient.setQueryData(QUERY_KEYS.assetInfo(symbol), assetInfo);
     await queryClient.prefetchQuery({
-        queryKey: QUERY_KEYS.bars(symbol, DEFAULT_TIMEFRAME, assetInfo.fmpSymbol),
+        queryKey: QUERY_KEYS.bars(
+            symbol,
+            DEFAULT_TIMEFRAME,
+            assetInfo.fmpSymbol
+        ),
         queryFn: ({ queryKey: [, qSymbol, qTimeframe, qFmpSymbol] }) =>
             getBarsAction(qSymbol, qTimeframe, qFmpSymbol),
     });
@@ -207,10 +213,12 @@ export default async function SymbolFearGreedPage({ params }: Props) {
                     </p>
                 </section>
                 <HydrationBoundary state={dehydrate(queryClient)}>
-                    <FearGreedPage
-                        symbol={ticker}
-                        fmpSymbol={assetInfo.fmpSymbol}
-                    />
+                    <ErrorBoundary FallbackComponent={FearGreedPageError}>
+                        <FearGreedPage
+                            symbol={ticker}
+                            fmpSymbol={assetInfo.fmpSymbol}
+                        />
+                    </ErrorBoundary>
                 </HydrationBoundary>
                 <CrossLinkCards symbol={ticker} current="fear-greed" />
             </main>

--- a/src/app/[symbol]/fear-greed/page.tsx
+++ b/src/app/[symbol]/fear-greed/page.tsx
@@ -1,6 +1,6 @@
 import { FearGreedPage } from '@/widgets/fear-greed/FearGreedPage';
 import { ErrorBoundary } from 'react-error-boundary';
-import { FearGreedPageError } from '@/widgets/fear-greed/FearGreedPageError';
+import { FearGreedPageError } from '@/widgets/fear-greed';
 import { CrossLinkCards } from '@/widgets/symbol-page';
 import { JsonLd } from '@/shared/ui/JsonLd';
 import { DEFAULT_TIMEFRAME, VALID_TICKER_RE } from '@/shared/config/market';

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -170,6 +170,12 @@ export default async function SymbolPage({ params, searchParams }: Props) {
 
     queryClient.setQueryData(QUERY_KEYS.assetInfo(symbol), assetInfo);
 
+    const barsQueryFn = ({
+        queryKey: [, qSymbol, qTimeframe, qFmpSymbol],
+    }: {
+        queryKey: ReturnType<typeof QUERY_KEYS.bars>;
+    }) => getBarsAction(qSymbol, qTimeframe, qFmpSymbol);
+
     await Promise.all([
         queryClient.prefetchQuery({
             queryKey: QUERY_KEYS.bars(
@@ -177,8 +183,7 @@ export default async function SymbolPage({ params, searchParams }: Props) {
                 initialTimeframe,
                 assetInfo.fmpSymbol
             ),
-            queryFn: ({ queryKey: [, qSymbol, qTimeframe, qFmpSymbol] }) =>
-                getBarsAction(qSymbol, qTimeframe, qFmpSymbol),
+            queryFn: barsQueryFn,
         }),
         ...(initialTimeframe !== DEFAULT_TIMEFRAME
             ? [
@@ -188,9 +193,7 @@ export default async function SymbolPage({ params, searchParams }: Props) {
                           DEFAULT_TIMEFRAME,
                           assetInfo.fmpSymbol
                       ),
-                      queryFn: ({
-                          queryKey: [, qSymbol, qTimeframe, qFmpSymbol],
-                      }) => getBarsAction(qSymbol, qTimeframe, qFmpSymbol),
+                      queryFn: barsQueryFn,
                   }),
               ]
             : []),

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -170,7 +170,7 @@ export default async function SymbolPage({ params, searchParams }: Props) {
 
     queryClient.setQueryData(QUERY_KEYS.assetInfo(symbol), assetInfo);
 
-    const prefetches = [
+    await Promise.all([
         queryClient.prefetchQuery({
             queryKey: QUERY_KEYS.bars(
                 symbol,
@@ -180,23 +180,21 @@ export default async function SymbolPage({ params, searchParams }: Props) {
             queryFn: ({ queryKey: [, qSymbol, qTimeframe, qFmpSymbol] }) =>
                 getBarsAction(qSymbol, qTimeframe, qFmpSymbol),
         }),
-    ];
-
-    if (initialTimeframe !== DEFAULT_TIMEFRAME) {
-        prefetches.push(
-            queryClient.prefetchQuery({
-                queryKey: QUERY_KEYS.bars(
-                    symbol,
-                    DEFAULT_TIMEFRAME,
-                    assetInfo.fmpSymbol
-                ),
-                queryFn: ({ queryKey: [, qSymbol, qTimeframe, qFmpSymbol] }) =>
-                    getBarsAction(qSymbol, qTimeframe, qFmpSymbol),
-            })
-        );
-    }
-
-    await Promise.all(prefetches);
+        ...(initialTimeframe !== DEFAULT_TIMEFRAME
+            ? [
+                  queryClient.prefetchQuery({
+                      queryKey: QUERY_KEYS.bars(
+                          symbol,
+                          DEFAULT_TIMEFRAME,
+                          assetInfo.fmpSymbol
+                      ),
+                      queryFn: ({
+                          queryKey: [, qSymbol, qTimeframe, qFmpSymbol],
+                      }) => getBarsAction(qSymbol, qTimeframe, qFmpSymbol),
+                  }),
+              ]
+            : []),
+    ]);
 
     return (
         <>

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -170,11 +170,33 @@ export default async function SymbolPage({ params, searchParams }: Props) {
 
     queryClient.setQueryData(QUERY_KEYS.assetInfo(symbol), assetInfo);
 
-    await queryClient.prefetchQuery({
-        queryKey: QUERY_KEYS.bars(symbol, initialTimeframe, assetInfo.fmpSymbol),
-        queryFn: ({ queryKey: [, qSymbol, qTimeframe, qFmpSymbol] }) =>
-            getBarsAction(qSymbol, qTimeframe, qFmpSymbol),
-    });
+    const prefetches = [
+        queryClient.prefetchQuery({
+            queryKey: QUERY_KEYS.bars(
+                symbol,
+                initialTimeframe,
+                assetInfo.fmpSymbol
+            ),
+            queryFn: ({ queryKey: [, qSymbol, qTimeframe, qFmpSymbol] }) =>
+                getBarsAction(qSymbol, qTimeframe, qFmpSymbol),
+        }),
+    ];
+
+    if (initialTimeframe !== DEFAULT_TIMEFRAME) {
+        prefetches.push(
+            queryClient.prefetchQuery({
+                queryKey: QUERY_KEYS.bars(
+                    symbol,
+                    DEFAULT_TIMEFRAME,
+                    assetInfo.fmpSymbol
+                ),
+                queryFn: ({ queryKey: [, qSymbol, qTimeframe, qFmpSymbol] }) =>
+                    getBarsAction(qSymbol, qTimeframe, qFmpSymbol),
+            })
+        );
+    }
+
+    await Promise.all(prefetches);
 
     return (
         <>

--- a/src/entities/news-article/__tests__/fmpNewsClient.test.ts
+++ b/src/entities/news-article/__tests__/fmpNewsClient.test.ts
@@ -1,3 +1,7 @@
+vi.mock('@/shared/lib/sleep', () => ({
+    sleep: vi.fn().mockResolvedValue(undefined),
+}));
+
 import {
     FmpNewsClient,
     computeCutoff,
@@ -138,7 +142,11 @@ describe('FmpNewsClient', () => {
 
     /** Helper — resolve fetch with a non-2xx status. */
     function mockError(status: number): void {
-        mockFetch.mockResolvedValueOnce({ ok: false, status });
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status,
+            headers: new Headers(),
+        });
     }
 
     // ------------------------------------------------------------------ //
@@ -161,9 +169,9 @@ describe('FmpNewsClient', () => {
 
     describe('non-2xx HTTP response', () => {
         it('fetchNews throws with status in message', async () => {
-            mockError(429);
+            mockError(404);
             const client = new FmpNewsClient();
-            await expect(client.fetchNews('AAPL', '7d')).rejects.toThrow('429');
+            await expect(client.fetchNews('AAPL', '7d')).rejects.toThrow('404');
         });
     });
 

--- a/src/shared/api/fmp/FmpHttpError.ts
+++ b/src/shared/api/fmp/FmpHttpError.ts
@@ -1,0 +1,15 @@
+export class FmpHttpError extends Error {
+    readonly status: number;
+    readonly retryAfterSeconds: number | null;
+
+    constructor(
+        path: string,
+        status: number,
+        retryAfterSeconds: number | null
+    ) {
+        super(`FMP ${path} ${status}`);
+        this.name = 'FmpHttpError';
+        this.status = status;
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+}

--- a/src/shared/api/fmp/__tests__/FmpHttpError.test.ts
+++ b/src/shared/api/fmp/__tests__/FmpHttpError.test.ts
@@ -1,0 +1,29 @@
+import { FmpHttpError } from '@/shared/api/fmp/FmpHttpError';
+
+describe('FmpHttpError', () => {
+    it('status와 retryAfterSeconds를 저장한다', () => {
+        const err = new FmpHttpError('profile', 429, 30);
+        expect(err.status).toBe(429);
+        expect(err.retryAfterSeconds).toBe(30);
+    });
+
+    it('메시지 형식이 `FMP ${path} ${status}`이다', () => {
+        const err = new FmpHttpError('profile', 404, null);
+        expect(err.message).toBe('FMP profile 404');
+    });
+
+    it('name 프로퍼티가 "FmpHttpError"이다', () => {
+        const err = new FmpHttpError('quote', 500, null);
+        expect(err.name).toBe('FmpHttpError');
+    });
+
+    it('retryAfterSeconds가 제공되지 않으면 null이다', () => {
+        const err = new FmpHttpError('stock-list', 503, null);
+        expect(err.retryAfterSeconds).toBeNull();
+    });
+
+    it('Error를 상속한다', () => {
+        const err = new FmpHttpError('profile', 500, null);
+        expect(err).toBeInstanceOf(Error);
+    });
+});

--- a/src/shared/api/fmp/__tests__/fmpRetry.test.ts
+++ b/src/shared/api/fmp/__tests__/fmpRetry.test.ts
@@ -1,0 +1,89 @@
+import { FmpHttpError } from '@/shared/api/fmp/FmpHttpError';
+import {
+    isFmpTransientError,
+    extractRetryAfterMs,
+    FMP_TRANSIENT_RETRY,
+} from '@/shared/api/fmp/fmpRetry';
+
+describe('isFmpTransientError', () => {
+    describe('FmpHttpError', () => {
+        it.each([429, 500, 502, 503])('status %i는 true를 반환한다', status => {
+            expect(
+                isFmpTransientError(new FmpHttpError('profile', status, null))
+            ).toBe(true);
+        });
+
+        it.each([400, 401, 403, 404])(
+            'status %i는 false를 반환한다',
+            status => {
+                expect(
+                    isFmpTransientError(
+                        new FmpHttpError('profile', status, null)
+                    )
+                ).toBe(false);
+            }
+        );
+    });
+
+    it('TypeError는 true를 반환한다', () => {
+        expect(isFmpTransientError(new TypeError('fetch failed'))).toBe(true);
+    });
+
+    it('DOMException은 true를 반환한다', () => {
+        expect(
+            isFmpTransientError(new DOMException('aborted', 'AbortError'))
+        ).toBe(true);
+    });
+
+    it('일반 Error는 false를 반환한다', () => {
+        expect(isFmpTransientError(new Error('something went wrong'))).toBe(
+            false
+        );
+    });
+
+    it('null은 false를 반환한다', () => {
+        expect(isFmpTransientError(null)).toBe(false);
+    });
+
+    it('string은 false를 반환한다', () => {
+        expect(isFmpTransientError('error')).toBe(false);
+    });
+});
+
+describe('extractRetryAfterMs', () => {
+    it('FmpHttpError의 retryAfterSeconds를 ms로 변환해 반환한다', () => {
+        const err = new FmpHttpError('profile', 429, 30);
+        expect(extractRetryAfterMs(err)).toBe(30_000);
+    });
+
+    it('retryAfterSeconds가 null이면 null을 반환한다', () => {
+        const err = new FmpHttpError('profile', 429, null);
+        expect(extractRetryAfterMs(err)).toBeNull();
+    });
+
+    it('FmpHttpError가 아니면 null을 반환한다', () => {
+        expect(extractRetryAfterMs(new Error('oops'))).toBeNull();
+        expect(extractRetryAfterMs(new TypeError('fetch failed'))).toBeNull();
+        expect(extractRetryAfterMs(null)).toBeNull();
+    });
+});
+
+describe('FMP_TRANSIENT_RETRY', () => {
+    it('예상 shape을 가진다', () => {
+        expect(FMP_TRANSIENT_RETRY.maxRetries).toBe(3);
+        expect(FMP_TRANSIENT_RETRY.baseDelayMs).toBe(500);
+        expect(FMP_TRANSIENT_RETRY.isRetryable).toBe(isFmpTransientError);
+        expect(FMP_TRANSIENT_RETRY.backoffBudgetMs).toBe(8000);
+    });
+
+    it('getRetryDelayMs가 FmpHttpError의 retryAfterSeconds를 ms로 변환한다', () => {
+        const getRetryDelayMs = FMP_TRANSIENT_RETRY.getRetryDelayMs!;
+        const err = new FmpHttpError('profile', 429, 60);
+        expect(getRetryDelayMs(err)).toBe(60_000);
+    });
+
+    it('getRetryDelayMs가 FmpHttpError가 아니면 null을 반환한다', () => {
+        const getRetryDelayMs = FMP_TRANSIENT_RETRY.getRetryDelayMs!;
+        expect(getRetryDelayMs(new TypeError('fetch failed'))).toBeNull();
+    });
+});

--- a/src/shared/api/fmp/__tests__/fmpRetry.test.ts
+++ b/src/shared/api/fmp/__tests__/fmpRetry.test.ts
@@ -48,6 +48,10 @@ describe('isFmpTransientError', () => {
     it('string은 false를 반환한다', () => {
         expect(isFmpTransientError('error')).toBe(false);
     });
+
+    it('undefined는 false를 반환한다', () => {
+        expect(isFmpTransientError(undefined)).toBe(false);
+    });
 });
 
 describe('extractRetryAfterMs', () => {
@@ -65,6 +69,10 @@ describe('extractRetryAfterMs', () => {
         expect(extractRetryAfterMs(new Error('oops'))).toBeNull();
         expect(extractRetryAfterMs(new TypeError('fetch failed'))).toBeNull();
         expect(extractRetryAfterMs(null)).toBeNull();
+    });
+
+    it('undefined를 전달하면 null을 반환한다', () => {
+        expect(extractRetryAfterMs(undefined)).toBeNull();
     });
 });
 

--- a/src/shared/api/fmp/__tests__/fundamentalClient.test.ts
+++ b/src/shared/api/fmp/__tests__/fundamentalClient.test.ts
@@ -1,3 +1,7 @@
+vi.mock('@/shared/lib/sleep', () => ({
+    sleep: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { FmpFundamentalClient } from '../fundamentalClient';
 
 const mockFetch = vi.fn();
@@ -29,7 +33,11 @@ describe('FmpFundamentalClient', () => {
 
     /** Helper — resolve fetch with a non-2xx status. */
     function mockError(status: number): void {
-        mockFetch.mockResolvedValueOnce({ ok: false, status });
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status,
+            headers: new Headers(),
+        });
     }
 
     // ------------------------------------------------------------------ //
@@ -58,8 +66,8 @@ describe('FmpFundamentalClient', () => {
         });
 
         it('getKeyMetricsTtm returns null when both optional endpoints fail', async () => {
-            mockError(500);
-            mockError(500);
+            mockError(400);
+            mockError(400);
             const client = new FmpFundamentalClient();
             await expect(client.getKeyMetricsTtm('AAPL')).resolves.toBeNull();
         });

--- a/src/shared/api/fmp/__tests__/httpClient.test.ts
+++ b/src/shared/api/fmp/__tests__/httpClient.test.ts
@@ -274,5 +274,32 @@ describe('fmpGet', () => {
             const error = await fmpGet('profile').catch((e: unknown) => e);
             expect((error as FmpHttpError).retryAfterSeconds).toBeNull();
         });
+
+        it.each(['', 'Infinity', 'NaN', 'tomorrow'])(
+            '유효하지 않은 Retry-After "%s" → null 반환',
+            async value => {
+                mockError(429, { 'Retry-After': value });
+                mockError(429);
+                mockError(429);
+                mockError(429);
+
+                const error = await fmpGet('profile').catch((e: unknown) => e);
+                expect((error as FmpHttpError).retryAfterSeconds).toBeNull();
+            }
+        );
+    });
+
+    describe('malformed JSON body', () => {
+        it('SyntaxError는 retryable이 아니므로 즉시 던진다', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => {
+                    throw new SyntaxError('Unexpected token');
+                },
+            });
+
+            await expect(fmpGet('profile')).rejects.toThrow(SyntaxError);
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/src/shared/api/fmp/__tests__/httpClient.test.ts
+++ b/src/shared/api/fmp/__tests__/httpClient.test.ts
@@ -1,9 +1,16 @@
+// `sleep` is the only side-effect inside `withRetry`. Stubbing it prevents
+// real wall-clock delays and keeps tests synchronous.
+vi.mock('@/shared/lib/sleep', () => ({
+    sleep: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('@y0ngha/siglens-core', () => ({
     readFmpConfig: vi.fn(() => ({ apiKey: 'test-fmp-key' })),
 }));
 
 import { readFmpConfig } from '@y0ngha/siglens-core';
 import { FMP_STABLE_BASE, fmpGet } from '@/shared/api/fmp/httpClient';
+import { FmpHttpError } from '@/shared/api/fmp/FmpHttpError';
 
 const mockFetch = vi.fn();
 
@@ -20,87 +27,252 @@ describe('fmpGet', () => {
         vi.stubGlobal('fetch', mockFetch);
         mockFetch.mockReset();
         vi.mocked(readFmpConfig).mockReturnValue({ apiKey: 'test-fmp-key' });
+        // Deterministic jitter so delay assertions can be exact.
+        vi.spyOn(Math, 'random').mockReturnValue(0);
     });
 
     afterEach(() => {
         vi.unstubAllGlobals();
+        vi.restoreAllMocks();
     });
 
     function mockOk(body: unknown): void {
         mockFetch.mockResolvedValueOnce({
             ok: true,
+            status: 200,
+            headers: new Headers(),
             json: async () => body,
         });
     }
 
-    function mockError(status: number): void {
-        mockFetch.mockResolvedValueOnce({ ok: false, status });
+    function mockError(status: number, headers?: Record<string, string>): void {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status,
+            headers: new Headers(headers),
+        });
     }
 
-    it('올바른 URL과 쿼리 파라미터로 fetch를 호출한다', async () => {
-        mockOk({ data: 'test' });
-        await fmpGet('profile', { symbol: 'AAPL' });
+    describe('happy path', () => {
+        it('올바른 URL과 쿼리 파라미터로 fetch를 호출한다', async () => {
+            mockOk({ data: 'test' });
+            await fmpGet('profile', { symbol: 'AAPL' });
 
-        const calledUrl = mockFetch.mock.calls[0]![0] as string;
-        expect(calledUrl).toContain(FMP_STABLE_BASE + '/profile');
-        expect(calledUrl).toContain('apikey=test-fmp-key');
-        expect(calledUrl).toContain('symbol=AAPL');
+            const calledUrl = mockFetch.mock.calls[0]![0] as string;
+            expect(calledUrl).toContain(FMP_STABLE_BASE + '/profile');
+            expect(calledUrl).toContain('apikey=test-fmp-key');
+            expect(calledUrl).toContain('symbol=AAPL');
+        });
+
+        it('query 파라미터 없이도 동작한다', async () => {
+            mockOk([]);
+            await fmpGet('stock-list');
+
+            const calledUrl = mockFetch.mock.calls[0]![0] as string;
+            expect(calledUrl).toContain(FMP_STABLE_BASE + '/stock-list');
+            expect(calledUrl).toContain('apikey=test-fmp-key');
+        });
+
+        it('응답 JSON을 파싱해서 반환한다', async () => {
+            const body = { symbol: 'AAPL', price: 150 };
+            mockOk(body);
+
+            const result = await fmpGet<typeof body>('profile');
+            expect(result).toEqual(body);
+        });
+
+        it('cache: no-store 옵션을 사용한다', async () => {
+            mockOk({});
+            await fmpGet('profile');
+
+            const options = mockFetch.mock.calls[0]![1] as RequestInit;
+            expect(options.cache).toBe('no-store');
+        });
+
+        it('AbortSignal timeout을 설정한다', async () => {
+            mockOk({});
+            await fmpGet('profile');
+
+            const options = mockFetch.mock.calls[0]![1] as RequestInit;
+            expect(options.signal).toBeInstanceOf(AbortSignal);
+        });
+
+        it('FMP_STABLE_BASE가 올바른 URL이다', () => {
+            expect(FMP_STABLE_BASE).toBe(
+                'https://financialmodelingprep.com/stable'
+            );
+        });
     });
 
-    it('query 파라미터 없이도 동작한다', async () => {
-        mockOk([]);
-        await fmpGet('stock-list');
+    describe('retry behavior', () => {
+        it('429 응답은 maxRetries 횟수만큼 재시도 후 FmpHttpError를 던진다', async () => {
+            // maxRetries=3 → 총 4번 호출
+            mockError(429);
+            mockError(429);
+            mockError(429);
+            mockError(429);
 
-        const calledUrl = mockFetch.mock.calls[0]![0] as string;
-        expect(calledUrl).toContain(FMP_STABLE_BASE + '/stock-list');
-        expect(calledUrl).toContain('apikey=test-fmp-key');
+            await expect(fmpGet('profile')).rejects.toThrow(FmpHttpError);
+            expect(mockFetch).toHaveBeenCalledTimes(4);
+        });
+
+        it('500 응답 후 재시도에서 성공하면 결과를 반환한다', async () => {
+            mockError(500);
+            mockOk({ symbol: 'AAPL' });
+
+            const result = await fmpGet('profile');
+            expect(result).toEqual({ symbol: 'AAPL' });
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+        });
+
+        it('429 with Retry-After header → FmpHttpError.retryAfterSeconds가 설정된다', async () => {
+            // Only 1 mock needed since we check the error shape; but withRetry
+            // will throw after all retries exhaust — mock all 4 calls.
+            mockError(429, { 'Retry-After': '120' });
+            mockError(429, { 'Retry-After': '120' });
+            mockError(429, { 'Retry-After': '120' });
+            mockError(429, { 'Retry-After': '120' });
+
+            const error = await fmpGet('profile').catch((e: unknown) => e);
+            expect(error).toBeInstanceOf(FmpHttpError);
+            expect((error as FmpHttpError).retryAfterSeconds).toBe(120);
+        });
+
+        it('429 without Retry-After header → FmpHttpError.retryAfterSeconds가 null이다', async () => {
+            mockError(429);
+            mockError(429);
+            mockError(429);
+            mockError(429);
+
+            const error = await fmpGet('profile').catch((e: unknown) => e);
+            expect(error).toBeInstanceOf(FmpHttpError);
+            expect((error as FmpHttpError).retryAfterSeconds).toBeNull();
+        });
     });
 
-    it('응답 JSON을 파싱해서 반환한다', async () => {
-        const body = { symbol: 'AAPL', price: 150 };
-        mockOk(body);
+    describe('non-retryable errors', () => {
+        it('404 응답은 즉시 FmpHttpError를 던진다 (재시도 없음)', async () => {
+            mockError(404);
 
-        const result = await fmpGet<typeof body>('profile');
-        expect(result).toEqual(body);
+            await expect(fmpGet('profile')).rejects.toThrow(FmpHttpError);
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+
+        it('400 응답은 즉시 FmpHttpError를 던진다 (재시도 없음)', async () => {
+            mockError(400);
+
+            await expect(fmpGet('profile')).rejects.toThrow(FmpHttpError);
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+
+        it('401 응답은 즉시 FmpHttpError를 던진다 (재시도 없음)', async () => {
+            mockError(401);
+
+            await expect(fmpGet('profile')).rejects.toThrow(FmpHttpError);
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
     });
 
-    it('cache: no-store 옵션을 사용한다', async () => {
-        mockOk({});
-        await fmpGet('profile');
+    describe('network errors', () => {
+        it('TypeError (fetch failed) 는 재시도된다', async () => {
+            mockFetch.mockRejectedValueOnce(new TypeError('fetch failed'));
+            mockOk({ ok: true });
 
-        const options = mockFetch.mock.calls[0]![1] as RequestInit;
-        expect(options.cache).toBe('no-store');
+            const result = await fmpGet('profile');
+            expect(result).toEqual({ ok: true });
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+        });
+
+        it('DOMException (AbortError timeout) 은 재시도된다', async () => {
+            mockFetch.mockRejectedValueOnce(
+                new DOMException('The operation was aborted', 'AbortError')
+            );
+            mockOk({ ok: true });
+
+            const result = await fmpGet('profile');
+            expect(result).toEqual({ ok: true });
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+        });
     });
 
-    it('AbortSignal timeout을 설정한다', async () => {
-        mockOk({});
-        await fmpGet('profile');
+    describe('FmpHttpError shape', () => {
+        it('던져진 에러가 FmpHttpError의 인스턴스다', async () => {
+            mockError(404);
+            await expect(fmpGet('profile')).rejects.toBeInstanceOf(
+                FmpHttpError
+            );
+        });
 
-        const options = mockFetch.mock.calls[0]![1] as RequestInit;
-        expect(options.signal).toBeInstanceOf(AbortSignal);
-    });
-
-    describe('에러 처리', () => {
-        it('4xx 응답 시 에러를 던진다', async () => {
+        it('에러 메시지가 "FMP {path} {status}" 형식이다', async () => {
             mockError(404);
             await expect(fmpGet('profile')).rejects.toThrow('FMP profile 404');
         });
 
-        it('5xx 응답 시 에러를 던진다', async () => {
-            mockError(500);
-            await expect(fmpGet('profile')).rejects.toThrow('FMP profile 500');
+        it('에러가 올바른 status 코드를 가진다', async () => {
+            mockError(403);
+            const error = await fmpGet('profile').catch((e: unknown) => e);
+            expect((error as FmpHttpError).status).toBe(403);
         });
 
-        it('FMP_API_KEY가 없으면 readFmpConfig에서 에러를 던진다', async () => {
+        it('FMP_API_KEY가 없으면 readFmpConfig에서 에러를 던진다 (재시도 안 함)', async () => {
             vi.mocked(readFmpConfig).mockImplementation(() => {
                 throw new Error('FMP_API_KEY is required');
             });
             await expect(fmpGet('profile')).rejects.toThrow('FMP_API_KEY');
+            // readFmpConfig throws before fetch is called
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('parseRetryAfterSeconds', () => {
+        it('"120" → 120으로 파싱한다', async () => {
+            mockError(429, { 'Retry-After': '120' });
+            mockError(429);
+            mockError(429);
+            mockError(429);
+
+            const error = await fmpGet('profile').catch((e: unknown) => e);
+            expect((error as FmpHttpError).retryAfterSeconds).toBe(120);
         });
 
-        it('fetch가 네트워크 에러를 던지면 전파된다', async () => {
-            mockFetch.mockRejectedValueOnce(new TypeError('fetch failed'));
-            await expect(fmpGet('profile')).rejects.toThrow('fetch failed');
+        it('non-numeric 문자열 → null 반환', async () => {
+            mockError(429, { 'Retry-After': 'tomorrow' });
+            mockError(429);
+            mockError(429);
+            mockError(429);
+
+            const error = await fmpGet('profile').catch((e: unknown) => e);
+            expect((error as FmpHttpError).retryAfterSeconds).toBeNull();
+        });
+
+        it('"0" → null 반환 (0은 유효하지 않은 delay)', async () => {
+            mockError(429, { 'Retry-After': '0' });
+            mockError(429);
+            mockError(429);
+            mockError(429);
+
+            const error = await fmpGet('profile').catch((e: unknown) => e);
+            expect((error as FmpHttpError).retryAfterSeconds).toBeNull();
+        });
+
+        it('음수 → null 반환', async () => {
+            mockError(429, { 'Retry-After': '-5' });
+            mockError(429);
+            mockError(429);
+            mockError(429);
+
+            const error = await fmpGet('profile').catch((e: unknown) => e);
+            expect((error as FmpHttpError).retryAfterSeconds).toBeNull();
+        });
+
+        it('Retry-After 헤더 없음 → null 반환', async () => {
+            mockError(429);
+            mockError(429);
+            mockError(429);
+            mockError(429);
+
+            const error = await fmpGet('profile').catch((e: unknown) => e);
+            expect((error as FmpHttpError).retryAfterSeconds).toBeNull();
         });
     });
 });

--- a/src/shared/api/fmp/fmpRetry.ts
+++ b/src/shared/api/fmp/fmpRetry.ts
@@ -1,0 +1,49 @@
+import type { WithRetryOptions } from '@/shared/lib/withRetry';
+import { FmpHttpError } from './FmpHttpError';
+
+/**
+ * True for transient HTTP errors worth retrying:
+ *   - FmpHttpError with status 429 (rate-limited) or >= 500 (server error)
+ *   - TypeError (network-level fetch failure, e.g. DNS / TCP timeout)
+ *   - DOMException (AbortError from request timeout)
+ *
+ * False for all other cases, including 4xx client errors (400, 401, 403, 404)
+ * that indicate a permanent caller-side problem and should not be retried.
+ */
+export function isFmpTransientError(error: unknown): boolean {
+    if (error instanceof FmpHttpError) {
+        return error.status === 429 || error.status >= 500;
+    }
+    return error instanceof TypeError || error instanceof DOMException;
+}
+
+/**
+ * Extract a server-suggested retry delay from an FmpHttpError's
+ * `retryAfterSeconds` field (converted to milliseconds). Returns `null` for
+ * any other error type or when `retryAfterSeconds` is null, falling back to
+ * the normal exponential+jitter schedule in `withRetry`.
+ */
+export function extractRetryAfterMs(error: unknown): number | null {
+    if (error instanceof FmpHttpError && error.retryAfterSeconds !== null) {
+        return error.retryAfterSeconds * 1000;
+    }
+    return null;
+}
+
+/**
+ * Shared retry policy for FMP HTTP client transient errors. Three retries with
+ * 500/1000/2000ms exponential backoff + jitter handle rate-limit windows and
+ * intermittent server errors while staying within serverless-function budgets.
+ *
+ * `backoffBudgetMs: 8000` caps cumulative backoff sleep — if the function
+ * itself runs slow and approaches the budget, `withRetry` bails out rather
+ * than queueing more sleeps. `getRetryDelayMs` honors any `Retry-After`
+ * header value the FMP API returns via `FmpHttpError.retryAfterSeconds`.
+ */
+export const FMP_TRANSIENT_RETRY: WithRetryOptions = {
+    maxRetries: 3,
+    baseDelayMs: 500,
+    isRetryable: isFmpTransientError,
+    backoffBudgetMs: 8000,
+    getRetryDelayMs: extractRetryAfterMs,
+};

--- a/src/shared/api/fmp/fmpRetry.ts
+++ b/src/shared/api/fmp/fmpRetry.ts
@@ -31,14 +31,10 @@ export function extractRetryAfterMs(error: unknown): number | null {
 }
 
 /**
- * Shared retry policy for FMP HTTP client transient errors. Three retries with
- * 500/1000/2000ms exponential backoff + jitter handle rate-limit windows and
- * intermittent server errors while staying within serverless-function budgets.
- *
- * `backoffBudgetMs: 8000` caps cumulative backoff sleep — if the function
- * itself runs slow and approaches the budget, `withRetry` bails out rather
- * than queueing more sleeps. `getRetryDelayMs` honors any `Retry-After`
- * header value the FMP API returns via `FmpHttpError.retryAfterSeconds`.
+ * Shared retry policy for FMP HTTP client transient errors. Exponential
+ * backoff + jitter handles rate-limit windows and intermittent server errors
+ * while staying within serverless-function budgets. `getRetryDelayMs` honors
+ * any `Retry-After` header value via `FmpHttpError.retryAfterSeconds`.
  */
 export const FMP_TRANSIENT_RETRY: WithRetryOptions = {
     maxRetries: 3,

--- a/src/shared/api/fmp/fmpRetry.ts
+++ b/src/shared/api/fmp/fmpRetry.ts
@@ -1,6 +1,6 @@
 import type { WithRetryOptions } from '@/shared/lib/withRetry';
 import { MS_PER_SECOND } from '@/shared/config/time';
-import { FmpHttpError } from './FmpHttpError';
+import { FmpHttpError } from '@/shared/api/fmp/FmpHttpError';
 
 /**
  * True for transient HTTP errors worth retrying:

--- a/src/shared/api/fmp/fmpRetry.ts
+++ b/src/shared/api/fmp/fmpRetry.ts
@@ -1,4 +1,5 @@
 import type { WithRetryOptions } from '@/shared/lib/withRetry';
+import { MS_PER_SECOND } from '@/shared/config/time';
 import { FmpHttpError } from './FmpHttpError';
 
 /**
@@ -25,7 +26,7 @@ export function isFmpTransientError(error: unknown): boolean {
  */
 export function extractRetryAfterMs(error: unknown): number | null {
     if (error instanceof FmpHttpError && error.retryAfterSeconds !== null) {
-        return error.retryAfterSeconds * 1000;
+        return error.retryAfterSeconds * MS_PER_SECOND;
     }
     return null;
 }

--- a/src/shared/api/fmp/httpClient.ts
+++ b/src/shared/api/fmp/httpClient.ts
@@ -1,7 +1,7 @@
 import { readFmpConfig } from '@y0ngha/siglens-core';
 import { withRetry } from '@/shared/lib/withRetry';
-import { FmpHttpError } from './FmpHttpError';
-import { FMP_TRANSIENT_RETRY } from './fmpRetry';
+import { FmpHttpError } from '@/shared/api/fmp/FmpHttpError';
+import { FMP_TRANSIENT_RETRY } from '@/shared/api/fmp/fmpRetry';
 
 /** Base URL for all FMP `/stable/*` endpoints. */
 export const FMP_STABLE_BASE = 'https://financialmodelingprep.com/stable';

--- a/src/shared/api/fmp/httpClient.ts
+++ b/src/shared/api/fmp/httpClient.ts
@@ -1,4 +1,7 @@
 import { readFmpConfig } from '@y0ngha/siglens-core';
+import { withRetry } from '@/shared/lib/withRetry';
+import { FmpHttpError } from './FmpHttpError';
+import { FMP_TRANSIENT_RETRY } from './fmpRetry';
 
 /** Base URL for all FMP `/stable/*` endpoints. */
 export const FMP_STABLE_BASE = 'https://financialmodelingprep.com/stable';
@@ -6,20 +9,47 @@ export const FMP_STABLE_BASE = 'https://financialmodelingprep.com/stable';
 /** Timeout for all FMP fetch calls (ms). */
 const FMP_FETCH_TIMEOUT_MS = 10_000;
 
-/** GET FMP /stable/<path>; appends apikey automatically; throws if FMP_API_KEY missing or non-2xx response. */
+/**
+ * Parse the `Retry-After` response header value (seconds as integer).
+ * Returns null if the header is absent, non-numeric, zero, or negative.
+ */
+function parseRetryAfterSeconds(header: string | null): number | null {
+    if (header === null) return null;
+    const seconds = Number(header);
+    return Number.isFinite(seconds) && seconds > 0 ? seconds : null;
+}
+
+/**
+ * GET FMP /stable/<path>; appends apikey automatically.
+ *
+ * Transient errors (429, 5xx, network failures, timeouts) are retried up to 3
+ * times with exponential backoff. Non-transient 4xx errors are thrown
+ * immediately as `FmpHttpError`. `readFmpConfig()` and `URLSearchParams` run
+ * once per call — only `fetch()` is inside the retry loop so each attempt gets
+ * a fresh `AbortSignal` timeout.
+ */
 export async function fmpGet<T>(
     path: string,
     query: Record<string, string> = {}
 ): Promise<T> {
     const { apiKey } = readFmpConfig();
     const params = new URLSearchParams({ ...query, apikey: apiKey });
-    const res = await fetch(`${FMP_STABLE_BASE}/${path}?${params.toString()}`, {
-        cache: 'no-store',
-        signal: AbortSignal.timeout(FMP_FETCH_TIMEOUT_MS),
-    });
-    if (!res.ok) {
-        throw new Error(`FMP ${path} ${res.status}`);
-    }
-    // Adapter methods narrow the result via explicit field mapping; malformation surfaces as TypeError in the mapper.
-    return (await res.json()) as T;
+
+    return withRetry(async () => {
+        const res = await fetch(
+            `${FMP_STABLE_BASE}/${path}?${params.toString()}`,
+            {
+                cache: 'no-store',
+                signal: AbortSignal.timeout(FMP_FETCH_TIMEOUT_MS),
+            }
+        );
+        if (!res.ok) {
+            const retryAfter = parseRetryAfterSeconds(
+                res.headers.get('Retry-After')
+            );
+            throw new FmpHttpError(path, res.status, retryAfter);
+        }
+        // Malformation surfaces as TypeError in the adapter mapper, not silently.
+        return (await res.json()) as T;
+    }, FMP_TRANSIENT_RETRY);
 }

--- a/src/shared/lib/__tests__/withRetry.test.ts
+++ b/src/shared/lib/__tests__/withRetry.test.ts
@@ -266,4 +266,20 @@ describe('withRetry', () => {
             expect(sleepMock).not.toHaveBeenCalled();
         });
     });
+
+    it('maxRetries=0 이면 재시도 없이 즉시 에러를 던진다', async () => {
+        const error = new Error('only-once');
+        const fn = vi.fn().mockRejectedValue(error);
+
+        await expect(
+            withRetry(fn, {
+                maxRetries: 0,
+                baseDelayMs: 200,
+                isRetryable: () => true,
+            })
+        ).rejects.toBe(error);
+
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(sleepMock).not.toHaveBeenCalled();
+    });
 });

--- a/src/shared/lib/__tests__/withRetry.test.ts
+++ b/src/shared/lib/__tests__/withRetry.test.ts
@@ -184,4 +184,86 @@ describe('withRetry', () => {
         // 첫 실패에 대한 sleep 1회만 발생.
         expect(sleepMock).toHaveBeenCalledTimes(1);
     });
+
+    describe('getRetryDelayMs', () => {
+        it('non-null을 반환하면 지수 백오프 대신 해당 값으로 sleep을 호출한다', async () => {
+            const fn = vi
+                .fn()
+                .mockRejectedValueOnce(new Error('rate-limited'))
+                .mockResolvedValueOnce('ok');
+            // Server says wait 5000ms regardless of backoff schedule.
+            const getRetryDelayMs = vi.fn().mockReturnValue(5000);
+
+            await withRetry(fn, {
+                maxRetries: 3,
+                baseDelayMs: 200,
+                isRetryable: () => true,
+                getRetryDelayMs,
+            });
+
+            // Math.random=0 ⇒ exponential would be 200ms; but override wins.
+            expect(sleepMock).toHaveBeenCalledTimes(1);
+            expect(sleepMock).toHaveBeenCalledWith(5000);
+        });
+
+        it('null을 반환하면 지수 백오프로 폴백한다', async () => {
+            const fn = vi
+                .fn()
+                .mockRejectedValueOnce(new Error('transient'))
+                .mockResolvedValueOnce('ok');
+            // No Retry-After header on this error → return null.
+            const getRetryDelayMs = vi.fn().mockReturnValue(null);
+
+            await withRetry(fn, {
+                maxRetries: 3,
+                baseDelayMs: 200,
+                isRetryable: () => true,
+                getRetryDelayMs,
+            });
+
+            // Math.random=0 ⇒ jitter=0, so pure exponential: 200ms.
+            expect(sleepMock).toHaveBeenCalledTimes(1);
+            expect(sleepMock).toHaveBeenCalledWith(200);
+        });
+
+        it('getRetryDelayMs가 없으면 기존 동작이 그대로 유지된다', async () => {
+            const fn = vi
+                .fn()
+                .mockRejectedValueOnce(new Error('a'))
+                .mockRejectedValueOnce(new Error('b'))
+                .mockResolvedValueOnce('done');
+
+            await withRetry(fn, {
+                maxRetries: 3,
+                baseDelayMs: 200,
+                isRetryable: () => true,
+                // no getRetryDelayMs
+            });
+
+            // Math.random=0 ⇒ 200ms then 400ms.
+            expect(sleepMock).toHaveBeenNthCalledWith(1, 200);
+            expect(sleepMock).toHaveBeenNthCalledWith(2, 400);
+        });
+
+        it('getRetryDelayMs가 반환한 값도 backoffBudgetMs 체크를 통과해야 sleep한다', async () => {
+            // backoffBudgetMs=50ms이면 deadline이 곧 지나므로, 커스텀 딜레이 5000ms는
+            // Date.now() + 5000 >= deadline을 만족해 sleep 없이 에러를 던진다.
+            const firstError = new Error('rate-limited');
+            const fn = vi.fn().mockRejectedValueOnce(firstError);
+            const getRetryDelayMs = vi.fn().mockReturnValue(5000);
+
+            await expect(
+                withRetry(fn, {
+                    maxRetries: 3,
+                    baseDelayMs: 200,
+                    isRetryable: () => true,
+                    backoffBudgetMs: 50,
+                    getRetryDelayMs,
+                })
+            ).rejects.toBe(firstError);
+
+            expect(fn).toHaveBeenCalledTimes(1);
+            expect(sleepMock).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/src/shared/lib/withRetry.ts
+++ b/src/shared/lib/withRetry.ts
@@ -41,6 +41,22 @@ export interface WithRetryOptions {
      * cap (legacy behavior).
      */
     backoffBudgetMs?: number;
+    /**
+     * Override the computed exponential+jitter delay for a specific retry.
+     *
+     * Called with the caught error before each retry sleep. When it returns
+     * a non-null number, that value is used as the sleep duration instead of
+     * the exponential+jitter computation. Returning `null` falls back to the
+     * normal backoff schedule.
+     *
+     * Intended use-case: HTTP clients that receive a `Retry-After` response
+     * header can extract the server-suggested delay from the error object and
+     * return it here so `withRetry` honors it instead of guessing.
+     *
+     * The returned delay still participates in the `backoffBudgetMs` check —
+     * if `Date.now() + delay >= deadline`, the error is re-thrown immediately.
+     */
+    getRetryDelayMs?: (error: unknown) => number | null;
 }
 
 /**
@@ -54,7 +70,13 @@ export async function withRetry<T>(
     fn: () => Promise<T>,
     options: WithRetryOptions
 ): Promise<T> {
-    const { maxRetries, baseDelayMs, isRetryable, backoffBudgetMs } = options;
+    const {
+        maxRetries,
+        baseDelayMs,
+        isRetryable,
+        backoffBudgetMs,
+        getRetryDelayMs,
+    } = options;
     const deadline =
         backoffBudgetMs !== undefined ? Date.now() + backoffBudgetMs : Infinity;
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -67,7 +89,9 @@ export async function withRetry<T>(
             }
             const exponential = baseDelayMs * 2 ** attempt;
             const jitter = Math.random() * exponential;
-            const sleepMs = exponential + jitter;
+            const customDelay = getRetryDelayMs?.(error) ?? null;
+            const sleepMs =
+                customDelay !== null ? customDelay : exponential + jitter;
             // 다음 backoff sleep을 마치는 시점이 deadline을 넘어서면 더 기다리지
             // 않고 즉시 마지막 에러를 던진다. fn() 자체의 진행 중인 호출은 멈출
             // 수 없지만, 적어도 retry sleep 으로 인한 추가 지연이 예상 예산을

--- a/src/widgets/fear-greed/FearGreedPageError.tsx
+++ b/src/widgets/fear-greed/FearGreedPageError.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import type { FallbackProps } from 'react-error-boundary';
+
+export function FearGreedPageError({
+    error,
+    resetErrorBoundary,
+}: FallbackProps) {
+    const message =
+        error instanceof Error
+            ? error.message
+            : '공포 탐욕 지수를 불러오는 중 오류가 발생했습니다.';
+
+    return (
+        <section
+            aria-labelledby="fear-greed-error-heading"
+            className="border-ui-danger/30 bg-secondary-800 rounded-xl border p-6"
+        >
+            <h2
+                id="fear-greed-error-heading"
+                className="mb-2 text-lg font-semibold tracking-tight"
+            >
+                공포 탐욕 지수
+            </h2>
+            <p className="text-ui-danger text-sm" role="alert">
+                {message}
+            </p>
+            <button
+                type="button"
+                onClick={resetErrorBoundary}
+                className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-800 mt-4 rounded px-3 py-1.5 text-xs text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            >
+                다시 시도
+            </button>
+        </section>
+    );
+}

--- a/src/widgets/fear-greed/FearGreedPageError.tsx
+++ b/src/widgets/fear-greed/FearGreedPageError.tsx
@@ -2,9 +2,7 @@
 
 import type { FallbackProps } from 'react-error-boundary';
 
-export function FearGreedPageError({
-    resetErrorBoundary,
-}: FallbackProps) {
+export function FearGreedPageError({ resetErrorBoundary }: FallbackProps) {
     return (
         <section
             aria-labelledby="fear-greed-error-heading"
@@ -16,10 +14,10 @@ export function FearGreedPageError({
             >
                 공포 탐욕 지수
             </h2>
-            <p className="text-ui-danger text-sm" role="alert">
+            <div className="text-ui-danger text-sm" role="alert">
                 공포 탐욕 지수를 불러오는 중 오류가 발생했습니다. 잠시 후 다시
                 시도해주세요.
-            </p>
+            </div>
             <button
                 type="button"
                 onClick={resetErrorBoundary}

--- a/src/widgets/fear-greed/FearGreedPageError.tsx
+++ b/src/widgets/fear-greed/FearGreedPageError.tsx
@@ -3,14 +3,8 @@
 import type { FallbackProps } from 'react-error-boundary';
 
 export function FearGreedPageError({
-    error,
     resetErrorBoundary,
 }: FallbackProps) {
-    const message =
-        error instanceof Error
-            ? error.message
-            : '공포 탐욕 지수를 불러오는 중 오류가 발생했습니다.';
-
     return (
         <section
             aria-labelledby="fear-greed-error-heading"
@@ -23,7 +17,8 @@ export function FearGreedPageError({
                 공포 탐욕 지수
             </h2>
             <p className="text-ui-danger text-sm" role="alert">
-                {message}
+                공포 탐욕 지수를 불러오는 중 오류가 발생했습니다. 잠시 후 다시
+                시도해주세요.
             </p>
             <button
                 type="button"

--- a/src/widgets/fear-greed/__tests__/FearGreedPageError.test.tsx
+++ b/src/widgets/fear-greed/__tests__/FearGreedPageError.test.tsx
@@ -3,43 +3,35 @@ import userEvent from '@testing-library/user-event';
 import { FearGreedPageError } from '../FearGreedPageError';
 
 describe('FearGreedPageError', () => {
-    it('renders error message from Error instance', () => {
-        const error = new Error('공포 탐욕 지수 데이터를 불러올 수 없습니다.');
+    it('기술적 에러 메시지 대신 고정 한국어 안내를 표시한다', () => {
+        const error = new Error('FMP news/stock 429');
         render(
             <FearGreedPageError error={error} resetErrorBoundary={vi.fn()} />
         );
         expect(
-            screen.getByText('공포 탐욕 지수 데이터를 불러올 수 없습니다.')
-        ).toBeInTheDocument();
-    });
-
-    it('renders default message for non-Error values', () => {
-        render(
-            <FearGreedPageError
-                error="string error"
-                resetErrorBoundary={vi.fn()}
-            />
-        );
-        expect(
             screen.getByText(
-                '공포 탐욕 지수를 불러오는 중 오류가 발생했습니다.'
+                '공포 탐욕 지수를 불러오는 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'
             )
         ).toBeInTheDocument();
     });
 
     it('has accessible alert role', () => {
-        const error = new Error('오류');
         render(
-            <FearGreedPageError error={error} resetErrorBoundary={vi.fn()} />
+            <FearGreedPageError
+                error={new Error('test')}
+                resetErrorBoundary={vi.fn()}
+            />
         );
         expect(screen.getByRole('alert')).toBeInTheDocument();
     });
 
-    it('renders retry button that calls resetErrorBoundary', async () => {
+    it('다시 시도 버튼 클릭 시 resetErrorBoundary를 호출한다', async () => {
         const resetFn = vi.fn();
-        const error = new Error('오류');
         render(
-            <FearGreedPageError error={error} resetErrorBoundary={resetFn} />
+            <FearGreedPageError
+                error={new Error('test')}
+                resetErrorBoundary={resetFn}
+            />
         );
         const user = userEvent.setup();
         await user.click(screen.getByRole('button', { name: '다시 시도' }));

--- a/src/widgets/fear-greed/__tests__/FearGreedPageError.test.tsx
+++ b/src/widgets/fear-greed/__tests__/FearGreedPageError.test.tsx
@@ -15,7 +15,7 @@ describe('FearGreedPageError', () => {
         ).toBeInTheDocument();
     });
 
-    it('has accessible alert role', () => {
+    it('alert role을 가진다', () => {
         render(
             <FearGreedPageError
                 error={new Error('test')}

--- a/src/widgets/fear-greed/__tests__/FearGreedPageError.test.tsx
+++ b/src/widgets/fear-greed/__tests__/FearGreedPageError.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FearGreedPageError } from '../FearGreedPageError';
+
+describe('FearGreedPageError', () => {
+    it('renders error message from Error instance', () => {
+        const error = new Error('공포 탐욕 지수 데이터를 불러올 수 없습니다.');
+        render(
+            <FearGreedPageError error={error} resetErrorBoundary={vi.fn()} />
+        );
+        expect(
+            screen.getByText('공포 탐욕 지수 데이터를 불러올 수 없습니다.')
+        ).toBeInTheDocument();
+    });
+
+    it('renders default message for non-Error values', () => {
+        render(
+            <FearGreedPageError
+                error="string error"
+                resetErrorBoundary={vi.fn()}
+            />
+        );
+        expect(
+            screen.getByText(
+                '공포 탐욕 지수를 불러오는 중 오류가 발생했습니다.'
+            )
+        ).toBeInTheDocument();
+    });
+
+    it('has accessible alert role', () => {
+        const error = new Error('오류');
+        render(
+            <FearGreedPageError error={error} resetErrorBoundary={vi.fn()} />
+        );
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('renders retry button that calls resetErrorBoundary', async () => {
+        const resetFn = vi.fn();
+        const error = new Error('오류');
+        render(
+            <FearGreedPageError error={error} resetErrorBoundary={resetFn} />
+        );
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('button', { name: '다시 시도' }));
+        expect(resetFn).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/widgets/fear-greed/index.ts
+++ b/src/widgets/fear-greed/index.ts
@@ -3,6 +3,7 @@
 // not re-exported here, to keep the barrel tree-shake-friendly for tests.
 
 export { FearGreedGauge } from './FearGreedGauge';
+export { FearGreedPageError } from './FearGreedPageError';
 export { SelfNormWarningBadge } from './SelfNormWarningBadge';
 
 // Hooks re-exported for cross-widget consumption

--- a/src/widgets/symbol-page/ChartContent.tsx
+++ b/src/widgets/symbol-page/ChartContent.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from 'react';
 import React, { Suspense, useEffect, useEffectEvent, useMemo } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import dynamic from 'next/dynamic';
 import { type AnalysisResponse, type Timeframe } from '@y0ngha/siglens-core';
 import { cn } from '@/shared/lib/cn';
@@ -185,12 +186,14 @@ export function ChartContent({
                         actionPricesVisible={actionPricesVisible}
                         onActionPricesVisibilityChange={setActionPricesVisible}
                     />
-                    <Suspense fallback={null}>
-                        <FearGreedCardMounted
-                            symbol={symbol}
-                            fmpSymbol={fmpSymbol}
-                        />
-                    </Suspense>
+                    <ErrorBoundary fallback={null}>
+                        <Suspense fallback={null}>
+                            <FearGreedCardMounted
+                                symbol={symbol}
+                                fmpSymbol={fmpSymbol}
+                            />
+                        </Suspense>
+                    </ErrorBoundary>
                 </>
             ),
         [

--- a/src/widgets/symbol-page/SymbolLayoutHeader.tsx
+++ b/src/widgets/symbol-page/SymbolLayoutHeader.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { SymbolTabs } from './SymbolTabs';
 import { SymbolTabsSkeleton } from './SymbolTabsSkeleton';
 import { useAssetInfo } from './hooks/useAssetInfo';
@@ -77,14 +78,16 @@ export function SymbolLayoutHeader({ symbol }: SymbolLayoutHeaderProps) {
                         두 인스턴스는 동일 React Query 캐시를 공유하므로 fetch는 한 번만 발생하지만,
                         FearGreedHeaderChipMounted에 mount-time side effect(analytics, ref 등)를
                         추가할 때는 두 번 실행되는 점에 유의한다. */}
-                    <Suspense fallback={null}>
-                        <span className="hidden sm:contents">
-                            <FearGreedHeaderChipMounted
-                                symbol={ticker}
-                                fmpSymbol={assetInfo?.fmpSymbol}
-                            />
-                        </span>
-                    </Suspense>
+                    <ErrorBoundary fallback={null}>
+                        <Suspense fallback={null}>
+                            <span className="hidden sm:contents">
+                                <FearGreedHeaderChipMounted
+                                    symbol={ticker}
+                                    fmpSymbol={assetInfo?.fmpSymbol}
+                                />
+                            </span>
+                        </Suspense>
+                    </ErrorBoundary>
                 </div>
 
                 <div className="flex items-center gap-2 sm:order-3 sm:shrink-0">
@@ -101,14 +104,16 @@ export function SymbolLayoutHeader({ symbol }: SymbolLayoutHeaderProps) {
                     />
                 </div>
 
-                <Suspense fallback={null}>
-                    <div className="sm:hidden">
-                        <FearGreedHeaderChipMounted
-                            symbol={ticker}
-                            fmpSymbol={assetInfo?.fmpSymbol}
-                        />
-                    </div>
-                </Suspense>
+                <ErrorBoundary fallback={null}>
+                    <Suspense fallback={null}>
+                        <div className="sm:hidden">
+                            <FearGreedHeaderChipMounted
+                                symbol={ticker}
+                                fmpSymbol={assetInfo?.fmpSymbol}
+                            />
+                        </div>
+                    </Suspense>
+                </ErrorBoundary>
             </div>
 
             <div className="-mx-4 mt-3">


### PR DESCRIPTION
## 관련 이슈

프로덕션 버그 수정 (이슈 번호 미지정)

## 구현 내용

두 가지 프로덕션 오류를 해결합니다:

### Bug 1: Fear-Greed SSR 오류 ("Server Functions cannot be called during initial render")

**원인**: chart page는 `initialTimeframe`에 대해서만 bars를 prefetch했으나, `FearGreedCardMounted`는 항상 `DEFAULT_TIMEFRAME`('1Day') bars가 필요합니다. Timeframe이 다르면 cache miss로 인해 SSR 중 `useSuspenseQuery`가 server action `getBarsAction`을 호출하게 됩니다.

**해결책**:
- Chart page에서 `initialTimeframe`과 `DEFAULT_TIMEFRAME`이 다를 때 둘 다 prefetch하도록 수정
- Fear-greed mount point 전체에 `ErrorBoundary` 추가 (ChartContent, SymbolLayoutHeader x2, fear-greed page)
- Prefetch 실패에 대한 안전 장치로 동작

### Bug 2: FMP 429 ("Too Many Requests") 재시도 없음

**해결책**:
- `withRetry`에 선택적 `getRetryDelayMs` 콜백 추가 (하위호환성 유지)
- `FmpHttpError` 클래스 추가 (status + `Retry-After` 헤더 캐리)
- `fmpRetry` 모듈 구현 (`isFmpTransientError`, `extractRetryAfterMs`, `FMP_TRANSIENT_RETRY`)
- `fmpGet`이 429/5xx를 지수 백오프로 재시도 (최대 3회, 500ms 기본값, 8초 예산)

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it
- [x] any 타입 없음

## 변경 파일 목록

[생성]
- src/shared/api/fmp/FmpHttpError.ts
- src/shared/api/fmp/fmpRetry.ts
- src/shared/api/fmp/__tests__/FmpHttpError.test.ts
- src/shared/api/fmp/__tests__/fmpRetry.test.ts
- src/widgets/fear-greed/FearGreedPageError.tsx
- src/widgets/fear-greed/__tests__/FearGreedPageError.test.tsx

[수정]
- src/shared/lib/withRetry.ts
- src/shared/lib/__tests__/withRetry.test.ts
- src/shared/api/fmp/httpClient.ts
- src/shared/api/fmp/__tests__/httpClient.test.ts
- src/shared/api/fmp/__tests__/fundamentalClient.test.ts
- src/entities/news-article/__tests__/fmpNewsClient.test.ts
- src/__tests__/worst-case/fmpRateLimit.test.ts
- src/app/[symbol]/page.tsx
- src/app/[symbol]/fear-greed/page.tsx
- src/widgets/symbol-page/ChartContent.tsx
- src/widgets/symbol-page/SymbolLayoutHeader.tsx

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build

## 테스트 계획

1. **Fear-Greed SSR 오류 검증**
   - [ ] Chart page에서 initialTimeframe ≠ DEFAULT_TIMEFRAME인 경우 정상 렌더링 (SSR 오류 없음)
   - [ ] Fear-greed card 마운트 시 network request 없이 캐시된 bars 사용
   - [ ] ErrorBoundary fallback이 제대로 표시되는지 확인 (prefetch 실패 시뮬레이션)

2. **FMP 429 재시도 검증**
   - [ ] FMP API 429 응답 시 자동 재시도 동작 (최대 3회)
   - [ ] Exponential backoff 적용 (500ms → 1s → 2s)
   - [ ] 8초 예산 내에서 재시도 완료
   - [ ] Retry-After 헤더 존재 시 해당 값 사용
   - [ ] 타임아웃된 요청은 재시도 하지 않음

3. **회귀 테스트**
   - [ ] 기존 FMP 호출 (200 응답) 정상 동작
   - [ ] 5xx 오류도 동일하게 재시도 처리