### PR TITLE
feat: restore data-layer caching to cut bot-driven server cost

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,21 +1,6 @@
 
 # Fix Log
 
-## [PR #513 Round 1 | fix/fear-greed-ssr-and-fmp-retry | 2026-05-26]
-- Violation: `page.tsx` prefetch 배열에 `.push()` 사용 — 배열 직접 변이
-  - Rule: MISTAKES.md §5 — Array/object mutation via push/splice 금지
-  - Context: 차트 페이지에서 조건부 prefetch를 추가할 때 spread 대신 push를 사용. spread 패턴으로 교체
-
-## [PR #432 Round 4 | fix/cancel-job-on-page-unload | 2026-05-09]
-- Violation: `route.ts` body validation used `!j.type` (falsy check only), allowing invalid type strings (e.g. `"unknown"`) to pass and silently return 204
-  - Rule: Infrastructure Functions — validate all inputs at API boundaries; invalid values must return 400
-  - Context: Added `VALID_JOB_TYPES` Set check so unrecognized job types are rejected with 400 rather than logged as a warning and treated as success
-
-## [feat/bot-cost-caching Round 1 | feat/bot-cost-caching | 2026-05-28]
-- Violation: Test file hardcoded boundary constant `POLL_MAX_ATTEMPTS = 30` instead of importing from source
-  - Rule: MISTAKES.md §15 — Hardcoded literals in function names or calculations (drift trap: when a constant exists, every use must reference it, including tests)
-  - Context: Added to fix by exporting constants from source and importing them in test. Relates to existing MISTAKES.md Tests #4.
-
 ## [feat/bot-cost-caching Round 1 | feat/bot-cost-caching | 2026-05-28]
 - Violation: 'use server' file exported non-async-function constants `POLL_INTERVAL_MS`, `POLL_MAX_ATTEMPTS`
   - Rule: entities/CONVENTIONS.md — 'use server' files may only export async functions; constants must live in separate modules

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -11,3 +11,18 @@
   - Rule: Infrastructure Functions — validate all inputs at API boundaries; invalid values must return 400
   - Context: Added `VALID_JOB_TYPES` Set check so unrecognized job types are rejected with 400 rather than logged as a warning and treated as success
 
+## [feat/bot-cost-caching Round 1 | feat/bot-cost-caching | 2026-05-28]
+- Violation: Test file hardcoded boundary constant `POLL_MAX_ATTEMPTS = 30` instead of importing from source
+  - Rule: MISTAKES.md §15 — Hardcoded literals in function names or calculations (drift trap: when a constant exists, every use must reference it, including tests)
+  - Context: Added to fix by exporting constants from source and importing them in test. Relates to existing MISTAKES.md Tests #4.
+
+## [feat/bot-cost-caching Round 1 | feat/bot-cost-caching | 2026-05-28]
+- Violation: 'use server' file exported non-async-function constants `POLL_INTERVAL_MS`, `POLL_MAX_ATTEMPTS`
+  - Rule: entities/CONVENTIONS.md — 'use server' files may only export async functions; constants must live in separate modules
+  - Context: Attempted to export constants in `ensureNewsCardsAnalyzedAction.ts` (a 'use server' file), caused Next.js error 71011. Corrected by moving constants to `lib/newsAnalysisConstants.ts` and importing them.
+
+## [feat/bot-cost-caching Round 1 | feat/bot-cost-caching | 2026-05-28]
+- Violation: Global `vi.mock('@upstash/redis', ...)` added to `vitest.setup.base.ts` when per-file mocks + resolve alias sufficed
+  - Rule: Test best practices — Global mocks weaken test isolation; per-file mocks keep missing-mock failures visible
+  - Context: Removed global mock to maintain test isolation and visibility of unintended missing dependencies.
+

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "@upstash/redis": "^1.37.0",
         "@vercel/analytics": "^2.0.1",
         "@vercel/functions": "^3.4.3",
-        "@y0ngha/siglens-core": "0.12.0",
+        "@y0ngha/siglens-core": "0.13.0",
         "bcryptjs": "^3.0.3",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",

--- a/src/__tests__/server-only-stub.ts
+++ b/src/__tests__/server-only-stub.ts
@@ -1,0 +1,4 @@
+// Vitest stub for `server-only`.
+// Next.js의 server-only 패키지는 실제 패키지가 설치되지 않아도
+// resolve alias로 이 파일을 가리켜 import 오류 없이 테스트가 실행된다.
+export {};

--- a/src/entities/bars/__tests__/barsDataCache.test.ts
+++ b/src/entities/bars/__tests__/barsDataCache.test.ts
@@ -123,4 +123,32 @@ describe('getCachedBarsWithIndicators', () => {
         expect(r).toEqual(sampleBars);
         errSpy.mockRestore();
     });
+
+    it('Redis set 예외는 흡수하고 fresh 값을 정상 반환', async () => {
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        mockRedisGet.mockResolvedValue(null);
+        mockFetch.mockResolvedValue(sampleBars);
+        mockRedisSet.mockRejectedValue(new Error('redis write fail'));
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        const r = await mod.getCachedBarsWithIndicators('AAPL', '1Day');
+        expect(errSpy).toHaveBeenCalled();
+        expect(r).toEqual(sampleBars);
+        errSpy.mockRestore();
+    });
+
+    it('getRedis 싱글턴 캐시 — 두 번째 호출은 재생성 없이 반환', async () => {
+        mockRedisGet.mockResolvedValue(sampleBars);
+        // Load the module once, then call twice — second call hits cachedRedis fast-path
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        await mod.getCachedBarsWithIndicators('AAPL', '1Day');
+        await mod.getCachedBarsWithIndicators('AAPL', '1Day');
+        // Redis constructor must have been called exactly once (singleton reused)
+        expect(mockRedisCtor).toHaveBeenCalledTimes(1);
+    });
 });

--- a/src/entities/bars/__tests__/barsDataCache.test.ts
+++ b/src/entities/bars/__tests__/barsDataCache.test.ts
@@ -1,0 +1,126 @@
+delete process.env.UPSTASH_REDIS_REST_URL;
+delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+vi.mock('server-only', () => ({}));
+
+const { mockFetch, mockRedisGet, mockRedisSet, mockRedisCtor } = vi.hoisted(
+    () => ({
+        mockFetch: vi.fn(),
+        mockRedisGet: vi.fn(),
+        mockRedisSet: vi.fn(),
+        mockRedisCtor: vi.fn(),
+    })
+);
+
+vi.mock('@y0ngha/siglens-core', async () => ({
+    ...(await vi.importActual('@y0ngha/siglens-core')),
+    fetchBarsWithIndicators: mockFetch,
+    computeBarsEffectiveTtl: vi.fn(() => 60),
+}));
+
+vi.mock('@upstash/redis', () => ({
+    Redis: vi.fn().mockImplementation(function (opts: unknown) {
+        mockRedisCtor(opts);
+        return { get: mockRedisGet, set: mockRedisSet };
+    }),
+}));
+
+vi.mock('@/shared/lib/sleep', () => ({
+    sleep: vi.fn().mockResolvedValue(undefined),
+}));
+
+import type { BarsData } from '@y0ngha/siglens-core';
+
+const sampleBars: BarsData = {
+    bars: [{ time: 1, open: 1, high: 2, low: 0, close: 1, volume: 10 }],
+    indicators: {} as BarsData['indicators'],
+};
+
+async function loadWithEnv(opts: { url?: string; token?: string }) {
+    process.env.UPSTASH_REDIS_REST_URL = opts.url ?? '';
+    process.env.UPSTASH_REDIS_REST_TOKEN = opts.token ?? '';
+    vi.resetModules();
+    return import('../lib/barsDataCache');
+}
+
+afterEach(() => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+});
+
+describe('getCachedBarsWithIndicators', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('Redis env 없으면 fetch 직행', async () => {
+        mockFetch.mockResolvedValue(sampleBars);
+        const mod = await loadWithEnv({});
+        const r = await mod.getCachedBarsWithIndicators('AAPL', '1Day');
+        expect(mockRedisCtor).not.toHaveBeenCalled();
+        expect(mockFetch).toHaveBeenCalledWith('AAPL', '1Day', undefined);
+        expect(r).toEqual(sampleBars);
+    });
+
+    it('Redis hit 시 fetch 안 함', async () => {
+        mockRedisGet.mockResolvedValue(sampleBars);
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        const r = await mod.getCachedBarsWithIndicators('AAPL', '1Day');
+        expect(mockRedisGet).toHaveBeenCalledWith('bars:AAPL:1Day');
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(r).toEqual(sampleBars);
+    });
+
+    it('Redis miss 시 fetch 후 computeBarsEffectiveTtl TTL로 set', async () => {
+        mockRedisGet.mockResolvedValue(null);
+        mockFetch.mockResolvedValue(sampleBars);
+        mockRedisSet.mockResolvedValue('OK');
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        await mod.getCachedBarsWithIndicators('AAPL', '1Day');
+        expect(mockRedisSet).toHaveBeenCalledWith(
+            'bars:AAPL:1Day',
+            sampleBars,
+            { ex: 60 }
+        );
+    });
+
+    it('fmpSymbol을 키에 포함', async () => {
+        mockRedisGet.mockResolvedValue(null);
+        mockFetch.mockResolvedValue(sampleBars);
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        await mod.getCachedBarsWithIndicators('SPX', '1Day', '^SPX');
+        expect(mockRedisGet).toHaveBeenCalledWith('bars:SPX:1Day:^SPX');
+    });
+
+    it('빈 봉은 캐시하지 않음', async () => {
+        mockRedisGet.mockResolvedValue(null);
+        mockFetch.mockResolvedValue({ ...sampleBars, bars: [] });
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        await mod.getCachedBarsWithIndicators('AAPL', '1Day');
+        expect(mockRedisSet).not.toHaveBeenCalled();
+    });
+
+    it('Redis get 예외는 흡수하고 fetch fallback', async () => {
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        mockRedisGet.mockRejectedValue(new Error('redis down'));
+        mockFetch.mockResolvedValue(sampleBars);
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        const r = await mod.getCachedBarsWithIndicators('AAPL', '1Day');
+        expect(errSpy).toHaveBeenCalled();
+        expect(r).toEqual(sampleBars);
+        errSpy.mockRestore();
+    });
+});

