### PR TITLE
feat: cache dashboard market summary (cut bot-driven FMP quote cost)

### DIFF
--- a/src/entities/market-summary/__tests__/getMarketSummaryAction.test.ts
+++ b/src/entities/market-summary/__tests__/getMarketSummaryAction.test.ts
@@ -141,7 +141,7 @@ describe('getMarketSummaryAction 함수는', () => {
             expect(result).toEqual({ ok: false, error: 'server_error' });
         });
 
-        it('submitBriefing 예외 시 에러 결과를 반환한다', async () => {
+        it('submitBriefing 예외 시 briefing: null을 반환하고 에러를 발생시키지 않는다', async () => {
             mockIsBot.mockReturnValue(false);
             mockSubmitBriefing.mockRejectedValueOnce(
                 new Error('briefing failed')
@@ -149,7 +149,11 @@ describe('getMarketSummaryAction 함수는', () => {
 
             const result = await getMarketSummaryAction();
 
-            expect(result).toEqual({ ok: false, error: 'server_error' });
+            expect(result).toEqual({
+                summary: summaryData,
+                briefing: null,
+                botBlocked: false,
+            });
         });
 
         it('봇 요청에서 getCachedMarketSummary 예외 시 에러 결과를 반환한다', async () => {

--- a/src/entities/market-summary/__tests__/getMarketSummaryAction.test.ts
+++ b/src/entities/market-summary/__tests__/getMarketSummaryAction.test.ts
@@ -1,17 +1,22 @@
 import type { MockedFunction } from 'vitest';
 import { getMarketSummaryAction } from '../actions/getMarketSummaryAction';
 import {
-    getMarketSummary,
-    getMarketSummaryWithBriefing,
+    submitBriefing,
     type MarketSummaryData,
-    type MarketSummaryWithBriefing,
+    type SubmitBriefingResult,
 } from '@y0ngha/siglens-core';
 import { isBot } from '@/shared/api/isBot';
+import { getCachedMarketSummary } from '../lib/marketSummaryCache';
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('../lib/marketSummaryCache', () => ({
+    getCachedMarketSummary: vi.fn(),
+}));
 
 vi.mock('@y0ngha/siglens-core', async () => ({
     ...(await vi.importActual('@y0ngha/siglens-core')),
-    getMarketSummaryWithBriefing: vi.fn(),
-    getMarketSummary: vi.fn(),
+    submitBriefing: vi.fn(),
 }));
 
 vi.mock('next/headers', () => ({
@@ -27,57 +32,45 @@ vi.mock('@/shared/api/market/getMarketDataProvider', () => ({
     getMarketDataProvider: vi.fn(() => mockProvider),
 }));
 
-const mockGetSummaryWithBriefing =
-    getMarketSummaryWithBriefing as MockedFunction<
-        typeof getMarketSummaryWithBriefing
-    >;
-const mockGetSummary = getMarketSummary as MockedFunction<
-    typeof getMarketSummary
+const mockGetCachedMarketSummary = getCachedMarketSummary as MockedFunction<
+    typeof getCachedMarketSummary
+>;
+const mockSubmitBriefing = submitBriefing as MockedFunction<
+    typeof submitBriefing
 >;
 const mockIsBot = isBot as MockedFunction<typeof isBot>;
 
-const summaryData: MarketSummaryData = { indices: [], sectors: [] };
+const summaryData: MarketSummaryData = {
+    indices: [
+        {
+            symbol: 'SPY',
+            fmpSymbol: '^GSPC',
+            displayName: 'S&P 500',
+            koreanName: 'S&P 500',
+            price: 5000,
+            changesPercentage: 0.5,
+        },
+    ],
+    sectors: [
+        {
+            symbol: 'XLK',
+            sectorName: 'Technology',
+            koreanName: '기술',
+            price: 200,
+            changesPercentage: 1.2,
+        },
+    ],
+};
 
-const summaryWithBriefing: MarketSummaryWithBriefing = {
-    summary: summaryData,
-    briefing: { status: 'submitted', jobId: 'test-job-id' },
+const briefingResult: SubmitBriefingResult = {
+    status: 'submitted',
+    jobId: 'test-job-id',
 };
 
 describe('getMarketSummaryAction 함수는', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-    });
-
-    describe('일반 사용자 요청 시', () => {
-        beforeEach(() => {
-            mockIsBot.mockReturnValue(false);
-        });
-
-        it('getMarketSummaryWithBriefing을 호출한다', async () => {
-            mockGetSummaryWithBriefing.mockResolvedValueOnce(
-                summaryWithBriefing
-            );
-
-            await getMarketSummaryAction();
-
-            expect(mockGetSummaryWithBriefing).toHaveBeenCalledWith(
-                mockProvider
-            );
-            expect(mockGetSummary).not.toHaveBeenCalled();
-        });
-
-        it('briefing과 botBlocked: false를 포함한 결과를 반환한다', async () => {
-            mockGetSummaryWithBriefing.mockResolvedValueOnce(
-                summaryWithBriefing
-            );
-
-            const result = await getMarketSummaryAction();
-
-            expect(result).toEqual({
-                ...summaryWithBriefing,
-                botBlocked: false,
-            });
-        });
+        mockGetCachedMarketSummary.mockResolvedValue(summaryData);
     });
 
     describe('봇 요청 시', () => {
@@ -85,18 +78,21 @@ describe('getMarketSummaryAction 함수는', () => {
             mockIsBot.mockReturnValue(true);
         });
 
-        it('getMarketSummary만 호출한다 (briefing 없이)', async () => {
-            mockGetSummary.mockResolvedValueOnce(summaryData);
-
+        it('getCachedMarketSummary를 호출한다', async () => {
             await getMarketSummaryAction();
 
-            expect(mockGetSummary).toHaveBeenCalledWith(mockProvider);
-            expect(mockGetSummaryWithBriefing).not.toHaveBeenCalled();
+            expect(mockGetCachedMarketSummary).toHaveBeenCalledWith(
+                mockProvider
+            );
+        });
+
+        it('submitBriefing을 호출하지 않는다', async () => {
+            await getMarketSummaryAction();
+
+            expect(mockSubmitBriefing).not.toHaveBeenCalled();
         });
 
         it('briefing: null과 botBlocked: true를 반환한다', async () => {
-            mockGetSummary.mockResolvedValueOnce(summaryData);
-
             const result = await getMarketSummaryAction();
 
             expect(result).toEqual({
@@ -107,10 +103,36 @@ describe('getMarketSummaryAction 함수는', () => {
         });
     });
 
-    describe('API 에러 발생 시', () => {
-        it('일반 사용자 요청에서 예외가 발생하면 에러 결과를 반환한다', async () => {
+    describe('일반 사용자 요청 시', () => {
+        beforeEach(() => {
             mockIsBot.mockReturnValue(false);
-            mockGetSummaryWithBriefing.mockRejectedValueOnce(
+            mockSubmitBriefing.mockResolvedValue(briefingResult);
+        });
+
+        it('getCachedMarketSummary와 submitBriefing(summary)를 호출한다', async () => {
+            await getMarketSummaryAction();
+
+            expect(mockGetCachedMarketSummary).toHaveBeenCalledWith(
+                mockProvider
+            );
+            expect(mockSubmitBriefing).toHaveBeenCalledWith(summaryData);
+        });
+
+        it('briefing과 botBlocked: false를 포함한 결과를 반환한다', async () => {
+            const result = await getMarketSummaryAction();
+
+            expect(result).toEqual({
+                summary: summaryData,
+                briefing: briefingResult,
+                botBlocked: false,
+            });
+        });
+    });
+
+    describe('API 에러 발생 시', () => {
+        it('getCachedMarketSummary 예외 시 에러 결과를 반환한다', async () => {
+            mockIsBot.mockReturnValue(false);
+            mockGetCachedMarketSummary.mockRejectedValueOnce(
                 new Error('network timeout')
             );
 
@@ -119,9 +141,22 @@ describe('getMarketSummaryAction 함수는', () => {
             expect(result).toEqual({ ok: false, error: 'server_error' });
         });
 
-        it('봇 요청에서 예외가 발생하면 에러 결과를 반환한다', async () => {
+        it('submitBriefing 예외 시 에러 결과를 반환한다', async () => {
+            mockIsBot.mockReturnValue(false);
+            mockSubmitBriefing.mockRejectedValueOnce(
+                new Error('briefing failed')
+            );
+
+            const result = await getMarketSummaryAction();
+
+            expect(result).toEqual({ ok: false, error: 'server_error' });
+        });
+
+        it('봇 요청에서 getCachedMarketSummary 예외 시 에러 결과를 반환한다', async () => {
             mockIsBot.mockReturnValue(true);
-            mockGetSummary.mockRejectedValueOnce(new Error('API unavailable'));
+            mockGetCachedMarketSummary.mockRejectedValueOnce(
+                new Error('API unavailable')
+            );
 
             const result = await getMarketSummaryAction();
 

--- a/src/entities/market-summary/__tests__/marketSummaryCache.test.ts
+++ b/src/entities/market-summary/__tests__/marketSummaryCache.test.ts
@@ -1,0 +1,166 @@
+delete process.env.UPSTASH_REDIS_REST_URL;
+delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+vi.mock('server-only', () => ({}));
+
+const { mockGetMarketSummary, mockRedisGet, mockRedisSet, mockRedisCtor } =
+    vi.hoisted(() => ({
+        mockGetMarketSummary: vi.fn(),
+        mockRedisGet: vi.fn(),
+        mockRedisSet: vi.fn(),
+        mockRedisCtor: vi.fn(),
+    }));
+
+vi.mock('@y0ngha/siglens-core', async () => ({
+    ...(await vi.importActual('@y0ngha/siglens-core')),
+    getMarketSummary: mockGetMarketSummary,
+    computeBarsEffectiveTtl: vi.fn(() => 60),
+}));
+
+const mockProvider = {} as import('@y0ngha/siglens-core').MarketDataProvider;
+
+vi.mock('@upstash/redis', () => ({
+    Redis: vi.fn().mockImplementation(function (opts: unknown) {
+        mockRedisCtor(opts);
+        return { get: mockRedisGet, set: mockRedisSet };
+    }),
+}));
+
+import type { MarketSummaryData } from '@y0ngha/siglens-core';
+
+const sampleSummary: MarketSummaryData = {
+    indices: [
+        {
+            symbol: 'SPY',
+            fmpSymbol: '^GSPC',
+            displayName: 'S&P 500',
+            koreanName: 'S&P 500',
+            price: 5000,
+            changesPercentage: 0.5,
+        },
+    ],
+    sectors: [
+        {
+            symbol: 'XLK',
+            sectorName: 'Technology',
+            koreanName: '기술',
+            price: 200,
+            changesPercentage: 1.2,
+        },
+    ],
+};
+
+const zeroSummary: MarketSummaryData = {
+    indices: [
+        {
+            symbol: 'SPY',
+            fmpSymbol: '^GSPC',
+            displayName: 'S&P 500',
+            koreanName: 'S&P 500',
+            price: 0,
+            changesPercentage: 0,
+        },
+    ],
+    sectors: [
+        {
+            symbol: 'XLK',
+            sectorName: 'Technology',
+            koreanName: '기술',
+            price: 0,
+            changesPercentage: 0,
+        },
+    ],
+};
+
+async function loadWithEnv(opts: { url?: string; token?: string }) {
+    process.env.UPSTASH_REDIS_REST_URL = opts.url ?? '';
+    process.env.UPSTASH_REDIS_REST_TOKEN = opts.token ?? '';
+    vi.resetModules();
+    return import('../lib/marketSummaryCache');
+}
+
+describe('getCachedMarketSummary', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    afterEach(() => {
+        delete process.env.UPSTASH_REDIS_REST_URL;
+        delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    });
+
+    it('Redis env 없으면 getMarketSummary 직행', async () => {
+        mockGetMarketSummary.mockResolvedValue(sampleSummary);
+        const mod = await loadWithEnv({});
+        const r = await mod.getCachedMarketSummary(mockProvider);
+        expect(mockRedisCtor).not.toHaveBeenCalled();
+        expect(mockGetMarketSummary).toHaveBeenCalledWith(mockProvider);
+        expect(r).toEqual(sampleSummary);
+    });
+
+    it('Redis hit 시 getMarketSummary 미호출, 캐시값 반환, key market:summary', async () => {
+        mockRedisGet.mockResolvedValue(sampleSummary);
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        const r = await mod.getCachedMarketSummary(mockProvider);
+        expect(mockRedisGet).toHaveBeenCalledWith('market:summary');
+        expect(mockGetMarketSummary).not.toHaveBeenCalled();
+        expect(r).toEqual(sampleSummary);
+    });
+
+    it('Redis miss 시 getMarketSummary 호출 후 redis.set(market:summary, fresh, { ex: 60 })', async () => {
+        mockRedisGet.mockResolvedValue(null);
+        mockGetMarketSummary.mockResolvedValue(sampleSummary);
+        mockRedisSet.mockResolvedValue('OK');
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        await mod.getCachedMarketSummary(mockProvider);
+        expect(mockRedisSet).toHaveBeenCalledWith(
+            'market:summary',
+            sampleSummary,
+            { ex: 60 }
+        );
+    });
+
+    it('전 종목 price=0 번들은 set 미호출', async () => {
+        mockRedisGet.mockResolvedValue(null);
+        mockGetMarketSummary.mockResolvedValue(zeroSummary);
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        await mod.getCachedMarketSummary(mockProvider);
+        expect(mockRedisSet).not.toHaveBeenCalled();
+    });
+
+    it('Redis get 예외는 흡수하고 provider fallback', async () => {
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        mockRedisGet.mockRejectedValue(new Error('redis down'));
+        mockGetMarketSummary.mockResolvedValue(sampleSummary);
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        const r = await mod.getCachedMarketSummary(mockProvider);
+        expect(errSpy).toHaveBeenCalled();
+        expect(r).toEqual(sampleSummary);
+        errSpy.mockRestore();
+    });
+
+    it('Redis set 예외는 흡수하고 fresh 반환', async () => {
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        mockRedisGet.mockResolvedValue(null);
+        mockGetMarketSummary.mockResolvedValue(sampleSummary);
+        mockRedisSet.mockRejectedValue(new Error('redis write fail'));
+        const mod = await loadWithEnv({
+            url: 'https://x.upstash.io',
+            token: 't',
+        });
+        const r = await mod.getCachedMarketSummary(mockProvider);
+        expect(errSpy).toHaveBeenCalled();
+        expect(r).toEqual(sampleSummary);
+        errSpy.mockRestore();
+    });
+});

--- a/src/entities/market-summary/actions/getMarketSummaryAction.ts
+++ b/src/entities/market-summary/actions/getMarketSummaryAction.ts
@@ -17,7 +17,15 @@ export async function getMarketSummaryAction(): Promise<MarketSummaryActionResul
             return { summary, briefing: null, botBlocked: true };
         }
 
-        const briefing = await submitBriefing(summary);
+        let briefing = null;
+        try {
+            briefing = await submitBriefing(summary);
+        } catch (briefingError) {
+            console.error(
+                '[getMarketSummaryAction] briefing submission failed:',
+                briefingError
+            );
+        }
         return { summary, briefing, botBlocked: false };
     } catch (e) {
         console.error('[getMarketSummaryAction] failed:', e);

--- a/src/entities/market-summary/actions/getMarketSummaryAction.ts
+++ b/src/entities/market-summary/actions/getMarketSummaryAction.ts
@@ -2,25 +2,23 @@
 
 import type { MarketSummaryActionResult } from '@/shared/lib/types';
 import { isBot } from '@/shared/api/isBot';
-import {
-    getMarketSummary,
-    getMarketSummaryWithBriefing,
-} from '@y0ngha/siglens-core';
+import { submitBriefing } from '@y0ngha/siglens-core';
 import { headers } from 'next/headers';
 import { getMarketDataProvider } from '@/shared/api/market/getMarketDataProvider';
+import { getCachedMarketSummary } from '../lib/marketSummaryCache';
 
 export async function getMarketSummaryAction(): Promise<MarketSummaryActionResult> {
     try {
         const requestHeaders = await headers();
         const provider = getMarketDataProvider();
+        const summary = await getCachedMarketSummary(provider);
 
         if (isBot(requestHeaders)) {
-            const summary = await getMarketSummary(provider);
             return { summary, briefing: null, botBlocked: true };
         }
 
-        const result = await getMarketSummaryWithBriefing(provider);
-        return { ...result, botBlocked: false };
+        const briefing = await submitBriefing(summary);
+        return { summary, briefing, botBlocked: false };
     } catch (e) {
         console.error('[getMarketSummaryAction] failed:', e);
         return { ok: false, error: 'server_error' };

--- a/src/entities/market-summary/lib/marketSummaryCache.ts
+++ b/src/entities/market-summary/lib/marketSummaryCache.ts
@@ -1,0 +1,56 @@
+import 'server-only';
+import { cache } from 'react';
+import { getRedisClient } from '@/shared/cache/redisClient';
+import {
+    type MarketDataProvider,
+    type MarketSummaryData,
+    getMarketSummary,
+    computeBarsEffectiveTtl,
+} from '@y0ngha/siglens-core';
+
+const MARKET_SUMMARY_CACHE_KEY = 'market:summary';
+
+/**
+ * 대시보드 시장 요약(지수 + 섹터 ETF 현재 시세)을 cache→provider로 가져온다.
+ *
+ * 캐시 레이어:
+ *   1. React.cache — 요청 내 dedup.
+ *   2. Upstash Redis — cross-request. TTL은 bars와 동일한 개장-경계 정책을 재사용:
+ *      `computeBarsEffectiveTtl`(장중 1분 / 장외·주말 min(24h, 다음 개장까지)).
+ *      이 정책은 timeframe과 무관하므로 placeholder('1Day')를 전달한다.
+ *      Redis 미설정 시 graceful fallback으로 주입된 provider를 직접 호출.
+ *
+ * 전 종목 quote가 0인 번들(FMP 전면 장애)은 캐시하지 않는다 — transient 장애를
+ * TTL 동안 굳히지 않도록(barsDataCache 빈봉 caution과 동일).
+ */
+export const getCachedMarketSummary = cache(
+    async (provider: MarketDataProvider): Promise<MarketSummaryData> => {
+        const redis = getRedisClient();
+        if (redis !== null) {
+            try {
+                const hit = await redis.get<MarketSummaryData>(
+                    MARKET_SUMMARY_CACHE_KEY
+                );
+                if (hit !== null) return hit;
+            } catch (error) {
+                console.error('[marketSummaryCache] Redis get failed', error);
+            }
+        }
+
+        const fresh = await getMarketSummary(provider);
+
+        const hasQuote = [...fresh.indices, ...fresh.sectors].some(
+            q => q.price !== 0
+        );
+        if (hasQuote && redis !== null) {
+            try {
+                await redis.set(MARKET_SUMMARY_CACHE_KEY, fresh, {
+                    ex: computeBarsEffectiveTtl('1Day', new Date()),
+                });
+            } catch (error) {
+                console.error('[marketSummaryCache] Redis set failed', error);
+            }
+        }
+        return fresh;
+    }
+);

--- a/src/entities/market-summary/lib/marketSummaryCache.ts
+++ b/src/entities/market-summary/lib/marketSummaryCache.ts
@@ -4,11 +4,15 @@ import { getRedisClient } from '@/shared/cache/redisClient';
 import {
     type MarketDataProvider,
     type MarketSummaryData,
+    type Timeframe,
     getMarketSummary,
     computeBarsEffectiveTtl,
 } from '@y0ngha/siglens-core';
 
 const MARKET_SUMMARY_CACHE_KEY = 'market:summary';
+
+/** 시장 요약은 bars 일봉 TTL 정책을 재사용 — 실제 timeframe과 무관한 placeholder. */
+const SUMMARY_TTL_TIMEFRAME = '1Day' as const satisfies Timeframe;
 
 /**
  * 대시보드 시장 요약(지수 + 섹터 ETF 현재 시세)을 cache→provider로 가져온다.
@@ -39,13 +43,16 @@ export const getCachedMarketSummary = cache(
 
         const fresh = await getMarketSummary(provider);
 
-        const hasQuote = [...fresh.indices, ...fresh.sectors].some(
-            q => q.price !== 0
-        );
+        const hasQuote =
+            fresh.indices.some(q => q.price !== 0) ||
+            fresh.sectors.some(q => q.price !== 0);
         if (hasQuote && redis !== null) {
             try {
                 await redis.set(MARKET_SUMMARY_CACHE_KEY, fresh, {
-                    ex: computeBarsEffectiveTtl('1Day', new Date()),
+                    ex: computeBarsEffectiveTtl(
+                        SUMMARY_TTL_TIMEFRAME,
+                        new Date()
+                    ),
                 });
             } catch (error) {
                 console.error('[marketSummaryCache] Redis set failed', error);

--- a/src/shared/lib/types.ts
+++ b/src/shared/lib/types.ts
@@ -2,10 +2,10 @@ import type {
     ChatMessage,
     FearGreedConfidence,
     MarketSummaryData,
-    MarketSummaryWithBriefing,
     NewsCategory,
     NewsImpact,
     NewsSentiment,
+    SubmitBriefingResult,
 } from '@y0ngha/siglens-core';
 
 /**
@@ -230,7 +230,11 @@ export interface ContextSwitchMessage {
 export type DisplayMessage = ChatMessage | ContextSwitchMessage;
 
 export type MarketSummaryActionResult =
-    | (MarketSummaryWithBriefing & { botBlocked: false })
+    | {
+          summary: MarketSummaryData;
+          briefing: SubmitBriefingResult | null;
+          botBlocked: false;
+      }
     | { summary: MarketSummaryData; briefing: null; botBlocked: true }
     | { ok: false; error: string };
 


### PR DESCRIPTION
## Summary
`/market` re-fetched the market summary (indices + 11 sector ETF quotes) from FMP on EVERY render — both the bot path (`getMarketSummary`) and the user/briefing path re-fetched uncached. This adds a siglens-side Redis cache so both paths collapse to one fetch per TTL window. No SEO/quality regression — same data, served from cache.

- New `entities/market-summary/lib/marketSummaryCache.ts` — `getCachedMarketSummary(provider)` mirroring `barsDataCache` (server-only, React.cache, shared `getRedisClient`, graceful fallback). Single key `market:summary`. Does NOT cache an all-zero bundle (total FMP outage).
- TTL reuses the bars open-boundary policy via core `computeBarsEffectiveTtl` (장중 1분 / 장외·주말 min(24h, 다음 개장까지)). timeframe arg is a placeholder (policy is timeframe-agnostic).
- `getMarketSummaryAction` now fetches the cached summary once and composes the briefing path itself (`submitBriefing(summary)`), so BOTH bot and user paths are cached. Behavior preserved (briefing dispatched as before).
- siglens-only; uses core 0.14.1's injected `MarketDataProvider` (already on master). No core change.

## Test
- New `marketSummaryCache.test.ts` (Redis hit/miss/set, get/set error absorption, no-Redis fallback, all-zero not cached) + updated `getMarketSummaryAction.test.ts` (bot vs user both route through the cache).
- `yarn lint`/`typecheck` pass; target tests 14 passing.

Temp branch — to be formalized with an issue number.