### PR TITLE
fix([symbol]): graceful fallback on infra failure (getAssetInfoResilient + degraded noindex)

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,6 +1,11 @@
 
 # Fix Log
 
+## [PR #545 Round 2 | fix/symbol-infra-fallback | 2026-06-02]
+- Violation: `DYNAMIC_SERVER_USAGE` rethrow 분기(catch 내 if 블록 true 경로)에 대한 테스트 케이스 누락
+  - Rule: MISTAKES.md Tests §18 — 신규 조건 분기는 true/false 두 경로 모두 테스트 케이스가 필요하다
+  - Context: Round 1에서 DynamicServerError rethrow 분기를 추가했지만 rethrow가 실제로 동작하는 경우(DYNAMIC_SERVER_USAGE digest)를 검증하는 테스트 누락
+
 ## [PR #545 Round 1 | fix/symbol-infra-fallback | 2026-06-02]
 - Violation: 변수명 `mockGetAssetInfoCached`가 실제로는 `getAssetInfoResilient`를 참조 (2개 파일)
   - Rule: MISTAKES.md §11 — 함수/변수명은 실제 참조 대상과 정확하게 일치해야 한다

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,6 +1,19 @@
 
 # Fix Log
 
+
+## [PR #545 Round 4 | fix/symbol-infra-fallback | 2026-06-02]
+- Violation: `expect.objectContaining({ index: false })` 부정확한 매처 사용
+  - Rule: MISTAKES.md §Tests §13 — 값이 결정론적(deterministic)일 때는 정확한 matcher 사용해야 함
+  - Context: `overall/__tests__/page.test.ts` line 99-101에서 invalid ticker 경로의 robots 값이 항상 `{ index: false, follow: false }`인데 `objectContaining`으로 부정확하게 테스트해 `follow: true` 회귀를 감지하지 못함
+- Violation: 테스트 mock 객체에서 AssetInfo required 필드 `symbol` 누락
+  - Rule: MISTAKES.md §TypeScript §2 — Mock 객체는 실제 타입 계약과 일치해야 함
+  - Context: `page.test.ts`와 `overall/__tests__/page.test.ts`의 mockGetAssetInfoResilient 모든 assetInfo 객체에 symbol 필드 누락
+- Violation: `ResilientAssetInfo` 타입이 barrel에서 export되지 않음
+  - Rule: CONVENTIONS.md FSD — production 코드는 슬라이스 barrel만 import
+  - Context: 함수 반환 타입인 `ResilientAssetInfo`를 직접 type annotation해야 할 때 barrel에 없으면 deep import 강제
+
+
 ## [PR #545 Round 3 | fix/symbol-infra-fallback | 2026-06-02]
 - Violation: JSDoc "세 가지로 끝난다" 서술이 실제 네 가지 경로(DYNAMIC_SERVER_USAGE rethrow 포함)와 불일치
   - Rule: MISTAKES.md §15.6 — 주석/JSDoc의 모든 서술은 실제 런타임/코드 현실과 일치해야 한다

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,6 +1,14 @@
 
 # Fix Log
 
+## [PR #545 Round 1 | fix/symbol-infra-fallback | 2026-06-02]
+- Violation: 변수명 `mockGetAssetInfoCached`가 실제로는 `getAssetInfoResilient`를 참조 (2개 파일)
+  - Rule: MISTAKES.md §11 — 함수/변수명은 실제 참조 대상과 정확하게 일치해야 한다
+  - Context: PR #545에서 `getAssetInfoCached` → `getAssetInfoResilient`로 교체 후 테스트 변수명 rename이 누락됨
+- Violation: `if (degraded)` 신규 분기에 대한 테스트 케이스 미커버 (5개 페이지: overall/news/fundamental/options/fear-greed)
+  - Rule: MISTAKES.md §18 — 새로운 조건 분기는 true/false 두 경로 모두 테스트 케이스가 필요하다
+  - Context: `getAssetInfoResilient` 교체 시 degraded 분기를 7개 라우트에 추가했지만 overall 외 5개 페이지 generateMetadata 테스트 누락
+
 ## [feat/bot-cost-caching Round 1 | feat/bot-cost-caching | 2026-05-28]
 - Violation: 'use server' file exported non-async-function constants `POLL_INTERVAL_MS`, `POLL_MAX_ATTEMPTS`
   - Rule: entities/CONVENTIONS.md — 'use server' files may only export async functions; constants must live in separate modules

--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -1,6 +1,11 @@
 
 # Fix Log
 
+## [PR #545 Round 3 | fix/symbol-infra-fallback | 2026-06-02]
+- Violation: JSDoc "세 가지로 끝난다" 서술이 실제 네 가지 경로(DYNAMIC_SERVER_USAGE rethrow 포함)와 불일치
+  - Rule: MISTAKES.md §15.6 — 주석/JSDoc의 모든 서술은 실제 런타임/코드 현실과 일치해야 한다
+  - Context: Round 1에서 DYNAMIC_SERVER_USAGE rethrow 경로를 추가했지만 JSDoc 요약은 "세 가지"로 유지되어 "throw → 여기서 흡수해"라는 표현이 rethrow 경로를 숨김
+
 ## [PR #545 Round 2 | fix/symbol-infra-fallback | 2026-06-02]
 - Violation: `DYNAMIC_SERVER_USAGE` rethrow 분기(catch 내 if 블록 true 경로)에 대한 테스트 케이스 누락
   - Rule: MISTAKES.md Tests §18 — 신규 조건 분기는 true/false 두 경로 모두 테스트 케이스가 필요하다

