### PR TITLE
fix(symbol): ISR cold-gen 500 on FMP infra failure (remove getAssetInfoResilient connection())

### DIFF
--- a/src/entities/ticker/__tests__/lib/getAssetInfoResilient.test.ts
+++ b/src/entities/ticker/__tests__/lib/getAssetInfoResilient.test.ts
@@ -2,27 +2,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { AssetInfo } from '@/shared/lib/types';
 import { getAssetInfoResilient } from '@/entities/ticker/lib/getAssetInfoResilient';
 import { getAssetInfoStatic } from '@/entities/ticker/lib/getAssetInfoStatic';
-import { connection } from 'next/server';
 
-// `connection()`은 렌더를 동적화하는 Next 16 dynamic API — 유닛에서는 호출 여부만 검증한다.
-vi.mock('next/server', () => ({
-    connection: vi.fn().mockResolvedValue(undefined),
-}));
 // 헬퍼가 감싸는 정적화 함수를 mock해 정상/throw/null 세 경로를 직접 제어한다.
-// (Task 5: resilient가 getAssetInfoCached 대신 getAssetInfoStatic을 호출하도록 변경됨.)
 vi.mock('@/entities/ticker/lib/getAssetInfoStatic', () => ({
     getAssetInfoStatic: vi.fn(),
 }));
 
 const mockGet = vi.mocked(getAssetInfoStatic);