--- a/src/entities/bars/__tests__/barsDataCache.test.ts
+++ b/src/entities/bars/__tests__/barsDataCache.test.ts
@@ -43,13 +43,13 @@ async function loadWithEnv(opts: { url?: string; token?: string }) {
     return import('../lib/barsDataCache');
 }
 
-afterEach(() => {
-    delete process.env.UPSTASH_REDIS_REST_URL;
-    delete process.env.UPSTASH_REDIS_REST_TOKEN;
-});
-
 describe('getCachedBarsWithIndicators', () => {
     beforeEach(() => vi.clearAllMocks());
+
+    afterEach(() => {
+        delete process.env.UPSTASH_REDIS_REST_URL;
+        delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    });
 
     it('Redis env 없으면 fetch 직행', async () => {
         mockFetch.mockResolvedValue(sampleBars);

--- a/src/entities/bars/__tests__/getBarsAction.test.ts
+++ b/src/entities/bars/__tests__/getBarsAction.test.ts
@@ -1,3 +1,10 @@
+delete process.env.UPSTASH_REDIS_REST_URL;
+delete process.env.UPSTASH_REDIS_REST_TOKEN;
+vi.mock('server-only', () => ({}));
+vi.mock('@upstash/redis', () => ({
+    Redis: vi.fn().mockImplementation(() => ({ get: vi.fn(), set: vi.fn() })),
+}));
+
 vi.mock('@/shared/lib/sleep', () => ({
     sleep: vi.fn().mockResolvedValue(undefined),
 }));

--- a/src/entities/bars/actions/getBarsAction.ts
+++ b/src/entities/bars/actions/getBarsAction.ts
@@ -1,35 +1,19 @@
 'use server';
 
-import {
-    type BarsData,
-    type Timeframe,
-    fetchBarsWithIndicators,
-} from '@y0ngha/siglens-core';
-import { withRetry } from '@/shared/lib/withRetry';
+import { type BarsData, type Timeframe } from '@y0ngha/siglens-core';
+import { getCachedBarsWithIndicators } from '../lib/barsDataCache';
 import {
     getFmpUserFacingMessage,
     logFmpPaymentRequiredError,
 } from '@/shared/api/fmp/fmpUserMessage';
-import { BARS_FMP_RETRY } from '../lib/barsRetry';
 
-// cacheComponents 비활성 기간 동안 'use cache' / cacheLife / cacheTag 제거.
-// bars API 호출은 매 요청마다 fresh — 캐싱 손실은 일시적이며 향후 PPR 재활성화
-// 또는 unstable_cache 도입 시 복원할 것 (이슈 #439 참조).
-//
-// fundamentalData/newsData와 달리 React.cache로 감싸지 않는 이유:
-// `'use server'` Server Action은 클라이언트에서 호출될 때 별도 RPC 경로로 실행되어
-// RSC render 컨텍스트의 per-request memoization을 공유하지 못한다. RSC에서
-// `prefetchQuery`로 호출되는 경로(layout.tsx)도 단일 호출이라 dedup 이득이 없다.
 export async function getBarsAction(
     symbol: string,
     timeframe: Timeframe,
     fmpSymbol?: string
 ): Promise<BarsData> {
     try {
-        return await withRetry(
-            () => fetchBarsWithIndicators(symbol, timeframe, fmpSymbol),
-            BARS_FMP_RETRY
-        );
+        return await getCachedBarsWithIndicators(symbol, timeframe, fmpSymbol);
     } catch (error) {
         logFmpPaymentRequiredError(error);
         const message = getFmpUserFacingMessage(error);

--- a/src/entities/bars/lib/barsDataCache.ts
+++ b/src/entities/bars/lib/barsDataCache.ts
@@ -1,0 +1,91 @@
+import 'server-only';
+import { cache } from 'react';
+import { Redis } from '@upstash/redis';
+import {
+    type BarsData,
+    type Timeframe,
+    fetchBarsWithIndicators,
+    computeBarsEffectiveTtl,
+} from '@y0ngha/siglens-core';
+import { withRetry } from '@/shared/lib/withRetry';
+import { BARS_FMP_RETRY } from './barsRetry';
+
+// optionsDataCache.ts와 같은 lazy-singleton 패턴.
+let cachedRedis: Redis | null | undefined;
+
+function getRedis(): Redis | null {
+    if (cachedRedis !== undefined) return cachedRedis;
+    const url = process.env.UPSTASH_REDIS_REST_URL;
+    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+    if (!url || !token) {
+        cachedRedis = null;
+        return null;
+    }
+    cachedRedis = new Redis({ url, token });
+    return cachedRedis;
+}
+
+/** fmpSymbol이 OHLCV 결과를 바꾸므로(예: '^SPX' vs 'SPX') 키에 포함. */
+function buildBarsKey(
+    symbol: string,
+    timeframe: Timeframe,
+    fmpSymbol?: string
+): string {
+    const suffix = fmpSymbol ? `:${fmpSymbol.toUpperCase()}` : '';
+    return `bars:${symbol.toUpperCase()}:${timeframe}${suffix}`;
+}
+
+/**
+ * OHLCV+지표를 cache→FMP로 가져온다.
+ *
+ * 캐시 레이어:
+ *   1. React.cache — 요청 내 dedup(layout/page가 같은 TF prefetch 시 1회).
+ *   2. Upstash Redis — cross-request, 시장 세션별 TTL(core `computeBarsEffectiveTtl`).
+ *      봇이 한 종목의 여러 탭을 연속 크롤링해도 fetch가 1회로 수렴.
+ *      Redis 미설정 시 graceful fallback으로 FMP 직접 호출.
+ *
+ * 에러는 캐시하지 않는다(throw가 set 이전에 전파). 빈 봉도 캐시하지 않는다
+ * (transient 장애를 TTL 동안 굳히지 않도록 — optionsDataCache의 null-caution과 동일).
+ */
+export const getCachedBarsWithIndicators = cache(
+    async (
+        symbol: string,
+        timeframe: Timeframe,
+        fmpSymbol?: string
+    ): Promise<BarsData> => {
+        const key = buildBarsKey(symbol, timeframe, fmpSymbol);
+        const redis = getRedis();
+        if (redis !== null) {
+            try {
+                const hit = await redis.get<BarsData>(key);
+                if (hit !== null) return hit;
+            } catch (error) {
+                console.error(
+                    '[barsDataCache] Redis get failed for',
+                    key,
+                    error
+                );
+            }
+        }
+
+        const fresh = await withRetry(
+            () => fetchBarsWithIndicators(symbol, timeframe, fmpSymbol),
+            BARS_FMP_RETRY
+        );
+
+        if (fresh.bars.length > 0 && redis !== null) {
+            try {
+                await redis.set(key, fresh, {
+                    ex: computeBarsEffectiveTtl(timeframe, new Date()),
+                });
+            } catch (error) {
+                console.error(
+                    '[barsDataCache] Redis set failed for',
+                    key,
+                    error
+                );
+            }
+        }
+        return fresh;
+    }
+);

--- a/src/entities/bars/lib/barsDataCache.ts
+++ b/src/entities/bars/lib/barsDataCache.ts
@@ -10,7 +10,7 @@ import {
 import { withRetry } from '@/shared/lib/withRetry';
 import { BARS_FMP_RETRY } from './barsRetry';
 
-// optionsDataCache.ts와 같은 lazy-singleton 패턴.
+// Redis 미설정 환경(로컬 dev 등)에서도 graceful fallback이 가능하도록 연결을 lazy 초기화로 지연한다.
 let cachedRedis: Redis | null | undefined;
 
 function getRedis(): Redis | null {

--- a/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
+++ b/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
@@ -431,7 +431,7 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
     });
 
     describe('poll 타임아웃은', () => {
-        it('POLL_MAX_ATTEMPTS(30)번 모두 processing이면 console.warn을 호출하고 attachAnalysis는 호출하지 않는다', async () => {
+        it(`POLL_MAX_ATTEMPTS(${POLL_MAX_ATTEMPTS})번 모두 processing이면 console.warn을 호출하고 attachAnalysis는 호출하지 않는다`, async () => {
             const warnSpy = vi
                 .spyOn(console, 'warn')
                 .mockImplementation(() => undefined);

--- a/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
+++ b/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
@@ -172,6 +172,7 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
             expect(mockUpsertNewsItem).toHaveBeenCalledTimes(2);
             expect(mockUpsertNewsItem).toHaveBeenCalledWith(NEWS_ITEM_1);
             expect(mockUpsertNewsItem).toHaveBeenCalledWith(NEWS_ITEM_2);
+            expect(mockMarkFetched).toHaveBeenCalledWith('AAPL');
         });
 
         it('각 뉴스 아이템에 대해 submitNewsCardAnalysis를 호출한다', async () => {

--- a/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
+++ b/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
@@ -18,6 +18,11 @@ import type {
 // Module mocks
 // ---------------------------------------------------------------------------
 
+vi.mock('../lib/newsRefreshFlag', () => ({
+    isRecentlyFetched: vi.fn(),
+    markFetched: vi.fn(),
+}));
+
 vi.mock('@y0ngha/siglens-core', async () => ({
     ...(await vi.importActual('@y0ngha/siglens-core')),
     submitNewsCardAnalysis: vi.fn(),
@@ -55,10 +60,13 @@ vi.mock('@/entities/news-article', () => ({
 // ---------------------------------------------------------------------------
 
 import { DrizzleNewsRepository } from '@/entities/news-article';
+import { isRecentlyFetched, markFetched } from '../lib/newsRefreshFlag';
 
 const MockNewsRepository = DrizzleNewsRepository as MockedClass<
     typeof DrizzleNewsRepository
 >;
+const mockIsRecentlyFetched = isRecentlyFetched as Mock;
+const mockMarkFetched = markFetched as Mock;
 const MockFmpNewsClient = FmpNewsClient as MockedClass<typeof FmpNewsClient>;
 
 const mockSubmitNewsCardAnalysis = submitNewsCardAnalysis as MockedFunction<
@@ -127,6 +135,8 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
         vi.clearAllMocks();
         mockSubmitNewsCardAnalysis.mockReset();
         mockPollNewsCardAnalysis.mockReset();
+        mockIsRecentlyFetched.mockReset();
+        mockMarkFetched.mockResolvedValue(undefined);
 
         mockFetchNewsForPeriod = vi.fn();
         mockUpsertNewsItem = vi.fn().mockResolvedValue(undefined);
@@ -397,6 +407,7 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
 
     describe('skipAnalysis 옵션은', () => {
         it('true이면 FMP fetch와 DB upsert는 수행하지만 LLM 분석은 건너뛴다', async () => {
+            mockIsRecentlyFetched.mockResolvedValue(false);
             mockFetchNewsForPeriod.mockResolvedValue([
                 NEWS_ITEM_1,
                 NEWS_ITEM_2,
@@ -416,6 +427,7 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
         });
 
         it('false이면 기존과 동일하게 LLM 분석까지 수행한다', async () => {
+            mockIsRecentlyFetched.mockResolvedValue(false);
             mockFetchNewsForPeriod.mockResolvedValue([NEWS_ITEM_1]);
             mockSubmitNewsCardAnalysis.mockResolvedValue(SUBMITTED_RESULT);
             mockPollNewsCardAnalysis.mockResolvedValue(POLL_DONE);
@@ -425,6 +437,67 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
             });
 
             expect(mockSubmitNewsCardAnalysis).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('봇 경로 refresh 가드는', () => {
+        it('봇 + 최근 fetch됨 → FMP fetch와 DB upsert를 스킵한다', async () => {
+            mockIsRecentlyFetched.mockResolvedValue(true);
+
+            await ensureNewsCardsAnalyzedAction('AAPL', {
+                skipAnalysis: true,
+            });
+
+            expect(mockFetchNewsForPeriod).not.toHaveBeenCalled();
+            expect(mockUpsertNewsItem).not.toHaveBeenCalled();
+        });
+
+        it('봇 + 미fetch → fetch + upsert + markFetched 호출', async () => {
+            mockIsRecentlyFetched.mockResolvedValue(false);
+            mockFetchNewsForPeriod.mockResolvedValue([NEWS_ITEM_1]);
+
+            await ensureNewsCardsAnalyzedAction('AAPL', {
+                skipAnalysis: true,
+            });
+
+            expect(mockFetchNewsForPeriod).toHaveBeenCalledWith(
+                'AAPL',
+                NEWS_LOOKBACK_MS
+            );
+            expect(mockUpsertNewsItem).toHaveBeenCalledTimes(1);
+            expect(mockMarkFetched).toHaveBeenCalledWith('AAPL');
+        });
+
+        it('사람 경로 → 최근 fetch됐어도 항상 fetch한다(가드 무시)', async () => {
+            mockIsRecentlyFetched.mockResolvedValue(true);
+            mockFetchNewsForPeriod.mockResolvedValue([NEWS_ITEM_1]);
+            mockSubmitNewsCardAnalysis.mockResolvedValue(SUBMITTED_RESULT);
+            mockPollNewsCardAnalysis.mockResolvedValue(POLL_DONE);
+
+            await ensureNewsCardsAnalyzedAction('AAPL');
+
+            expect(mockFetchNewsForPeriod).toHaveBeenCalledWith(
+                'AAPL',
+                NEWS_LOOKBACK_MS
+            );
+        });
+
+        it('upsert 과반 실패 시 markFetched를 호출하지 않는다', async () => {
+            mockIsRecentlyFetched.mockResolvedValue(false);
+            mockFetchNewsForPeriod.mockResolvedValue([
+                NEWS_ITEM_1,
+                NEWS_ITEM_2,
+            ]);
+            // Both upserts fail → majority failure → action throws before markFetched.
+            mockUpsertNewsItem
+                .mockRejectedValueOnce(new Error('DB down'))
+                .mockRejectedValueOnce(new Error('DB down'));
+
+            await expect(
+                ensureNewsCardsAnalyzedAction('AAPL', { skipAnalysis: true })
+            ).rejects.toThrow('majority upsert failure');
+
+            expect(mockMarkFetched).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
+++ b/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
@@ -440,6 +440,37 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
         });
     });
 
+    describe('poll 타임아웃은', () => {
+        it('POLL_MAX_ATTEMPTS(30)번 모두 processing이면 console.warn을 호출하고 attachAnalysis는 호출하지 않는다', async () => {
+            const warnSpy = vi
+                .spyOn(console, 'warn')
+                .mockImplementation(() => undefined);
+
+            mockIsRecentlyFetched.mockResolvedValue(false);
+            mockFetchNewsForPeriod.mockResolvedValue([NEWS_ITEM_1]);
+            mockUpsertNewsItem.mockResolvedValue(undefined);
+            mockListBySymbol.mockResolvedValue([
+                { id: NEWS_ITEM_1.id, analyzedAt: null },
+            ]);
+            mockSubmitNewsCardAnalysis.mockResolvedValue({
+                status: 'submitted',
+                jobId: 'job-1',
+            } satisfies SubmitNewsCardAnalysisResult);
+            // Always returns 'processing' — worker never finishes.
+            mockPollNewsCardAnalysis.mockResolvedValue({
+                status: 'processing',
+            });
+
+            await ensureNewsCardsAnalyzedAction('AAPL');
+
+            expect(warnSpy).toHaveBeenCalled();
+            expect(mockPollNewsCardAnalysis).toHaveBeenCalledTimes(30);
+            expect(mockAttachAnalysis).not.toHaveBeenCalled();
+
+            warnSpy.mockRestore();
+        });
+    });
+
     describe('봇 경로 refresh 가드는', () => {
         it('봇 + 최근 fetch됨 → FMP fetch와 DB upsert를 스킵한다', async () => {
             mockIsRecentlyFetched.mockResolvedValue(true);

--- a/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
+++ b/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
@@ -1,5 +1,9 @@
 import type { MockedFunction, MockedClass, Mock } from 'vitest';
-import { ensureNewsCardsAnalyzedAction } from '../actions/ensureNewsCardsAnalyzedAction';
+import {
+    ensureNewsCardsAnalyzedAction,
+    POLL_INTERVAL_MS,
+    POLL_MAX_ATTEMPTS,
+} from '../actions/ensureNewsCardsAnalyzedAction';
 import { DISABLED_THINKING_BUDGET } from '../lib/newsAnalysisConstants';
 import { NEWS_LOOKBACK_MS } from '../lib/newsLookback';
 import {
@@ -13,10 +17,6 @@ import type {
     SubmitNewsCardAnalysisResult,
     PollNewsCardAnalysisResult,
 } from '@y0ngha/siglens-core';
-
-// ---------------------------------------------------------------------------
-// Module mocks
-// ---------------------------------------------------------------------------
 
 vi.mock('../lib/newsRefreshFlag', () => ({
     isRecentlyFetched: vi.fn(),
@@ -54,10 +54,6 @@ vi.mock('@/entities/news-article', () => ({
         };
     }),
 }));
-
-// ---------------------------------------------------------------------------
-// Typed mocks & fixtures
-// ---------------------------------------------------------------------------
 
 import { DrizzleNewsRepository } from '@/entities/news-article';
 import { isRecentlyFetched, markFetched } from '../lib/newsRefreshFlag';
@@ -120,10 +116,6 @@ const POLL_ERROR: PollNewsCardAnalysisResult = {
     status: 'error',
     error: 'LLM worker failed',
 };
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe('ensureNewsCardsAnalyzedAction 함수는', () => {
     let mockFetchNewsForPeriod: Mock;
@@ -464,7 +456,9 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
             await ensureNewsCardsAnalyzedAction('AAPL');
 
             expect(warnSpy).toHaveBeenCalled();
-            expect(mockPollNewsCardAnalysis).toHaveBeenCalledTimes(30);
+            expect(mockPollNewsCardAnalysis).toHaveBeenCalledTimes(
+                POLL_MAX_ATTEMPTS
+            );
             expect(mockAttachAnalysis).not.toHaveBeenCalled();
 
             warnSpy.mockRestore();

--- a/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
+++ b/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
@@ -125,7 +125,7 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
         vi.clearAllMocks();
         mockSubmitNewsCardAnalysis.mockReset();
         mockPollNewsCardAnalysis.mockReset();
-        mockIsRecentlyFetched.mockReset();
+        mockIsRecentlyFetched.mockResolvedValue(false);
         mockMarkFetched.mockResolvedValue(undefined);
 
         mockFetchNewsForPeriod = vi.fn();

--- a/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
+++ b/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
@@ -1,22 +1,3 @@
-import type { MockedFunction, MockedClass, Mock } from 'vitest';
-import { ensureNewsCardsAnalyzedAction } from '../actions/ensureNewsCardsAnalyzedAction';
-import {
-    DISABLED_THINKING_BUDGET,
-    POLL_MAX_ATTEMPTS,
-} from '../lib/newsAnalysisConstants';
-import { NEWS_LOOKBACK_MS } from '../lib/newsLookback';
-import {
-    submitNewsCardAnalysis,
-    pollNewsCardAnalysis,
-} from '@y0ngha/siglens-core';
-import { FmpNewsClient } from '../lib/fmpNewsClient';
-import type {
-    NewsItem,
-    NewsCardAnalysis,
-    SubmitNewsCardAnalysisResult,
-    PollNewsCardAnalysisResult,
-} from '@y0ngha/siglens-core';
-
 vi.mock('../lib/newsRefreshFlag', () => ({
     isRecentlyFetched: vi.fn(),
     markFetched: vi.fn(),
@@ -54,6 +35,24 @@ vi.mock('@/entities/news-article', () => ({
     }),
 }));
 
+import type { MockedFunction, MockedClass, Mock } from 'vitest';
+import { ensureNewsCardsAnalyzedAction } from '../actions/ensureNewsCardsAnalyzedAction';
+import {
+    DISABLED_THINKING_BUDGET,
+    POLL_MAX_ATTEMPTS,
+} from '../lib/newsAnalysisConstants';
+import { NEWS_LOOKBACK_MS } from '../lib/newsLookback';
+import {
+    submitNewsCardAnalysis,
+    pollNewsCardAnalysis,
+} from '@y0ngha/siglens-core';
+import { FmpNewsClient } from '../lib/fmpNewsClient';
+import type {
+    NewsItem,
+    NewsCardAnalysis,
+    SubmitNewsCardAnalysisResult,
+    PollNewsCardAnalysisResult,
+} from '@y0ngha/siglens-core';
 import { DrizzleNewsRepository } from '@/entities/news-article';
 import { isRecentlyFetched, markFetched } from '../lib/newsRefreshFlag';
 
@@ -489,6 +488,13 @@ describe('ensureNewsCardsAnalyzedAction 함수는', () => {
                 NEWS_LOOKBACK_MS
             );
             expect(mockUpsertNewsItem).toHaveBeenCalledTimes(1);
+            expect(mockMarkFetched).toHaveBeenCalledWith('AAPL');
+        });
+
+        it('봇 경로 + 뉴스 없음(fresh=[]) → markFetched는 여전히 호출된다', async () => {
+            mockIsRecentlyFetched.mockResolvedValue(false);
+            mockFetchNewsForPeriod.mockResolvedValue([]);
+            await ensureNewsCardsAnalyzedAction('AAPL', { skipAnalysis: true });
             expect(mockMarkFetched).toHaveBeenCalledWith('AAPL');
         });
 

--- a/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
+++ b/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
@@ -1,10 +1,9 @@
 import type { MockedFunction, MockedClass, Mock } from 'vitest';
+import { ensureNewsCardsAnalyzedAction } from '../actions/ensureNewsCardsAnalyzedAction';
 import {
-    ensureNewsCardsAnalyzedAction,
-    POLL_INTERVAL_MS,
+    DISABLED_THINKING_BUDGET,
     POLL_MAX_ATTEMPTS,
-} from '../actions/ensureNewsCardsAnalyzedAction';
-import { DISABLED_THINKING_BUDGET } from '../lib/newsAnalysisConstants';
+} from '../lib/newsAnalysisConstants';
 import { NEWS_LOOKBACK_MS } from '../lib/newsLookback';
 import {
     submitNewsCardAnalysis,

--- a/src/entities/news-article/__tests__/newsRefreshFlag.test.ts
+++ b/src/entities/news-article/__tests__/newsRefreshFlag.test.ts
@@ -20,13 +20,13 @@ async function loadWithEnv(opts: { url?: string; token?: string }) {
     vi.resetModules();
     return import('../lib/newsRefreshFlag');
 }
-afterEach(() => {
-    delete process.env.UPSTASH_REDIS_REST_URL;
-    delete process.env.UPSTASH_REDIS_REST_TOKEN;
-});
-
 describe('newsRefreshFlag', () => {
     beforeEach(() => vi.clearAllMocks());
+
+    afterEach(() => {
+        delete process.env.UPSTASH_REDIS_REST_URL;
+        delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    });
 
     it('Redis 없으면 isRecentlyFetched=false, markFetched noop', async () => {
         const mod = await loadWithEnv({});

--- a/src/entities/news-article/__tests__/newsRefreshFlag.test.ts
+++ b/src/entities/news-article/__tests__/newsRefreshFlag.test.ts
@@ -1,0 +1,87 @@
+delete process.env.UPSTASH_REDIS_REST_URL;
+delete process.env.UPSTASH_REDIS_REST_TOKEN;
+vi.mock('server-only', () => ({}));
+
+const { mockGet, mockSet, mockCtor } = vi.hoisted(() => ({
+    mockGet: vi.fn(),
+    mockSet: vi.fn(),
+    mockCtor: vi.fn(),
+}));
+vi.mock('@upstash/redis', () => ({
+    Redis: vi.fn().mockImplementation(function (o: unknown) {
+        mockCtor(o);
+        return { get: mockGet, set: mockSet };
+    }),
+}));
+
+async function loadWithEnv(opts: { url?: string; token?: string }) {
+    process.env.UPSTASH_REDIS_REST_URL = opts.url ?? '';
+    process.env.UPSTASH_REDIS_REST_TOKEN = opts.token ?? '';
+    vi.resetModules();
+    return import('../lib/newsRefreshFlag');
+}
+afterEach(() => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+});
+
+describe('newsRefreshFlag', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('Redis 없으면 isRecentlyFetched=false, markFetched noop', async () => {
+        const mod = await loadWithEnv({});
+        expect(await mod.isRecentlyFetched('AAPL')).toBe(false);
+        await mod.markFetched('AAPL');
+        expect(mockCtor).not.toHaveBeenCalled();
+    });
+    it('플래그 있으면 isRecentlyFetched=true', async () => {
+        mockGet.mockResolvedValue('1');
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        expect(await mod.isRecentlyFetched('AAPL')).toBe(true);
+        expect(mockGet).toHaveBeenCalledWith('news:refresh:AAPL');
+    });
+    it('플래그 없으면(null) isRecentlyFetched=false', async () => {
+        mockGet.mockResolvedValue(null);
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        expect(await mod.isRecentlyFetched('AAPL')).toBe(false);
+    });
+    it('markFetched는 TTL과 함께 set (대문자 정규화)', async () => {
+        mockSet.mockResolvedValue('OK');
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        await mod.markFetched('aapl');
+        expect(mockSet).toHaveBeenCalledWith('news:refresh:AAPL', '1', {
+            ex: mod.NEWS_REFRESH_FLAG_TTL_SECONDS,
+        });
+    });
+    it('Redis get 예외는 흡수하고 false', async () => {
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        mockGet.mockRejectedValue(new Error('down'));
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        expect(await mod.isRecentlyFetched('AAPL')).toBe(false);
+        expect(errSpy).toHaveBeenCalled();
+        errSpy.mockRestore();
+    });
+    it('Redis set 예외는 흡수(throw 안 함)', async () => {
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        mockSet.mockRejectedValue(new Error('down'));
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        await expect(mod.markFetched('AAPL')).resolves.toBeUndefined();
+        expect(errSpy).toHaveBeenCalled();
+        errSpy.mockRestore();
+    });
+});

--- a/src/entities/news-article/actions/ensureNewsCardsAnalyzedAction.ts
+++ b/src/entities/news-article/actions/ensureNewsCardsAnalyzedAction.ts
@@ -18,12 +18,12 @@ import {
     type NewsItem,
 } from '@y0ngha/siglens-core';
 
-const POLL_INTERVAL_MS = 2_000;
+export const POLL_INTERVAL_MS = 2_000;
 /**
  * Flash-lite typical wall-clock: <10 s. 30 attempts × 2 s = 60 s ceiling,
  * well within waitUntil's serverless budget.
  */
-const POLL_MAX_ATTEMPTS = 30;
+export const POLL_MAX_ATTEMPTS = 30;
 
 /**
  * Submit card analysis for a single item and wait for the worker to finish,

--- a/src/entities/news-article/actions/ensureNewsCardsAnalyzedAction.ts
+++ b/src/entities/news-article/actions/ensureNewsCardsAnalyzedAction.ts
@@ -10,6 +10,7 @@ import {
 } from '@/shared/api/fmp/fmpUserMessage';
 import { DISABLED_THINKING_BUDGET } from '../lib/newsAnalysisConstants';
 import { NEWS_LOOKBACK_MS } from '../lib/newsLookback';
+import { isRecentlyFetched, markFetched } from '../lib/newsRefreshFlag';
 import { sleep } from '@/shared/lib/sleep';
 import {
     pollNewsCardAnalysis,
@@ -76,6 +77,12 @@ export async function ensureNewsCardsAnalyzedAction(
     symbol: string,
     options?: { skipAnalysis?: boolean }
 ): Promise<void> {
+    // 봇 경로만 가드: 최근 TTL 내 fetch했으면 FMP fetch + N건 DB upsert를 스킵한다.
+    // 봇은 DB의 기존 뉴스를 그대로 읽으므로 SEO 무해. 사람 경로는 항상 fresh.
+    if (options?.skipAnalysis && (await isRecentlyFetched(symbol))) {
+        return;
+    }
+
     const newsClient = new FmpNewsClient();
     const { db } = getDatabaseClient();
     const repo = new DrizzleNewsRepository(db);
@@ -123,6 +130,7 @@ export async function ensureNewsCardsAnalyzedAction(
             `[ensureNewsCardsAnalyzedAction] majority upsert failure (${upsertFailures.length}/${fresh.length})`
         );
     }
+    await markFetched(symbol);
 
     if (fresh.length === 0) return;
 

--- a/src/entities/news-article/actions/ensureNewsCardsAnalyzedAction.ts
+++ b/src/entities/news-article/actions/ensureNewsCardsAnalyzedAction.ts
@@ -8,7 +8,11 @@ import {
     isFmpPaymentRequiredError,
     logFmpPaymentRequiredError,
 } from '@/shared/api/fmp/fmpUserMessage';
-import { DISABLED_THINKING_BUDGET } from '../lib/newsAnalysisConstants';
+import {
+    DISABLED_THINKING_BUDGET,
+    POLL_INTERVAL_MS,
+    POLL_MAX_ATTEMPTS,
+} from '../lib/newsAnalysisConstants';
 import { NEWS_LOOKBACK_MS } from '../lib/newsLookback';
 import { isRecentlyFetched, markFetched } from '../lib/newsRefreshFlag';
 import { sleep } from '@/shared/lib/sleep';
@@ -17,13 +21,6 @@ import {
     submitNewsCardAnalysis,
     type NewsItem,
 } from '@y0ngha/siglens-core';
-
-export const POLL_INTERVAL_MS = 2_000;
-/**
- * Flash-lite typical wall-clock: <10 s. 30 attempts × 2 s = 60 s ceiling,
- * well within waitUntil's serverless budget.
- */
-export const POLL_MAX_ATTEMPTS = 30;
 
 /**
  * Submit card analysis for a single item and wait for the worker to finish,

--- a/src/entities/news-article/lib/newsAnalysisConstants.ts
+++ b/src/entities/news-article/lib/newsAnalysisConstants.ts
@@ -4,3 +4,11 @@
  * thinking while incurring extra latency and cost.
  */
 export const DISABLED_THINKING_BUDGET = 0;
+
+/** 카드 분석 워커 폴링 간격(ms). */
+export const POLL_INTERVAL_MS = 2_000;
+/**
+ * Flash-lite typical wall-clock: <10 s. 30 attempts × 2 s = 60 s ceiling,
+ * well within waitUntil's serverless budget.
+ */
+export const POLL_MAX_ATTEMPTS = 30;

--- a/src/entities/news-article/lib/newsRefreshFlag.ts
+++ b/src/entities/news-article/lib/newsRefreshFlag.ts
@@ -1,0 +1,48 @@
+import 'server-only';
+import { Redis } from '@upstash/redis';
+import { SECONDS_PER_MINUTE } from '@/shared/config/time';
+
+/** 뉴스 refresh 플래그 TTL — 이 시간 내 재크롤링(봇)은 FMP fetch+upsert를 스킵. */
+export const NEWS_REFRESH_FLAG_TTL_SECONDS = 10 * SECONDS_PER_MINUTE;
+
+let cachedRedis: Redis | null | undefined;
+function getRedis(): Redis | null {
+    if (cachedRedis !== undefined) return cachedRedis;
+    const url = process.env.UPSTASH_REDIS_REST_URL;
+    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+    if (!url || !token) {
+        cachedRedis = null;
+        return null;
+    }
+    cachedRedis = new Redis({ url, token });
+    return cachedRedis;
+}
+
+function buildKey(symbol: string): string {
+    return `news:refresh:${symbol.toUpperCase()}`;
+}
+
+/** 최근(TTL 내) 이 symbol의 뉴스를 fetch했는지. Redis 미설정/장애 시 false(=항상 fetch). */
+export async function isRecentlyFetched(symbol: string): Promise<boolean> {
+    const redis = getRedis();
+    if (redis === null) return false;
+    try {
+        return (await redis.get(buildKey(symbol))) !== null;
+    } catch (error) {
+        console.error('[newsRefreshFlag] get failed', error);
+        return false;
+    }
+}
+
+/** 이 symbol을 "최근 fetch함"으로 표시. Redis 미설정/장애 시 noop. */
+export async function markFetched(symbol: string): Promise<void> {
+    const redis = getRedis();
+    if (redis === null) return;
+    try {
+        await redis.set(buildKey(symbol), '1', {
+            ex: NEWS_REFRESH_FLAG_TTL_SECONDS,
+        });
+    } catch (error) {
+        console.error('[newsRefreshFlag] set failed', error);
+    }
+}

--- a/src/shared/api/fmp/__tests__/fundamentalClient.test.ts
+++ b/src/shared/api/fmp/__tests__/fundamentalClient.test.ts
@@ -3,6 +3,7 @@ vi.mock('@/shared/lib/sleep', () => ({
 }));
 
 import { FmpFundamentalClient } from '../fundamentalClient';
+import { SECONDS_PER_HOUR } from '@/shared/config/time';
 
 const mockFetch = vi.fn();
 
@@ -809,6 +810,40 @@ describe('FmpFundamentalClient', () => {
             expect(url).toContain('symbol=MSFT');
             expect(url).toContain('limit=5');
             expect(url).toContain(`apikey=${TEST_API_KEY}`);
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // 캐시 옵션
+    // ------------------------------------------------------------------ //
+
+    describe('캐시 옵션', () => {
+        it('fundamental fetch는 1h next.revalidate로 캐싱된다', async () => {
+            mockOk([
+                {
+                    symbol: 'AAPL',
+                    companyName: 'Apple Inc.',
+                    sector: 'Technology',
+                    industry: 'Consumer Electronics',
+                    marketCap: 3_000_000_000_000,
+                    ceo: 'Tim Cook',
+                    website: 'https://apple.com',
+                    description: 'Apple designs consumer electronics.',
+                },
+            ]);
+            await new FmpFundamentalClient().getProfile('AAPL');
+            const opts = mockFetch.mock.calls[0]![1] as RequestInit & {
+                next?: { revalidate?: number };
+            };
+            expect(opts.next?.revalidate).toBe(SECONDS_PER_HOUR);
+        });
+
+        it('earnings fetch는 no-store(캐시 안 함)다', async () => {
+            mockOk([]);
+            await new FmpFundamentalClient().getEarningsReports('AAPL');
+            const opts = mockFetch.mock.calls[0]![1] as RequestInit;
+            expect(opts.cache).toBe('no-store');
+            expect(opts).not.toHaveProperty('next');
         });
     });
 });

--- a/src/shared/api/fmp/__tests__/fundamentalClient.test.ts
+++ b/src/shared/api/fmp/__tests__/fundamentalClient.test.ts
@@ -289,6 +289,30 @@ describe('FmpFundamentalClient', () => {
                 currentRatioTTM: 0.94,
             });
         });
+
+        it('currentRatioTTM falls back to metrics when ratios row omits it', async () => {
+            // ratios row has no currentRatioTTM → `ratios?.currentRatioTTM` is
+            // undefined → the ?? right-hand branch reads metrics?.currentRatioTTM.
+            mockOk([
+                {
+                    // ratios-ttm row — omits currentRatioTTM
+                    returnOnEquityTTM: 1.0,
+                    returnOnAssetsTTM: 0.2,
+                    operatingProfitMarginTTM: 0.3,
+                    netProfitMarginTTM: 0.25,
+                    debtToAssetsRatioTTM: 0.31,
+                },
+            ]);
+            mockOk([
+                {
+                    // key-metrics-ttm row — provides currentRatioTTM
+                    currentRatioTTM: 1.85,
+                },
+            ]);
+            const client = new FmpFundamentalClient();
+            const result = await client.getRatiosTtm('AAPL');
+            expect(result?.currentRatioTTM).toBe(1.85);
+        });
     });
 
     // ------------------------------------------------------------------ //
@@ -420,6 +444,21 @@ describe('FmpFundamentalClient', () => {
             mockOk([]);
             const client = new FmpFundamentalClient();
             expect(await client.getAnalystEstimates('X')).toBeNull();
+        });
+
+        it('uses estimatedEpsAvg / estimatedRevenueAvg alias fields when primary epsAvg / revenueAvg are absent', async () => {
+            // Row has the alias field names only — epsAvg/revenueAvg are absent so
+            // the ?? right-hand branch in the mapping is exercised.
+            mockOk([
+                {
+                    estimatedEpsAvg: 2.34,
+                    estimatedRevenueAvg: 120_000_000_000,
+                },
+            ]);
+            const client = new FmpFundamentalClient();
+            const result = await client.getAnalystEstimates('AAPL');
+            expect(result?.estimatedEpsAvg).toBe(2.34);
+            expect(result?.estimatedRevenueAvg).toBe(120_000_000_000);
         });
     });
 
@@ -660,6 +699,37 @@ describe('FmpFundamentalClient', () => {
             expect(
                 await client.getSectorPerformanceSnapshot('2024-01-15')
             ).toEqual([]);
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // getHistoricalSectorPerformance — unconditional stub
+    // ------------------------------------------------------------------ //
+
+    describe('getHistoricalSectorPerformance', () => {
+        it('always resolves to [] without making any HTTP request', async () => {
+            const client = new FmpFundamentalClient();
+            await expect(
+                client.getHistoricalSectorPerformance('Technology')
+            ).resolves.toEqual([]);
+            // The stub never calls fetch — no mock call should have been made.
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // getEarningsReports — malformed row (no date fields)
+    // ------------------------------------------------------------------ //
+
+    describe('getEarningsReports — malformed rows', () => {
+        it('drops a row that has neither date nor earningsDate → returns []', async () => {
+            // Row has a symbol but no string date / earningsDate → toEarningsDate
+            // returns null → toFmpEarningsReportItem returns [] → flatMap drops it.
+            mockOk([{ symbol: 'AAPL', epsActual: 1.5 }]);
+            const client = new FmpFundamentalClient();
+            await expect(client.getEarningsReports('AAPL')).resolves.toEqual(
+                []
+            );
         });
     });
 

--- a/src/shared/api/fmp/__tests__/httpClient.test.ts
+++ b/src/shared/api/fmp/__tests__/httpClient.test.ts
@@ -323,4 +323,31 @@ describe('fmpGet 함수는', () => {
             expect(mockFetch).toHaveBeenCalledTimes(1);
         });
     });
+
+    describe('캐시 옵션에서는', () => {
+        it('revalidate 미지정 시 cache:no-store', async () => {
+            const fetchMock = vi
+                .spyOn(global, 'fetch')
+                .mockResolvedValue(
+                    new Response(JSON.stringify([]), { status: 200 })
+                );
+            await fmpGet('profile', { symbol: 'AAPL' });
+            expect(fetchMock.mock.calls[0]![1]).toMatchObject({
+                cache: 'no-store',
+            });
+            expect(fetchMock.mock.calls[0]![1]).not.toHaveProperty('next');
+        });
+
+        it('revalidate 지정 시 next.revalidate 사용', async () => {
+            const fetchMock = vi
+                .spyOn(global, 'fetch')
+                .mockResolvedValue(
+                    new Response(JSON.stringify([]), { status: 200 })
+                );
+            await fmpGet('profile', { symbol: 'AAPL' }, { revalidate: 3600 });
+            expect(fetchMock.mock.calls[0]![1]).toMatchObject({
+                next: { revalidate: 3600 },
+            });
+        });
+    });
 });

--- a/src/shared/api/fmp/__tests__/httpClient.test.ts
+++ b/src/shared/api/fmp/__tests__/httpClient.test.ts
@@ -13,6 +13,7 @@ import { readFmpConfig } from '@y0ngha/siglens-core';
 import { FMP_STABLE_BASE, fmpGet } from '@/shared/api/fmp/httpClient';
 import { FmpHttpError } from '@/shared/api/fmp/FmpHttpError';
 import { sleep } from '@/shared/lib/sleep';
+import { SECONDS_PER_HOUR } from '@/shared/config/time';
 
 const mockFetch = vi.fn();
 const sleepMock = sleep as MockedFunction<typeof sleep>;
@@ -325,9 +326,9 @@ describe('fmpGet 함수는', () => {
                 .mockResolvedValue(
                     new Response(JSON.stringify([]), { status: 200 })
                 );
-            await fmpGet('profile', { symbol: 'AAPL' }, { revalidate: 3600 });
+            await fmpGet('profile', { symbol: 'AAPL' }, { revalidate: SECONDS_PER_HOUR });
             expect(fetchMock.mock.calls[0]![1]).toMatchObject({
-                next: { revalidate: 3600 },
+                next: { revalidate: SECONDS_PER_HOUR },
             });
         });
     });

--- a/src/shared/api/fmp/__tests__/httpClient.test.ts
+++ b/src/shared/api/fmp/__tests__/httpClient.test.ts
@@ -100,12 +100,6 @@ describe('fmpGet 함수는', () => {
             const options = mockFetch.mock.calls[0]![1] as RequestInit;
             expect(options.signal).toBeInstanceOf(AbortSignal);
         });
-
-        it('FMP_STABLE_BASE가 올바른 URL이다', () => {
-            expect(FMP_STABLE_BASE).toBe(
-                'https://financialmodelingprep.com/stable'
-            );
-        });
     });
 
     describe('재시도 동작에서는', () => {
@@ -325,19 +319,6 @@ describe('fmpGet 함수는', () => {
     });
 
     describe('캐시 옵션에서는', () => {
-        it('revalidate 미지정 시 cache:no-store', async () => {
-            const fetchMock = vi
-                .spyOn(global, 'fetch')
-                .mockResolvedValue(
-                    new Response(JSON.stringify([]), { status: 200 })
-                );
-            await fmpGet('profile', { symbol: 'AAPL' });
-            expect(fetchMock.mock.calls[0]![1]).toMatchObject({
-                cache: 'no-store',
-            });
-            expect(fetchMock.mock.calls[0]![1]).not.toHaveProperty('next');
-        });
-
         it('revalidate 지정 시 next.revalidate 사용', async () => {
             const fetchMock = vi
                 .spyOn(global, 'fetch')

--- a/src/shared/api/fmp/__tests__/httpClient.test.ts
+++ b/src/shared/api/fmp/__tests__/httpClient.test.ts
@@ -326,10 +326,15 @@ describe('fmpGet 함수는', () => {
                 .mockResolvedValue(
                     new Response(JSON.stringify([]), { status: 200 })
                 );
-            await fmpGet('profile', { symbol: 'AAPL' }, { revalidate: SECONDS_PER_HOUR });
+            await fmpGet(
+                'profile',
+                { symbol: 'AAPL' },
+                { revalidate: SECONDS_PER_HOUR }
+            );
             expect(fetchMock.mock.calls[0]![1]).toMatchObject({
                 next: { revalidate: SECONDS_PER_HOUR },
             });
+            fetchMock.mockRestore();
         });
     });
 });

--- a/src/shared/api/fmp/fundamentalClient.ts
+++ b/src/shared/api/fmp/fundamentalClient.ts
@@ -386,7 +386,8 @@ export class FmpFundamentalClient implements FundamentalDataProvider {
         symbol: string,
         limit = EARNINGS_REPORT_LIMIT
     ): Promise<FmpEarningsReportItem[]> {
-        const arr = await fmpGet<RawFmpEarningsReport[]>('earnings', {
+        // earnings는 실적 발표 시점 실시간성이 중요 → 1h 캐시 대신 no-store(fmpGetRaw).
+        const arr = await fmpGetRaw<RawFmpEarningsReport[]>('earnings', {
             symbol,
             limit: String(limit),
         });

--- a/src/shared/api/fmp/fundamentalClient.ts
+++ b/src/shared/api/fmp/fundamentalClient.ts
@@ -1,4 +1,5 @@
-import { fmpGet } from './httpClient';
+import { fmpGet as fmpGetRaw } from './httpClient';
+import { SECONDS_PER_HOUR } from '@/shared/config/time';
 import type {
     RawFmpAnalystEstimate,
     RawFmpCashFlowStatement,
@@ -34,6 +35,18 @@ import type {
     GradesAction,
     GradesEvent,
 } from '@y0ngha/siglens-core';
+
+/** 펀더멘털 데이터는 장중에도 거의 불변 → 1시간 cross-request 캐시. */
+const FMP_FUNDAMENTAL_REVALIDATE_SECONDS = SECONDS_PER_HOUR;
+
+function fmpGet<T>(
+    path: string,
+    query: Record<string, string> = {}
+): Promise<T> {
+    return fmpGetRaw<T>(path, query, {
+        revalidate: FMP_FUNDAMENTAL_REVALIDATE_SECONDS,
+    });
+}
 
 const ANALYST_ESTIMATES_PERIOD = 'annual';
 const ANALYST_ESTIMATES_PAGE = '0';

--- a/src/shared/api/fmp/httpClient.ts
+++ b/src/shared/api/fmp/httpClient.ts
@@ -10,6 +10,11 @@ export const FMP_STABLE_BASE = 'https://financialmodelingprep.com/stable';
 /** Timeout for all FMP fetch calls (ms). */
 const FMP_FETCH_TIMEOUT_MS = 10_000;
 
+/** Options for {@link fmpGet}. */
+export interface FmpGetOptions {
+    revalidate?: number;
+}
+
 /**
  * Parse the `Retry-After` response header value (seconds as integer).
  * Returns null if the header is absent, non-numeric, zero, or negative.
@@ -36,7 +41,7 @@ function parseRetryAfterSeconds(header: string | null): number | null {
 export async function fmpGet<T>(
     path: string,
     query: Record<string, string> = {},
-    opts: { revalidate?: number } = {}
+    opts: FmpGetOptions = {}
 ): Promise<T> {
     const { apiKey } = readFmpConfig();
     const params = new URLSearchParams({ ...query, apikey: apiKey });

--- a/src/shared/api/fmp/httpClient.ts
+++ b/src/shared/api/fmp/httpClient.ts
@@ -28,10 +28,15 @@ function parseRetryAfterSeconds(header: string | null): number | null {
  * immediately as `FmpHttpError`. `readFmpConfig()` and `URLSearchParams` run
  * once per call — only `fetch()` is inside the retry loop so each attempt gets
  * a fresh `AbortSignal` timeout.
+ *
+ * Pass `opts.revalidate` (seconds) to opt into Next.js Data Cache instead of
+ * the default `cache: 'no-store'`. Callers that handle caching at a higher
+ * level (e.g. Redis) should omit `opts` to keep the per-request bypass.
  */
 export async function fmpGet<T>(
     path: string,
-    query: Record<string, string> = {}
+    query: Record<string, string> = {},
+    opts: { revalidate?: number } = {}
 ): Promise<T> {
     const { apiKey } = readFmpConfig();
     const params = new URLSearchParams({ ...query, apikey: apiKey });
@@ -40,7 +45,9 @@ export async function fmpGet<T>(
         const res = await fetch(
             `${FMP_STABLE_BASE}/${path}?${params.toString()}`,
             {
-                cache: 'no-store',
+                ...(opts.revalidate !== undefined
+                    ? { next: { revalidate: opts.revalidate } }
+                    : { cache: 'no-store' }),
                 signal: AbortSignal.timeout(FMP_FETCH_TIMEOUT_MS),
             }
         );

--- a/src/widgets/symbol-page/ChartContent.tsx
+++ b/src/widgets/symbol-page/ChartContent.tsx
@@ -322,7 +322,7 @@ export function ChartContent({
                 않게 하되, scrollbar-none으로 스크롤바 자체는 감춰 페이지 스크롤과
                 시각적으로 겹쳐 보이지 않게 한다. */}
             <aside
-                className="border-secondary-700 scrollbar-none relative hidden min-h-0 flex-none overflow-y-auto border-l p-4 md:flex md:h-full md:w-(--panel-width) md:flex-col"
+                className="border-secondary-700 relative hidden min-h-0 flex-none scrollbar-none overflow-y-auto border-l p-4 md:flex md:h-full md:w-(--panel-width) md:flex-col"
                 style={
                     {
                         // panelWidth는 드래그 상태에서 런타임에 결정되므로 정적 Tailwind 클래스로 표현 불가

--- a/src/widgets/symbol-page/__tests__/ChartContent.test.tsx
+++ b/src/widgets/symbol-page/__tests__/ChartContent.test.tsx
@@ -30,7 +30,11 @@ vi.mock('@/widgets/chart', () => ({
 // tests below can drive a genuinely long vs. short panel and assert where that
 // content lands (inside the scroll container, not the chart column).
 vi.mock('@/widgets/analysis', () => ({
-    AnalysisPanel: ({ analysis }: { analysis?: { paragraphCount?: number } }) => (
+    AnalysisPanel: ({
+        analysis,
+    }: {
+        analysis?: { paragraphCount?: number };
+    }) => (
         <div data-testid="analysis-panel">
             {Array.from({ length: analysis?.paragraphCount ?? 0 }, (_, i) => (
                 <p data-testid="analysis-paragraph" key={i}>
@@ -243,7 +247,8 @@ describe('ChartContent', () => {
 
         describe('AI 분석 패널이 길 때', () => {
             it('긴 분석이 aside(overflow-y-auto + md:h-full) 안에 담겨 패널 내부에서 스크롤되고 차트 행을 늘리지 않는다', async () => {
-                const aside = await renderAsideWithParagraphs(LONG_PARAGRAPH_COUNT);
+                const aside =
+                    await renderAsideWithParagraphs(LONG_PARAGRAPH_COUNT);
 
                 // 긴 콘텐츠가 스크롤 컨테이너(aside) 안에 위치 = 차트가 아니라 패널이 스크롤된다.
                 expect(paragraphsInside(aside)).toBe(LONG_PARAGRAPH_COUNT);
@@ -252,7 +257,8 @@ describe('ChartContent', () => {
             });
 
             it('scrollbar-none으로 스크롤바를 감춰 페이지 스크롤과 겹쳐 보이지 않게 한다', async () => {
-                const aside = await renderAsideWithParagraphs(LONG_PARAGRAPH_COUNT);
+                const aside =
+                    await renderAsideWithParagraphs(LONG_PARAGRAPH_COUNT);
 
                 expect(aside.className).toContain('scrollbar-none');
             });
@@ -260,7 +266,9 @@ describe('ChartContent', () => {
 
         describe('AI 분석 패널이 짧을 때', () => {
             it('짧은 분석도 같은 aside 안에 담기며 overflow-y-auto + md:h-full + scrollbar-none 계약을 그대로 유지한다', async () => {
-                const aside = await renderAsideWithParagraphs(SHORT_PARAGRAPH_COUNT);
+                const aside = await renderAsideWithParagraphs(
+                    SHORT_PARAGRAPH_COUNT
+                );
 
                 expect(paragraphsInside(aside)).toBe(SHORT_PARAGRAPH_COUNT);
                 expect(aside.className).toContain('overflow-y-auto');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,12 @@ const sharedConfig = {
     resolve: {
         alias: {
             '@': path.resolve(__dirname, 'src'),
+            // server-only는 Next.js 전용 guard 패키지로 실제 설치 불필요.
+            // Vitest 환경에서는 빈 stub으로 resolve해 transform 오류를 방지한다.
+            'server-only': path.resolve(
+                __dirname,
+                'src/__tests__/server-only-stub.ts'
+            ),
         },
     },
 };

--- a/vitest.setup.base.ts
+++ b/vitest.setup.base.ts
@@ -45,6 +45,12 @@ if (
     });
 }
 
+// @upstash/redis는 실제 Redis 연결이 없으므로 전역 stub.
+// 개별 테스트가 Redis 동작을 검증할 때는 vi.mock('@upstash/redis', ...)으로 덮어쓸 수 있다.
+vi.mock('@upstash/redis', () => ({
+    Redis: vi.fn().mockImplementation(() => ({ get: vi.fn(), set: vi.fn() })),
+}));
+
 vi.mock('next/cache', () => ({
     cacheLife: () => {},
     cacheTag: () => {},

--- a/vitest.setup.base.ts
+++ b/vitest.setup.base.ts
@@ -45,12 +45,6 @@ if (
     });
 }
 
-// @upstash/redis는 실제 Redis 연결이 없으므로 전역 stub.
-// 개별 테스트가 Redis 동작을 검증할 때는 vi.mock('@upstash/redis', ...)으로 덮어쓸 수 있다.
-vi.mock('@upstash/redis', () => ({
-    Redis: vi.fn().mockImplementation(() => ({ get: vi.fn(), set: vi.fn() })),
-}));
-
 vi.mock('next/cache', () => ({
     cacheLife: () => {},
     cacheTag: () => {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -3456,14 +3456,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@y0ngha/siglens-core@npm:0.12.0":
-  version: 0.12.0
-  resolution: "@y0ngha/siglens-core@npm:0.12.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.12.0%2F5919d83342216757d2961beebf0e749d41a3a1e2"
+"@y0ngha/siglens-core@npm:0.13.0":
+  version: 0.13.0
+  resolution: "@y0ngha/siglens-core@npm:0.13.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.13.0%2Ff06bae495d18a21d17009b16cf1591b8d4e6f7e7"
   dependencies:
     jsonrepair: "npm:^3.14.0"
   peerDependencies:
     "@upstash/redis": ^1.37.0
-  checksum: 10c0/f229a0866ddd39d4e27b2d2e0d1cfff6707957b1ae51651687b0eb2fbce4ab714db5725c6d460ade3e8119f2ebd022b89b8a025f1450f33c16bc4fcacfdc75b8
+  checksum: 10c0/d04695dca0eaba489125de8f8edfb399c0137a4dfbdd07b4aef2f5441438d38d024fa76954fcc8259704203468078a0113f3a513727cfff9dfefd7cddd8c44da
   languageName: node
   linkType: hard
 
@@ -10323,7 +10323,7 @@ __metadata:
     "@vercel/analytics": "npm:^2.0.1"
     "@vercel/functions": "npm:^3.4.3"
     "@vitest/coverage-v8": "npm:^4.1.7"
-    "@y0ngha/siglens-core": "npm:0.12.0"
+    "@y0ngha/siglens-core": "npm:0.13.0"
     babel-plugin-react-compiler: "npm:^1.0.0"
     bcryptjs: "npm:^3.0.3"
     clsx: "npm:^2.1.1"


### PR DESCRIPTION
## Summary
PPR(cacheComponents) is disabled (#439), which removed cross-request data caching and let crawler bots drive up Vercel/Redis/DB/FMP cost. This restores caching at the data layer (PPR-independent), with no SEO/quality regression — bots still receive the same content, just from cache.

- **bars (biggest lever):** `entities/bars/lib/barsDataCache.ts` — Upstash Redis cross-request cache (mirrors `optionsDataCache.ts`), session-aware TTL from siglens-core `computeBarsEffectiveTtl` (60s during the regular session; off-hours capped at the next market open, ≤24h). `getBarsAction` now delegates to it.
- **FMP fundamentals:** `fmpGet` gained an optional `revalidate`; the fundamental client opts into a 1h Next.js Data Cache (14 FMP calls/render → 1 per TTL). News/earnings stay `no-store`.
- **news:** bot-path-only freshness guard in `ensureNewsCardsAnalyzedAction` via a per-symbol Redis flag (`newsRefreshFlag.ts`, 10min TTL) — skips redundant FMP fetch + N DB upserts on repeat bot crawls; the human path is unchanged.
- Test infra: `server-only` resolve alias for Vitest.

## ⚠️ Depends on siglens-core PR #102 (merge order)
This branch imports `computeBarsEffectiveTtl` from `@y0ngha/siglens-core`, added in core PR #102. **Do not merge until core #102 is merged + published and the `@y0ngha/siglens-core` version is bumped here.** CI will fail until then (the pinned published core version lacks the export). Kept as a Draft for this reason. (Temp branch — to be formalized with an issue number.)

## Test / coverage
- Full siglens suite green; global coverage Statements 94.6 / Branches 90.3 / Functions 93.4 / Lines 95.4%.
- New/changed files at 100% (bars cache, newsRefreshFlag, getBarsAction, httpClient, fundamentalClient); ensureNewsCardsAnalyzedAction 100% lines (2 unreachable type-narrowing branches remain). Worst-case paths covered (Redis get/set failures, FMP 402/429, news poll-timeout, weekend/DST boundaries).
- Production build compiles + passes TypeScript.