### PR TITLE
feat(chat): Anthropic prompt caching for multi-turn chat (E4)

### DIFF
--- a/src/entities/llm-provider/__tests__/api/anthropic.test.ts
+++ b/src/entities/llm-provider/__tests__/api/anthropic.test.ts
@@ -23,8 +23,12 @@ vi.mock('@y0ngha/siglens-core', async () => {
     };
 });
 
-import { callAnthropicChat } from '@/entities/llm-provider/api/anthropic';
+import {
+    callAnthropicChat,
+    withHistoryCacheBreakpoint,
+} from '@/entities/llm-provider/api/anthropic';
 import { MODEL_SPECS } from '@y0ngha/siglens-core';
+import type Anthropic from '@anthropic-ai/sdk';
 
 const BASE_OPTIONS = {
     serverApiKey: 'server-key',
@@ -233,7 +237,8 @@ describe('callAnthropicChat', () => {
             const msgs = call.messages;
             expect(msgs).toHaveLength(3);
 
-            // second-to-last (history) message: block content with cache_control
+            expect(msgs[0]).toEqual({ role: 'user', content: 'first' });
+
             expect(msgs[1]).toEqual({
                 role: 'assistant',
                 content: [
@@ -245,8 +250,39 @@ describe('callAnthropicChat', () => {
                 ],
             });
 
-            // last (new) user turn: plain string, no cache_control
             expect(msgs[2]).toEqual({ role: 'user', content: 'second' });
+        });
+
+        it('정확히 2턴이면 첫 메시지(breakpointIdx === 0)에 캐시 브레이크포인트를 붙이고 마지막 turn은 plain string으로 둔다', async () => {
+            mockFinalMessage.mockResolvedValue({
+                content: [{ type: 'text', text: 'ok' }],
+                stop_reason: 'end_turn',
+            });
+
+            await callAnthropicChat({
+                ...BASE_OPTIONS,
+                contents: [
+                    { role: 'user', text: 'first' },
+                    { role: 'assistant', text: 'reply' },
+                ],
+            });
+
+            const call = mockStream.mock.calls[0][0];
+            const msgs = call.messages;
+            expect(msgs).toHaveLength(2);
+
+            expect(msgs[0]).toEqual({
+                role: 'user',
+                content: [
+                    {
+                        type: 'text',
+                        text: 'first',
+                        cache_control: { type: 'ephemeral' },
+                    },
+                ],
+            });
+
+            expect(msgs[1]).toEqual({ role: 'assistant', content: 'reply' });
         });
 
         it('단일 메시지면 history 브레이크포인트를 추가하지 않고 system 브레이크포인트만 적용한다', async () => {
@@ -263,12 +299,10 @@ describe('callAnthropicChat', () => {
 
             const call = mockStream.mock.calls[0][0];
             expect(call.messages).toHaveLength(1);
-            // only/last message stays plain string (no cache_control)
             expect(call.messages[0]).toEqual({
                 role: 'user',
                 content: 'only message',
             });
-            // system breakpoint still present
             expect(call.system).toEqual([
                 {
                     type: 'text',
@@ -306,6 +340,29 @@ describe('callAnthropicChat', () => {
             });
 
             expect(result).toBe('final answer');
+        });
+    });
+
+    describe('withHistoryCacheBreakpoint', () => {
+        it('second-to-last 메시지가 이미 block content면 그대로 반환한다 (중복 래핑 없음)', () => {
+            const messages: Anthropic.MessageParam[] = [
+                {
+                    role: 'user',
+                    content: [{ type: 'text', text: 'already block' }],
+                },
+                { role: 'assistant', content: 'reply' },
+            ];
+
+            const result = withHistoryCacheBreakpoint(messages);
+
+            expect(result).toBe(messages);
+            expect(result).toEqual([
+                {
+                    role: 'user',
+                    content: [{ type: 'text', text: 'already block' }],
+                },
+                { role: 'assistant', content: 'reply' },
+            ]);
         });
     });
 

--- a/src/entities/llm-provider/__tests__/api/anthropic.test.ts
+++ b/src/entities/llm-provider/__tests__/api/anthropic.test.ts
@@ -179,7 +179,7 @@ describe('callAnthropicChat', () => {
     });
 
     describe('systemInstruction', () => {
-        it('systemInstruction이 있으면 system 파라미터로 전달한다', async () => {
+        it('systemInstruction이 있으면 ephemeral 캐시 브레이크포인트가 붙은 text 블록 배열로 전달한다', async () => {
             mockFinalMessage.mockResolvedValue({
                 content: [{ type: 'text', text: 'ok' }],
                 stop_reason: 'end_turn',
@@ -191,7 +191,13 @@ describe('callAnthropicChat', () => {
             });
 
             const call = mockStream.mock.calls[0][0];
-            expect(call.system).toBe('Be concise');
+            expect(call.system).toEqual([
+                {
+                    type: 'text',
+                    text: 'Be concise',
+                    cache_control: { type: 'ephemeral' },
+                },
+            ]);
         });
 
         it('systemInstruction이 없으면 system 파라미터를 포함하지 않는다', async () => {
@@ -204,6 +210,102 @@ describe('callAnthropicChat', () => {
 
             const call = mockStream.mock.calls[0][0];
             expect(call).not.toHaveProperty('system');
+        });
+    });
+
+    describe('prompt caching — history 브레이크포인트', () => {
+        it('멀티턴(>=2)이면 마지막 직전 history 메시지에 ephemeral 캐시 브레이크포인트를 붙이고 마지막 turn은 plain string으로 둔다', async () => {
+            mockFinalMessage.mockResolvedValue({
+                content: [{ type: 'text', text: 'ok' }],
+                stop_reason: 'end_turn',
+            });
+
+            await callAnthropicChat({
+                ...BASE_OPTIONS,
+                contents: [
+                    { role: 'user', text: 'first' },
+                    { role: 'assistant', text: 'reply' },
+                    { role: 'user', text: 'second' },
+                ],
+            });
+
+            const call = mockStream.mock.calls[0][0];
+            const msgs = call.messages;
+            expect(msgs).toHaveLength(3);
+
+            // second-to-last (history) message: block content with cache_control
+            expect(msgs[1]).toEqual({
+                role: 'assistant',
+                content: [
+                    {
+                        type: 'text',
+                        text: 'reply',
+                        cache_control: { type: 'ephemeral' },
+                    },
+                ],
+            });
+
+            // last (new) user turn: plain string, no cache_control
+            expect(msgs[2]).toEqual({ role: 'user', content: 'second' });
+        });
+
+        it('단일 메시지면 history 브레이크포인트를 추가하지 않고 system 브레이크포인트만 적용한다', async () => {
+            mockFinalMessage.mockResolvedValue({
+                content: [{ type: 'text', text: 'ok' }],
+                stop_reason: 'end_turn',
+            });
+
+            await callAnthropicChat({
+                ...BASE_OPTIONS,
+                contents: [{ role: 'user', text: 'only message' }],
+                systemInstruction: 'Be concise',
+            });
+
+            const call = mockStream.mock.calls[0][0];
+            expect(call.messages).toHaveLength(1);
+            // only/last message stays plain string (no cache_control)
+            expect(call.messages[0]).toEqual({
+                role: 'user',
+                content: 'only message',
+            });
+            // system breakpoint still present
+            expect(call.system).toEqual([
+                {
+                    type: 'text',
+                    text: 'Be concise',
+                    cache_control: { type: 'ephemeral' },
+                },
+            ]);
+        });
+
+        it('string contents(단일 user 메시지)면 history 브레이크포인트가 없다', async () => {
+            mockFinalMessage.mockResolvedValue({
+                content: [{ type: 'text', text: 'ok' }],
+                stop_reason: 'end_turn',
+            });
+
+            await callAnthropicChat(BASE_OPTIONS);
+
+            const call = mockStream.mock.calls[0][0];
+            expect(call.messages).toEqual([{ role: 'user', content: 'Hello' }]);
+        });
+
+        it('반환값은 캐싱 변경과 무관하게 동일하다', async () => {
+            mockFinalMessage.mockResolvedValue({
+                content: [{ type: 'text', text: 'final answer' }],
+                stop_reason: 'end_turn',
+            });
+
+            const result = await callAnthropicChat({
+                ...BASE_OPTIONS,
+                contents: [
+                    { role: 'user', text: 'first' },
+                    { role: 'assistant', text: 'reply' },
+                    { role: 'user', text: 'second' },
+                ],
+            });
+
+            expect(result).toBe('final answer');
         });
     });
 

--- a/src/entities/llm-provider/__tests__/api/anthropic.test.ts
+++ b/src/entities/llm-provider/__tests__/api/anthropic.test.ts
@@ -343,29 +343,6 @@ describe('callAnthropicChat', () => {
         });
     });
 
-    describe('withHistoryCacheBreakpoint', () => {
-        it('second-to-last 메시지가 이미 block content면 그대로 반환한다 (중복 래핑 없음)', () => {
-            const messages: Anthropic.MessageParam[] = [
-                {
-                    role: 'user',
-                    content: [{ type: 'text', text: 'already block' }],
-                },
-                { role: 'assistant', content: 'reply' },
-            ];
-
-            const result = withHistoryCacheBreakpoint(messages);
-
-            expect(result).toBe(messages);
-            expect(result).toEqual([
-                {
-                    role: 'user',
-                    content: [{ type: 'text', text: 'already block' }],
-                },
-                { role: 'assistant', content: 'reply' },
-            ]);
-        });
-    });
-
     describe('effort 검증', () => {
         it('유효한 effort(medium)는 통과한다', async () => {
             mockFinalMessage.mockResolvedValue({
@@ -401,5 +378,28 @@ describe('callAnthropicChat', () => {
                 specs['claude-sonnet-4-6'] = original;
             }
         });
+    });
+});
+
+describe('withHistoryCacheBreakpoint', () => {
+    it('second-to-last 메시지가 이미 block content면 그대로 반환한다 (중복 래핑 없음)', () => {
+        const messages: Anthropic.MessageParam[] = [
+            {
+                role: 'user',
+                content: [{ type: 'text', text: 'already block' }],
+            },
+            { role: 'assistant', content: 'reply' },
+        ];
+
+        const result = withHistoryCacheBreakpoint(messages);
+
+        expect(result).toBe(messages);
+        expect(result).toEqual([
+            {
+                role: 'user',
+                content: [{ type: 'text', text: 'already block' }],
+            },
+            { role: 'assistant', content: 'reply' },
+        ]);
     });
 });

--- a/src/entities/llm-provider/__tests__/api/anthropic.test.ts
+++ b/src/entities/llm-provider/__tests__/api/anthropic.test.ts
@@ -382,6 +382,17 @@ describe('callAnthropicChat', () => {
 });
 
 describe('withHistoryCacheBreakpoint', () => {
+    it('메시지가 2개 미만이면 원본을 그대로 반환한다 (히스토리 없음)', () => {
+        const messages: Anthropic.MessageParam[] = [
+            { role: 'user', content: 'only turn' },
+        ];
+
+        const result = withHistoryCacheBreakpoint(messages);
+
+        expect(result).toBe(messages);
+        expect(result).toEqual([{ role: 'user', content: 'only turn' }]);
+    });
+
     it('second-to-last 메시지가 이미 block content면 그대로 반환한다 (중복 래핑 없음)', () => {
         const messages: Anthropic.MessageParam[] = [
             {

--- a/src/entities/llm-provider/api/anthropic.ts
+++ b/src/entities/llm-provider/api/anthropic.ts
@@ -37,9 +37,53 @@ function findSpecByApiModelId(apiModelId: string): ModelSpec | undefined {
     );
 }
 
+/**
+ * Ephemeral prompt-cache breakpoint. Reused for the stable system prefix and the
+ * conversation-history breakpoint so repeated chat turns reuse the cached prefix
+ * instead of re-billing it as fresh input tokens.
+ */
+const EPHEMERAL_CACHE_CONTROL = { type: 'ephemeral' } as const;
+
 function toAnthropicMessages(contents: AiContents): Anthropic.MessageParam[] {
     // Safe cast: ProviderTurn is structurally compatible with MessageParam (role literals + string content).
     return toProviderTurns(contents) as Anthropic.MessageParam[];
+}
+
+/**
+ * Marks the last *history* message (second-to-last overall) with an ephemeral
+ * cache breakpoint, so the conversation prefix up to the previous turn is cached
+ * and only the new (final) user turn is uncached.
+ *
+ * Returns a new array — never mutates the caller's messages — and is a no-op when
+ * there is no history yet (fewer than 2 messages). Anthropic silently ignores
+ * prefixes below the model's min-cacheable size, so no token counting is needed.
+ */
+function withHistoryCacheBreakpoint(
+    messages: Anthropic.MessageParam[]
+): Anthropic.MessageParam[] {
+    if (messages.length < 2) {
+        return messages;
+    }
+    const breakpointIdx = messages.length - 2;
+    const target = messages[breakpointIdx];
+    const text =
+        typeof target.content === 'string' ? target.content : undefined;
+    if (text === undefined) {
+        // Already block content (shouldn't happen for our string turns); leave as-is.
+        return messages;
+    }
+    const next = [...messages];
+    next[breakpointIdx] = {
+        role: target.role,
+        content: [
+            {
+                type: 'text',
+                text,
+                cache_control: EPHEMERAL_CACHE_CONTROL,
+            },
+        ],
+    };
+    return next;
 }
 
 export async function callAnthropicChat({
@@ -59,12 +103,25 @@ export async function callAnthropicChat({
     const maxTokens = spec.maxOutputTokens;
 
     const client = new Anthropic({ apiKey: serverApiKey });
+    // Two prompt-cache breakpoints keep repeated chat turns cheap: the stable
+    // system prefix (persona + analysis context + few-shot) and the conversation
+    // prefix up to the previous turn are cached, so each new turn only bills the
+    // latest user message as fresh input tokens.
+    const messages = withHistoryCacheBreakpoint(toAnthropicMessages(contents));
     const stream = client.messages.stream({
         model,
         max_tokens: maxTokens,
-        messages: toAnthropicMessages(contents),
+        messages,
         ...(systemInstruction !== undefined
-            ? { system: systemInstruction }
+            ? {
+                  system: [
+                      {
+                          type: 'text',
+                          text: systemInstruction,
+                          cache_control: EPHEMERAL_CACHE_CONTROL,
+                      },
+                  ],
+              }
             : {}),
         ...(adaptiveThinking
             ? {

--- a/src/entities/llm-provider/api/anthropic.ts
+++ b/src/entities/llm-provider/api/anthropic.ts
@@ -54,9 +54,11 @@ function toAnthropicMessages(contents: AiContents): Anthropic.MessageParam[] {
  * cache breakpoint, so the conversation prefix up to the previous turn is cached
  * and only the new (final) user turn is uncached.
  *
- * Returns a new array — never mutates the caller's messages — and is a no-op when
- * there is no history yet (fewer than 2 messages). Anthropic silently ignores
- * prefixes below the model's min-cacheable size, so no token counting is needed.
+ * Returns the original `messages` unchanged (same reference) when there is no
+ * history yet (fewer than 2 messages) or the second-to-last message already has
+ * block content; otherwise returns a new array and never mutates the caller's
+ * messages. Anthropic silently ignores prefixes below the model's min-cacheable
+ * size, so no token counting is needed.
  *
  * Exported for unit-testing the already-block-content branch, which
  * `toAnthropicMessages` never produces in normal flow.

--- a/src/entities/llm-provider/api/anthropic.ts
+++ b/src/entities/llm-provider/api/anthropic.ts
@@ -57,8 +57,11 @@ function toAnthropicMessages(contents: AiContents): Anthropic.MessageParam[] {
  * Returns a new array — never mutates the caller's messages — and is a no-op when
  * there is no history yet (fewer than 2 messages). Anthropic silently ignores
  * prefixes below the model's min-cacheable size, so no token counting is needed.
+ *
+ * @internal Exported only for unit-testing the already-block-content branch,
+ * which `toAnthropicMessages` never produces in normal flow.
  */
-function withHistoryCacheBreakpoint(
+export function withHistoryCacheBreakpoint(
     messages: Anthropic.MessageParam[]
 ): Anthropic.MessageParam[] {
     if (messages.length < 2) {
@@ -72,18 +75,20 @@ function withHistoryCacheBreakpoint(
         // Already block content (shouldn't happen for our string turns); leave as-is.
         return messages;
     }
-    const next = [...messages];
-    next[breakpointIdx] = {
-        role: target.role,
-        content: [
-            {
-                type: 'text',
-                text,
-                cache_control: EPHEMERAL_CACHE_CONTROL,
-            },
-        ],
-    };
-    return next;
+    return messages.map((message, index) =>
+        index === breakpointIdx
+            ? {
+                  role: message.role,
+                  content: [
+                      {
+                          type: 'text',
+                          text,
+                          cache_control: EPHEMERAL_CACHE_CONTROL,
+                      },
+                  ],
+              }
+            : message
+    );
 }
 
 export async function callAnthropicChat({

--- a/src/entities/llm-provider/api/anthropic.ts
+++ b/src/entities/llm-provider/api/anthropic.ts
@@ -58,8 +58,8 @@ function toAnthropicMessages(contents: AiContents): Anthropic.MessageParam[] {
  * there is no history yet (fewer than 2 messages). Anthropic silently ignores
  * prefixes below the model's min-cacheable size, so no token counting is needed.
  *
- * @internal Exported only for unit-testing the already-block-content branch,
- * which `toAnthropicMessages` never produces in normal flow.
+ * Exported for unit-testing the already-block-content branch, which
+ * `toAnthropicMessages` never produces in normal flow.
  */
 export function withHistoryCacheBreakpoint(
     messages: Anthropic.MessageParam[]


### PR DESCRIPTION
## 배경
멀티턴 챗봇은 매 턴 동일한 system prompt(페르소나+분석 컨텍스트+few-shot)와 누적 대화를 재전송합니다. provider prompt caching으로 토큰 비용을 절감합니다.

## 변경 (chat 경로 — `anthropic.ts`만)
- **system 블록**: `cache_control: ephemeral`로 안정적 prefix 캐싱.
- **히스토리 브레이크포인트**: 새 user turn 직전(`messages[len-2]`, 마지막 history turn)에 두 번째 `cache_control` → 대화 prefix 캐싱, 새 turn만 uncached. len<2면 system 브레이크포인트만.
- 불변 헬퍼(`withHistoryCacheBreakpoint`)로 messages 비파괴 처리.
- **Gemini/OpenAI 무변경** — 각각 implicit/automatic prompt caching이라 코드 불필요.

## 효과
빠른 멀티턴 챗에서 캐시된 입력 토큰 ~90%↓ (TTL 5분). 출력·동작 불변.

## 검증
typecheck/lint clean, anthropic 어댑터 17/17 통과(system 블록·히스토리 브레이크포인트·단일턴·문자열 contents).

⚠️ e2e CI는 별개 사유(master의 E2 per/psr 코드가 미릴리스 core 의존)로 실패하며, 본 변경과 무관합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)