### PR TITLE
test(e2e): resilience spec via deterministic E2E error-injection seam

### DIFF
--- a/e2e/specs/resilience.spec.ts
+++ b/e2e/specs/resilience.spec.ts
@@ -38,7 +38,6 @@ test.describe('widget resilience', () => {
 
         await page.goto('/AAPL/options');
 
-        // 1) 강제 실패 → 격리된 에러 fallback이 노출된다.
         await expect(page.getByText(OPTIONS_ANALYSIS_ERROR)).toBeVisible();
 
         // 에러는 한 위젯에 격리된다 — 페이지 탭 네비게이션은 여전히 살아 있다.
@@ -46,7 +45,7 @@ test.describe('widget resilience', () => {
             page.getByRole('navigation', { name: '분석 종류' })
         ).toBeVisible();
 
-        // 2) 쿠키 제거 → 재시도하면 캐시 픽스처로 복구된다.
+        // 쿠키를 비워야 재시도가 강제 에러 대신 캐시 픽스처로 복구된다.
         await context.clearCookies({ name: E2E_FORCE_ANALYSIS_ERROR_COOKIE });
         await page.getByRole('button', { name: '다시 시도' }).click();
 

--- a/e2e/specs/resilience.spec.ts
+++ b/e2e/specs/resilience.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../support/fixtures';
+import { E2E_FORCE_ANALYSIS_ERROR_COOKIE } from '@/shared/api/e2eAnalysisStub';
 
 /**
  * Widget resilience (`/AAPL/options`) — error boundary → retry → recovery.
@@ -16,10 +17,9 @@ import { test, expect } from '../support/fixtures';
  * non-zero-OI snapshot → never oiStale), so this is deterministic without a
  * frozen clock. Chromium-only desktop interaction check.
  *
- * Cookie literal mirrors E2E_FORCE_ANALYSIS_ERROR_COOKIE in
- * src/shared/api/e2eAnalysisStub.ts — keep in sync.
+ * The force-error cookie name is imported from the stub (single source of truth)
+ * rather than mirrored as a literal.
  */
-const FORCE_ERROR_COOKIE = 'e2e_force_analysis_error';
 const OPTIONS_ANALYSIS_ERROR =
     '옵션 분석을 가져오지 못했어요. 잠시 후 다시 시도해주세요.';
 
@@ -30,7 +30,7 @@ test.describe('widget resilience', () => {
     }) => {
         await context.addCookies([
             {
-                name: FORCE_ERROR_COOKIE,
+                name: E2E_FORCE_ANALYSIS_ERROR_COOKIE,
                 value: '1',
                 url: 'http://localhost:4300',
             },
@@ -47,7 +47,7 @@ test.describe('widget resilience', () => {
         ).toBeVisible();
 
         // 2) 쿠키 제거 → 재시도하면 캐시 픽스처로 복구된다.
-        await context.clearCookies({ name: FORCE_ERROR_COOKIE });
+        await context.clearCookies({ name: E2E_FORCE_ANALYSIS_ERROR_COOKIE });
         await page.getByRole('button', { name: '다시 시도' }).click();
 
         await expect(page.getByText(OPTIONS_ANALYSIS_ERROR)).toHaveCount(0);

--- a/e2e/specs/resilience.spec.ts
+++ b/e2e/specs/resilience.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '../support/fixtures';
+
+/**
+ * Widget resilience (`/AAPL/options`) — error boundary → retry → recovery.
+ *
+ * The options AI-analysis card is isolated in a react-error-boundary
+ * (OptionsPageClient → ErrorBoundary → OptionsAiAnalysisError, with a "다시 시도"
+ * wired to the hook's retry). Triggering its failure deterministically under E2E
+ * is otherwise hard — the analysis short-circuits to a cached fixture server-side
+ * and network interception of the server-action POST races. So the submit action
+ * honors a force-error cookie under E2E_TEST (see e2eAnalysisStub
+ * `E2E_FORCE_ANALYSIS_ERROR_COOKIE` / `e2eForcedOptionsError`): with the cookie
+ * set it returns a transient error, without it the cached fixture.
+ *
+ * The options card always renders under E2E (FakeOptionsDataProvider seeds a
+ * non-zero-OI snapshot → never oiStale), so this is deterministic without a
+ * frozen clock. Chromium-only desktop interaction check.
+ *
+ * Cookie literal mirrors E2E_FORCE_ANALYSIS_ERROR_COOKIE in
+ * src/shared/api/e2eAnalysisStub.ts — keep in sync.
+ */
+const FORCE_ERROR_COOKIE = 'e2e_force_analysis_error';
+const OPTIONS_ANALYSIS_ERROR =
+    '옵션 분석을 가져오지 못했어요. 잠시 후 다시 시도해주세요.';
+
+test.describe('widget resilience', () => {
+    test('options analysis error boundary recovers via retry', async ({
+        page,
+        context,
+    }) => {
+        await context.addCookies([
+            {
+                name: FORCE_ERROR_COOKIE,
+                value: '1',
+                url: 'http://localhost:4300',
+            },
+        ]);
+
+        await page.goto('/AAPL/options');
+
+        // 1) 강제 실패 → 격리된 에러 fallback이 노출된다.
+        await expect(page.getByText(OPTIONS_ANALYSIS_ERROR)).toBeVisible();
+
+        // 에러는 한 위젯에 격리된다 — 페이지 탭 네비게이션은 여전히 살아 있다.
+        await expect(
+            page.getByRole('navigation', { name: '분석 종류' })
+        ).toBeVisible();
+
+        // 2) 쿠키 제거 → 재시도하면 캐시 픽스처로 복구된다.
+        await context.clearCookies({ name: FORCE_ERROR_COOKIE });
+        await page.getByRole('button', { name: '다시 시도' }).click();
+
+        await expect(page.getByText(OPTIONS_ANALYSIS_ERROR)).toHaveCount(0);
+    });
+});

--- a/src/entities/options-chain/__tests__/optionsActions.test.ts
+++ b/src/entities/options-chain/__tests__/optionsActions.test.ts
@@ -5,6 +5,18 @@ vi.mock('@vercel/functions', () => ({
 
 vi.mock('next/headers', () => ({
     headers: vi.fn(() => Promise.resolve(new Headers())),
+    cookies: vi.fn(),
+}));
+
+// E2E 쿠키 seam 분기 테스트용 — 액션이 require하는 stub을 결정적 mock으로 대체.
+vi.mock('@/shared/api/e2eAnalysisStub', () => ({
+    E2E_FORCE_ANALYSIS_ERROR_COOKIE: 'e2e_force_analysis_error',
+    e2eForcedOptionsError: vi.fn(() => ({
+        status: 'no_chains_error',
+        code: 'no_options_chains',
+        error: 'E2E 강제 분석 실패 (resilience 테스트용)',
+    })),
+    e2eCachedOptions: vi.fn(() => ({ status: 'cached', result: {} })),
 }));
 
 vi.mock('@y0ngha/siglens-core', async () => ({
@@ -39,6 +51,7 @@ import {
     type OptionsSnapshot,
     type OptionsChain,
 } from '@y0ngha/siglens-core';
+import { cookies } from 'next/headers';
 import { fetchOptionsSnapshot } from '../lib/optionsDataCache';
 import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 import { resolveTierAndByok } from '@/shared/lib/byokGate';
@@ -65,6 +78,7 @@ const mockResolveTierAndByok = resolveTierAndByok as MockedFunction<
     typeof resolveTierAndByok
 >;
 const mockCancelJob = cancelJob as MockedFunction<typeof cancelJob>;
+const mockCookies = cookies as MockedFunction<typeof cookies>;
 
 const MODEL_ID = 'gemini-2.5-flash' as ModelId;
 const PREMIUM_MODEL = 'claude-opus-4-7' as ModelId;
@@ -306,5 +320,58 @@ describe('cancelOptionsAnalysisJobAction', () => {
         );
 
         consoleWarnSpy.mockRestore();
+    });
+});
+
+describe('submitOptionsAnalysisAction — E2E force-error cookie seam', () => {
+    const originalE2E = process.env.E2E_TEST;
+
+    beforeEach(() => {
+        mockCookies.mockReset();
+        process.env.E2E_TEST = '1';
+    });
+
+    afterEach(() => {
+        if (originalE2E === undefined) {
+            delete process.env.E2E_TEST;
+        } else {
+            process.env.E2E_TEST = originalE2E;
+        }
+    });
+
+    it('returns the forced error result when the force-error cookie is present', async () => {
+        mockCookies.mockResolvedValue({
+            get: vi.fn(() => ({
+                name: 'e2e_force_analysis_error',
+                value: '1',
+            })),
+        } as never);
+
+        const result = await submitOptionsAnalysisAction(
+            'AAPL',
+            'Apple Inc.',
+            'all',
+            MODEL_ID
+        );
+
+        expect(result.status).toBe('no_chains_error');
+        // 강제 에러 경로는 core 제출을 건드리지 않는다.
+        expect(mockSubmitOptionsAnalysis).not.toHaveBeenCalled();
+    });
+
+    it('returns the cached fixture when the force-error cookie is absent', async () => {
+        mockCookies.mockResolvedValue({
+            get: vi.fn(() => undefined),
+        } as never);
+
+        const result = await submitOptionsAnalysisAction(
+            'AAPL',
+            'Apple Inc.',
+            'all',
+            MODEL_ID
+        );
+
+        expect(result.status).toBe('cached');
+        expect(mockSubmitOptionsAnalysis).not.toHaveBeenCalled();
     });
 });

--- a/src/entities/options-chain/__tests__/optionsActions.test.ts
+++ b/src/entities/options-chain/__tests__/optionsActions.test.ts
@@ -340,11 +340,9 @@ describe('submitOptionsAnalysisAction — E2E force-error cookie seam', () => {
     });
 
     it('returns the forced error result when the force-error cookie is present', async () => {
+        // 액션은 .get(name)의 truthy 여부만 보므로 value만 있으면 충분하다.
         mockCookies.mockResolvedValue({
-            get: vi.fn(() => ({
-                name: 'e2e_force_analysis_error',
-                value: '1',
-            })),
+            get: vi.fn(() => ({ value: '1' })),
         } as never);
 
         const result = await submitOptionsAnalysisAction(

--- a/src/entities/options-chain/__tests__/optionsActions.test.ts
+++ b/src/entities/options-chain/__tests__/optionsActions.test.ts
@@ -8,8 +8,11 @@ vi.mock('next/headers', () => ({
     cookies: vi.fn(),
 }));
 
-// E2E 쿠키 seam 분기 테스트용 — 액션이 require하는 stub을 결정적 mock으로 대체.
+// E2E 쿠키 seam 분기 테스트용 — 액션이 동적 import하는 stub을 결정적 mock으로 대체.
 vi.mock('@/shared/api/e2eAnalysisStub', () => ({
+    // Mirrors E2E_FORCE_ANALYSIS_ERROR_COOKIE in @/shared/api/e2eAnalysisStub.
+    // vi.mock factories are hoisted above imports, so the constant can't be
+    // imported here — keep this literal in sync if the source value changes.
     E2E_FORCE_ANALYSIS_ERROR_COOKIE: 'e2e_force_analysis_error',
     e2eForcedOptionsError: vi.fn(() => ({
         status: 'no_chains_error',
@@ -328,6 +331,9 @@ describe('submitOptionsAnalysisAction — E2E force-error cookie seam', () => {
 
     beforeEach(() => {
         mockCookies.mockReset();
+        // 누적 call count를 초기화 — not.toHaveBeenCalled()가 외부 describe의
+        // 테스트 실행 순서에 묵시적으로 의존하지 않도록 한다(resetMocks 미설정).
+        mockSubmitOptionsAnalysis.mockReset();
         process.env.E2E_TEST = '1';
     });
 

--- a/src/entities/options-chain/actions/optionsActions.ts
+++ b/src/entities/options-chain/actions/optionsActions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { waitUntil } from '@vercel/functions';
-import { headers } from 'next/headers';
+import { headers, cookies } from 'next/headers';
 import {
     submitOptionsAnalysis,
     pollOptionsAnalysis,
@@ -42,9 +42,16 @@ export async function submitOptionsAnalysisAction(
         // bundle (matches getMarketDataProvider). Lives inside try so a require()
         // throw can't propagate to the client (mirrors submitAnalysisAction).
         if (process.env.E2E_TEST === '1') {
-            const { e2eCachedOptions } =
+            const stub =
                 require('@/shared/api/e2eAnalysisStub') as typeof import('@/shared/api/e2eAnalysisStub');
-            return e2eCachedOptions();
+            // resilience 스펙이 설정하는 force-error 쿠키가 있으면 일시적 실패를
+            // 결정적으로 주입해 에러 바운더리 → 재시도 → 복구를 검증할 수 있게 한다.
+            const forceError = (await cookies()).get(
+                stub.E2E_FORCE_ANALYSIS_ERROR_COOKIE
+            );
+            return forceError
+                ? stub.e2eForcedOptionsError()
+                : stub.e2eCachedOptions();
         }
         const requestHeaders = await headers();
         const skipEnqueueIfMiss = isBot(requestHeaders);

--- a/src/entities/options-chain/actions/optionsActions.ts
+++ b/src/entities/options-chain/actions/optionsActions.ts
@@ -36,14 +36,14 @@ export async function submitOptionsAnalysisAction(
     modelId: ModelId
 ): Promise<SubmitOptionsAnalysisActionResult> {
     try {
-        // E2E short-circuits the LLM/worker; returns a deterministic cached fixture
-        // (see e2eAnalysisStub). The stub + JSON fixture are require'd (not statically
-        // imported) under the inline E2E guard so they stay out of the production
-        // bundle (matches getMarketDataProvider). Lives inside try so a require()
-        // throw can't propagate to the client (mirrors submitAnalysisAction).
+        // E2E short-circuits the LLM/worker with a deterministic fixture (see
+        // e2eAnalysisStub). Loaded via a DYNAMIC import under the inline E2E guard
+        // so the stub + JSON fixture sit in a lazy chunk (never in the prod main
+        // bundle; the branch is dead when E2E_TEST is unset). Dynamic import (vs a
+        // bare require) is also resolvable by the vitest runner, so this branch is
+        // unit-tested. Inside try so a load failure can't propagate to the client.
         if (process.env.E2E_TEST === '1') {
-            const stub =
-                require('@/shared/api/e2eAnalysisStub') as typeof import('@/shared/api/e2eAnalysisStub');
+            const stub = await import('@/shared/api/e2eAnalysisStub');
             // resilience 스펙이 설정하는 force-error 쿠키가 있으면 일시적 실패를
             // 결정적으로 주입해 에러 바운더리 → 재시도 → 복구를 검증할 수 있게 한다.
             const forceError = (await cookies()).get(

--- a/src/shared/api/__tests__/e2eAnalysisStub.test.ts
+++ b/src/shared/api/__tests__/e2eAnalysisStub.test.ts
@@ -96,6 +96,6 @@ describe('e2eForcedOptionsError (resilience seam)', () => {
         // useOptionsAnalysis throws on this status → OptionsAiAnalysisError ("다시 시도").
         expect(result.status).toBe('no_chains_error');
         expect(result.code).toBe('no_options_chains');
-        expect(result.error).toContain('E2E 강제 분석 실패');
+        expect(result.error).toBe('E2E 강제 분석 실패 (resilience 테스트용)');
     });
 });

--- a/src/shared/api/__tests__/e2eAnalysisStub.test.ts
+++ b/src/shared/api/__tests__/e2eAnalysisStub.test.ts
@@ -6,6 +6,8 @@ import {
     e2eCachedFundamental,
     e2eCachedNews,
     e2eCachedOptions,
+    e2eForcedOptionsError,
+    E2E_FORCE_ANALYSIS_ERROR_COOKIE,
 } from '@/shared/api/e2eAnalysisStub';
 
 describe('isE2E', () => {
@@ -86,5 +88,21 @@ describe('e2eCached* fixture getters', () => {
             throw new Error('unreachable: stub always returns cached');
         }
         expect(a.result).toBe(b.result);
+    });
+});
+
+describe('e2eForcedOptionsError (resilience seam)', () => {
+    it('exposes a stable cookie name the e2e spec mirrors', () => {
+        expect(E2E_FORCE_ANALYSIS_ERROR_COOKIE).toBe(
+            'e2e_force_analysis_error'
+        );
+    });
+
+    it('returns a no_chains_error result that drives the options error boundary', () => {
+        const result = e2eForcedOptionsError();
+        // useOptionsAnalysis throws on this status → OptionsAiAnalysisError ("다시 시도").
+        expect(result.status).toBe('no_chains_error');
+        expect(result.code).toBe('no_options_chains');
+        expect(result.error).toContain('E2E 강제 분석 실패');
     });
 });

--- a/src/shared/api/__tests__/e2eAnalysisStub.test.ts
+++ b/src/shared/api/__tests__/e2eAnalysisStub.test.ts
@@ -7,7 +7,6 @@ import {
     e2eCachedNews,
     e2eCachedOptions,
     e2eForcedOptionsError,
-    E2E_FORCE_ANALYSIS_ERROR_COOKIE,
 } from '@/shared/api/e2eAnalysisStub';
 
 describe('isE2E', () => {
@@ -92,12 +91,6 @@ describe('e2eCached* fixture getters', () => {
 });
 
 describe('e2eForcedOptionsError (resilience seam)', () => {
-    it('exposes a stable cookie name the e2e spec mirrors', () => {
-        expect(E2E_FORCE_ANALYSIS_ERROR_COOKIE).toBe(
-            'e2e_force_analysis_error'
-        );
-    });
-
     it('returns a no_chains_error result that drives the options error boundary', () => {
         const result = e2eForcedOptionsError();
         // useOptionsAnalysis throws on this status → OptionsAiAnalysisError ("다시 시도").

--- a/src/shared/api/e2eAnalysisStub.ts
+++ b/src/shared/api/e2eAnalysisStub.ts
@@ -80,7 +80,9 @@ export function e2eCachedOptions(): SubmitOptionsAnalysisCached {
  * return a transient failure instead of the cached fixture. Read server-side by
  * `submitOptionsAnalysisAction` (only under `E2E_TEST=1`). The resilience spec
  * sets it, asserts the error fallback, then clears it so the retry recovers.
- * The e2e spec mirrors this literal — keep them in sync.
+ * The e2e spec imports this constant directly; the only literal copy is the
+ * vi.mock factory in optionsActions.test.ts (hoisted before imports) — keep that
+ * one in sync if this value changes.
  */
 export const E2E_FORCE_ANALYSIS_ERROR_COOKIE = 'e2e_force_analysis_error';
 

--- a/src/shared/api/e2eAnalysisStub.ts
+++ b/src/shared/api/e2eAnalysisStub.ts
@@ -8,6 +8,7 @@ import type {
     SubmitFundamentalAnalysisCached,
     SubmitNewsAnalysisCached,
     SubmitOptionsAnalysisCached,
+    SubmitOptionsAnalysisNoChainsError,
     SubmitOverallAnalysisCached,
 } from '@y0ngha/siglens-core';
 import fixture from '@e2e/fixtures/analysis.json';
@@ -72,4 +73,28 @@ export function e2eCachedNews(): SubmitNewsAnalysisCached {
 /** Fixed `{ status: 'cached' }` options analysis result for E2E runs. */
 export function e2eCachedOptions(): SubmitOptionsAnalysisCached {
     return { status: 'cached', result: typedFixture.options };
+}
+
+/**
+ * Cookie name an E2E test sets to force the next options-analysis submit to
+ * return a transient failure instead of the cached fixture. Read server-side by
+ * `submitOptionsAnalysisAction` (only under `E2E_TEST=1`). The resilience spec
+ * sets it, asserts the error fallback, then clears it so the retry recovers.
+ * The e2e spec mirrors this literal — keep them in sync.
+ */
+export const E2E_FORCE_ANALYSIS_ERROR_COOKIE = 'e2e_force_analysis_error';
+
+/**
+ * Deterministic transient-failure result for E2E resilience tests. Returned by
+ * the options submit action (under E2E_TEST) when the force-error cookie is
+ * present, so `useOptionsAnalysis` throws and surfaces OptionsAiAnalysisError
+ * ("다시 시도"). Reuses the real `no_chains_error` variant — any error-producing
+ * status drives the same error boundary, and this one needs no jobId/poll.
+ */
+export function e2eForcedOptionsError(): SubmitOptionsAnalysisNoChainsError {
+    return {
+        status: 'no_chains_error',
+        code: 'no_options_chains',
+        error: 'E2E 강제 분석 실패 (resilience 테스트용)',
+    };
 }

--- a/src/widgets/symbol-page/ChartContent.tsx
+++ b/src/widgets/symbol-page/ChartContent.tsx
@@ -185,9 +185,7 @@ export function ChartContent({
         // DOM에도 항상 남고, 봇으로 오판된 실사용자에게도 actionable hint가 유지된다.
         return !hasNarrative ? (
             <div className="flex flex-col gap-3">
-                <AnalysisStatusBanner
-                    status={analysisStatus}
-                />
+                <AnalysisStatusBanner status={analysisStatus} />
                 <TechnicalFactsSummary
                     symbol={symbol}
                     bars={bars}
@@ -198,9 +196,7 @@ export function ChartContent({
             </div>
         ) : (
             <div className="flex flex-col gap-3">
-                <AnalysisStatusBanner
-                    status={analysisStatus}
-                />
+                <AnalysisStatusBanner status={analysisStatus} />
                 <TechnicalFactsSummary
                     symbol={symbol}
                     bars={bars}


### PR DESCRIPTION
## 개요
Tier 4에서 디스코프했던 **resilience 스펙**(위젯 에러 바운더리 → 재시도 → 복구)을 결정적 seam으로 구현한 follow-up PR.

## 왜 seam이 필요했나
E2E에서 분석은 서버사이드 cached로 단락되어 클라이언트 관측 가능한 실패가 자연 발생하지 않고, 서버 액션 POST를 네트워크 인터셉트로 강제 실패시키면 레이스로 **flaky**(1/2 입증). 그래서 `E2E_TEST` 게이트 + 요청 스코프 쿠키로 일시 실패를 **결정적으로** 주입.

## 변경
- **`e2eAnalysisStub.ts`**: `E2E_FORCE_ANALYSIS_ERROR_COOKIE` 상수 + `e2eForcedOptionsError()`(no_chains_error 반환) 추가 + colocated 테스트.
- **`submitOptionsAnalysisAction`**: `E2E_TEST=1`에서만, force-error 쿠키가 있으면 cached 대신 강제 에러 반환. **prod 경로 불변**(분기 전체가 E2E_TEST 게이트).
- **`resilience.spec.ts`**: 쿠키 set → 격리된 에러 fallback + 탭 nav 생존 확인 → 쿠키 clear → "다시 시도" → 복구.

## 결정성
옵션 카드는 E2E에서 항상 렌더(`FakeOptionsDataProvider`가 non-zero OI 시드 → `oiStale` 항상 false), 쿠키 seam은 인터셉트 레이스를 제거. **`--repeat-each=5` 5/5 통과**, 단위 테스트 22 passed.

## 검증
- typecheck 0 / lint clean / vitest 22 passed (신규 헬퍼 + optionsActions 회귀)
- resilience 스펙 chromium 5/5 (repeat-each=5), prod 빌드 성공 확인
- E2E_TEST 미설정 시 prod 동작 불변

## 참고

🤖 Generated with [Claude Code](https://claude.com/claude-code)