-const mockConnection = vi.mocked(connection);
 
 describe('getAssetInfoResilient', () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
 
-    it('passes a successful AssetInfo through (degraded: false) and does not opt out of caching', async () => {
+    it('passes a successful AssetInfo through (degraded: false)', async () => {
         const info: AssetInfo = {
             symbol: 'AAPL',
             name: 'Apple Inc.',
@@ -33,7 +26,6 @@ describe('getAssetInfoResilient', () => {
         const result = await getAssetInfoResilient('AAPL');
 
         expect(result).toEqual({ assetInfo: info, degraded: false });
-        expect(mockConnection).not.toHaveBeenCalled();
     });
 
     it('passes null (non-existent ticker) through (degraded: false) so the caller can notFound()', async () => {
@@ -42,7 +34,6 @@ describe('getAssetInfoResilient', () => {
         const result = await getAssetInfoResilient('ZZZZ');
 
         expect(result).toEqual({ assetInfo: null, degraded: false });
-        expect(mockConnection).not.toHaveBeenCalled();
     });
 
     it('rethrows DYNAMIC_SERVER_USAGE errors without fallback (Next.js control-flow signal)', async () => {
@@ -52,7 +43,6 @@ describe('getAssetInfoResilient', () => {
         mockGet.mockRejectedValue(dynamicErr);
 
         await expect(getAssetInfoResilient('AAPL')).rejects.toBe(dynamicErr);
-        expect(mockConnection).not.toHaveBeenCalled();
     });
 
     it('rethrows when only message matches (no digest field)', async () => {
@@ -60,10 +50,12 @@ describe('getAssetInfoResilient', () => {
         mockGet.mockRejectedValue(dynamicErr);
 
         await expect(getAssetInfoResilient('AAPL')).rejects.toBe(dynamicErr);
-        expect(mockConnection).not.toHaveBeenCalled();
     });
 
-    it('on infra failure (throw) returns a ticker fallback with degraded: true and opts the render out of the ISR cache', async () => {
+    it('on infra failure (throw) returns a ticker fallback with degraded: true — does not throw, so ISR cold-gen renders the degrade page (noindex) instead of crashing with 500', async () => {
+        // 과거 catch의 connection()이 ISR cold-gen에서 DYNAMIC_SERVER_USAGE를 throw해
+        // 500을 냈다(F2). 이제 throw 없이 degrade를 반환하므로 cold-gen이 200(noindex)으로
+        // 완료된다. degraded: true → 호출부 generateMetadata가 noindex 처리.
         mockGet.mockRejectedValue(
             new Error('[fmpTickerApi] search-symbol fetch failed')
         );
@@ -74,6 +66,5 @@ describe('getAssetInfoResilient', () => {
             assetInfo: { symbol: 'IONQ', name: 'IONQ' },
             degraded: true,
         });
-        expect(mockConnection).toHaveBeenCalledOnce();
     });
 });

--- a/src/entities/ticker/lib/getAssetInfoResilient.ts
+++ b/src/entities/ticker/lib/getAssetInfoResilient.ts
@@ -1,4 +1,3 @@
-import { connection } from 'next/server';
 import type { AssetInfo } from '@/shared/lib/types';
 import { getAssetInfoStatic } from './getAssetInfoStatic';
 
@@ -21,10 +20,8 @@ export interface ResilientAssetInfo {
  *   - DYNAMIC_SERVER_USAGE throw → Next.js 제어 흐름 에러이므로 그대로 rethrow한다.
  *                              인프라 실패로 오인 시 불필요한 에러 로그 + fallback degrade가 발생한다.
  *   - 기타 throw             → FMP 인프라 일시 실패(throwOnInfraFailure). 여기서 흡수해
- *                              `{symbol, name: ticker}` fallback으로 degrade하고, 이 degrade
- *                              응답이 ISR(revalidate=3600)로 굳지 않도록 `connection()`으로
- *                              해당 렌더만 동적화한다 — 인프라 복구 즉시 다음 요청부터 정상화.
- *                              `degraded: true`로 표시해 metadata가 noindex 처리할 수 있게 한다.
+ *                              `{symbol, name: ticker}` fallback으로 degrade하고 `degraded: true`로
+ *                              표시해 호출부 generateMetadata가 noindex 처리하게 한다.
  *
  * fallback 객체는 symbol/name만 채운다. fmpSymbol은 생략하는데, AssetInfo에서
  * 이미 optional("일반 주식은 undefined")이라 다운스트림(getBarsAction/peekAnalysisCache)이
@@ -32,8 +29,16 @@ export interface ResilientAssetInfo {
  *
  * ISR 정적화: inner 데이터 호출을 `getAssetInfoStatic`(=unstable_cache(getAssetInfo))으로
  * 정적화해 static gen 중 redis no-store fetch가 `DYNAMIC_SERVER_USAGE`를 throw하지 않게 한다.
- * `connection()`(catch 내)은 의도적으로 `unstable_cache` 밖에 둔다 — 인프라 실패 시 degrade
- * 렌더만 동적화하는 escape이며, `unstable_cache` 안에서 호출하면 throw하기 때문이다.
+ *
+ * degrade 응답의 캐싱(#545 connection() 제거 배경): 이 함수의 소비자는 전부 `[symbol]` ISR
+ * 라우트(generateStaticParams=[])다. 과거 #545는 degrade 렌더가 ISR(revalidate=3600)로 1h
+ * 굳지 않도록 catch에서 `connection()`으로 동적화하려 했으나, ISR 라우트의 on-demand cold-gen
+ * 안에서 `connection()`은 "단일 렌더 동적화"가 아니라 `DYNAMIC_SERVER_USAGE`를 throw해 cold-gen을
+ * 500으로 깨뜨린다(ISR은 per-request 동적화가 불가). #545 추가 시점엔 ISR 자체가 깨져 있어(전
+ * 라우트 DSU) 이 500이 가려져 있다가, Phase 0~2가 ISR을 정상화하면서 드러났다. 그래서 connection()을
+ * 제거하고 degrade 렌더가 ISR로 캐시되는 것을 허용한다 — degrade는 `degraded:true`로 noindex라
+ * 검색 노출 위험이 없고, 다음 revalidate(또는 데이터 갱신 시 on-demand 무효화)에 인프라가 복구돼
+ * 있으면 정상 데이터로 자동 갱신된다. 500(깨진 페이지)보다 degraded 200(noindex, fallback UX)이 낫다.
  */
 export async function getAssetInfoResilient(
     ticker: string
@@ -60,7 +65,6 @@ export async function getAssetInfoResilient(
             '[getAssetInfoResilient] infra failure, ticker fallback:',
             e
         );
-        await connection();
         return { assetInfo: { symbol: ticker, name: ticker }, degraded: true };
     }
 }

--- a/src/entities/ticker/lib/getAssetInfoStatic.ts
+++ b/src/entities/ticker/lib/getAssetInfoStatic.ts
@@ -12,8 +12,8 @@ import { SECONDS_PER_HOUR } from '@/shared/config/time';
  * `DYNAMIC_SERVER_USAGE`를 그대로 rethrow한다. inner redis 호출이 정적화되지 않으면 static
  * gen 중 no-store fetch가 `DYNAMIC_SERVER_USAGE`를 throw → resilient가 faithfully rethrow →
  * 라우트가 dynamic으로 떨어진다. 그래서 데이터 호출 자체를 `unstable_cache`로 감싸 정적화한다.
- * resilient의 `connection()`/rethrow는 이 래퍼 밖에 그대로 남아(인프라 실패 시 의도된
- * dynamic-escape) `unstable_cache` 안에서 throw하지 않는다.
+ * resilient의 DSU rethrow는 이 래퍼 밖에 그대로 남아 `unstable_cache` 안에서 throw하지 않는다
+ * (인프라 실패는 degrade fallback으로 흡수 — resilient JSDoc의 #545 connection() 제거 배경 참조).
  *
  * 왜 clean lib `getAssetInfo`가 아니라 `getAssetInfoAction`('use server')을 감싸는가:
  * `getAssetInfoResilient`는 ticker barrel(index.ts)에서 export되고, 그 barrel은 client


### PR DESCRIPTION
## Summary

Follow-up to the [symbol] ISR+SEO work (flagged as F2 during the Phase 3 SEO audit). During an FMP (asset-info API) outage, the first request to any **uncached** `[symbol]` ticker returned **HTTP 500**.

### Root cause
`getAssetInfoResilient` (used only by the 6 `[symbol]` ISR routes + their `generateMetadata`) caught FMP infra failures and called `await connection()` to opt the degraded render out of the ISR cache so a transient failure would not be cached for 1h (PR #545's intent). But `connection()` inside an ISR route's on-demand **cold-generation** throws `DYNAMIC_SERVER_USAGE` (an ISR route cannot be dynamically rendered per-request) → the cold-gen crashes with 500.

**Timeline:** `connection()` (PR #545, 06-02 03:17) was added *after* ISR was declared (PR #543, 06-01 21:47) but while ISR was still broken (every route DSU-bailing), so the incompatibility was masked. The Phase 0–2 ISR fix made ISR actually work and exposed the 500.

### Fix
Remove `connection()` + its now-unused import. The degrade fallback (`{symbol, name: ticker}`, `degraded:true`) returns without throwing → cold-gen completes → **200 instead of 500**. The degrade page is ISR-cached but **noindex** (each route's `generateMetadata` returns `robots:{index:false,follow:false}` when `degraded`), so no SEO harm, and it self-heals on the next revalidate (≤1h) or on-demand invalidation. The "degrade caches noindex ≤1h" tradeoff strictly beats a 500; per-render dynamic escape is structurally impossible for ISR routes (the only API for it — `connection()` — is what throws). The DSU-rethrow branch (Next control-flow signal) is unchanged.

### Verification
- Experiment (prod build + curl): uncached ticker **500 → 200**, runtime `DYNAMIC_SERVER_USAGE = 0`, `/AAPL` unaffected (200)
- lint clean · vitest 4710 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)