### PR TITLE
refactor: unify Upstash Redis client into shared/cache/redisClient

### DIFF
--- a/docs/superpowers/plans/2026-05-28-redis-client-unification.md
+++ b/docs/superpowers/plans/2026-05-28-redis-client-unification.md
@@ -1,0 +1,427 @@
+# Redis Client Unification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Centralize all Upstash Redis client construction (currently duplicated across 5 entity files) into one `shared/cache/redisClient.ts` module, with the 5 consumers importing it.
+
+**Architecture:** New `shared/cache/redisClient.ts` reads `UPSTASH_REDIS_REST_*` env once and exposes `getRedisClient(): Redis | null` (singleton writer, null when unconfigured) and `getRedisReaderWriter(): { writer, reader } | null` (readonly-token aware, shares the writer instance). Each consumer drops its local env-read + `new Redis(...)` and imports from the shared module; all domain logic (keys, TTLs, store interfaces, graceful-null handling) is unchanged.
+
+**Tech Stack:** TypeScript, `@upstash/redis`, vitest, Next.js (FSD layers). Spec: `docs/superpowers/specs/2026-05-28-redis-client-unification-design.md`. Worktree: `/Users/y0ngha/Project/siglens-redis-unification` (branch `refactor/redis-client-unification`).
+
+**Working directory for all tasks:** `/Users/y0ngha/Project/siglens-redis-unification`. Commands: `yarn test <path>`, `yarn typecheck`, `yarn lint`, `yarn build`.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `src/shared/cache/redisClient.ts` | **create** | The single Upstash Redis client factory (writer singleton + reader/writer pair) |
+| `src/shared/cache/__tests__/redisClient.test.ts` | **create** | Unit tests for the factory |
+| `src/entities/options-chain/lib/optionsDataCache.ts` | modify | use `getRedisClient()` |
+| `src/entities/news-article/lib/newsRefreshFlag.ts` | modify | use `getRedisClient()` |
+| `src/entities/bars/lib/barsDataCache.ts` | modify | use `getRedisClient()` |
+| `src/entities/oauth-account/lib/pendingOAuthSignupStore.ts` | modify | use `getRedisClient()` |
+| `src/entities/email-token/api.ts` | modify | use `getRedisReaderWriter()` + delegate reset |
+
+**Test note (applies to every consumer task):** The existing consumer tests mock `@upstash/redis` (the `Redis` class) and control `process.env.UPSTASH_REDIS_REST_*`, often via `vi.resetModules()` + dynamic import (e.g. `optionsDataCache.test.ts`'s `loadWithEnv`). After migration, the consumer calls `getRedisClient()` from the shared module, which still does `new Redis(...)` against the mocked class reading the same env. `vi.resetModules()` resets the shared module's singleton too. **So these tests should pass unchanged.** Run each consumer's existing test after the source edit; only if a test directly asserted the local `getRedis` internals (it should not) adapt it minimally. Do NOT weaken assertions.
+
+---
+
+## Task 1: Create the shared Redis client module
+
+**Files:**
+- Create: `src/shared/cache/redisClient.ts`
+- Create: `src/shared/cache/__tests__/redisClient.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/shared/cache/__tests__/redisClient.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockRedisConstructor } = vi.hoisted(() => ({
+    mockRedisConstructor: vi.fn(),
+}));
+
+vi.mock('@upstash/redis', () => ({
+    Redis: vi.fn().mockImplementation(function (opts: unknown) {
+        mockRedisConstructor(opts);
+        return { __opts: opts };
+    }),
+}));
+
+import {
+    getRedisClient,
+    getRedisReaderWriter,
+    __resetRedisClientForTests,
+} from '@/shared/cache/redisClient';
+
+const URL = 'https://test.upstash.io';
+const TOKEN = 'writer-token';
+const RO = 'readonly-token';
+
+beforeEach(() => {
+    __resetRedisClientForTests();
+    mockRedisConstructor.mockClear();
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    delete process.env.UPSTASH_REDIS_REST_READONLY_TOKEN;
+});
+
+describe('getRedisClient', () => {
+    it('env 미설정 시 null을 반환하고 Redis를 생성하지 않는다', () => {
+        expect(getRedisClient()).toBeNull();
+        expect(mockRedisConstructor).not.toHaveBeenCalled();
+    });
+
+    it('env 설정 시 반복 호출이 동일 인스턴스를 반환한다(싱글톤)', () => {
+        process.env.UPSTASH_REDIS_REST_URL = URL;
+        process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
+        const a = getRedisClient();
+        const b = getRedisClient();
+        expect(a).not.toBeNull();
+        expect(a).toBe(b);
+        expect(mockRedisConstructor).toHaveBeenCalledTimes(1);
+        expect(mockRedisConstructor).toHaveBeenCalledWith({ url: URL, token: TOKEN });
+    });
+});
+
+describe('getRedisReaderWriter', () => {
+    it('env 미설정 시 null', () => {
+        expect(getRedisReaderWriter()).toBeNull();
+    });
+
+    it('readonly token 미설정 시 reader === writer 이고 writer === getRedisClient()', () => {
+        process.env.UPSTASH_REDIS_REST_URL = URL;
+        process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
+        const pair = getRedisReaderWriter();
+        expect(pair).not.toBeNull();
+        expect(pair!.reader).toBe(pair!.writer);
+        expect(pair!.writer).toBe(getRedisClient());
+        expect(mockRedisConstructor).toHaveBeenCalledTimes(1);
+    });
+
+    it('readonly token 설정 시 reader는 별도 인스턴스(readonly 토큰)', () => {
+        process.env.UPSTASH_REDIS_REST_URL = URL;
+        process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
+        process.env.UPSTASH_REDIS_REST_READONLY_TOKEN = RO;
+        const pair = getRedisReaderWriter();
+        expect(pair!.reader).not.toBe(pair!.writer);
+        expect(pair!.writer).toBe(getRedisClient());
+        expect(mockRedisConstructor).toHaveBeenCalledTimes(2);
+        expect(mockRedisConstructor).toHaveBeenNthCalledWith(1, { url: URL, token: TOKEN });
+        expect(mockRedisConstructor).toHaveBeenNthCalledWith(2, { url: URL, token: RO });
+    });
+
+    it('빈 문자열 readonly token은 미설정으로 취급한다(reader === writer)', () => {
+        process.env.UPSTASH_REDIS_REST_URL = URL;
+        process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
+        process.env.UPSTASH_REDIS_REST_READONLY_TOKEN = '';
+        const pair = getRedisReaderWriter();
+        expect(pair!.reader).toBe(pair!.writer);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `yarn test src/shared/cache/__tests__/redisClient.test.ts`
+Expected: FAIL — module `@/shared/cache/redisClient` does not exist.
+
+- [ ] **Step 3: Implement `src/shared/cache/redisClient.ts`**
+
+```ts
+import { Redis } from '@upstash/redis';
+
+interface UpstashEnv {
+    url: string;
+    token: string;
+    /** Read-only token; null when the env var is unset or empty (no separate reader created). */
+    readonlyToken: string | null;
+}
+
+// undefined = not yet initialized; null = env not configured (graceful fallback).
+let cachedWriter: Redis | null | undefined;
+let cachedReader: Redis | null | undefined;
+
+function readUpstashEnv(): UpstashEnv | null {
+    const url = process.env.UPSTASH_REDIS_REST_URL;
+    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+    if (!url || !token) return null;
+    // Treat empty string as "unset" so a literal empty env var doesn't create a reader.
+    const raw = process.env.UPSTASH_REDIS_REST_READONLY_TOKEN;
+    const readonlyToken = raw === undefined || raw === '' ? null : raw;
+    return { url, token, readonlyToken };
+}
+
+/**
+ * The app's shared Upstash Redis writer client (singleton).
+ *
+ * Returns `null` when `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` are
+ * not set, so callers can degrade gracefully (cache miss / direct fetch) in
+ * environments without Redis (local dev, tests).
+ */
+export function getRedisClient(): Redis | null {
+    if (cachedWriter !== undefined) return cachedWriter;
+    const env = readUpstashEnv();
+    cachedWriter = env ? new Redis({ url: env.url, token: env.token }) : null;
+    return cachedWriter;
+}
+
+/**
+ * Writer + reader pair (singleton). When `UPSTASH_REDIS_REST_READONLY_TOKEN` is
+ * set, `reader` uses the read-only token; otherwise `reader === writer`. The
+ * `writer` is the same instance returned by {@link getRedisClient}. Returns
+ * `null` when Redis env is not configured.
+ */
+export function getRedisReaderWriter(): { writer: Redis; reader: Redis } | null {
+    const writer = getRedisClient();
+    if (writer === null) return null;
+    if (cachedReader === undefined) {
+        // writer is non-null here, so readUpstashEnv() is also non-null.
+        const env = readUpstashEnv()!;
+        cachedReader =
+            env.readonlyToken !== null
+                ? new Redis({ url: env.url, token: env.readonlyToken })
+                : writer;
+    }
+    return { writer, reader: cachedReader };
+}
+
+/** @internal Reset the cached singletons between test runs. */
+export function __resetRedisClientForTests(): void {
+    cachedWriter = undefined;
+    cachedReader = undefined;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `yarn test src/shared/cache/__tests__/redisClient.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `yarn typecheck`
+Expected: exit 0 (the new module compiles; consumers not yet changed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/shared/cache/redisClient.ts src/shared/cache/__tests__/redisClient.test.ts
+git commit -m "feat: add shared Upstash Redis client (getRedisClient + getRedisReaderWriter)"
+```
+
+## Task 2: Migrate `optionsDataCache.ts`
+
+**Files:**
+- Modify: `src/entities/options-chain/lib/optionsDataCache.ts`
+- Test: `src/entities/options-chain/__tests__/optionsDataCache.test.ts`
+
+- [ ] **Step 1: Replace the local `getRedis` with the shared client**
+
+In `src/entities/options-chain/lib/optionsDataCache.ts`:
+- Remove `import { Redis } from '@upstash/redis';` (line 3).
+- Add `import { getRedisClient } from '@/shared/cache/redisClient';` (with the other imports).
+- Delete the `// tokenStore.ts / ... lazy-singleton 패턴.` comment, the `let cachedRedis: ...` declaration, and the entire `function getRedis(): Redis | null { ... }` block (lines ~41-55).
+- In `hasOptionsMarket` and `fetchOptionsSnapshot`, replace each `const redis = getRedis();` with `const redis = getRedisClient();` (2 call sites).
+
+- [ ] **Step 2: Run the existing test**
+
+Run: `yarn test src/entities/options-chain/__tests__/optionsDataCache.test.ts`
+Expected: PASS unchanged. (`loadWithEnv` uses `vi.resetModules()` + dynamic import, which resets the shared singleton; `@upstash/redis` is mocked; `mockRedisConstructor` is still invoked through `getRedisClient`.) If a case fails purely because it asserted the old local-singleton timing, adjust the test's reset to also call `__resetRedisClientForTests` from `@/shared/cache/redisClient` — but first confirm whether `vi.resetModules()` already covers it (it should).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `yarn typecheck`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/entities/options-chain/lib/optionsDataCache.ts
+git commit -m "refactor: use shared getRedisClient in optionsDataCache"
+```
+
+## Task 3: Migrate `newsRefreshFlag.ts`
+
+**Files:**
+- Modify: `src/entities/news-article/lib/newsRefreshFlag.ts`
+- Test: `src/entities/news-article/__tests__/newsRefreshFlag.test.ts`
+
+- [ ] **Step 1: Replace the local `getRedis`**
+
+In `src/entities/news-article/lib/newsRefreshFlag.ts`:
+- Remove `import { Redis } from '@upstash/redis';` (line 2).
+- Add `import { getRedisClient } from '@/shared/cache/redisClient';`.
+- Delete `let cachedRedis: Redis | null | undefined;` and the `function getRedis(): Redis | null { ... }` block (lines ~8-19).
+- In `isRecentlyFetched` and `markFetched`, replace `const redis = getRedis();` with `const redis = getRedisClient();` (2 sites).
+
+- [ ] **Step 2: Run the existing test**
+
+Run: `yarn test src/entities/news-article/__tests__/newsRefreshFlag.test.ts`
+Expected: PASS unchanged (same reasoning as Task 2). If the test resets via module reload, it already covers the shared singleton; otherwise add `__resetRedisClientForTests()` in its `beforeEach`.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `yarn typecheck`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/entities/news-article/lib/newsRefreshFlag.ts
+git commit -m "refactor: use shared getRedisClient in newsRefreshFlag"
+```
+
+## Task 4: Migrate `barsDataCache.ts`
+
+**Files:**
+- Modify: `src/entities/bars/lib/barsDataCache.ts`
+- Test: `src/entities/bars/__tests__/barsDataCache.test.ts`
+
+- [ ] **Step 1: Replace the local `getRedis`**
+
+In `src/entities/bars/lib/barsDataCache.ts`:
+- Remove `import { Redis } from '@upstash/redis';` (line 3).
+- Add `import { getRedisClient } from '@/shared/cache/redisClient';`.
+- Delete the `// Redis 미설정 환경 ... lazy 초기화로 지연한다.` comment, `let cachedRedis: ...`, and the `function getRedis(): Redis | null { ... }` block (lines ~12-25).
+- In `getCachedBarsWithIndicators`, replace `const redis = getRedis();` with `const redis = getRedisClient();` (1 site, ~line 57).
+- Leave the `MarketDataProvider` / `fetchBarsWithIndicators` / TTL logic untouched.
+
+- [ ] **Step 2: Run the existing test**
+
+Run: `yarn test src/entities/bars/__tests__/barsDataCache.test.ts`
+Expected: PASS unchanged.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `yarn typecheck`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/entities/bars/lib/barsDataCache.ts
+git commit -m "refactor: use shared getRedisClient in barsDataCache"
+```
+
+## Task 5: Migrate `pendingOAuthSignupStore.ts`
+
+**Files:**
+- Modify: `src/entities/oauth-account/lib/pendingOAuthSignupStore.ts`
+- Test: `src/entities/oauth-account/__tests__/lib/pendingOAuthSignupStore.test.ts`
+
+- [ ] **Step 1: Use the shared client in the env factory**
+
+In `src/entities/oauth-account/lib/pendingOAuthSignupStore.ts`:
+- Remove `import { Redis } from '@upstash/redis';` (line 2) **only if** `Redis` is not referenced elsewhere in the file. NOTE: `createPendingOAuthSignupStore(client: Redis)` (the injection entrypoint) uses the `Redis` type in its signature — if so, change that import to a type-only import: `import type { Redis } from '@upstash/redis';`.
+- Add `import { getRedisClient } from '@/shared/cache/redisClient';`.
+- Replace the body of `createPendingOAuthSignupStoreFromEnv()` (lines ~76-82):
+```ts
+export function createPendingOAuthSignupStoreFromEnv(): PendingOAuthSignupStore | null {
+    const client = getRedisClient();
+    if (client === null) return null;
+    return createPendingOAuthSignupStore(client);
+}
+```
+- Leave `createPendingOAuthSignupStore(client: Redis)` and the store interface unchanged.
+
+- [ ] **Step 2: Run the existing test**
+
+Run: `yarn test src/entities/oauth-account/__tests__/lib/pendingOAuthSignupStore.test.ts`
+Expected: PASS. The store tests inject a fake client into `createPendingOAuthSignupStore` directly; the `FromEnv` test controls env + mocks `@upstash/redis`. If the `FromEnv` test relied on `new Redis` per call, it now goes through the shared singleton — assertions on the returned store still hold; if it asserted constructor-call counts across env toggles, add `__resetRedisClientForTests()` between toggles.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `yarn typecheck`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/entities/oauth-account/lib/pendingOAuthSignupStore.ts
+git commit -m "refactor: use shared getRedisClient in pendingOAuthSignupStore"
+```
+
+## Task 6: Migrate `email-token/api.ts` (reader/writer)
+
+**Files:**
+- Modify: `src/entities/email-token/api.ts`
+- Test: `src/entities/email-token/__tests__/api.test.ts`
+
+- [ ] **Step 1: Replace the local pair logic with the shared reader/writer**
+
+In `src/entities/email-token/api.ts`:
+- Remove `import { Redis } from '@upstash/redis';` (line 1).
+- Add `import { getRedisReaderWriter, __resetRedisClientForTests } from '@/shared/cache/redisClient';`.
+- Delete the `UpstashConfig` interface (lines ~41-46), the `RedisPair` interface (~48-51), the `cachedRedisPair` / `cachedConfigKey` vars (~53-54), `readUpstashConfig()` (~56-66), and `getRedisPair()` (~82-102).
+- Change `__resetEmailTokenStoreCacheForTests` to delegate to the shared reset (keep the exported name — the test imports it):
+```ts
+/** Test-only reset of the cached Redis client. Delegates to the shared module. */
+export function __resetEmailTokenStoreCacheForTests(): void {
+    __resetRedisClientForTests();
+}
+```
+- Change `createEmailTokenStore()` to use the shared pair:
+```ts
+export function createEmailTokenStore(): EmailTokenStore | null {
+    const pair = getRedisReaderWriter();
+    if (pair === null) return null;
+    const { writer, reader } = pair;
+
+    return {
+        // ...existing set/get/delete/consume bodies unchanged
+    };
+}
+```
+Keep `EmailTokenStore`, `EmailTokenPurpose`, `EmailTokenValue`, `KEY_PREFIX`, `buildEmailTokenKey`, and the `set/get/delete/consume` method bodies exactly as they are.
+
+- [ ] **Step 2: Run the existing test**
+
+Run: `yarn test src/entities/email-token/__tests__/api.test.ts`
+Expected: PASS. The test mocks `@upstash/redis` and calls `__resetEmailTokenStoreCacheForTests()` (which now resets the shared singleton). The writer/reader split behavior is preserved by `getRedisReaderWriter`. If the test set `UPSTASH_REDIS_REST_READONLY_TOKEN` to assert reader-token usage, those assertions still hold (the shared module reads the same var). Adjust only if a test reached into the deleted `readUpstashConfig`/`getRedisPair` internals directly (it should only use the public `createEmailTokenStore` + env + the reset).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `yarn typecheck`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/entities/email-token/api.ts
+git commit -m "refactor: use shared getRedisReaderWriter in email-token store"
+```
+
+## Task 7: Full verification
+
+- [ ] **Step 1: Confirm no stray local Redis construction remains**
+
+Run: `git grep -n "new Redis(" src` and `git grep -n "from '@upstash/redis'" src`
+Expected: the ONLY `new Redis(` is in `src/shared/cache/redisClient.ts`. The ONLY runtime `import { Redis }` is in `redisClient.ts`; any other `@upstash/redis` import is `import type { Redis }` (e.g. pendingOAuthSignupStore's signature). No consumer reads `process.env.UPSTASH_REDIS_REST_*` directly anymore: `git grep -n "UPSTASH_REDIS_REST" src` should match only `redisClient.ts` (+ test files).
+
+- [ ] **Step 2: Typecheck, lint, full test, build**
+
+Run: `yarn typecheck && yarn lint && yarn test && yarn build`
+Expected: all PASS. (`build` runs `next build`; if `DATABASE_URL`/secrets are absent in the environment, run `yarn build:local` instead, or skip the build step and rely on typecheck+test — note this to the user.)
+
+- [ ] **Step 3: Commit (if any verification fixups)**
+
+```bash
+git add -A
+git commit -m "chore: redis client unification verification fixups"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Spec §3 (shared module API: getRedisClient + getRedisReaderWriter + __resetRedisClientForTests, null fallback, writer sharing) → Task 1. Spec §4 migrations (5 consumers) → Tasks 2–6 (options/news/bars/oauth/email respectively). Spec §6 tests (new redisClient test + consumer test pass-through) → Task 1 step 1 + each consumer task step 2. Spec §5 (preserve domain logic, non-goals) → each task leaves keys/TTL/store interfaces untouched. Spec §7 (oauth singleton change, email reset delegation) → Task 5 + Task 6 step 1. No spec requirement left without a task.
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases". Every code step shows the real edit; every run step gives a command + expected result. The build step names a concrete fallback (`build:local`) for the env-missing case rather than leaving it vague.
+
+**Type/name consistency:** `getRedisClient` / `getRedisReaderWriter` / `__resetRedisClientForTests` used identically in Task 1 (definition + test) and Tasks 2–6 (consumers). `{ writer, reader }` shape consistent between Task 1 and Task 6. `__resetEmailTokenStoreCacheForTests` retained as a delegating wrapper (Task 6) so its test import keeps working. Env var names (`UPSTASH_REDIS_REST_URL`/`_TOKEN`/`_READONLY_TOKEN`) consistent across Task 1 and Task 7's grep.

--- a/docs/superpowers/specs/2026-05-28-redis-client-unification-design.md
+++ b/docs/superpowers/specs/2026-05-28-redis-client-unification-design.md
@@ -1,0 +1,129 @@
+# Redis 클라이언트 통합 설계
+
+- 작성일: 2026-05-28
+- 상태: 설계 승인 완료 (구현 계획 작성 대기)
+- 관련: 원래 사용자 요청 "문제 2 — getRedis 등 공통 함수 통합" · `src/shared/CLAUDE.md`(`shared/cache/` = Redis client)
+
+## 1. 배경 / 문제
+
+siglens 앱이 Upstash Redis 클라이언트를 **5곳에서 각자 생성**한다. 모두 동일한
+`UPSTASH_REDIS_REST_*` 환경변수를 읽어 `new Redis(...)`를 만들며, 3곳은 사실상 복붙이다.
+관리 지점이 분산되어 있어 연결 설정·graceful fallback 정책을 한 곳에서 바꿀 수 없다.
+
+> 범위 확인: DB(`shared/db/getDatabaseClient`), FMP(`shared/api/fmp/httpClient.fmpGet`),
+> yahoo-finance2(`options-chain`의 단일 `YahooOptionsAdapter`), AI provider(`entities/llm-provider/api`의
+> SDK별 단일 생성점), Email(`shared/email/dispatcher`의 단일 `Resend`)은 **이미 단일화**되어 있어
+> 본 작업 대상이 아니다. core의 `createCacheProvider`(분석 캐시)는 core 소유로 유지한다(SCOPE).
+
+## 2. 현황 인벤토리 (분산 5곳)
+
+| # | 파일 | 현재 패턴 |
+|---|---|---|
+| 1 | `src/entities/options-chain/lib/optionsDataCache.ts` | `getRedis(): Redis \| null` lazy 싱글톤, env 미설정 시 null |
+| 2 | `src/entities/news-article/lib/newsRefreshFlag.ts` | 동일 `getRedis()` (복붙) |
+| 3 | `src/entities/bars/lib/barsDataCache.ts` | 동일 `getRedis()` (복붙) |
+| 4 | `src/entities/oauth-account/lib/pendingOAuthSignupStore.ts` | `createPendingOAuthSignupStoreFromEnv()`가 매 호출 `new Redis`(캐싱 없음) |
+| 5 | `src/entities/email-token/api.ts` | `getRedisPair()` writer/reader 쌍(`UPSTASH_REDIS_REST_READONLY_TOKEN`) + config-key 무효화 |
+
+모두 `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN`(+ #5는 `_READONLY_TOKEN`)을 직접 읽는다.
+
+## 3. 설계 — `src/shared/cache/redisClient.ts` (신규)
+
+Upstash Redis 생성과 env 읽기를 단일 모듈로 일원화한다. (FSD: `shared`는 최하위 레이어 —
+모든 entity가 `@/shared/cache`에서 import 가능. 레이어 위반 없음.)
+
+```ts
+import { Redis } from '@upstash/redis';
+
+interface UpstashEnv {
+    url: string;
+    token: string;
+    readonlyToken: string | null; // 빈 문자열/미설정은 null로 정규화
+}
+
+let cachedWriter: Redis | null | undefined;       // undefined = 미초기화, null = env 미설정
+let cachedReader: Redis | null | undefined;
+
+function readUpstashEnv(): UpstashEnv | null {
+    const url = process.env.UPSTASH_REDIS_REST_URL;
+    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+    if (!url || !token) return null;
+    const raw = process.env.UPSTASH_REDIS_REST_READONLY_TOKEN;
+    const readonlyToken = raw === undefined || raw === '' ? null : raw;
+    return { url, token, readonlyToken };
+}
+
+/**
+ * 앱 공용 Upstash Redis writer 클라이언트(싱글톤). env 미설정 시 `null`을 반환해
+ * 소비자가 graceful degrade(캐시 미스/직접 호출)할 수 있게 한다.
+ */
+export function getRedisClient(): Redis | null {
+    if (cachedWriter !== undefined) return cachedWriter;
+    const env = readUpstashEnv();
+    cachedWriter = env ? new Redis({ url: env.url, token: env.token }) : null;
+    return cachedWriter;
+}
+
+/**
+ * writer/reader 쌍(싱글톤). `UPSTASH_REDIS_REST_READONLY_TOKEN`이 있으면 reader는
+ * read-only 토큰을 쓰고, 없으면 `reader === writer`. writer는 `getRedisClient()`와
+ * 동일 인스턴스를 공유한다(중복 생성 방지). env 미설정 시 `null`.
+ */
+export function getRedisReaderWriter(): { writer: Redis; reader: Redis } | null {
+    const writer = getRedisClient();
+    if (writer === null) return null;
+    if (cachedReader === undefined) {
+        const env = readUpstashEnv(); // writer가 non-null이므로 env도 non-null
+        cachedReader =
+            env && env.readonlyToken !== null
+                ? new Redis({ url: env.url, token: env.readonlyToken })
+                : writer;
+    }
+    return { writer, reader: cachedReader ?? writer };
+}
+
+/** @internal 테스트 간 싱글톤 초기화. */
+export function __resetRedisClientForTests(): void {
+    cachedWriter = undefined;
+    cachedReader = undefined;
+}
+```
+
+핵심 속성:
+- **null fallback 보존**: env 미설정(로컬 dev 등) 시 `null` — 기존 소비자의 null 체크가 그대로 동작.
+- **싱글톤**: 요청/모듈 수명 동안 writer·reader를 재사용. oauth는 기존에 매 호출 `new Redis`였으나
+  이제 싱글톤 재사용(부수 개선).
+- **writer 공유**: `getRedisReaderWriter().writer`와 `getRedisClient()`는 동일 인스턴스.
+
+## 4. 마이그레이션 (소비자 5곳 — 도메인 로직 불변, client 생성만 교체)
+
+각 파일에서 로컬 env 읽기 + `new Redis` 생성만 제거하고 shared 모듈을 import한다.
+key 빌더 / TTL / store 인터페이스 / try-catch graceful 처리는 **그대로 유지**.
+
+1. **optionsDataCache.ts**: 로컬 `getRedis()`(+`cachedRedis`) 삭제 → `import { getRedisClient } from '@/shared/cache/redisClient'`. 본문 `getRedis()` → `getRedisClient()`. `import { Redis }` 제거.
+2. **newsRefreshFlag.ts**: 동일.
+3. **barsDataCache.ts**: 동일.
+4. **pendingOAuthSignupStore.ts**: `createPendingOAuthSignupStoreFromEnv()`의 env 읽기 + `new Redis`를 `getRedisClient()`로 교체(null이면 기존대로 null 반환). `createPendingOAuthSignupStore(client: Redis)`(주입형)는 그대로 둔다.
+5. **email-token/api.ts**: 로컬 `readUpstashConfig()` + `getRedisPair()` + `UpstashConfig`/`RedisPair`/캐시 변수 삭제 → `import { getRedisReaderWriter } from '@/shared/cache/redisClient'`. `createEmailTokenStore()`에서 `const pair = getRedisReaderWriter(); if (!pair) return null; const { writer, reader } = pair;`. `EmailTokenStore` 인터페이스·`buildEmailTokenKey`·`__resetEmailTokenStoreCacheForTests`(또는 shared reset로 위임)는 유지.
+
+## 5. 보존 / 비목표
+
+- 보존: 각 소비자의 graceful null 처리, key 네임스페이스, TTL, store 인터페이스.
+- 비목표: DB/FMP/yahoo/AI/Email 통합(이미 단일), core `createCacheProvider`(core 소유), Redis 명령 사용 방식 변경, 캐시 키/TTL 정책 변경.
+
+## 6. 테스트
+
+- 신규 `src/shared/cache/__tests__/redisClient.test.ts`:
+  - env 미설정 → `getRedisClient()`·`getRedisReaderWriter()` 모두 `null`.
+  - env 설정 → `getRedisClient()` 반복 호출이 **동일 인스턴스**(싱글톤).
+  - readonly token 설정 → `getRedisReaderWriter().reader !== .writer`, 그리고 `.writer === getRedisClient()`.
+  - readonly token 미설정 → `.reader === .writer`.
+  - 각 테스트 전 `__resetRedisClientForTests()` + `process.env` 제어(`@upstash/redis`의 `Redis`는 mock 또는 instanceof 확인).
+- 소비자 테스트 5곳: 로컬 `getRedis`/`getRedisPair` mock을 `vi.mock('@/shared/cache/redisClient', ...)`로 전환. 기존 동작 단언(캐시 hit/miss, null fallback, writer/reader 사용)은 그대로 유지·통과.
+
+## 7. 영향 / 리스크
+
+- 순수 내부 리팩토링 — 외부 동작(캐시 동작, env 계약) 불변.
+- env 계약 동일(`UPSTASH_REDIS_REST_URL`/`_TOKEN`/`_READONLY_TOKEN`).
+- oauth만 "매 호출 new" → "싱글톤"으로 바뀌어 연결 재사용(개선, 동작 동일).
+- `__resetEmailTokenStoreCacheForTests`가 로컬 캐시를 리셋하던 부분은 shared `__resetRedisClientForTests`로 대체 또는 위임 필요(테스트 격리 유지).

--- a/src/entities/bars/lib/barsDataCache.ts
+++ b/src/entities/bars/lib/barsDataCache.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { cache } from 'react';
-import { Redis } from '@upstash/redis';
+import { getRedisClient } from '@/shared/cache/redisClient';
 import {
     type BarsData,
     type MarketDataProvider,
@@ -8,21 +8,6 @@ import {
     fetchBarsWithIndicators,
     computeBarsEffectiveTtl,
 } from '@y0ngha/siglens-core';
-
-// Redis 미설정 환경(로컬 dev 등)에서도 graceful fallback이 가능하도록 연결을 lazy 초기화로 지연한다.
-let cachedRedis: Redis | null | undefined;
-
-function getRedis(): Redis | null {
-    if (cachedRedis !== undefined) return cachedRedis;
-    const url = process.env.UPSTASH_REDIS_REST_URL;
-    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-    if (!url || !token) {
-        cachedRedis = null;
-        return null;
-    }
-    cachedRedis = new Redis({ url, token });
-    return cachedRedis;
-}
 
 /** fmpSymbol이 OHLCV 결과를 바꾸므로(예: '^SPX' vs 'SPX') 키에 포함. */
 function buildBarsKey(
@@ -54,7 +39,7 @@ export const getCachedBarsWithIndicators = cache(
         fmpSymbol?: string
     ): Promise<BarsData> => {
         const key = buildBarsKey(symbol, timeframe, fmpSymbol);
-        const redis = getRedis();
+        const redis = getRedisClient();
         if (redis !== null) {
             try {
                 const hit = await redis.get<BarsData>(key);

--- a/src/entities/email-token/__tests__/api.test.ts
+++ b/src/entities/email-token/__tests__/api.test.ts
@@ -205,7 +205,6 @@ describe('createEmailTokenStore', () => {
         createEmailTokenStore();
         const callsAfterUnset = MockRedis.mock.calls.length;
 
-        // Reset the shared singleton so that the env change is picked up on the next call.
         __resetRedisClientForTests();
 
         // After the reset, configure a real readonly token. getRedisReaderWriter

--- a/src/entities/email-token/__tests__/api.test.ts
+++ b/src/entities/email-token/__tests__/api.test.ts
@@ -1,4 +1,3 @@
-import type { Mock } from 'vitest';
 vi.mock('@upstash/redis', () => {
     const MockRedis = vi.fn(function () {
         return {
@@ -10,6 +9,7 @@ vi.mock('@upstash/redis', () => {
     return { Redis: MockRedis };
 });
 
+import type { Mock } from 'vitest';
 import { Redis } from '@upstash/redis';
 import { __resetRedisClientForTests } from '@/shared/cache/redisClient';
 import {

--- a/src/entities/email-token/__tests__/api.test.ts
+++ b/src/entities/email-token/__tests__/api.test.ts
@@ -208,10 +208,10 @@ describe('createEmailTokenStore', () => {
         // Reset the shared singleton so that the env change is picked up on the next call.
         __resetRedisClientForTests();
 
-        // Now configure a readonly token equal to the empty string. With the
-        // old `?? ''` sentinel, this would collide with the unset case (config
-        // key identical: "...:master-token:"). After the fix, the keys differ:
-        // "url:master-token" vs "url:master-token:somevalue".
+        // After the reset, configure a real readonly token. getRedisReaderWriter
+        // builds a fresh writer plus a separate reader (the readonly token differs
+        // from the writer token), so more Redis instances are constructed than the
+        // earlier empty/unset-token case where the reader reused the writer.
         setEnv({
             UPSTASH_REDIS_REST_URL: 'https://example.upstash.io',
             UPSTASH_REDIS_REST_TOKEN: 'master-token',

--- a/src/entities/email-token/__tests__/api.test.ts
+++ b/src/entities/email-token/__tests__/api.test.ts
@@ -205,6 +205,9 @@ describe('createEmailTokenStore', () => {
         createEmailTokenStore();
         const callsAfterUnset = MockRedis.mock.calls.length;
 
+        // Reset the shared singleton so that the env change is picked up on the next call.
+        __resetEmailTokenStoreCacheForTests();
+
         // Now configure a readonly token equal to the empty string. With the
         // old `?? ''` sentinel, this would collide with the unset case (config
         // key identical: "...:master-token:"). After the fix, the keys differ:

--- a/src/entities/email-token/__tests__/api.test.ts
+++ b/src/entities/email-token/__tests__/api.test.ts
@@ -4,6 +4,7 @@ vi.mock('@upstash/redis', () => {
             get: vi.fn(),
             set: vi.fn(),
             del: vi.fn(),
+            getdel: vi.fn(),
         };
     });
     return { Redis: MockRedis };
@@ -57,6 +58,7 @@ describe('createEmailTokenStore', () => {
                 get: vi.fn(),
                 set: vi.fn(),
                 del: vi.fn(),
+                getdel: vi.fn(),
             };
         });
     });
@@ -192,6 +194,32 @@ describe('createEmailTokenStore', () => {
             expect(mockDel).toHaveBeenCalledWith(
                 'email_token:password_reset:user@example.com'
             );
+        });
+
+        it('consume delegates to writer.getdel with the namespaced key and returns the value', async () => {
+            const stored: EmailTokenValue = {
+                status: 'pending',
+                tokenHash: 'hash',
+            };
+            const mockGetdel = vi.fn().mockResolvedValue(stored);
+            MockRedis.mockImplementation(function () {
+                return {
+                    get: vi.fn(),
+                    set: vi.fn(),
+                    del: vi.fn(),
+                    getdel: mockGetdel,
+                };
+            });
+
+            const store = createEmailTokenStore()!;
+            const result = await store.consume(
+                'password_reset',
+                'user@example.com'
+            );
+            expect(mockGetdel).toHaveBeenCalledWith(
+                'email_token:password_reset:user@example.com'
+            );
+            expect(result).toEqual(stored);
         });
     });
 

--- a/src/entities/email-token/__tests__/api.test.ts
+++ b/src/entities/email-token/__tests__/api.test.ts
@@ -11,8 +11,8 @@ vi.mock('@upstash/redis', () => {
 });
 
 import { Redis } from '@upstash/redis';
+import { __resetRedisClientForTests } from '@/shared/cache/redisClient';
 import {
-    __resetEmailTokenStoreCacheForTests,
     buildEmailTokenKey,
     createEmailTokenStore,
     type EmailTokenValue,
@@ -50,7 +50,7 @@ describe('createEmailTokenStore', () => {
         delete process.env.UPSTASH_REDIS_REST_URL;
         delete process.env.UPSTASH_REDIS_REST_TOKEN;
         delete process.env.UPSTASH_REDIS_REST_READONLY_TOKEN;
-        __resetEmailTokenStoreCacheForTests();
+        __resetRedisClientForTests();
         MockRedis.mockReset();
         MockRedis.mockImplementation(function () {
             return {
@@ -206,7 +206,7 @@ describe('createEmailTokenStore', () => {
         const callsAfterUnset = MockRedis.mock.calls.length;
 
         // Reset the shared singleton so that the env change is picked up on the next call.
-        __resetEmailTokenStoreCacheForTests();
+        __resetRedisClientForTests();
 
         // Now configure a readonly token equal to the empty string. With the
         // old `?? ''` sentinel, this would collide with the unset case (config

--- a/src/entities/email-token/api.ts
+++ b/src/entities/email-token/api.ts
@@ -1,7 +1,4 @@
-import {
-    getRedisReaderWriter,
-    __resetRedisClientForTests,
-} from '@/shared/cache/redisClient';
+import { getRedisReaderWriter } from '@/shared/cache/redisClient';
 
 /** Purpose tag namespacing email-token Redis keys so password-reset and email-verification tokens for the same email never collide. */
 export type EmailTokenPurpose = 'password_reset' | 'email_verification';
@@ -40,11 +37,6 @@ export interface EmailTokenStore {
 }
 
 const KEY_PREFIX = 'email_token';
-
-/** Test-only reset of the cached Redis client. Delegates to the shared module. */
-export function __resetEmailTokenStoreCacheForTests(): void {
-    __resetRedisClientForTests();
-}
 
 /** Build the Redis key for an email-token entry. */
 export function buildEmailTokenKey(

--- a/src/entities/email-token/api.ts
+++ b/src/entities/email-token/api.ts
@@ -1,4 +1,7 @@
-import { Redis } from '@upstash/redis';
+import {
+    getRedisReaderWriter,
+    __resetRedisClientForTests,
+} from '@/shared/cache/redisClient';
 
 /** Purpose tag namespacing email-token Redis keys so password-reset and email-verification tokens for the same email never collide. */
 export type EmailTokenPurpose = 'password_reset' | 'email_verification';
@@ -38,37 +41,9 @@ export interface EmailTokenStore {
 
 const KEY_PREFIX = 'email_token';
 
-interface UpstashConfig {
-    url: string;
-    token: string;
-    /** Optional read-only token; null when the env var is unset (no separate reader is created in that case). */
-    readonlyToken: string | null;
-}
-
-interface RedisPair {
-    writer: Redis;
-    reader: Redis;
-}
-
-let cachedRedisPair: RedisPair | null = null;
-let cachedConfigKey: string | null = null;
-
-function readUpstashConfig(): UpstashConfig | null {
-    const url = process.env.UPSTASH_REDIS_REST_URL;
-    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-    if (!url || !token) return null;
-    // Treat empty string as "unset" so a literal empty env var doesn't collide
-    // with a real readonly token in the cache key below.
-    const rawReadonly = process.env.UPSTASH_REDIS_REST_READONLY_TOKEN;
-    const readonlyToken =
-        rawReadonly === undefined || rawReadonly === '' ? null : rawReadonly;
-    return { url, token, readonlyToken };
-}
-
-/** Test-only reset of the cached Redis client pair. */
+/** Test-only reset of the cached Redis client. Delegates to the shared module. */
 export function __resetEmailTokenStoreCacheForTests(): void {
-    cachedRedisPair = null;
-    cachedConfigKey = null;
+    __resetRedisClientForTests();
 }
 
 /** Build the Redis key for an email-token entry. */
@@ -79,34 +54,11 @@ export function buildEmailTokenKey(
     return `${KEY_PREFIX}:${purpose}:${email}`;
 }
 
-function getRedisPair(config: UpstashConfig): RedisPair {
-    // Encode "no readonly token" distinctly from "configured empty string" so a
-    // future change in env handling can never collide identities. The 2-segment
-    // form is reserved for the unset case; the 3-segment form for configured.
-    const configKey =
-        config.readonlyToken === null
-            ? `${config.url}:${config.token}`
-            : `${config.url}:${config.token}:${config.readonlyToken}`;
-    if (cachedRedisPair !== null && cachedConfigKey === configKey) {
-        return cachedRedisPair;
-    }
-
-    const writer = new Redis({ url: config.url, token: config.token });
-    const reader =
-        config.readonlyToken !== null
-            ? new Redis({ url: config.url, token: config.readonlyToken })
-            : writer;
-    cachedRedisPair = { writer, reader };
-    cachedConfigKey = configKey;
-    return cachedRedisPair;
-}
-
 /** Upstash Redis 기반 EmailTokenStore 생성 — 환경변수 부재 시 null (caller가 graceful degrade 결정). */
 export function createEmailTokenStore(): EmailTokenStore | null {
-    const config = readUpstashConfig();
-    if (!config) return null;
-
-    const { writer, reader } = getRedisPair(config);
+    const pair = getRedisReaderWriter();
+    if (pair === null) return null;
+    const { writer, reader } = pair;
 
     return {
         async set(purpose, email, value, ttlSeconds) {

--- a/src/entities/news-article/lib/newsRefreshFlag.ts
+++ b/src/entities/news-article/lib/newsRefreshFlag.ts
@@ -1,22 +1,9 @@
 import 'server-only';
-import { Redis } from '@upstash/redis';
+import { getRedisClient } from '@/shared/cache/redisClient';
 import { SECONDS_PER_MINUTE } from '@/shared/config/time';
 
 /** 뉴스 refresh 플래그 TTL — 이 시간 내 재크롤링(봇)은 FMP fetch+upsert를 스킵. */
 export const NEWS_REFRESH_FLAG_TTL_SECONDS = 10 * SECONDS_PER_MINUTE;
-
-let cachedRedis: Redis | null | undefined;
-function getRedis(): Redis | null {
-    if (cachedRedis !== undefined) return cachedRedis;
-    const url = process.env.UPSTASH_REDIS_REST_URL;
-    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-    if (!url || !token) {
-        cachedRedis = null;
-        return null;
-    }
-    cachedRedis = new Redis({ url, token });
-    return cachedRedis;
-}
 
 function buildKey(symbol: string): string {
     return `news:refresh:${symbol.toUpperCase()}`;
@@ -24,7 +11,7 @@ function buildKey(symbol: string): string {
 
 /** 최근(TTL 내) 이 symbol의 뉴스를 fetch했는지. Redis 미설정/장애 시 false(=항상 fetch). */
 export async function isRecentlyFetched(symbol: string): Promise<boolean> {
-    const redis = getRedis();
+    const redis = getRedisClient();
     if (redis === null) return false;
     try {
         return (await redis.get(buildKey(symbol))) !== null;
@@ -36,7 +23,7 @@ export async function isRecentlyFetched(symbol: string): Promise<boolean> {
 
 /** 이 symbol을 "최근 fetch함"으로 표시. Redis 미설정/장애 시 noop. */
 export async function markFetched(symbol: string): Promise<void> {
-    const redis = getRedis();
+    const redis = getRedisClient();
     if (redis === null) return;
     try {
         await redis.set(buildKey(symbol), '1', {

--- a/src/entities/oauth-account/lib/pendingOAuthSignupStore.ts
+++ b/src/entities/oauth-account/lib/pendingOAuthSignupStore.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
-import { Redis } from '@upstash/redis';
+import type { Redis } from '@upstash/redis';
+import { getRedisClient } from '@/shared/cache/redisClient';
 import type { SupportedOAuthProvider } from '@/shared/lib/types';
 
 const NAMESPACE = 'pending_oauth_signup';
@@ -74,9 +75,7 @@ export function createPendingOAuthSignupStore(
 
 /** Factory that reads Redis env vars and returns a store, or null if unavailable. */
 export function createPendingOAuthSignupStoreFromEnv(): PendingOAuthSignupStore | null {
-    const url = process.env.UPSTASH_REDIS_REST_URL;
-    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-    if (!url || !token) return null;
-    const client = new Redis({ url, token });
+    const client = getRedisClient();
+    if (client === null) return null;
     return createPendingOAuthSignupStore(client);
 }

--- a/src/entities/oauth-account/lib/pendingOAuthSignupStore.ts
+++ b/src/entities/oauth-account/lib/pendingOAuthSignupStore.ts
@@ -1,10 +1,11 @@
 import crypto from 'crypto';
 import type { Redis } from '@upstash/redis';
 import { getRedisClient } from '@/shared/cache/redisClient';
+import { SECONDS_PER_MINUTE } from '@/shared/config/time';
 import type { SupportedOAuthProvider } from '@/shared/lib/types';
 
 const NAMESPACE = 'pending_oauth_signup';
-const TTL_SECONDS = 600;
+const TTL_SECONDS = 10 * SECONDS_PER_MINUTE;
 
 export interface PendingOAuthSignup {
     provider: SupportedOAuthProvider;

--- a/src/entities/options-chain/lib/optionsDataCache.ts
+++ b/src/entities/options-chain/lib/optionsDataCache.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { cache } from 'react';
-import { Redis } from '@upstash/redis';
+import { getRedisClient } from '@/shared/cache/redisClient';
 import { SECONDS_PER_HOUR, SECONDS_PER_MINUTE } from '@/shared/config/time';
 import { YahooOptionsAdapter } from './YahooOptionsAdapter';
 import {
@@ -38,22 +38,6 @@ export const OPTIONS_SNAPSHOT_TTL_SECONDS: Record<
     'options-weekend': 4 * SECONDS_PER_HOUR,
 };
 
-// tokenStore.ts / pendingOAuthSignupStore.ts와 같은 lazy-singleton 패턴.
-let cachedRedis: Redis | null | undefined;
-
-function getRedis(): Redis | null {
-    if (cachedRedis !== undefined) return cachedRedis;
-    const url = process.env.UPSTASH_REDIS_REST_URL;
-    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-    if (!url || !token) {
-        // Redis 미설정(로컬 dev 등)에서는 fetch 직행 — graceful fallback.
-        cachedRedis = null;
-        return null;
-    }
-    cachedRedis = new Redis({ url, token });
-    return cachedRedis;
-}
-
 function buildHasOptionsKey(symbol: string): string {
     return `options:has-market:${symbol.toUpperCase()}`;
 }
@@ -74,7 +58,7 @@ function buildSnapshotKey(symbol: string): string {
 export const hasOptionsMarket = cache(
     async (symbol: string): Promise<boolean> => {
         const key = buildHasOptionsKey(symbol);
-        const redis = getRedis();
+        const redis = getRedisClient();
         if (redis !== null) {
             try {
                 const cached = await redis.get<boolean>(key);
@@ -140,7 +124,7 @@ export const hasOptionsMarket = cache(
 export const fetchOptionsSnapshot = cache(
     async (symbol: string): Promise<OptionsSnapshot | null> => {
         const key = buildSnapshotKey(symbol);
-        const redis = getRedis();
+        const redis = getRedisClient();
         if (redis !== null) {
             try {
                 const cached = await redis.get<OptionsSnapshot>(key);

--- a/src/shared/cache/__tests__/redisClient.test.ts
+++ b/src/shared/cache/__tests__/redisClient.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockRedisConstructor } = vi.hoisted(() => ({
+    mockRedisConstructor: vi.fn(),
+}));
+
+vi.mock('@upstash/redis', () => ({
+    Redis: vi.fn().mockImplementation(function (opts: unknown) {
+        mockRedisConstructor(opts);
+        return { __opts: opts };
+    }),
+}));
+
+import {
+    getRedisClient,
+    getRedisReaderWriter,
+    __resetRedisClientForTests,
+} from '@/shared/cache/redisClient';
+
+const URL = 'https://test.upstash.io';
+const TOKEN = 'writer-token';
+const RO = 'readonly-token';
+
+beforeEach(() => {
+    __resetRedisClientForTests();
+    mockRedisConstructor.mockClear();
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    delete process.env.UPSTASH_REDIS_REST_READONLY_TOKEN;
+});
+
+describe('getRedisClient', () => {
+    it('env 미설정 시 null을 반환하고 Redis를 생성하지 않는다', () => {
+        expect(getRedisClient()).toBeNull();
+        expect(mockRedisConstructor).not.toHaveBeenCalled();
+    });
+
+    it('env 설정 시 반복 호출이 동일 인스턴스를 반환한다(싱글톤)', () => {
+        process.env.UPSTASH_REDIS_REST_URL = URL;
+        process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
+        const a = getRedisClient();
+        const b = getRedisClient();
+        expect(a).not.toBeNull();
+        expect(a).toBe(b);
+        expect(mockRedisConstructor).toHaveBeenCalledTimes(1);
+        expect(mockRedisConstructor).toHaveBeenCalledWith({
+            url: URL,
+            token: TOKEN,
+        });
+    });
+});
+
+describe('getRedisReaderWriter', () => {
+    it('env 미설정 시 null', () => {
+        expect(getRedisReaderWriter()).toBeNull();
+    });
+
+    it('readonly token 미설정 시 reader === writer 이고 writer === getRedisClient()', () => {
+        process.env.UPSTASH_REDIS_REST_URL = URL;
+        process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
+        const pair = getRedisReaderWriter();
+        expect(pair).not.toBeNull();
+        expect(pair!.reader).toBe(pair!.writer);
+        expect(pair!.writer).toBe(getRedisClient());
+        expect(mockRedisConstructor).toHaveBeenCalledTimes(1);
+    });
+
+    it('readonly token 설정 시 reader는 별도 인스턴스(readonly 토큰)', () => {
+        process.env.UPSTASH_REDIS_REST_URL = URL;
+        process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
+        process.env.UPSTASH_REDIS_REST_READONLY_TOKEN = RO;
+        const pair = getRedisReaderWriter();
+        expect(pair!.reader).not.toBe(pair!.writer);
+        expect(pair!.writer).toBe(getRedisClient());
+        expect(mockRedisConstructor).toHaveBeenCalledTimes(2);
+        expect(mockRedisConstructor).toHaveBeenNthCalledWith(1, {
+            url: URL,
+            token: TOKEN,
+        });
+        expect(mockRedisConstructor).toHaveBeenNthCalledWith(2, {
+            url: URL,
+            token: RO,
+        });
+    });
+
+    it('빈 문자열 readonly token은 미설정으로 취급한다(reader === writer)', () => {
+        process.env.UPSTASH_REDIS_REST_URL = URL;
+        process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
+        process.env.UPSTASH_REDIS_REST_READONLY_TOKEN = '';
+        const pair = getRedisReaderWriter();
+        expect(pair!.reader).toBe(pair!.writer);
+    });
+});

--- a/src/shared/cache/__tests__/redisClient.test.ts
+++ b/src/shared/cache/__tests__/redisClient.test.ts
@@ -89,5 +89,16 @@ describe('redisClient', () => {
             const pair = getRedisReaderWriter();
             expect(pair!.reader).toBe(pair!.writer);
         });
+
+        it('두 번 호출해도 Redis constructor가 추가로 호출되지 않는다(reader 싱글톤 히트)', () => {
+            process.env.UPSTASH_REDIS_REST_URL = URL;
+            process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
+            process.env.UPSTASH_REDIS_REST_READONLY_TOKEN = RO;
+            const first = getRedisReaderWriter();
+            const second = getRedisReaderWriter();
+            expect(mockRedisConstructor).toHaveBeenCalledTimes(2); // writer + reader, once each
+            expect(first!.reader).toBe(second!.reader);
+            expect(first!.writer).toBe(second!.writer);
+        });
     });
 });

--- a/src/shared/cache/__tests__/redisClient.test.ts
+++ b/src/shared/cache/__tests__/redisClient.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-
 const { mockRedisConstructor } = vi.hoisted(() => ({
     mockRedisConstructor: vi.fn(),
 }));

--- a/src/shared/cache/__tests__/redisClient.test.ts
+++ b/src/shared/cache/__tests__/redisClient.test.ts
@@ -19,73 +19,75 @@ const URL = 'https://test.upstash.io';
 const TOKEN = 'writer-token';
 const RO = 'readonly-token';
 
-beforeEach(() => {
-    __resetRedisClientForTests();
-    mockRedisConstructor.mockClear();
-    delete process.env.UPSTASH_REDIS_REST_URL;
-    delete process.env.UPSTASH_REDIS_REST_TOKEN;
-    delete process.env.UPSTASH_REDIS_REST_READONLY_TOKEN;
-});
-
-describe('getRedisClient', () => {
-    it('env 미설정 시 null을 반환하고 Redis를 생성하지 않는다', () => {
-        expect(getRedisClient()).toBeNull();
-        expect(mockRedisConstructor).not.toHaveBeenCalled();
+describe('redisClient', () => {
+    beforeEach(() => {
+        __resetRedisClientForTests();
+        mockRedisConstructor.mockClear();
+        delete process.env.UPSTASH_REDIS_REST_URL;
+        delete process.env.UPSTASH_REDIS_REST_TOKEN;
+        delete process.env.UPSTASH_REDIS_REST_READONLY_TOKEN;
     });
 
-    it('env 설정 시 반복 호출이 동일 인스턴스를 반환한다(싱글톤)', () => {
-        process.env.UPSTASH_REDIS_REST_URL = URL;
-        process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
-        const a = getRedisClient();
-        const b = getRedisClient();
-        expect(a).not.toBeNull();
-        expect(a).toBe(b);
-        expect(mockRedisConstructor).toHaveBeenCalledTimes(1);
-        expect(mockRedisConstructor).toHaveBeenCalledWith({
-            url: URL,
-            token: TOKEN,
+    describe('getRedisClient', () => {
+        it('env 미설정 시 null을 반환하고 Redis를 생성하지 않는다', () => {
+            expect(getRedisClient()).toBeNull();
+            expect(mockRedisConstructor).not.toHaveBeenCalled();
         });
-    });
-});
 
-describe('getRedisReaderWriter', () => {
-    it('env 미설정 시 null', () => {
-        expect(getRedisReaderWriter()).toBeNull();
-    });
-
-    it('readonly token 미설정 시 reader === writer 이고 writer === getRedisClient()', () => {
-        process.env.UPSTASH_REDIS_REST_URL = URL;
-        process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
-        const pair = getRedisReaderWriter();
-        expect(pair).not.toBeNull();
-        expect(pair!.reader).toBe(pair!.writer);
-        expect(pair!.writer).toBe(getRedisClient());
-        expect(mockRedisConstructor).toHaveBeenCalledTimes(1);
-    });
-
-    it('readonly token 설정 시 reader는 별도 인스턴스(readonly 토큰)', () => {
-        process.env.UPSTASH_REDIS_REST_URL = URL;
-        process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
-        process.env.UPSTASH_REDIS_REST_READONLY_TOKEN = RO;
-        const pair = getRedisReaderWriter();
-        expect(pair!.reader).not.toBe(pair!.writer);
-        expect(pair!.writer).toBe(getRedisClient());
-        expect(mockRedisConstructor).toHaveBeenCalledTimes(2);
-        expect(mockRedisConstructor).toHaveBeenNthCalledWith(1, {
-            url: URL,
-            token: TOKEN,
-        });
-        expect(mockRedisConstructor).toHaveBeenNthCalledWith(2, {
-            url: URL,
-            token: RO,
+        it('env 설정 시 반복 호출이 동일 인스턴스를 반환한다(싱글톤)', () => {
+            process.env.UPSTASH_REDIS_REST_URL = URL;
+            process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
+            const a = getRedisClient();
+            const b = getRedisClient();
+            expect(a).not.toBeNull();
+            expect(a).toBe(b);
+            expect(mockRedisConstructor).toHaveBeenCalledTimes(1);
+            expect(mockRedisConstructor).toHaveBeenCalledWith({
+                url: URL,
+                token: TOKEN,
+            });
         });
     });
 
-    it('빈 문자열 readonly token은 미설정으로 취급한다(reader === writer)', () => {
-        process.env.UPSTASH_REDIS_REST_URL = URL;
-        process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
-        process.env.UPSTASH_REDIS_REST_READONLY_TOKEN = '';
-        const pair = getRedisReaderWriter();
-        expect(pair!.reader).toBe(pair!.writer);
+    describe('getRedisReaderWriter', () => {
+        it('env 미설정 시 null', () => {
+            expect(getRedisReaderWriter()).toBeNull();
+        });
+
+        it('readonly token 미설정 시 reader === writer 이고 writer === getRedisClient()', () => {
+            process.env.UPSTASH_REDIS_REST_URL = URL;
+            process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
+            const pair = getRedisReaderWriter();
+            expect(pair).not.toBeNull();
+            expect(pair!.reader).toBe(pair!.writer);
+            expect(pair!.writer).toBe(getRedisClient());
+            expect(mockRedisConstructor).toHaveBeenCalledTimes(1);
+        });
+
+        it('readonly token 설정 시 reader는 별도 인스턴스(readonly 토큰)', () => {
+            process.env.UPSTASH_REDIS_REST_URL = URL;
+            process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
+            process.env.UPSTASH_REDIS_REST_READONLY_TOKEN = RO;
+            const pair = getRedisReaderWriter();
+            expect(pair!.reader).not.toBe(pair!.writer);
+            expect(pair!.writer).toBe(getRedisClient());
+            expect(mockRedisConstructor).toHaveBeenCalledTimes(2);
+            expect(mockRedisConstructor).toHaveBeenNthCalledWith(1, {
+                url: URL,
+                token: TOKEN,
+            });
+            expect(mockRedisConstructor).toHaveBeenNthCalledWith(2, {
+                url: URL,
+                token: RO,
+            });
+        });
+
+        it('빈 문자열 readonly token은 미설정으로 취급한다(reader === writer)', () => {
+            process.env.UPSTASH_REDIS_REST_URL = URL;
+            process.env.UPSTASH_REDIS_REST_TOKEN = TOKEN;
+            process.env.UPSTASH_REDIS_REST_READONLY_TOKEN = '';
+            const pair = getRedisReaderWriter();
+            expect(pair!.reader).toBe(pair!.writer);
+        });
     });
 });

--- a/src/shared/cache/redisClient.ts
+++ b/src/shared/cache/redisClient.ts
@@ -1,0 +1,66 @@
+import { Redis } from '@upstash/redis';
+
+interface UpstashEnv {
+    url: string;
+    token: string;
+    /** Read-only token; null when the env var is unset or empty (no separate reader created). */
+    readonlyToken: string | null;
+}
+
+// undefined = not yet initialized; null = env not configured (graceful fallback).
+let cachedWriter: Redis | null | undefined;
+let cachedReader: Redis | null | undefined;
+
+function readUpstashEnv(): UpstashEnv | null {
+    const url = process.env.UPSTASH_REDIS_REST_URL;
+    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+    if (!url || !token) return null;
+    // Treat empty string as "unset" so a literal empty env var doesn't create a reader.
+    const raw = process.env.UPSTASH_REDIS_REST_READONLY_TOKEN;
+    const readonlyToken = raw === undefined || raw === '' ? null : raw;
+    return { url, token, readonlyToken };
+}
+
+/**
+ * The app's shared Upstash Redis writer client (singleton).
+ *
+ * Returns `null` when `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` are
+ * not set, so callers can degrade gracefully (cache miss / direct fetch) in
+ * environments without Redis (local dev, tests).
+ */
+export function getRedisClient(): Redis | null {
+    if (cachedWriter !== undefined) return cachedWriter;
+    const env = readUpstashEnv();
+    cachedWriter = env ? new Redis({ url: env.url, token: env.token }) : null;
+    return cachedWriter;
+}
+
+/**
+ * Writer + reader pair (singleton). When `UPSTASH_REDIS_REST_READONLY_TOKEN` is
+ * set, `reader` uses the read-only token; otherwise `reader === writer`. The
+ * `writer` is the same instance returned by {@link getRedisClient}. Returns
+ * `null` when Redis env is not configured.
+ */
+export function getRedisReaderWriter(): {
+    writer: Redis;
+    reader: Redis;
+} | null {
+    const writer = getRedisClient();
+    if (writer === null) return null;
+    if (cachedReader === undefined) {
+        // writer is non-null here, so readUpstashEnv() is also non-null.
+        const env = readUpstashEnv()!;
+        cachedReader =
+            env.readonlyToken !== null
+                ? new Redis({ url: env.url, token: env.readonlyToken })
+                : writer;
+    }
+    // cachedReader is always set to a Redis instance above (never null); assert non-null.
+    return { writer, reader: cachedReader! };
+}
+
+/** @internal Reset the cached singletons between test runs. */
+export function __resetRedisClientForTests(): void {
+    cachedWriter = undefined;
+    cachedReader = undefined;
+}

--- a/src/shared/cache/redisClient.ts
+++ b/src/shared/cache/redisClient.ts
@@ -16,7 +16,8 @@ interface UpstashEnv {
 // undefined = not yet initialized; null = env not configured (graceful fallback).
 let cachedWriter: Redis | null | undefined;
 let cachedEnv: UpstashEnv | null | undefined;
-// undefined until first getRedisReaderWriter() call; then the writer or a readonly client.
+// No null state: once initialized, reader is always a Redis instance
+// (either the writer itself or a dedicated readonly client).
 let cachedReader: Redis | undefined;
 
 function getUpstashEnv(): UpstashEnv | null {

--- a/src/shared/cache/redisClient.ts
+++ b/src/shared/cache/redisClient.ts
@@ -1,4 +1,10 @@
+import 'server-only';
 import { Redis } from '@upstash/redis';
+
+interface RedisClientPair {
+    writer: Redis;
+    reader: Redis;
+}
 
 interface UpstashEnv {
     url: string;
@@ -41,10 +47,7 @@ export function getRedisClient(): Redis | null {
  * `writer` is the same instance returned by {@link getRedisClient}. Returns
  * `null` when Redis env is not configured.
  */
-export function getRedisReaderWriter(): {
-    writer: Redis;
-    reader: Redis;
-} | null {
+export function getRedisReaderWriter(): RedisClientPair | null {
     const writer = getRedisClient();
     if (writer === null) return null;
     if (cachedReader === undefined) {
@@ -59,7 +62,7 @@ export function getRedisReaderWriter(): {
     return { writer, reader: cachedReader! };
 }
 
-/** @internal Reset the cached singletons between test runs. */
+/** Reset the cached singletons between test runs. */
 export function __resetRedisClientForTests(): void {
     cachedWriter = undefined;
     cachedReader = undefined;

--- a/src/shared/cache/redisClient.ts
+++ b/src/shared/cache/redisClient.ts
@@ -15,8 +15,9 @@ interface UpstashEnv {
 
 // undefined = not yet initialized; null = env not configured (graceful fallback).
 let cachedWriter: Redis | null | undefined;
-let cachedReader: Redis | null | undefined;
 let cachedEnv: UpstashEnv | null | undefined;
+// undefined until first getRedisReaderWriter() call; then the writer or a readonly client.
+let cachedReader: Redis | undefined;
 
 function getUpstashEnv(): UpstashEnv | null {
     if (cachedEnv === undefined) cachedEnv = readUpstashEnv();
@@ -64,8 +65,7 @@ export function getRedisReaderWriter(): RedisClientPair | null {
                 ? new Redis({ url: env.url, token: env.readonlyToken })
                 : writer;
     }
-    // cachedReader is always set to a Redis instance above (never null); assert non-null.
-    return { writer, reader: cachedReader! };
+    return { writer, reader: cachedReader };
 }
 
 /** Reset the cached singletons between test runs. */

--- a/src/shared/cache/redisClient.ts
+++ b/src/shared/cache/redisClient.ts
@@ -16,6 +16,12 @@ interface UpstashEnv {
 // undefined = not yet initialized; null = env not configured (graceful fallback).
 let cachedWriter: Redis | null | undefined;
 let cachedReader: Redis | null | undefined;
+let cachedEnv: UpstashEnv | null | undefined;
+
+function getUpstashEnv(): UpstashEnv | null {
+    if (cachedEnv === undefined) cachedEnv = readUpstashEnv();
+    return cachedEnv;
+}
 
 function readUpstashEnv(): UpstashEnv | null {
     const url = process.env.UPSTASH_REDIS_REST_URL;
@@ -36,7 +42,7 @@ function readUpstashEnv(): UpstashEnv | null {
  */
 export function getRedisClient(): Redis | null {
     if (cachedWriter !== undefined) return cachedWriter;
-    const env = readUpstashEnv();
+    const env = getUpstashEnv();
     cachedWriter = env ? new Redis({ url: env.url, token: env.token }) : null;
     return cachedWriter;
 }
@@ -51,8 +57,8 @@ export function getRedisReaderWriter(): RedisClientPair | null {
     const writer = getRedisClient();
     if (writer === null) return null;
     if (cachedReader === undefined) {
-        // writer is non-null here, so readUpstashEnv() is also non-null.
-        const env = readUpstashEnv()!;
+        // writer is non-null here, so getUpstashEnv() is also non-null.
+        const env = getUpstashEnv()!;
         cachedReader =
             env.readonlyToken !== null
                 ? new Redis({ url: env.url, token: env.readonlyToken })
@@ -66,4 +72,5 @@ export function getRedisReaderWriter(): RedisClientPair | null {
 export function __resetRedisClientForTests(): void {
     cachedWriter = undefined;
     cachedReader = undefined;
+    cachedEnv = undefined;
 }

--- a/src/shared/cache/redisClient.ts
+++ b/src/shared/cache/redisClient.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 import { Redis } from '@upstash/redis';
 
-interface RedisClientPair {
+export interface RedisClientPair {
     writer: Redis;
     reader: Redis;
 }


### PR DESCRIPTION
## Summary
- Centralize all Upstash Redis client construction into `src/shared/cache/redisClient.ts` — `getRedisClient(): Redis | null` (singleton writer, null when unconfigured) and `getRedisReaderWriter(): { writer, reader } | null` (readonly-token aware, shares the writer instance), plus `__resetRedisClientForTests()`.
- Migrate the 5 consumers that each built their own client — `optionsDataCache`, `newsRefreshFlag`, `barsDataCache`, `pendingOAuthSignupStore`, `email-token/api` — to import from the shared module. Removes the duplicated `UPSTASH_REDIS_REST_*` env-reading + `new Redis(...)` (now only in `redisClient.ts`).
- Behavior preserved: graceful null fallback (Redis-unconfigured → degrade), key builders, TTLs, store interfaces, and the email-token writer/reader (readonly-token) split. `pendingOAuthSignupStore` now reuses the singleton instead of constructing a client per call.

## Test plan
- [x] \`yarn typecheck\` — clean
- [x] \`yarn lint\` — clean
- [x] \`yarn test\` — 4456 passed (incl. new \`shared/cache/__tests__/redisClient.test.ts\`: null / singleton / readonly-token cases)
- [x] \`next build\` via pre-push \`build:local\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)