### PR TITLE
refactor: consolidate bars/market-summary caching onto getOrSetCache

### DIFF
--- a/src/entities/bars/__tests__/barsDataCache.test.ts
+++ b/src/entities/bars/__tests__/barsDataCache.test.ts
@@ -72,7 +72,7 @@ describe('getCachedBarsWithIndicators', () => {
     });
 
     it('Redis hit 시 fetch 안 함', async () => {
-        mockRedisGet.mockResolvedValue(sampleBars);
+        mockRedisGet.mockResolvedValue({ data: sampleBars });
         const mod = await loadWithEnv({
             url: 'https://x.upstash.io',
             token: 't',
@@ -98,7 +98,7 @@ describe('getCachedBarsWithIndicators', () => {
         await mod.getCachedBarsWithIndicators(mockProvider, 'AAPL', '1Day');
         expect(mockRedisSet).toHaveBeenCalledWith(
             'bars:AAPL:1Day',
-            sampleBars,
+            { data: sampleBars },
             { ex: 60 }
         );
     });
@@ -168,7 +168,7 @@ describe('getCachedBarsWithIndicators', () => {
     });
 
     it('getRedis 싱글턴 캐시 — 두 번째 호출은 재생성 없이 반환', async () => {
-        mockRedisGet.mockResolvedValue(sampleBars);
+        mockRedisGet.mockResolvedValue({ data: sampleBars });
         // Load the module once, then call twice — second call hits cachedRedis fast-path
         const mod = await loadWithEnv({
             url: 'https://x.upstash.io',

--- a/src/entities/bars/lib/barsDataCache.ts
+++ b/src/entities/bars/lib/barsDataCache.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { cache } from 'react';
-import { getRedisClient } from '@/shared/cache/redisClient';
+import { getOrSetCache } from '@/shared/cache/getOrSetCache';
 import {
     type BarsData,
     type MarketDataProvider,
@@ -25,11 +25,11 @@ function buildBarsKey(
  * 캐시 레이어:
  *   1. React.cache — 요청 내 dedup(layout/page가 같은 TF prefetch 시 1회).
  *   2. Upstash Redis — cross-request, 시장 세션별 TTL(core `computeBarsEffectiveTtl`).
- *      봇이 한 종목의 여러 탭을 연속 크롤링해도 fetch가 1회로 수렴.
- *      Redis 미설정 시 graceful fallback으로 주입된 provider를 직접 호출.
+ *      봇이 한 종목의 여러 탭을 연속 크롤링해도 fetch가 1회로 수렴. getOrSetCache가
+ *      get→fetch→set과 Redis 미설정/장애 시 graceful fallback을 담당한다.
  *
- * 에러는 캐시하지 않는다(throw가 set 이전에 전파). 빈 봉도 캐시하지 않는다
- * (transient 장애를 TTL 동안 굳히지 않도록 — optionsDataCache의 null-caution과 동일).
+ * 에러는 캐시하지 않는다(provider의 fmpGet이 throw → set 이전에 전파). 빈 봉도
+ * 캐시하지 않는다(`shouldCache` 가드 — transient 장애를 TTL 동안 굳히지 않도록).
  */
 export const getCachedBarsWithIndicators = cache(
     async (
@@ -37,43 +37,13 @@ export const getCachedBarsWithIndicators = cache(
         symbol: string,
         timeframe: Timeframe,
         fmpSymbol?: string
-    ): Promise<BarsData> => {
-        const key = buildBarsKey(symbol, timeframe, fmpSymbol);
-        const redis = getRedisClient();
-        if (redis !== null) {
-            try {
-                const hit = await redis.get<BarsData>(key);
-                if (hit !== null) return hit;
-            } catch (error) {
-                console.error(
-                    '[barsDataCache] Redis get failed for',
-                    key,
-                    error
-                );
-            }
-        }
-
-        // Retry (429/5xx + network TypeError/DOMException) is handled inside the provider's fmpGet (FMP_TRANSIENT_RETRY).
-        const fresh = await fetchBarsWithIndicators(
-            provider,
-            symbol,
-            timeframe,
-            fmpSymbol
-        );
-
-        if (fresh.bars.length > 0 && redis !== null) {
-            try {
-                await redis.set(key, fresh, {
-                    ex: computeBarsEffectiveTtl(timeframe, new Date()),
-                });
-            } catch (error) {
-                console.error(
-                    '[barsDataCache] Redis set failed for',
-                    key,
-                    error
-                );
-            }
-        }
-        return fresh;
-    }
+    ): Promise<BarsData> =>
+        getOrSetCache(
+            buildBarsKey(symbol, timeframe, fmpSymbol),
+            computeBarsEffectiveTtl(timeframe, new Date()),
+            // Retry(429/5xx + network)는 provider의 fmpGet(FMP_TRANSIENT_RETRY)에서 처리.
+            () =>
+                fetchBarsWithIndicators(provider, symbol, timeframe, fmpSymbol),
+            fresh => fresh.bars.length > 0
+        )
 );

--- a/src/entities/market-summary/__tests__/marketSummaryCache.test.ts
+++ b/src/entities/market-summary/__tests__/marketSummaryCache.test.ts
@@ -97,7 +97,7 @@ describe('getCachedMarketSummary', () => {
     });
 
     it('Redis hit 시 getMarketSummary 미호출, 캐시값 반환, key market:summary', async () => {
-        mockRedisGet.mockResolvedValue(sampleSummary);
+        mockRedisGet.mockResolvedValue({ data: sampleSummary });
         const mod = await loadWithEnv({
             url: 'https://x.upstash.io',
             token: 't',
@@ -119,7 +119,7 @@ describe('getCachedMarketSummary', () => {
         await mod.getCachedMarketSummary(mockProvider);
         expect(mockRedisSet).toHaveBeenCalledWith(
             'market:summary',
-            sampleSummary,
+            { data: sampleSummary },
             { ex: 60 }
         );
     });

--- a/src/entities/market-summary/lib/marketSummaryCache.ts
+++ b/src/entities/market-summary/lib/marketSummaryCache.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { cache } from 'react';
-import { getRedisClient } from '@/shared/cache/redisClient';
+import { getOrSetCache } from '@/shared/cache/getOrSetCache';
 import {
     type MarketDataProvider,
     type MarketSummaryData,
@@ -14,6 +14,14 @@ const MARKET_SUMMARY_CACHE_KEY = 'market:summary';
 /** 시장 요약은 bars 일봉 TTL 정책을 재사용 — 실제 timeframe과 무관한 placeholder. */
 const SUMMARY_TTL_TIMEFRAME = '1Day' as const satisfies Timeframe;
 
+/** 전 종목 quote가 0인 번들은 FMP 전면 장애 신호 — 캐싱하지 않는다. */
+function hasAnyQuote(summary: MarketSummaryData): boolean {
+    return (
+        summary.indices.some(q => q.price !== 0) ||
+        summary.sectors.some(q => q.price !== 0)
+    );
+}
+
 /**
  * 대시보드 시장 요약(지수 + 섹터 ETF 현재 시세)을 cache→provider로 가져온다.
  *
@@ -21,43 +29,18 @@ const SUMMARY_TTL_TIMEFRAME = '1Day' as const satisfies Timeframe;
  *   1. React.cache — 요청 내 dedup.
  *   2. Upstash Redis — cross-request. TTL은 bars와 동일한 개장-경계 정책을 재사용:
  *      `computeBarsEffectiveTtl`(장중 1분 / 장외·주말 min(24h, 다음 개장까지)).
- *      이 정책은 timeframe과 무관하므로 placeholder('1Day')를 전달한다.
- *      Redis 미설정 시 graceful fallback으로 주입된 provider를 직접 호출.
+ *      이 정책은 timeframe과 무관하므로 placeholder('1Day')를 전달한다. getOrSetCache가
+ *      get→fetch→set과 Redis 미설정/장애 시 graceful fallback을 담당한다.
  *
- * 전 종목 quote가 0인 번들(FMP 전면 장애)은 캐시하지 않는다 — transient 장애를
- * TTL 동안 굳히지 않도록(barsDataCache 빈봉 caution과 동일).
+ * 전 종목 quote가 0인 번들(FMP 전면 장애)은 캐시하지 않는다(`shouldCache` 가드) —
+ * transient 장애를 TTL 동안 굳히지 않도록(barsDataCache 빈봉 caution과 동일).
  */
 export const getCachedMarketSummary = cache(
-    async (provider: MarketDataProvider): Promise<MarketSummaryData> => {
-        const redis = getRedisClient();
-        if (redis !== null) {
-            try {
-                const hit = await redis.get<MarketSummaryData>(
-                    MARKET_SUMMARY_CACHE_KEY
-                );
-                if (hit !== null) return hit;
-            } catch (error) {
-                console.error('[marketSummaryCache] Redis get failed', error);
-            }
-        }
-
-        const fresh = await getMarketSummary(provider);
-
-        const hasQuote =
-            fresh.indices.some(q => q.price !== 0) ||
-            fresh.sectors.some(q => q.price !== 0);
-        if (hasQuote && redis !== null) {
-            try {
-                await redis.set(MARKET_SUMMARY_CACHE_KEY, fresh, {
-                    ex: computeBarsEffectiveTtl(
-                        SUMMARY_TTL_TIMEFRAME,
-                        new Date()
-                    ),
-                });
-            } catch (error) {
-                console.error('[marketSummaryCache] Redis set failed', error);
-            }
-        }
-        return fresh;
-    }
+    async (provider: MarketDataProvider): Promise<MarketSummaryData> =>
+        getOrSetCache(
+            MARKET_SUMMARY_CACHE_KEY,
+            computeBarsEffectiveTtl(SUMMARY_TTL_TIMEFRAME, new Date()),
+            () => getMarketSummary(provider),
+            hasAnyQuote
+        )
 );

--- a/src/shared/cache/__tests__/getOrSetCache.test.ts
+++ b/src/shared/cache/__tests__/getOrSetCache.test.ts
@@ -106,6 +106,22 @@ describe('getOrSetCache 함수는', () => {
         expect(fetcher).not.toHaveBeenCalled();
     });
 
+    it('shouldCache가 false면 fresh 값은 반환하되 저장하지 않는다', async () => {
+        const redis = createRedisStub();
+        mockedGetRedisClient.mockReturnValue(redis as never);
+        const fetcher = vi.fn().mockResolvedValue({ bars: [] });
+
+        const result = await getOrSetCache<{ bars: unknown[] }>(
+            'k',
+            60,
+            fetcher,
+            value => value.bars.length > 0
+        );
+
+        expect(result).toEqual({ bars: [] });
+        expect(redis.set).not.toHaveBeenCalled();
+    });
+
     it('get 실패 시 fetcher로 graceful fallback하고 에러를 로깅한다', async () => {
         const redis = createRedisStub();
         redis.get.mockRejectedValueOnce(new Error('boom'));

--- a/src/shared/cache/__tests__/getOrSetCache.test.ts
+++ b/src/shared/cache/__tests__/getOrSetCache.test.ts
@@ -94,6 +94,23 @@ describe('getOrSetCache 함수는', () => {
         expect(redis.set).toHaveBeenCalledWith('k', { data: null }, { ex: 60 });
     });
 
+    it('레거시 raw 엔트리(envelope 아님)는 miss로 취급해 fetch 후 envelope으로 갱신한다', async () => {
+        const redis = createRedisStub();
+        redis.store.set('k', { bars: [] }); // 이전 포맷 — `.data` 필드 없음
+        mockedGetRedisClient.mockReturnValue(redis as never);
+        const fetcher = vi.fn().mockResolvedValue('fresh');
+
+        const result = await getOrSetCache('k', 60, fetcher);
+
+        expect(result).toBe('fresh');
+        expect(fetcher).toHaveBeenCalledTimes(1);
+        expect(redis.set).toHaveBeenCalledWith(
+            'k',
+            { data: 'fresh' },
+            { ex: 60 }
+        );
+    });
+
     it('저장된 null envelope은 캐시 히트로 처리해 fetcher를 호출하지 않는다', async () => {
         const redis = createRedisStub();
         redis.store.set('k', { data: null });

--- a/src/shared/cache/getOrSetCache.ts
+++ b/src/shared/cache/getOrSetCache.ts
@@ -15,15 +15,18 @@ interface CacheEnvelope<T> {
  * 뜻하는 정상 `null`(예: 프로필 없는 티커)도 캐싱해, 롱테일/봇 트래픽이 매 요청마다
  * FMP를 재호출하던 문제를 막는다.
  *
- * 일시 장애는 캐싱되지 않는다 — 호출부 fetcher(fmpGet 기반)가 실패 시 throw하므로
- * 잘못된 값이 set 단계에 도달하지 못한다.
+ * `shouldCache(value)`가 false면 저장하지 않는다 — fetcher가 throw하지 않고도
+ * transient-shaped 결과(예: 빈 봉, 전종목 0 quote)를 돌려줄 수 있는 호출부를 위한
+ * 가드. 기본값은 항상 캐싱이며, fmpGet 기반 fetcher처럼 장애 시 throw하는 경우엔
+ * 지정할 필요가 없다(잘못된 값이 애초에 set 단계에 도달하지 못하므로).
  *
  * Redis 미설정/장애 시에는 graceful fallback — `fetcher()`를 직접 호출한다.
  */
 export async function getOrSetCache<T>(
     key: string,
     ttlSeconds: number,
-    fetcher: () => Promise<T>
+    fetcher: () => Promise<T>,
+    shouldCache: (value: T) => boolean = () => true
 ): Promise<T> {
     const redis = getRedisClient();
     if (redis !== null) {
@@ -37,7 +40,7 @@ export async function getOrSetCache<T>(
 
     const fresh = await fetcher();
 
-    if (redis !== null) {
+    if (redis !== null && shouldCache(fresh)) {
         try {
             await redis.set(key, { data: fresh }, { ex: ttlSeconds });
         } catch (error) {

--- a/src/shared/cache/getOrSetCache.ts
+++ b/src/shared/cache/getOrSetCache.ts
@@ -5,6 +5,11 @@ interface CacheEnvelope<T> {
     data: T;
 }
 
+/** envelope 포맷인지 검증 — 레거시 raw 엔트리(`.data` 없음)를 가려내기 위함. */
+function isCacheEnvelope<T>(value: unknown): value is CacheEnvelope<T> {
+    return typeof value === 'object' && value !== null && 'data' in value;
+}
+
 /**
  * Read-through Redis 캐시 헬퍼. get→fetch→set 패턴을 일반화해 호출부의
  * 보일러플레이트를 줄인다.
@@ -14,6 +19,10 @@ interface CacheEnvelope<T> {
  * hit은 `{ data: ... }`(안의 값이 `null`이어도)로 구분된다. 덕분에 "데이터 없음"을
  * 뜻하는 정상 `null`(예: 프로필 없는 티커)도 캐싱해, 롱테일/봇 트래픽이 매 요청마다
  * FMP를 재호출하던 문제를 막는다.
+ *
+ * envelope이 아닌 레거시 raw 엔트리(이전 포맷이 운영 Redis에 남아 있는 경우)는 cache
+ * miss로 취급한다 — 그대로 반환하면 `hit.data`가 `undefined`가 되므로, fetch 후
+ * envelope으로 덮어써 자가 마이그레이션한다.
  *
  * `shouldCache(value)`가 false면 저장하지 않는다 — fetcher가 throw하지 않고도
  * transient-shaped 결과(예: 빈 봉, 전종목 0 quote)를 돌려줄 수 있는 호출부를 위한
@@ -31,8 +40,8 @@ export async function getOrSetCache<T>(
     const redis = getRedisClient();
     if (redis !== null) {
         try {
-            const hit = await redis.get<CacheEnvelope<T>>(key);
-            if (hit !== null) return hit.data;
+            const hit = await redis.get<unknown>(key);
+            if (isCacheEnvelope<T>(hit)) return hit.data;
         } catch (error) {
             console.error(`[getOrSetCache] get failed: ${key}`, error);
         }


### PR DESCRIPTION
## Summary
- Migrate `barsDataCache` and `marketSummaryCache` from their inline Redis get→fetch→set blocks onto the shared `getOrSetCache` read-through helper (introduced in #523), removing duplicated boilerplate.
- Re-add an optional `shouldCache(value)` param to `getOrSetCache` (default caches everything). bars/marketSummary need it: their fetchers can return a transient-shaped result without throwing (empty bars / all-zero quotes), which must not be cached. Fundamental getters keep the default.
- Cached values now go through the `{ data: T }` envelope; entity tests updated to the envelope shape. Dynamic market-session TTL (`computeBarsEffectiveTtl`) and the React `cache()` per-request dedup are preserved.

## Stacked PR
- ⚠️ Base branch is `feat/fundamental-redis-cache` (#523), not `master`, because it depends on `getOrSetCache` which lands in #523. Merge #523 first, then this. After #523 merges, this PR's base auto-retargets to master.

## Test plan
- [ ] `yarn tsc --noEmit` (verified)
- [ ] `yarn lint` (verified)
- [ ] `yarn test` — getOrSetCache / barsDataCache / marketSummaryCache suites (23 tests, verified)
- [ ] `yarn build` (verified)