--- a/docs/superpowers/plans/2026-06-02-symbol-infra-fallback.md
+++ b/docs/superpowers/plans/2026-06-02-symbol-infra-fallback.md
@@ -1,0 +1,265 @@
+# [symbol] 인프라 실패 graceful fallback — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** [symbol] 라우트가 FMP 인프라 일시 실패(getAssetInfo throw) 시 깨지지 않고 ticker fallback으로 정상 렌더하게 하되, 그 degrade 응답은 ISR 캐시에서 제외한다.
+
+**Architecture:** `getAssetInfoCached`를 감싸는 `getAssetInfoResilient` 헬퍼를 추가한다. 헬퍼는 throw(인프라 실패)를 catch해 `{symbol, name: ticker}` fallback을 반환하고 `connection()`으로 해당 렌더를 동적화(캐시 회피)한다. null(실재하지 않는 종목)은 그대로 통과시켜 호출부의 `notFound()`가 동작하게 한다. [symbol] 7개 파일의 `getAssetInfoCached` 호출을 이 헬퍼로 교체한다 — drop-in replacement이므로 각 라우트의 null 처리 로직은 그대로 둔다.
+
+**Tech Stack:** Next.js 16.2.0 (App Router, ISR), TypeScript, vitest, FSD(entities/ticker)
+
+---
+
+## File Structure
+
+| 파일 | 책임 | 변경 |
+|---|---|---|
+| `src/entities/ticker/lib/getAssetInfoResilient.ts` | throw→fallback, null→통과, fallback 시 캐시 회피 | Create |
+| `src/entities/ticker/__tests__/lib/getAssetInfoResilient.test.ts` | 헬퍼 유닛 테스트 | Create |
+| `src/entities/ticker/index.ts` | barrel: `getAssetInfoCached` export를 `getAssetInfoResilient`로 교체 | Modify |
+| `src/app/[symbol]/layout.tsx` | 호출 교체 | Modify |
+| `src/app/[symbol]/page.tsx` | import + 호출 2곳 교체 | Modify |
+| `src/app/[symbol]/news/page.tsx` | import + 호출 2곳 교체 | Modify |
+| `src/app/[symbol]/fundamental/page.tsx` | import + 호출 2곳 교체 | Modify |
+| `src/app/[symbol]/options/page.tsx` | import + 호출 2곳 교체 | Modify |
+| `src/app/[symbol]/overall/page.tsx` | import + 호출 2곳 교체 | Modify |
+| `src/app/[symbol]/fear-greed/page.tsx` | import + 호출 2곳 교체 | Modify |
+
+---
+
+## Task 1: `getAssetInfoResilient` 헬퍼 (TDD)
+
+**Files:**
+- Create: `src/entities/ticker/lib/getAssetInfoResilient.ts`
+- Test: `src/entities/ticker/__tests__/lib/getAssetInfoResilient.test.ts`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`src/entities/ticker/__tests__/lib/getAssetInfoResilient.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AssetInfo } from '@/shared/lib/types';
+
+// `connection()`은 렌더를 동적화하는 Next 16 dynamic API — 유닛에서는 호출 여부만 검증한다.
+vi.mock('next/server', () => ({
+    connection: vi.fn().mockResolvedValue(undefined),
+}));
+// 헬퍼가 감싸는 캐시 함수를 mock해 정상/throw/null 세 경로를 직접 제어한다.
+vi.mock('@/entities/ticker/lib/getAssetInfoCached', () => ({
+    getAssetInfoCached: vi.fn(),
+}));
+
+import { getAssetInfoResilient } from '@/entities/ticker/lib/getAssetInfoResilient';
+import { getAssetInfoCached } from '@/entities/ticker/lib/getAssetInfoCached';
+import { connection } from 'next/server';
+
+const mockGet = vi.mocked(getAssetInfoCached);
+const mockConnection = vi.mocked(connection);
+
+describe('getAssetInfoResilient', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('passes a successful AssetInfo through unchanged and does not opt out of caching', async () => {
+        const info: AssetInfo = {
+            symbol: 'AAPL',
+            name: 'Apple Inc.',
+            koreanName: '애플',
+        };
+        mockGet.mockResolvedValue(info);
+
+        const result = await getAssetInfoResilient('AAPL');
+
+        expect(result).toBe(info);
+        expect(mockConnection).not.toHaveBeenCalled();
+    });
+
+    it('passes null (non-existent ticker) through so the caller can notFound()', async () => {
+        mockGet.mockResolvedValue(null);
+
+        const result = await getAssetInfoResilient('ZZZZ');
+
+        expect(result).toBeNull();
+        expect(mockConnection).not.toHaveBeenCalled();
+    });
+
+    it('on infra failure (throw) returns a ticker fallback and opts the render out of the ISR cache', async () => {
+        mockGet.mockRejectedValue(new Error('[fmpTickerApi] search-symbol fetch failed'));
+
+        const result = await getAssetInfoResilient('IONQ');
+
+        expect(result).toEqual({ symbol: 'IONQ', name: 'IONQ' });
+        expect(mockConnection).toHaveBeenCalledOnce();
+    });
+});
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `yarn test src/entities/ticker/__tests__/lib/getAssetInfoResilient.test.ts`
+Expected: FAIL — `getAssetInfoResilient` 모듈이 없어 import 에러.
+
+- [ ] **Step 3: 헬퍼 구현**
+
+`src/entities/ticker/lib/getAssetInfoResilient.ts`:
+
+```ts
+import { connection } from 'next/server';
+import type { AssetInfo } from '@/shared/lib/types';
+import { getAssetInfoCached } from './getAssetInfoCached';
+
+/**
+ * `getAssetInfoCached`의 graceful 래퍼. `getAssetInfo`는 세 가지로 끝난다:
+ *   - AssetInfo 반환 → 그대로 통과(정상, ISR 캐시 대상).
+ *   - throw         → FMP 인프라 일시 실패(throwOnInfraFailure). 여기서 흡수해
+ *                     `{symbol, name: ticker}` fallback으로 degrade하고, 이 degrade
+ *                     응답이 ISR(revalidate=3600)로 굳지 않도록 `connection()`으로
+ *                     해당 렌더만 동적화한다 — 인프라 복구 즉시 다음 요청부터 정상화.
+ *   - null 반환     → FMP 200 + 빈 결과 = 실재하지 않는 종목. 그대로 null을 통과시켜
+ *                     호출부의 `notFound()`(404)가 동작하게 한다.
+ *
+ * fallback 객체는 symbol/name만 채운다. fmpSymbol은 생략하는데, AssetInfo에서
+ * 이미 optional("일반 주식은 undefined")이라 다운스트림(getBarsAction/peekAnalysisCache)이
+ * symbol로 degrade하는 기존 정상 경로와 동일하다. koreanName 생략 시 표시명이 영문 ticker.
+ */
+export async function getAssetInfoResilient(
+    ticker: string
+): Promise<AssetInfo | null> {
+    try {
+        return await getAssetInfoCached(ticker);
+    } catch (e) {
+        console.error(
+            '[getAssetInfoResilient] infra failure, ticker fallback:',
+            e
+        );
+        await connection();
+        return { symbol: ticker, name: ticker };
+    }
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `yarn test src/entities/ticker/__tests__/lib/getAssetInfoResilient.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/entities/ticker/lib/getAssetInfoResilient.ts src/entities/ticker/__tests__/lib/getAssetInfoResilient.test.ts
+git commit -m "feat(ticker): add getAssetInfoResilient — infra-failure ticker fallback"
+```
+
+---
+
+## Task 2: barrel 교체 + 7개 라우트 호출 교체
+
+**Files:**
+- Modify: `src/entities/ticker/index.ts:7`
+- Modify: `src/app/[symbol]/layout.tsx:16,72`
+- Modify: `src/app/[symbol]/page.tsx:16,56,96`
+- Modify: `src/app/[symbol]/news/page.tsx:19,53,152`
+- Modify: `src/app/[symbol]/fundamental/page.tsx:33,69,276`
+- Modify: `src/app/[symbol]/options/page.tsx:9,55,98`
+- Modify: `src/app/[symbol]/overall/page.tsx:13,52,92`
+- Modify: `src/app/[symbol]/fear-greed/page.tsx:14,55,93`
+
+- [ ] **Step 1: barrel export 교체**
+
+`src/entities/ticker/index.ts` 의 `getAssetInfoCached` export 줄을 교체한다. `getAssetInfoCached`는 헬퍼 내부에서만 쓰이므로 barrel에서 노출하지 않는다.
+
+```diff
+- export { getAssetInfoCached } from './lib/getAssetInfoCached';
++ export { getAssetInfoResilient } from './lib/getAssetInfoResilient';
+```
+
+- [ ] **Step 2: 7개 라우트의 import + 호출을 교체**
+
+각 파일에서 barrel import 식별자 `getAssetInfoCached` → `getAssetInfoResilient`, 그리고 모든 호출 `getAssetInfoCached(` → `getAssetInfoResilient(` 로 바꾼다. null 처리(`if (!assetInfo) notFound()`, `assetInfo ? ... : ticker`)는 **변경하지 않는다** — 헬퍼는 null을 그대로 통과시키므로 기존 로직이 유효하다.
+
+`layout.tsx`는 barrel default-style import(`import { getAssetInfoCached } from '@/entities/ticker';`)이므로 식별자만 바꾼다:
+
+```diff
+- import { getAssetInfoCached } from '@/entities/ticker';
++ import { getAssetInfoResilient } from '@/entities/ticker';
+...
+-    const assetInfo = await getAssetInfoCached(ticker);
++    const assetInfo = await getAssetInfoResilient(ticker);
+```
+
+나머지 6개 page는 multi-line barrel import 블록 안의 `getAssetInfoCached,` 한 줄을 `getAssetInfoResilient,`로 바꾸고, 파일 내 모든 `getAssetInfoCached(` 호출(각 2곳)을 `getAssetInfoResilient(`로 바꾼다.
+
+빠짐없이 바꾸려면 파일별로 다음을 실행해 잔여를 0으로 만든다:
+
+```bash
+grep -rn "getAssetInfoCached" "src/app/[symbol]/" --include="*.tsx"
+```
+Expected: (no output) — 모든 라우트가 헬퍼로 교체됨.
+
+- [ ] **Step 3: 타입체크 + 빌드**
+
+Run: `yarn typecheck`
+Expected: 0 errors.
+
+Run (직접 캡처 — 파이프 금지): `rm -rf .next && yarn build > /tmp/plan_build.log 2>&1; echo "EXIT=$?"`
+Expected: `EXIT=0`, 로그에 `Compiled successfully` + `Generating static pages`.
+
+- [ ] **Step 4: 전체 테스트 (회귀 없음 확인)**
+
+Run: `yarn test`
+Expected: 전부 통과(신규 3 포함).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/entities/ticker/index.ts "src/app/[symbol]"
+git commit -m "fix([symbol]): route getAssetInfo through resilient fallback helper"
+```
+
+---
+
+## Task 3: fallback 경로 실측 검증
+
+**Files:** (검증 전용 — 코드 변경 없음. `connection()`이 ISR 라우트에서 동작하지 않으면 Task 1로 돌아가 `unstable_noStore`로 교체)
+
+- [ ] **Step 1: dev 서버 기동**
+
+Run: `yarn dev > /tmp/plan_dev.log 2>&1 &` 후 `until grep -q "Ready in" /tmp/plan_dev.log; do sleep 1; done`
+
+- [ ] **Step 2: 정상 경로 회귀 없음 확인 (cache/DB hit 종목)**
+
+Run: `for t in AAPL IONQ TSLA; do echo "$t: $(curl -s -o /dev/null -w '%{http_code}' --max-time 60 http://localhost:4200/$t)"; done`
+Expected: 모두 `200`.
+
+- [ ] **Step 3: fallback 경로 강제 — 임시 throw 주입으로 검증**
+
+`getAssetInfoResilient.ts` 헬퍼 try 블록 첫 줄에 임시로 `if (ticker === 'TESTFB') throw new Error('forced infra failure');` 를 넣고 저장(HMR), 요청:
+
+Run: `echo "TESTFB: $(curl -s -o /dev/null -w '%{http_code}' --max-time 60 http://localhost:4200/TESTFB)"`
+Expected: `200` (notFound 404가 아니라 fallback 렌더). dev 로그에 `[getAssetInfoResilient] infra failure` 1줄.
+
+검증 후 임시 throw 줄을 **반드시 제거**한다. 제거 확인:
+```bash
+grep -n "TESTFB\|forced infra" src/entities/ticker/lib/getAssetInfoResilient.ts || echo "임시 코드 제거됨"
+```
+Expected: `임시 코드 제거됨`.
+
+- [ ] **Step 4: 실재하지 않는 종목은 404 유지 확인**
+
+Run: `echo "ZZZZ: $(curl -s -o /dev/null -w '%{http_code}' --max-time 60 http://localhost:4200/ZZZZ)"`
+Expected: `404` (getAssetInfo null → notFound). 단 이 결과는 FMP가 ZZZZ에 빈 결과를 반환할 때만 보장되므로, 200이 나오면 dev 로그에 fallback 로그가 없는지(=정상 null 경로인지)만 확인한다.
+
+- [ ] **Step 5: dev 종료 + 커밋(없음)**
+
+Run: `pkill -f "next dev"`
+Task 3은 코드 변경이 없으므로 커밋하지 않는다(임시 throw는 Step 3에서 제거됨).
+
+---
+
+## Self-Review (작성자 체크 결과)
+
+- **Spec coverage:** throwOnInfraFailure 유지(비목표) ✓ / 경계 catch+fallback(Task1) ✓ / null→notFound 유지(Task2 Step2) ✓ / fallback 캐시 회피 connection()(Task1) ✓ / 6라우트+generateMetadata 교체(Task2) — layout 포함 7파일 ✓ / 테스트(Task1) ✓ / fmpSymbol 호환(이미 optional, 본문 명시) ✓ / noStore·connection 실동작 검증(Task3 Step3) ✓.
+- **Placeholder scan:** 없음. Task3는 실측이라 코드 step은 임시 throw(제거 step 포함)뿐.
+- **Type consistency:** `getAssetInfoResilient(ticker: string): Promise<AssetInfo | null>` — Task1 정의와 Task2 호출부(기존 `getAssetInfoCached`와 동일 시그니처) 일치. fallback `{symbol, name}`은 AssetInfo의 required 필드만 채움(koreanName/fmpSymbol optional).

--- a/docs/superpowers/specs/2026-06-02-symbol-infra-fallback-design.md
+++ b/docs/superpowers/specs/2026-06-02-symbol-infra-fallback-design.md
@@ -1,0 +1,124 @@
+# [symbol] 인프라 실패 graceful fallback — 설계
+
+- 날짜: 2026-06-02
+- 상태: 설계 승인됨, 구현 대기
+- 관련: PR #543(b3c220dc, `throwOnInfraFailure` 도입), 회귀 핫픽스
+
+## 배경 / 문제
+
+PR #543(b3c220dc, "FMP 404 safety")이 `getAssetInfo`의 FMP 조회를 바꿨다:
+
+```diff
+- const fmpResults = await searchBySymbol(upper);
++ const fmpResults = await searchBySymbol(upper, { throwOnInfraFailure: true });
+```
+
+`throwOnInfraFailure`는 FMP 인프라 에러(config 누락 / HTTP 에러 / fetch 실패 / JSON 파싱 실패 / 비배열 응답)일 때 빈 배열로 degrade하는 대신 **throw**한다. 원래 의도는 *transient FMP outage가 `null → notFound()` 404로 ISR(`revalidate=3600`)에 영구 캐시되는 것을 막기 위함*이었다(throw하면 ISR이 에러를 캐시하지 않으므로 복구 후 재시도 가능).
+
+### 회귀 증상
+
+`[symbol]` 라우트에는 `error.tsx`가 없다. 그래서 `getAssetInfo`의 throw가 **global-error 화면**으로 떨어진다(사용자가 prod에서 본 "500"). 데이터 흐름은 **cache(Upstash) → DB(Neon) → FMP**이고, 세 단계가 모두 miss/실패해야 throw에 도달한다:
+
+- 평상시: 인기 종목은 cache/DB hit → 200 정상.
+- 봇 공격 + 캐시율 5.8% 상황(prod): 봇이 cache/DB에 없는 다양한 ticker를 대량 요청 → FMP rate limit/과부하 → `throwOnInfraFailure` throw 연쇄 → **정상 종목 페이지까지 깨짐**.
+
+`[symbol]` 6개 라우트(차트/news/fundamental/options/overall/fear-greed)가 모두 `getAssetInfoCached`에 의존하므로 한 번에 영향받는다.
+
+## 목표
+
+1. 인프라 일시 실패가 **정상 종목 페이지를 깨지 않게** 한다(graceful degrade — ticker만으로 페이지 렌더).
+2. 실재하지 않는 종목은 그대로 **notFound 404**를 유지한다(SEO — 무한 [symbol] 페이지 방지).
+3. degrade된 fallback 응답이 ISR에 굳지 않게 한다(인프라 복구 즉시 정상 회복).
+
+## 비목표
+
+- `getAssetInfo` / `throwOnInfraFailure` 자체는 바꾸지 않는다. throw는 "인프라 실패" vs null "실재 안 함"을 가르는 **유일한 시그널**이므로 유지한다.
+- 캐시/DB/FMP 인프라 자체의 부하 대응(캐시율 개선, 봇 차단 강화)은 별도 후속 작업이다.
+
+## 접근
+
+`getAssetInfo` 내부는 손대지 않고, **데이터 fetch 경계(page RSC)에서** throw를 흡수한다. 세 상황을 구분한다:
+
+| getAssetInfo 결과 | 의미 | 처리 |
+|---|---|---|
+| `AssetInfo` 반환 | 정상 | 그대로 렌더, ISR 캐시 |
+| **throw** | 인프라 일시 실패 | catch → 캐시 회피 + ticker fallback 렌더 |
+| `null` 반환 | 실재하지 않는 종목 (FMP 200 + 빈 결과) | `notFound()` 404 |
+
+## 컴포넌트
+
+### 새 헬퍼: `getAssetInfoResilient(ticker)`
+
+`entities/ticker`에 추가. `getAssetInfoCached`를 감싸 throw를 ticker fallback으로 흡수한다.
+
+```ts
+export async function getAssetInfoResilient(
+    ticker: string
+): Promise<AssetInfo | null> {
+    try {
+        return await getAssetInfoCached(ticker); // null이면 그대로 null → notFound
+    } catch (e) {
+        // 인프라 일시 실패(FMP throwOnInfraFailure 등). 이 degrade 응답이 ISR로
+        // 굳으면 revalidate 주기 동안 fallback이 노출되므로, 이 렌더만 동적 처리해
+        // 캐시를 건너뛴다 — 인프라 복구 즉시 다음 요청부터 정상 assetInfo로 회복.
+        console.error(
+            '[getAssetInfoResilient] infra failure, ticker fallback:',
+            e
+        );
+        // Next 16에서 단일 렌더 캐시 opt-out API(unstable_noStore / connection 등)
+        // 중 ISR 라우트에서 실제로 동작하는 것을 구현 시 검증해 적용한다.
+        noStore();
+        return { symbol: ticker, name: ticker };
+    }
+}
+```
+
+- fallback 객체는 **`symbol` + `name`만** 채운다. `fmpSymbol`/`koreanName`은 생략한다.
+  - `fmpSymbol` 생략 → 다운스트림 bars/peek가 `symbol`(ticker)로 fetch. US 종목은 canonical === fmpSymbol이라 정상. 해외 심볼(예: 캐시 miss + 인프라 실패가 겹친 비-US 종목)은 일시적으로 부정확할 수 있으나, 인프라 복구 후 정상화되는 짧은 degrade 구간으로 수용한다.
+  - `koreanName` 생략 → 표시명이 영문 ticker로 degrade.
+
+### 적용 범위
+
+6개 라우트의 `getAssetInfoCached(...)` 호출을 `getAssetInfoResilient(...)`로 교체:
+
+- `app/[symbol]/page.tsx` (page body)
+- `app/[symbol]/news/page.tsx`
+- `app/[symbol]/fundamental/page.tsx`
+- `app/[symbol]/options/page.tsx`
+- `app/[symbol]/overall/page.tsx`
+- `app/[symbol]/fear-greed/page.tsx`
+- `app/[symbol]/layout.tsx` (assetInfo 사용 시)
+
+`generateMetadata`의 호출도 함께 교체한다. fallback 시 ticker 기반 메타로 degrade되며, 이는 기존 `assetInfo ? ... : ticker` null 처리와 일관된다. `getAssetInfoCached`가 `React.cache`로 dedupe되므로 generateMetadata와 body가 같은 throw를 공유하고, 각자 catch하여 동일한 fallback을 얻는다.
+
+> 구현 시 확인: `noStore()`(또는 동등 API)를 어느 호출에서 부르는지에 따라 라우트 전체가 동적화된다. fallback 경로에서만 호출되어 **정상 경로의 ISR 캐시는 그대로 유지**되어야 한다.
+
+## 데이터 흐름
+
+```
+GET /AAPL
+  → SymbolPage RSC
+    → getAssetInfoResilient('AAPL')
+        → getAssetInfoCached → getAssetInfo: cache → DB → FMP
+        ├─ 정상:     AssetInfo            → ISR 캐시, 200 정상 렌더
+        ├─ throw:    catch → noStore()    → 캐시 회피, 200 ticker fallback 렌더
+        └─ null:     null                 → notFound() 404
+```
+
+## 에러 처리
+
+- throw(인프라) ↔ null(실재 안 함) 구분은 `throwOnInfraFailure`가 보장한다. 이 시그널을 page 경계에서 분기 처리한다.
+- catch에서 에러를 **로깅**하되 삼키지 않고 fallback으로 degrade한다(렌더는 절대 깨지 않는다).
+
+## 테스트
+
+- `getAssetInfoResilient` 유닛 테스트(`getAssetInfoCached` mock):
+  - 정상 → 반환값 그대로 통과
+  - throw → `{ symbol: ticker, name: ticker }` fallback 객체 반환
+  - null → null 그대로 반환(notFound 트리거 위임)
+- `noStore()` 캐시 회피 동작은 단위 테스트 범위 밖(통합/실측)이라, 구현 시 `E2E_TEST=1 yarn build` 또는 dev 재현으로 fallback 경로가 정상 200을 내는지 확인한다.
+
+## 미해결 / 구현 시 검증
+
+- Next.js 16(`cacheComponents` 비활성) ISR 라우트에서 단일 렌더 캐시 opt-out API의 정확한 형태(`unstable_noStore` vs `connection()` vs 기타)와 동작.
+- fallback 객체 `fmpSymbol` 생략이 `peekAnalysisCache` / `getBarsAction` 시그니처(undefined 허용 여부)와 호환되는지.

--- a/docs/superpowers/specs/2026-06-02-symbol-infra-fallback-design.md
+++ b/docs/superpowers/specs/2026-06-02-symbol-infra-fallback-design.md
@@ -45,6 +45,13 @@ PR #543(b3c220dc, "FMP 404 safety")이 `getAssetInfo`의 FMP 조회를 바꿨다
 | **throw** | 인프라 일시 실패 | catch → 캐시 회피 + ticker fallback 렌더 |
 | `null` 반환 | 실재하지 않는 종목 (FMP 200 + 빈 결과) | `notFound()` 404 |
 
+> **구현 중 보강 (noindex):** 사용자 결정으로, throw(존재 불명) 시 body는 fallback 200을 렌더하되
+> `generateMetadata`는 noindex(`{ robots: { index: false, follow: false } }`)를 반환해 가짜 티커가
+> 검색에 노출되지 않게 한다. 이를 위해 헬퍼는 아래 코드 블록의 `AssetInfo | null` 대신
+> `{ assetInfo: AssetInfo | null; degraded: boolean }`(`ResilientAssetInfo`)를 반환한다. body 호출부는
+> `const { assetInfo } = ...`로 `degraded`를 무시(fallback 렌더), `generateMetadata`는
+> `const { assetInfo, degraded } = ...` 후 `if (degraded) return { robots: { index: false, follow: false } }`.
+
 ## 컴포넌트
 
 ### 새 헬퍼: `getAssetInfoResilient(ticker)`

--- a/src/app/[symbol]/__tests__/page.test.ts
+++ b/src/app/[symbol]/__tests__/page.test.ts
@@ -96,14 +96,13 @@ describe('Symbol page', () => {
                 params: Promise.resolve({ symbol: '!!!invalid' }),
             });
 
-            expect(metadata.robots).toEqual(
-                expect.objectContaining({ index: false })
-            );
+            expect(metadata.robots).toEqual({ index: false, follow: false });
         });
 
         it('returns metadata with title for valid ticker', async () => {
             mockGetAssetInfoResilient.mockResolvedValue({
                 assetInfo: {
+                    symbol: 'AAPL',
                     name: 'Apple Inc.',
                     koreanName: '애플',
                     fmpSymbol: 'AAPL',
@@ -121,6 +120,7 @@ describe('Symbol page', () => {
         it('canonical excludes tf — ISR page uses clean canonical regardless of query params', async () => {
             mockGetAssetInfoResilient.mockResolvedValue({
                 assetInfo: {
+                    symbol: 'AAPL',
                     name: 'Apple Inc.',
                     koreanName: '애플',
                     fmpSymbol: 'AAPL',
@@ -142,6 +142,7 @@ describe('Symbol page', () => {
         it('does not add noindex when no tf param', async () => {
             mockGetAssetInfoResilient.mockResolvedValue({
                 assetInfo: {
+                    symbol: 'AAPL',
                     name: 'Apple Inc.',
                     koreanName: '애플',
                     fmpSymbol: 'AAPL',
@@ -180,6 +181,7 @@ describe('Symbol page', () => {
             mockPeekAnalysisCache.mockReset();
             mockGetAssetInfoResilient.mockResolvedValue({
                 assetInfo: {
+                    symbol: 'AAPL',
                     name: 'Apple Inc.',
                     koreanName: '애플',
                     fmpSymbol: 'AAPL',

--- a/src/app/[symbol]/__tests__/page.test.ts
+++ b/src/app/[symbol]/__tests__/page.test.ts
@@ -16,7 +16,7 @@ vi.mock('@/shared/config/market', () => ({
 vi.mock('@/entities/ticker', () => ({
     buildAssetAboutNode: vi.fn().mockReturnValue(undefined),
     buildDisplayName: vi.fn().mockReturnValue('Apple Inc.'),
-    getAssetInfoCached: vi.fn(),
+    getAssetInfoResilient: vi.fn(),
 }));
 vi.mock('@/entities/bars/actions', () => ({
     getBarsAction: vi.fn().mockResolvedValue({ bars: [] }),
@@ -64,7 +64,7 @@ vi.mock('next/navigation', () => ({
 }));
 
 import { generateMetadata, default as SymbolPage } from '@/app/[symbol]/page';
-import { getAssetInfoCached } from '@/entities/ticker';
+import { getAssetInfoResilient } from '@/entities/ticker';
 import {
     GEMINI_2_5_FLASH_LITE_MODEL,
     peekAnalysisCache,
@@ -73,8 +73,8 @@ import { SymbolPageClient } from '@/widgets/symbol-page/SymbolPageClient';
 import { findElementByType } from '@/__tests__/utils/findElementByType';
 import type { MockedFunction } from 'vitest';
 
-const mockGetAssetInfoCached = getAssetInfoCached as MockedFunction<
-    typeof getAssetInfoCached
+const mockGetAssetInfoCached = getAssetInfoResilient as MockedFunction<
+    typeof getAssetInfoResilient
 >;
 const mockPeekAnalysisCache = peekAnalysisCache as MockedFunction<
     typeof peekAnalysisCache
@@ -103,9 +103,12 @@ describe('Symbol page', () => {
 
         it('returns metadata with title for valid ticker', async () => {
             mockGetAssetInfoCached.mockResolvedValue({
-                name: 'Apple Inc.',
-                koreanName: '애플',
-                fmpSymbol: 'AAPL',
+                assetInfo: {
+                    name: 'Apple Inc.',
+                    koreanName: '애플',
+                    fmpSymbol: 'AAPL',
+                },
+                degraded: false,
             } as never);
 
             const metadata = await generateMetadata({
@@ -117,9 +120,12 @@ describe('Symbol page', () => {
 
         it('canonical excludes tf — ISR page uses clean canonical regardless of query params', async () => {
             mockGetAssetInfoCached.mockResolvedValue({
-                name: 'Apple Inc.',
-                koreanName: '애플',
-                fmpSymbol: 'AAPL',
+                assetInfo: {
+                    name: 'Apple Inc.',
+                    koreanName: '애플',
+                    fmpSymbol: 'AAPL',
+                },
+                degraded: false,
             } as never);
 
             const metadata = await generateMetadata({
@@ -135,9 +141,12 @@ describe('Symbol page', () => {
 
         it('does not add noindex when no tf param', async () => {
             mockGetAssetInfoCached.mockResolvedValue({
-                name: 'Apple Inc.',
-                koreanName: '애플',
-                fmpSymbol: 'AAPL',
+                assetInfo: {
+                    name: 'Apple Inc.',
+                    koreanName: '애플',
+                    fmpSymbol: 'AAPL',
+                },
+                degraded: false,
             } as never);
 
             const metadata = await generateMetadata({
@@ -145,6 +154,20 @@ describe('Symbol page', () => {
             });
 
             expect(metadata.robots).toBeUndefined();
+        });
+
+        it('returns noindex when getAssetInfoResilient degrades on infra failure', async () => {
+            // 인프라 실패 시 fallback의 종목 실재 여부가 불명하므로 검색 노출을 막는다.
+            mockGetAssetInfoCached.mockResolvedValue({
+                assetInfo: { symbol: 'AAPL', name: 'AAPL' },
+                degraded: true,
+            } as never);
+
+            const metadata = await generateMetadata({
+                params: Promise.resolve({ symbol: 'aapl' }),
+            });
+
+            expect(metadata.robots).toEqual({ index: false, follow: false });
         });
     });
 
@@ -156,9 +179,12 @@ describe('Symbol page', () => {
             mockGetAssetInfoCached.mockReset();
             mockPeekAnalysisCache.mockReset();
             mockGetAssetInfoCached.mockResolvedValue({
-                name: 'Apple Inc.',
-                koreanName: '애플',
-                fmpSymbol: 'AAPL',
+                assetInfo: {
+                    name: 'Apple Inc.',
+                    koreanName: '애플',
+                    fmpSymbol: 'AAPL',
+                },
+                degraded: false,
             } as never);
         });
 

--- a/src/app/[symbol]/__tests__/page.test.ts
+++ b/src/app/[symbol]/__tests__/page.test.ts
@@ -73,7 +73,7 @@ import { SymbolPageClient } from '@/widgets/symbol-page/SymbolPageClient';
 import { findElementByType } from '@/__tests__/utils/findElementByType';
 import type { MockedFunction } from 'vitest';
 
-const mockGetAssetInfoCached = getAssetInfoResilient as MockedFunction<
+const mockGetAssetInfoResilient = getAssetInfoResilient as MockedFunction<
     typeof getAssetInfoResilient
 >;
 const mockPeekAnalysisCache = peekAnalysisCache as MockedFunction<
@@ -102,7 +102,7 @@ describe('Symbol page', () => {
         });
 
         it('returns metadata with title for valid ticker', async () => {
-            mockGetAssetInfoCached.mockResolvedValue({
+            mockGetAssetInfoResilient.mockResolvedValue({
                 assetInfo: {
                     name: 'Apple Inc.',
                     koreanName: '애플',
@@ -119,7 +119,7 @@ describe('Symbol page', () => {
         });
 
         it('canonical excludes tf — ISR page uses clean canonical regardless of query params', async () => {
-            mockGetAssetInfoCached.mockResolvedValue({
+            mockGetAssetInfoResilient.mockResolvedValue({
                 assetInfo: {
                     name: 'Apple Inc.',
                     koreanName: '애플',
@@ -140,7 +140,7 @@ describe('Symbol page', () => {
         });
 
         it('does not add noindex when no tf param', async () => {
-            mockGetAssetInfoCached.mockResolvedValue({
+            mockGetAssetInfoResilient.mockResolvedValue({
                 assetInfo: {
                     name: 'Apple Inc.',
                     koreanName: '애플',
@@ -158,7 +158,7 @@ describe('Symbol page', () => {
 
         it('returns noindex when getAssetInfoResilient degrades on infra failure', async () => {
             // 인프라 실패 시 fallback의 종목 실재 여부가 불명하므로 검색 노출을 막는다.
-            mockGetAssetInfoCached.mockResolvedValue({
+            mockGetAssetInfoResilient.mockResolvedValue({
                 assetInfo: { symbol: 'AAPL', name: 'AAPL' },
                 degraded: true,
             } as never);
@@ -176,9 +176,9 @@ describe('Symbol page', () => {
             // vi.clearAllMocks()를 쓰지 않는 이유: QueryClient 등 mockImplementation
             // 으로 구성한 모듈 모킹의 구현까지 지워져 생성자 모킹이 깨진다. 이 블록이
             // 의존하는 두 mock만 선택적으로 초기화한다.
-            mockGetAssetInfoCached.mockReset();
+            mockGetAssetInfoResilient.mockReset();
             mockPeekAnalysisCache.mockReset();
-            mockGetAssetInfoCached.mockResolvedValue({
+            mockGetAssetInfoResilient.mockResolvedValue({
                 assetInfo: {
                     name: 'Apple Inc.',
                     koreanName: '애플',

--- a/src/app/[symbol]/__tests__/symbol-metadata.test.ts
+++ b/src/app/[symbol]/__tests__/symbol-metadata.test.ts
@@ -109,7 +109,10 @@ const { mockGetAssetInfoCached } = vi.hoisted(() => ({
 }));
 
 vi.mock('@/entities/ticker', () => ({
-    getAssetInfoCached: (...args: unknown[]) => mockGetAssetInfoCached(...args),
+    getAssetInfoResilient: async (...args: unknown[]) => ({
+        assetInfo: await mockGetAssetInfoCached(...args),
+        degraded: false,
+    }),
 }));
 
 // react.cache는 Node 환경에서 identity wrapper로 대체

--- a/src/app/[symbol]/__tests__/symbol-metadata.test.ts
+++ b/src/app/[symbol]/__tests__/symbol-metadata.test.ts
@@ -79,6 +79,17 @@ vi.mock('@/widgets/fear-greed/FearGreedPage', () => ({
     FearGreedPage: () => null,
 }));
 
+vi.mock('@/widgets/options/OptionsPageClient', () => ({
+    OptionsPageClient: () => null,
+}));
+vi.mock('@/widgets/options/OptionsEmptyState', () => ({
+    OptionsEmptyState: () => null,
+}));
+vi.mock('@/entities/options-chain/lib/optionsDataCache', () => ({
+    hasOptionsMarket: vi.fn().mockResolvedValue(true),
+    fetchOptionsSnapshot: vi.fn().mockResolvedValue(null),
+}));
+
 vi.mock('@/app/[symbol]/fundamental/fundamentalData', () => ({
     getAnalystEstimates: vi.fn(),
     getCashFlowStatement: vi.fn(),
@@ -104,15 +115,12 @@ vi.mock('@/shared/lib/dateKey', () => ({
     todayKstIsoDate: vi.fn(() => '2026-05-21'),
 }));
 
-const { mockGetAssetInfoCached } = vi.hoisted(() => ({
-    mockGetAssetInfoCached: vi.fn(),
+const { mockGetAssetInfoResilient } = vi.hoisted(() => ({
+    mockGetAssetInfoResilient: vi.fn(),
 }));
 
 vi.mock('@/entities/ticker', () => ({
-    getAssetInfoResilient: async (...args: unknown[]) => ({
-        assetInfo: await mockGetAssetInfoCached(...args),
-        degraded: false,
-    }),
+    getAssetInfoResilient: mockGetAssetInfoResilient,
 }));
 
 // react.cache는 Node 환경에서 identity wrapper로 대체
@@ -162,6 +170,7 @@ import { generateMetadata as generateFundamentalMetadata } from '@/app/[symbol]/
 import { generateMetadata as generateNewsMetadata } from '@/app/[symbol]/news/page';
 import { generateMetadata as generateOverallMetadata } from '@/app/[symbol]/overall/page';
 import { generateMetadata as generateFearGreedMetadata } from '@/app/[symbol]/fear-greed/page';
+import { generateMetadata as generateOptionsMetadata } from '@/app/[symbol]/options/page';
 
 function makeParams(symbol: string): { params: Promise<{ symbol: string }> } {
     return { params: Promise.resolve({ symbol }) };
@@ -184,7 +193,7 @@ describe('generateMetadata — canonical URL 회귀 가드', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         // assetInfo null 반환 → ticker fallback 경로 검증
-        mockGetAssetInfoCached.mockResolvedValue(null);
+        mockGetAssetInfoResilient.mockResolvedValue({ assetInfo: null, degraded: false });
     });
 
     describe('[symbol] 루트 페이지 (/AAPL)', () => {
@@ -326,5 +335,57 @@ describe('generateMetadata — canonical URL 회귀 가드', () => {
                 'https://siglens.io/AAPL/overall'
             );
         });
+    });
+
+    describe('degraded fallback — noindex 전 라우트', () => {
+        /**
+         * 인프라 실패로 getAssetInfoResilient가 degraded:true를 반환할 때,
+         * 각 라우트의 generateMetadata가 noindex로 응답하는지 검증한다.
+         * (MISTAKES.md §18: 신규 조건 분기는 true/false 두 경로 모두 커버)
+         */
+        const degradedCases = [
+            {
+                name: '[symbol] 루트',
+                fn: () => generateSymbolMetadata(makeParamsWithSearch('aapl')),
+            },
+            {
+                name: 'news',
+                fn: () => generateNewsMetadata(makeParams('aapl')),
+            },
+            {
+                name: 'fundamental',
+                fn: () => generateFundamentalMetadata(makeParams('aapl')),
+            },
+            {
+                name: 'options',
+                fn: () => generateOptionsMetadata(makeParams('aapl')),
+            },
+            {
+                name: 'fear-greed',
+                fn: () => generateFearGreedMetadata(makeParams('aapl')),
+            },
+            {
+                name: 'overall',
+                fn: () => generateOverallMetadata(makeParamsWithSearch('aapl')),
+            },
+        ] as const;
+
+        beforeEach(() => {
+            mockGetAssetInfoResilient.mockResolvedValue({
+                assetInfo: { symbol: 'AAPL', name: 'AAPL' },
+                degraded: true,
+            });
+        });
+
+        it.each(degradedCases)(
+            '$name — degraded 시 noindex 반환',
+            async ({ fn }) => {
+                const metadata = await fn();
+                expect(metadata.robots).toEqual({
+                    index: false,
+                    follow: false,
+                });
+            }
+        );
     });
 });

--- a/src/app/[symbol]/fear-greed/page.tsx
+++ b/src/app/[symbol]/fear-greed/page.tsx
@@ -11,7 +11,7 @@ import {
 import {
     buildAssetAboutNode,
     buildDisplayName,
-    getAssetInfoCached,
+    getAssetInfoResilient,
 } from '@/entities/ticker';
 import { getBarsAction } from '@/entities/bars/actions';
 import { QUERY_KEYS, QUERY_STALE_TIME_MS } from '@/shared/config/queryConfig';
@@ -52,7 +52,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!VALID_TICKER_RE.test(ticker)) {
         return { robots: { index: false, follow: false } };
     }
-    const assetInfo = await getAssetInfoCached(ticker);
+    const { assetInfo, degraded } = await getAssetInfoResilient(ticker);
+    if (degraded) {
+        return { robots: { index: false, follow: false } };
+    }
     const displayName = assetInfo
         ? buildDisplayName(assetInfo, ticker)
         : ticker;
@@ -90,7 +93,7 @@ export default async function SymbolFearGreedPage({ params }: Props) {
         notFound();
     }
 
-    const assetInfo = await getAssetInfoCached(ticker);
+    const { assetInfo } = await getAssetInfoResilient(ticker);
     if (!assetInfo) {
         notFound();
     }

--- a/src/app/[symbol]/fundamental/page.tsx
+++ b/src/app/[symbol]/fundamental/page.tsx
@@ -30,7 +30,7 @@ import { SymbolRouteParams, VALID_TICKER_RE } from '@/shared/config/market';
 import {
     buildAssetAboutNode,
     buildDisplayName,
-    getAssetInfoCached,
+    getAssetInfoResilient,
 } from '@/entities/ticker';
 import {
     buildBreadcrumbJsonLd,
@@ -66,7 +66,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!VALID_TICKER_RE.test(upper)) {
         return { robots: { index: false, follow: false } };
     }
-    const assetInfo = await getAssetInfoCached(upper);
+    const { assetInfo, degraded } = await getAssetInfoResilient(upper);
+    if (degraded) {
+        return { robots: { index: false, follow: false } };
+    }
     const displayName = assetInfo ? buildDisplayName(assetInfo, upper) : upper;
     // sector는 의도적으로 generateMetadata에서 사용하지 않는다. sector는 FMP getProfile 응답에만 있고
     // generateMetadata에서 별도 fetch하면 페이지 본문과 합쳐 round-trip이 두 배가 된다(SEO 메타에 sector 한 줄 더
@@ -271,9 +274,9 @@ export default async function FundamentalPage({ params }: Props) {
 
     // notFound guard + sector resolution을 위해 profile을 먼저 가져온다.
     // assetInfo는 한국어 종목명을 displayName에 합치기 위해 병렬로 가져온다.
-    const [profile, assetInfo] = await Promise.all([
+    const [profile, { assetInfo }] = await Promise.all([
         getProfile(upper),
-        getAssetInfoCached(upper),
+        getAssetInfoResilient(upper),
     ]);
     if (profile === null) {
         notFound();

--- a/src/app/[symbol]/layout.tsx
+++ b/src/app/[symbol]/layout.tsx
@@ -13,7 +13,7 @@ import { SymbolLayoutHeader } from '@/widgets/symbol-page/SymbolLayoutHeader';
 import { SymbolTabsSkeleton } from '@/widgets/symbol-page/SymbolTabsSkeleton';
 import { DEFAULT_TIMEFRAME } from '@/shared/config/market';
 import { getBarsAction } from '@/entities/bars/actions';
-import { getAssetInfoCached } from '@/entities/ticker';
+import { getAssetInfoResilient } from '@/entities/ticker';
 import { QUERY_KEYS, QUERY_STALE_TIME_MS } from '@/shared/config/queryConfig';
 
 interface SymbolLayoutProps {
@@ -43,7 +43,7 @@ interface SymbolLayoutProps {
 // `params` is async (Next.js 16) and the chrome depends on it + a bars prefetch,
 // so the chrome lives behind Suspense with a header-shaped skeleton. `children`
 // (the active page subtree) is kept outside that Suspense so a page's LCP never
-// waits on the layout chrome's async work (getAssetInfoCached + prefetchQuery(bars)).
+// waits on the layout chrome's async work (getAssetInfoResilient + prefetchQuery(bars)).
 export default function SymbolLayout({ children, params }: SymbolLayoutProps) {
     return (
         <SymbolLayoutProviders>
@@ -69,7 +69,7 @@ interface SymbolLayoutSegmentProps {
 async function SymbolLayoutChrome({ params }: SymbolLayoutSegmentProps) {
     const { symbol } = await params;
     const ticker = symbol.toUpperCase();
-    const assetInfo = await getAssetInfoCached(ticker);
+    const { assetInfo } = await getAssetInfoResilient(ticker);
 
     // FearGreedHeaderChipMounted (in SymbolLayoutHeader) calls useBars with DEFAULT_TIMEFRAME
     // via useSuspenseQuery + getBarsAction (a Server Action). Server Actions cannot be invoked

--- a/src/app/[symbol]/news/page.tsx
+++ b/src/app/[symbol]/news/page.tsx
@@ -16,7 +16,7 @@ import { VALID_TICKER_RE } from '@/shared/config/market';
 import {
     buildAssetAboutNode,
     buildDisplayName,
-    getAssetInfoCached,
+    getAssetInfoResilient,
 } from '@/entities/ticker';
 import { ensureNewsCardsAnalyzedAction } from '@/entities/news-article/actions';
 import { getTodayIsoDay } from '@/shared/lib/getTodayIsoDay';
@@ -50,7 +50,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!VALID_TICKER_RE.test(upper)) {
         return { robots: { index: false, follow: false } };
     }
-    const assetInfo = await getAssetInfoCached(upper);
+    const { assetInfo, degraded } = await getAssetInfoResilient(upper);
+    if (degraded) {
+        return { robots: { index: false, follow: false } };
+    }
     const displayName = assetInfo ? buildDisplayName(assetInfo, upper) : upper;
     const { title, fullTitle, description, url, keywords } =
         buildSymbolNewsSeoContent(upper, {
@@ -149,7 +152,7 @@ export default async function NewsPage({ params }: Props) {
         notFound();
     }
 
-    const assetInfo = await getAssetInfoCached(upper);
+    const { assetInfo } = await getAssetInfoResilient(upper);
     if (!assetInfo) {
         notFound();
     }

--- a/src/app/[symbol]/options/page.tsx
+++ b/src/app/[symbol]/options/page.tsx
@@ -6,7 +6,7 @@ import { SymbolRouteParams, VALID_TICKER_RE } from '@/shared/config/market';
 import {
     buildAssetAboutNode,
     buildDisplayName,
-    getAssetInfoCached,
+    getAssetInfoResilient,
 } from '@/entities/ticker';
 import { mapExpirationsToSlots } from '@y0ngha/siglens-core';
 import {
@@ -51,10 +51,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!VALID_TICKER_RE.test(upper)) {
         return { robots: { index: false, follow: false } };
     }
-    const [assetInfo, hasOptions] = await Promise.all([
-        getAssetInfoCached(upper),
+    const [{ assetInfo, degraded }, hasOptions] = await Promise.all([
+        getAssetInfoResilient(upper),
         hasOptionsMarket(upper),
     ]);
+    if (degraded) {
+        return { robots: { index: false, follow: false } };
+    }
     const displayName = assetInfo ? buildDisplayName(assetInfo, upper) : upper;
     const { title, fullTitle, description, url, keywords } =
         buildSymbolOptionsSeoContent(upper, {
@@ -94,8 +97,8 @@ export default async function OptionsPage({ params }: Props) {
 
     if (!VALID_TICKER_RE.test(upper)) notFound();
 
-    const [assetInfo, hasOptions] = await Promise.all([
-        getAssetInfoCached(upper),
+    const [{ assetInfo }, hasOptions] = await Promise.all([
+        getAssetInfoResilient(upper),
         hasOptionsMarket(upper),
     ]);
 

--- a/src/app/[symbol]/overall/__tests__/page.test.ts
+++ b/src/app/[symbol]/overall/__tests__/page.test.ts
@@ -69,6 +69,7 @@ describe('generateMetadata', () => {
         vi.clearAllMocks();
         mockGetAssetInfoResilient.mockResolvedValue({
             assetInfo: {
+                symbol: 'AAPL',
                 name: 'Apple Inc.',
                 koreanName: '애플',
                 fmpSymbol: 'AAPL',
@@ -132,6 +133,7 @@ describe('Overall page (narrative seed)', () => {
         mockPeekOverall.mockReset();
         mockGetAssetInfoResilient.mockResolvedValue({
             assetInfo: {
+                symbol: 'AAPL',
                 name: 'Apple Inc.',
                 koreanName: '애플',
                 fmpSymbol: 'AAPL',

--- a/src/app/[symbol]/overall/__tests__/page.test.ts
+++ b/src/app/[symbol]/overall/__tests__/page.test.ts
@@ -22,7 +22,7 @@ vi.mock('@/shared/config/market', () => ({
 vi.mock('@/entities/ticker', () => ({
     buildAssetAboutNode: vi.fn().mockReturnValue(undefined),
     buildDisplayName: vi.fn().mockReturnValue('Apple Inc.'),
-    getAssetInfoCached: vi.fn(),
+    getAssetInfoResilient: vi.fn(),
 }));
 vi.mock('@/shared/lib/seo', () => ({
     buildBreadcrumbJsonLd: vi.fn().mockReturnValue({}),
@@ -48,7 +48,7 @@ vi.mock('next/navigation', () => ({
 }));
 
 import { default as OverallPage } from '@/app/[symbol]/overall/page';
-import { getAssetInfoCached } from '@/entities/ticker';
+import { getAssetInfoResilient } from '@/entities/ticker';
 import {
     GEMINI_2_5_FLASH_LITE_MODEL,
     peekOverallAnalysisCache,
@@ -57,8 +57,8 @@ import { OverallContent } from '@/widgets/overall/OverallContent';
 import { findElementByType } from '@/__tests__/utils/findElementByType';
 import type { MockedFunction } from 'vitest';
 
-const mockGetAssetInfoCached = getAssetInfoCached as MockedFunction<
-    typeof getAssetInfoCached
+const mockGetAssetInfoCached = getAssetInfoResilient as MockedFunction<
+    typeof getAssetInfoResilient
 >;
 const mockPeekOverall = peekOverallAnalysisCache as MockedFunction<
     typeof peekOverallAnalysisCache
@@ -86,9 +86,12 @@ describe('Overall page (narrative seed)', () => {
         mockGetAssetInfoCached.mockReset();
         mockPeekOverall.mockReset();
         mockGetAssetInfoCached.mockResolvedValue({
-            name: 'Apple Inc.',
-            koreanName: '애플',
-            fmpSymbol: 'AAPL',
+            assetInfo: {
+                name: 'Apple Inc.',
+                koreanName: '애플',
+                fmpSymbol: 'AAPL',
+            },
+            degraded: false,
         } as never);
     });
 

--- a/src/app/[symbol]/overall/__tests__/page.test.ts
+++ b/src/app/[symbol]/overall/__tests__/page.test.ts
@@ -47,7 +47,7 @@ vi.mock('next/navigation', () => ({
     notFound: vi.fn(),
 }));
 
-import { default as OverallPage } from '@/app/[symbol]/overall/page';
+import { generateMetadata, default as OverallPage } from '@/app/[symbol]/overall/page';
 import { getAssetInfoResilient } from '@/entities/ticker';
 import {
     GEMINI_2_5_FLASH_LITE_MODEL,
@@ -57,12 +57,57 @@ import { OverallContent } from '@/widgets/overall/OverallContent';
 import { findElementByType } from '@/__tests__/utils/findElementByType';
 import type { MockedFunction } from 'vitest';
 
-const mockGetAssetInfoCached = getAssetInfoResilient as MockedFunction<
+const mockGetAssetInfoResilient = getAssetInfoResilient as MockedFunction<
     typeof getAssetInfoResilient
 >;
 const mockPeekOverall = peekOverallAnalysisCache as MockedFunction<
     typeof peekOverallAnalysisCache
 >;
+
+describe('generateMetadata', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetAssetInfoResilient.mockResolvedValue({
+            assetInfo: {
+                name: 'Apple Inc.',
+                koreanName: '애플',
+                fmpSymbol: 'AAPL',
+            },
+            degraded: false,
+        } as never);
+    });
+
+    it('returns noindex when degraded on infra failure', async () => {
+        mockGetAssetInfoResilient.mockResolvedValue({
+            assetInfo: { symbol: 'AAPL', name: 'AAPL' },
+            degraded: true,
+        } as never);
+
+        const metadata = await generateMetadata({
+            params: Promise.resolve({ symbol: 'aapl' }),
+        });
+
+        expect(metadata.robots).toEqual({ index: false, follow: false });
+    });
+
+    it('returns normal metadata when not degraded', async () => {
+        const metadata = await generateMetadata({
+            params: Promise.resolve({ symbol: 'aapl' }),
+        });
+
+        expect(metadata.robots).toBeUndefined();
+    });
+
+    it('returns noindex for invalid ticker', async () => {
+        const metadata = await generateMetadata({
+            params: Promise.resolve({ symbol: '!!!invalid' }),
+        });
+
+        expect(metadata.robots).toEqual(
+            expect.objectContaining({ index: false })
+        );
+    });
+});
 
 describe('Overall page (narrative seed)', () => {
     interface OverallSeedProps {
@@ -83,9 +128,9 @@ describe('Overall page (narrative seed)', () => {
     }
 
     beforeEach(() => {
-        mockGetAssetInfoCached.mockReset();
+        mockGetAssetInfoResilient.mockReset();
         mockPeekOverall.mockReset();
-        mockGetAssetInfoCached.mockResolvedValue({
+        mockGetAssetInfoResilient.mockResolvedValue({
             assetInfo: {
                 name: 'Apple Inc.',
                 koreanName: '애플',

--- a/src/app/[symbol]/overall/__tests__/page.test.ts
+++ b/src/app/[symbol]/overall/__tests__/page.test.ts
@@ -47,7 +47,10 @@ vi.mock('next/navigation', () => ({
     notFound: vi.fn(),
 }));
 
-import { generateMetadata, default as OverallPage } from '@/app/[symbol]/overall/page';
+import {
+    generateMetadata,
+    default as OverallPage,
+} from '@/app/[symbol]/overall/page';
 import { getAssetInfoResilient } from '@/entities/ticker';
 import {
     GEMINI_2_5_FLASH_LITE_MODEL,
@@ -104,9 +107,7 @@ describe('generateMetadata', () => {
             params: Promise.resolve({ symbol: '!!!invalid' }),
         });
 
-        expect(metadata.robots).toEqual(
-            expect.objectContaining({ index: false })
-        );
+        expect(metadata.robots).toEqual({ index: false, follow: false });
     });
 });
 

--- a/src/app/[symbol]/overall/page.tsx
+++ b/src/app/[symbol]/overall/page.tsx
@@ -10,7 +10,7 @@ import { Suspense } from 'react';
 import {
     buildAssetAboutNode,
     buildDisplayName,
-    getAssetInfoCached,
+    getAssetInfoResilient,
 } from '@/entities/ticker';
 import {
     buildBreadcrumbJsonLd,
@@ -49,7 +49,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!VALID_TICKER_RE.test(upper)) {
         return { robots: { index: false, follow: false } };
     }
-    const assetInfo = await getAssetInfoCached(upper);
+    const { assetInfo, degraded } = await getAssetInfoResilient(upper);
+    if (degraded) {
+        return { robots: { index: false, follow: false } };
+    }
     const displayName = assetInfo ? buildDisplayName(assetInfo, upper) : upper;
     const { title, fullTitle, description, url, keywords } =
         buildSymbolOverallSeoContent(upper, {
@@ -89,7 +92,7 @@ export default async function OverallPage({ params }: Props) {
         notFound();
     }
 
-    const assetInfo = await getAssetInfoCached(upper);
+    const { assetInfo } = await getAssetInfoResilient(upper);
     if (!assetInfo) {
         notFound();
     }

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -13,7 +13,7 @@ import {
 import {
     buildAssetAboutNode,
     buildDisplayName,
-    getAssetInfoCached,
+    getAssetInfoResilient,
 } from '@/entities/ticker';
 import { getBarsAction } from '@/entities/bars/actions';
 import { countSkillFiles } from '@/entities/skill';
@@ -53,7 +53,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!VALID_TICKER_RE.test(ticker)) {
         return { robots: { index: false, follow: false } };
     }
-    const assetInfo = await getAssetInfoCached(ticker);
+    const { assetInfo, degraded } = await getAssetInfoResilient(ticker);
+    if (degraded) {
+        return { robots: { index: false, follow: false } };
+    }
     const displayName = assetInfo
         ? buildDisplayName(assetInfo, ticker)
         : ticker;
@@ -92,8 +95,8 @@ export default async function SymbolPage({ params }: Props) {
     // 다른 5개 sibling 페이지(news/fundamental/options/overall/fear-greed)와 일관:
     // 잘못된 ticker 형식은 본문에서도 notFound로 즉시 차단한다 (generateMetadata 가드와 짝).
     if (!VALID_TICKER_RE.test(ticker)) notFound();
-    const [assetInfo, skillCounts] = await Promise.all([
-        getAssetInfoCached(ticker),
+    const [{ assetInfo }, skillCounts] = await Promise.all([
+        getAssetInfoResilient(ticker),
         countSkillFiles(),
     ]);
     if (!assetInfo) return notFound();

--- a/src/entities/ticker/__tests__/lib/getAssetInfoResilient.test.ts
+++ b/src/entities/ticker/__tests__/lib/getAssetInfoResilient.test.ts
@@ -44,6 +44,16 @@ describe('getAssetInfoResilient', () => {
         expect(mockConnection).not.toHaveBeenCalled();
     });
 
+    it('rethrows DYNAMIC_SERVER_USAGE errors without fallback (Next.js control-flow signal)', async () => {
+        const dynamicErr = Object.assign(new Error('Dynamic server usage'), {
+            digest: 'DYNAMIC_SERVER_USAGE',
+        });
+        mockGet.mockRejectedValue(dynamicErr);
+
+        await expect(getAssetInfoResilient('AAPL')).rejects.toBe(dynamicErr);
+        expect(mockConnection).not.toHaveBeenCalled();
+    });
+
     it('on infra failure (throw) returns a ticker fallback with degraded: true and opts the render out of the ISR cache', async () => {
         mockGet.mockRejectedValue(
             new Error('[fmpTickerApi] search-symbol fetch failed')

--- a/src/entities/ticker/__tests__/lib/getAssetInfoResilient.test.ts
+++ b/src/entities/ticker/__tests__/lib/getAssetInfoResilient.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AssetInfo } from '@/shared/lib/types';
+import { getAssetInfoResilient } from '@/entities/ticker/lib/getAssetInfoResilient';
+import { getAssetInfoCached } from '@/entities/ticker/lib/getAssetInfoCached';
+import { connection } from 'next/server';
+
+// `connection()`은 렌더를 동적화하는 Next 16 dynamic API — 유닛에서는 호출 여부만 검증한다.
+vi.mock('next/server', () => ({
+    connection: vi.fn().mockResolvedValue(undefined),
+}));
+// 헬퍼가 감싸는 캐시 함수를 mock해 정상/throw/null 세 경로를 직접 제어한다.
+vi.mock('@/entities/ticker/lib/getAssetInfoCached', () => ({
+    getAssetInfoCached: vi.fn(),
+}));
+
+const mockGet = vi.mocked(getAssetInfoCached);
+const mockConnection = vi.mocked(connection);
+
+describe('getAssetInfoResilient', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('passes a successful AssetInfo through (degraded: false) and does not opt out of caching', async () => {
+        const info: AssetInfo = {
+            symbol: 'AAPL',
+            name: 'Apple Inc.',
+            koreanName: '애플',
+        };
+        mockGet.mockResolvedValue(info);
+
+        const result = await getAssetInfoResilient('AAPL');
+
+        expect(result).toEqual({ assetInfo: info, degraded: false });
+        expect(mockConnection).not.toHaveBeenCalled();
+    });
+
+    it('passes null (non-existent ticker) through (degraded: false) so the caller can notFound()', async () => {
+        mockGet.mockResolvedValue(null);
+
+        const result = await getAssetInfoResilient('ZZZZ');
+
+        expect(result).toEqual({ assetInfo: null, degraded: false });
+        expect(mockConnection).not.toHaveBeenCalled();
+    });
+
+    it('on infra failure (throw) returns a ticker fallback with degraded: true and opts the render out of the ISR cache', async () => {
+        mockGet.mockRejectedValue(
+            new Error('[fmpTickerApi] search-symbol fetch failed')
+        );
+
+        const result = await getAssetInfoResilient('IONQ');
+
+        expect(result).toEqual({
+            assetInfo: { symbol: 'IONQ', name: 'IONQ' },
+            degraded: true,
+        });
+        expect(mockConnection).toHaveBeenCalledOnce();
+    });
+});

--- a/src/entities/ticker/__tests__/lib/getAssetInfoResilient.test.ts
+++ b/src/entities/ticker/__tests__/lib/getAssetInfoResilient.test.ts
@@ -54,6 +54,14 @@ describe('getAssetInfoResilient', () => {
         expect(mockConnection).not.toHaveBeenCalled();
     });
 
+    it('rethrows when only message matches (no digest field)', async () => {
+        const dynamicErr = new Error('Dynamic server usage');
+        mockGet.mockRejectedValue(dynamicErr);
+
+        await expect(getAssetInfoResilient('AAPL')).rejects.toBe(dynamicErr);
+        expect(mockConnection).not.toHaveBeenCalled();
+    });
+
     it('on infra failure (throw) returns a ticker fallback with degraded: true and opts the render out of the ISR cache', async () => {
         mockGet.mockRejectedValue(
             new Error('[fmpTickerApi] search-symbol fetch failed')

--- a/src/entities/ticker/index.ts
+++ b/src/entities/ticker/index.ts
@@ -4,7 +4,7 @@ export {
     DrizzleProfileDescriptionTranslationRepository,
 } from './api';
 
-export { getAssetInfoResilient } from './lib/getAssetInfoResilient';
+export { getAssetInfoResilient, type ResilientAssetInfo } from './lib/getAssetInfoResilient';
 
 export {
     translateCompanyNames,

--- a/src/entities/ticker/index.ts
+++ b/src/entities/ticker/index.ts
@@ -4,7 +4,7 @@ export {
     DrizzleProfileDescriptionTranslationRepository,
 } from './api';
 
-export { getAssetInfoCached } from './lib/getAssetInfoCached';
+export { getAssetInfoResilient } from './lib/getAssetInfoResilient';
 
 export {
     translateCompanyNames,

--- a/src/entities/ticker/lib/getAssetInfoResilient.ts
+++ b/src/entities/ticker/lib/getAssetInfoResilient.ts
@@ -39,6 +39,8 @@ export async function getAssetInfoResilient(
         // 남고 fallback degrade 응답이 반환된다. 제어 흐름 에러는 그대로 rethrow한다.
         if (
             e instanceof Error &&
+            // e가 Error인 것은 위에서 확인됨; Next.js DynamicServerError는 digest 필드를 추가하므로
+            // unknown → { digest? } 캐스팅은 안전 — digest가 없으면 undefined → 비교 false.
             ((e as { digest?: string }).digest === 'DYNAMIC_SERVER_USAGE' ||
                 e.message.includes('Dynamic server usage'))
         ) {

--- a/src/entities/ticker/lib/getAssetInfoResilient.ts
+++ b/src/entities/ticker/lib/getAssetInfoResilient.ts
@@ -14,15 +14,17 @@ export interface ResilientAssetInfo {
 }
 
 /**
- * `getAssetInfoCached`의 graceful 래퍼. `getAssetInfo`는 세 가지로 끝난다:
- *   - AssetInfo 반환 → `{ assetInfo, degraded: false }`(정상, ISR 캐시 대상).
- *   - throw         → FMP 인프라 일시 실패(throwOnInfraFailure). 여기서 흡수해
- *                     `{symbol, name: ticker}` fallback으로 degrade하고, 이 degrade
- *                     응답이 ISR(revalidate=3600)로 굳지 않도록 `connection()`으로
- *                     해당 렌더만 동적화한다 — 인프라 복구 즉시 다음 요청부터 정상화.
- *                     `degraded: true`로 표시해 metadata가 noindex 처리할 수 있게 한다.
- *   - null 반환     → FMP 200 + 빈 결과 = 실재하지 않는 종목. `{ assetInfo: null }`로
- *                     통과시켜 호출부의 `notFound()`(404)가 동작하게 한다.
+ * `getAssetInfoCached`의 graceful 래퍼. `getAssetInfo`는 네 가지로 끝난다:
+ *   - AssetInfo 반환         → `{ assetInfo, degraded: false }`(정상, ISR 캐시 대상).
+ *   - null 반환              → FMP 200 + 빈 결과 = 실재하지 않는 종목. `{ assetInfo: null }`로
+ *                              통과시켜 호출부의 `notFound()`(404)가 동작하게 한다.
+ *   - DYNAMIC_SERVER_USAGE throw → Next.js 제어 흐름 에러이므로 그대로 rethrow한다.
+ *                              인프라 실패로 오인 시 불필요한 에러 로그 + fallback degrade가 발생한다.
+ *   - 기타 throw             → FMP 인프라 일시 실패(throwOnInfraFailure). 여기서 흡수해
+ *                              `{symbol, name: ticker}` fallback으로 degrade하고, 이 degrade
+ *                              응답이 ISR(revalidate=3600)로 굳지 않도록 `connection()`으로
+ *                              해당 렌더만 동적화한다 — 인프라 복구 즉시 다음 요청부터 정상화.
+ *                              `degraded: true`로 표시해 metadata가 noindex 처리할 수 있게 한다.
  *
  * fallback 객체는 symbol/name만 채운다. fmpSymbol은 생략하는데, AssetInfo에서
  * 이미 optional("일반 주식은 undefined")이라 다운스트림(getBarsAction/peekAnalysisCache)이

--- a/src/entities/ticker/lib/getAssetInfoResilient.ts
+++ b/src/entities/ticker/lib/getAssetInfoResilient.ts
@@ -1,0 +1,44 @@
+import { connection } from 'next/server';
+import type { AssetInfo } from '@/shared/lib/types';
+import { getAssetInfoCached } from './getAssetInfoCached';
+
+export interface ResilientAssetInfo {
+    /** 정상 AssetInfo, 인프라 실패 시 fallback ticker 객체, 또는 실재하지 않는 종목일 때 null. */
+    assetInfo: AssetInfo | null;
+    /**
+     * true = 인프라 실패로 fallback degrade됨. 이때는 FMP를 못 물어봐 종목의 실재
+     * 여부를 알 수 없으므로(가짜 티커일 수도), 호출부의 generateMetadata가 noindex로
+     * 응답해 검색 노출을 막는다. body는 그대로 fallback을 렌더해 정상 종목의 UX를 유지한다.
+     */
+    degraded: boolean;
+}
+
+/**
+ * `getAssetInfoCached`의 graceful 래퍼. `getAssetInfo`는 세 가지로 끝난다:
+ *   - AssetInfo 반환 → `{ assetInfo, degraded: false }`(정상, ISR 캐시 대상).
+ *   - throw         → FMP 인프라 일시 실패(throwOnInfraFailure). 여기서 흡수해
+ *                     `{symbol, name: ticker}` fallback으로 degrade하고, 이 degrade
+ *                     응답이 ISR(revalidate=3600)로 굳지 않도록 `connection()`으로
+ *                     해당 렌더만 동적화한다 — 인프라 복구 즉시 다음 요청부터 정상화.
+ *                     `degraded: true`로 표시해 metadata가 noindex 처리할 수 있게 한다.
+ *   - null 반환     → FMP 200 + 빈 결과 = 실재하지 않는 종목. `{ assetInfo: null }`로
+ *                     통과시켜 호출부의 `notFound()`(404)가 동작하게 한다.
+ *
+ * fallback 객체는 symbol/name만 채운다. fmpSymbol은 생략하는데, AssetInfo에서
+ * 이미 optional("일반 주식은 undefined")이라 다운스트림(getBarsAction/peekAnalysisCache)이
+ * symbol로 degrade하는 기존 정상 경로와 동일하다. koreanName 생략 시 표시명이 영문 ticker.
+ */
+export async function getAssetInfoResilient(
+    ticker: string
+): Promise<ResilientAssetInfo> {
+    try {
+        return { assetInfo: await getAssetInfoCached(ticker), degraded: false };
+    } catch (e) {
+        console.error(
+            '[getAssetInfoResilient] infra failure, ticker fallback:',
+            e
+        );
+        await connection();
+        return { assetInfo: { symbol: ticker, name: ticker }, degraded: true };
+    }
+}

--- a/src/entities/ticker/lib/getAssetInfoResilient.ts
+++ b/src/entities/ticker/lib/getAssetInfoResilient.ts
@@ -34,6 +34,16 @@ export async function getAssetInfoResilient(
     try {
         return { assetInfo: await getAssetInfoCached(ticker), degraded: false };
     } catch (e) {
+        // Next.js가 static generation / ISR 중 dynamic API를 만나면 DynamicServerError를
+        // 제어 흐름 수단으로 throw한다. 이를 인프라 실패로 오인하면 불필요한 에러 로그가
+        // 남고 fallback degrade 응답이 반환된다. 제어 흐름 에러는 그대로 rethrow한다.
+        if (
+            e instanceof Error &&
+            ((e as { digest?: string }).digest === 'DYNAMIC_SERVER_USAGE' ||
+                e.message.includes('Dynamic server usage'))
+        ) {
+            throw e;
+        }
         console.error(
             '[getAssetInfoResilient] infra failure, ticker fallback:',
             e


### PR DESCRIPTION
## 관련 이슈

PR #543의 회귀 수정 (getAssetInfo 인프라 실패 시 graceful fallback + noindex)

## 구현 내용

- `getAssetInfoResilient`: getAssetInfoCached 래퍼. 인프라 실패(throw) 시 로그 + connection 호출 + ticker fallback `{symbol, name, degraded: true}` 반환. null(비존재)은 통과→notFound 변경 없음.
- [symbol] 7개 라우트 (layout/page/news/fundamental/options/overall/fear-greed): body에서 `{ assetInfo }` 구조분해 (200 응답), generateMetadata에서 `{ assetInfo, degraded }` 구조분해하여 degraded=true시 `robots: { index: false, follow: false }` 반환 (인프라 실패 중 가짜 티커는 검색 색인 제외).
- 3개 page 테스트 업데이트 및 degraded→noindex 테스트 추가.
- docs 명세 및 구현 계획서 작성.

## 변경 파일 목록

[생성]
- src/entities/ticker/lib/getAssetInfoResilient.ts
- src/entities/ticker/__tests__/lib/getAssetInfoResilient.test.ts
- docs/superpowers/plans/2026-06-02-symbol-infra-fallback.md

[수정]
- src/app/[symbol]/layout.tsx
- src/app/[symbol]/page.tsx
- src/app/[symbol]/fear-greed/page.tsx
- src/app/[symbol]/fundamental/page.tsx
- src/app/[symbol]/news/page.tsx
- src/app/[symbol]/options/page.tsx
- src/app/[symbol]/overall/page.tsx
- src/app/[symbol]/__tests__/page.test.ts
- src/app/[symbol]/__tests__/symbol-metadata.test.ts
- src/app/[symbol]/overall/__tests__/page.test.ts
- src/entities/ticker/index.ts
- docs/superpowers/specs/2026-06-02-symbol-infra-fallback-design.md

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build

---

### ⚠️ E2E CI 주의

E2E(CI)는 현재 ~17개 실패를 보이지만, **이 PR과 무관**합니다. PR #543의 [symbol] ISR(`generateStaticParams=[]`) + redis 캐시(`@upstash/redis`/srh no-store fetch) 충돌 → `DYNAMIC_SERVER_USAGE` 에러입니다. 증거: AAPL (DB 시드, 이 PR의 fallback path 미사용) 역시 62회 DYNAMIC_SERVER_USAGE 발생. ISR↔redis 충돌은 별도 후속 수정. 이 PR은 인프라 실패 fallback 동작 개선 + typecheck/build/unit tests 모두 green 확인.