### PR TITLE
fix: FileSkillsLoader dedupe by skill name

### DIFF
--- a/src/entities/skill/__tests__/api.test.ts
+++ b/src/entities/skill/__tests__/api.test.ts
@@ -1128,7 +1128,6 @@ describe('dedupeByName', () => {
             skill('C'),
         ]);
         expect(out.map(s => s.name)).toEqual(['A', 'B', 'C']);
-        // 첫 번째 A가 유지되고 이후 동명 항목은 버려진다.
         expect(out[0].description).toBe('first');
     });
 

--- a/src/entities/skill/__tests__/api.test.ts
+++ b/src/entities/skill/__tests__/api.test.ts
@@ -1,5 +1,6 @@
 import { countSkillFiles, FileSkillsLoader } from '@/entities/skill';
-import { parseGating } from '../api';
+import type { Skill } from '@y0ngha/siglens-core';
+import { dedupeByName, parseGating } from '../api';
 import path from 'node:path';
 
 const { mockReaddir, mockReadFile } = vi.hoisted(() => ({
@@ -1106,5 +1107,37 @@ describe('countSkillFiles', () => {
         );
 
         await expect(countSkillFiles()).rejects.toThrow('ENOENT');
+    });
+});
+
+describe('dedupeByName', () => {
+    const skill = (name: string, description = 'd'): Skill => ({
+        name,
+        description,
+        indicators: [],
+        confidenceWeight: 0,
+        content: '',
+        smcFullGuide: false,
+    });
+
+    it('이름 중복 시 첫 번째만 남기고 이후 중복을 제거한다', () => {
+        const out = dedupeByName([
+            skill('A', 'first'),
+            skill('B'),
+            skill('A', 'dup'),
+            skill('C'),
+        ]);
+        expect(out.map(s => s.name)).toEqual(['A', 'B', 'C']);
+        // 첫 번째 A가 유지되고 이후 동명 항목은 버려진다.
+        expect(out[0].description).toBe('first');
+    });
+
+    it('빈 입력은 빈 배열을 반환한다', () => {
+        expect(dedupeByName([])).toEqual([]);
+    });
+
+    it('이름이 모두 고유하면 순서를 유지한 채 그대로 반환한다', () => {
+        const out = dedupeByName([skill('A'), skill('B'), skill('C')]);
+        expect(out.map(s => s.name)).toEqual(['A', 'B', 'C']);
     });
 });

--- a/src/entities/skill/api.ts
+++ b/src/entities/skill/api.ts
@@ -421,6 +421,10 @@ const countMdFiles = async (subdir: string): Promise<number> => {
 
 // cacheComponents 비활성 기간 동안 'use cache' 제거.
 // skills 디렉토리는 빌드 산출물이라 매 요청 fs.readdir이 사실상 OS page cache hit.
+//
+// 디스크 .md 파일 개수를 카테고리별로 집계한다(카탈로그 규모 표시용). loadSkills는
+// dedupeByName으로 동명 스킬을 제거하지만, 이 카운트는 파일 수를 그대로 반영한다
+// — 목적이 달라 의도적으로 dedup하지 않는다.
 export async function countSkillFiles(): Promise<SkillCounts> {
     const [
         indicators,

--- a/src/entities/skill/api.ts
+++ b/src/entities/skill/api.ts
@@ -450,6 +450,24 @@ export async function countSkillFiles(): Promise<SkillCounts> {
     };
 }
 
+/**
+ * Drop skills whose `name` already appeared (first occurrence wins). Mirrors the
+ * core loader's `dedupeByName`: the production prompt path is core-fed, but
+ * `FileSkillsLoader` is also consumed directly (e.g. the backtest script), so two
+ * `.md` files sharing a `name` must not inject the same skill twice or make
+ * selection order-dependent.
+ *
+ * Exported for unit testing; not re-exported via the entity barrel.
+ */
+export const dedupeByName = (skills: Skill[]): Skill[] => {
+    const seen = new Set<string>();
+    return skills.filter(skill => {
+        if (seen.has(skill.name)) return false;
+        seen.add(skill.name);
+        return true;
+    });
+};
+
 export class FileSkillsLoader implements SkillsProvider {
     async loadSkills(): Promise<Skill[]> {
         const mdFiles = await collectMdFiles(SKILLS_DIR);
@@ -463,6 +481,6 @@ export class FileSkillsLoader implements SkillsProvider {
             })
         );
 
-        return skills.filter((s): s is Skill => s !== null);
+        return dedupeByName(skills.filter((s): s is Skill => s !== null));
     }
 }


### PR DESCRIPTION
## 관련 이슈

Group F skill-gating audit finding — FileSkillsLoader lacked deduplication while the core loader had it.

## 구현 내용

Added `dedupeByName` utility function to FileSkillsLoader (mirrors core loader implementation).
- Prevents two `.md` files sharing the same skill `name` from double-injecting or making selection order-dependent
- Applied in `FileSkillsLoader.loadSkills`
- 3 unit tests validating dedupe logic

Low risk — production prompt path is core-fed, but FileSkillsLoader is consumed directly (e.g. backtest script), so keeping it consistent improves robustness.

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] 단위 테스트 포함 및 통과
- [x] 타입 안전성 확인 (any 없음)
- [x] 함수형 프로그래밍 (map/filter/reduce)

## 변경 파일 목록

[수정]
- src/entities/skill/api.ts
- src/entities/skill/__tests__/api.test.ts

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn test
- [x] yarn build