### PR TITLE
fix([symbol]): remove duplicate ticker in fear-greed / chart headings

### DIFF
--- a/src/app/[symbol]/fear-greed/page.tsx
+++ b/src/app/[symbol]/fear-greed/page.tsx
@@ -142,7 +142,7 @@ export default async function SymbolFearGreedPage({ params }: Props) {
                 name: `${displayName} 공포 탐욕 지수는 무엇을 측정하나요?`,
                 acceptedAnswer: {
                     '@type': 'Answer',
-                    text: `${displayName}(${ticker}) 한 종목의 단기 매매 심리를 0~100 점수로 측정합니다. CNN의 시장 전체 Fear & Greed Index와 달리 종목별 자체 분포(self-normalization)로 산출하므로, 다른 종목과 점수를 직접 비교하기보다는 같은 종목의 시간 흐름 변화를 보는 데 적합합니다.`,
+                    text: `${displayName} 한 종목의 단기 매매 심리를 0~100 점수로 측정합니다. CNN의 시장 전체 Fear & Greed Index와 달리 종목별 자체 분포(self-normalization)로 산출하므로, 다른 종목과 점수를 직접 비교하기보다는 같은 종목의 시간 흐름 변화를 보는 데 적합합니다.`,
                 },
             },
             {
@@ -188,7 +188,7 @@ export default async function SymbolFearGreedPage({ params }: Props) {
             <JsonLd data={faqJsonLd} />
             <main className="mx-auto max-w-5xl space-y-6 px-4 py-8">
                 <SymbolPageHeading>
-                    {displayName} ({ticker}) 공포 탐욕 지수와 단기 매수 분위기
+                    {displayName} 공포 탐욕 지수와 단기 매수 분위기
                 </SymbolPageHeading>
                 <section className="sr-only">
                     <h2>{displayName} 공포 탐욕 지수 개요</h2>
@@ -210,11 +210,11 @@ export default async function SymbolFearGreedPage({ params }: Props) {
                         {displayName} 공포 탐욕 지수는 어떻게 봐야 할까
                     </h2>
                     <p className="text-secondary-400 text-sm leading-relaxed">
-                        {displayName}({ticker}) 한 종목의 단기 매매 심리를 0~100
-                        점수로 나타냅니다. CNN의 시장 전체 Fear &amp; Greed
-                        Index가 여러 자산을 합쳐 시장 감정을 보여 준다면, 이
-                        페이지는 한 종목의 거래량 흐름과 체결 흐름, 가격 위치를
-                        그 종목의 자체 분포 안에서 환산해 점수로 만듭니다.
+                        {displayName} 한 종목의 단기 매매 심리를 0~100 점수로
+                        나타냅니다. CNN의 시장 전체 Fear &amp; Greed Index가
+                        여러 자산을 합쳐 시장 감정을 보여 준다면, 이 페이지는 한
+                        종목의 거래량 흐름과 체결 흐름, 가격 위치를 그 종목의
+                        자체 분포 안에서 환산해 점수로 만듭니다.
                     </p>
                     <p className="text-secondary-400 text-sm leading-relaxed">
                         Volume z-score, Buy/Sell volume 불균형, Volume Profile

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -254,8 +254,8 @@ export default async function SymbolPage({ params }: Props) {
                         (WCAG 1.3.1). 보조 설명은 heading 없이 p로만 노출한다. */}
                     <p>{displayName} 차트 분석 개요</p>
                     <p>
-                        {displayName}({ticker})의 기술적 분석 페이지입니다.
-                        보조지표 {skillCounts.indicators}종, 캔들 패턴{' '}
+                        {displayName}의 기술적 분석 페이지입니다. 보조지표{' '}
+                        {skillCounts.indicators}종, 캔들 패턴{' '}
                         {skillCounts.candlesticks}종, 차트 패턴{' '}
                         {skillCounts.patterns}종을 활용해 추세, 진입 구간,
                         지지선과 저항선을 분석합니다.


### PR DESCRIPTION
## What

A pre-deploy Chrome verification caught the fear-greed page rendering the ticker **twice** in its h1:

> 애플, Apple Inc. (AAPL) **(AAPL)** 공포 탐욕 지수와 단기 매수 분위기

`displayName` (from `buildDisplayName`) already encodes the ticker — either parenthesized (`애플, Apple Inc. (AAPL)`) or as the bare-ticker fallback — yet the text appended ` (${ticker})` again.

## Fix

Remove the redundant `(${ticker})` after `displayName` in 4 spots:
- **`fear-greed/page.tsx`** — the visible `<h1>`, the FAQ JSON-LD answer text, and the visible guide paragraph.
- **`[symbol]/page.tsx`** — the chart route's `sr-only` description paragraph (the same redundancy, screen-reader-only).

The other four `[symbol]` routes never had this pattern. This was **pre-existing** (identical in v0.15.0) — not a regression introduced by the recent ISR work — but clearly unintended, so it's cleaned up here. `ticker` remains used elsewhere in both files (metadata, breadcrumb, prefetch).

## Verification
- `tsc --noEmit` clean, `yarn lint` clean.
- Full vitest suite passes (635 files / 4749 tests).
- `e2e/specs/symbol-tabs.spec.ts` asserts the heading via the partial regex `/공포 탐욕 지수와 단기 매수 분위기/`, which still matches.
- review-agent (Opus 4.8) approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)