### PR TITLE
fix: 종목 차트 페이지에서 AI 분석이 길어도 차트 높이 고정

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,6 +1,14 @@
 
 # Fix Log
 
+## [PR #515 Round 1 | fix/0/종목-차트-페이지-ai-분석-높이-고정 | 2026-05-28]
+- Violation: 테스트에서 매직 넘버 `80`이 입력값과 단언값으로 중복 등장 (ChartContent.test.tsx, SymbolLayoutClient.test.tsx)
+  - Rule: 매직 넘버 상수화 / DRY — 한쪽만 바뀌면 테스트가 조용히 오동작 (MISTAKES.md §15 일반 원칙, Pure Logic 체크리스트 "No hardcoded literals → extract to constants")
+  - Context: AI 분석 패널 길이 시뮬레이션 문단 수를 `LONG_PARAGRAPH_COUNT`/`SHORT_PARAGRAPH_COUNT` 상수로 추출
+- Violation: globals.css에 Tailwind v4 `@utility` + `&` 중첩 사용 → stylelint `at-rule-no-unknown` / `nesting-selector-no-missing-scoping-root` 오류
+  - Rule: lint:style 통과 (`.stylelintrc.cjs`의 `at-rule-no-unknown` ignoreAtRules는 v3 지시어만 등록)
+  - Context: 변형 조합이 불필요하므로 동일 파일 관례(`.hero-report-lines`)에 맞춰 일반 클래스 + `::-webkit-scrollbar` 별도 셀렉터로 전환
+
 ## [PR #513 Round 1 | fix/fear-greed-ssr-and-fmp-retry | 2026-05-26]
 - Violation: `page.tsx` prefetch 배열에 `.push()` 사용 — 배열 직접 변이
   - Rule: MISTAKES.md §5 — Array/object mutation via push/splice 금지

--- a/src/app/[symbol]/SymbolLayoutClient.tsx
+++ b/src/app/[symbol]/SymbolLayoutClient.tsx
@@ -1,9 +1,59 @@
 'use client';
 
 import { type ReactNode } from 'react';
+import { useSelectedLayoutSegment } from 'next/navigation';
 import { FloatingChatButton } from '@/widgets/chat/FloatingChatButton';
 import { SymbolChatProvider } from '@/features/symbol-chat';
 import { SymbolModelProvider } from '@/widgets/symbol-page/SymbolModelContext';
+import { cn } from '@/shared/lib/cn';
+
+interface SymbolLayoutJailProps {
+    children: ReactNode;
+}
+
+/**
+ * Sticky-footer jail wrapper shared by every `/[symbol]/*` route.
+ *
+ * Height behavior differs by route because the chart (index) page and the
+ * sibling tabs (news/fundamental/options/overall/fear-greed) have opposite
+ * needs:
+ *
+ * - Chart route (`useSelectedLayoutSegment() === null`): chart + AI panel must
+ *   fill exactly the first viewport with a *definite* height so the AI panel's
+ *   own `overflow-y-auto` scrolls internally and the chart keeps a fixed height.
+ *   A definite `h-[calc(...)]` (not `min-h`) is required: percentage/`flex-1`
+ *   height resolution inside ChartContent (`h-full` aside) only works when an
+ *   ancestor has a definite height. `<body>` is `min-h-full` and provides none,
+ *   so the jail must establish it here. `overflow-hidden` keeps the chart + AI
+ *   flex column contained within that definite height so the fixed-viewport block
+ *   never spills past the first screen. (The gate modal and mobile sheet are
+ *   `position: fixed`, so they escape the clip; the model dropdown is `absolute`
+ *   but opens downward from the header at the top of the jail, well clear of the
+ *   bottom edge, so it is not clipped in practice.)
+ * - Sibling routes (segment !== null): content flows and grows. `min-h-[calc]`
+ *   keeps short pages tall enough for the sticky footer while letting long pages
+ *   expand and scroll the page naturally.
+ *
+ * The footer lives in the root layout as the jail's sibling, so it sits below
+ * the jail and is reached by scrolling on every route.
+ */
+export function SymbolLayoutJail({ children }: SymbolLayoutJailProps) {
+    const isChartRoute = useSelectedLayoutSegment() === null;
+    // Class strings are written out in full (not interpolated) so Tailwind's JIT
+    // content scanner can statically detect and generate them.
+    return (
+        <div
+            className={cn(
+                'flex flex-col',
+                isChartRoute
+                    ? 'h-[calc(100dvh-var(--header-h,3.5rem)-var(--pwa-banner-h,0px))] overflow-hidden'
+                    : 'min-h-[calc(100dvh-var(--header-h,3.5rem)-var(--pwa-banner-h,0px))]'
+            )}
+        >
+            {children}
+        </div>
+    );
+}
 
 interface SymbolLayoutProvidersProps {
     children: ReactNode;

--- a/src/app/[symbol]/__tests__/SymbolLayoutClient.test.tsx
+++ b/src/app/[symbol]/__tests__/SymbolLayoutClient.test.tsx
@@ -13,12 +13,19 @@ vi.mock('@/widgets/symbol-page/SymbolModelContext', () => ({
         <div data-testid="model-provider">{children}</div>
     ),
 }));
