### PR TITLE
fix(seo): [symbol] SEO audit (Phase 3) — SSR h1 on chart route

### DIFF
--- a/src/app/[symbol]/__tests__/page.factlayer.test.tsx
+++ b/src/app/[symbol]/__tests__/page.factlayer.test.tsx
@@ -159,6 +159,53 @@ describe('SymbolPage — FactLayer SSR integration', () => {
         expect((fact?.props as { symbol: string }).symbol).toBe('AAPL');
     });
 
+    it('SSR 크롤용 h1: fallback에 sr-only h1(회사명 + 차트 분석)이 있어 JS 미실행 크롤러가 메인 h1을 받는다', async () => {
+        mockBarsStatic.mockResolvedValue({
+            bars: [
+                {
+                    time: 1,
+                    open: 1,
+                    high: 2,
+                    low: 0.5,
+                    close: 1.5,
+                    volume: 100,
+                },
+            ],
+            indicators: {},
+        } as never);
+
+        const tree = await SymbolPage({
+            params: Promise.resolve({ symbol: 'aapl' }),
+        });
+        const fallback = findSuspenseFallback(tree);
+        const h1 = findElementByType(fallback, 'h1');
+
+        expect(h1).not.toBeNull();
+        // 보장: findElementByType이 host element 'h1'을 반환했으므로 props.children은
+        // buildChartPageHeading(displayName) 결과 문자열이다. displayName mock = 'Apple Inc.'
+        // → 결정적 값이므로 toBe로 정밀 검증.
+        const children = (h1?.props as { children?: ReactNode }).children;
+        const text = Array.isArray(children)
+            ? children.join('')
+            : String(children);
+        expect(text).toBe('Apple Inc. 차트 분석');
+        // sr-only라 가시 레이아웃(jail) 영향 없음 — 크롤 전용.
+        expect((h1?.props as { className?: string }).className).toContain(
+            'sr-only'
+        );
+    });
+
+    it('SSR 크롤용 h1: bars 빈 결과(cold)에서도 fallback h1은 존재한다(데이터 유무와 무관)', async () => {
+        mockBarsStatic.mockResolvedValue({ bars: [], indicators: {} } as never);
+
+        const tree = await SymbolPage({
+            params: Promise.resolve({ symbol: 'aapl' }),
+        });
+        const fallback = findSuspenseFallback(tree);
+
+        expect(findElementByType(fallback, 'h1')).not.toBeNull();
+    });
+
     it('Worst: bars 빈 결과면 FactLayer 대신 빈 fallback(div) — 크래시 없이 페이지 정상', async () => {
         mockBarsStatic.mockResolvedValue({ bars: [], indicators: {} } as never);
 

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -1,5 +1,8 @@
 import { SymbolPageClient } from '@/widgets/symbol-page/SymbolPageClient';
-import { TechnicalFactsSummary } from '@/widgets/symbol-page';
+import {
+    TechnicalFactsSummary,
+    buildChartPageHeading,
+} from '@/widgets/symbol-page';
 import { JsonLd } from '@/shared/ui/JsonLd';
 import { FALLBACK_ANALYSIS } from '@/entities/chat-message';
 import { GEMINI_2_5_FLASH_LITE_MODEL } from '@y0ngha/siglens-core';
@@ -278,18 +281,30 @@ export default async function SymbolPage({ params }: Props) {
                            받는다. 사용자는 hydration 후 인터랙티브 SymbolPageClient로 교체된다. */}
                     <Suspense
                         fallback={
-                            factBars && factBars.bars.length > 0 ? (
-                                <TechnicalFactsSummary
-                                    symbol={ticker}
-                                    bars={factBars.bars}
-                                    indicators={factBars.indicators}
-                                />
-                            ) : (
-                                <div
-                                    className="bg-secondary-900 flex min-h-0 flex-1 flex-col overflow-hidden"
-                                    aria-hidden="true"
-                                />
-                            )
+                            <>
+                                {/* SSR 크롤용 h1: 가시 h1은 SymbolPageClient(useSearchParams
+                                    CSR-bailout)에 있어 SSR HTML에 박히지 않는다. hydration 후
+                                    그 가시 h1으로 교체되는 이 fallback에 동일 텍스트의 sr-only
+                                    h1을 둬, JS 미실행 크롤러(Naver Yeti 등)가 메인 페이지 h1을
+                                    받게 한다(나머지 5라우트의 SymbolPageHeading h1과 정합). fallback이
+                                    hydration 시 교체되므로 가시 클라 h1과 동시 존재하지 않아 h1 중복은
+                                    없고, 텍스트가 동일해 cloaking도 아니다. */}
+                                <h1 className="sr-only">
+                                    {buildChartPageHeading(displayName)}
+                                </h1>
+                                {factBars && factBars.bars.length > 0 ? (
+                                    <TechnicalFactsSummary
+                                        symbol={ticker}
+                                        bars={factBars.bars}
+                                        indicators={factBars.indicators}
+                                    />
+                                ) : (
+                                    <div
+                                        className="bg-secondary-900 flex min-h-0 flex-1 flex-col overflow-hidden"
+                                        aria-hidden="true"
+                                    />
+                                )}
+                            </>
                         }
                     >
                         <SymbolPageClient

--- a/src/widgets/symbol-page/SymbolPageClient.tsx
+++ b/src/widgets/symbol-page/SymbolPageClient.tsx
@@ -12,6 +12,7 @@ import { useAssetInfo } from './hooks/useAssetInfo';
 import { useMobileSheet } from './hooks/useMobileSheet';
 import { useTimeframeChange } from './hooks/useTimeframeChange';
 import { SymbolPageProvider } from './SymbolPageContext';
+import { buildChartPageHeading } from './utils/chartPageHeading';
 import type { AnalysisResponse } from '@y0ngha/siglens-core';
 import dynamic from 'next/dynamic';
 import { Suspense } from 'react';
@@ -70,11 +71,13 @@ export function SymbolPageClient({
                 <div className="border-secondary-700 flex items-center justify-between gap-3 border-b px-4 py-2 sm:py-1.5">
                     {/* 차트 페이지 가시 h1: jail(first-viewport 고정 + overflow-hidden)이라
                         본문에 별도 블록을 얹으면 chart 가시 영역이 침범된다. 그래서
-                        timeframe bar 행에 짧은 한 줄로 둔다. truncate로 좁은 화면에서
-                        TimeframeSelector와 한 줄 공존하고, SSR 렌더되어 크롤러가
-                        가시 텍스트로 읽는다(기존 sr-only h1을 대체). */}
+                        timeframe bar 행에 짧은 한 줄로 둔다(truncate로 좁은 화면에서
+                        TimeframeSelector와 한 줄 공존). 단 이 컴포넌트는 useSearchParams로
+                        CSR-bailout되므로 이 가시 h1은 SSR HTML엔 박히지 않는다 — JS 미실행
+                        크롤러용 h1은 page.tsx의 Suspense fallback에 동일 텍스트 sr-only h1으로
+                        제공하고, hydration 후 이 가시 h1이 fallback을 대체한다. */}
                     <h1 className="text-secondary-100 min-w-0 truncate text-sm font-semibold sm:text-base">
-                        {displayName} 차트 분석
+                        {buildChartPageHeading(displayName)}
                     </h1>
                     <TimeframeSelector
                         value={timeframe}

--- a/src/widgets/symbol-page/__tests__/utils/chartPageHeading.test.ts
+++ b/src/widgets/symbol-page/__tests__/utils/chartPageHeading.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { buildChartPageHeading } from '@/widgets/symbol-page/utils/chartPageHeading';
+
+describe('buildChartPageHeading', () => {
+    it('displayName 뒤에 " 차트 분석" suffix를 붙인다 (SSR fallback h1 / 가시 h1 단일 소스)', () => {
+        expect(buildChartPageHeading('애플, Apple Inc. (AAPL)')).toBe(
+            '애플, Apple Inc. (AAPL) 차트 분석'
+        );
+    });
+});

--- a/src/widgets/symbol-page/index.ts
+++ b/src/widgets/symbol-page/index.ts
@@ -8,6 +8,9 @@ export { SymbolModelProvider, useSymbolModel } from './SymbolModelContext';
 
 export { CrossLinkCards } from './CrossLinkCards';
 export { SymbolPageHeading } from './ui/SymbolPageHeading';
+// 차트 라우트 h1 텍스트 단일 소스 — SSR fallback h1(page.tsx)과 가시 h1(SymbolPageClient)
+// 일치 보장(cloaking 방지). 순수 string 헬퍼라 barrel 노출 안전.
+export { buildChartPageHeading } from './utils/chartPageHeading';
 // 경량 순수 컴포넌트(priceFormat/technicalFacts util만 의존) — heavy 컴포넌트 deep-import
 // 정책에 해당하지 않아 barrel로 노출한다. app route의 FactLayer SSR fallback이 소비.
 export { TechnicalFactsSummary } from './TechnicalFactsSummary';

--- a/src/widgets/symbol-page/utils/chartPageHeading.ts
+++ b/src/widgets/symbol-page/utils/chartPageHeading.ts
@@ -1,0 +1,10 @@
+/**
+ * 차트 라우트 h1 텍스트의 단일 소스.
+ *
+ * `page.tsx`의 SSR 크롤용 sr-only h1과 `SymbolPageClient`의 가시 h1은 반드시 동일해야
+ * 한다 — 둘이 다르면 크롤러가 받는 h1 ≠ 사용자가 보는 h1, 즉 cloaking이 된다(SEO 위험).
+ * 두 파일에 리터럴을 각각 두면 한쪽만 수정될 때 조용히 drift하므로 여기서 한 번만 만든다.
+ */
+export function buildChartPageHeading(displayName: string): string {
+    return `${displayName} 차트 분석`;
+}


### PR DESCRIPTION
## Summary

Phase 3 of the [symbol] ISR+SEO work: ran the `seo-audit` skill against all 6 `[symbol]` routes (prod build + curl) after the Phase 2 ISR/SSR migration and fixed the one defect found.

### Audit result (all green except F1)
- ISR: all 6 routes HTTP 200 + `x-nextjs-cache: HIT` + runtime `DYNAMIC_SERVER_USAGE=0`
- title / description: unique, descriptive, keyword-first per route
- canonical: self-referencing uppercase ticker (localhost base is a local-env artifact; prod uses the real domain)
- robots: valid ticker → `index, follow`
- JSON-LD (SSR'd): WebPage / FAQPage / BreadcrumbList / Corporation / WebSite / SearchAction; news adds Article / NewsArticle / ItemList / ImageObject
- og:image + `twitter:card=summary_large_image`

### F1 (fixed) — chart route missing SSR h1
The main `/[symbol]` (chart) route rendered **no `<h1>` in its crawlable SSR HTML** (h1 count 0; the other 5 routes each have 1). The visible h1 lives in `SymbolPageClient`, which CSR-bailouts via `useSearchParams(timeframe)` — so during SSR the Suspense fallback renders and the client h1 never reaches the static HTML. Fix: sr-only h1 in the Suspense fallback (replaced by the client on hydration → no double-h1; identical text → not cloaking; sr-only → no jail-layout impact). Verified: h1 0→1, hierarchy h1→h2, other routes unchanged, ISR HIT, DSU=0.

### F2 (flagged — NOT in this PR, follow-up) — invalid ticker → 500 under FMP rate-limit
`/ZZZZ` returned HTTP 500. Root cause observed: FMP `search-symbol` HTTP 429 (local rate-limit from repeated audit curls) → `getAssetInfoResilient` infra-failure path → `DYNAMIC_SERVER_USAGE` re-throw (PR #545's deliberate design) → cold-gen 500. This is largely a local-env artifact (prod FMP quota is higher), but the underlying "new ticker + FMP hiccup during cold ISR generation → 500 instead of a graceful noindex/dynamic render" is worth a separate look. Out of SEO-audit scope; not changed here. (Invalid-ticker `noindex` consistency could not be locally verified due to the 429.)

### Verification
- lint clean · vitest 4709 passed · prod build + curl re-measurement (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)