### PR TITLE
fix([symbol]): pre-deploy hardening — error boundary + resilient fundamental + canonical

### DIFF
--- a/src/app/[symbol]/__tests__/error.test.tsx
+++ b/src/app/[symbol]/__tests__/error.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SymbolError from '../error';
+
+describe('SymbolError ([symbol] subtree error boundary)', () => {
+    const error = Object.assign(new Error('boom'), { digest: 'deadbeef' });
+
+    it('renders exactly one h1 (single-h1 contract is preserved even on error)', () => {
+        const { container } = render(
+            <SymbolError error={error} reset={vi.fn()} />
+        );
+        expect(container.querySelectorAll('h1')).toHaveLength(1);
+    });
+
+    it('wires the retry button to reset()', () => {
+        const reset = vi.fn();
+        render(<SymbolError error={error} reset={reset} />);
+
+        screen.getByRole('button', { name: '다시 시도' }).click();
+
+        expect(reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('offers a working home link', () => {
+        render(<SymbolError error={error} reset={vi.fn()} />);
+
+        expect(screen.getByRole('link', { name: /홈으로/ })).toHaveAttribute(
+            'href',
+            '/'
+        );
+    });
+
+    it('logs the error (with its digest) for server-side correlation', () => {
+        const errorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined);
+
+        render(<SymbolError error={error} reset={vi.fn()} />);
+
+        expect(errorSpy).toHaveBeenCalledWith(
+            '[SymbolRoute] render error:',
+            error
+        );
+        errorSpy.mockRestore();
+    });
+});

--- a/src/app/[symbol]/__tests__/page.factlayer.test.tsx
+++ b/src/app/[symbol]/__tests__/page.factlayer.test.tsx
@@ -62,7 +62,9 @@ vi.mock('@/shared/config/queryConfig', () => ({
     },
     QUERY_STALE_TIME_MS: 5000,
 }));
-vi.mock('@/shared/lib/seo', () => ({
+vi.mock('@/shared/lib/seo', async importOriginal => ({
+    // 실제 seo를 스프레드해 NOINDEX_SYMBOL_METADATA 등 정적 export를 가져온다(drift 방지).
+    ...(await importOriginal<typeof import('@/shared/lib/seo')>()),
     buildBreadcrumbJsonLd: vi.fn().mockReturnValue({}),
     buildSymbolSeoContent: vi.fn().mockReturnValue({
         title: 'AAPL 차트',

--- a/src/app/[symbol]/__tests__/page.test.ts
+++ b/src/app/[symbol]/__tests__/page.test.ts
@@ -37,7 +37,10 @@ vi.mock('@/shared/config/queryConfig', () => ({
     },
     QUERY_STALE_TIME_MS: 5000,
 }));
-vi.mock('@/shared/lib/seo', () => ({
+vi.mock('@/shared/lib/seo', async importOriginal => ({
+    // 실제 seo 모듈을 스프레드해 NOINDEX_SYMBOL_METADATA 같은 정적 export를 그대로
+    // 가져온다(상수 인라인 복제 → drift 방지). 빌더만 아래에서 결정적으로 오버라이드한다.
+    ...(await importOriginal<typeof import('@/shared/lib/seo')>()),
     buildBreadcrumbJsonLd: vi.fn().mockReturnValue({}),
     buildSymbolSeoContent: vi.fn().mockReturnValue({
         title: 'AAPL 차트',

--- a/src/app/[symbol]/__tests__/symbol-metadata.test.ts
+++ b/src/app/[symbol]/__tests__/symbol-metadata.test.ts
@@ -115,12 +115,20 @@ vi.mock('@/shared/lib/dateKey', () => ({
     todayKstIsoDate: vi.fn(() => '2026-05-21'),
 }));
 
-const { mockGetAssetInfoResilient } = vi.hoisted(() => ({
-    mockGetAssetInfoResilient: vi.fn(),
-}));
+const { mockGetAssetInfoResilient, mockGetProfileResilient } = vi.hoisted(
+    () => ({
+        mockGetAssetInfoResilient: vi.fn(),
+        mockGetProfileResilient: vi.fn(),
+    })
+);
 
 vi.mock('@/entities/ticker', () => ({
     getAssetInfoResilient: mockGetAssetInfoResilient,
+}));
+
+// fundamental generateMetadata는 noindex 게이트로 getProfileResilient를 호출한다.
+vi.mock('@/app/[symbol]/fundamental/getProfileResilient', () => ({
+    getProfileResilient: mockGetProfileResilient,
 }));
 
 // react.cache는 Node 환경에서 identity wrapper로 대체
@@ -195,6 +203,11 @@ describe('generateMetadata — canonical URL 회귀 가드', () => {
         // assetInfo null 반환 → ticker fallback 경로 검증
         mockGetAssetInfoResilient.mockResolvedValue({
             assetInfo: null,
+            degraded: false,
+        });
+        // fundamental의 noindex 게이트 기본값: profile 존재 + 비-degraded(정상 happy-path).
+        mockGetProfileResilient.mockResolvedValue({
+            profile: { symbol: 'AAPL' },
             degraded: false,
         });
     });
@@ -388,7 +401,36 @@ describe('generateMetadata — canonical URL 회귀 가드', () => {
                     index: false,
                     follow: false,
                 });
+                // M1: degraded/invalid noindex는 루트 레이아웃의 home canonical을
+                // 상속하지 않는다(canonical: null로 omit).
+                expect(metadata.alternates?.canonical).toBeNull();
             }
         );
+    });
+
+    describe('fundamental — profile 인프라 실패/부재 시 noindex (본문 결과와 일치)', () => {
+        it('profile degraded(FMP 인프라 실패) → noindex + canonical null', async () => {
+            mockGetProfileResilient.mockResolvedValue({
+                profile: null,
+                degraded: true,
+            });
+            const metadata = await generateFundamentalMetadata(
+                makeParams('aapl')
+            );
+            expect(metadata.robots).toEqual({ index: false, follow: false });
+            expect(metadata.alternates?.canonical).toBeNull();
+        });
+
+        it('profile null(실존하지 않는 종목) → noindex (본문 notFound와 짝)', async () => {
+            mockGetProfileResilient.mockResolvedValue({
+                profile: null,
+                degraded: false,
+            });
+            const metadata = await generateFundamentalMetadata(
+                makeParams('aapl')
+            );
+            expect(metadata.robots).toEqual({ index: false, follow: false });
+            expect(metadata.alternates?.canonical).toBeNull();
+        });
     });
 });

--- a/src/app/[symbol]/error.tsx
+++ b/src/app/[symbol]/error.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { SITE_NAME } from '@/shared/lib/seo';
+
+interface SymbolErrorProps {
+    error: Error & { digest?: string };
+    reset: () => void;
+}
+
+/**
+ * Error boundary for the whole `[symbol]` subtree (chart / fundamental / news /
+ * options / fear-greed / overall).
+ *
+ * These routes fan out to external providers (FMP / Yahoo / LLM). Most call
+ * sites degrade gracefully, but any uncaught throw during render — e.g. an FMP
+ * infra failure on a cold ISR cache — would otherwise surface as a bare 500.
+ * This boundary contains that into a branded, retryable UI. `reset()` re-renders
+ * the segment (a fresh attempt, which on transient outages will often succeed).
+ */
+export default function SymbolError({ error, reset }: SymbolErrorProps) {
+    useEffect(() => {
+        // `digest` ties this client log to the server-side error entry.
+        console.error('[SymbolRoute] render error:', error);
+    }, [error]);
+
+    return (
+        <main className="flex flex-1 flex-col items-center px-6 py-20 text-center">
+            <p className="text-primary-400 font-mono text-sm tracking-widest">
+                일시 오류
+            </p>
+            <h1 className="text-secondary-100 mt-4 text-2xl font-bold sm:text-3xl">
+                데이터를 불러오지 못했어요
+            </h1>
+            <p className="text-secondary-400 mt-3 max-w-md text-sm leading-relaxed">
+                외부 데이터 제공처가 일시적으로 응답하지 않을 수 있어요. 잠시 후
+                다시 시도해 주세요.
+            </p>
+            <div className="mt-8 flex gap-3">
+                <button
+                    type="button"
+                    onClick={reset}
+                    className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-950 inline-flex min-h-11 items-center rounded-lg px-6 text-sm font-medium text-white transition-colors focus-visible:ring-1 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                    다시 시도
+                </button>
+                <Link
+                    href="/"
+                    className="text-secondary-200 hover:text-secondary-50 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-950 inline-flex min-h-11 items-center rounded-lg px-6 text-sm font-medium transition-colors focus-visible:ring-1 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                    {SITE_NAME} 홈으로
+                </Link>
+            </div>
+        </main>
+    );
+}

--- a/src/app/[symbol]/fear-greed/page.tsx
+++ b/src/app/[symbol]/fear-greed/page.tsx
@@ -19,6 +19,7 @@ import {
     buildBreadcrumbJsonLd,
     buildSymbolFearGreedSeoContent,
     buildSymbolSeoContent,
+    NOINDEX_SYMBOL_METADATA,
     SITE_NAME,
     SITE_URL,
 } from '@/shared/lib/seo';
@@ -50,11 +51,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const ticker = symbol.toUpperCase();
     // 본문 notFound()와 일관: 잘못된 ticker는 메타데이터를 비우고 noindex로 응답한다.
     if (!VALID_TICKER_RE.test(ticker)) {
-        return { robots: { index: false, follow: false } };
+        return NOINDEX_SYMBOL_METADATA;
     }
     const { assetInfo, degraded } = await getAssetInfoResilient(ticker);
     if (degraded) {
-        return { robots: { index: false, follow: false } };
+        return NOINDEX_SYMBOL_METADATA;
     }
     const displayName = assetInfo
         ? buildDisplayName(assetInfo, ticker)

--- a/src/app/[symbol]/fundamental/FundamentalDegraded.tsx
+++ b/src/app/[symbol]/fundamental/FundamentalDegraded.tsx
@@ -1,0 +1,40 @@
+import { CrossLinkCards, SymbolPageHeading } from '@/widgets/symbol-page';
+
+interface FundamentalDegradedProps {
+    /** Resolved display name (Korean+English+ticker, or bare-ticker fallback). */
+    displayName: string;
+    symbol: string;
+}
+
+/**
+ * Rendered when the FMP company profile is temporarily unavailable (infra
+ * failure) on the fundamental route.
+ *
+ * `getProfileResilient` reports `degraded` and `generateMetadata` responds
+ * noindex, so this is a soft, non-indexed 200 — never a 500. It keeps exactly
+ * one `<h1>` (SEO) and the cross-route links, so the visitor can still reach the
+ * other tabs while the data provider recovers (the next ISR revalidate /
+ * on-demand invalidation restores the real content automatically).
+ */
+export function FundamentalDegraded({
+    displayName,
+    symbol,
+}: FundamentalDegradedProps) {
+    return (
+        <main className="mx-auto max-w-5xl space-y-6 px-4 py-8">
+            <SymbolPageHeading>
+                {displayName} 재무지표와 애널리스트 의견
+            </SymbolPageHeading>
+            <section className="border-secondary-800 bg-secondary-900/40 rounded-lg border px-5 py-8 text-center">
+                <p className="text-secondary-200 text-sm font-medium">
+                    재무 데이터를 일시적으로 불러올 수 없어요
+                </p>
+                <p className="text-secondary-400 mt-2 text-sm leading-relaxed">
+                    외부 데이터 제공처가 잠시 응답하지 않고 있어요. 잠시 후 다시
+                    방문하시면 PER·ROE·애널리스트 컨센서스를 보실 수 있습니다.
+                </p>
+            </section>
+            <CrossLinkCards symbol={symbol} current="fundamental" />
+        </main>
+    );
+}

--- a/src/app/[symbol]/fundamental/__tests__/FundamentalDegraded.test.tsx
+++ b/src/app/[symbol]/fundamental/__tests__/FundamentalDegraded.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import { FundamentalDegraded } from '../FundamentalDegraded';
+
+vi.mock('@/widgets/symbol-page', () => ({
+    SymbolPageHeading: ({ children }: { children: ReactNode }) => (
+        <h1>{children}</h1>
+    ),
+    CrossLinkCards: ({
+        symbol,
+        current,
+    }: {
+        symbol: string;
+        current: string;
+    }) => (
+        <div
+            data-testid="cross-links"
+            data-symbol={symbol}
+            data-current={current}
+        />
+    ),
+}));
+
+describe('FundamentalDegraded', () => {
+    it('renders exactly one h1 carrying the display name (single-h1 SEO contract)', () => {
+        const { container } = render(
+            <FundamentalDegraded displayName="애플 (AAPL)" symbol="AAPL" />
+        );
+
+        const h1s = container.querySelectorAll('h1');
+        expect(h1s).toHaveLength(1);
+        expect(h1s[0].textContent).toContain('애플 (AAPL)');
+    });
+
+    it('shows the temporary-unavailable notice', () => {
+        render(<FundamentalDegraded displayName="AAPL" symbol="AAPL" />);
+
+        expect(
+            screen.getByText(/일시적으로 불러올 수 없어요/)
+        ).toBeInTheDocument();
+    });
+
+    it('keeps the cross-route links so the visitor can still reach other tabs', () => {
+        render(<FundamentalDegraded displayName="AAPL" symbol="TSLA" />);
+
+        const links = screen.getByTestId('cross-links');
+        expect(links).toHaveAttribute('data-symbol', 'TSLA');
+        expect(links).toHaveAttribute('data-current', 'fundamental');
+    });
+});

--- a/src/app/[symbol]/fundamental/__tests__/getProfileResilient.test.ts
+++ b/src/app/[symbol]/fundamental/__tests__/getProfileResilient.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { FundamentalProfile } from '@y0ngha/siglens-core';
+import { getProfileResilient } from '../getProfileResilient';
+import { staticSymbolCache } from '@/shared/cache/staticSymbolCache';
+
+// getProfileResilient wraps staticSymbolCache(getProfile); mock the cache to
+// drive the three outcomes (profile / null / throw) without FMP or Redis.
+vi.mock('@/shared/cache/staticSymbolCache', () => ({
+    staticSymbolCache: vi.fn(),
+}));
+// fundamentalData pulls in the DB client + FMP provider; stub it so the import
+// graph stays light (the fetcher closure is never invoked under the cache mock).
+vi.mock('../fundamentalData', () => ({ getProfile: vi.fn() }));
+
+const mockCache = vi.mocked(staticSymbolCache);
+
+describe('getProfileResilient', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('passes a resolved profile through (degraded: false)', async () => {
+        const profile = {
+            symbol: 'AAPL',
+            sector: 'Technology',
+        } as unknown as FundamentalProfile;
+        mockCache.mockResolvedValue(profile);
+
+        expect(await getProfileResilient('AAPL')).toEqual({
+            profile,
+            degraded: false,
+        });
+    });
+
+    it('passes null (non-existent ticker) through (degraded: false) so the caller can notFound()', async () => {
+        mockCache.mockResolvedValue(null);
+
+        expect(await getProfileResilient('ZZZZ')).toEqual({
+            profile: null,
+            degraded: false,
+        });
+    });
+
+    it('rethrows DYNAMIC_SERVER_USAGE (Next.js control-flow signal, not an infra failure)', async () => {
+        const dynamicErr = Object.assign(new Error('Dynamic server usage'), {
+            digest: 'DYNAMIC_SERVER_USAGE',
+        });
+        mockCache.mockRejectedValue(dynamicErr);
+
+        await expect(getProfileResilient('AAPL')).rejects.toBe(dynamicErr);
+    });
+
+    it('on FMP infra throw → { profile: null, degraded: true } (no throw → 200 noindex, never 500)', async () => {
+        const errorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined);
+        mockCache.mockRejectedValue(new Error('[fmpGet] profile HTTP 429'));
+
+        expect(await getProfileResilient('AAPL')).toEqual({
+            profile: null,
+            degraded: true,
+        });
+        expect(errorSpy).toHaveBeenCalledWith(
+            '[getProfileResilient] FMP profile infra failure, degrading:',
+            expect.any(Error)
+        );
+        errorSpy.mockRestore();
+    });
+});

--- a/src/app/[symbol]/fundamental/getProfileResilient.ts
+++ b/src/app/[symbol]/fundamental/getProfileResilient.ts
@@ -1,0 +1,52 @@
+import type { FundamentalProfile } from '@y0ngha/siglens-core';
+import { staticSymbolCache } from '@/shared/cache/staticSymbolCache';
+import { isDynamicServerError } from '@/shared/lib/isDynamicServerError';
+import { getProfile } from './fundamentalData';
+
+export interface ResilientProfile {
+    /**
+     * FMP company profile, or null when the ticker genuinely has no profile
+     * (FMP 200 + empty → non-existent ticker → caller `notFound()`).
+     */
+    profile: FundamentalProfile | null;
+    /**
+     * true = FMP infra failure (`getProfile` threw, NOT a null result). The
+     * fundamental page body needs the profile to render, so on infra failure the
+     * caller renders a degraded notice (a 200, not a 500) and `generateMetadata`
+     * responds noindex — mirroring `getAssetInfoResilient`'s degrade policy. The
+     * next revalidate/on-demand invalidation recovers automatically once FMP is
+     * back. A degraded-200(noindex) beats both a hard 500 and a transient 404.
+     */
+    degraded: boolean;
+}
+
+/**
+ * Graceful wrapper around the ISR-static `getProfile` fetch. `getProfile` ends
+ * three ways: a profile (render), `null` (non-existent → notFound), or a throw
+ * (FMP infra failure / DSU control-flow).
+ *
+ * The cache call is byte-identical to the one `ProfileSection` issues
+ * (`['fundamental:profile', upper]`), so both share one `unstable_cache` entry
+ * (and `getProfile`'s React `cache()` dedups within a request) — wrapping it
+ * here adds no extra FMP round-trip.
+ */
+export async function getProfileResilient(
+    upper: string
+): Promise<ResilientProfile> {
+    try {
+        const profile = await staticSymbolCache(
+            ['fundamental:profile', upper],
+            upper,
+            () => getProfile(upper)
+        );
+        return { profile, degraded: false };
+    } catch (e) {
+        // Next's static/ISR control-flow error must propagate untouched.
+        if (isDynamicServerError(e)) throw e;
+        console.error(
+            '[getProfileResilient] FMP profile infra failure, degrading:',
+            e
+        );
+        return { profile: null, degraded: true };
+    }
+}

--- a/src/app/[symbol]/fundamental/page.tsx
+++ b/src/app/[symbol]/fundamental/page.tsx
@@ -37,9 +37,12 @@ import {
     buildBreadcrumbJsonLd,
     buildSymbolFundamentalSeoContent,
     buildSymbolSeoContent,
+    NOINDEX_SYMBOL_METADATA,
     SITE_NAME,
     SITE_URL,
 } from '@/shared/lib/seo';
+import { getProfileResilient } from './getProfileResilient';
+import { FundamentalDegraded } from './FundamentalDegraded';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
@@ -65,17 +68,26 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const upper = symbol.toUpperCase();
     // 본문 notFound()와 일관: 잘못된 ticker는 메타데이터를 비우고 noindex로 응답한다.
     if (!VALID_TICKER_RE.test(upper)) {
-        return { robots: { index: false, follow: false } };
+        return NOINDEX_SYMBOL_METADATA;
     }
     const { assetInfo, degraded } = await getAssetInfoResilient(upper);
     if (degraded) {
-        return { robots: { index: false, follow: false } };
+        return NOINDEX_SYMBOL_METADATA;
+    }
+    // 펀더멘털 페이지는 FMP profile이 있어야 렌더된다. profile을 본문/ProfileSection과
+    // 동일한 정적 캐시 키로 미리 확인한다(같은 요청 내 React.cache + unstable_cache 공유라
+    // 추가 FMP round-trip 없음). 그래서 본문 렌더 결과와 metadata noindex 판단이 일치한다:
+    //   - profileDegraded(FMP 인프라 실패) → 본문은 degrade(200)를 렌더하므로 noindex.
+    //   - profile === null(실존하지 않는 종목) → 본문은 notFound()이므로 noindex.
+    const { profile, degraded: profileDegraded } =
+        await getProfileResilient(upper);
+    if (profileDegraded || profile === null) {
+        return NOINDEX_SYMBOL_METADATA;
     }
     const displayName = assetInfo ? buildDisplayName(assetInfo, upper) : upper;
-    // sector는 의도적으로 generateMetadata에서 사용하지 않는다. sector는 FMP getProfile 응답에만 있고
-    // generateMetadata에서 별도 fetch하면 페이지 본문과 합쳐 round-trip이 두 배가 된다(SEO 메타에 sector 한 줄 더
-    // 넣는 비용이 비대칭으로 큼). 결과적으로 <meta description>은 sector 없는 base 카피, 페이지 본문 JSON-LD는
-    // sector 보강 카피라는 차이가 있지만, 두 description 모두 동일 함수에서 파생되므로 핵심 의미는 일치한다.
+    // sector는 의도적으로 <meta description>에 쓰지 않는다(description은 sector 없는 base
+    // 카피, 페이지 본문 JSON-LD만 sector 보강 카피). 위 profile 조회는 noindex 게이트 용도이며
+    // 두 description 모두 동일 함수에서 파생되므로 핵심 의미는 일치한다.
     const { title, fullTitle, description, url, keywords } =
         buildSymbolFundamentalSeoContent(upper, {
             displayName,
@@ -316,13 +328,21 @@ export default async function FundamentalPage({ params }: Props) {
 
     // notFound guard + sector resolution을 위해 profile을 먼저 가져온다.
     // assetInfo는 한국어 종목명을 displayName에 합치기 위해 병렬로 가져온다.
-    // ['fundamental:profile', upper] 키를 ProfileSection과 공유 → cross-request ISR 캐시 공유.
-    const [profile, { assetInfo }] = await Promise.all([
-        staticSymbolCache(['fundamental:profile', upper], upper, () =>
-            getProfile(upper)
-        ),
-        getAssetInfoResilient(upper),
-    ]);
+    // getProfileResilient는 ['fundamental:profile', upper] 키를 ProfileSection과 공유한다
+    // → cross-request ISR 캐시 + 같은 요청 React.cache 공유(추가 FMP round-trip 없음).
+    const [{ profile, degraded: profileDegraded }, { assetInfo }] =
+        await Promise.all([
+            getProfileResilient(upper),
+            getAssetInfoResilient(upper),
+        ]);
+    const displayName = assetInfo ? buildDisplayName(assetInfo, upper) : upper;
+    // FMP 인프라 일시 실패: 500 대신 degrade 안내(200)를 렌더한다. generateMetadata가
+    // 동일 조건을 noindex 처리하므로 이 thin 페이지는 색인되지 않고, 다음 revalidate에
+    // 인프라가 복구되면 정상 데이터로 자동 갱신된다.
+    if (profileDegraded) {
+        return <FundamentalDegraded displayName={displayName} symbol={upper} />;
+    }
+    // profile === null = FMP 200 + 빈 결과 = 실존하지 않는 종목 → 404.
     if (profile === null) {
         notFound();
     }
@@ -331,7 +351,6 @@ export default async function FundamentalPage({ params }: Props) {
     // 않은 종목도 PER/ROE/애널리스트 컨센서스를 보여줄 수 있어야 한다. 따라서 news/overall과 달리
     // assetInfo null을 notFound()로 막지 않고 ticker fallback을 허용한다 (generateMetadata와 동일 패턴).
     const sector = profile.sector ?? '';
-    const displayName = assetInfo ? buildDisplayName(assetInfo, upper) : upper;
     const { fullTitle, description, url } = buildSymbolFundamentalSeoContent(
         upper,
         {

--- a/src/app/[symbol]/news/page.tsx
+++ b/src/app/[symbol]/news/page.tsx
@@ -26,6 +26,7 @@ import {
     buildBreadcrumbJsonLd,
     buildSymbolNewsSeoContent,
     buildSymbolSeoContent,
+    NOINDEX_SYMBOL_METADATA,
     SITE_NAME,
     SITE_URL,
 } from '@/shared/lib/seo';
@@ -54,11 +55,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const upper = symbol.toUpperCase();
     // 본문 notFound()와 일관: 잘못된 ticker는 메타데이터를 비우고 noindex로 응답한다.
     if (!VALID_TICKER_RE.test(upper)) {
-        return { robots: { index: false, follow: false } };
+        return NOINDEX_SYMBOL_METADATA;
     }
     const { assetInfo, degraded } = await getAssetInfoResilient(upper);
     if (degraded) {
-        return { robots: { index: false, follow: false } };
+        return NOINDEX_SYMBOL_METADATA;
     }
     const displayName = assetInfo ? buildDisplayName(assetInfo, upper) : upper;
     const { title, fullTitle, description, url, keywords } =

--- a/src/app/[symbol]/options/page.tsx
+++ b/src/app/[symbol]/options/page.tsx
@@ -19,6 +19,7 @@ import {
     buildBreadcrumbJsonLd,
     buildSymbolOptionsSeoContent,
     buildSymbolSeoContent,
+    NOINDEX_SYMBOL_METADATA,
     SITE_NAME,
     SITE_URL,
 } from '@/shared/lib/seo';
@@ -50,16 +51,28 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const upper = symbol.toUpperCase();
     // 본문 notFound()와 일관: 잘못된 ticker는 메타데이터를 비우고 noindex로 응답한다.
     if (!VALID_TICKER_RE.test(upper)) {
-        return { robots: { index: false, follow: false } };
+        return NOINDEX_SYMBOL_METADATA;
     }
     const [{ assetInfo, degraded }, hasOptions] = await Promise.all([
         getAssetInfoResilient(upper),
+        // hasOptionsMarket는 Yahoo 인프라 실패 시 throw한다. getAssetInfoResilient와
+        // 함께 Promise.all로 묶여 있어, 여기서 흡수하지 않으면 throw가 degraded 조기 반환
+        // 전에 Promise.all을 reject시켜 generateMetadata가 ISR cold-gen에서 500을 낸다.
+        // 옵션 시장 여부를 모르면 false(노출 안 함)로 degrade → noindex로 안전하게 처리한다.
+        // (이 fetch는 staticSymbolCache로 감싸져 DSU를 throw하지 않고, DSU가 발생하더라도
+        // 같은 Promise.all의 getAssetInfoResilient가 rethrow하므로 제어 흐름은 보존된다.)
         staticSymbolCache(['options:has', upper], upper, () =>
             hasOptionsMarket(upper)
-        ),
+        ).catch((e: unknown) => {
+            console.error(
+                '[generateMetadata:options] hasOptionsMarket infra failure, degrading to false:',
+                e
+            );
+            return false;
+        }),
     ]);
     if (degraded) {
-        return { robots: { index: false, follow: false } };
+        return NOINDEX_SYMBOL_METADATA;
     }
     const displayName = assetInfo ? buildDisplayName(assetInfo, upper) : upper;
     const { title, fullTitle, description, url, keywords } =

--- a/src/app/[symbol]/overall/__tests__/page.factlayer.test.tsx
+++ b/src/app/[symbol]/overall/__tests__/page.factlayer.test.tsx
@@ -36,7 +36,9 @@ vi.mock('@/entities/ticker', () => ({
         degraded: false,
     }),
 }));
-vi.mock('@/shared/lib/seo', () => ({
+vi.mock('@/shared/lib/seo', async importOriginal => ({
+    // 실제 seo를 스프레드해 NOINDEX_SYMBOL_METADATA 등 정적 export를 가져온다(drift 방지).
+    ...(await importOriginal<typeof import('@/shared/lib/seo')>()),
     buildBreadcrumbJsonLd: vi.fn().mockReturnValue({}),
     buildSymbolSeoContent: vi
         .fn()

--- a/src/app/[symbol]/overall/__tests__/page.test.ts
+++ b/src/app/[symbol]/overall/__tests__/page.test.ts
@@ -24,7 +24,9 @@ vi.mock('@/entities/ticker', () => ({
     buildDisplayName: vi.fn().mockReturnValue('Apple Inc.'),
     getAssetInfoResilient: vi.fn(),
 }));
-vi.mock('@/shared/lib/seo', () => ({
+vi.mock('@/shared/lib/seo', async importOriginal => ({
+    // 실제 seo를 스프레드해 NOINDEX_SYMBOL_METADATA 등 정적 export를 가져온다(drift 방지).
+    ...(await importOriginal<typeof import('@/shared/lib/seo')>()),
     buildBreadcrumbJsonLd: vi.fn().mockReturnValue({}),
     buildSymbolSeoContent: vi
         .fn()

--- a/src/app/[symbol]/overall/page.tsx
+++ b/src/app/[symbol]/overall/page.tsx
@@ -17,6 +17,7 @@ import {
     buildBreadcrumbJsonLd,
     buildSymbolOverallSeoContent,
     buildSymbolSeoContent,
+    NOINDEX_SYMBOL_METADATA,
     SITE_NAME,
     SITE_URL,
 } from '@/shared/lib/seo';
@@ -49,11 +50,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const upper = symbol.toUpperCase();
     // 본문 notFound()와 일관: 잘못된 ticker는 메타데이터를 비우고 noindex로 응답한다.
     if (!VALID_TICKER_RE.test(upper)) {
-        return { robots: { index: false, follow: false } };
+        return NOINDEX_SYMBOL_METADATA;
     }
     const { assetInfo, degraded } = await getAssetInfoResilient(upper);
     if (degraded) {
-        return { robots: { index: false, follow: false } };
+        return NOINDEX_SYMBOL_METADATA;
     }
     const displayName = assetInfo ? buildDisplayName(assetInfo, upper) : upper;
     const { title, fullTitle, description, url, keywords } =

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -25,6 +25,7 @@ import {
     buildSymbolSeoContent,
     SITE_NAME,
     SITE_URL,
+    NOINDEX_SYMBOL_METADATA,
 } from '@/shared/lib/seo';
 import {
     dehydrate,
@@ -53,11 +54,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const ticker = symbol.toUpperCase();
     // 본문 notFound()와 일관: 잘못된 ticker는 메타데이터를 비우고 noindex로 응답한다.
     if (!VALID_TICKER_RE.test(ticker)) {
-        return { robots: { index: false, follow: false } };
+        return NOINDEX_SYMBOL_METADATA;
     }
     const { assetInfo, degraded } = await getAssetInfoResilient(ticker);
     if (degraded) {
-        return { robots: { index: false, follow: false } };
+        return NOINDEX_SYMBOL_METADATA;
     }
     const displayName = assetInfo
         ? buildDisplayName(assetInfo, ticker)

--- a/src/entities/ticker/lib/getAssetInfoResilient.ts
+++ b/src/entities/ticker/lib/getAssetInfoResilient.ts
@@ -1,4 +1,5 @@
 import type { AssetInfo } from '@/shared/lib/types';
+import { isDynamicServerError } from '@/shared/lib/isDynamicServerError';
 import { getAssetInfoStatic } from './getAssetInfoStatic';
 
 export interface ResilientAssetInfo {
@@ -49,16 +50,7 @@ export async function getAssetInfoResilient(
         // Next.js가 static generation / ISR 중 dynamic API를 만나면 DynamicServerError를
         // 제어 흐름 수단으로 throw한다. 이를 인프라 실패로 오인하면 불필요한 에러 로그가
         // 남고 fallback degrade 응답이 반환된다. 제어 흐름 에러는 그대로 rethrow한다.
-        if (
-            e instanceof Error &&
-            // e가 Error인 것은 위에서 확인됨; Next.js DynamicServerError는 digest 필드를 추가하므로
-            // unknown → { digest? } 캐스팅은 안전 — digest가 없으면 undefined → 비교 false.
-            // message.includes(부분 일치, === 아님)는 의도적이다: DynamicServerError 메시지는
-            // "Dynamic server usage: Route ... couldn't be rendered statically ..." 처럼 가변 접미부를
-            // 가져 정확 일치(===)로는 매치되지 않는다. digest(1차 검출)가 빠진 케이스용 방어적 폴백이다.
-            ((e as { digest?: string }).digest === 'DYNAMIC_SERVER_USAGE' ||
-                e.message.includes('Dynamic server usage'))
-        ) {
+        if (isDynamicServerError(e)) {
             throw e;
         }
         console.error(

--- a/src/shared/lib/__tests__/isDynamicServerError.test.ts
+++ b/src/shared/lib/__tests__/isDynamicServerError.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { isDynamicServerError } from '@/shared/lib/isDynamicServerError';
+
+describe('isDynamicServerError', () => {
+    it('true when digest === DYNAMIC_SERVER_USAGE', () => {
+        const e = Object.assign(new Error('anything'), {
+            digest: 'DYNAMIC_SERVER_USAGE',
+        });
+        expect(isDynamicServerError(e)).toBe(true);
+    });
+
+    it('true when the message carries "Dynamic server usage" (digest absent)', () => {
+        const e = new Error(
+            "Dynamic server usage: Route /AAPL couldn't be rendered statically"
+        );
+        expect(isDynamicServerError(e)).toBe(true);
+    });
+
+    it('false for an unrelated infra Error', () => {
+        expect(isDynamicServerError(new Error('FMP request timed out'))).toBe(
+            false
+        );
+    });
+
+    it('false for an Error with a different digest and unrelated message', () => {
+        const e = Object.assign(new Error('not found'), {
+            digest: 'NEXT_NOT_FOUND',
+        });
+        expect(isDynamicServerError(e)).toBe(false);
+    });
+
+    it('false for non-Error values, even if they look like the signal', () => {
+        expect(isDynamicServerError('Dynamic server usage')).toBe(false);
+        expect(isDynamicServerError({ digest: 'DYNAMIC_SERVER_USAGE' })).toBe(
+            false
+        );
+        expect(isDynamicServerError(null)).toBe(false);
+        expect(isDynamicServerError(undefined)).toBe(false);
+    });
+});

--- a/src/shared/lib/isDynamicServerError.ts
+++ b/src/shared/lib/isDynamicServerError.ts
@@ -1,0 +1,26 @@
+/**
+ * Detect Next.js's `DYNAMIC_SERVER_USAGE` control-flow error.
+ *
+ * Next throws a `DynamicServerError` (as a control-flow signal, NOT a real
+ * failure) when a dynamic API runs during static / ISR generation. Resilient
+ * data wrappers must RETHROW it untouched — swallowing it as an "infra failure"
+ * would both log noise and wrongly degrade a render that Next intended to bail
+ * out of.
+ *
+ * Detection is two-pronged because the error shape isn't fully stable:
+ *  - `digest === 'DYNAMIC_SERVER_USAGE'` is the primary, exact signal Next sets.
+ *  - `message.includes('Dynamic server usage')` is a defensive fallback for
+ *    cases where `digest` is absent. It is a SUBSTRING check on purpose — the
+ *    message carries a variable suffix ("Route … couldn't be rendered
+ *    statically …"), so an exact match would miss it.
+ */
+export function isDynamicServerError(e: unknown): boolean {
+    return (
+        e instanceof Error &&
+        // `e` is confirmed an Error above; Next's DynamicServerError adds a
+        // `digest` field, so the `unknown → { digest? }` read is safe (a missing
+        // digest is `undefined`, which fails the comparison).
+        ((e as { digest?: string }).digest === 'DYNAMIC_SERVER_USAGE' ||
+            e.message.includes('Dynamic server usage'))
+    );
+}

--- a/src/shared/lib/seo.ts
+++ b/src/shared/lib/seo.ts
@@ -1,3 +1,5 @@
+import type { Metadata } from 'next';
+
 export interface BreadcrumbItem {
     name: string;
     url: string;
@@ -7,6 +9,20 @@ export const SITE_URL =
     process.env.NEXT_PUBLIC_SITE_URL ?? 'https://siglens.io';
 
 export const SITE_NAME = 'Siglens';
+
+/**
+ * Shared metadata for the noindex early-returns on the `[symbol]` routes
+ * (invalid ticker, infra-degraded asset, FMP-degraded profile).
+ *
+ * `canonical: null` is the important part: it OVERRIDES the root layout's
+ * `alternates.canonical: SITE_URL`, so a noindexed symbol page does not falsely
+ * advertise the homepage as its canonical. Without it these early-returns
+ * inherit the layout canonical (a wrong cross-page signal).
+ */
+export const NOINDEX_SYMBOL_METADATA: Metadata = {
+    robots: { index: false, follow: false },
+    alternates: { canonical: null },
+};
 
 // 빌드 시각 — 매 요청마다 변동되면 안 되는 schema.org datePublished 등에 사용.
 // NEXT_BUILD_DATE env가 있으면 우선, 없으면 모듈 로드 시각(deploy 시점)을 한 번만 캐시.


### PR DESCRIPTION
## What

Pre-deploy hardening for the `[symbol]` ISR routes, from the deployment audit. No new features — runtime-safety + SEO correctness.

### Runtime safety
- **`[symbol]/error.tsx`** (new) — a client error boundary for the whole `[symbol]` subtree. Any uncaught render throw (e.g. an FMP infra failure on a cold ISR cache) now renders a branded retry UI instead of a bare 500. Closes the "uncontained 500" class across all six routes.
- **Resilient fundamental** — `getProfileResilient` wraps the profile fetch (same cache key as `ProfileSection`, so no extra FMP round-trip). On an FMP infra throw the route renders `FundamentalDegraded` (a 200 + noindex) instead of a 500; a genuine `null` profile still `notFound()`s. `generateMetadata` gates noindex on the same `degraded || null` conditions, so metadata and body agree.
- **options `generateMetadata`** — the `hasOptionsMarket` fetch is now `.catch(() => false)`, so an options-infra throw degrades to noindex instead of rejecting the `Promise.all` (→ 500).

### SEO
- **`NOINDEX_SYMBOL_METADATA`** (`canonical: null`) replaces the bare `{ robots: noindex }` early-returns on every degraded/invalid branch, so a noindexed symbol page no longer inherits the root layout's home canonical.

### Refactor
- Extracted `isDynamicServerError` (shared) from `getAssetInfoResilient`; reused by `getProfileResilient`.

## Verification
- `tsc --noEmit` clean, `yarn lint` clean.
- **Full vitest suite passes: 634 files / 4745 tests** (3 new test files; `symbol-metadata` updated with a getProfileResilient mock, `canonical: null` guards, and fundamental profileDegraded/null → noindex; 4 seo test mocks switched to `importOriginal` to re-export the real `NOINDEX_SYMBOL_METADATA`).
- Full prod build + curl/Chrome verification is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)