+vi.mock('next/navigation', () => ({
+    useSelectedLayoutSegment: vi.fn(),
+}));
 
 import { render, screen } from '@testing-library/react';
+import { useSelectedLayoutSegment } from 'next/navigation';
 import {
     SymbolLayoutProviders,
     SymbolLayoutFloatingChat,
+    SymbolLayoutJail,
 } from '@/app/[symbol]/SymbolLayoutClient';
+
+const mockSegment = vi.mocked(useSelectedLayoutSegment);
 
 describe('SymbolLayoutProviders', () => {
     it('renders children inside SymbolChatProvider and SymbolModelProvider', () => {
@@ -39,5 +46,103 @@ describe('SymbolLayoutFloatingChat', () => {
         render(<SymbolLayoutFloatingChat symbol="AAPL" />);
 
         expect(screen.getByTestId('chat-button')).toHaveTextContent('AAPL');
+    });
+});
+
+// "AI 분석이 길어지면 차트도 길어진다" 회귀 가드 — 차트 높이 고정 부분.
+//
+// jsdom에는 레이아웃 엔진이 없어 차트가 실제로 고정 픽셀 높이를 유지하는지 측정할 수
+// 없다. 대신 그 동작을 만들어내는 CSS 계약을 검증한다: 차트(index) 라우트에서 jail은
+// definite height로 고정되고 overflow-hidden으로 클립되므로, 긴 AI 분석은 차트 행을
+// 늘리지 못하고 패널 자체의 overflow-y-auto 영역 안에서 스크롤된다. 이 계약은 분석이
+// 길든 짧든 동일해야 한다 — 그 불변성이 바로 회귀 가드다(버그의 본질은 "분석 길이가
+// 레이아웃 높이를 바꾼다"였다). 형제 탭은 반대로 min-h를 유지해 콘텐츠 길이에 따라
+// 자라고 페이지가 스크롤된다.
+describe('SymbolLayoutJail (차트 높이 고정)', () => {
+    const DEFINITE_HEIGHT =
+        'h-[calc(100dvh-var(--header-h,3.5rem)-var(--pwa-banner-h,0px))]';
+    const MIN_HEIGHT =
+        'min-h-[calc(100dvh-var(--header-h,3.5rem)-var(--pwa-banner-h,0px))]';
+    const SIBLING_SEGMENTS = [
+        'news',
+        'fundamental',
+        'options',
+        'overall',
+        'fear-greed',
+    ];
+
+    // 긴 AI 분석 패널과 짧은 패널의 대역. 콘텐츠 길이는 의도적으로 단언 결과에 영향을
+    // 주지 않는다 — 그 무관함(불변성)이 바로 이 테스트가 지키려는 핵심이다.
+    const LONG_ANALYSIS = (
+        <div data-testid="analysis">
+            {Array.from({ length: 80 }, (_, i) => (
+                <p key={i}>분석 문단 {i}</p>
+            ))}
+        </div>
+    );
+    const SHORT_ANALYSIS = <div data-testid="analysis">짧은 분석</div>;
+
+    const renderJail = (child: React.ReactNode) => {
+        const { container } = render(
+            <SymbolLayoutJail>{child}</SymbolLayoutJail>
+        );
+        return container.firstElementChild as HTMLElement;
+    };
+
+    describe('차트(index) 라우트', () => {
+        beforeEach(() => {
+            mockSegment.mockReturnValue(null);
+        });
+
+        describe('AI 분석 패널이 길 때', () => {
+            it('jail이 definite height + overflow-hidden을 유지해 패널이 내부 스크롤되고 차트는 늘어나지 않는다', () => {
+                const jail = renderJail(LONG_ANALYSIS);
+
+                expect(jail.className).toContain(DEFINITE_HEIGHT);
+                expect(jail.className).toContain('overflow-hidden');
+                // 버그는 min-h로 되돌아간다 — min-h면 긴 패널이 차트를 늘린다.
+                expect(jail.className).not.toContain(MIN_HEIGHT);
+            });
+        });
+
+        describe('AI 분석 패널이 짧을 때', () => {
+            it('콘텐츠가 짧아도 동일한 definite height(min-height 아님)를 유지해 차트가 viewport를 채운다', () => {
+                const jail = renderJail(SHORT_ANALYSIS);
+
+                expect(jail.className).toContain(DEFINITE_HEIGHT);
+                expect(jail.className).toContain('overflow-hidden');
+                expect(jail.className).not.toContain(MIN_HEIGHT);
+            });
+        });
+    });
+
+    describe('형제 탭 라우트', () => {
+        describe('콘텐츠가 길 때', () => {
+            it.each(SIBLING_SEGMENTS)(
+                '"%s" 라우트는 overflow-hidden 없이 growable min-height라 긴 콘텐츠가 페이지를 스크롤한다',
+                segment => {
+                    mockSegment.mockReturnValue(segment);
+
+                    const jail = renderJail(LONG_ANALYSIS);
+
+                    expect(jail.className).toContain(MIN_HEIGHT);
+                    expect(jail.className).not.toContain('overflow-hidden');
+                }
+            );
+        });
+
+        describe('콘텐츠가 짧을 때', () => {
+            it.each(SIBLING_SEGMENTS)(
+                '"%s" 라우트는 min-height를 유지해 짧은 페이지도 viewport를 채우고 sticky footer가 하단에 남는다',
+                segment => {
+                    mockSegment.mockReturnValue(segment);
+
+                    const jail = renderJail(SHORT_ANALYSIS);
+
+                    expect(jail.className).toContain(MIN_HEIGHT);
+                    expect(jail.className).not.toContain('overflow-hidden');
+                }
+            );
+        });
     });
 });

--- a/src/app/[symbol]/__tests__/SymbolLayoutClient.test.tsx
+++ b/src/app/[symbol]/__tests__/SymbolLayoutClient.test.tsx
@@ -73,9 +73,11 @@ describe('SymbolLayoutJail (차트 높이 고정)', () => {
 
     // 긴 AI 분석 패널과 짧은 패널의 대역. 콘텐츠 길이는 의도적으로 단언 결과에 영향을
     // 주지 않는다 — 그 무관함(불변성)이 바로 이 테스트가 지키려는 핵심이다.
+    // 긴 패널을 시뮬레이션하기에 충분한 문단 수.
+    const LONG_PARAGRAPH_COUNT = 80;
     const LONG_ANALYSIS = (
         <div data-testid="analysis">
-            {Array.from({ length: 80 }, (_, i) => (
+            {Array.from({ length: LONG_PARAGRAPH_COUNT }, (_, i) => (
                 <p key={i}>분석 문단 {i}</p>
             ))}
         </div>

--- a/src/app/[symbol]/layout.tsx
+++ b/src/app/[symbol]/layout.tsx
@@ -6,6 +6,7 @@ import {
 } from '@tanstack/react-query';
 import {
     SymbolLayoutFloatingChat,
+    SymbolLayoutJail,
     SymbolLayoutProviders,
 } from '@/app/[symbol]/SymbolLayoutClient';
 import { SymbolLayoutHeader } from '@/widgets/symbol-page/SymbolLayoutHeader';
@@ -23,12 +24,16 @@ interface SymbolLayoutProps {
 // Layout shell stays as an RSC: it composes a shared provider subtree (chat/model
 // contexts) around the chrome (header) and the active page subtree.
 //
-// Sticky-footer jail: SymbolLayoutHeader + page main(`flex-1`)을 viewport 잔여 영역에
-// 맞춘 컨테이너로 감싼다. viewport에서 site Header(`var(--header-h)` = 3.5rem) + PwaBanner
-// (`var(--pwa-banner-h, 0px)`, banner 표시 중일 때만 3rem)를 빼면 jail이 첫 화면의 잔여
-// 영역을 정확히 차지하고, 그 안에서 layout header가 자기 자리 + page main(flex-1)이
-// viewport 잔여를 차지해 차트 페이지의 chart+AI가 한 화면을 가득 채운다. footer는 root
-// layout에서 jail의 형제로 위치하므로 자연스럽게 jail 아래로 push되어 스크롤해야 보인다.
+// Sticky-footer jail (SymbolLayoutJail): SymbolLayoutHeader + page main을 viewport
+// 잔여 영역에 맞춘 컨테이너로 감싼다. viewport에서 site Header(`var(--header-h)` = 3.5rem)
+// + PwaBanner(`var(--pwa-banner-h, 0px)`, banner 표시 중일 때만 3rem)를 빼면 jail이 첫
+// 화면의 잔여 영역을 정확히 차지하고, 그 안에서 layout header가 자기 자리 + page main이
+// 나머지를 차지한다. footer는 root layout에서 jail의 형제로 위치하므로 자연스럽게 jail
+// 아래로 push되어 스크롤해야 보인다.
+//
+// jail 높이는 라우트별로 다르다 (SymbolLayoutJail JSDoc 참조). 차트(index) 라우트는
+// definite `h-[calc(...)]` + overflow-hidden으로 chart+AI를 첫 viewport에 고정해 AI 패널이
+// 내부 스크롤되게 하고, sibling 탭은 `min-h-[calc(...)]`으로 콘텐츠 길이에 따라 자란다.
 //
 // `--header-h`는 globals.css의 @theme에서 3.5rem 기본값으로 정의되어 site Header h-14와
 // 동기화된다. `--pwa-banner-h`는 PwaBanner mount 시점에 3rem으로 set, dismiss/unmount
@@ -42,12 +47,12 @@ interface SymbolLayoutProps {
 export default function SymbolLayout({ children, params }: SymbolLayoutProps) {
     return (
         <SymbolLayoutProviders>
-            <div className="flex min-h-[calc(100dvh-var(--header-h,3.5rem)-var(--pwa-banner-h,0px))] flex-col">
+            <SymbolLayoutJail>
                 <Suspense fallback={<SymbolHeaderShellFallback />}>
                     <SymbolLayoutChrome params={params} />
                 </Suspense>
                 {children}
-            </div>
+            </SymbolLayoutJail>
             <Suspense fallback={null}>
                 <SymbolFloatingChat params={params} />
             </Suspense>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -111,6 +111,17 @@
     left: 0 !important;
 }
 
+/* 스크롤은 유지하되 시각적 스크롤바만 감춘다. 차트 페이지 AI 분석 패널처럼
+   페이지 스크롤(footer 도달용)과 패널 내부 스크롤이 공존할 때, 내부 스크롤바가
+   같이 보이면 스크롤바가 둘로 겹쳐 보여 산만하다. 패널은 여전히 내부 스크롤로
+   콘텐츠를 담아 차트 높이를 고정하므로 overflow-y-auto는 그대로 두고 바만 숨긴다. */
+@utility scrollbar-none {
+    scrollbar-width: none; /* Firefox */
+    &::-webkit-scrollbar {
+        display: none; /* WebKit (Chrome/Safari/Edge) */
+    }
+}
+
 body {
     /* Tailwind v4 preflight가 --font-sans를 자동 매핑하지만, 한글 폰트 fallback이
        실제로 발동되는지 시각 확인이 어려워 명시적으로 한 번 더 박는다. var() 체인

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -76,6 +76,7 @@
        조합해 `calc(100dvh - var(--header-h) - var(--pwa-banner-h, 0px))`로 viewport
        잔여 영역을 정확히 계산한다. */
     --header-h: 3.5rem;
+
     /* font stack 순서: Geist(라틴)가 한글 글리프를 못 가지므로 자동으로
        다음 폰트(Pretendard, self-host)로 fallback된다. next/font/local이
        --font-pretendard CSS 변수를 주입하고 size-adjust를 자동 측정해
@@ -84,7 +85,7 @@
        디바이스마다 typography가 달라지고 CLS도 발생했다. */
     --font-sans:
         var(--font-geist-sans), var(--font-pretendard), -apple-system,
-        BlinkMacSystemFont, system-ui, 'Helvetica Neue', Arial, sans-serif;
+        blinkmacsystemfont, system-ui, 'Helvetica Neue', arial, sans-serif;
     --font-mono: var(--font-geist-mono);
 }
 
@@ -114,12 +115,15 @@
 /* 스크롤은 유지하되 시각적 스크롤바만 감춘다. 차트 페이지 AI 분석 패널처럼
    페이지 스크롤(footer 도달용)과 패널 내부 스크롤이 공존할 때, 내부 스크롤바가
    같이 보이면 스크롤바가 둘로 겹쳐 보여 산만하다. 패널은 여전히 내부 스크롤로
-   콘텐츠를 담아 차트 높이를 고정하므로 overflow-y-auto는 그대로 두고 바만 숨긴다. */
-@utility scrollbar-none {
+   콘텐츠를 담아 차트 높이를 고정하므로 overflow-y-auto는 그대로 두고 바만 숨긴다.
+   (Tailwind v4 @utility 대신 일반 클래스로 둔다 — 변형 조합이 필요 없고
+   stylelint의 @utility 미인식 + & 스코핑 경고를 피한다.) */
+.scrollbar-none {
     scrollbar-width: none; /* Firefox */
-    &::-webkit-scrollbar {
-        display: none; /* WebKit (Chrome/Safari/Edge) */
-    }
+}
+
+.scrollbar-none::-webkit-scrollbar {
+    display: none; /* WebKit (Chrome/Safari/Edge) */
 }
 
 body {

--- a/src/widgets/symbol-page/ChartContent.tsx
+++ b/src/widgets/symbol-page/ChartContent.tsx
@@ -318,9 +318,9 @@ export function ChartContent({
                 onKeyDown={handleKeyDown}
             />
 
-            {/* AI 분석 패널 — 데스크톱. overflow-y-auto로 내부 스크롤을 유지해
-                긴 분석이 차트 높이를 밀어내지 않게 하되, scrollbar-none으로 스크롤바
-                자체는 감춰 페이지 스크롤과 시각적으로 겹쳐 보이지 않게 한다. */}
+            {/* overflow-y-auto로 내부 스크롤을 유지해 긴 분석이 차트 높이를 밀어내지
+                않게 하되, scrollbar-none으로 스크롤바 자체는 감춰 페이지 스크롤과
+                시각적으로 겹쳐 보이지 않게 한다. */}
             <aside
                 className="border-secondary-700 scrollbar-none relative hidden min-h-0 flex-none overflow-y-auto border-l p-4 md:flex md:h-full md:w-(--panel-width) md:flex-col"
                 style={

--- a/src/widgets/symbol-page/ChartContent.tsx
+++ b/src/widgets/symbol-page/ChartContent.tsx
@@ -318,9 +318,11 @@ export function ChartContent({
                 onKeyDown={handleKeyDown}
             />
 
-            {/* AI 분석 패널 — 데스크톱 */}
+            {/* AI 분석 패널 — 데스크톱. overflow-y-auto로 내부 스크롤을 유지해
+                긴 분석이 차트 높이를 밀어내지 않게 하되, scrollbar-none으로 스크롤바
+                자체는 감춰 페이지 스크롤과 시각적으로 겹쳐 보이지 않게 한다. */}
             <aside
-                className="border-secondary-700 relative hidden min-h-0 flex-none overflow-y-auto border-l p-4 md:flex md:h-full md:w-(--panel-width) md:flex-col"
+                className="border-secondary-700 scrollbar-none relative hidden min-h-0 flex-none overflow-y-auto border-l p-4 md:flex md:h-full md:w-(--panel-width) md:flex-col"
                 style={
                     {
                         // panelWidth는 드래그 상태에서 런타임에 결정되므로 정적 Tailwind 클래스로 표현 불가

--- a/src/widgets/symbol-page/__tests__/ChartContent.test.tsx
+++ b/src/widgets/symbol-page/__tests__/ChartContent.test.tsx
@@ -212,6 +212,11 @@ describe('ChartContent', () => {
     // 페이지 스크롤과 시각적으로 겹치지 않게 한다. 이 계약은 분석 길이와 무관하게
     // 유지되어야 한다 — 그 불변성이 회귀 가드다.
     describe('AI 분석 패널 스크롤', () => {
+        // 패널을 길게/짧게 시뮬레이션하기 위한 문단 수. 입력값과 단언값에서 함께
+        // 쓰이므로 이름 있는 상수로 묶어 한쪽만 바뀌는 drift를 막는다.
+        const LONG_PARAGRAPH_COUNT = 80;
+        const SHORT_PARAGRAPH_COUNT = 1;
+
         // 분석 문단 수를 주입해 긴/짧은 패널을 실제로 다르게 렌더한 뒤, 그 콘텐츠가
         // 차트 컬럼이 아니라 스크롤 컨테이너(aside) 안에 위치하는지 확인한다.
         const renderAsideWithParagraphs = async (paragraphCount: number) => {
@@ -238,16 +243,16 @@ describe('ChartContent', () => {
 
         describe('AI 분석 패널이 길 때', () => {
             it('긴 분석이 aside(overflow-y-auto + md:h-full) 안에 담겨 패널 내부에서 스크롤되고 차트 행을 늘리지 않는다', async () => {
-                const aside = await renderAsideWithParagraphs(80);
+                const aside = await renderAsideWithParagraphs(LONG_PARAGRAPH_COUNT);
 
                 // 긴 콘텐츠가 스크롤 컨테이너(aside) 안에 위치 = 차트가 아니라 패널이 스크롤된다.
-                expect(paragraphsInside(aside)).toBe(80);
+                expect(paragraphsInside(aside)).toBe(LONG_PARAGRAPH_COUNT);
                 expect(aside.className).toContain('overflow-y-auto');
                 expect(aside.className).toContain('md:h-full');
             });
 
             it('scrollbar-none으로 스크롤바를 감춰 페이지 스크롤과 겹쳐 보이지 않게 한다', async () => {
-                const aside = await renderAsideWithParagraphs(80);
+                const aside = await renderAsideWithParagraphs(LONG_PARAGRAPH_COUNT);
 
                 expect(aside.className).toContain('scrollbar-none');
             });
@@ -255,9 +260,9 @@ describe('ChartContent', () => {
 
         describe('AI 분석 패널이 짧을 때', () => {
             it('짧은 분석도 같은 aside 안에 담기며 overflow-y-auto + md:h-full + scrollbar-none 계약을 그대로 유지한다', async () => {
-                const aside = await renderAsideWithParagraphs(1);
+                const aside = await renderAsideWithParagraphs(SHORT_PARAGRAPH_COUNT);
 
-                expect(paragraphsInside(aside)).toBe(1);
+                expect(paragraphsInside(aside)).toBe(SHORT_PARAGRAPH_COUNT);
                 expect(aside.className).toContain('overflow-y-auto');
                 expect(aside.className).toContain('md:h-full');
                 expect(aside.className).toContain('scrollbar-none');

--- a/src/widgets/symbol-page/__tests__/ChartContent.test.tsx
+++ b/src/widgets/symbol-page/__tests__/ChartContent.test.tsx
@@ -26,9 +26,18 @@ vi.mock('@/widgets/chart', () => ({
     }),
 }));
 
+// The mock renders one paragraph per `analysis.paragraphCount` so the scroll
+// tests below can drive a genuinely long vs. short panel and assert where that
+// content lands (inside the scroll container, not the chart column).
 vi.mock('@/widgets/analysis', () => ({
-    AnalysisPanel: (_props: Record<string, unknown>) => (
-        <div data-testid="analysis-panel" />
+    AnalysisPanel: ({ analysis }: { analysis?: { paragraphCount?: number } }) => (
+        <div data-testid="analysis-panel">
+            {Array.from({ length: analysis?.paragraphCount ?? 0 }, (_, i) => (
+                <p data-testid="analysis-paragraph" key={i}>
+                    분석 문단 {i}
+                </p>
+            ))}
+        </div>
     ),
 }));
 
@@ -191,6 +200,68 @@ describe('ChartContent', () => {
             handleReanalyze: vi.fn(),
             reanalyzeCooldownMs: 0,
             cooldownNotice: null,
+        });
+    });
+
+    // "AI 분석이 길어지면 차트도 길어진다" 회귀 가드 — AI 분석 패널 스크롤 부분.
+    //
+    // jsdom에는 레이아웃 엔진이 없어 패널이 실제로 스크롤되는지 측정할 수 없다. 대신
+    // 그 동작을 만드는 CSS 계약을 검증한다: 데스크톱 분석 패널(aside)은 md:h-full로 차트
+    // 행 높이에 바운드되고 overflow-y-auto로 자체 스크롤하므로, 긴 분석이 행(=차트)을
+    // 늘리지 못하고 패널 안에서만 스크롤된다. scrollbar-none으로 스크롤바는 감춰
+    // 페이지 스크롤과 시각적으로 겹치지 않게 한다. 이 계약은 분석 길이와 무관하게
+    // 유지되어야 한다 — 그 불변성이 회귀 가드다.
+    describe('AI 분석 패널 스크롤', () => {
+        // 분석 문단 수를 주입해 긴/짧은 패널을 실제로 다르게 렌더한 뒤, 그 콘텐츠가
+        // 차트 컬럼이 아니라 스크롤 컨테이너(aside) 안에 위치하는지 확인한다.
+        const renderAsideWithParagraphs = async (paragraphCount: number) => {
+            const { useAnalysis } =
+                await import('@/widgets/symbol-page/hooks/useAnalysis');
+            (useAnalysis as ReturnType<typeof vi.fn>).mockReturnValue({
+                analysis: { paragraphCount } as unknown as AnalysisResponse,
+                analysisResult: null,
+                isAnalyzing: false,
+                analysisError: null,
+                isBotBlocked: false,
+                handleReanalyze: vi.fn(),
+                reanalyzeCooldownMs: 0,
+                cooldownNotice: null,
+            });
+            const { container } = render(<ChartContent {...defaultProps} />);
+            const aside = container.querySelector('aside');
+            expect(aside).not.toBeNull();
+            return aside as HTMLElement;
+        };
+
+        const paragraphsInside = (aside: HTMLElement) =>
+            aside.querySelectorAll('[data-testid="analysis-paragraph"]').length;
+
+        describe('AI 분석 패널이 길 때', () => {
+            it('긴 분석이 aside(overflow-y-auto + md:h-full) 안에 담겨 패널 내부에서 스크롤되고 차트 행을 늘리지 않는다', async () => {
+                const aside = await renderAsideWithParagraphs(80);
+
+                // 긴 콘텐츠가 스크롤 컨테이너(aside) 안에 위치 = 차트가 아니라 패널이 스크롤된다.
+                expect(paragraphsInside(aside)).toBe(80);
+                expect(aside.className).toContain('overflow-y-auto');
+                expect(aside.className).toContain('md:h-full');
+            });
+
+            it('scrollbar-none으로 스크롤바를 감춰 페이지 스크롤과 겹쳐 보이지 않게 한다', async () => {
+                const aside = await renderAsideWithParagraphs(80);
+
+                expect(aside.className).toContain('scrollbar-none');
+            });
+        });
+
+        describe('AI 분석 패널이 짧을 때', () => {
+            it('짧은 분석도 같은 aside 안에 담기며 overflow-y-auto + md:h-full + scrollbar-none 계약을 그대로 유지한다', async () => {
+                const aside = await renderAsideWithParagraphs(1);
+
+                expect(paragraphsInside(aside)).toBe(1);
+                expect(aside.className).toContain('overflow-y-auto');
+                expect(aside.className).toContain('md:h-full');
+                expect(aside.className).toContain('scrollbar-none');
+            });
         });
     });
 });


### PR DESCRIPTION
## 관련 이슈

closes #0

## 구현 내용

### 문제
- `/[symbol]` 차트 페이지에서 AI 분석 패널 콘텐츠가 길어지면 차트 캔버스도 함께 커지는 회귀 발생
- 원래는 차트가 고정 높이를 유지하고 분석 패널만 내부 스크롤되어야 함

### 근본 원인
- 이전 sticky-footer 재설계(commit 5653cce8)에서 `useBodyScrollLock` 제거
- `/[symbol]/layout.tsx`의 jail wrapper가 `min-h-[calc(100dvh-...)]`로 변경됨
- 확정 높이 조상이 없어져서 ChartContent의 `<aside>` `md:h-full`이 `auto`로 폴백
- flex 행과 차트 열이 콘텐츠에 따라 늘어남

### 해결책
1. **SymbolLayoutJail 클라이언트 컴포넌트** (`SymbolLayoutClient.tsx`)
   - `useSelectedLayoutSegment()` 읽어 라우트 판단
   - 차트(index) 라우트(`segment === null`)는 확정 높이 + overflow-hidden
   - 형제 탭(news/fundamental/options/overall/fear-greed)은 growable `min-h-[calc(...)]` 유지로 스크롤 페이지 지원

2. **Tailwind v4 @utility scrollbar-none** (`globals.css`)
   - 데스크톱 분석 `<aside>`에 적용
   - 내부 스크롤바가 페이지 스크롤바와 겹치지 않게 함 (스크롤은 정상 작동)

3. **회귀 테스트**
   - `SymbolLayoutClient.test.tsx`: 라우트별 jail 높이 고정 계약 확인
   - `ChartContent.test.tsx`: aside 스크롤 계약 확인 (overflow-y-auto + md:h-full + scrollbar-none) + 긴 분석 콘텐츠가 aside 스크롤 컨테이너 내부에 위치 확인

## 테스트

- [x] yarn format 통과
- [x] yarn lint 통과
- [x] yarn lint:style 통과
- [x] yarn test (관련 6파일) 통과 (22개 테스트)
- [x] 브로드 symbol-page + app/[symbol] 스위트 통과 (296개 테스트)
- [x] Chrome 데스크톱 + 모바일 + 형제 라우트에서 동작 확인
- [x] ModelSelector 드롭다운이 클리핑되지 않음 확인

## 변경 파일 목록

[수정]
- src/app/[symbol]/SymbolLayoutClient.tsx (신규)
- src/app/[symbol]/layout.tsx
- src/app/globals.css
- src/widgets/symbol-page/ChartContent.tsx
- src/app/[symbol]/__tests__/SymbolLayoutClient.test.tsx (신규)
- src/widgets/symbol-page/__tests__/ChartContent.test.tsx

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build