### PR TITLE
perf(vercel): cut Fast Origin/Data Transfer — bot block, page+OG ISR, FMP 404 safety

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -915,8 +915,11 @@ UI state that should survive page refresh or be shareable via link must be refle
 
 The selected timeframe is synchronized to the `tf` query parameter.
 
-**Reading (server):** `app/[symbol]/page.tsx` reads `searchParams.tf`, validates with `isValidTimeframe()`,
-and passes the result as `initialTimeframe` prop to `SymbolPageClient`.
+**Reading (client):** to keep `[symbol]` routes ISR-cacheable, `tf` is read on the **client**, never on the
+server (a server `searchParams` read forces dynamic rendering and disables ISR). The chart page uses
+`useTimeframeChange` (`useSearchParams().get('tf')`); `OverallContent` reads it inline the same way. Server
+components seed `DEFAULT_TIMEFRAME` and let the client reconcile to the URL value on mount. The canonical URL
+excludes `tf`, so the client-only read does not affect SEO/indexing.
 
 **Writing (client):** `useTimeframeChange` calls `router.replace(...?tf=<value>, { scroll: false })`
 inside `startTransition` whenever the user changes the timeframe.
@@ -925,9 +928,12 @@ inside `startTransition` whenever the user changes the timeframe.
 as the source of truth for valid values. Never validate against hardcoded string literals at the call site.
 
 ```typescript
-// ✅ Server reads initial timeframe from URL
-const { tf } = await searchParams;
-const initialTimeframe = isValidTimeframe(tf) ? tf : DEFAULT_TIMEFRAME;
+// ✅ Client reads timeframe from URL (keeps the route static/ISR)
+const tfParam = useSearchParams().get('tf');
+const timeframe = isValidTimeframe(tfParam) ? tfParam : DEFAULT_TIMEFRAME;
+
+// ❌ Server reading searchParams.tf — forces dynamic rendering, breaks ISR
+// const { tf } = await searchParams;
 
 // ✅ Client updates URL on change (inside startTransition)
 router.replace(`/${symbol}?tf=${nextTimeframe}`, { scroll: false });

--- a/docs/superpowers/plans/2026-06-01-vercel-transfer-cost.md
+++ b/docs/superpowers/plans/2026-06-01-vercel-transfer-cost.md
@@ -1,0 +1,661 @@
+# Vercel 트랜스퍼 비용 절감 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** robots.txt 봇 차단 + OG 이미지/[symbol] 페이지 엣지 캐싱 + 404 캐시 오염 방지로 Vercel Fast Origin/Data Transfer 비용을 절감한다.
+
+**Architecture:** (1) robots.txt로 기생 SEO 봇 차단(요청 수↓). (2) OG 이미지·정적 성격 페이지에 `revalidate` 부여(compute 호출↓). (3) `tf`를 읽는 chart/overall은 서버 searchParams 읽기를 제거하고 client `useSearchParams`로 위임(+`<Suspense>`)해 ISR 가능화. (4) FMP 인프라 에러를 throw로 바꿔 ISR이 일시 장애를 404로 캐싱하는 오염을 차단.
+
+**Tech Stack:** Next.js 16 (App Router, ISR `revalidate`), React `Suspense`, Vitest, `@y0ngha/siglens-core`.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-vercel-transfer-cost-design.md`
+
+**Git/Review flow (project convention, CLAUDE.md):** 구현은 orchestrator가 수행하고, 커밋·push·PR은 **git-agent**가 담당한다. 전체 구현 후 `review-agent → mistake-managing-agent → git-agent` 사이클을 거친다. 각 Task 끝의 "Checkpoint"는 typecheck/test green 확인 지점이며, 직접 커밋하지 않는다.
+
+**공통 검증 명령:**
+- 타입체크 + 린트: `yarn lint`
+- 단위 테스트(특정 파일): `yarn test <path>`
+- 전체 테스트: `yarn test`
+- 빌드(라우트 캐싱 타입 확인): `yarn build`
+
+---
+
+## ⚠️ 구현 중 발견된 정정 (Corrections)
+
+구현·빌드 검증 중 발견: **동적 라우트 `[symbol]`에는 `export const revalidate`만으로 ISR이 걸리지 않는다** (빌드가 `ƒ Dynamic`으로 표기, 매 요청 동적 렌더). Next.js 공식 동작상 "generateStaticParams가 배열을 반환(빈 배열이라도)하거나 `dynamic = 'force-static'`이어야 런타임 ISR이 활성화"된다.
+
+따라서 아래 Task들의 실제 구현은 plan 원문에 더해 다음을 포함한다:
+- **Task 5·6·7 (페이지 ISR)**: `revalidate`에 더해 각 page에 `export async function generateStaticParams(): Promise<{ symbol: string }[]> { return []; }` 추가 → 빌드에서 `● (SSG)`로 전환 확인.
+- **Task 4 (OG/트위터 이미지)**: `revalidate`만으로는 `ƒ`로 남아, 12개 파일에 `export const dynamic = 'force-static'` 추가(이미지가 동적 요청 API 미사용이라 안전) → 빌드에서 `○ (Static)`로 전환 확인.
+- `[symbol]/news`는 의도대로 `ƒ` 유지(D2①).
+
+(이 정정은 `docs/MISTAKES.md` 후보: "동적 라우트 ISR엔 revalidate만으로 부족 — generateStaticParams/force-static 필요".)
+
+## File Structure
+
+| 파일 | 책임 | 변경 |
+|---|---|---|
+| `src/app/robots.ts` | robots.txt 생성 | 기생봇 Disallow 규칙 추가 (rules 배열화) |
+| `src/app/__tests__/robots.test.ts` | robots 단위 테스트 | 배열 구조에 맞게 갱신 + 봇 차단 케이스 |
+| `src/entities/ticker/lib/fmpTickerApi.ts` | FMP 티커 검색 | `strict` 옵션 추가 — 인프라 에러 throw |
+| `src/entities/ticker/__tests__/lib/fmpTickerApi.test.ts` | 위 단위 테스트 | strict throw/lenient degrade 케이스 |
+| `src/entities/ticker/lib/getAssetInfo.ts` | 티커 정보 resolve | `searchBySymbol(upper, { strict: true })` |
+| `src/entities/ticker/__tests__/lib/getAssetInfo.test.ts` | 위 단위 테스트 | FMP throw 전파 케이스 |
+| `src/app/[symbol]/**/{opengraph-image,twitter-image}.tsx` (12) | OG/트위터 이미지 | `export const revalidate = 2592000` |
+| `src/app/[symbol]/options/page.tsx` · `fundamental/page.tsx` · `fear-greed/page.tsx` | 종목 탭(동적 트리거 없음) | `export const revalidate = 3600` |
+| `src/app/[symbol]/page.tsx` | 차트 페이지 | 서버 `searchParams(tf)` 제거 + `<Suspense>` + `revalidate=3600` |
+| `src/app/[symbol]/overall/page.tsx` | 종합 분석 페이지 | 서버 `searchParams(tf)` 제거 + `<Suspense>` + `revalidate=3600` |
+| `src/widgets/overall/OverallContent.tsx` | 종합 분석 client | `timeframe` prop 제거 → `useSearchParams`로 client read |
+
+**구현 순서(의존):** Task 1(봇, 독립) → Task 2·3(D3 안전장치, ISR 선결) → Task 4(OG) → Task 5(클린 페이지 ISR) → Task 6(차트 ISR) → Task 7(overall ISR) → Task 8(빌드 검증).
+
+---
+
+## Task 1: robots.txt 기생 봇 차단
+
+**Files:**
+- Modify: `src/app/robots.ts`
+- Test: `src/app/__tests__/robots.test.ts`
+
+- [ ] **Step 1: 기존 테스트를 배열 구조로 갱신 (실패 유도)**
+
+`src/app/__tests__/robots.test.ts`의 `describe('robots', ...)` 내부를 아래로 교체. (기존 `rules`를 객체로 단언하던 3개 케이스가 배열로 바뀜)
+
+```ts
+    it('returns a valid robots config', () => {
+        const result = robots();
+        expect(result).toBeDefined();
+        expect(Array.isArray(result.rules)).toBe(true);
+    });
+
+    it('allows all paths for the default user agent but disallows /api/', () => {
+        const result = robots();
+        expect(result.rules).toContainEqual(
+            expect.objectContaining({
+                userAgent: '*',
+                allow: '/',
+                disallow: ['/api/'],
+            })
+        );
+    });
+
+    it('disallows parasite SEO crawlers entirely', () => {
+        const result = robots();
+        expect(result.rules).toContainEqual(
+            expect.objectContaining({
+                userAgent: expect.arrayContaining([
+                    'AhrefsBot',
+                    'SemrushBot',
+                    'MJ12bot',
+                    'DotBot',
+                    'BLEXBot',
+                    'DataForSeoBot',
+                ]),
+                disallow: '/',
+            })
+        );
+    });
+
+    it('points sitemap to the correct URL', () => {
+        const result = robots();
+        expect(result.sitemap).toBe('https://siglens.io/sitemap.xml');
+    });
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `yarn test src/app/__tests__/robots.test.ts`
+Expected: FAIL — `result.rules`가 아직 객체라 `toContainEqual`/`Array.isArray` 실패.
+
+- [ ] **Step 3: robots.ts 구현**
+
+`src/app/robots.ts`를 아래로 교체:
+
+```ts
+import type { MetadataRoute } from 'next';
+import { SITE_URL } from '@/shared/lib/seo';
+
+// 검색엔진이 아닌 기생 SEO 크롤러(백링크/순위 분석 SaaS). 포털 랭킹에 기여하지 않으면서
+// 트래픽만 유발하므로 전면 Disallow한다 — Googlebot/Yeti/Bingbot/Daumoa 등 실제
+// 검색엔진은 절대 포함하지 않는다. 이 봇들은 robots.txt를 준수한다.
+const PARASITE_BOT_USER_AGENTS = [
+    'AhrefsBot',
+    'SemrushBot',
+    'MJ12bot',
+    'DotBot',
+    'BLEXBot',
+    'DataForSeoBot',
+];
+
+export default function robots(): MetadataRoute.Robots {
+    return {
+        rules: [
+            {
+                userAgent: '*',
+                allow: '/',
+                // API 라우트는 disallow로 유지 — 응답이 JSON/이미지 등 SEO 가치
+                // 없는 자원이라 crawl budget 절약 목적.
+                disallow: ['/api/'],
+            },
+            {
+                userAgent: PARASITE_BOT_USER_AGENTS,
+                disallow: '/',
+            },
+        ],
+        sitemap: `${SITE_URL}/sitemap.xml`,
+    };
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `yarn test src/app/__tests__/robots.test.ts`
+Expected: PASS (4 케이스)
+
+- [ ] **Step 5: Checkpoint**
+
+Run: `yarn lint`
+Expected: 통과. (다음 Task로 진행)
+
+---
+
+## Task 2: fmpTickerApi `strict` 에러 모드 (D3 part 1)
+
+**Files:**
+- Modify: `src/entities/ticker/lib/fmpTickerApi.ts`
+- Test: `src/entities/ticker/__tests__/lib/fmpTickerApi.test.ts`
+
+**배경:** 현재 `fetchFmpEndpoint`는 `!config`·`!res.ok`·network/timeout을 전부 `return []`로 삼킨다. `getAssetInfo`(ISR 렌더 경로)가 이를 통해 일시 장애를 "no-match"로 오인 → `notFound()` → ISR이 정상 종목 404를 캐시. `strict` 옵션을 추가해 **인프라 실패는 throw**, **200+빈배열만 `[]`**(legit no-match)로 구분한다. 인터랙티브 검색(`searchTicker.ts`)은 lenient 기본값 유지.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`src/entities/ticker/__tests__/lib/fmpTickerApi.test.ts`의 `describe('searchBySymbol/searchByName', ...)` 블록 안(기존 `beforeEach` 뒤)에 추가:
+
+```ts
+    describe('strict mode (getAssetInfo 경로)', () => {
+        it('!res.ok(429/5xx)면 throw한다', async () => {
+            mockFetch.mockResolvedValue({ ok: false, status: 429 });
+            await expect(
+                searchBySymbol('AAPL', { strict: true })
+            ).rejects.toThrow();
+        });
+
+        it('network/timeout 예외면 throw한다', async () => {
+            mockFetch.mockRejectedValue(new Error('network down'));
+            await expect(
+                searchBySymbol('AAPL', { strict: true })
+            ).rejects.toThrow();
+        });
+
+        it('200 + 빈 배열은 throw하지 않고 [] 반환 (legit no-match)', async () => {
+            mockFetch.mockResolvedValue({
+                ok: true,
+                json: async () => [],
+            });
+            await expect(
+                searchBySymbol('NOPE', { strict: true })
+            ).resolves.toEqual([]);
+        });
+
+        it('lenient(기본값)는 에러 시 여전히 []로 degrade한다', async () => {
+            mockFetch.mockResolvedValue({ ok: false, status: 500 });
+            await expect(searchBySymbol('AAPL')).resolves.toEqual([]);
+        });
+    });
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `yarn test src/entities/ticker/__tests__/lib/fmpTickerApi.test.ts`
+Expected: FAIL — `searchBySymbol`가 아직 `strict` 옵션을 모르고 throw하지 않음.
+
+- [ ] **Step 3: fmpTickerApi.ts 구현**
+
+`fetchFmpEndpoint`와 `searchBySymbol`을 아래로 교체 (`searchByName`은 그대로 둔다):
+
+```ts
+async function fetchFmpEndpoint(
+    endpoint: FmpEndpoint,
+    query: string,
+    options?: { strict?: boolean }
+): Promise<FmpSearchResult[]> {
+    const strict = options?.strict ?? false;
+
+    const config = tryReadFmpConfig();
+    if (!config) {
+        // strict(getAssetInfo): 미설정은 인프라 문제 — null→404 캐싱을 막기 위해 throw.
+        // lenient(검색 UI): 기존대로 빈 결과로 degrade.
+        if (strict) throw new Error('[fmpTickerApi] FMP config missing');
+        return [];
+    }
+
+    const params = new URLSearchParams({
+        query,
+        limit: String(FMP_SEARCH_LIMIT),
+        apikey: config.apiKey,
+    });
+    const url = `${FMP_BASE_URL}/${endpoint}?${params}`;
+
+    let res: Response;
+    try {
+        res = await fetch(url, {
+            signal: AbortSignal.timeout(FMP_FETCH_TIMEOUT_MS),
+        });
+    } catch (e) {
+        if (strict)
+            throw new Error(`[fmpTickerApi] ${endpoint} fetch failed`, {
+                cause: e,
+            });
+        return [];
+    }
+
+    if (!res.ok) {
+        if (strict)
+            throw new Error(`[fmpTickerApi] ${endpoint} HTTP ${res.status}`);
+        return [];
+    }
+
+    let raw: unknown;
+    try {
+        raw = await res.json();
+    } catch (e) {
+        if (strict)
+            throw new Error(`[fmpTickerApi] ${endpoint} JSON parse failed`, {
+                cause: e,
+            });
+        return [];
+    }
+
+    // 비배열 응답은 신뢰할 수 없는 형태 — strict에선 throw해 no-match로 오인/캐싱 방지.
+    if (!Array.isArray(raw)) {
+        if (strict)
+            throw new Error(
+                `[fmpTickerApi] ${endpoint} unexpected non-array response`
+            );
+        return [];
+    }
+
+    // FMP search endpoints return a JSON array of records matching FmpSearchResult.
+    // 200 + 빈 배열은 정상적인 "매칭 없음"이므로 strict에서도 throw하지 않는다.
+    return toFmpSearchResults(raw);
+}
+
+export async function searchBySymbol(
+    query: string,
+    options?: { strict?: boolean }
+): Promise<FmpSearchResult[]> {
+    return fetchFmpEndpoint('search-symbol', query, options);
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `yarn test src/entities/ticker/__tests__/lib/fmpTickerApi.test.ts`
+Expected: PASS (신규 4 + 기존 케이스 전부)
+
+- [ ] **Step 5: Checkpoint**
+
+Run: `yarn lint`
+Expected: 통과.
+
+---
+
+## Task 3: getAssetInfo strict 적용 (D3 part 2)
+
+**Files:**
+- Modify: `src/entities/ticker/lib/getAssetInfo.ts:186`
+- Test: `src/entities/ticker/__tests__/lib/getAssetInfo.test.ts`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`getAssetInfo.test.ts` 상단 mock 중 `searchBySymbol` mock이 options를 전달하도록 보정 (정확성):
+
+```ts
+vi.mock('../../lib/fmpTickerApi', async () => {
+    const actual = await vi.importActual('../../lib/fmpTickerApi');
+    return {
+        ...actual,
+        searchBySymbol: (q: string, options?: { strict?: boolean }) =>
+            searchBySymbolMock(q, options),
+    };
+});
+```
+
+그리고 테스트 케이스 추가 (적절한 `describe` 블록 내):
+
+```ts
+    it('FMP 인프라 에러를 throw로 전파한다 (null로 degrade하지 않음)', async () => {
+        createCacheProviderMock.mockReturnValue(null); // 캐시 미스
+        tryGetTickerDatabaseClientMock.mockReturnValue(null); // DB 미가용 → FMP로 fall-through
+        searchBySymbolMock.mockRejectedValue(new Error('FMP HTTP 429'));
+
+        await expect(getAssetInfo('AAPL')).rejects.toThrow('FMP HTTP 429');
+    });
+
+    it('getAssetInfo가 searchBySymbol을 strict로 호출한다', async () => {
+        createCacheProviderMock.mockReturnValue(null);
+        tryGetTickerDatabaseClientMock.mockReturnValue(null);
+        searchBySymbolMock.mockResolvedValue([]); // 200 빈 결과 → null
+
+        await getAssetInfo('NOPE');
+
+        expect(searchBySymbolMock).toHaveBeenCalledWith('NOPE', {
+            strict: true,
+        });
+    });
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `yarn test src/entities/ticker/__tests__/lib/getAssetInfo.test.ts`
+Expected: FAIL — 두 번째 케이스에서 `searchBySymbol`이 `{ strict: true }` 없이 호출됨.
+
+- [ ] **Step 3: getAssetInfo.ts 구현**
+
+`src/entities/ticker/lib/getAssetInfo.ts:186` 한 줄을 변경:
+
+```ts
+    const fmpResults = await searchBySymbol(upper, { strict: true });
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `yarn test src/entities/ticker/__tests__/lib/getAssetInfo.test.ts`
+Expected: PASS (신규 2 + 기존 전부). 기존 케이스는 `searchBySymbolMock`이 resolve 값을 반환하므로 영향 없음.
+
+- [ ] **Step 5: Checkpoint**
+
+Run: `yarn lint && yarn test src/entities/ticker`
+Expected: 통과. (D3 완료 — 이제 ISR 적용 안전)
+
+---
+
+## Task 4: OG/트위터 이미지 캐싱 (12개 파일)
+
+**Files (각각 Modify):**
+- `src/app/[symbol]/opengraph-image.tsx`, `twitter-image.tsx`
+- `src/app/[symbol]/options/opengraph-image.tsx`, `twitter-image.tsx`
+- `src/app/[symbol]/fundamental/opengraph-image.tsx`, `twitter-image.tsx`
+- `src/app/[symbol]/news/opengraph-image.tsx`, `twitter-image.tsx`
+- `src/app/[symbol]/fear-greed/opengraph-image.tsx`, `twitter-image.tsx`
+- `src/app/[symbol]/overall/opengraph-image.tsx`, `twitter-image.tsx`
+
+**배경:** 이미지 콘텐츠는 `buildSymbolOgImage({ ticker, label })`의 순수 함수 — fresh 데이터/`getAssetInfo` 호출 없음 → 404 위험 없이 길게 캐시 가능. 템플릿 변경은 배포 시 캐시 자동 무효화.
+
+- [ ] **Step 1: 12개 파일 각각에 revalidate 추가**
+
+각 파일의 기존 `export const size = ...` 줄 **위**(import 직후)에 한 줄 추가:
+
+```ts
+// OG 이미지는 (ticker, label) 순수 함수라 fresh 데이터가 없음 → 길게 캐시.
+// 템플릿 변경은 배포 시 캐시가 무효화된다.
+export const revalidate = 2592000; // 30d
+```
+
+- [ ] **Step 2: 빌드로 OG 라우트 캐싱 확인**
+
+Run: `yarn build`
+Expected: 빌드 성공. 빌드 라우트 목록에서 `/[symbol]/.../opengraph-image`·`twitter-image`가 동적(ƒ)이 아닌 캐시/ISR 표기로 전환(또는 revalidate 표기). 에러 없음.
+
+- [ ] **Step 3: Checkpoint**
+
+Run: `yarn lint`
+Expected: 통과.
+
+---
+
+## Task 5: 클린 종목 탭 ISR (options / fundamental / fear-greed)
+
+**Files (각각 Modify):**
+- `src/app/[symbol]/options/page.tsx`
+- `src/app/[symbol]/fundamental/page.tsx`
+- `src/app/[symbol]/fear-greed/page.tsx`
+
+**배경:** 세 페이지는 동적 트리거(`searchParams`/`headers`/`cookies`)가 없어 `revalidate`만 추가하면 ISR된다. 렌더 중 데이터 fetch(예: `fetchOptionsSnapshot`)는 재검증 시점에 실행되어 baked되고, 클라가 재hydrate한다. `getAssetInfo` null만이 404를 만들며 Task 3로 안전.
+
+- [ ] **Step 1: 세 page.tsx 각각에 revalidate 추가**
+
+각 파일 상단(첫 `export async function generateMetadata` **위**, import 직후)에 추가:
+
+```ts
+// 종목당 SEO 콘텐츠는 고정이고 동적 데이터는 클라가 재hydrate한다. 엣지 캐시로
+// compute 호출을 줄인다. (일시 인프라 장애의 404 캐싱은 getAssetInfo strict로 차단)
+export const revalidate = 3600; // 1h
+```
+
+- [ ] **Step 2: 빌드로 ISR 전환 확인**
+
+Run: `yarn build`
+Expected: 빌드 성공. `/[symbol]/options`·`/fundamental`·`/fear-greed`가 동적(ƒ)에서 ISR(revalidate 1h)로 전환 표기.
+
+- [ ] **Step 3: Checkpoint**
+
+Run: `yarn lint`
+Expected: 통과.
+
+---
+
+## Task 6: 차트 페이지 ISR (서버 tf 제거 + Suspense)
+
+**Files:**
+- Modify: `src/app/[symbol]/page.tsx`
+
+**배경:** `searchParams(tf)` 서버 읽기가 라우트를 동적으로 강제. tf는 클라(`SymbolPageClient` → `useTimeframeChange` → `useSearchParams`)가 이미 소유하므로 서버 읽기를 제거하고 prefetch/peek은 `DEFAULT_TIMEFRAME`로 seed한다. **CSR-bailout 주의**: 정적 렌더에서 `useSearchParams`를 쓰는 client 서브트리는 `<Suspense>`로 감싸야 하며, 그 서브트리는 client에서 렌더된다(페이지 레벨 sr-only SEO 콘텐츠·JSON-LD는 서버 정적 유지). canonical은 이미 tf 제외라 색인 무영향.
+
+- [ ] **Step 1: Props에서 searchParams 제거 + Suspense import + revalidate**
+
+`src/app/[symbol]/page.tsx` 상단:
+- `import { notFound } from 'next/navigation';` 아래에 `import { Suspense } from 'react';` 추가.
+- `Props` 인터페이스에서 `searchParams: Promise<{ tf?: string }>;` 줄 삭제.
+- 파일 상단(첫 export 위)에 추가:
+```ts
+export const revalidate = 3600; // 1h — ISR
+```
+
+- [ ] **Step 2: 본문에서 tf 읽기 제거 + DEFAULT_TIMEFRAME 사용**
+
+`SymbolPage` 함수 시그니처와 도입부 변경:
+
+```ts
+export default async function SymbolPage({ params }: Props) {
+    const { symbol } = await params;
+    const ticker = symbol.toUpperCase();
+    if (!VALID_TICKER_RE.test(ticker)) notFound();
+    const [assetInfo, skillCounts] = await Promise.all([
+        getAssetInfoCached(ticker),
+        countSkillFiles(),
+    ]);
+    if (!assetInfo) return notFound();
+```
+
+(즉 `const { tf } = await searchParams;`와 `const initialTimeframe = isValidTimeframe(tf) ? tf : DEFAULT_TIMEFRAME;` 두 줄 삭제. `isValidTimeframe` import가 더 이상 안 쓰이면 import도 제거.)
+
+- [ ] **Step 3: prefetch/peek을 DEFAULT_TIMEFRAME로 단일화**
+
+`const [, cachedAnalysis] = await Promise.all([ ... ]);` 블록을 아래로 교체:
+
+```ts
+    const [, cachedAnalysis] = await Promise.all([
+        // 차트 페이지는 ISR로 캐시되므로 prefetch는 기본 timeframe만 seed한다.
+        // ?tf= 딥링크는 클라(useTimeframeChange→useSearchParams)가 마운트 시 읽어
+        // 해당 timeframe bars를 fetch한다.
+        queryClient.prefetchQuery({
+            queryKey: QUERY_KEYS.bars(
+                symbol,
+                DEFAULT_TIMEFRAME,
+                assetInfo.fmpSymbol
+            ),
+            queryFn: barsQueryFn,
+        }),
+        peekAnalysisCache(
+            ticker,
+            DEFAULT_TIMEFRAME,
+            assetInfo.fmpSymbol,
+            GEMINI_2_5_FLASH_LITE_MODEL
+        ).catch((error: unknown) => {
+            console.error('[SymbolPage] peekAnalysisCache failed:', error);
+            return null;
+        }),
+    ]);
+```
+
+- [ ] **Step 4: SymbolPageClient를 Suspense로 감싸기**
+
+`<HydrationBoundary state={dehydrate(queryClient)}>` 안의 `<SymbolPageClient ... />`를 `<Suspense>`로 감싼다:
+
+```tsx
+                <HydrationBoundary state={dehydrate(queryClient)}>
+                    <Suspense fallback={null}>
+                        <SymbolPageClient
+                            symbol={symbol}
+                            companyName={assetInfo.name}
+                            displayName={displayName}
+                            initialAnalysis={initialAnalysis}
+                            initialAnalysisFailed={true}
+                            indicatorCount={skillCounts.indicators}
+                        />
+                    </Suspense>
+                </HydrationBoundary>
+```
+
+> fallback=null인 이유: route-level `[symbol]/loading.tsx`가 내비게이션 스켈레톤을 이미 담당하고, SymbolPageClient는 차트(canvas) 기반이라 어차피 client 렌더가 필요하다. 레이아웃 시프트가 보이면 loading.tsx의 스켈레톤을 추출해 fallback으로 재사용한다.
+
+- [ ] **Step 5: 빌드로 ISR 전환 + 타입 확인**
+
+Run: `yarn build`
+Expected: 빌드 성공(`missing-suspense-with-csr-bailout` 에러 없음). `/[symbol]`이 동적(ƒ)에서 ISR(revalidate)로 전환 표기. 타입 에러 없음(`searchParams`/`isValidTimeframe` 미사용 정리됨).
+
+- [ ] **Step 6: Checkpoint**
+
+Run: `yarn lint`
+Expected: 통과.
+
+---
+
+## Task 7: overall 페이지 ISR (서버 tf 제거 + OverallContent client-read + Suspense)
+
+**Files:**
+- Modify: `src/app/[symbol]/overall/page.tsx`
+- Modify: `src/widgets/overall/OverallContent.tsx`
+
+**배경:** overall은 차트와 달리 `OverallContent`가 `timeframe`을 **서버 prop**으로 받는다. ISR화하려면 서버 searchParams 읽기를 제거하고, `OverallContent`가 `useSearchParams`로 tf를 직접 읽도록 바꾼다(read-only — overall엔 tf 셀렉터 UI가 없고 차트에서 넘어온 tf를 소비만 함). 서버 peek seed는 `DEFAULT_TIMEFRAME`로. widgets→widgets import는 허용.
+
+- [ ] **Step 1: OverallContent가 useSearchParams로 tf를 읽도록 변경**
+
+`src/widgets/overall/OverallContent.tsx`:
+- import 추가:
+```ts
+import { useSearchParams } from 'next/navigation';
+import { DEFAULT_TIMEFRAME, isValidTimeframe } from '@/shared/config/market';
+```
+- `OverallContentProps`에서 `timeframe: Timeframe;` 줄 삭제.
+- 구조분해에서 `timeframe`을 제거하고, 함수 본문 첫 줄에서 URL로부터 read:
+
+```ts
+export function OverallContent({
+    symbol,
+    companyName,
+    initialAnalysis,
+}: OverallContentProps) {
+    // ISR 정적 렌더 — tf는 서버가 아니라 client가 URL에서 읽는다(차트와 동일 소스).
+    const tfParam = useSearchParams().get('tf');
+    const timeframe = isValidTimeframe(tfParam) ? tfParam : DEFAULT_TIMEFRAME;
+    const modelId = useDefaultModelId();
+    const { state, trigger } = useOverallAnalysis(
+        symbol,
+        companyName,
+        timeframe,
+        modelId,
+        initialAnalysis
+    );
+```
+
+(이후 `buildChatState(state, timeframe)` 등 `timeframe` 사용부는 그대로 동작.)
+
+> `Timeframe` 타입 import는 다른 곳에서 계속 쓰이면 유지, `timeframe` prop 제거로 미사용이 되면 제거.
+
+- [ ] **Step 2: overall/page.tsx — 서버 tf 제거 + DEFAULT_TIMEFRAME peek + Suspense + revalidate**
+
+`src/app/[symbol]/overall/page.tsx`:
+- 상단 import에 `import { Suspense } from 'react';` 추가. 파일 상단에 `export const revalidate = 3600;` 추가.
+- `Props`에서 `searchParams: Promise<{ tf?: string }>;` 삭제.
+- 함수 시그니처를 `export default async function OverallPage({ params }: Props)`로 변경.
+- 본문의 `const { tf } = await searchParams;`와 `const timeframe: Timeframe = isValidTimeframe(tf) ? tf : DEFAULT_TIMEFRAME;` 두 줄 삭제.
+- `peekOverallAnalysisCache(upper, assetInfo.name, timeframe, GEMINI_2_5_FLASH_LITE_MODEL)`의 `timeframe`을 `DEFAULT_TIMEFRAME`로 교체.
+- 미사용이 된 `isValidTimeframe`/`Timeframe` import 정리.
+- 렌더의 `<OverallContent timeframe={timeframe} ... />`에서 `timeframe` prop 제거하고 `<Suspense fallback={null}>`로 감싼다:
+
+```tsx
+    return (
+        <>
+            {/* ...JsonLd 등 서버 정적 콘텐츠... */}
+            <main className="mx-auto max-w-5xl space-y-6 px-4 py-8">
+                <Suspense fallback={null}>
+                    <OverallContent
+                        symbol={upper}
+                        companyName={assetInfo.name}
+                        initialAnalysis={cachedOverall ?? undefined}
+                    />
+                </Suspense>
+            </main>
+        </>
+    );
+```
+
+> `OverallContent`에 넘기던 기존 props(`symbol`/`companyName`/`initialAnalysis`)는 유지하고 `timeframe`만 제거한다. 기존 prop 전달 형태(예: `initialAnalysis` 전달 방식)는 현재 코드를 따른다.
+
+- [ ] **Step 3: 빌드 + 타입 확인**
+
+Run: `yarn build`
+Expected: 빌드 성공(CSR-bailout 에러 없음). `/[symbol]/overall`이 ISR로 전환 표기. 타입 에러 없음.
+
+- [ ] **Step 4: Checkpoint**
+
+Run: `yarn lint && yarn test src/widgets/overall`
+Expected: 통과. (OverallContent 관련 기존 테스트가 `timeframe` prop을 넘기고 있으면 그 테스트를 prop 제거 + `useSearchParams` mock 형태로 갱신한다.)
+
+---
+
+## Task 8: 통합 빌드 검증 + 라우트 캐싱 표 확인
+
+**Files:** 없음 (검증만)
+
+- [ ] **Step 1: 전체 테스트**
+
+Run: `yarn test`
+Expected: 전부 PASS.
+
+- [ ] **Step 2: 전체 빌드 + 라우트 타입 확인**
+
+Run: `yarn build`
+Expected:
+- `/[symbol]`, `/[symbol]/options`, `/[symbol]/fundamental`, `/[symbol]/fear-greed`, `/[symbol]/overall` → ISR(revalidate) 표기.
+- `/[symbol]/news` → 여전히 동적(ƒ) (D2① 의도된 유지).
+- OG/twitter 이미지 라우트 → 캐시/revalidate 표기.
+- `missing-suspense-with-csr-bailout` 등 빌드 에러 없음.
+
+- [ ] **Step 3: (권장) 로컬 동작 검증**
+
+`verify` 스킬 또는 수동으로:
+- `/{TICKER}` 및 `/{TICKER}?tf=1W` 접속 → 차트 정상, tf 딥링크가 1W로 표시되는지(클라 read).
+- `/{TICKER}/overall` 접속 → 종합 분석 정상 렌더.
+- 존재하지 않는 티커(`/{ZZINVALID}`) → 404. (FMP 정상 응답 시)
+
+---
+
+## Self-Review (작성자 체크)
+
+**Spec coverage:**
+- §4.1 봇 관리 → Task 1 ✓
+- §4.2 OG 캐싱 → Task 4 ✓
+- §4.3 페이지 ISR (options/fundamental/fear-greed) → Task 5 ✓; (chart) → Task 6 ✓; (overall) → Task 7 ✓; (news 유지) → Task 8 Step 2 검증 ✓
+- §4.4 D3 404 안전 → Task 2(fmpTickerApi) + Task 3(getAssetInfo) ✓
+- §5 영향 파일 → Task 매핑 일치, news 무변경 ✓
+
+**Placeholder scan:** 모든 코드 스텝에 실제 코드 포함. "TBD"/"적절히 처리" 없음. ✓
+
+**Type consistency:** `searchBySymbol(query, options?: { strict?: boolean })` 시그니처가 Task 2 정의 ↔ Task 3 호출(`{ strict: true }`) ↔ getAssetInfo.test mock에서 일치. `revalidate` 값(OG 2592000 / 페이지 3600) 일관. `DEFAULT_TIMEFRAME`/`isValidTimeframe`는 `@/shared/config/market`에서 일관 사용. ✓
+
+**알려진 비결정/주의:**
+- Task 6·7의 `<Suspense fallback={null}>`는 레이아웃 시프트가 보이면 `loading.tsx` 스켈레톤 추출로 교체(주석에 명시). 이는 UX 폴리시 항목이며 ISR 동작 자체와 무관.
+- OverallContent 기존 테스트가 `timeframe` prop을 넘기면 Task 7 Step 4에서 갱신.

--- a/docs/superpowers/specs/2026-06-01-vercel-transfer-cost-design.md
+++ b/docs/superpowers/specs/2026-06-01-vercel-transfer-cost-design.md
@@ -1,0 +1,157 @@
+# Vercel 트랜스퍼 비용 절감 설계 (Origin + Data Transfer)
+
+- 작성일: 2026-06-01
+- 상태: 설계 승인 대기
+- 범위: siglens 앱 (인프라/캐싱). siglens-core 변경 없음.
+
+## 1. 배경 / 문제
+
+Vercel 비용 중 트랜스퍼 항목이 과도하게 발생. Observability "Fast Data Transfer" 라우트별 내역(최근 12h)에서 전 비용이 `/[symbol]/*`에 집중:
+
+| Route | Requests | Transfer Out |
+|---|---|---|
+| `/[symbol]/options` | 11K | 1.39 GB |
+| `/[symbol]/fundamental` | 8.6K | 730 MB |
+| `/[symbol]/news` | 4.2K | 375 MB |
+| `/[symbol]/options/opengraph-image` | 9K | 312 MB |
+| `/[symbol]/fear-greed` · `/overall` · `/[symbol]` | 3~4K each | 245~283 MB |
+| (기타 opengraph-image 들) | 1~1.8K | 37~59 MB |
+
+진단:
+- **Page Caching 0%** — 모든 요청이 compute에서 동적 SSR. 엣지 캐시 전무.
+- **AhrefsBot 폭주** — 12h 동안 한 페이지(=`options/opengraph-image` 9K와 일치)에 9천+ 요청. AhrefsBot은 검색엔진이 아니라 SEO SaaS 크롤러로, 포털 랭킹에 기여 0.
+- 사이트맵은 top 비용에 미등장(이미 `Cache-Control` 보유) → 대상 아님.
+
+### 두 메트릭 구분 (Vercel 공식)
+
+| 메트릭 | 정의 | 무료/단가(Pro) | 캐싱으로 줄어드나 |
+|---|---|---|---|
+| **Fast Origin Transfer** | CDN ↔ Functions ("CDN→Compute") | 100GB / $0.06/GB | **예** — ISR로 compute 호출이 재검증 시에만 발생 (단 Data Cache 자체도 origin transfer 일부 유발) |
+| **Fast Data Transfer** | CDN ↔ 방문자 | 1TB / $0.15/GB | **아니오** — 응답 바이트는 캐시 hit이든 동일. 줄이려면 요청 수↓(봇 차단) 또는 payload↓ |
+
+→ **봇 차단만이 두 메트릭을 동시에 절감**(요청 수 자체↓). ISR은 Origin Transfer를 절감.
+
+## 2. 목표 / 비목표
+
+목표:
+1. 기생 봇(AhrefsBot 등) 트래픽 차단 → Origin + Data Transfer 동시 절감.
+2. `/[symbol]/*` OG 이미지 + 페이지를 엣지 캐시(ISR/revalidate)해 compute 호출 절감.
+3. **UX/SEO 무해(또는 유리)** 보장 — 특히 ISR로 인한 404 캐시 오염 방지.
+
+비목표(이번 범위 제외):
+- 서버액션 → GET 라우트 변환(POST는 CDN 캐시 불가, 지배적 비용도 아님).
+- SSR 데이터 seed 제거를 통한 Data Transfer payload 경량화(D4=① 유지. Data Transfer가 측정 후에도 크면 후속 검토).
+- `news` 페이지 ISR화(D2=① 동적 유지).
+- Vercel WAF/Firewall 룰(robots.txt만 사용).
+
+## 3. 결정 요약
+
+| ID | 결정 |
+|---|---|
+| D1 | 봇 목록 = AhrefsBot + SemrushBot + MJ12bot + DotBot + BLEXBot + DataForSeoBot |
+| D2 | `news` 페이지는 현행 동적 유지 (per-request `ensureNewsCardsAnalyzed` 부수효과 보존) |
+| D3 | `getAssetInfo`가 인프라 에러는 throw, "no-match"만 null 반환 → ISR 404 캐시 오염 방지 |
+| D4 | SSR 데이터 prefetch seed 현행 유지 (UX 보존) |
+| D5 | revalidate: 페이지 1h(3600), OG 이미지 30d(2592000) |
+
+## 4. 설계
+
+### 4.1 봇 관리 — `src/app/robots.ts`
+
+`rules`를 단일 객체 → 배열로 변경. 기존 `*` 규칙 유지 + 기생 봇 전면 Disallow.
+
+```ts
+rules: [
+  { userAgent: '*', allow: '/', disallow: ['/api/'] },
+  {
+    userAgent: ['AhrefsBot', 'SemrushBot', 'MJ12bot', 'DotBot', 'BLEXBot', 'DataForSeoBot'],
+    disallow: '/',
+  },
+],
+```
+
+- 이 봇들은 robots.txt를 준수 → 다음 재확인 시(보통 하루 내) 크롤 중단.
+- 검색엔진(Googlebot/Yeti/Bingbot/Daumoa)은 미포함 → SEO 영향 0.
+
+### 4.2 OG 이미지 캐싱 — 12개 파일
+
+대상: `src/app/[symbol]/{,fear-greed/,fundamental/,news/,options/,overall/}{opengraph-image,twitter-image}.tsx`
+
+각 파일에 추가:
+```ts
+export const revalidate = 2592000; // 30d
+```
+
+- 이미지 내용은 `buildSymbolOgImage({ ticker, label })`로 `(ticker, label)`의 순수 함수 — fresh 데이터·`getAssetInfo` 호출 없음 → **404 위험 없음**, 길게 캐시 안전. 템플릿 변경은 배포 시 캐시 자동 무효화.
+- 봇 차단으로 Ahrefs분은 소멸, 이 캐싱은 정상 크롤러/SNS(Google·Kakao·Naver·FB)의 반복 fetch를 엣지에서 처리.
+
+### 4.3 페이지 ISR — `/[symbol]/*`
+
+| 페이지 | 동적 트리거 | 변경 |
+|---|---|---|
+| `options`, `fundamental`, `fear-greed` | 없음 | `export const revalidate = 3600` 추가 |
+| `page.tsx`(차트), `overall` | `searchParams(tf)` | **서버 tf 읽기 제거** + `revalidate = 3600` |
+| `news` | `headers()` → `isBot` → `waitUntil` | 변경 없음(D2). 동적 유지 |
+
+**tf 제거 안전성**: 클라이언트(`SymbolPageClient`)가 이미 `useSearchParams`로 timeframe을 직접 소유(L53/67). 서버는 `initialTimeframe`을 클라에 전달하지도 않음 → 서버 tf 읽기는 prefetch 키 선택에만 쓰임. 제거 시 SSR은 항상 `DEFAULT_TIMEFRAME` bars를 seed하고, `?tf=1W` 딥링크는 클라가 마운트 시 읽어 해당 tf를 fetch. canonical은 이미 tf 제외 → 색인 무영향.
+
+**구현 주의**: 정적 렌더 라우트에서 client의 `useSearchParams()`는 `<Suspense>` 경계가 필요(없으면 빌드 에러/클라 deopt). 기존 경계 유지 확인 필요.
+
+**`cacheComponents`와 무관**: 일반 ISR(`revalidate`)은 #439로 비활성된 `cacheComponents`(PPR/`use cache`)와 별개 기능. 막히지 않음.
+
+### 4.4 D3 — 404 캐시 오염 방지 (핵심 안전장치)
+
+**문제 (확정)**: `src/entities/ticker/lib/fmpTickerApi.ts`의 `fetchFmpEndpoint`가 모든 실패를 `return []`로 삼킴:
+- `!config` → `[]`
+- `!res.ok`(429/5xx) → `[]`
+- `catch`(network/timeout) → `[]`
+
+→ FMP 일시 장애 시 `searchBySymbol`이 `[]` → `getAssetInfo`가 `null` → 페이지 `notFound()` → **ISR이 정상 종목의 404를 revalidate 창(1h) 동안 캐시**(SEO 디인덱스 위험).
+
+**해결 계약(invariant)**:
+> `getAssetInfo`는 **인프라 실패 시 throw**, "조회가 정상 완료됐고 매칭이 없을 때만 `null`" 반환.
+
+구현 방향:
+1. **FMP fetch 경로**(getAssetInfo가 쓰는 `searchBySymbol`)가 인프라 실패를 **throw**하도록:
+   - `!res.ok`(특히 429/5xx), network error/timeout, `!config`(미설정) → throw.
+   - 200 응답인데 매칭 없음(빈 배열) → `[]` 정상 반환(legit no-match).
+2. **인터랙티브 검색(search-as-you-type)의 graceful degradation은 유지**해야 함. `fetchFmpEndpoint`/`searchByName`은 검색 UI에서 에러 시 빈 결과로 degrade하는 동작이 의도된 것 → throw 동작은 getAssetInfo 경로에만 적용(예: `strict` 옵션 또는 전용 strict 함수 분리). 단일 공유 함수를 무조건 throw로 바꾸지 말 것.
+3. `readFromDatabase`의 catch→null은 **유지 가능**(DB null은 FMP로 fall-through하며, FMP가 authoritative-or-throw이므로 false 404를 만들지 않음).
+
+**결과**: 일시 인프라 장애 → 페이지 render throw → Next는 에러를 캐시하지 않음(다음 요청 재시도) → poisoned 404 없음. 진짜 없는 종목만 404 캐시(정상).
+
+**부가 영향**: `options`/`fundamental`/`fear-greed`의 데이터 fetch 실패는 `notFound`이 아니라 빈/empty-state로 degrade(예: `OptionsEmptyState`) → 캐시되어도 self-healing, 디인덱스 위험 없음. 단 `getAssetInfo` null만이 404를 만들므로 D3로 충분.
+
+## 5. 영향 파일
+
+- `src/app/robots.ts` — 봇 규칙 배열화 (4.1)
+- `src/app/[symbol]/**/{opengraph-image,twitter-image}.tsx` (12개) — `revalidate` 추가 (4.2)
+- `src/app/[symbol]/page.tsx`, `src/app/[symbol]/overall/page.tsx` — 서버 `searchParams(tf)` 제거 + `revalidate` (4.3)
+- `src/app/[symbol]/options/page.tsx`, `fundamental/page.tsx`, `fear-greed/page.tsx` — `revalidate` 추가 (4.3)
+- `src/entities/ticker/lib/fmpTickerApi.ts` (및 필요 시 `getAssetInfo.ts`) — FMP 인프라 에러 throw 계약 (4.4)
+- `src/app/[symbol]/news/page.tsx` — **변경 없음** (D2)
+
+## 6. UX / SEO 안전성 (제약 충족 근거)
+
+- **SEO**: 크롤러가 완전 렌더된 정적 HTML(메타데이터·JSON-LD·sr-only 콘텐츠 포함) 수신 → 유리. ISR로 페이지가 캐시되면 `htmlLimitedBots: /.*/`의 head-metadata도 캐시 HTML에 박힌 채 제공 → Naver/Kakao 미리보기 보존. tf-less canonical 유지 → 색인 변화 없음. **404 오염은 D3로 차단**.
+- **UX**: 데이터는 클라가 재hydrate(D4 seed 유지 → 첫 페인트 데이터 보존). `?tf=` 딥링크 정상(클라 소유). 비기본 tf 딥링크만 첫 페인트에 기본 tf가 잠깐 보였다 교체 — 경미.
+- **봇 차단**: 검색엔진 미포함 → 포털 SEO 영향 0.
+
+## 7. 테스트
+
+- `robots.ts`: 반환 규칙에 `*` allow + 기생봇 Disallow 배열 포함 검증 (단위).
+- `fmpTickerApi`(D3): `!res.ok`/timeout/network/`!config` → throw, 200+빈배열 → `[]` 반환 검증. 인터랙티브 검색 경로는 여전히 degrade하는지 검증.
+- `getAssetInfo`: FMP throw가 전파되는지(= null 아님), DB 실패는 FMP fall-through 후 정상 동작.
+- ISR 페이지: 동적 트리거 제거 후 정적 생성 가능(빌드), `useSearchParams` Suspense 경계 유지.
+
+## 8. 롤아웃 / 측정
+
+- 단일 PR로 4.1~4.4 함께 머지. 배포는 사용자 담당(`chore: release`).
+- 배포 후 24h Vercel Usage(Fast Origin + Fast Data Transfer)와 Page Caching 비율 변화 측정.
+- 봇 차단이 robots 재확인까지 수일 걸릴 수 있음 → 즉시 0이 아님(자율 준수 특성). AhrefsBot 요청 수 추이로 확인.
+
+## 9. 향후(측정 후 검토)
+
+- Fast Data Transfer($0.15)가 여전히 크면 → D4②(SSR seed 제거로 HTML 경량화), 특히 `options`(옵션 체인 페이로드 큼).
+- `news` ISR화(부수효과를 렌더 밖 client/cron으로 이전).
+- 마운트마다 강제 재분석(`initialAnalysisFailed={true}`)·react-query `staleTime` 재검토로 클라 서버액션 호출 절감.

--- a/src/app/CLAUDE.md
+++ b/src/app/CLAUDE.md
@@ -56,6 +56,21 @@ const data = await fetch(url, {
 > 임시로 꺼 둔 상태이며, 추후 재활성화 시 `'use cache'` / `cacheLife` / `cacheTag` 패턴과
 > dynamic metadata 처리 방식을 함께 재설계해야 한다.
 
+### ISR / Route Segment Config (⚠️ 리터럴 강제)
+
+`export const revalidate` / `dynamic` 등 route segment config는 **반드시 정적 분석 가능한
+리터럴**이어야 한다. import한 상수나 식(`SECONDS_PER_HOUR`, `60 * 60`)으로 추출하면 Next.js가
+값을 정적 분석하지 못해 `⨯ Invalid segment configuration export detected ... configs not being
+applied`로 **config를 조용히 무시 → ISR이 깨진다**. 따라서 **`docs/MISTAKES.md` §15(매직넘버
+상수 추출)은 route segment config에 적용하지 않는다** — 리터럴을 유지하고 `// 1h` / `// 30d`
+인라인 코멘트로 의미만 표기한다. (`app/page.tsx`도 이미 `revalidate = 3600` 리터럴.)
+
+동적 세그먼트(`[symbol]`) 라우트는 `revalidate`만으로 ISR이 걸리지 않는다 — `ƒ (Dynamic)`로
+남아 매 요청 렌더된다. **`export async function generateStaticParams() { return [] }`**(빈 배열 =
+on-demand ISR)를 함께 export해야 빌드에서 `● (SSG)`로 전환된다. 메타데이터 이미지
+(opengraph/twitter)는 `export const dynamic = 'force-static'`로 정적화한다 — `force-static`은
+`cookies()/headers()/searchParams`만 비우고 `params`는 유지하므로 종목별로 정상 렌더된다.
+
 ---
 
 ## Server Actions

--- a/src/app/[symbol]/__tests__/page.test.ts
+++ b/src/app/[symbol]/__tests__/page.test.ts
@@ -11,7 +11,6 @@ vi.mock('@y0ngha/siglens-core', () => ({
 }));
 vi.mock('@/shared/config/market', () => ({
     DEFAULT_TIMEFRAME: '1Day',
-    isValidTimeframe: vi.fn().mockReturnValue(false),
     VALID_TICKER_RE: /^[A-Z]{1,5}$/,
 }));
 vi.mock('@/entities/ticker', () => ({
@@ -95,7 +94,6 @@ describe('Symbol page', () => {
         it('returns noindex for invalid ticker', async () => {
             const metadata = await generateMetadata({
                 params: Promise.resolve({ symbol: '!!!invalid' }),
-                searchParams: Promise.resolve({}),
             });
 
             expect(metadata.robots).toEqual(
@@ -112,13 +110,12 @@ describe('Symbol page', () => {
 
             const metadata = await generateMetadata({
                 params: Promise.resolve({ symbol: 'aapl' }),
-                searchParams: Promise.resolve({}),
             });
 
             expect(metadata.title).toBe('AAPL 차트');
         });
 
-        it('does not add noindex when tf query param is present (canonical consolidates)', async () => {
+        it('canonical excludes tf — ISR page uses clean canonical regardless of query params', async () => {
             mockGetAssetInfoCached.mockResolvedValue({
                 name: 'Apple Inc.',
                 koreanName: '애플',
@@ -127,10 +124,9 @@ describe('Symbol page', () => {
 
             const metadata = await generateMetadata({
                 params: Promise.resolve({ symbol: 'aapl' }),
-                searchParams: Promise.resolve({ tf: '1Hour' }),
             });
 
-            // variant URL은 noindex 대신 clean canonical로 색인 통합 (SEO 신호 충돌 제거)
+            // ISR 페이지: searchParams 없이 렌더되므로 canonical은 clean URL
             expect(metadata.robots).toBeUndefined();
             expect(metadata.alternates?.canonical).toBe(
                 'https://siglens.io/AAPL'
@@ -146,7 +142,6 @@ describe('Symbol page', () => {
 
             const metadata = await generateMetadata({
                 params: Promise.resolve({ symbol: 'aapl' }),
-                searchParams: Promise.resolve({}),
             });
 
             expect(metadata.robots).toBeUndefined();
@@ -170,7 +165,6 @@ describe('Symbol page', () => {
         async function getClientProps(): Promise<ClientSeedProps> {
             const tree = await SymbolPage({
                 params: Promise.resolve({ symbol: 'aapl' }),
-                searchParams: Promise.resolve({}),
             });
             const client = findElementByType(tree, SymbolPageClient);
             if (client === null) {

--- a/src/app/[symbol]/fear-greed/opengraph-image.tsx
+++ b/src/app/[symbol]/fear-greed/opengraph-image.tsx
@@ -1,6 +1,13 @@
 import { OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/shared/lib/og';
 import { buildSymbolOgImage } from '@/entities/og-image';
 
+// 동적 세그먼트([symbol]) 하위라 revalidate만으로는 캐시되지 않는다. 이미지가
+// (ticker, label) 순수 함수(동적 요청 API 미사용)이므로 force-static으로 정적 생성·캐시.
+export const dynamic = 'force-static';
+// OG 이미지는 (ticker, label) 순수 함수라 fresh 데이터가 없음 → 길게 캐시.
+// 템플릿 변경은 배포 시 캐시가 무효화된다.
+export const revalidate = 2592000; // 30d
+
 export const size = { width: OG_IMAGE_WIDTH, height: OG_IMAGE_HEIGHT };
 export const contentType = 'image/png';
 // alt는 module-scope const라 ticker 동적 주입 불가 — 페이지 카테고리까지만 명시한다.

--- a/src/app/[symbol]/fear-greed/page.tsx
+++ b/src/app/[symbol]/fear-greed/page.tsx
@@ -3,7 +3,11 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { FearGreedPageError } from '@/widgets/fear-greed';
 import { CrossLinkCards, SymbolPageHeading } from '@/widgets/symbol-page';
 import { JsonLd } from '@/shared/ui/JsonLd';
-import { DEFAULT_TIMEFRAME, VALID_TICKER_RE } from '@/shared/config/market';
+import {
+    DEFAULT_TIMEFRAME,
+    SymbolRouteParams,
+    VALID_TICKER_RE,
+} from '@/shared/config/market';
 import {
     buildAssetAboutNode,
     buildDisplayName,
@@ -33,7 +37,7 @@ export const revalidate = 3600; // 1h
 // generateStaticParams가 없으면 동적 라우트는 매 요청 동적 렌더돼 revalidate가
 // 무력화된다(Next.js). 빈 배열 = 빌드 시 prebuild 없이, 첫 요청에 렌더+캐시 후
 // revalidate 주기로 재생성하는 on-demand ISR. (cacheComponents 비활성이라 빈 배열 허용)
-export async function generateStaticParams(): Promise<{ symbol: string }[]> {
+export async function generateStaticParams(): Promise<SymbolRouteParams[]> {
     return [];
 }
 

--- a/src/app/[symbol]/fear-greed/page.tsx
+++ b/src/app/[symbol]/fear-greed/page.tsx
@@ -26,6 +26,17 @@ import {
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
+// 종목당 SEO 콘텐츠는 고정이고 동적 데이터는 클라가 재hydrate한다. 엣지 캐시로
+// compute 호출을 줄인다. (일시 인프라 장애의 404 캐싱은 getAssetInfo strict로 차단)
+export const revalidate = 3600; // 1h
+
+// generateStaticParams가 없으면 동적 라우트는 매 요청 동적 렌더돼 revalidate가
+// 무력화된다(Next.js). 빈 배열 = 빌드 시 prebuild 없이, 첫 요청에 렌더+캐시 후
+// revalidate 주기로 재생성하는 on-demand ISR. (cacheComponents 비활성이라 빈 배열 허용)
+export async function generateStaticParams(): Promise<{ symbol: string }[]> {
+    return [];
+}
+
 interface Props {
     params: Promise<{ symbol: string }>;
 }

--- a/src/app/[symbol]/fear-greed/twitter-image.tsx
+++ b/src/app/[symbol]/fear-greed/twitter-image.tsx
@@ -1,3 +1,10 @@
+// 동적 세그먼트([symbol]) 하위라 revalidate만으로는 캐시되지 않는다. 이미지가
+// (ticker, label) 순수 함수(동적 요청 API 미사용)이므로 force-static으로 정적 생성·캐시.
+export const dynamic = 'force-static';
+// OG 이미지는 (ticker, label) 순수 함수라 fresh 데이터가 없음 → 길게 캐시.
+// 템플릿 변경은 배포 시 캐시가 무효화된다.
+export const revalidate = 2592000; // 30d
+
 export {
     default,
     size,

--- a/src/app/[symbol]/fundamental/opengraph-image.tsx
+++ b/src/app/[symbol]/fundamental/opengraph-image.tsx
@@ -1,6 +1,13 @@
 import { OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/shared/lib/og';
 import { buildSymbolOgImage } from '@/entities/og-image';
 
+// 동적 세그먼트([symbol]) 하위라 revalidate만으로는 캐시되지 않는다. 이미지가
+// (ticker, label) 순수 함수(동적 요청 API 미사용)이므로 force-static으로 정적 생성·캐시.
+export const dynamic = 'force-static';
+// OG 이미지는 (ticker, label) 순수 함수라 fresh 데이터가 없음 → 길게 캐시.
+// 템플릿 변경은 배포 시 캐시가 무효화된다.
+export const revalidate = 2592000; // 30d
+
 export const size = { width: OG_IMAGE_WIDTH, height: OG_IMAGE_HEIGHT };
 export const contentType = 'image/png';
 // alt는 module-scope const라 ticker 동적 주입 불가 — 페이지 카테고리까지만 명시한다.

--- a/src/app/[symbol]/fundamental/page.tsx
+++ b/src/app/[symbol]/fundamental/page.tsx
@@ -44,6 +44,17 @@ import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
+// 종목당 SEO 콘텐츠는 고정이고 동적 데이터는 클라가 재hydrate한다. 엣지 캐시로
+// compute 호출을 줄인다. (일시 인프라 장애의 404 캐싱은 getAssetInfo strict로 차단)
+export const revalidate = 3600; // 1h
+
+// generateStaticParams가 없으면 동적 라우트는 매 요청 동적 렌더돼 revalidate가
+// 무력화된다(Next.js). 빈 배열 = 빌드 시 prebuild 없이, 첫 요청에 렌더+캐시 후
+// revalidate 주기로 재생성하는 on-demand ISR. (cacheComponents 비활성이라 빈 배열 허용)
+export async function generateStaticParams(): Promise<{ symbol: string }[]> {
+    return [];
+}
+
 interface Props {
     params: Promise<{ symbol: string }>;
 }

--- a/src/app/[symbol]/fundamental/page.tsx
+++ b/src/app/[symbol]/fundamental/page.tsx
@@ -26,7 +26,7 @@ import { ValuationCard } from '@/widgets/fundamental/sections/ValuationCard';
 import { CrossLinkCards, SymbolPageHeading } from '@/widgets/symbol-page';
 import { SectionSkeleton } from '@/widgets/symbol-page/SectionSkeleton';
 import { JsonLd } from '@/shared/ui/JsonLd';
-import { VALID_TICKER_RE } from '@/shared/config/market';
+import { SymbolRouteParams, VALID_TICKER_RE } from '@/shared/config/market';
 import {
     buildAssetAboutNode,
     buildDisplayName,
@@ -51,7 +51,7 @@ export const revalidate = 3600; // 1h
 // generateStaticParams가 없으면 동적 라우트는 매 요청 동적 렌더돼 revalidate가
 // 무력화된다(Next.js). 빈 배열 = 빌드 시 prebuild 없이, 첫 요청에 렌더+캐시 후
 // revalidate 주기로 재생성하는 on-demand ISR. (cacheComponents 비활성이라 빈 배열 허용)
-export async function generateStaticParams(): Promise<{ symbol: string }[]> {
+export async function generateStaticParams(): Promise<SymbolRouteParams[]> {
     return [];
 }
 

--- a/src/app/[symbol]/fundamental/twitter-image.tsx
+++ b/src/app/[symbol]/fundamental/twitter-image.tsx
@@ -1,3 +1,10 @@
+// 동적 세그먼트([symbol]) 하위라 revalidate만으로는 캐시되지 않는다. 이미지가
+// (ticker, label) 순수 함수(동적 요청 API 미사용)이므로 force-static으로 정적 생성·캐시.
+export const dynamic = 'force-static';
+// OG 이미지는 (ticker, label) 순수 함수라 fresh 데이터가 없음 → 길게 캐시.
+// 템플릿 변경은 배포 시 캐시가 무효화된다.
+export const revalidate = 2592000; // 30d
+
 export {
     default,
     size,

--- a/src/app/[symbol]/news/opengraph-image.tsx
+++ b/src/app/[symbol]/news/opengraph-image.tsx
@@ -1,6 +1,13 @@
 import { OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/shared/lib/og';
 import { buildSymbolOgImage } from '@/entities/og-image';
 
+// 동적 세그먼트([symbol]) 하위라 revalidate만으로는 캐시되지 않는다. 이미지가
+// (ticker, label) 순수 함수(동적 요청 API 미사용)이므로 force-static으로 정적 생성·캐시.
+export const dynamic = 'force-static';
+// OG 이미지는 (ticker, label) 순수 함수라 fresh 데이터가 없음 → 길게 캐시.
+// 템플릿 변경은 배포 시 캐시가 무효화된다.
+export const revalidate = 2592000; // 30d
+
 export const size = { width: OG_IMAGE_WIDTH, height: OG_IMAGE_HEIGHT };
 export const contentType = 'image/png';
 // alt는 module-scope const라 ticker 동적 주입 불가 — 페이지 카테고리까지만 명시한다.

--- a/src/app/[symbol]/news/twitter-image.tsx
+++ b/src/app/[symbol]/news/twitter-image.tsx
@@ -1,3 +1,10 @@
+// 동적 세그먼트([symbol]) 하위라 revalidate만으로는 캐시되지 않는다. 이미지가
+// (ticker, label) 순수 함수(동적 요청 API 미사용)이므로 force-static으로 정적 생성·캐시.
+export const dynamic = 'force-static';
+// OG 이미지는 (ticker, label) 순수 함수라 fresh 데이터가 없음 → 길게 캐시.
+// 템플릿 변경은 배포 시 캐시가 무효화된다.
+export const revalidate = 2592000; // 30d
+
 export {
     default,
     size,

--- a/src/app/[symbol]/opengraph-image.tsx
+++ b/src/app/[symbol]/opengraph-image.tsx
@@ -1,6 +1,13 @@
 import { OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/shared/lib/og';
 import { buildSymbolOgImage } from '@/entities/og-image';
 
+// 동적 세그먼트([symbol]) 하위라 revalidate만으로는 캐시되지 않는다. 이미지가
+// (ticker, label) 순수 함수(동적 요청 API 미사용)이므로 force-static으로 정적 생성·캐시.
+export const dynamic = 'force-static';
+// OG 이미지는 (ticker, label) 순수 함수라 fresh 데이터가 없음 → 길게 캐시.
+// 템플릿 변경은 배포 시 캐시가 무효화된다.
+export const revalidate = 2592000; // 30d
+
 export const size = { width: OG_IMAGE_WIDTH, height: OG_IMAGE_HEIGHT };
 export const contentType = 'image/png';
 // alt는 module-scope const라 ticker 동적 주입 불가 — 페이지 카테고리까지만 명시한다.

--- a/src/app/[symbol]/options/opengraph-image.tsx
+++ b/src/app/[symbol]/options/opengraph-image.tsx
@@ -1,6 +1,13 @@
 import { OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/shared/lib/og';
 import { buildSymbolOgImage } from '@/entities/og-image';
 
+// 동적 세그먼트([symbol]) 하위라 revalidate만으로는 캐시되지 않는다. 이미지가
+// (ticker, label) 순수 함수(동적 요청 API 미사용)이므로 force-static으로 정적 생성·캐시.
+export const dynamic = 'force-static';
+// OG 이미지는 (ticker, label) 순수 함수라 fresh 데이터가 없음 → 길게 캐시.
+// 템플릿 변경은 배포 시 캐시가 무효화된다.
+export const revalidate = 2592000; // 30d
+
 export const size = { width: OG_IMAGE_WIDTH, height: OG_IMAGE_HEIGHT };
 export const contentType = 'image/png';
 // alt는 module-scope const라 ticker 동적 주입 불가 — 페이지 카테고리까지만 명시한다.

--- a/src/app/[symbol]/options/page.tsx
+++ b/src/app/[symbol]/options/page.tsx
@@ -2,7 +2,7 @@ import { OptionsPageClient } from '@/widgets/options/OptionsPageClient';
 import { SymbolPageHeading } from '@/widgets/symbol-page';
 import { OptionsEmptyState } from '@/widgets/options/OptionsEmptyState';
 import { JsonLd } from '@/shared/ui/JsonLd';
-import { VALID_TICKER_RE } from '@/shared/config/market';
+import { SymbolRouteParams, VALID_TICKER_RE } from '@/shared/config/market';
 import {
     buildAssetAboutNode,
     buildDisplayName,
@@ -36,7 +36,7 @@ export const revalidate = 3600; // 1h
 // generateStaticParams가 없으면 동적 라우트는 매 요청 동적 렌더돼 revalidate가
 // 무력화된다(Next.js). 빈 배열 = 빌드 시 prebuild 없이, 첫 요청에 렌더+캐시 후
 // revalidate 주기로 재생성하는 on-demand ISR. (cacheComponents 비활성이라 빈 배열 허용)
-export async function generateStaticParams(): Promise<{ symbol: string }[]> {
+export async function generateStaticParams(): Promise<SymbolRouteParams[]> {
     return [];
 }
 

--- a/src/app/[symbol]/options/page.tsx
+++ b/src/app/[symbol]/options/page.tsx
@@ -29,6 +29,17 @@ import {
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
+// 종목당 SEO 콘텐츠는 고정이고 동적 데이터는 클라가 재hydrate한다. 엣지 캐시로
+// compute 호출을 줄인다. (일시 인프라 장애의 404 캐싱은 getAssetInfo strict로 차단)
+export const revalidate = 3600; // 1h
+
+// generateStaticParams가 없으면 동적 라우트는 매 요청 동적 렌더돼 revalidate가
+// 무력화된다(Next.js). 빈 배열 = 빌드 시 prebuild 없이, 첫 요청에 렌더+캐시 후
+// revalidate 주기로 재생성하는 on-demand ISR. (cacheComponents 비활성이라 빈 배열 허용)
+export async function generateStaticParams(): Promise<{ symbol: string }[]> {
+    return [];
+}
+
 interface Props {
     params: Promise<{ symbol: string }>;
 }

--- a/src/app/[symbol]/options/twitter-image.tsx
+++ b/src/app/[symbol]/options/twitter-image.tsx
@@ -1,3 +1,10 @@
+// 동적 세그먼트([symbol]) 하위라 revalidate만으로는 캐시되지 않는다. 이미지가
+// (ticker, label) 순수 함수(동적 요청 API 미사용)이므로 force-static으로 정적 생성·캐시.
+export const dynamic = 'force-static';
+// OG 이미지는 (ticker, label) 순수 함수라 fresh 데이터가 없음 → 길게 캐시.
+// 템플릿 변경은 배포 시 캐시가 무효화된다.
+export const revalidate = 2592000; // 30d
+
 export {
     default,
     size,

--- a/src/app/[symbol]/overall/__tests__/page.test.ts
+++ b/src/app/[symbol]/overall/__tests__/page.test.ts
@@ -74,7 +74,6 @@ describe('Overall page (narrative seed)', () => {
     async function getOverallProps(): Promise<OverallSeedProps> {
         const tree = await OverallPage({
             params: Promise.resolve({ symbol: 'aapl' }),
-            searchParams: Promise.resolve({}),
         });
         const content = findElementByType(tree, OverallContent);
         if (content === null) {

--- a/src/app/[symbol]/overall/opengraph-image.tsx
+++ b/src/app/[symbol]/overall/opengraph-image.tsx
@@ -1,6 +1,13 @@
 import { OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/shared/lib/og';
 import { buildSymbolOgImage } from '@/entities/og-image';
 
+// 동적 세그먼트([symbol]) 하위라 revalidate만으로는 캐시되지 않는다. 이미지가
+// (ticker, label) 순수 함수(동적 요청 API 미사용)이므로 force-static으로 정적 생성·캐시.
+export const dynamic = 'force-static';
+// OG 이미지는 (ticker, label) 순수 함수라 fresh 데이터가 없음 → 길게 캐시.
+// 템플릿 변경은 배포 시 캐시가 무효화된다.
+export const revalidate = 2592000; // 30d
+
 export const size = { width: OG_IMAGE_WIDTH, height: OG_IMAGE_HEIGHT };
 export const contentType = 'image/png';
 // alt는 module-scope const라 ticker 동적 주입 불가 — 페이지 카테고리까지만 명시한다.

--- a/src/app/[symbol]/overall/page.tsx
+++ b/src/app/[symbol]/overall/page.tsx
@@ -222,7 +222,20 @@ export default async function OverallPage({ params }: Props) {
                         한 번 훑어보면 도움이 됩니다.
                     </p>
                 </section>
-                <Suspense fallback={null}>
+                {/* fallback은 종합 분석 섹션 높이를 미리 차지해, useSearchParams CSR-bailout
+                    서브트리가 hydration 전 비어 보이는 flash/CLS를 방지한다(overall/loading.tsx와 동일 룩). */}
+                <Suspense
+                    fallback={
+                        <div className="space-y-6" aria-hidden="true">
+                            {[0, 1, 2].map(i => (
+                                <div
+                                    key={i}
+                                    className="bg-secondary-700 h-32 animate-pulse rounded-xl"
+                                />
+                            ))}
+                        </div>
+                    }
+                >
                     <OverallContent
                         symbol={upper}
                         companyName={assetInfo.name}

--- a/src/app/[symbol]/overall/page.tsx
+++ b/src/app/[symbol]/overall/page.tsx
@@ -31,6 +31,9 @@ export async function generateStaticParams(): Promise<{ symbol: string }[]> {
     return [];
 }
 
+// Suspense fallback 스켈레톤 박스 개수 (CLS 방지용 placeholder).
+const SUSPENSE_SKELETON_COUNT = 3;
+
 interface Props {
     params: Promise<{ symbol: string }>;
 }
@@ -227,12 +230,15 @@ export default async function OverallPage({ params }: Props) {
                 <Suspense
                     fallback={
                         <div className="space-y-6" aria-hidden="true">
-                            {[0, 1, 2].map(i => (
-                                <div
-                                    key={i}
-                                    className="bg-secondary-700 h-32 animate-pulse rounded-xl"
-                                />
-                            ))}
+                            {Array.from(
+                                { length: SUSPENSE_SKELETON_COUNT },
+                                (_, i) => (
+                                    <div
+                                        key={i}
+                                        className="bg-secondary-700 h-32 animate-pulse rounded-xl"
+                                    />
+                                )
+                            )}
                         </div>
                     }
                 >

--- a/src/app/[symbol]/overall/page.tsx
+++ b/src/app/[symbol]/overall/page.tsx
@@ -1,7 +1,11 @@
 import { OverallContent } from '@/widgets/overall/OverallContent';
 import { CrossLinkCards, SymbolPageHeading } from '@/widgets/symbol-page';
 import { JsonLd } from '@/shared/ui/JsonLd';
-import { DEFAULT_TIMEFRAME, VALID_TICKER_RE } from '@/shared/config/market';
+import {
+    DEFAULT_TIMEFRAME,
+    SymbolRouteParams,
+    VALID_TICKER_RE,
+} from '@/shared/config/market';
 import { Suspense } from 'react';
 import {
     buildAssetAboutNode,
@@ -27,7 +31,7 @@ export const revalidate = 3600; // 1h — ISR
 // generateStaticParams가 없으면 동적 라우트는 매 요청 동적 렌더돼 revalidate가
 // 무력화된다(Next.js). 빈 배열 = 빌드 prebuild 없이 첫 요청에 렌더+캐시하는 on-demand
 // ISR. (cacheComponents 비활성이라 빈 배열 허용)
-export async function generateStaticParams(): Promise<{ symbol: string }[]> {
+export async function generateStaticParams(): Promise<SymbolRouteParams[]> {
     return [];
 }
 

--- a/src/app/[symbol]/overall/page.tsx
+++ b/src/app/[symbol]/overall/page.tsx
@@ -1,11 +1,8 @@
 import { OverallContent } from '@/widgets/overall/OverallContent';
 import { CrossLinkCards, SymbolPageHeading } from '@/widgets/symbol-page';
 import { JsonLd } from '@/shared/ui/JsonLd';
-import {
-    DEFAULT_TIMEFRAME,
-    isValidTimeframe,
-    VALID_TICKER_RE,
-} from '@/shared/config/market';
+import { DEFAULT_TIMEFRAME, VALID_TICKER_RE } from '@/shared/config/market';
+import { Suspense } from 'react';
 import {
     buildAssetAboutNode,
     buildDisplayName,
@@ -21,14 +18,21 @@ import {
 import {
     GEMINI_2_5_FLASH_LITE_MODEL,
     peekOverallAnalysisCache,
-    type Timeframe,
 } from '@y0ngha/siglens-core';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
+export const revalidate = 3600; // 1h — ISR
+
+// generateStaticParams가 없으면 동적 라우트는 매 요청 동적 렌더돼 revalidate가
+// 무력화된다(Next.js). 빈 배열 = 빌드 prebuild 없이 첫 요청에 렌더+캐시하는 on-demand
+// ISR. (cacheComponents 비활성이라 빈 배열 허용)
+export async function generateStaticParams(): Promise<{ symbol: string }[]> {
+    return [];
+}
+
 interface Props {
     params: Promise<{ symbol: string }>;
-    searchParams: Promise<{ tf?: string }>;
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -69,8 +73,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     };
 }
 
-// `?tf=` is read into a Client prop; canonical URL excludes it so search engines see one URL per page.
-export default async function OverallPage({ params, searchParams }: Props) {
+// `?tf=` is read by the client component (useSearchParams); canonical URL excludes it so search engines see one URL per page.
+export default async function OverallPage({ params }: Props) {
     const { symbol } = await params;
     const upper = symbol.toUpperCase();
 
@@ -82,9 +86,6 @@ export default async function OverallPage({ params, searchParams }: Props) {
     if (!assetInfo) {
         notFound();
     }
-
-    const { tf } = await searchParams;
-    const timeframe: Timeframe = isValidTimeframe(tf) ? tf : DEFAULT_TIMEFRAME;
 
     // peek은 읽기 전용 — enqueue/생성 없음. MISS·corrupt·read 실패는 모두 null로
     // degrade하므로 OverallContent는 idle CTA로 자연 폴백한다(렌더를 깨지 않음).
@@ -98,10 +99,12 @@ export default async function OverallPage({ params, searchParams }: Props) {
     // 시그니처가 chart의 peekAnalysisCache(symbol, timeframe, fmpSymbol?, modelId?)와
     // 다른 건 의도적이다 — overall은 2번째 인자로 companyName을 받는다. 각 core peek
     // 함수가 자기 캐시 키 구성에 맞춰 서로 다른 시그니처를 갖는다.
+    //
+    // ISR: tf는 client가 URL에서 읽으므로 서버는 DEFAULT_TIMEFRAME으로 peek한다.
     const cachedOverall = await peekOverallAnalysisCache(
         upper,
         assetInfo.name,
-        timeframe,
+        DEFAULT_TIMEFRAME,
         GEMINI_2_5_FLASH_LITE_MODEL
     ).catch((error: unknown) => {
         console.error('[OverallPage] peekOverallAnalysisCache failed:', error);
@@ -219,12 +222,13 @@ export default async function OverallPage({ params, searchParams }: Props) {
                         한 번 훑어보면 도움이 됩니다.
                     </p>
                 </section>
-                <OverallContent
-                    symbol={upper}
-                    companyName={assetInfo.name}
-                    timeframe={timeframe}
-                    initialAnalysis={cachedOverall ?? undefined}
-                />
+                <Suspense fallback={null}>
+                    <OverallContent
+                        symbol={upper}
+                        companyName={assetInfo.name}
+                        initialAnalysis={cachedOverall ?? undefined}
+                    />
+                </Suspense>
                 <CrossLinkCards symbol={upper} current="overall" />
             </main>
         </>

--- a/src/app/[symbol]/overall/twitter-image.tsx
+++ b/src/app/[symbol]/overall/twitter-image.tsx
@@ -1,3 +1,10 @@
+// 동적 세그먼트([symbol]) 하위라 revalidate만으로는 캐시되지 않는다. 이미지가
+// (ticker, label) 순수 함수(동적 요청 API 미사용)이므로 force-static으로 정적 생성·캐시.
+export const dynamic = 'force-static';
+// OG 이미지는 (ticker, label) 순수 함수라 fresh 데이터가 없음 → 길게 캐시.
+// 템플릿 변경은 배포 시 캐시가 무효화된다.
+export const revalidate = 2592000; // 30d
+
 export {
     default,
     size,

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -5,11 +5,7 @@ import {
     GEMINI_2_5_FLASH_LITE_MODEL,
     peekAnalysisCache,
 } from '@y0ngha/siglens-core';
-import {
-    DEFAULT_TIMEFRAME,
-    isValidTimeframe,
-    VALID_TICKER_RE,
-} from '@/shared/config/market';
+import { DEFAULT_TIMEFRAME, VALID_TICKER_RE } from '@/shared/config/market';
 import {
     buildAssetAboutNode,
     buildDisplayName,
@@ -31,10 +27,19 @@ import {
 } from '@tanstack/react-query';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
+
+export const revalidate = 3600; // 1h — ISR
+
+// generateStaticParams가 없으면 동적 라우트는 매 요청 동적 렌더돼 revalidate가
+// 무력화된다(Next.js). 빈 배열 = 빌드 시 prebuild 없이, 첫 요청에 렌더+캐시 후
+// revalidate 주기로 재생성하는 on-demand ISR. (cacheComponents 비활성이라 빈 배열 허용)
+export async function generateStaticParams(): Promise<{ symbol: string }[]> {
+    return [];
+}
 
 interface Props {
     params: Promise<{ symbol: string }>;
-    searchParams: Promise<{ tf?: string }>;
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -77,10 +82,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     };
 }
 
-export default async function SymbolPage({ params, searchParams }: Props) {
+export default async function SymbolPage({ params }: Props) {
     const { symbol } = await params;
-    const { tf } = await searchParams;
-    const initialTimeframe = isValidTimeframe(tf) ? tf : DEFAULT_TIMEFRAME;
     const ticker = symbol.toUpperCase();
     // 다른 5개 sibling 페이지(news/fundamental/options/overall/fear-greed)와 일관:
     // 잘못된 ticker 형식은 본문에서도 notFound로 즉시 차단한다 (generateMetadata 가드와 짝).
@@ -181,34 +184,20 @@ export default async function SymbolPage({ params, searchParams }: Props) {
     // peek도 동일 모델을 넘겨야 HIT한다.
     // bars prefetch와 독립이므로 함께 await해 병렬화한다.
     const [, cachedAnalysis] = await Promise.all([
-        Promise.all([
-            queryClient.prefetchQuery({
-                queryKey: QUERY_KEYS.bars(
-                    symbol,
-                    initialTimeframe,
-                    assetInfo.fmpSymbol
-                ),
-                queryFn: barsQueryFn,
-            }),
-            ...(initialTimeframe !== DEFAULT_TIMEFRAME
-                ? [
-                      queryClient.prefetchQuery({
-                          queryKey: QUERY_KEYS.bars(
-                              symbol,
-                              DEFAULT_TIMEFRAME,
-                              assetInfo.fmpSymbol
-                          ),
-                          queryFn: barsQueryFn,
-                      }),
-                  ]
-                : []),
-        ]),
-        // ticker(표시 심볼)와 assetInfo.fmpSymbol(FMP 제공자 심볼)은 별개 값이다.
-        // peek은 submitAnalysis와의 호출부 parity를 위해 fmpSymbol을 받지만, 분석
-        // 캐시 키는 symbol+timeframe+modelId만 사용하므로 fmpSymbol은 조회에 무시된다.
+        // 차트 페이지는 ISR로 캐시되므로 prefetch는 기본 timeframe만 seed한다.
+        // ?tf= 딥링크는 클라(useTimeframeChange→useSearchParams)가 마운트 시 읽어
+        // 해당 timeframe bars를 fetch한다.
+        queryClient.prefetchQuery({
+            queryKey: QUERY_KEYS.bars(
+                symbol,
+                DEFAULT_TIMEFRAME,
+                assetInfo.fmpSymbol
+            ),
+            queryFn: barsQueryFn,
+        }),
         peekAnalysisCache(
             ticker,
-            initialTimeframe,
+            DEFAULT_TIMEFRAME,
             assetInfo.fmpSymbol,
             GEMINI_2_5_FLASH_LITE_MODEL
         ).catch((error: unknown) => {
@@ -261,17 +250,19 @@ export default async function SymbolPage({ params, searchParams }: Props) {
                     </p>
                 </section>
                 <HydrationBoundary state={dehydrate(queryClient)}>
-                    <SymbolPageClient
-                        symbol={symbol}
-                        companyName={assetInfo.name}
-                        displayName={displayName}
-                        initialAnalysis={initialAnalysis}
-                        // 순수 additive: 캐시 seed 여부와 무관하게 클라이언트는
-                        // 마운트 시 useAnalysis가 자동으로 재분석을 트리거하도록
-                        // 항상 true를 유지한다(봇은 enqueue가 skip되어 생성 안 됨).
-                        initialAnalysisFailed={true}
-                        indicatorCount={skillCounts.indicators}
-                    />
+                    <Suspense fallback={null}>
+                        <SymbolPageClient
+                            symbol={symbol}
+                            companyName={assetInfo.name}
+                            displayName={displayName}
+                            initialAnalysis={initialAnalysis}
+                            // 순수 additive: 캐시 seed 여부와 무관하게 클라이언트는
+                            // 마운트 시 useAnalysis가 자동으로 재분석을 트리거하도록
+                            // 항상 true를 유지한다(봇은 enqueue가 skip되어 생성 안 됨).
+                            initialAnalysisFailed={true}
+                            indicatorCount={skillCounts.indicators}
+                        />
+                    </Suspense>
                 </HydrationBoundary>
             </main>
         </>

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -5,7 +5,11 @@ import {
     GEMINI_2_5_FLASH_LITE_MODEL,
     peekAnalysisCache,
 } from '@y0ngha/siglens-core';
-import { DEFAULT_TIMEFRAME, VALID_TICKER_RE } from '@/shared/config/market';
+import {
+    DEFAULT_TIMEFRAME,
+    SymbolRouteParams,
+    VALID_TICKER_RE,
+} from '@/shared/config/market';
 import {
     buildAssetAboutNode,
     buildDisplayName,
@@ -34,7 +38,7 @@ export const revalidate = 3600; // 1h — ISR
 // generateStaticParams가 없으면 동적 라우트는 매 요청 동적 렌더돼 revalidate가
 // 무력화된다(Next.js). 빈 배열 = 빌드 시 prebuild 없이, 첫 요청에 렌더+캐시 후
 // revalidate 주기로 재생성하는 on-demand ISR. (cacheComponents 비활성이라 빈 배열 허용)
-export async function generateStaticParams(): Promise<{ symbol: string }[]> {
+export async function generateStaticParams(): Promise<SymbolRouteParams[]> {
     return [];
 }
 

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -250,7 +250,16 @@ export default async function SymbolPage({ params }: Props) {
                     </p>
                 </section>
                 <HydrationBoundary state={dehydrate(queryClient)}>
-                    <Suspense fallback={null}>
+                    {/* fallback은 차트 영역(flex-1)을 미리 차지해, useSearchParams CSR-bailout
+                        서브트리가 hydration 전 비어 보이는 flash/CLS를 방지한다. */}
+                    <Suspense
+                        fallback={
+                            <div
+                                className="bg-secondary-900 flex min-h-0 flex-1 flex-col overflow-hidden"
+                                aria-hidden="true"
+                            />
+                        }
+                    >
                         <SymbolPageClient
                             symbol={symbol}
                             companyName={assetInfo.name}

--- a/src/app/[symbol]/twitter-image.tsx
+++ b/src/app/[symbol]/twitter-image.tsx
@@ -2,6 +2,14 @@
 // 분리해서 처리한다. opengraph-image만 있으면 Twitter는 root layout의 정적
 // og-image.png로 fallback되므로, sibling 라우트의 동적 OG 이미지를 그대로
 // twitter:image에도 노출하기 위해 re-export한다.
+
+// 동적 세그먼트([symbol]) 하위라 revalidate만으로는 캐시되지 않는다. 이미지가
+// (ticker, label) 순수 함수(동적 요청 API 미사용)이므로 force-static으로 정적 생성·캐시.
+export const dynamic = 'force-static';
+// OG 이미지는 (ticker, label) 순수 함수라 fresh 데이터가 없음 → 길게 캐시.
+// 템플릿 변경은 배포 시 캐시가 무효화된다.
+export const revalidate = 2592000; // 30d
+
 export {
     default,
     size,

--- a/src/app/__tests__/robots.test.ts
+++ b/src/app/__tests__/robots.test.ts
@@ -7,35 +7,40 @@ import robots from '@/app/robots';
 describe('robots', () => {
     it('returns a valid robots config', () => {
         const result = robots();
-
         expect(result).toBeDefined();
-        expect(result.rules).toBeDefined();
+        expect(Array.isArray(result.rules)).toBe(true);
     });
 
-    it('allows all paths for all user agents', () => {
+    it('allows all paths for the default user agent but disallows /api/', () => {
         const result = robots();
-
-        expect(result.rules).toEqual(
+        expect(result.rules).toContainEqual(
             expect.objectContaining({
                 userAgent: '*',
                 allow: '/',
+                disallow: ['/api/'],
             })
         );
     });
 
-    it('disallows /api/ routes', () => {
+    it('disallows parasite SEO crawlers entirely', () => {
         const result = robots();
-
-        expect(result.rules).toEqual(
+        expect(result.rules).toContainEqual(
             expect.objectContaining({
-                disallow: ['/api/'],
+                userAgent: expect.arrayContaining([
+                    'AhrefsBot',
+                    'SemrushBot',
+                    'MJ12bot',
+                    'DotBot',
+                    'BLEXBot',
+                    'DataForSeoBot',
+                ]),
+                disallow: '/',
             })
         );
     });
 
     it('points sitemap to the correct URL', () => {
         const result = robots();
-
         expect(result.sitemap).toBe('https://siglens.io/sitemap.xml');
     });
 });

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,23 +1,41 @@
 import type { MetadataRoute } from 'next';
 import { SITE_URL } from '@/shared/lib/seo';
 
+// 검색엔진이 아닌 기생 SEO 크롤러(백링크/순위 분석 SaaS). 포털 랭킹에 기여하지 않으면서
+// 트래픽만 유발하므로 전면 Disallow한다 — Googlebot/Yeti/Bingbot/Daumoa 등 실제
+// 검색엔진은 절대 포함하지 않는다. 이 봇들은 robots.txt를 준수한다.
+const PARASITE_BOT_USER_AGENTS = [
+    'AhrefsBot',
+    'SemrushBot',
+    'MJ12bot',
+    'DotBot',
+    'BLEXBot',
+    'DataForSeoBot',
+];
+
 export default function robots(): MetadataRoute.Robots {
     return {
-        rules: {
-            userAgent: '*',
-            allow: '/',
-            // API 라우트는 disallow로 유지 — 응답이 JSON/이미지 등 SEO 가치
-            // 없는 자원이라 crawl budget 절약 목적.
-            //
-            // 인증 페이지(/login, /signup, /forgot-password, /reset-password)
-            // 와 /account는 페이지 metadata에 `robots: { index: false }`로
-            // noindex가 박혀 있다. 이전엔 robots.txt에서도 Disallow했었지만,
-            // 그 조합은 Googlebot이 페이지를 crawl 못해 noindex 태그를 보지
-            // 못하는 충돌을 만든다 — 외부 백링크가 생기면 "Indexed though
-            // blocked by robots.txt" 상태로 SERP에 빈 카드로 노출될 위험.
-            // noindex가 더 강한 신호이므로 그쪽만 유지하고 Disallow는 제거.
-            disallow: ['/api/'],
-        },
+        rules: [
+            {
+                userAgent: '*',
+                allow: '/',
+                // API 라우트는 disallow로 유지 — 응답이 JSON/이미지 등 SEO 가치
+                // 없는 자원이라 crawl budget 절약 목적.
+                //
+                // 인증 페이지(/login, /signup, /forgot-password, /reset-password)
+                // 와 /account는 페이지 metadata에 `robots: { index: false }`로
+                // noindex가 박혀 있다. 이전엔 robots.txt에서도 Disallow했었지만,
+                // 그 조합은 Googlebot이 페이지를 crawl 못해 noindex 태그를 보지
+                // 못하는 충돌을 만든다 — 외부 백링크가 생기면 "Indexed though
+                // blocked by robots.txt" 상태로 SERP에 빈 카드로 노출될 위험.
+                // noindex가 더 강한 신호이므로 그쪽만 유지하고 Disallow는 제거.
+                disallow: ['/api/'],
+            },
+            {
+                userAgent: PARASITE_BOT_USER_AGENTS,
+                disallow: '/',
+            },
+        ],
         sitemap: `${SITE_URL}/sitemap.xml`,
     };
 }

--- a/src/entities/chat-message/__tests__/chatAction.test.ts
+++ b/src/entities/chat-message/__tests__/chatAction.test.ts
@@ -151,7 +151,6 @@ describe('chatAction 함수는', () => {
                 { callAiProvider: callAiProviderRouter }
             );
         });
-
     });
 
     describe('Anthropic 모델을 사용할 때', () => {

--- a/src/entities/ticker/__tests__/lib/fmpTickerApi.test.ts
+++ b/src/entities/ticker/__tests__/lib/fmpTickerApi.test.ts
@@ -134,4 +134,65 @@ describe('searchBySymbol/searchByName', () => {
         );
         warnSpy.mockRestore();
     });
+
+    describe('strict mode (getAssetInfo 경로)', () => {
+        it('!res.ok(429/5xx)면 throw한다', async () => {
+            mockFetch.mockResolvedValue({ ok: false, status: 429 });
+            await expect(
+                searchBySymbol('AAPL', { strict: true })
+            ).rejects.toThrow();
+        });
+
+        it('network/timeout 예외면 throw한다', async () => {
+            mockFetch.mockRejectedValue(new Error('network down'));
+            await expect(
+                searchBySymbol('AAPL', { strict: true })
+            ).rejects.toThrow();
+        });
+
+        it('200 + 빈 배열은 throw하지 않고 [] 반환 (legit no-match)', async () => {
+            mockFetch.mockResolvedValue({
+                ok: true,
+                json: async () => [],
+            });
+            await expect(
+                searchBySymbol('NOPE', { strict: true })
+            ).resolves.toEqual([]);
+        });
+
+        it('lenient(기본값)는 에러 시 여전히 []로 degrade한다', async () => {
+            mockFetch.mockResolvedValue({ ok: false, status: 500 });
+            await expect(searchBySymbol('AAPL')).resolves.toEqual([]);
+        });
+
+        it('FMP config 없음(strict)이면 throw하고 fetch하지 않는다', async () => {
+            delete process.env.FMP_API_KEY;
+            await expect(
+                searchBySymbol('AAPL', { strict: true })
+            ).rejects.toThrow();
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it('200 + 비배열 응답(strict)이면 throw한다', async () => {
+            mockFetch.mockResolvedValue({
+                ok: true,
+                json: async () => ({ error: 'invalid' }),
+            });
+            await expect(
+                searchBySymbol('AAPL', { strict: true })
+            ).rejects.toThrow();
+        });
+
+        it('JSON 파싱 실패(strict)면 throw한다', async () => {
+            mockFetch.mockResolvedValue({
+                ok: true,
+                json: async () => {
+                    throw new Error('invalid json');
+                },
+            });
+            await expect(
+                searchBySymbol('AAPL', { strict: true })
+            ).rejects.toThrow();
+        });
+    });
 });

--- a/src/entities/ticker/__tests__/lib/fmpTickerApi.test.ts
+++ b/src/entities/ticker/__tests__/lib/fmpTickerApi.test.ts
@@ -135,18 +135,18 @@ describe('searchBySymbol/searchByName', () => {
         warnSpy.mockRestore();
     });
 
-    describe('strict mode (getAssetInfo 경로)', () => {
+    describe('throwOnInfraFailure 모드 (getAssetInfo 경로)', () => {
         it('!res.ok(429/5xx)면 throw한다', async () => {
             mockFetch.mockResolvedValue({ ok: false, status: 429 });
             await expect(
-                searchBySymbol('AAPL', { strict: true })
+                searchBySymbol('AAPL', { throwOnInfraFailure: true })
             ).rejects.toThrow();
         });
 
         it('network/timeout 예외면 throw한다', async () => {
             mockFetch.mockRejectedValue(new Error('network down'));
             await expect(
-                searchBySymbol('AAPL', { strict: true })
+                searchBySymbol('AAPL', { throwOnInfraFailure: true })
             ).rejects.toThrow();
         });
 
@@ -156,7 +156,7 @@ describe('searchBySymbol/searchByName', () => {
                 json: async () => [],
             });
             await expect(
-                searchBySymbol('NOPE', { strict: true })
+                searchBySymbol('NOPE', { throwOnInfraFailure: true })
             ).resolves.toEqual([]);
         });
 
@@ -165,25 +165,25 @@ describe('searchBySymbol/searchByName', () => {
             await expect(searchBySymbol('AAPL')).resolves.toEqual([]);
         });
 
-        it('FMP config 없음(strict)이면 throw하고 fetch하지 않는다', async () => {
+        it('FMP config 없음이면 throw하고 fetch하지 않는다', async () => {
             delete process.env.FMP_API_KEY;
             await expect(
-                searchBySymbol('AAPL', { strict: true })
+                searchBySymbol('AAPL', { throwOnInfraFailure: true })
             ).rejects.toThrow();
             expect(mockFetch).not.toHaveBeenCalled();
         });
 
-        it('200 + 비배열 응답(strict)이면 throw한다', async () => {
+        it('200 + 비배열 응답이면 throw한다', async () => {
             mockFetch.mockResolvedValue({
                 ok: true,
                 json: async () => ({ error: 'invalid' }),
             });
             await expect(
-                searchBySymbol('AAPL', { strict: true })
+                searchBySymbol('AAPL', { throwOnInfraFailure: true })
             ).rejects.toThrow();
         });
 
-        it('JSON 파싱 실패(strict)면 throw한다', async () => {
+        it('JSON 파싱 실패면 throw한다', async () => {
             mockFetch.mockResolvedValue({
                 ok: true,
                 json: async () => {
@@ -191,7 +191,7 @@ describe('searchBySymbol/searchByName', () => {
                 },
             });
             await expect(
-                searchBySymbol('AAPL', { strict: true })
+                searchBySymbol('AAPL', { throwOnInfraFailure: true })
             ).rejects.toThrow();
         });
     });

--- a/src/entities/ticker/__tests__/lib/getAssetInfo.test.ts
+++ b/src/entities/ticker/__tests__/lib/getAssetInfo.test.ts
@@ -57,7 +57,8 @@ vi.mock('../../lib/fmpTickerApi', async () => {
     const actual = await vi.importActual('../../lib/fmpTickerApi');
     return {
         ...actual,
-        searchBySymbol: (q: string) => searchBySymbolMock(q),
+        searchBySymbol: (q: string, options?: { strict?: boolean }) =>
+            searchBySymbolMock(q, options),
     };
 });
 vi.mock('../../lib/koreanNameStore', () => ({
@@ -406,5 +407,25 @@ describe('getAssetInfo', () => {
         mockRepository.findBySymbol.mockResolvedValue(null);
         searchBySymbolMock.mockRejectedValue(new Error('FMP timeout'));
         await expect(getAssetInfo('AAPL')).rejects.toThrow('FMP timeout');
+    });
+
+    it('FMP 인프라 에러를 throw로 전파한다 (null로 degrade하지 않음)', async () => {
+        createCacheProviderMock.mockReturnValue(null); // 캐시 미스
+        tryGetTickerDatabaseClientMock.mockReturnValue(null); // DB 미가용 → FMP fall-through
+        searchBySymbolMock.mockRejectedValue(new Error('FMP HTTP 429'));
+
+        await expect(getAssetInfo('AAPL')).rejects.toThrow('FMP HTTP 429');
+    });
+
+    it('getAssetInfo가 searchBySymbol을 strict로 호출한다', async () => {
+        createCacheProviderMock.mockReturnValue(null);
+        tryGetTickerDatabaseClientMock.mockReturnValue(null);
+        searchBySymbolMock.mockResolvedValue([]); // 200 빈 결과 → null
+
+        await getAssetInfo('NOPE');
+
+        expect(searchBySymbolMock).toHaveBeenCalledWith('NOPE', {
+            strict: true,
+        });
     });
 });

--- a/src/entities/ticker/__tests__/lib/getAssetInfo.test.ts
+++ b/src/entities/ticker/__tests__/lib/getAssetInfo.test.ts
@@ -57,8 +57,10 @@ vi.mock('../../lib/fmpTickerApi', async () => {
     const actual = await vi.importActual('../../lib/fmpTickerApi');
     return {
         ...actual,
-        searchBySymbol: (q: string, options?: { strict?: boolean }) =>
-            searchBySymbolMock(q, options),
+        searchBySymbol: (
+            q: string,
+            options?: { throwOnInfraFailure?: boolean }
+        ) => searchBySymbolMock(q, options),
     };
 });
 vi.mock('../../lib/koreanNameStore', () => ({
@@ -417,7 +419,7 @@ describe('getAssetInfo', () => {
         await expect(getAssetInfo('AAPL')).rejects.toThrow('FMP HTTP 429');
     });
 
-    it('getAssetInfo가 searchBySymbol을 strict로 호출한다', async () => {
+    it('getAssetInfo가 searchBySymbol을 throwOnInfraFailure로 호출한다', async () => {
         createCacheProviderMock.mockReturnValue(null);
         tryGetTickerDatabaseClientMock.mockReturnValue(null);
         searchBySymbolMock.mockResolvedValue([]); // 200 빈 결과 → null
@@ -425,7 +427,7 @@ describe('getAssetInfo', () => {
         await getAssetInfo('NOPE');
 
         expect(searchBySymbolMock).toHaveBeenCalledWith('NOPE', {
-            strict: true,
+            throwOnInfraFailure: true,
         });
     });
 });

--- a/src/entities/ticker/lib/fmpTickerApi.ts
+++ b/src/entities/ticker/lib/fmpTickerApi.ts
@@ -17,6 +17,11 @@ const US_EXCHANGES: ReadonlySet<string> = new Set([
 
 type FmpEndpoint = 'search-symbol' | 'search-name';
 
+/** getAssetInfo의 strict 경로(인프라 에러 throw) vs 검색 UI의 lenient(빈 배열 degrade)를 가르는 옵션. */
+interface FmpSearchOptions {
+    strict?: boolean;
+}
+
 /** Type guard validating per-element FMP response shape before trusting it as `FmpSearchResult`. */
 function isFmpSearchResultLike(value: unknown): value is FmpSearchResult {
     if (value === null || typeof value !== 'object') return false;
@@ -60,7 +65,7 @@ export function filterUsExchanges(
 async function fetchFmpEndpoint(
     endpoint: FmpEndpoint,
     query: string,
-    options?: { strict?: boolean }
+    options?: FmpSearchOptions
 ): Promise<FmpSearchResult[]> {
     const strict = options?.strict ?? false;
 
@@ -128,7 +133,7 @@ async function fetchFmpEndpoint(
 
 export async function searchBySymbol(
     query: string,
-    options?: { strict?: boolean }
+    options?: FmpSearchOptions
 ): Promise<FmpSearchResult[]> {
     return fetchFmpEndpoint('search-symbol', query, options);
 }

--- a/src/entities/ticker/lib/fmpTickerApi.ts
+++ b/src/entities/ticker/lib/fmpTickerApi.ts
@@ -17,9 +17,9 @@ const US_EXCHANGES: ReadonlySet<string> = new Set([
 
 type FmpEndpoint = 'search-symbol' | 'search-name';
 
-/** getAssetInfo의 strict 경로(인프라 에러 throw) vs 검색 UI의 lenient(빈 배열 degrade)를 가르는 옵션. */
+/** getAssetInfo가 쓰는 throwOnInfraFailure(인프라 에러 throw) vs 검색 UI 기본(빈 배열 degrade)을 가르는 옵션. */
 interface FmpSearchOptions {
-    strict?: boolean;
+    throwOnInfraFailure?: boolean;
 }
 
 /** Type guard validating per-element FMP response shape before trusting it as `FmpSearchResult`. */
@@ -67,13 +67,14 @@ async function fetchFmpEndpoint(
     query: string,
     options?: FmpSearchOptions
 ): Promise<FmpSearchResult[]> {
-    const strict = options?.strict ?? false;
+    const throwOnInfraFailure = options?.throwOnInfraFailure ?? false;
 
     const config = tryReadFmpConfig();
     if (!config) {
-        // strict(getAssetInfo): 미설정은 인프라 문제 — null→404 캐싱을 막기 위해 throw.
-        // lenient(검색 UI): 기존대로 빈 결과로 degrade.
-        if (strict) throw new Error('[fmpTickerApi] FMP config missing');
+        // throwOnInfraFailure(getAssetInfo): 미설정은 인프라 문제 — null→404 캐싱을 막기 위해 throw.
+        // 기본(검색 UI): 빈 결과로 degrade.
+        if (throwOnInfraFailure)
+            throw new Error('[fmpTickerApi] FMP config missing');
         return [];
     }
 
@@ -90,7 +91,7 @@ async function fetchFmpEndpoint(
             signal: AbortSignal.timeout(FMP_FETCH_TIMEOUT_MS),
         });
     } catch (e) {
-        if (strict)
+        if (throwOnInfraFailure)
             throw new Error(`[fmpTickerApi] ${endpoint} fetch failed`, {
                 cause: e,
             });
@@ -98,7 +99,7 @@ async function fetchFmpEndpoint(
     }
 
     if (!res.ok) {
-        if (strict)
+        if (throwOnInfraFailure)
             throw new Error(`[fmpTickerApi] ${endpoint} HTTP ${res.status}`);
         return [];
     }
@@ -107,16 +108,16 @@ async function fetchFmpEndpoint(
     try {
         raw = await res.json();
     } catch (e) {
-        if (strict)
+        if (throwOnInfraFailure)
             throw new Error(`[fmpTickerApi] ${endpoint} JSON parse failed`, {
                 cause: e,
             });
         return [];
     }
 
-    // 비배열 응답은 신뢰할 수 없는 형태 — strict에선 throw해 no-match 오인/캐싱 방지.
+    // 비배열 응답은 신뢰할 수 없는 형태 — throwOnInfraFailure면 throw해 no-match 오인/캐싱 방지.
     if (!Array.isArray(raw)) {
-        if (strict)
+        if (throwOnInfraFailure)
             throw new Error(
                 `[fmpTickerApi] ${endpoint} unexpected non-array response`
             );
@@ -127,7 +128,7 @@ async function fetchFmpEndpoint(
     // We validate per-element shape with `toFmpSearchResults` so malformed rows
     // (missing required fields) are dropped before reaching downstream consumers
     // (`filterUsExchanges`, `toTickerSearchResult`).
-    // 200 + 빈 배열은 정상적인 "매칭 없음"이므로 strict에서도 throw하지 않는다.
+    // 200 + 빈 배열은 정상적인 "매칭 없음"이므로 throwOnInfraFailure여도 throw하지 않는다.
     return toFmpSearchResults(raw);
 }
 

--- a/src/entities/ticker/lib/fmpTickerApi.ts
+++ b/src/entities/ticker/lib/fmpTickerApi.ts
@@ -59,39 +59,78 @@ export function filterUsExchanges(
 
 async function fetchFmpEndpoint(
     endpoint: FmpEndpoint,
-    query: string
+    query: string,
+    options?: { strict?: boolean }
 ): Promise<FmpSearchResult[]> {
+    const strict = options?.strict ?? false;
+
     const config = tryReadFmpConfig();
-    if (!config) return [];
+    if (!config) {
+        // strict(getAssetInfo): 미설정은 인프라 문제 — null→404 캐싱을 막기 위해 throw.
+        // lenient(검색 UI): 기존대로 빈 결과로 degrade.
+        if (strict) throw new Error('[fmpTickerApi] FMP config missing');
+        return [];
+    }
 
     const params = new URLSearchParams({
         query,
         limit: String(FMP_SEARCH_LIMIT),
         apikey: config.apiKey,
     });
-
     const url = `${FMP_BASE_URL}/${endpoint}?${params}`;
 
+    let res: Response;
     try {
-        const res = await fetch(url, {
+        res = await fetch(url, {
             signal: AbortSignal.timeout(FMP_FETCH_TIMEOUT_MS),
         });
-        if (!res.ok) return [];
-        const raw: unknown = await res.json();
-        // FMP search endpoints return a JSON array of records matching FmpSearchResult.
-        // We validate per-element shape with `toFmpSearchResults` so malformed rows
-        // (missing required fields) are dropped before reaching downstream consumers
-        // (`filterUsExchanges`, `toTickerSearchResult`).
-        return Array.isArray(raw) ? toFmpSearchResults(raw) : [];
-    } catch {
+    } catch (e) {
+        if (strict)
+            throw new Error(`[fmpTickerApi] ${endpoint} fetch failed`, {
+                cause: e,
+            });
         return [];
     }
+
+    if (!res.ok) {
+        if (strict)
+            throw new Error(`[fmpTickerApi] ${endpoint} HTTP ${res.status}`);
+        return [];
+    }
+
+    let raw: unknown;
+    try {
+        raw = await res.json();
+    } catch (e) {
+        if (strict)
+            throw new Error(`[fmpTickerApi] ${endpoint} JSON parse failed`, {
+                cause: e,
+            });
+        return [];
+    }
+
+    // 비배열 응답은 신뢰할 수 없는 형태 — strict에선 throw해 no-match 오인/캐싱 방지.
+    if (!Array.isArray(raw)) {
+        if (strict)
+            throw new Error(
+                `[fmpTickerApi] ${endpoint} unexpected non-array response`
+            );
+        return [];
+    }
+
+    // FMP search endpoints return a JSON array of records matching FmpSearchResult.
+    // We validate per-element shape with `toFmpSearchResults` so malformed rows
+    // (missing required fields) are dropped before reaching downstream consumers
+    // (`filterUsExchanges`, `toTickerSearchResult`).
+    // 200 + 빈 배열은 정상적인 "매칭 없음"이므로 strict에서도 throw하지 않는다.
+    return toFmpSearchResults(raw);
 }
 
 export async function searchBySymbol(
-    query: string
+    query: string,
+    options?: { strict?: boolean }
 ): Promise<FmpSearchResult[]> {
-    return fetchFmpEndpoint('search-symbol', query);
+    return fetchFmpEndpoint('search-symbol', query, options);
 }
 
 export async function searchByName(query: string): Promise<FmpSearchResult[]> {

--- a/src/entities/ticker/lib/getAssetInfo.ts
+++ b/src/entities/ticker/lib/getAssetInfo.ts
@@ -183,7 +183,7 @@ export async function getAssetInfo(symbol: string): Promise<AssetInfo | null> {
         return fromDb;
     }
 
-    const fmpResults = await searchBySymbol(upper);
+    const fmpResults = await searchBySymbol(upper, { strict: true });
     const usResults = filterUsExchanges(fmpResults);
     const match = usResults.find(r => r.symbol === upper) ?? usResults[0];
     if (!match) return null;

--- a/src/entities/ticker/lib/getAssetInfo.ts
+++ b/src/entities/ticker/lib/getAssetInfo.ts
@@ -183,7 +183,9 @@ export async function getAssetInfo(symbol: string): Promise<AssetInfo | null> {
         return fromDb;
     }
 
-    const fmpResults = await searchBySymbol(upper, { strict: true });
+    const fmpResults = await searchBySymbol(upper, {
+        throwOnInfraFailure: true,
+    });
     const usResults = filterUsExchanges(fmpResults);
     const match = usResults.find(r => r.symbol === upper) ?? usResults[0];
     if (!match) return null;

--- a/src/shared/config/market.ts
+++ b/src/shared/config/market.ts
@@ -10,6 +10,9 @@ export const VALID_TICKER_RE = TICKER_RE;
 
 export const DEFAULT_TIMEFRAME: Timeframe = '1Day';
 
+/** `[symbol]` 동적 라우트의 params 형태 (generateStaticParams 반환 타입 등에 사용). */
+export type SymbolRouteParams = { symbol: string };
+
 export const TIMEFRAMES: readonly Timeframe[] = [
     '5Min',
     '15Min',

--- a/src/widgets/overall/OverallContent.tsx
+++ b/src/widgets/overall/OverallContent.tsx
@@ -46,7 +46,7 @@ export function OverallContent({
     const searchParams = useSearchParams();
     const modelId = useDefaultModelId();
 
-    const tfParam = searchParams.get('tf'); // 훅 아님 — 단순 메서드 호출
+    const tfParam = searchParams.get('tf');
     const timeframe = isValidTimeframe(tfParam) ? tfParam : DEFAULT_TIMEFRAME;
 
     // 훅 선언 순서 예외(MISTAKES.md §17): useOverallAnalysis는 파생 변수 timeframe을

--- a/src/widgets/overall/OverallContent.tsx
+++ b/src/widgets/overall/OverallContent.tsx
@@ -41,7 +41,6 @@ export function OverallContent({
     initialAnalysis,
 }: OverallContentProps) {
     // tf는 서버가 아니라 client가 URL에서 읽어 [symbol] ISR(정적 렌더)을 유지한다.
-    // timeframe도 useTimeframeFromUrl 훅의 반환값이라 모든 선언이 훅으로 유지된다(§17).
     const timeframe = useTimeframeFromUrl();
     const modelId = useDefaultModelId();
     const { state, trigger } = useOverallAnalysis(

--- a/src/widgets/overall/OverallContent.tsx
+++ b/src/widgets/overall/OverallContent.tsx
@@ -19,8 +19,7 @@ import { useDefaultModelId } from '@/widgets/symbol-page/hooks/useDefaultModelId
 import { cn } from '@/shared/lib/cn';
 import { type OverallAnalysisResponse } from '@y0ngha/siglens-core';
 import { type CSSProperties, useMemo } from 'react';
-import { useSearchParams } from 'next/navigation';
-import { DEFAULT_TIMEFRAME, isValidTimeframe } from '@/shared/config/market';
+import { useTimeframeFromUrl } from './hooks/useTimeframeFromUrl';
 
 const SKELETON_LINE_COUNT = 3;
 const SKELETON_WIDTH_START_PCT = 85;
@@ -41,16 +40,10 @@ export function OverallContent({
     companyName,
     initialAnalysis,
 }: OverallContentProps) {
-    // ISR 정적 렌더 — tf는 서버가 아니라 client가 URL에서 읽는다(차트와 동일 소스).
-    // MISTAKES.md §17: 모든 훅 호출은 파생 변수보다 먼저 선언한다.
-    const searchParams = useSearchParams();
+    // tf는 서버가 아니라 client가 URL에서 읽어 [symbol] ISR(정적 렌더)을 유지한다.
+    // timeframe도 useTimeframeFromUrl 훅의 반환값이라 모든 선언이 훅으로 유지된다(§17).
+    const timeframe = useTimeframeFromUrl();
     const modelId = useDefaultModelId();
-
-    const tfParam = searchParams.get('tf');
-    const timeframe = isValidTimeframe(tfParam) ? tfParam : DEFAULT_TIMEFRAME;
-
-    // 훅 선언 순서 예외(MISTAKES.md §17): useOverallAnalysis는 파생 변수 timeframe을
-    // 인자로 받아야 해 부득이 파생 변수 뒤에 위치한다(아래 usePublishSymbolChat과 동일 맥락).
     const { state, trigger } = useOverallAnalysis(
         symbol,
         companyName,
@@ -59,8 +52,7 @@ export function OverallContent({
         initialAnalysis
     );
 
-    // 훅 선언 순서 예외(MISTAKES.md #17): usePublishSymbolChat은 chatState(파생 변수)를
-    // 인자로 받기 때문에 useMemo 뒤에 위치해야 한다.
+    // usePublishSymbolChat은 chatState(useMemo 반환값)를 인자로 받으므로 useMemo 뒤에 둔다(§17 의존 순서).
     const chatState = useMemo(
         () => buildChatState(state, timeframe),
         [state, timeframe]

--- a/src/widgets/overall/OverallContent.tsx
+++ b/src/widgets/overall/OverallContent.tsx
@@ -42,9 +42,15 @@ export function OverallContent({
     initialAnalysis,
 }: OverallContentProps) {
     // ISR 정적 렌더 — tf는 서버가 아니라 client가 URL에서 읽는다(차트와 동일 소스).
-    const tfParam = useSearchParams().get('tf');
-    const timeframe = isValidTimeframe(tfParam) ? tfParam : DEFAULT_TIMEFRAME;
+    // MISTAKES.md §17: 모든 훅 호출은 파생 변수보다 먼저 선언한다.
+    const searchParams = useSearchParams();
     const modelId = useDefaultModelId();
+
+    const tfParam = searchParams.get('tf'); // 훅 아님 — 단순 메서드 호출
+    const timeframe = isValidTimeframe(tfParam) ? tfParam : DEFAULT_TIMEFRAME;
+
+    // 훅 선언 순서 예외(MISTAKES.md §17): useOverallAnalysis는 파생 변수 timeframe을
+    // 인자로 받아야 해 부득이 파생 변수 뒤에 위치한다(아래 usePublishSymbolChat과 동일 맥락).
     const { state, trigger } = useOverallAnalysis(
         symbol,
         companyName,

--- a/src/widgets/overall/OverallContent.tsx
+++ b/src/widgets/overall/OverallContent.tsx
@@ -17,11 +17,10 @@ import { buildChatState } from './utils/buildChatState';
 import { BotBlockedNotice } from '@/shared/ui/BotBlockedNotice';
 import { useDefaultModelId } from '@/widgets/symbol-page/hooks/useDefaultModelId';
 import { cn } from '@/shared/lib/cn';
-import {
-    type OverallAnalysisResponse,
-    type Timeframe,
-} from '@y0ngha/siglens-core';
+import { type OverallAnalysisResponse } from '@y0ngha/siglens-core';
 import { type CSSProperties, useMemo } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { DEFAULT_TIMEFRAME, isValidTimeframe } from '@/shared/config/market';
 
 const SKELETON_LINE_COUNT = 3;
 const SKELETON_WIDTH_START_PCT = 85;
@@ -30,7 +29,6 @@ const SKELETON_WIDTH_STEP_PCT = 12;
 interface OverallContentProps {
     symbol: string;
     companyName: string;
-    timeframe: Timeframe;
     /**
      * 서버에서 peek로 미리 읽은 캐시 종합 분석 서사(SSR seed). 주어지면
      * useOverallAnalysis가 마운트 즉시 done 상태로 렌더한다(LLM 비용 0).
@@ -41,9 +39,11 @@ interface OverallContentProps {
 export function OverallContent({
     symbol,
     companyName,
-    timeframe,
     initialAnalysis,
 }: OverallContentProps) {
+    // ISR 정적 렌더 — tf는 서버가 아니라 client가 URL에서 읽는다(차트와 동일 소스).
+    const tfParam = useSearchParams().get('tf');
+    const timeframe = isValidTimeframe(tfParam) ? tfParam : DEFAULT_TIMEFRAME;
     const modelId = useDefaultModelId();
     const { state, trigger } = useOverallAnalysis(
         symbol,

--- a/src/widgets/overall/__tests__/OverallContent.flow.test.tsx
+++ b/src/widgets/overall/__tests__/OverallContent.flow.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { MockedFunction } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -42,8 +42,12 @@ vi.mock('@/features/symbol-chat', () => ({
 vi.mock('@/widgets/symbol-page/hooks/useDefaultModelId', () => ({
     useDefaultModelId: vi.fn(() => 'gemini-2.5-flash-lite'),
 }));
+// useSearchParams를 테스트별로 바꿀 수 있도록 mutable ref로 모킹한다(고정 빈 값 X).
+const { searchParamsRef } = vi.hoisted(() => ({
+    searchParamsRef: { value: new URLSearchParams() },
+}));
 vi.mock('next/navigation', () => ({
-    useSearchParams: () => new URLSearchParams(),
+    useSearchParams: () => searchParamsRef.value,
 }));
 // react-markdown은 ESM-only라 테스트 환경에서 직접 로드하면 실패한다. 본 테스트는
 // 서사 텍스트 노출 여부만 보므로 MarkdownText를 단순 wrapper로 대체한다.
@@ -91,6 +95,40 @@ describe('OverallContent 사용자 분석 플로우 (userEvent)', () => {
     beforeEach(() => {
         mockSubmit.mockReset();
         mockPollOverall.mockReset();
+        searchParamsRef.value = new URLSearchParams();
+    });
+
+    afterEach(() => {
+        searchParamsRef.value = new URLSearchParams();
+    });
+
+    // tf 분기의 단위 검증(참/거짓 양쪽)은 OverallContent.test.tsx에 있고, 여기서는
+    // 실제 useOverallAnalysis를 통해 유효 tf가 submit까지 전파되는지(참 분기)를 확인한다.
+    it('유효한 tf 쿼리가 있으면 그 timeframe으로 submit한다 (§18 참 분기)', async () => {
+        const user = userEvent.setup();
+        searchParamsRef.value = new URLSearchParams('tf=1Hour');
+        mockSubmit.mockResolvedValue({
+            status: 'submitted',
+            jobId: 'overall-job',
+        });
+        mockPollOverall.mockResolvedValueOnce({
+            status: 'done',
+            result: DONE_RESULT,
+        });
+
+        renderOverall();
+        await user.click(
+            await screen.findByRole('button', { name: /AI 종합 분석 받기/ })
+        );
+        await screen.findByText('AAPL 종합 분석 헤드라인');
+
+        expect(mockSubmit).toHaveBeenCalledWith(
+            'AAPL',
+            'Apple Inc.',
+            '1Hour',
+            expect.anything(),
+            expect.anything()
+        );
     });
 
     it('CTA 클릭 → submit → polling → done 서사를 렌더한다', async () => {

--- a/src/widgets/overall/__tests__/OverallContent.flow.test.tsx
+++ b/src/widgets/overall/__tests__/OverallContent.flow.test.tsx
@@ -42,6 +42,9 @@ vi.mock('@/features/symbol-chat', () => ({
 vi.mock('@/widgets/symbol-page/hooks/useDefaultModelId', () => ({
     useDefaultModelId: vi.fn(() => 'gemini-2.5-flash-lite'),
 }));
+vi.mock('next/navigation', () => ({
+    useSearchParams: () => new URLSearchParams(),
+}));
 // react-markdown은 ESM-only라 테스트 환경에서 직접 로드하면 실패한다. 본 테스트는
 // 서사 텍스트 노출 여부만 보므로 MarkdownText를 단순 wrapper로 대체한다.
 vi.mock('@/shared/ui/MarkdownText', () => ({
@@ -79,14 +82,9 @@ function renderOverall() {
     // 매 호출이 격리된 새 QueryClient를 만들어 테스트 간 캐시 공유가 없다. 그래서
     // hook 테스트(useOverallAnalysis.test.tsx)처럼 client를 추적해 afterEach에서
     // clear할 필요가 없다 — 컴포넌트는 RTL cleanup이 unmount하고 client는 GC된다.
-    return render(
-        <OverallContent
-            symbol="AAPL"
-            companyName="Apple Inc."
-            timeframe="1Day"
-        />,
-        { wrapper: createQueryClientWrapper().wrapper }
-    );
+    return render(<OverallContent symbol="AAPL" companyName="Apple Inc." />, {
+        wrapper: createQueryClientWrapper().wrapper,
+    });
 }
 
 describe('OverallContent 사용자 분석 플로우 (userEvent)', () => {

--- a/src/widgets/overall/__tests__/OverallContent.test.tsx
+++ b/src/widgets/overall/__tests__/OverallContent.test.tsx
@@ -48,8 +48,12 @@ vi.mock('@/entities/options-chain/actions', () => ({
     pollOptionsAnalysisAction: vi.fn(),
     cancelOptionsAnalysisJobAction: vi.fn().mockResolvedValue(undefined),
 }));
+// useSearchParams를 테스트별로 바꿀 수 있도록 mutable ref로 모킹한다(§18 tf 분기 검증용).
+const { searchParamsRef } = vi.hoisted(() => ({
+    searchParamsRef: { value: new URLSearchParams() },
+}));
 vi.mock('next/navigation', () => ({
-    useSearchParams: () => new URLSearchParams(),
+    useSearchParams: () => searchParamsRef.value,
 }));
 
 import { render, screen, fireEvent } from '@testing-library/react';
@@ -57,6 +61,7 @@ import type { ReactNode } from 'react';
 import type { OverallAnalysisResponse } from '@y0ngha/siglens-core';
 
 import { OverallContent } from '@/widgets/overall/OverallContent';
+import { DEFAULT_TIMEFRAME } from '@/shared/config/market';
 import { useOverallAnalysis } from '@/widgets/overall/hooks/useOverallAnalysis';
 import { submitOverallAnalysisAction } from '@/entities/analysis/actions';
 import { createQueryClientWrapper } from '@/__tests__/utils/createQueryClientWrapper';
@@ -90,6 +95,45 @@ function mockDoneState(result: OverallAnalysisResponse, trigger = vi.fn()) {
         trigger,
     });
 }
+
+describe('OverallContent tf 쿼리 파라미터 처리 (§18 분기)', () => {
+    beforeEach(() => {
+        mockUseOverallAnalysis.mockReset();
+        mockUseOverallAnalysis.mockReturnValue({
+            state: { status: 'idle' },
+            trigger: vi.fn(),
+        });
+        searchParamsRef.value = new URLSearchParams();
+    });
+
+    afterEach(() => {
+        searchParamsRef.value = new URLSearchParams();
+    });
+
+    it('유효한 tf가 있으면 그 timeframe으로 useOverallAnalysis를 호출한다 (참 분기)', () => {
+        searchParamsRef.value = new URLSearchParams('tf=1Hour');
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
+        expect(mockUseOverallAnalysis).toHaveBeenCalledWith(
+            'AAPL',
+            'Apple Inc.',
+            '1Hour',
+            'gemini-2.5-flash-lite',
+            undefined
+        );
+    });
+
+    it('유효하지 않은 tf는 DEFAULT_TIMEFRAME(1Day)으로 폴백한다 (거짓 분기)', () => {
+        searchParamsRef.value = new URLSearchParams('tf=not-a-timeframe');
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
+        expect(mockUseOverallAnalysis).toHaveBeenCalledWith(
+            'AAPL',
+            'Apple Inc.',
+            DEFAULT_TIMEFRAME,
+            'gemini-2.5-flash-lite',
+            undefined
+        );
+    });
+});
 
 describe('OverallContent non-done branches', () => {
     beforeEach(() => {

--- a/src/widgets/overall/__tests__/OverallContent.test.tsx
+++ b/src/widgets/overall/__tests__/OverallContent.test.tsx
@@ -48,6 +48,9 @@ vi.mock('@/entities/options-chain/actions', () => ({
     pollOptionsAnalysisAction: vi.fn(),
     cancelOptionsAnalysisJobAction: vi.fn().mockResolvedValue(undefined),
 }));
+vi.mock('next/navigation', () => ({
+    useSearchParams: () => new URLSearchParams(),
+}));
 
 import { render, screen, fireEvent } from '@testing-library/react';
 import type { ReactNode } from 'react';
@@ -98,13 +101,7 @@ describe('OverallContent non-done branches', () => {
             state: { status: 'idle' },
             trigger: vi.fn(),
         });
-        render(
-            <OverallContent
-                symbol="AAPL"
-                companyName="Apple Inc."
-                timeframe="1Day"
-            />
-        );
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
         expect(
             screen.getByRole('button', { name: /AI 종합 분석 받기/ })
         ).toBeInTheDocument();
@@ -115,13 +112,7 @@ describe('OverallContent non-done branches', () => {
             state: { status: 'bot_blocked' },
             trigger: vi.fn(),
         });
-        render(
-            <OverallContent
-                symbol="AAPL"
-                companyName="Apple Inc."
-                timeframe="1Day"
-            />
-        );
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
         expect(
             screen.getByText(/봇 트래픽으로 보여 분석 결과를 표시하지 않았어요/)
         ).toBeInTheDocument();
@@ -141,13 +132,7 @@ describe('OverallContent non-done branches', () => {
             },
             trigger: vi.fn(),
         });
-        render(
-            <OverallContent
-                symbol="AAPL"
-                companyName="Apple Inc."
-                timeframe="1Day"
-            />
-        );
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
         // DependencyProgress 헤딩(완료/총합 카운트)으로 렌더 확인. 2개 axis가
         // pending이므로 완료 2/4.
         expect(
@@ -163,13 +148,7 @@ describe('OverallContent non-done branches', () => {
             state: { status: 'submitting' },
             trigger: vi.fn(),
         });
-        render(
-            <OverallContent
-                symbol="AAPL"
-                companyName="Apple Inc."
-                timeframe="1Day"
-            />
-        );
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
         expect(screen.getByText('AI 종합 분석 요청 중…')).toBeInTheDocument();
     });
 
@@ -178,13 +157,7 @@ describe('OverallContent non-done branches', () => {
             state: { status: 'polling' },
             trigger: vi.fn(),
         });
-        render(
-            <OverallContent
-                symbol="AAPL"
-                companyName="Apple Inc."
-                timeframe="1Day"
-            />
-        );
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
         expect(screen.getByText('AI 종합 분석 생성 중…')).toBeInTheDocument();
     });
 
@@ -193,13 +166,7 @@ describe('OverallContent non-done branches', () => {
             state: { status: 'error', error: '분석 중 오류가 발생했습니다.' },
             trigger: vi.fn(),
         });
-        render(
-            <OverallContent
-                symbol="AAPL"
-                companyName="Apple Inc."
-                timeframe="1Day"
-            />
-        );
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
         expect(
             screen.getByText(/분석 중 오류가 발생했습니다/)
         ).toBeInTheDocument();
@@ -210,13 +177,7 @@ describe('OverallContent non-done branches', () => {
             state: { status: 'error', error: '커스텀 에러' },
             trigger: vi.fn(),
         });
-        render(
-            <OverallContent
-                symbol="AAPL"
-                companyName="Apple Inc."
-                timeframe="1Day"
-            />
-        );
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
         expect(screen.getByText(/커스텀 에러/)).toBeInTheDocument();
     });
 
@@ -225,13 +186,7 @@ describe('OverallContent non-done branches', () => {
             state: { status: 'error', error: '분석 오류', axis: 'technical' },
             trigger: vi.fn(),
         });
-        render(
-            <OverallContent
-                symbol="AAPL"
-                companyName="Apple Inc."
-                timeframe="1Day"
-            />
-        );
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
         expect(screen.getByText(/technical 축 실패/)).toBeInTheDocument();
     });
 
@@ -241,13 +196,7 @@ describe('OverallContent non-done branches', () => {
             state: { status: 'error', error: '오류' },
             trigger,
         });
-        render(
-            <OverallContent
-                symbol="AAPL"
-                companyName="Apple Inc."
-                timeframe="1Day"
-            />
-        );
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
         fireEvent.click(screen.getByText('다시 시도'));
         expect(trigger).toHaveBeenCalled();
     });
@@ -260,13 +209,7 @@ describe('OverallContent done branch', () => {
 
     it('TechnicalSummary와 FundamentalSummary 사이에 OptionsSummary를 렌더한다', () => {
         mockDoneState(makeDoneResult());
-        render(
-            <OverallContent
-                symbol="AAPL"
-                companyName="Apple Inc."
-                timeframe="1Day"
-            />
-        );
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
         // 헤딩 텍스트 순서를 DOM 순서로 비교
         const headings = screen
             .getAllByRole('heading')
@@ -281,13 +224,7 @@ describe('OverallContent done branch', () => {
 
     it('IntegratedConclusion("통합 결론") 헤딩을 렌더한다 (3축 종합 결론 X)', () => {
         mockDoneState(makeDoneResult());
-        render(
-            <OverallContent
-                symbol="AAPL"
-                companyName="Apple Inc."
-                timeframe="1Day"
-            />
-        );
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
         expect(
             screen.getByRole('heading', { name: /통합 결론/ })
         ).toBeInTheDocument();
@@ -298,13 +235,7 @@ describe('OverallContent done branch', () => {
 
     it('ReanalyzeButton(재분석)이 done 상태에서 노출된다', () => {
         mockDoneState(makeDoneResult());
-        render(
-            <OverallContent
-                symbol="AAPL"
-                companyName="Apple Inc."
-                timeframe="1Day"
-            />
-        );
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
         expect(
             screen.getByRole('button', { name: /재분석/ })
         ).toBeInTheDocument();
@@ -317,13 +248,7 @@ describe('OverallContent done branch', () => {
                 optionsOiStale: true,
             })
         );
-        render(
-            <OverallContent
-                symbol="AAPL"
-                companyName="Apple Inc."
-                timeframe="1Day"
-            />
-        );
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
         const btn = screen.getByRole('button', { name: /재분석/ });
         expect(btn.className).toMatch(/ui-warning/);
     });
@@ -335,13 +260,7 @@ describe('OverallContent done branch', () => {
                 optionsOiStale: true,
             })
         );
-        render(
-            <OverallContent
-                symbol="AAPL"
-                companyName="Apple Inc."
-                timeframe="1Day"
-            />
-        );
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
         const btn = screen.getByRole('button', { name: /재분석/ });
         expect(btn.className).not.toMatch(/ui-warning/);
     });
@@ -349,13 +268,7 @@ describe('OverallContent done branch', () => {
     it('ReanalyzeButton 클릭 시 trigger를 호출한다', () => {
         const trigger = vi.fn();
         mockDoneState(makeDoneResult(), trigger);
-        render(
-            <OverallContent
-                symbol="AAPL"
-                companyName="Apple Inc."
-                timeframe="1Day"
-            />
-        );
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />);
         fireEvent.click(screen.getByRole('button', { name: /재분석/ }));
         expect(trigger).toHaveBeenCalledTimes(1);
     });
@@ -399,7 +312,6 @@ describe('OverallContent SSR seed', () => {
             <OverallContent
                 symbol="AAPL"
                 companyName="Apple Inc."
-                timeframe="1Day"
                 initialAnalysis={SEED_RESULT}
             />,
             { wrapper: createQueryClientWrapper().wrapper }
@@ -410,14 +322,9 @@ describe('OverallContent SSR seed', () => {
     });
 
     it('initialAnalysis가 없으면 idle CTA(분석 받기)를 렌더한다', () => {
-        render(
-            <OverallContent
-                symbol="AAPL"
-                companyName="Apple Inc."
-                timeframe="1Day"
-            />,
-            { wrapper: createQueryClientWrapper().wrapper }
-        );
+        render(<OverallContent symbol="AAPL" companyName="Apple Inc." />, {
+            wrapper: createQueryClientWrapper().wrapper,
+        });
 
         expect(
             screen.getByRole('button', { name: /AI 종합 분석 받기/ })

--- a/src/widgets/overall/__tests__/hooks/useTimeframeFromUrl.test.ts
+++ b/src/widgets/overall/__tests__/hooks/useTimeframeFromUrl.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const { searchParamsRef } = vi.hoisted(() => ({
+    searchParamsRef: { value: new URLSearchParams() },
+}));
+vi.mock('next/navigation', () => ({
+    useSearchParams: () => searchParamsRef.value,
+}));
+
+import { useTimeframeFromUrl } from '@/widgets/overall/hooks/useTimeframeFromUrl';
+import { DEFAULT_TIMEFRAME } from '@/shared/config/market';
+
+describe('useTimeframeFromUrl', () => {
+    it('유효한 tf 쿼리는 그대로 반환한다', () => {
+        searchParamsRef.value = new URLSearchParams('tf=1Hour');
+        const { result } = renderHook(() => useTimeframeFromUrl());
+        expect(result.current).toBe('1Hour');
+    });
+
+    it('유효하지 않은 tf는 DEFAULT_TIMEFRAME으로 폴백한다', () => {
+        searchParamsRef.value = new URLSearchParams('tf=not-a-timeframe');
+        const { result } = renderHook(() => useTimeframeFromUrl());
+        expect(result.current).toBe(DEFAULT_TIMEFRAME);
+    });
+
+    it('tf가 없으면 DEFAULT_TIMEFRAME으로 폴백한다', () => {
+        searchParamsRef.value = new URLSearchParams();
+        const { result } = renderHook(() => useTimeframeFromUrl());
+        expect(result.current).toBe(DEFAULT_TIMEFRAME);
+    });
+});

--- a/src/widgets/overall/hooks/useTimeframeFromUrl.ts
+++ b/src/widgets/overall/hooks/useTimeframeFromUrl.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import type { Timeframe } from '@y0ngha/siglens-core';
+import { DEFAULT_TIMEFRAME, isValidTimeframe } from '@/shared/config/market';
+
+/**
+ * URL의 `tf` 쿼리에서 timeframe을 읽어 검증한다. 서버가 아닌 **client**에서 읽어야
+ * `[symbol]` 라우트가 ISR(정적 렌더) 가능하게 유지된다(서버 searchParams 읽기는 동적 렌더 강제).
+ * 유효하지 않거나 없으면 `DEFAULT_TIMEFRAME`. 호출부가 timeframe을 파생 변수가 아니라
+ * 훅 반환값으로 받게 해 MISTAKES.md §17(훅 선언이 파생 변수보다 앞) 준수를 돕는다.
+ */
+export function useTimeframeFromUrl(): Timeframe {
+    const tfParam = useSearchParams().get('tf');
+    return isValidTimeframe(tfParam) ? tfParam : DEFAULT_TIMEFRAME;
+}


### PR DESCRIPTION
## Why
Vercel transfer cost was dominated by `/[symbol]/*` routes with **Page Caching 0%** (every request hit compute) and heavy **AhrefsBot** traffic (~9K hits/12h to one OG image route). Two billed metrics: Fast Origin Transfer (CDN↔compute, 100GB free / $0.06) and Fast Data Transfer (CDN↔visitor, 1TB / $0.15).

## Changes
- **Bot management** (`robots.ts`): Disallow parasite SEO crawlers (Ahrefs/Semrush/MJ12/DotBot/BLEXBot/DataForSEO). Real search engines untouched → cuts request volume on both metrics with zero SEO impact.
- **Page ISR**: chart / options / fundamental / fear-greed / overall → `revalidate=3600` + `generateStaticParams()=[]` (on-demand ISR; build flips `ƒ`→`●`). Server-side `searchParams(tf)` removed; tf read client-side (`useSearchParams`, canonical excludes tf); client subtrees wrapped in `<Suspense>`. `news` stays dynamic (per-request news refresh side-effect preserved).
- **OG/twitter images** (12): `dynamic='force-static'` + `revalidate=30d` → static (`○`).
- **FMP 404-cache safety**: `fetchFmpEndpoint` strict mode throws on infra failure; `getAssetInfo` uses it so transient FMP outages don't get cached as 404s under ISR. Interactive search stays lenient.

## SEO / UX safety
- Crawlers receive fully-rendered static HTML (metadata, JSON-LD, sr-only content stay server-static, outside Suspense). canonical unchanged → no index impact.
- 404 cache-poisoning prevented via the FMP strict-error contract.

## Verification
- `yarn test`: 620 files / 4650 tests pass.
- `yarn build`: target pages `●`, OG images `○`, `[symbol]/news` `ƒ` (intended). No `missing-suspense-with-csr-bailout`.

## Notes
- Deploy is performed by the maintainer (not in this PR). Bot-block takes effect once crawlers re-read robots.txt.
- Design/plan docs: `docs/superpowers/specs/2026-06-01-vercel-transfer-cost-design.md`, `docs/superpowers/plans/2026-06-01-vercel-transfer-cost.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)