### PR TITLE
fix: symbol metadata inconsistency (soft-404 missing noindex)

### DIFF
--- a/src/app/[symbol]/__tests__/symbol-metadata.test.ts
+++ b/src/app/[symbol]/__tests__/symbol-metadata.test.ts
@@ -124,6 +124,14 @@ const { mockGetAssetInfoResilient, mockGetProfileResilient } = vi.hoisted(
 
 vi.mock('@/entities/ticker', () => ({
     getAssetInfoResilient: mockGetAssetInfoResilient,
+    // assetInfo가 존재하는 happy-path에서 generateMetadata가 호출한다. canonical은
+    // ticker(params) 기반이라 displayName 정확도는 회귀 검증과 무관 — 간단 stub으로 충분.
+    buildDisplayName: (
+        info: { name?: string; koreanName?: string } | null,
+        ticker: string
+    ) => info?.koreanName ?? info?.name ?? ticker,
+    // page.tsx 본문이 import(generateMetadata 경로에선 미사용)하므로 stub만 제공.
+    buildAssetAboutNode: vi.fn(() => undefined),
 }));
 
 // fundamental generateMetadata는 noindex 게이트로 getProfileResilient를 호출한다.
@@ -200,9 +208,12 @@ function makeParamsWithSearch(
 describe('generateMetadata — canonical URL 회귀 가드', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        // assetInfo null 반환 → ticker fallback 경로 검증
+        // happy-path 기본값: 실존하는 종목(assetInfo 존재, 비-degraded).
+        // canonical은 ticker(params) 기반이라 assetInfo 유무와 무관하므로,
+        // 회귀 가드(플레이스홀더 누출)에는 generic assetInfo로 충분하다.
+        // 실존하지 않는 ticker(assetInfo: null) 경로는 아래 별도 describe에서 검증.
         mockGetAssetInfoResilient.mockResolvedValue({
-            assetInfo: null,
+            assetInfo: { symbol: 'AAPL', name: 'Apple Inc.' },
             degraded: false,
         });
         // fundamental의 noindex 게이트 기본값: profile 존재 + 비-degraded(정상 happy-path).
@@ -340,8 +351,8 @@ describe('generateMetadata — canonical URL 회귀 가드', () => {
     });
 
     describe('variant noindex 제거 — clean canonical 통합', () => {
-        // 최상위 beforeEach가 assetInfo=null로 설정 → buildDisplayName 미호출
-        // (ticker fallback). variant noindex 제거 검증에는 assetInfo 유무가 무관하다.
+        // 최상위 beforeEach가 실존 종목(assetInfo 존재)으로 설정 → 정상 index 메타데이터.
+        // variant noindex 제거 검증에는 tf searchParam이 robots를 바꾸지 않음만 보면 된다.
         it('overall: tf variant여도 noindex 없음, canonical은 clean', async () => {
             const metadata = await generateOverallMetadata(
                 makeParamsWithSearch('aapl', { tf: '1Hour' })
@@ -403,6 +414,61 @@ describe('generateMetadata — canonical URL 회귀 가드', () => {
                 });
                 // M1: degraded/invalid noindex는 루트 레이아웃의 home canonical을
                 // 상속하지 않는다(canonical: null로 omit).
+                expect(metadata.alternates?.canonical).toBeNull();
+            }
+        );
+    });
+
+    describe('실존하지 않는 ticker (assetInfo null) — noindex 전 라우트', () => {
+        /**
+         * 형식은 유효하나 FMP에 실재하지 않는 ticker는 getAssetInfoResilient가
+         * { assetInfo: null, degraded: false }를 반환한다. 본문은 `if (!assetInfo)
+         * notFound()`로 404/not-found(noindex)를 렌더하므로, generateMetadata도 noindex +
+         * canonical null로 맞춰야 한다. 가드가 없으면 한 페이지에 robots index(메타)와
+         * noindex(not-found)가 충돌하고 존재하지 않는 URL을 canonical로 자기참조하는
+         * soft-404가 발생한다 (실측: HTTP 200 + robots ['index, follow', 'noindex']).
+         *
+         * fundamental은 제외 — 실재성 게이트가 assetInfo가 아닌 getProfileResilient의
+         * profile===null이며, 아래 별도 describe에서 검증한다.
+         */
+        const nonExistentCases = [
+            {
+                name: '[symbol] 루트',
+                fn: () => generateSymbolMetadata(makeParamsWithSearch('zzzq')),
+            },
+            {
+                name: 'news',
+                fn: () => generateNewsMetadata(makeParams('zzzq')),
+            },
+            {
+                name: 'options',
+                fn: () => generateOptionsMetadata(makeParams('zzzq')),
+            },
+            {
+                name: 'fear-greed',
+                fn: () => generateFearGreedMetadata(makeParams('zzzq')),
+            },
+            {
+                name: 'overall',
+                fn: () => generateOverallMetadata(makeParamsWithSearch('zzzq')),
+            },
+        ] as const;
+
+        beforeEach(() => {
+            mockGetAssetInfoResilient.mockResolvedValue({
+                assetInfo: null,
+                degraded: false,
+            });
+        });
+
+        it.each(nonExistentCases)(
+            '$name — assetInfo null 시 noindex + canonical null',
+            async ({ fn }) => {
+                const metadata = await fn();
+                expect(metadata.robots).toEqual({
+                    index: false,
+                    follow: false,
+                });
                 expect(metadata.alternates?.canonical).toBeNull();
             }
         );

--- a/src/app/[symbol]/fear-greed/page.tsx
+++ b/src/app/[symbol]/fear-greed/page.tsx
@@ -57,13 +57,17 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (degraded) {
         return NOINDEX_SYMBOL_METADATA;
     }
-    const displayName = assetInfo
-        ? buildDisplayName(assetInfo, ticker)
-        : ticker;
+    // 본문 `if (!assetInfo) notFound()`와 일관: 실재하지 않는 ticker(assetInfo: null,
+    // degraded: false)는 메타데이터도 noindex로 맞춘다. 가드가 없으면 본문 not-found(noindex)와
+    // 메타데이터 index가 충돌하는 soft-404가 만들어진다.
+    if (!assetInfo) {
+        return NOINDEX_SYMBOL_METADATA;
+    }
+    const displayName = buildDisplayName(assetInfo, ticker);
     const { title, fullTitle, description, url, keywords } =
         buildSymbolFearGreedSeoContent(ticker, {
             displayName,
-            koreanName: assetInfo?.koreanName,
+            koreanName: assetInfo.koreanName,
         });
     return {
         title,

--- a/src/app/[symbol]/news/page.tsx
+++ b/src/app/[symbol]/news/page.tsx
@@ -61,11 +61,17 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (degraded) {
         return NOINDEX_SYMBOL_METADATA;
     }
-    const displayName = assetInfo ? buildDisplayName(assetInfo, upper) : upper;
+    // 본문 `if (!assetInfo) notFound()`와 일관: 실재하지 않는 ticker(assetInfo: null,
+    // degraded: false)는 메타데이터도 noindex로 맞춘다. 가드가 없으면 본문 not-found(noindex)와
+    // 메타데이터 index가 충돌하는 soft-404가 만들어진다.
+    if (!assetInfo) {
+        return NOINDEX_SYMBOL_METADATA;
+    }
+    const displayName = buildDisplayName(assetInfo, upper);
     const { title, fullTitle, description, url, keywords } =
         buildSymbolNewsSeoContent(upper, {
             displayName,
-            koreanName: assetInfo?.koreanName,
+            koreanName: assetInfo.koreanName,
         });
 
     return {
@@ -297,7 +303,7 @@ export default async function NewsPage({ params }: Props) {
                     <Suspense fallback={<NewsAiSummarySkeleton />}>
                         <NewsAiSummary
                             symbol={upper}
-                            companyName={assetInfo?.name ?? upper}
+                            companyName={assetInfo.name}
                             hasEnrichedNews={hasEnrichedNews}
                         />
                     </Suspense>

--- a/src/app/[symbol]/options/page.tsx
+++ b/src/app/[symbol]/options/page.tsx
@@ -74,11 +74,17 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (degraded) {
         return NOINDEX_SYMBOL_METADATA;
     }
-    const displayName = assetInfo ? buildDisplayName(assetInfo, upper) : upper;
+    // 본문 `if (!assetInfo) notFound()`와 일관: 실재하지 않는 ticker(assetInfo: null,
+    // degraded: false)는 메타데이터도 noindex로 맞춘다. 가드가 없으면 본문 not-found(noindex)와
+    // 메타데이터 index가 충돌하는 soft-404가 만들어진다.
+    if (!assetInfo) {
+        return NOINDEX_SYMBOL_METADATA;
+    }
+    const displayName = buildDisplayName(assetInfo, upper);
     const { title, fullTitle, description, url, keywords } =
         buildSymbolOptionsSeoContent(upper, {
             displayName,
-            koreanName: assetInfo?.koreanName,
+            koreanName: assetInfo.koreanName,
             hasOptions,
         });
     return {

--- a/src/app/[symbol]/overall/page.tsx
+++ b/src/app/[symbol]/overall/page.tsx
@@ -56,11 +56,17 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (degraded) {
         return NOINDEX_SYMBOL_METADATA;
     }
-    const displayName = assetInfo ? buildDisplayName(assetInfo, upper) : upper;
+    // 본문 `if (!assetInfo) notFound()`와 일관: 실재하지 않는 ticker(assetInfo: null,
+    // degraded: false)는 메타데이터도 noindex로 맞춘다. 가드가 없으면 본문 not-found(noindex)와
+    // 메타데이터 index가 충돌하는 soft-404가 만들어진다.
+    if (!assetInfo) {
+        return NOINDEX_SYMBOL_METADATA;
+    }
+    const displayName = buildDisplayName(assetInfo, upper);
     const { title, fullTitle, description, url, keywords } =
         buildSymbolOverallSeoContent(upper, {
             displayName,
-            koreanName: assetInfo?.koreanName,
+            koreanName: assetInfo.koreanName,
         });
 
     return {

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -60,13 +60,19 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (degraded) {
         return NOINDEX_SYMBOL_METADATA;
     }
-    const displayName = assetInfo
-        ? buildDisplayName(assetInfo, ticker)
-        : ticker;
+    // 본문 `if (!assetInfo) notFound()`와 일관: 형식은 유효하나 실재하지 않는 ticker
+    // (FMP 빈 결과 → assetInfo: null, degraded: false)는 메타데이터도 noindex로 맞춘다.
+    // 이 가드가 없으면 본문은 not-found(noindex)를 렌더하는데 메타데이터는 index,follow +
+    // canonical을 생성해, 한 페이지에 robots 태그가 충돌(index + noindex)하고 존재하지 않는
+    // URL을 canonical로 자기참조하는 soft-404가 만들어진다.
+    if (!assetInfo) {
+        return NOINDEX_SYMBOL_METADATA;
+    }
+    const displayName = buildDisplayName(assetInfo, ticker);
     const { title, fullTitle, description, url, keywords } =
         buildSymbolSeoContent(ticker, {
             displayName,
-            koreanName: assetInfo?.koreanName,
+            koreanName: assetInfo.koreanName,
         });
 
     return {


### PR DESCRIPTION
## 관련 이슈

Fixes production soft-404 SEO defect.

## 구현 내용

Syntactically-valid but non-existent tickers (e.g. ZZZQ) were returning HTTP 200 with **conflicting robots meta** — `index,follow` (from generateMetadata) AND `noindex` (from the not-found boundary) on the same page — plus a self-referencing canonical to a non-existent URL.

**Root cause**: each `[symbol]` route's `generateMetadata` only returned NOINDEX for the `degraded` (infra failure) branch. The `assetInfo === null` case (valid ticker format but FMP returns empty = ticker doesn't exist, `degraded: false`) fell through to normal `index,follow` + canonical metadata, while the page body's `if (!assetInfo) notFound()` rendered the noindex not-found UI — creating an inconsistent state.

**Fix**:
- Added `if (!assetInfo) return NOINDEX_SYMBOL_METADATA;` after the degraded guard in 5 routes: page.tsx (chart), news, fear-greed, overall, options
- Simplified displayName/koreanName access since assetInfo is now non-null past the guard
- fundamental/page.tsx intentionally unchanged — already gates on `getProfileResilient` profile===null
- news/page.tsx: also removed dead optional chaining (`assetInfo?.name ?? upper` → `assetInfo.name`) at the NewsAiSummary call site
- symbol-metadata.test.ts: updated the default mock from the buggy `{assetInfo: null}` to a valid assetInfo, added buildDisplayName/buildAssetAboutNode to the ticker mock, and added a worst-case describe asserting `assetInfo: null` → noindex + canonical null across the 5 routes

## 레이어 및 코드 품질 체크

- [x] @docs/CONVENTIONS.md 준수 확인
- [x] @docs/FF.md 준수 확인
- [x] @docs/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] 타입 안전성 검증 완료
- [x] 새 파일에 대응하는 테스트 파일 포함

## 변경 파일 목록

[수정]
- src/app/[symbol]/page.tsx (chart)
- src/app/[symbol]/news/page.tsx
- src/app/[symbol]/fear-greed/page.tsx
- src/app/[symbol]/overall/page.tsx
- src/app/[symbol]/options/page.tsx
- src/app/[symbol]/__tests__/symbol-metadata.test.ts

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test (134 passed)
- [x] yarn build
- [x] review-agent (Opus): approved round 2