### PR TITLE
chore: housekeeping — news-refresh TTL constant, drop dead Alpaca test env

### DIFF
--- a/src/entities/news-article/lib/newsRefreshFlag.ts
+++ b/src/entities/news-article/lib/newsRefreshFlag.ts
@@ -2,7 +2,6 @@ import 'server-only';
 import { getRedisClient } from '@/shared/cache/redisClient';
 import { SECONDS_PER_MINUTE } from '@/shared/config/time';
 
-/** 봇 재크롤링 가드 TTL — 분 단위 정책값. */
 const NEWS_REFRESH_FLAG_TTL_MINUTES = 10;
 
 /** 뉴스 refresh 플래그 TTL — 이 시간 내 재크롤링(봇)은 FMP fetch+upsert를 스킵. */

--- a/src/entities/news-article/lib/newsRefreshFlag.ts
+++ b/src/entities/news-article/lib/newsRefreshFlag.ts
@@ -2,8 +2,12 @@ import 'server-only';
 import { getRedisClient } from '@/shared/cache/redisClient';
 import { SECONDS_PER_MINUTE } from '@/shared/config/time';
 
+/** 봇 재크롤링 가드 TTL — 분 단위 정책값. */
+const NEWS_REFRESH_FLAG_TTL_MINUTES = 10;
+
 /** 뉴스 refresh 플래그 TTL — 이 시간 내 재크롤링(봇)은 FMP fetch+upsert를 스킵. */
-export const NEWS_REFRESH_FLAG_TTL_SECONDS = 10 * SECONDS_PER_MINUTE;
+export const NEWS_REFRESH_FLAG_TTL_SECONDS =
+    NEWS_REFRESH_FLAG_TTL_MINUTES * SECONDS_PER_MINUTE;
 
 function buildKey(symbol: string): string {
     return `news:refresh:${symbol.toUpperCase()}`;

--- a/vitest.setup.base.ts
+++ b/vitest.setup.base.ts
@@ -10,8 +10,6 @@ if (typeof globalThis.TextEncoder === 'undefined') {
         TextEncoder;
 }
 
-process.env.ALPACA_API_KEY = 'test-alpaca-key';
-process.env.ALPACA_API_SECRET = 'test-alpaca-secret';
 process.env.AI_PROVIDER = 'claude';
 process.env.GEMINI_CHAT_FREE_API_KEY = 'test-gemini-user-api-key';
 process.env.GEMINI_CHAT_API_KEY = 'test-gemini-key';


### PR DESCRIPTION
## Summary
Small housekeeping (no behavior change):

- `entities/news-article/lib/newsRefreshFlag.ts`: extract the magic `10` minutes into a named `NEWS_REFRESH_FLAG_TTL_MINUTES` constant (MISTAKES.md §15), so `NEWS_REFRESH_FLAG_TTL_SECONDS = NEWS_REFRESH_FLAG_TTL_MINUTES * SECONDS_PER_MINUTE`.
- `vitest.setup.base.ts`: remove the dead `ALPACA_API_KEY` / `ALPACA_API_SECRET` test env stubs — Alpaca was removed by the market-provider ejection (provider is FMP-only); no code reads them (`grep ALPACA src` → none).

## Test
- `yarn lint` / `typecheck` clean; full suite (4466 tests) passes — no test depended on the Alpaca env.

Temp branch — to be formalized with an issue number.