### PR TITLE
feat(fmp): FMP 펀더멘털 Redis 캐싱 데코레이터 — 분석 경로 우회 제거 + 이중 fetch/포이즌 fix

### DIFF
--- a/docs/superpowers/plans/2026-06-04-fmp-fundamental-cache-adapter.md
+++ b/docs/superpowers/plans/2026-06-04-fmp-fundamental-cache-adapter.md
@@ -1,0 +1,1060 @@
+# FMP 펀더멘털 캐싱 데코레이터 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** FMP 펀더멘털 데이터의 Redis 캐싱을 분석 경로까지 통일하고(분석 경로의 Redis 우회 제거), key-metrics/ratios 이중 fetch를 제거하며, peer PER/PSR enrich를 통일한다.
+
+**Architecture:** `getFundamentalDataProvider()` 팩토리가 raw `FmpFundamentalClient`를 `CachedFundamentalProvider` 데코레이터로 감싸 반환한다. 데코레이터는 각 메서드를 `getOrSetCache`(기존 `fundamental:*` 키 / 1h)로 감싸므로, 페이지 SSR과 core 분석 경로가 동일 캐시를 공유한다. inner client는 km-ttm/r-ttm raw fetch를 공통 `getValuationRaw` 헬퍼(`React.cache` 메모이즈)로 합쳐 이중 fetch를 없앤다. core 코드 변경 없음.
+
+**Tech Stack:** TypeScript, Next.js 16 (RSC/Server Actions), `react` `cache()`, Upstash Redis (`getOrSetCache`), Vitest, `@y0ngha/siglens-core` (`FundamentalDataProvider` 포트).
+
+---
+
+## File Structure
+
+| 파일 | 책임 |
+|---|---|
+| `src/shared/api/fmp/fundamentalClient.ts` (수정) | inner client. km-ttm/r-ttm를 `getValuationRaw`로 합치고 `React.cache` 메모이즈 |
+| `src/shared/api/fmp/CachedFundamentalProvider.ts` (신규) | 캐싱 데코레이터. `FundamentalProvider` 구현, 메서드별 `getOrSetCache` + peer enrich |
+| `src/shared/api/fmp/getFundamentalDataProvider.ts` (수정) | prod에서 데코레이터 반환 (E2E Fake는 그대로) |
+| `src/app/[symbol]/fundamental/fundamentalData.ts` (수정) | `getOrSetCache`·enrich 제거, provider 위임 |
+| `src/app/[symbol]/news/newsData.ts` (수정) | `getGradeEvents`의 `getOrSetCache` 제거, provider 위임 |
+| `src/shared/api/fmp/__tests__/fundamentalClient.valuation.test.ts` (신규) | `getValuationRaw` + km/r 가공 + 이중 fetch 제거 |
+| `src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts` (신규) | 캐시 히트/미스, 키, enrich, pass-through, worst case |
+
+**테스트 커버리지 목표: 신규 파일 90% 이상** (`yarn test-coverage`로 측정).
+
+**E2E:** 신규 E2E 불필요 — 캐시 히트/미스는 단위 테스트로 정확히 검증 가능하고 E2E로는 관측이 어렵다. 기존 E2E 스위트(펀더멘털 페이지·분석)가 회귀 가드 역할을 한다. Task 8에서 기존 스위트 영향만 확인한다.
+
+---
+
+## 사전 참고 (구현 전 읽기)
+
+- `src/shared/cache/getOrSetCache.ts` — `getOrSetCache(key, ttlSeconds, fetcher, shouldCache?)`. 값은 `{ data }` envelope으로 저장, null/빈 배열도 캐싱, Redis 미설정/장애 시 `fetcher()` 직접 호출(graceful fallback).
+- `src/shared/api/fmp/fundamentalClient.ts` — `FMP_FUNDAMENTAL_REVALIDATE_SECONDS`(=3600), `getOptionalArray`, `FmpEarningsReportItem`.
+- `src/shared/api/fmp/getFundamentalDataProvider.ts` — `FundamentalProvider` 인터페이스(= 포트 + `getGrades` required + `getEarningsReports`).
+- `docs/SCOPE.md` — core의 분석 결과 캐시/Job 큐/쿨다운은 건드리지 않는다(이번 범위 밖).
+
+---
+
+## Task 1: inner client — `getValuationRaw`로 km/r 이중 fetch 제거
+
+`getKeyMetricsTtm`·`getRatiosTtm`가 각각 두 엔드포인트를 fetch하던 것을, 공통 `getValuationRaw`(React.cache 메모이즈) 하나로 합친다.
+
+**Files:**
+- Modify: `src/shared/api/fmp/fundamentalClient.ts`
+- Test: `src/shared/api/fmp/__tests__/fundamentalClient.valuation.test.ts`
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+Create `src/shared/api/fmp/__tests__/fundamentalClient.valuation.test.ts`:
+
+```typescript
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// React.cache를 동기 메모이즈 stub으로 대체 — 비-RSC(vitest) 컨텍스트에서도
+// same-request dedup을 검증하기 위함. 인스턴스별 격리는 각 it()에서 새 client로 보장.
+vi.mock('react', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('react')>();
+    return {
+        ...actual,
+        cache: <A extends unknown[], R>(fn: (...args: A) => R) => {
+            const store = new Map<string, R>();
+            return (...args: A): R => {
+                const key = JSON.stringify(args);
+                if (!store.has(key)) store.set(key, fn(...args));
+                return store.get(key) as R;
+            };
+        },
+    };
+});
+
+const fmpGet = vi.fn();
+vi.mock('@/shared/api/fmp/httpClient', () => ({
+    fmpGet: (...args: unknown[]) => fmpGet(...args),
+    FMP_STABLE_BASE: 'https://example.test/stable',
+}));
+
+import { FmpFundamentalClient } from '@/shared/api/fmp/fundamentalClient';
+
+beforeEach(() => {
+    fmpGet.mockReset();
+});
+
+describe('FmpFundamentalClient valuation fetch sharing', () => {
+    it('getKeyMetricsTtm + getRatiosTtm in same request fetch each endpoint once', async () => {
+        fmpGet.mockImplementation((path: string) => {
+            if (path === 'key-metrics-ttm')
+                return Promise.resolve([{ peRatioTTM: 10, returnOnEquityTTM: 0.2 }]);
+            if (path === 'ratios-ttm')
+                return Promise.resolve([{ priceToSalesRatioTTM: 3, netProfitMarginTTM: 0.15 }]);
+            return Promise.resolve([]);
+        });
+
+        const client = new FmpFundamentalClient();
+        const [km, ratios] = await Promise.all([
+            client.getKeyMetricsTtm('AAPL'),
+            client.getRatiosTtm('AAPL'),
+        ]);
+
+        expect(km?.peRatioTTM).toBe(10);
+        expect(km?.priceToSalesRatioTTM).toBe(3);
+        expect(ratios?.netProfitMarginTTM).toBe(0.15);
+
+        const kmCalls = fmpGet.mock.calls.filter(c => c[0] === 'key-metrics-ttm');
+        const rCalls = fmpGet.mock.calls.filter(c => c[0] === 'ratios-ttm');
+        expect(kmCalls).toHaveLength(1);
+        expect(rCalls).toHaveLength(1);
+    });
+
+    it('returns null when both endpoints are empty (worst case)', async () => {
+        fmpGet.mockResolvedValue([]);
+        const client = new FmpFundamentalClient();
+        expect(await client.getKeyMetricsTtm('ZZZZ')).toBeNull();
+        expect(await client.getRatiosTtm('ZZZZ')).toBeNull();
+    });
+
+    it('falls back to key-metrics fields when ratios endpoint is empty', async () => {
+        fmpGet.mockImplementation((path: string) =>
+            path === 'key-metrics-ttm'
+                ? Promise.resolve([{ peRatioTTM: 12, pbRatioTTM: 2, returnOnEquityTTM: 0.3 }])
+                : Promise.resolve([])
+        );
+        const client = new FmpFundamentalClient();
+        const km = await client.getKeyMetricsTtm('MSFT');
+        expect(km?.peRatioTTM).toBe(12);
+        expect(km?.pbRatioTTM).toBe(2);
+        const ratios = await client.getRatiosTtm('MSFT');
+        expect(ratios?.returnOnEquityTTM).toBe(0.3);
+    });
+});
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `yarn test src/shared/api/fmp/__tests__/fundamentalClient.valuation.test.ts`
+Expected: FAIL — 현재 `getKeyMetricsTtm`+`getRatiosTtm`가 km-ttm/r-ttm을 각 2회 fetch하므로 `kmCalls`/`rCalls` 길이가 2.
+
+- [ ] **Step 3: inner client 리팩토링**
+
+`src/shared/api/fmp/fundamentalClient.ts` 상단 import에 `react` cache 추가:
+
+```typescript
+import { cache } from 'react';
+```
+
+`FmpFundamentalClient` 클래스 안에 private 헬퍼를 추가하고 두 메서드를 이 헬퍼 기반으로 교체한다. 기존 `getKeyMetricsTtm`(현 :130-164)·`getRatiosTtm`(현 :167-195) 본문을 다음으로 대체:
+
+```typescript
+    /**
+     * key-metrics-ttm + ratios-ttm을 한 번에 fetch해 raw 쌍을 반환한다.
+     * `React.cache`로 요청 스코프 메모이즈하므로, 같은 요청에서 getKeyMetricsTtm과
+     * getRatiosTtm이 모두 호출돼도(분석 Promise.all) 각 엔드포인트 fetch는 1회로
+     * 수렴한다. 두 메서드가 서로의 필드를 fallback으로 쓰므로 raw 쌍을 공유한다.
+     */
+    private getValuationRaw = cache(
+        async (
+            symbol: string
+        ): Promise<{
+            metrics: RawFmpKeyMetricsTtm | null;
+            ratios: RawFmpRatiosTtm | null;
+        }> => {
+            const [arr, ratiosArr] = await Promise.all([
+                getOptionalArray<RawFmpKeyMetricsTtm>('key-metrics-ttm', {
+                    symbol,
+                }),
+                getOptionalArray<RawFmpRatiosTtm>('ratios-ttm', { symbol }),
+            ]);
+            return { metrics: arr[0] ?? null, ratios: ratiosArr[0] ?? null };
+        }
+    );
+
+    /** Fetch TTM key metrics (valuation multiples + EPS); returns `null` when unavailable. */
+    async getKeyMetricsTtm(
+        symbol: string
+    ): Promise<FundamentalValuationMetrics | null> {
+        const { metrics, ratios } = await this.getValuationRaw(symbol);
+        if (metrics === null && ratios === null) return null;
+        return {
+            peRatioTTM: toFiniteNumber(
+                ratios?.priceToEarningsRatioTTM ?? metrics?.peRatioTTM
+            ),
+            priceToSalesRatioTTM: toFiniteNumber(
+                ratios?.priceToSalesRatioTTM ?? metrics?.priceToSalesRatioTTM
+            ),
+            pbRatioTTM: toFiniteNumber(
+                ratios?.priceToBookRatioTTM ?? metrics?.pbRatioTTM
+            ),
+            pegRatioTTM: toFiniteNumber(
+                ratios?.priceToEarningsGrowthRatioTTM ?? metrics?.pegRatioTTM
+            ),
+            enterpriseValueOverEBITDATTM: toFiniteNumber(
+                metrics?.evToEBITDATTM ??
+                    ratios?.enterpriseValueMultipleTTM ??
+                    metrics?.enterpriseValueOverEBITDATTM
+            ),
+            epsTTM: toFiniteNumber(
+                ratios?.netIncomePerShareTTM ?? metrics?.epsTTM
+            ),
+        };
+    }
+
+    /** Fetch TTM profitability and financial health ratios; returns `null` when unavailable. */
+    async getRatiosTtm(symbol: string): Promise<FundamentalRatiosInput | null> {
+        const { metrics, ratios } = await this.getValuationRaw(symbol);
+        if (ratios === null && metrics === null) return null;
+        return {
+            returnOnEquityTTM: toFiniteNumber(
+                metrics?.returnOnEquityTTM ?? ratios?.returnOnEquityTTM
+            ),
+            returnOnAssetsTTM: toFiniteNumber(
+                metrics?.returnOnAssetsTTM ?? ratios?.returnOnAssetsTTM
+            ),
+            operatingProfitMarginTTM: toFiniteNumber(
+                ratios?.operatingProfitMarginTTM
+            ),
+            netProfitMarginTTM: toFiniteNumber(ratios?.netProfitMarginTTM),
+            debtRatioTTM: toFiniteNumber(
+                ratios?.debtToAssetsRatioTTM ?? ratios?.debtRatioTTM
+            ),
+            currentRatioTTM: toFiniteNumber(
+                ratios?.currentRatioTTM ?? metrics?.currentRatioTTM
+            ),
+        };
+    }
+```
+
+> 가공 로직(필드 매핑)은 기존과 동일하다 — fetch 구조만 `getValuationRaw`로 합쳤다. 기존 메서드의 `getOptionalArray` 두 호출은 제거된다.
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `yarn test src/shared/api/fmp/__tests__/fundamentalClient.valuation.test.ts`
+Expected: PASS (km/r 각 1회 fetch, null/ fallback 케이스 통과).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/api/fmp/fundamentalClient.ts src/shared/api/fmp/__tests__/fundamentalClient.valuation.test.ts
+git commit -m "refactor(fmp): share key-metrics/ratios raw fetch via getValuationRaw"
+```
+
+---
+
+## Task 2: `CachedFundamentalProvider` — 단순 캐싱 메서드
+
+1:1 캐싱 메서드들(profile, keyMetrics, ratios, cashFlow, growth, scores, estimates, grades, gradesConsensus, priceTargetConsensus, priceTargetSummary)을 먼저 구현한다. peer/sector/pass-through는 Task 3·4.
+
+**Files:**
+- Create: `src/shared/api/fmp/CachedFundamentalProvider.ts`
+- Test: `src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts`
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+Create `src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts`:
+
+```typescript
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('react')>();
+    return {
+        ...actual,
+        cache: <A extends unknown[], R>(fn: (...args: A) => R) => {
+            const store = new Map<string, R>();
+            return (...args: A): R => {
+                const key = JSON.stringify(args);
+                if (!store.has(key)) store.set(key, fn(...args));
+                return store.get(key) as R;
+            };
+        },
+    };
+});
+
+// 인메모리 fake Redis. envelope 포맷({data})을 그대로 저장/반환.
+const store = new Map<string, unknown>();
+const fakeRedis = {
+    get: vi.fn(async (key: string) => (store.has(key) ? store.get(key) : null)),
+    set: vi.fn(async (key: string, value: unknown) => {
+        store.set(key, value);
+    }),
+};
+let redisEnabled = true;
+vi.mock('@/shared/cache/redisClient', () => ({
+    getRedisClient: () => (redisEnabled ? fakeRedis : null),
+}));
+
+import { CachedFundamentalProvider } from '@/shared/api/fmp/CachedFundamentalProvider';
+import type { FundamentalProvider } from '@/shared/api/fmp/getFundamentalDataProvider';
+
+function makeInner(overrides: Partial<FundamentalProvider> = {}): FundamentalProvider {
+    return {
+        getProfile: vi.fn(async (s: string) => ({
+            symbol: s.toUpperCase(),
+            companyName: 'X',
+            sector: 'Tech',
+            industry: 'SW',
+            marketCap: 1e12,
+            ceo: 'A',
+            website: 'w',
+            description: 'd',
+        })),
+        getKeyMetricsTtm: vi.fn(async () => ({
+            peRatioTTM: 10,
+            priceToSalesRatioTTM: 3,
+            pbRatioTTM: null,
+            pegRatioTTM: null,
+            enterpriseValueOverEBITDATTM: null,
+            epsTTM: null,
+        })),
+        getRatiosTtm: vi.fn(async () => null),
+        getCashFlowStatement: vi.fn(async () => null),
+        getIncomeStatementGrowth: vi.fn(async () => null),
+        getFinancialScores: vi.fn(async () => null),
+        getStockPeers: vi.fn(async () => []),
+        getAnalystEstimates: vi.fn(async () => null),
+        getGrades: vi.fn(async () => []),
+        getGradesConsensus: vi.fn(async () => null),
+        getPriceTargetConsensus: vi.fn(async () => null),
+        getPriceTargetSummary: vi.fn(async () => null),
+        getSectorPerformanceSnapshot: vi.fn(async () => []),
+        getHistoricalSectorPerformance: vi.fn(async () => []),
+        getEarningsReport: vi.fn(async () => null),
+        getEarningsReports: vi.fn(async () => []),
+        ...overrides,
+    } as FundamentalProvider;
+}
+
+beforeEach(() => {
+    store.clear();
+    redisEnabled = true;
+    fakeRedis.get.mockClear();
+    fakeRedis.set.mockClear();
+});
+
+describe('CachedFundamentalProvider — simple cached methods', () => {
+    it('caches getProfile under fundamental:profile:<SYM> and uppercases symbol', async () => {
+        const inner = makeInner();
+        const provider = new CachedFundamentalProvider(inner);
+
+        const first = await provider.getProfile('aapl');
+        expect(first?.symbol).toBe('AAPL');
+        expect(inner.getProfile).toHaveBeenCalledTimes(1);
+        expect(store.has('fundamental:profile:AAPL')).toBe(true);
+
+        // 두 번째 호출: 캐시 히트 → inner 재호출 없음
+        const second = await provider.getProfile('aapl');
+        expect(second?.symbol).toBe('AAPL');
+        expect(inner.getProfile).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches null result (no-data ticker) so it is not refetched', async () => {
+        const inner = makeInner({ getCashFlowStatement: vi.fn(async () => null) });
+        const provider = new CachedFundamentalProvider(inner);
+
+        expect(await provider.getCashFlowStatement('NODATA')).toBeNull();
+        expect(await provider.getCashFlowStatement('NODATA')).toBeNull();
+        expect(inner.getCashFlowStatement).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches empty array result for getGrades', async () => {
+        const inner = makeInner({ getGrades: vi.fn(async () => []) });
+        const provider = new CachedFundamentalProvider(inner);
+
+        expect(await provider.getGrades('EMPTY')).toEqual([]);
+        expect(await provider.getGrades('EMPTY')).toEqual([]);
+        expect(inner.getGrades).toHaveBeenCalledTimes(1);
+        expect(store.has('fundamental:grades:EMPTY')).toBe(true);
+    });
+
+    it('propagates inner errors WITHOUT caching them (worst case)', async () => {
+        const boom = vi.fn(async () => {
+            throw new Error('FMP 502');
+        });
+        const inner = makeInner({ getFinancialScores: boom });
+        const provider = new CachedFundamentalProvider(inner);
+
+        await expect(provider.getFinancialScores('ERR')).rejects.toThrow('FMP 502');
+        expect(store.has('fundamental:scores:ERR')).toBe(false);
+        // 재시도 시 다시 inner 호출(에러가 캐싱되지 않음)
+        await expect(provider.getFinancialScores('ERR')).rejects.toThrow('FMP 502');
+        expect(boom).toHaveBeenCalledTimes(2);
+    });
+
+    it('falls back to inner when Redis is unavailable (worst case)', async () => {
+        redisEnabled = false;
+        const inner = makeInner();
+        const provider = new CachedFundamentalProvider(inner);
+
+        const profile = await provider.getProfile('TSLA');
+        expect(profile?.symbol).toBe('TSLA');
+        expect(inner.getProfile).toHaveBeenCalledTimes(1);
+        expect(store.size).toBe(0);
+    });
+});
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `yarn test src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts`
+Expected: FAIL — `CachedFundamentalProvider` 모듈이 없음.
+
+- [ ] **Step 3: 데코레이터 구현 (단순 메서드)**
+
+Create `src/shared/api/fmp/CachedFundamentalProvider.ts`:
+
+```typescript
+import 'server-only';
+import { cache } from 'react';
+import { getOrSetCache } from '@/shared/cache/getOrSetCache';
+import { FMP_FUNDAMENTAL_REVALIDATE_SECONDS } from './fundamentalClient';
+import type { FmpEarningsReportItem } from './fundamentalClient';
+import type { FundamentalProvider } from './getFundamentalDataProvider';
+import type {
+    EarningsReport,
+    FundamentalAnalystEstimateInput,
+    FundamentalCashFlowInput,
+    FundamentalFinancialScoresInput,
+    FundamentalGradesConsensusInput,
+    FundamentalGrowthInput,
+    FundamentalPeerInput,
+    FundamentalPriceTargetConsensusInput,
+    FundamentalPriceTargetSummaryInput,
+    FundamentalProfile,
+    FundamentalRatiosInput,
+    FundamentalSectorHistoricalInput,
+    FundamentalSectorPerformanceInput,
+    FundamentalValuationMetrics,
+    GradesEvent,
+} from '@y0ngha/siglens-core';
+
+const TTL = FMP_FUNDAMENTAL_REVALIDATE_SECONDS;
+const sym = (s: string): string => s.toUpperCase();
+
+/**
+ * `FundamentalProvider`를 감싸 메서드별 Redis 캐싱을 주입하는 데코레이터.
+ *
+ * 페이지 SSR(`fundamentalData.ts`)과 core 분석 경로(provider 주입)가 둘 다 이
+ * 데코레이터를 통과하므로 동일한 `fundamental:*` 캐시를 공유한다 — 한쪽이 워밍한
+ * 데이터를 다른 쪽이 재사용해 FMP 호출을 절감한다. 각 메서드는 `React.cache`로
+ * 요청 스코프 dedup + `getOrSetCache`로 cross-request 캐싱을 적용한다(`barsDataCache`와
+ * 동일 형태). 키/TTL은 기존 `fundamentalData.ts`·`newsData.ts` 스킴을 그대로 따른다.
+ *
+ * earnings(no-store + DB 영속)와 historical-sector(빈 stub)는 pass-through한다.
+ */
+export class CachedFundamentalProvider implements FundamentalProvider {
+    constructor(private readonly inner: FundamentalProvider) {}
+
+    getProfile = cache(
+        (symbol: string): Promise<FundamentalProfile | null> =>
+            getOrSetCache(`fundamental:profile:${sym(symbol)}`, TTL, () =>
+                this.inner.getProfile(symbol)
+            )
+    );
+
+    getKeyMetricsTtm = cache(
+        (symbol: string): Promise<FundamentalValuationMetrics | null> =>
+            getOrSetCache(`fundamental:key-metrics:${sym(symbol)}`, TTL, () =>
+                this.inner.getKeyMetricsTtm(symbol)
+            )
+    );
+
+    getRatiosTtm = cache(
+        (symbol: string): Promise<FundamentalRatiosInput | null> =>
+            getOrSetCache(`fundamental:ratios:${sym(symbol)}`, TTL, () =>
+                this.inner.getRatiosTtm(symbol)
+            )
+    );
+
+    getCashFlowStatement = cache(
+        (symbol: string): Promise<FundamentalCashFlowInput | null> =>
+            getOrSetCache(`fundamental:cash-flow:${sym(symbol)}`, TTL, () =>
+                this.inner.getCashFlowStatement(symbol)
+            )
+    );
+
+    getIncomeStatementGrowth = cache(
+        (symbol: string): Promise<FundamentalGrowthInput | null> =>
+            getOrSetCache(`fundamental:growth:${sym(symbol)}`, TTL, () =>
+                this.inner.getIncomeStatementGrowth(symbol)
+            )
+    );
+
+    getFinancialScores = cache(
+        (symbol: string): Promise<FundamentalFinancialScoresInput | null> =>
+            getOrSetCache(`fundamental:scores:${sym(symbol)}`, TTL, () =>
+                this.inner.getFinancialScores(symbol)
+            )
+    );
+
+    getAnalystEstimates = cache(
+        (symbol: string): Promise<FundamentalAnalystEstimateInput | null> =>
+            getOrSetCache(`fundamental:estimates:${sym(symbol)}`, TTL, () =>
+                this.inner.getAnalystEstimates(symbol)
+            )
+    );
+
+    getGrades = cache(
+        (symbol: string): Promise<GradesEvent[]> =>
+            getOrSetCache(`fundamental:grades:${sym(symbol)}`, TTL, () =>
+                this.inner.getGrades(symbol)
+            )
+    );
+
+    getGradesConsensus = cache(
+        (symbol: string): Promise<FundamentalGradesConsensusInput | null> =>
+            getOrSetCache(`fundamental:grades-consensus:${sym(symbol)}`, TTL, () =>
+                this.inner.getGradesConsensus(symbol)
+            )
+    );
+
+    getPriceTargetConsensus = cache(
+        (symbol: string): Promise<FundamentalPriceTargetConsensusInput | null> =>
+            getOrSetCache(
+                `fundamental:price-target-consensus:${sym(symbol)}`,
+                TTL,
+                () => this.inner.getPriceTargetConsensus(symbol)
+            )
+    );
+
+    getPriceTargetSummary = cache(
+        (symbol: string): Promise<FundamentalPriceTargetSummaryInput | null> =>
+            getOrSetCache(
+                `fundamental:price-target-summary:${sym(symbol)}`,
+                TTL,
+                () => this.inner.getPriceTargetSummary(symbol)
+            )
+    );
+
+    // --- Task 3에서 추가: getStockPeers ---
+    // --- Task 4에서 추가: getSectorPerformanceSnapshot + pass-through ---
+    getStockPeers = (symbol: string): Promise<FundamentalPeerInput[]> =>
+        this.inner.getStockPeers(symbol);
+
+    getSectorPerformanceSnapshot = (
+        date: string
+    ): Promise<FundamentalSectorPerformanceInput[]> =>
+        this.inner.getSectorPerformanceSnapshot(date);
+
+    getHistoricalSectorPerformance = (
+        sector: string
+    ): Promise<FundamentalSectorHistoricalInput[]> =>
+        this.inner.getHistoricalSectorPerformance(sector);
+
+    getEarningsReport = (symbol: string): Promise<EarningsReport | null> =>
+        this.inner.getEarningsReport(symbol);
+
+    getEarningsReports = (
+        symbol: string,
+        limit?: number
+    ): Promise<FmpEarningsReportItem[]> =>
+        this.inner.getEarningsReports(symbol, limit);
+}
+```
+
+> `getStockPeers`·`getSectorPerformanceSnapshot`는 Task 3·4에서 캐싱/enrich로 교체된다. 여기서는 컴파일을 위해 pass-through stub으로 둔다.
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `yarn test src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts`
+Expected: PASS (단순 캐싱 메서드 5개 테스트).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/api/fmp/CachedFundamentalProvider.ts src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
+git commit -m "feat(fmp): add CachedFundamentalProvider with per-method Redis caching"
+```
+
+---
+
+## Task 3: 데코레이터 `getStockPeers` — 캐싱 + per/psr enrich 통일
+
+raw peer 목록은 `fundamental:peers:<SYM>`에 캐싱하고, 각 peer를 캐싱된 `getKeyMetricsTtm`으로 enrich한다. (분석 경로의 peer PER/PSR 누락 정상화.)
+
+**Files:**
+- Modify: `src/shared/api/fmp/CachedFundamentalProvider.ts`
+- Test: `src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts`
+
+- [ ] **Step 1: 실패하는 테스트 추가**
+
+`CachedFundamentalProvider.test.ts`에 describe 블록 추가:
+
+```typescript
+describe('CachedFundamentalProvider — getStockPeers enrich', () => {
+    it('caches raw peers and enriches per/psr from getKeyMetricsTtm', async () => {
+        const inner = makeInner({
+            getStockPeers: vi.fn(async () => [
+                { symbol: 'MSFT', companyName: 'Microsoft', marketCap: 2e12 },
+                { symbol: 'GOOG', companyName: 'Alphabet', marketCap: 1.5e12 },
+            ]),
+            getKeyMetricsTtm: vi.fn(async (s: string) =>
+                s === 'MSFT'
+                    ? {
+                          peRatioTTM: 30,
+                          priceToSalesRatioTTM: 11,
+                          pbRatioTTM: null,
+                          pegRatioTTM: null,
+                          enterpriseValueOverEBITDATTM: null,
+                          epsTTM: null,
+                      }
+                    : null
+            ),
+        });
+        const provider = new CachedFundamentalProvider(inner);
+
+        const peers = await provider.getStockPeers('AAPL');
+
+        expect(peers).toEqual([
+            { symbol: 'MSFT', companyName: 'Microsoft', marketCap: 2e12, per: 30, psr: 11 },
+            { symbol: 'GOOG', companyName: 'Alphabet', marketCap: 1.5e12, per: null, psr: null },
+        ]);
+        expect(store.has('fundamental:peers:AAPL')).toBe(true);
+        // raw peer 목록 캐싱: 두 번째 호출 시 inner.getStockPeers 재호출 없음
+        await provider.getStockPeers('AAPL');
+        expect(inner.getStockPeers).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns empty array for a symbol with no peers (worst case)', async () => {
+        const inner = makeInner({ getStockPeers: vi.fn(async () => []) });
+        const provider = new CachedFundamentalProvider(inner);
+        expect(await provider.getStockPeers('NONE')).toEqual([]);
+    });
+});
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `yarn test src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts -t "getStockPeers"`
+Expected: FAIL — 현재 stub은 per/psr 없이 raw를 그대로 반환.
+
+- [ ] **Step 3: `getStockPeers` 구현**
+
+`CachedFundamentalProvider.ts`의 `getStockPeers` pass-through stub을 다음으로 교체:
+
+```typescript
+    /**
+     * raw peer 목록을 `fundamental:peers:<SYM>`에 캐싱한 뒤, 각 peer를 캐싱된
+     * `getKeyMetricsTtm`으로 enrich해 per/psr을 채운다. 페이지·분석이 동일한
+     * enrich된 peer를 받아 core 프롬프트의 PER/PSR이 정상 채워진다.
+     *
+     * enrich는 콜드 캐시 시 peer당 동시 FMP 요청 폭증(rate-limit)을 피하려 순차
+     * 실행한다 — warm 캐시에서는 getKeyMetricsTtm 히트로 비용이 낮다.
+     */
+    getStockPeers = cache(
+        async (symbol: string): Promise<FundamentalPeerInput[]> => {
+            const peers = await getOrSetCache(
+                `fundamental:peers:${sym(symbol)}`,
+                TTL,
+                () => this.inner.getStockPeers(symbol)
+            );
+            const enriched: FundamentalPeerInput[] = [];
+            for (const peer of peers) {
+                const metrics = await this.getKeyMetricsTtm(peer.symbol);
+                enriched.push({
+                    ...peer,
+                    per: metrics?.peRatioTTM ?? null,
+                    psr: metrics?.priceToSalesRatioTTM ?? null,
+                });
+            }
+            return enriched;
+        }
+    );
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `yarn test src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts -t "getStockPeers"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/api/fmp/CachedFundamentalProvider.ts src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
+git commit -m "feat(fmp): cache + enrich stock peers in decorator (fix analysis PER/PSR gap)"
+```
+
+---
+
+## Task 4: 데코레이터 sector-performance 캐싱 + pass-through 검증
+
+`getSectorPerformanceSnapshot`을 `fundamental:sector-performance:<DATE>` 키로 캐싱하고, earnings/historical pass-through(캐싱 안 함)를 테스트로 못 박는다.
+
+**Files:**
+- Modify: `src/shared/api/fmp/CachedFundamentalProvider.ts`
+- Test: `src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts`
+
+- [ ] **Step 1: 실패하는 테스트 추가**
+
+```typescript
+describe('CachedFundamentalProvider — sector + pass-through', () => {
+    it('caches sector performance under fundamental:sector-performance:<DATE>', async () => {
+        const inner = makeInner({
+            getSectorPerformanceSnapshot: vi.fn(async () => [
+                { sector: 'Technology', changesPercentage: 1.2 },
+            ]),
+        });
+        const provider = new CachedFundamentalProvider(inner);
+
+        const out = await provider.getSectorPerformanceSnapshot('2026-06-04');
+        expect(out).toEqual([{ sector: 'Technology', changesPercentage: 1.2 }]);
+        expect(store.has('fundamental:sector-performance:2026-06-04')).toBe(true);
+
+        await provider.getSectorPerformanceSnapshot('2026-06-04');
+        expect(inner.getSectorPerformanceSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT cache earnings (pass-through, fresh each call)', async () => {
+        const inner = makeInner({
+            getEarningsReports: vi.fn(async () => []),
+            getEarningsReport: vi.fn(async () => null),
+        });
+        const provider = new CachedFundamentalProvider(inner);
+
+        await provider.getEarningsReports('AAPL', 5);
+        await provider.getEarningsReports('AAPL', 5);
+        await provider.getEarningsReport('AAPL');
+        await provider.getEarningsReport('AAPL');
+
+        expect(inner.getEarningsReports).toHaveBeenCalledTimes(2);
+        expect(inner.getEarningsReport).toHaveBeenCalledTimes(2);
+        expect(store.size).toBe(0);
+    });
+
+    it('passes through historical sector performance without caching', async () => {
+        const inner = makeInner();
+        const provider = new CachedFundamentalProvider(inner);
+        expect(await provider.getHistoricalSectorPerformance('Technology')).toEqual([]);
+        expect(store.size).toBe(0);
+    });
+});
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `yarn test src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts -t "sector"`
+Expected: FAIL — sector pass-through stub은 캐싱하지 않아 `store.has(...)`가 false.
+
+- [ ] **Step 3: `getSectorPerformanceSnapshot` 캐싱 구현**
+
+`CachedFundamentalProvider.ts`의 `getSectorPerformanceSnapshot` stub을 교체:
+
+```typescript
+    /**
+     * 섹터 스냅샷은 날짜 단위 데이터이므로 키를 `<DATE>`로 잡는다(심볼 무관).
+     * 분석 경로에서만 호출되며 기존엔 무캐시였다 — 캐싱으로 분석마다의 FMP 호출을 막는다.
+     */
+    getSectorPerformanceSnapshot = cache(
+        (date: string): Promise<FundamentalSectorPerformanceInput[]> =>
+            getOrSetCache(`fundamental:sector-performance:${date}`, TTL, () =>
+                this.inner.getSectorPerformanceSnapshot(date)
+            )
+    );
+```
+
+(earnings/historical pass-through 메서드는 Task 2에서 이미 stub으로 구현됨 — 변경 없음.)
+
+- [ ] **Step 4: 전체 데코레이터 테스트 통과 확인**
+
+Run: `yarn test src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts`
+Expected: PASS (전체).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/api/fmp/CachedFundamentalProvider.ts src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
+git commit -m "feat(fmp): cache sector-performance snapshot, pass through earnings"
+```
+
+---
+
+## Task 5: 팩토리에서 데코레이터 반환
+
+`getFundamentalDataProvider()`가 prod에서 raw client를 데코레이터로 감싸 반환한다. E2E Fake는 그대로(캐싱 미적용).
+
+**Files:**
+- Modify: `src/shared/api/fmp/getFundamentalDataProvider.ts`
+- Test: `src/shared/api/fmp/__tests__/getFundamentalDataProvider.test.ts` (신규)
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+Create `src/shared/api/fmp/__tests__/getFundamentalDataProvider.test.ts`:
+
+```typescript
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/shared/api/e2eEnv', () => ({ isE2E: () => false }));
+
+afterEach(() => {
+    vi.resetModules();
+});
+
+describe('getFundamentalDataProvider (prod)', () => {
+    it('returns a CachedFundamentalProvider instance in prod', async () => {
+        const { getFundamentalDataProvider } = await import(
+            '@/shared/api/fmp/getFundamentalDataProvider'
+        );
+        const { CachedFundamentalProvider } = await import(
+            '@/shared/api/fmp/CachedFundamentalProvider'
+        );
+        expect(getFundamentalDataProvider()).toBeInstanceOf(CachedFundamentalProvider);
+    });
+
+    it('returns the same singleton across calls', async () => {
+        const { getFundamentalDataProvider } = await import(
+            '@/shared/api/fmp/getFundamentalDataProvider'
+        );
+        expect(getFundamentalDataProvider()).toBe(getFundamentalDataProvider());
+    });
+});
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `yarn test src/shared/api/fmp/__tests__/getFundamentalDataProvider.test.ts`
+Expected: FAIL — 현재 prod는 `FmpFundamentalClient`를 반환.
+
+- [ ] **Step 3: 팩토리 수정**
+
+`src/shared/api/fmp/getFundamentalDataProvider.ts`의 import와 prod 분기 수정:
+
+```typescript
+import { CachedFundamentalProvider } from './CachedFundamentalProvider';
+```
+
+`getFundamentalDataProvider`의 마지막 두 줄(현 :37-38)을 교체:
+
+```typescript
+    cached = new CachedFundamentalProvider(new FmpFundamentalClient());
+    return cached;
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `yarn test src/shared/api/fmp/__tests__/getFundamentalDataProvider.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/api/fmp/getFundamentalDataProvider.ts src/shared/api/fmp/__tests__/getFundamentalDataProvider.test.ts
+git commit -m "feat(fmp): wrap fundamental provider with cache decorator in factory"
+```
+
+---
+
+## Task 6: `fundamentalData.ts` 정리 — 중복 캐싱·enrich 제거
+
+데코레이터가 캐싱·enrich를 담당하므로, 페이지 데이터 파일의 `getOrSetCache` 래핑과 enrich 루프를 제거하고 provider 메서드 위임으로 축소한다. `getProfileDescriptionKo`의 DB 번역 로직은 유지.
+
+**Files:**
+- Modify: `src/app/[symbol]/fundamental/fundamentalData.ts`
+- Test: 기존 `fundamentalData` 관련 테스트가 있으면 갱신(없으면 Task 5/2~4 커버리지로 충분 — 신규 테스트 생략).
+
+- [ ] **Step 1: 파일 재작성**
+
+`src/app/[symbol]/fundamental/fundamentalData.ts`를 다음으로 교체(상단 주석은 캐싱 이관 사실을 반영):
+
+```typescript
+import { cache } from 'react';
+import { getDatabaseClient } from '@/shared/db/client';
+import {
+    DrizzleProfileDescriptionTranslationRepository,
+    translateCompanyDescription,
+} from '@/entities/ticker';
+import { getFundamentalDataProvider } from '@/shared/api/fmp/getFundamentalDataProvider';
+import type {
+    FundamentalProfile,
+    FundamentalPeerInput,
+    FundamentalValuationMetrics,
+    FundamentalRatiosInput,
+    FundamentalGrowthInput,
+    FundamentalFinancialScoresInput,
+    FundamentalCashFlowInput,
+    FundamentalAnalystEstimateInput,
+    FundamentalGradesConsensusInput,
+    FundamentalPriceTargetConsensusInput,
+    FundamentalPriceTargetSummaryInput,
+} from '@y0ngha/siglens-core';
+
+// Redis 캐싱(`fundamental:*` 키)·per/psr enrich는 CachedFundamentalProvider
+// (getFundamentalDataProvider가 반환)로 이관됐다. 페이지·core 분석 경로가 동일
+// provider를 통과해 같은 캐시를 공유한다. 이 파일은 provider 위임 + DB 번역
+// (getProfileDescriptionKo)만 담당한다.
+const fundamentalClient = getFundamentalDataProvider();
+
+export const getProfile = (
+    symbol: string
+): Promise<FundamentalProfile | null> => fundamentalClient.getProfile(symbol);
+
+export const getKeyMetricsTtm = (
+    symbol: string
+): Promise<FundamentalValuationMetrics | null> =>
+    fundamentalClient.getKeyMetricsTtm(symbol);
+
+export const getStockPeers = (
+    symbol: string
+): Promise<FundamentalPeerInput[]> => fundamentalClient.getStockPeers(symbol);
+
+export const getRatiosTtm = (
+    symbol: string
+): Promise<FundamentalRatiosInput | null> =>
+    fundamentalClient.getRatiosTtm(symbol);
+
+export const getIncomeStatementGrowth = (
+    symbol: string
+): Promise<FundamentalGrowthInput | null> =>
+    fundamentalClient.getIncomeStatementGrowth(symbol);
+
+export const getFinancialScores = (
+    symbol: string
+): Promise<FundamentalFinancialScoresInput | null> =>
+    fundamentalClient.getFinancialScores(symbol);
+
+export const getCashFlowStatement = (
+    symbol: string
+): Promise<FundamentalCashFlowInput | null> =>
+    fundamentalClient.getCashFlowStatement(symbol);
+
+export const getAnalystEstimates = (
+    symbol: string
+): Promise<FundamentalAnalystEstimateInput | null> =>
+    fundamentalClient.getAnalystEstimates(symbol);
+
+export const getGradesConsensus = (
+    symbol: string
+): Promise<FundamentalGradesConsensusInput | null> =>
+    fundamentalClient.getGradesConsensus(symbol);
+
+export const getPriceTargetConsensus = (
+    symbol: string
+): Promise<FundamentalPriceTargetConsensusInput | null> =>
+    fundamentalClient.getPriceTargetConsensus(symbol);
+
+export const getPriceTargetSummary = (
+    symbol: string
+): Promise<FundamentalPriceTargetSummaryInput | null> =>
+    fundamentalClient.getPriceTargetSummary(symbol);
+
+/**
+ * 회사 설명의 한국어 번역을 반환하고, 최초 호출 시 DB에 저장해 배포 간에도
+ * 유지한다. Read: DB 조회(히트 시 즉시). Write: Gemini 번역 → DB upsert(심볼당 최초 1회).
+ */
+export const getProfileDescriptionKo = cache(
+    async (symbol: string): Promise<string | null> => {
+        const { db } = getDatabaseClient();
+        const repo = new DrizzleProfileDescriptionTranslationRepository(db);
+
+        const existing = await repo.findBySymbol(symbol);
+        if (existing !== null) return existing.descriptionKo;
+
+        const profile = await getProfile(symbol);
+        if (profile === null || profile.description === null) return null;
+
+        const translated = await translateCompanyDescription(profile.description);
+        if (translated === null) return null;
+
+        await repo.upsert({ symbol, descriptionKo: translated });
+        return translated;
+    }
+);
+```
+
+> per-request dedup은 이제 데코레이터의 `cache()`가 담당하므로 이 파일의 export는 얇은 위임으로 충분하다. `getProfileDescriptionKo`만 자체 DB 로직이 있어 `cache()`를 유지한다.
+
+- [ ] **Step 2: 타입체크/테스트**
+
+Run: `yarn test src/app/[symbol]/fundamental/` (관련 테스트 있으면) 및 `yarn lint src/app/[symbol]/fundamental/fundamentalData.ts`
+Expected: PASS / lint 통과. (호출부 page.tsx의 시그니처는 동일하므로 변경 불필요.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/[symbol]/fundamental/fundamentalData.ts
+git commit -m "refactor(fundamental): delegate caching/enrich to CachedFundamentalProvider"
+```
+
+---
+
+## Task 7: `newsData.ts` 정리 — grades 중복 캐싱 제거
+
+`getGradeEvents`의 `getOrSetCache` 래핑을 제거하고 `provider.getGrades`(데코레이터 캐싱)에 위임한다. 페이지·뉴스가 동일 `fundamental:grades:*` 키를 공유한다.
+
+**Files:**
+- Modify: `src/app/[symbol]/news/newsData.ts`
+
+- [ ] **Step 1: import·getGradeEvents 수정**
+
+`src/app/[symbol]/news/newsData.ts`에서 `getOrSetCache` import와 `FMP_FUNDAMENTAL_REVALIDATE_SECONDS` import를 제거(다른 곳에서 안 쓰면). `getGradeEvents`(현 :39-46)를 교체:
+
+```typescript
+// 애널리스트 등급 이벤트는 CachedFundamentalProvider가 `fundamental:grades:*` 키로
+// 캐싱한다(페이지 fundamental 경로와 동일 키 공유). 빈 배열도 캐싱된다 — getGrades는
+// FMP 장애 시 throw하므로 빈 배열은 "등급 이벤트 없음"이라는 정상·안정 결과다.
+export const getGradeEvents = (symbol: string): Promise<GradesEvent[]> =>
+    fundamentalClient.getGrades(symbol);
+```
+
+import 정리:
+- 제거: `import { getOrSetCache } from '@/shared/cache/getOrSetCache';`
+- `FMP_FUNDAMENTAL_REVALIDATE_SECONDS`는 이 파일에서 더 이상 안 쓰이면 import에서 제거. (다른 사용처 확인: `EARNINGS_REPORT_STALE_MS` 등은 별개이므로 영향 없음.)
+- `import { cache } from 'react';`는 `getNewsList`가 계속 사용하므로 유지.
+
+- [ ] **Step 2: 타입체크/lint**
+
+Run: `yarn lint src/app/[symbol]/news/newsData.ts`
+Expected: 통과 (미사용 import 없음).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/[symbol]/news/newsData.ts
+git commit -m "refactor(news): delegate grades caching to CachedFundamentalProvider"
+```
+
+---
+
+## Task 8: 전체 검증 — 커버리지·빌드·lint·기존 테스트
+
+**Files:** 없음 (검증만)
+
+- [ ] **Step 1: 신규 파일 커버리지 확인 (≥90%)**
+
+Run: `yarn test-coverage src/shared/api/fmp/`
+Expected: `CachedFundamentalProvider.ts`, `fundamentalClient.ts`(valuation 부분) 라인/브랜치 커버리지 90% 이상. 미달 시 부족한 브랜치(예: enrich에서 metrics null, fallback 분기)를 커버하는 테스트를 추가한다.
+
+- [ ] **Step 2: 전체 테스트 스위트**
+
+Run: `yarn test`
+Expected: PASS (기존 테스트 회귀 없음).
+
+- [ ] **Step 3: Lint / 타입 / 빌드**
+
+Run: `yarn lint && yarn build`
+Expected: 통과. (`yarn build`는 exit code를 직접 확인 — `> /tmp/build.log 2>&1; echo $?`.)
+
+- [ ] **Step 4: 최종 커밋(필요 시)**
+
+커버리지 보강 테스트를 추가했다면:
+
+```bash
+git add -A
+git commit -m "test(fmp): raise CachedFundamentalProvider coverage to >=90%"
+```
+
+---
+
+## Self-Review 결과
+
+- **Spec 커버리지**: ① 분석 경로 Redis 우회 제거 → Task 5(팩토리 데코레이터). ② km/r 이중 fetch 제거 → Task 1. ③ peer PER/PSR enrich 통일 → Task 3. ④ 키/TTL 일관성 → Task 2~4(기존 `fundamental:*` 키). ⑤ sector-performance 신규 캐싱 → Task 4. ⑥ earnings/historical pass-through → Task 4. ⑦ 호출부 정리 → Task 6·7. 모든 spec 요구가 task에 매핑됨.
+- **Placeholder 스캔**: 모든 코드 step에 실제 코드 포함. "적절히 처리" 류 없음.
+- **타입 일관성**: `getValuationRaw` 반환 `{ metrics, ratios }`, 데코레이터 메서드 시그니처는 `FundamentalProvider` 포트와 일치. `FmpEarningsReportItem`은 `fundamentalClient`에서 import.
+- **주의**: Task 2에서 `getStockPeers`/`getSectorPerformanceSnapshot`를 pass-through stub으로 먼저 두고 Task 3·4에서 캐싱 구현으로 교체한다(중간 단계도 컴파일 가능).
+
+---
+
+## 실행 후 (이 플랜 범위 밖, 사용자 지시)
+
+구현·테스트 완료 후:
+1. **review-agent를 Opus 4.8로 spawn**해 코드 리뷰 → findings 반영 → re-review 루프.
+2. mistake-managing-agent → git-agent로 커밋/푸시/PR 생성.
+3. **PR 리뷰 자동 반영 모니터**: claude-code-review Action을 60초 간격(최대 20분) 백그라운드 폴링. Changes Requested면 코멘트 전부 반영 후 Draft↔Ready 토글로 re-review. Approved면 Suggestion/Question까지 반영 후 모니터 종료(토글 없음). 병합은 일반 merge.

--- a/docs/superpowers/specs/2026-06-04-fmp-fundamental-cache-adapter-design.md
+++ b/docs/superpowers/specs/2026-06-04-fmp-fundamental-cache-adapter-design.md
@@ -1,0 +1,159 @@
+# FMP 펀더멘털 캐싱 데코레이터 설계
+
+> 2026-06-04 · FMP 펀더멘털 데이터의 Redis 캐싱을 분석 경로까지 통일하고, key-metrics/ratios 이중 fetch를 제거한다.
+
+## 1. 배경 / 문제
+
+FMP API 사용량 점검에서 `key-metrics-ttm`과 `ratios-ttm`이 **1시간당 각각 ~2,000회(합 ~4,000회)** 호출되는 이상 현상을 확인했다. 코드 추적 결과 두 가지 원인이 드러났다.
+
+### 원인 1 — 분석 경로가 Redis를 우회
+
+펀더멘털 데이터에는 두 진입점이 있는데, 캐싱이 한쪽에만 걸려 있다.
+
+| 진입점 | Redis(`getOrSetCache`) | 비고 |
+|---|---|---|
+| 펀더멘털 페이지 SSR (`fundamental/page.tsx` → `fundamentalData.ts`) | ✅ 통과 | `fundamental:*` 키 / 1h |
+| AI 분석 (`submitFundamentalAnalysisAction`, `submitOverallAnalysisAction` → core) | ❌ **우회** | core `submitFundamentalAnalysis.js:25-40`이 raw `FmpFundamentalClient`를 직접 호출 |
+
+`getFundamentalDataProvider()`가 raw `FmpFundamentalClient`를 반환하고, core가 이 raw provider의 메서드를 직접 호출하므로 분석이 트리거될 때마다 14개 엔드포인트가 캐시 없이 FMP로 직행한다. (분석 *결과* 캐시는 core에 있으나, 그건 입력 데이터를 보호하지 않는다.)
+
+### 원인 2 — key-metrics/ratios 이중 fetch
+
+`FmpFundamentalClient`의 두 메서드가 둘 다 두 엔드포인트를 모두 fetch한다(서로 fallback 병합용):
+
+- `getKeyMetricsTtm()` → `Promise.all([key-metrics-ttm, ratios-ttm])` (`fundamentalClient.ts:133-138`)
+- `getRatiosTtm()` → `Promise.all([ratios-ttm, key-metrics-ttm])` (`fundamentalClient.ts:168-173`)
+
+core가 두 메서드를 `Promise.all`로 동시에 부르므로(`submitFundamentalAnalysis.js:27-28`) 같은 요청에서 각 엔드포인트가 2회씩 발사된다. 두 엔드포인트가 항상 쌍으로 나가 호출 수가 **완전 대칭(각 ~2,000)** 인 관측과 일치한다.
+
+### 부수 발견 — 분석 프롬프트의 peer PER/PSR 누락
+
+core `fundamentalPrompt.js:73`은 peer 비교에 `PER ${p.per}, PSR ${p.psr}`를 사용하고 `normalizeFundamentalSnapshot.js:60-63`은 peer input의 per/psr을 읽되 기본값 `null`이다. 그런데 분석 경로가 호출하는 raw `getStockPeers`는 per/psr을 **채우지 않으며**(`fundamentalClient.ts:242-256`), enrich(per/psr 채우기)는 `fundamentalData.ts`(페이지)에만 존재한다. → **현재 AI 펀더멘털 분석의 peer PER/PSR이 항상 N/A로 들어가고 있다.** (회귀 아님, 처음부터 있던 누락.)
+
+## 2. 목표 / 비목표
+
+### 목표
+1. 분석 경로와 페이지 SSR이 **동일한 Redis 캐시를 공유**하게 해 FMP 호출을 줄인다.
+2. key-metrics/ratios **이중 fetch를 제거**한다(콜드 상태에서도 엔드포인트당 1회).
+3. peer enrich를 통일해 **분석 프롬프트의 PER/PSR 누락을 정상화**한다.
+4. 기존 캐싱 패턴(`getOrSetCache` + `React.cache`, `fundamental:*` 키, 1h TTL)과 **일관성**을 유지한다.
+
+### 비목표 (이번 범위 밖)
+- core의 Redis 사용(분석 결과/브리핑 캐시, Job 큐, 재분석 쿨다운, 채팅 토큰스토어, skills loader)은 **건드리지 않는다**. `docs/SCOPE.md`(:36-38, :218, :280)가 이를 명시적으로 core 책임으로 두고 있으며, 변경 시 core 레포 작업 + SCOPE 재정의가 선행돼야 한다.
+- ticker 검색(`/search-symbol`, `/search-name`)은 **최신성 유지를 위해 무캐시로 둔다**(사용자 결정).
+- market provider(bars/quote) 캐싱 구조는 변경하지 않는다.
+- earnings(`/earnings`)는 no-store + DB 영속 설계를 유지한다.
+
+## 3. 설계
+
+### 3.1 아키텍처 — 캐싱 데코레이터 Provider
+
+기존 팩토리 패턴(`getFundamentalDataProvider()` 싱글톤) 위에 캐싱 데코레이터를 얹는다.
+
+```
+getFundamentalDataProvider()
+  ├─ prod: new CachedFundamentalProvider( new FmpFundamentalClient() )   ← 변경점
+  └─ E2E:  FakeFundamentalDataProvider (그대로, 캐싱 미적용)
+```
+
+- **`CachedFundamentalProvider implements FundamentalProvider`** — 생성자에서 raw `FundamentalProvider`(inner)를 위임받는다. 각 메서드를 `getOrSetCache(key, ttl, () => inner.method(...))`로 감싼다.
+- 페이지·분석이 둘 다 이 팩토리를 통과하므로 provider 주입만으로 양쪽이 동일 캐시를 공유한다. **core 코드 변경 0.**
+- per-request dedup: 생성자에서 각 메서드를 `React.cache`로 한 번 더 감싸(예: `this.getProfile = cache((s) => getOrSetCache(...))`) 같은 요청 내 중복 Redis get을 방지한다. (기존 `barsDataCache`의 `cache(...) + getOrSetCache(...)` 조합과 동일 형태.)
+
+> **패턴 정합성**: bars/market은 "함수 래퍼(`getCachedBarsWithIndicators`)"지만 그건 페이지 전용이다. 분석 경로는 core가 provider를 직접 호출해 함수 래퍼를 끼울 자리가 없으므로, provider 데코레이터가 양쪽을 커버하는 유일한 형태다. 캐싱 헬퍼(`getOrSetCache`)·키 규칙·TTL은 그대로 따른다.
+
+### 3.2 캐시 키 / TTL
+
+`FMP_FUNDAMENTAL_REVALIDATE_SECONDS`(=3600, 1h)를 그대로 사용. 키는 현재 `fundamentalData.ts`·`newsData.ts`의 `fundamental:*` 스킴을 데코레이터로 이관한다.
+
+| 메서드 | 키 | 처리 |
+|---|---|---|
+| getProfile | `fundamental:profile:<SYM>` | 캐싱 |
+| getKeyMetricsTtm | `fundamental:key-metrics:<SYM>` | 캐싱 |
+| getRatiosTtm | `fundamental:ratios:<SYM>` | 캐싱 |
+| getCashFlowStatement | `fundamental:cash-flow:<SYM>` | 캐싱 |
+| getIncomeStatementGrowth | `fundamental:growth:<SYM>` | 캐싱 |
+| getFinancialScores | `fundamental:scores:<SYM>` | 캐싱 |
+| getStockPeers | `fundamental:peers:<SYM>` | raw peer 목록 캐싱 + enrich(아래 3.4) |
+| getAnalystEstimates | `fundamental:estimates:<SYM>` | 캐싱 |
+| getGrades | `fundamental:grades:<SYM>` | 캐싱 (페이지·뉴스 공유 키) |
+| getGradesConsensus | `fundamental:grades-consensus:<SYM>` | 캐싱 |
+| getPriceTargetConsensus | `fundamental:price-target-consensus:<SYM>` | 캐싱 |
+| getPriceTargetSummary | `fundamental:price-target-summary:<SYM>` | 캐싱 |
+| **getSectorPerformanceSnapshot** | **`fundamental:sector-performance:<DATE>`** | **신규 캐싱** (현재 무캐시, 분석 경로 전용) |
+| getEarningsReport(s) | — | **pass-through** (no-store + DB 영속 유지) |
+| getHistoricalSectorPerformance | — | pass-through (빈 배열 stub) |
+
+`getOrSetCache`는 값을 envelope으로 감싸 `null`·빈 배열도 캐싱하므로 "데이터 없는 티커"도 재호출되지 않는다(에러는 inner의 fmpGet throw로 set 이전에 전파 → 캐싱 안 됨). 키 정규화는 기존대로 `symbol.toUpperCase()`.
+
+### 3.3 A안 — key-metrics/ratios 이중 fetch 제거
+
+`FmpFundamentalClient` 내부에서 `key-metrics-ttm`·`ratios-ttm` raw fetch를 **공통 헬퍼로 추출하고 `React.cache`로 메모이즈**한다.
+
+```
+// 개념
+private fetchKeyMetricsRaw = cache((symbol) => getOptionalArray('key-metrics-ttm', { symbol }));
+private fetchRatiosRaw     = cache((symbol) => getOptionalArray('ratios-ttm', { symbol }));
+
+getKeyMetricsTtm(symbol) → fetchKeyMetricsRaw + fetchRatiosRaw 로 가공
+getRatiosTtm(symbol)     → fetchRatiosRaw + fetchKeyMetricsRaw 로 가공
+```
+
+- 같은 요청에서 두 메서드가 호출되면(분석 `Promise.all`, 페이지) raw fetch가 엔드포인트당 1회로 수렴한다.
+- 데코레이터의 도메인 키(`fundamental:key-metrics`, `fundamental:ratios`)는 **그대로 유지**한다. 콜드(두 도메인 키 + inner React.cache 모두 미스)에서도 raw는 km-ttm 1회·r-ttm 1회.
+- inner의 `fmpGet`은 기존대로 `revalidate: 3600`(Next Data Cache)을 유지한다 — Redis가 미설정/장애일 때의 2차 방어선.
+
+> `React.cache`는 요청 스코프(RSC 렌더 + Server Action 호출 각각)로 동작하므로 분석 Server Action 경로에서도 유효하다.
+
+### 3.4 peer enrich 통일
+
+peer per/psr enrich 루프를 **`fundamentalData.ts`에서 `CachedFundamentalProvider.getStockPeers`로 이관**한다.
+
+- `getStockPeers(symbol)`: raw peer 목록을 `fundamental:peers:<SYM>`에 캐싱한 뒤, 각 peer에 대해 `this.getKeyMetricsTtm(peer.symbol)`(이제 캐싱됨)을 호출해 `per`/`psr`을 채워 반환한다.
+- enrich는 콜드 캐시 시 peer당 추가 호출을 막기 위해 **순차 실행**(기존 `fundamentalData.ts` 주석의 rate-limit 회피 정책 유지). warm 캐시에서는 `getKeyMetricsTtm` 히트로 저렴하다.
+- 결과: 분석 경로도 enrich된 peer를 받아 프롬프트 PER/PSR이 정상 채워진다. core는 `FundamentalPeerInput`의 per/psr(optional)을 이미 소화하므로 호환된다.
+
+### 3.5 호출부 정리
+
+- **`fundamentalData.ts`**: 내부 `getOrSetCache` 래핑과 enrich 루프를 데코레이터로 이관한다. export 함수는 `provider.method(symbol)`를 호출하는 얇은 래퍼로 축소(또는 provider를 직접 노출). `getProfileDescriptionKo`의 DB 번역 로직은 유지하되 내부 `getProfile`은 캐싱된 provider 메서드를 부른다.
+- **`newsData.ts`**: `getGradeEvents`의 `fundamental:grades` `getOrSetCache` 래핑을 제거하고 `provider.getGrades(symbol)`(데코레이터 캐싱)를 호출한다. 페이지·뉴스가 동일 키를 공유한다. `getEarningsReportComparison`(DB-first)은 그대로.
+
+## 4. 영향받는 파일
+
+| 파일 | 변경 |
+|---|---|
+| `src/shared/api/fmp/CachedFundamentalProvider.ts` | **신규** — 데코레이터 + 키 빌더 + enrich |
+| `src/shared/api/fmp/getFundamentalDataProvider.ts` | prod에서 데코레이터 반환 |
+| `src/shared/api/fmp/fundamentalClient.ts` | km-ttm/r-ttm raw fetch를 React.cache 헬퍼로 추출 |
+| `src/app/[symbol]/fundamental/fundamentalData.ts` | getOrSetCache·enrich 제거, provider 위임 |
+| `src/app/[symbol]/news/newsData.ts` | getGradeEvents의 getOrSetCache 제거, provider 위임 |
+| `src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts` | **신규** — 캐시 히트/미스, 키, enrich, pass-through |
+| `src/shared/api/fmp/__tests__/fundamentalClient.*.test.ts` | km/r 단일 fetch 검증 추가 |
+
+## 5. 테스트 전략
+
+- **CachedFundamentalProvider**: ① 캐시 미스 시 inner 1회 호출 + set, ② 히트 시 inner 미호출, ③ 키 포맷(대문자 정규화, sector-performance는 DATE 키), ④ null/빈 배열 캐싱, ⑤ earnings/historical pass-through(캐싱 안 함), ⑥ Redis 미설정 시 graceful fallback(inner 직접). fake Redis/inner mock 사용.
+- **fundamentalClient (A안)**: `getKeyMetricsTtm`+`getRatiosTtm`를 같은 요청에서 호출 시 `key-metrics-ttm`·`ratios-ttm` fetch가 각 1회인지(mock fetch 호출 수 검증).
+- **enrich**: getStockPeers 결과의 per/psr이 각 peer의 keyMetrics에서 채워지는지, 순차 호출인지.
+- **회귀**: 페이지·뉴스가 동일 grades 키를 공유해 한쪽 워밍이 다른 쪽에 반영되는지.
+
+## 6. 위험 / 완화
+
+| 위험 | 완화 |
+|---|---|
+| 분석 경로 enrich 추가로 콜드 시 peer당 `getKeyMetricsTtm` 호출 증가 | 캐싱 공유(페이지 워밍 재사용) + 순차 실행. 순효과는 PER/PSR 정상화 + 전체 호출 급감(우회 제거)이 압도 |
+| `React.cache`가 Server Action에서 기대대로 동작하지 않을 가능성 | 요청 스코프 동작 확인 + 테스트로 fetch 호출 수 검증 |
+| 데코레이터/E2E Fake 경로 분기 누락 | E2E는 Fake 그대로(캐싱 미적용) — 팩토리 분기 유지, E2E 스위트로 검증 |
+| 키 스킴 변경 없음이지만 newsData↔fundamentalData grades 키 공유로 인한 미묘한 동작 차이 | 동일 키이므로 동작 동일. 테스트로 확인 |
+
+## 7. 검증 방법
+
+1. `yarn test` — 신규/수정 테스트 통과.
+2. `yarn build` + 로컬 실행 — 펀더멘털 페이지·AI 분석 동작 확인.
+3. 배포 후 FMP 사용량 대시보드에서 `key-metrics-ttm`·`ratios-ttm` 시간당 호출 수 급감 확인(콜드 종목당 1회 + 분석/페이지 캐시 공유).
+4. 분석 결과 프롬프트(또는 로그)에서 peer PER/PSR이 N/A가 아닌 실제 값으로 채워지는지 확인.
+
+## 8. 향후 (별도 결정 필요)
+
+- core의 분석 결과 캐시/Job 큐/쿨다운을 siglens로 이전할지 여부 — SCOPE.md 재정의 + core 레포 작업으로 별도 프로젝트화.
+- ticker 검색 사용량이 별도 폭증원인지 모니터링.

--- a/src/app/[symbol]/fundamental/__tests__/fundamentalData.delegation.test.ts
+++ b/src/app/[symbol]/fundamental/__tests__/fundamentalData.delegation.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Delegation wiring tests for fundamentalData.ts.
+ *
+ * Purpose: assert that each thin-delegation export calls the CORRECT provider
+ * method with the symbol passed through, and that NO OTHER provider method is
+ * called (catches mis-wiring such as getProfile accidentally calling
+ * getKeyMetricsTtm).
+ *
+ * The module obtains its provider at import time via a top-level const:
+ *   const fundamentalClient = getFundamentalDataProvider();
+ *
+ * `vi.mock` is hoisted by Vitest so the factory runs before the module-level
+ * `getFundamentalDataProvider()` call, ensuring the mock is in place from the
+ * first import. A stable mock object is shared via `vi.hoisted` so both the
+ * factory and the test body reference the same vi.fn() instances.
+ *
+ * `getProfileDescriptionKo` is intentionally excluded — it has DB + translation
+ * logic that is orthogonal to provider delegation.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Stable mock provider — created before any module-level code runs (hoisted).
+// ---------------------------------------------------------------------------
+const mockProvider = vi.hoisted(() => ({
+    getProfile: vi.fn(),
+    getKeyMetricsTtm: vi.fn(),
+    getStockPeers: vi.fn(),
+    getRatiosTtm: vi.fn(),
+    getIncomeStatementGrowth: vi.fn(),
+    getFinancialScores: vi.fn(),
+    getCashFlowStatement: vi.fn(),
+    getAnalystEstimates: vi.fn(),
+    getGradesConsensus: vi.fn(),
+    getPriceTargetConsensus: vi.fn(),
+    getPriceTargetSummary: vi.fn(),
+    // extras required by FundamentalProvider interface
+    getGrades: vi.fn(),
+    getEarningsReports: vi.fn(),
+    getEarningsReport: vi.fn(),
+    getSectorPerformanceSnapshot: vi.fn(),
+    getHistoricalSectorPerformance: vi.fn(),
+}));
+
+// Hoist the mock before the fundamentalData module runs its top-level import.
+vi.mock('@/shared/api/fmp/getFundamentalDataProvider', () => ({
+    getFundamentalDataProvider: () => mockProvider,
+}));
+
+// React.cache is a no-op in test environments — unwrap it so the delegating
+// functions are callable without RSC context.
+vi.mock('react', async () => {
+    const actual = await vi.importActual<typeof import('react')>('react');
+    return {
+        ...actual,
+        cache: <T extends (...args: unknown[]) => unknown>(fn: T): T => fn,
+    };
+});
+
+// DB / entity mocks — required so the module parses, but these paths are not
+// exercised in this test file (getProfileDescriptionKo is excluded).
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: vi.fn().mockReturnValue({ db: {} }),
+}));
+vi.mock('@/entities/ticker', () => ({
+    DrizzleProfileDescriptionTranslationRepository: vi.fn(),
+    translateCompanyDescription: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import the module under test AFTER mocks are in place.
+// ---------------------------------------------------------------------------
+import {
+    getProfile,
+    getKeyMetricsTtm,
+    getStockPeers,
+    getRatiosTtm,
+    getIncomeStatementGrowth,
+    getFinancialScores,
+    getCashFlowStatement,
+    getAnalystEstimates,
+    getGradesConsensus,
+    getPriceTargetConsensus,
+    getPriceTargetSummary,
+} from '@/app/[symbol]/fundamental/fundamentalData';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** All provider methods tracked in mockProvider. */
+const allMethods = Object.keys(mockProvider) as (keyof typeof mockProvider)[];
+
+/**
+ * Assert that exactly one provider method was called (with the given symbol),
+ * and that every other provider method remained un-called.
+ */
+function assertOnlyMethodCalled(
+    calledMethod: keyof typeof mockProvider,
+    symbol: string
+): void {
+    expect(mockProvider[calledMethod]).toHaveBeenCalledWith(symbol);
+    for (const m of allMethods) {
+        if (m === calledMethod) continue;
+        expect(mockProvider[m]).not.toHaveBeenCalled();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fundamentalData delegation wiring', () => {
+    beforeEach(() => {
+        // Reset all mocks before each test so call counts don't leak between cases.
+        for (const m of allMethods) {
+            mockProvider[m].mockReset();
+            // Default return values — prevents unhandled promise rejections in
+            // the rare case a method returns before the assertion runs.
+            (mockProvider[m] as ReturnType<typeof vi.fn>).mockResolvedValue(
+                null
+            );
+        }
+    });
+
+    it('getProfile delegates to provider.getProfile only', async () => {
+        mockProvider.getProfile.mockResolvedValue({ symbol: 'AAPL' });
+        const result = await getProfile('AAPL');
+        expect(result).toEqual({ symbol: 'AAPL' });
+        assertOnlyMethodCalled('getProfile', 'AAPL');
+    });
+
+    it('getKeyMetricsTtm delegates to provider.getKeyMetricsTtm only', async () => {
+        const metrics = { peRatioTTM: 25, priceToSalesRatioTTM: 7 };
+        mockProvider.getKeyMetricsTtm.mockResolvedValue(metrics);
+        const result = await getKeyMetricsTtm('MSFT');
+        expect(result).toEqual(metrics);
+        assertOnlyMethodCalled('getKeyMetricsTtm', 'MSFT');
+    });
+
+    it('getStockPeers delegates to provider.getStockPeers only', async () => {
+        const peers = [
+            { symbol: 'GOOG', companyName: 'Alphabet', marketCap: 2_000_000 },
+        ];
+        mockProvider.getStockPeers.mockResolvedValue(peers);
+        const result = await getStockPeers('AAPL');
+        expect(result).toEqual(peers);
+        assertOnlyMethodCalled('getStockPeers', 'AAPL');
+    });
+
+    it('getRatiosTtm delegates to provider.getRatiosTtm only', async () => {
+        const ratios = { returnOnEquityTTM: 0.4, netProfitMarginTTM: 0.2 };
+        mockProvider.getRatiosTtm.mockResolvedValue(ratios);
+        const result = await getRatiosTtm('NVDA');
+        expect(result).toEqual(ratios);
+        assertOnlyMethodCalled('getRatiosTtm', 'NVDA');
+    });
+
+    it('getIncomeStatementGrowth delegates to provider.getIncomeStatementGrowth only', async () => {
+        const growth = { growthRevenue: 0.12, growthEPS: 0.08 };
+        mockProvider.getIncomeStatementGrowth.mockResolvedValue(growth);
+        const result = await getIncomeStatementGrowth('TSLA');
+        expect(result).toEqual(growth);
+        assertOnlyMethodCalled('getIncomeStatementGrowth', 'TSLA');
+    });
+
+    it('getFinancialScores delegates to provider.getFinancialScores only', async () => {
+        const scores = { altmanZScore: 3.1, piotroskiScore: 7 };
+        mockProvider.getFinancialScores.mockResolvedValue(scores);
+        const result = await getFinancialScores('AMZN');
+        expect(result).toEqual(scores);
+        assertOnlyMethodCalled('getFinancialScores', 'AMZN');
+    });
+
+    it('getCashFlowStatement delegates to provider.getCashFlowStatement only', async () => {
+        const cf = { operatingCashFlow: 100_000_000 };
+        mockProvider.getCashFlowStatement.mockResolvedValue(cf);
+        const result = await getCashFlowStatement('META');
+        expect(result).toEqual(cf);
+        assertOnlyMethodCalled('getCashFlowStatement', 'META');
+    });
+
+    it('getAnalystEstimates delegates to provider.getAnalystEstimates only', async () => {
+        const estimates = {
+            estimatedEpsAvg: 5.2,
+            estimatedRevenueAvg: 90_000_000_000,
+        };
+        mockProvider.getAnalystEstimates.mockResolvedValue(estimates);
+        const result = await getAnalystEstimates('AAPL');
+        expect(result).toEqual(estimates);
+        assertOnlyMethodCalled('getAnalystEstimates', 'AAPL');
+    });
+
+    it('getGradesConsensus delegates to provider.getGradesConsensus only', async () => {
+        const consensus = {
+            strongBuy: 10,
+            buy: 15,
+            hold: 5,
+            sell: 1,
+            strongSell: 0,
+        };
+        mockProvider.getGradesConsensus.mockResolvedValue(consensus);
+        const result = await getGradesConsensus('AAPL');
+        expect(result).toEqual(consensus);
+        assertOnlyMethodCalled('getGradesConsensus', 'AAPL');
+    });
+
+    it('getPriceTargetConsensus delegates to provider.getPriceTargetConsensus only', async () => {
+        const pt = {
+            targetHigh: 250,
+            targetLow: 180,
+            targetMedian: 215,
+            targetConsensus: 210,
+        };
+        mockProvider.getPriceTargetConsensus.mockResolvedValue(pt);
+        const result = await getPriceTargetConsensus('AAPL');
+        expect(result).toEqual(pt);
+        assertOnlyMethodCalled('getPriceTargetConsensus', 'AAPL');
+    });
+
+    it('getPriceTargetSummary delegates to provider.getPriceTargetSummary only', async () => {
+        const summary = {
+            lastMonth: { avgPriceTarget: 205 },
+            lastQuarter: { avgPriceTarget: 200 },
+            lastYear: { avgPriceTarget: 195 },
+        };
+        mockProvider.getPriceTargetSummary.mockResolvedValue(summary);
+        const result = await getPriceTargetSummary('AAPL');
+        expect(result).toEqual(summary);
+        assertOnlyMethodCalled('getPriceTargetSummary', 'AAPL');
+    });
+});

--- a/src/app/[symbol]/fundamental/fundamentalData.ts
+++ b/src/app/[symbol]/fundamental/fundamentalData.ts
@@ -85,31 +85,12 @@ export const getKeyMetricsTtm = cache(
         )
 );
 
-// 메트릭은 primary 심볼과 동일하게 getKeyMetricsTtm의 캐시
-// (`fundamental:key-metrics:<SYM>`)를 그대로 재사용하므로 새로운 캐시 키 스킴을
-// 도입하지 않는다. 외부 `fundamental:peers:<SYM>` 캐시에는 원본 peer 목록만
-// 저장되고, enrich는 요청마다 수행되지만 각 메트릭 호출은 캐싱된다. 메트릭이 없는
-// peer는 throw하지 않고 per/psr을 null로 둔다(core 프롬프트가 N/A로 렌더). 콜드
-// 캐시에서 peer당 FMP 요청이 동시 발사되면 rate-limit 위험이 있어 enrich는 순차로
-// 수행한다(warm 캐시에서는 getKeyMetricsTtm 캐시 히트로 비용이 낮다).
+// CachedFundamentalProvider.getStockPeers가 peers 캐싱 + per/psr enrich를 일괄
+// 처리한다(peers fetch → key-metrics enrich → Redis 캐시). 이 레이어는 이중
+// enrich 없이 프로바이더에 위임한다.
 export const getStockPeers = cache(
-    async (symbol: string): Promise<FundamentalPeerInput[]> => {
-        const peers = await getOrSetCache(
-            `fundamental:peers:${symbol.toUpperCase()}`,
-            FMP_FUNDAMENTAL_REVALIDATE_SECONDS,
-            () => fundamentalClient.getStockPeers(symbol)
-        );
-        const enriched: FundamentalPeerInput[] = [];
-        for (const peer of peers) {
-            const metrics = await getKeyMetricsTtm(peer.symbol);
-            enriched.push({
-                ...peer,
-                per: metrics?.peRatioTTM ?? null,
-                psr: metrics?.priceToSalesRatioTTM ?? null,
-            });
-        }
-        return enriched;
-    }
+    (symbol: string): Promise<FundamentalPeerInput[]> =>
+        fundamentalClient.getStockPeers(symbol)
 );
 
 export const getRatiosTtm = cache(

--- a/src/app/[symbol]/fundamental/fundamentalData.ts
+++ b/src/app/[symbol]/fundamental/fundamentalData.ts
@@ -64,9 +64,7 @@ export const getKeyMetricsTtm = (
 ): Promise<FundamentalValuationMetrics | null> =>
     fundamentalClient.getKeyMetricsTtm(symbol);
 
-// CachedFundamentalProvider.getStockPeers가 peers 캐싱 + per/psr enrich를 일괄
-// 처리한다(peers fetch → key-metrics enrich → Redis 캐시). 이 레이어는 이중
-// enrich 없이 프로바이더에 위임한다.
+// 캐싱·enrich가 CachedFundamentalProvider로 이관됐으므로 이중 처리 없이 위임한다.
 export const getStockPeers = (
     symbol: string
 ): Promise<FundamentalPeerInput[]> => fundamentalClient.getStockPeers(symbol);

--- a/src/app/[symbol]/fundamental/fundamentalData.ts
+++ b/src/app/[symbol]/fundamental/fundamentalData.ts
@@ -4,9 +4,7 @@ import {
     DrizzleProfileDescriptionTranslationRepository,
     translateCompanyDescription,
 } from '@/entities/ticker';
-import { FMP_FUNDAMENTAL_REVALIDATE_SECONDS } from '@/shared/api/fmp/fundamentalClient';
 import { getFundamentalDataProvider } from '@/shared/api/fmp/getFundamentalDataProvider';
-import { getOrSetCache } from '@/shared/cache/getOrSetCache';
 import type {
     FundamentalProfile,
     FundamentalPeerInput,
@@ -21,34 +19,19 @@ import type {
     FundamentalPriceTargetSummaryInput,
 } from '@y0ngha/siglens-core';
 
-// 동일 요청 내 중복 호출은 React.cache로 per-request memoization을 적용해 FMP HTTP
-// 호출 중복을 막는다(예: 페이지 본문 + metadata). cross-request 캐싱은 getOrSetCache
-// (Upstash Redis, TTL = FMP_FUNDAMENTAL_REVALIDATE_SECONDS — Next Data Cache `revalidate`와
-// 같은 단일 freshness 상수)가 담당한다. Next Data Cache는 region별/배포마다 초기화되어
-// 봇 트래픽이 같은 티커를 반복 fetch하던 문제를 해결한다(이슈 #439). getOrSetCache가 값을
-// envelope으로 감싸므로 null·빈 배열("데이터 없음")도 캐싱돼 데이터 없는 티커도 재호출되지
-// 않는다 — fmpGet은 장애 시 throw하므로 일시 실패가 캐싱될 일은 없다.
-//
-// Redis 키 네임스페이스 `fundamental:*` — 이 파일이 11개 키를 소유하고,
-// newsData.ts의 `fundamental:grades:*`(getGradeEvents)도 같은 네임스페이스를 공유한다.
-// 키를 rename할 때는 두 파일을 함께 수정할 것.
+// Redis 캐싱(`fundamental:*` 키)·per/psr enrich는 CachedFundamentalProvider
+// (getFundamentalDataProvider가 반환)로 이관됐다. 페이지·core 분석 경로가 동일
+// provider를 통과해 같은 캐시를 공유한다. 이 파일은 provider 위임 + DB 번역
+// (getProfileDescriptionKo)만 담당한다.
 const fundamentalClient = getFundamentalDataProvider();
 
-export const getProfile = cache(
-    async (symbol: string): Promise<FundamentalProfile | null> =>
-        getOrSetCache(
-            `fundamental:profile:${symbol.toUpperCase()}`,
-            FMP_FUNDAMENTAL_REVALIDATE_SECONDS,
-            () => fundamentalClient.getProfile(symbol)
-        )
-);
+export const getProfile = (
+    symbol: string
+): Promise<FundamentalProfile | null> => fundamentalClient.getProfile(symbol);
 
 /**
- * Returns the Korean translation of the company description, storing it in
- * the DB on first call so it persists across deployments.
- *
- * Read path: DB lookup (instant on cache hit).
- * Write path: Gemini translation → DB upsert (first visit per symbol only).
+ * 회사 설명의 한국어 번역을 반환하고, 최초 호출 시 DB에 저장해 배포 간에도
+ * 유지한다. Read: DB 조회(히트 시 즉시). Write: Gemini 번역 → DB upsert(심볼당 최초 1회).
  *
  * Nested `cache()` 호출 의도: 이 함수와 내부에서 호출하는 `getProfile`이 둘 다
  * 별도 per-request memoization을 갖는다. 같은 요청에서 description-Ko 미스이지만
@@ -76,95 +59,54 @@ export const getProfileDescriptionKo = cache(
     }
 );
 
-export const getKeyMetricsTtm = cache(
-    async (symbol: string): Promise<FundamentalValuationMetrics | null> =>
-        getOrSetCache(
-            `fundamental:key-metrics:${symbol.toUpperCase()}`,
-            FMP_FUNDAMENTAL_REVALIDATE_SECONDS,
-            () => fundamentalClient.getKeyMetricsTtm(symbol)
-        )
-);
+export const getKeyMetricsTtm = (
+    symbol: string
+): Promise<FundamentalValuationMetrics | null> =>
+    fundamentalClient.getKeyMetricsTtm(symbol);
 
 // CachedFundamentalProvider.getStockPeers가 peers 캐싱 + per/psr enrich를 일괄
 // 처리한다(peers fetch → key-metrics enrich → Redis 캐시). 이 레이어는 이중
 // enrich 없이 프로바이더에 위임한다.
-export const getStockPeers = cache(
-    (symbol: string): Promise<FundamentalPeerInput[]> =>
-        fundamentalClient.getStockPeers(symbol)
-);
+export const getStockPeers = (
+    symbol: string
+): Promise<FundamentalPeerInput[]> => fundamentalClient.getStockPeers(symbol);
 
-export const getRatiosTtm = cache(
-    async (symbol: string): Promise<FundamentalRatiosInput | null> =>
-        getOrSetCache(
-            `fundamental:ratios:${symbol.toUpperCase()}`,
-            FMP_FUNDAMENTAL_REVALIDATE_SECONDS,
-            () => fundamentalClient.getRatiosTtm(symbol)
-        )
-);
+export const getRatiosTtm = (
+    symbol: string
+): Promise<FundamentalRatiosInput | null> =>
+    fundamentalClient.getRatiosTtm(symbol);
 
-export const getIncomeStatementGrowth = cache(
-    async (symbol: string): Promise<FundamentalGrowthInput | null> =>
-        getOrSetCache(
-            `fundamental:growth:${symbol.toUpperCase()}`,
-            FMP_FUNDAMENTAL_REVALIDATE_SECONDS,
-            () => fundamentalClient.getIncomeStatementGrowth(symbol)
-        )
-);
+export const getIncomeStatementGrowth = (
+    symbol: string
+): Promise<FundamentalGrowthInput | null> =>
+    fundamentalClient.getIncomeStatementGrowth(symbol);
 
-export const getFinancialScores = cache(
-    async (symbol: string): Promise<FundamentalFinancialScoresInput | null> =>
-        getOrSetCache(
-            `fundamental:scores:${symbol.toUpperCase()}`,
-            FMP_FUNDAMENTAL_REVALIDATE_SECONDS,
-            () => fundamentalClient.getFinancialScores(symbol)
-        )
-);
+export const getFinancialScores = (
+    symbol: string
+): Promise<FundamentalFinancialScoresInput | null> =>
+    fundamentalClient.getFinancialScores(symbol);
 
-export const getCashFlowStatement = cache(
-    async (symbol: string): Promise<FundamentalCashFlowInput | null> =>
-        getOrSetCache(
-            `fundamental:cash-flow:${symbol.toUpperCase()}`,
-            FMP_FUNDAMENTAL_REVALIDATE_SECONDS,
-            () => fundamentalClient.getCashFlowStatement(symbol)
-        )
-);
+export const getCashFlowStatement = (
+    symbol: string
+): Promise<FundamentalCashFlowInput | null> =>
+    fundamentalClient.getCashFlowStatement(symbol);
 
-export const getAnalystEstimates = cache(
-    async (symbol: string): Promise<FundamentalAnalystEstimateInput | null> =>
-        getOrSetCache(
-            `fundamental:estimates:${symbol.toUpperCase()}`,
-            FMP_FUNDAMENTAL_REVALIDATE_SECONDS,
-            () => fundamentalClient.getAnalystEstimates(symbol)
-        )
-);
+export const getAnalystEstimates = (
+    symbol: string
+): Promise<FundamentalAnalystEstimateInput | null> =>
+    fundamentalClient.getAnalystEstimates(symbol);
 
-export const getGradesConsensus = cache(
-    async (symbol: string): Promise<FundamentalGradesConsensusInput | null> =>
-        getOrSetCache(
-            `fundamental:grades-consensus:${symbol.toUpperCase()}`,
-            FMP_FUNDAMENTAL_REVALIDATE_SECONDS,
-            () => fundamentalClient.getGradesConsensus(symbol)
-        )
-);
+export const getGradesConsensus = (
+    symbol: string
+): Promise<FundamentalGradesConsensusInput | null> =>
+    fundamentalClient.getGradesConsensus(symbol);
 
-export const getPriceTargetConsensus = cache(
-    async (
-        symbol: string
-    ): Promise<FundamentalPriceTargetConsensusInput | null> =>
-        getOrSetCache(
-            `fundamental:price-target-consensus:${symbol.toUpperCase()}`,
-            FMP_FUNDAMENTAL_REVALIDATE_SECONDS,
-            () => fundamentalClient.getPriceTargetConsensus(symbol)
-        )
-);
+export const getPriceTargetConsensus = (
+    symbol: string
+): Promise<FundamentalPriceTargetConsensusInput | null> =>
+    fundamentalClient.getPriceTargetConsensus(symbol);
 
-export const getPriceTargetSummary = cache(
-    async (
-        symbol: string
-    ): Promise<FundamentalPriceTargetSummaryInput | null> =>
-        getOrSetCache(
-            `fundamental:price-target-summary:${symbol.toUpperCase()}`,
-            FMP_FUNDAMENTAL_REVALIDATE_SECONDS,
-            () => fundamentalClient.getPriceTargetSummary(symbol)
-        )
-);
+export const getPriceTargetSummary = (
+    symbol: string
+): Promise<FundamentalPriceTargetSummaryInput | null> =>
+    fundamentalClient.getPriceTargetSummary(symbol);

--- a/src/app/[symbol]/fundamental/fundamentalData.ts
+++ b/src/app/[symbol]/fundamental/fundamentalData.ts
@@ -33,10 +33,10 @@ export const getProfile = (
  * 회사 설명의 한국어 번역을 반환하고, 최초 호출 시 DB에 저장해 배포 간에도
  * 유지한다. Read: DB 조회(히트 시 즉시). Write: Gemini 번역 → DB upsert(심볼당 최초 1회).
  *
- * Nested `cache()` 호출 의도: 이 함수와 내부에서 호출하는 `getProfile`이 둘 다
- * 별도 per-request memoization을 갖는다. 같은 요청에서 description-Ko 미스이지만
- * profile은 이미 다른 호출자가 캐싱한 경우, 내부 `getProfile(symbol)`이 추가 FMP
- * 호출을 발생시키지 않는다.
+ * `cache()` 래핑 의도: 같은 요청에서 description-Ko를 여러 번 조회해도 DB lookup·
+ * 번역을 1회로 묶는다. 내부 `getProfile(symbol)`은 이제 단순 위임이지만, 프로바이더
+ * (CachedFundamentalProvider)의 `getProfile`이 `React.cache`로 per-request dedup하므로,
+ * 같은 요청에서 profile을 이미 다른 호출자가 가져왔다면 추가 FMP 호출이 발생하지 않는다.
  */
 export const getProfileDescriptionKo = cache(
     async (symbol: string): Promise<string | null> => {

--- a/src/app/[symbol]/fundamental/getProfileResilient.ts
+++ b/src/app/[symbol]/fundamental/getProfileResilient.ts
@@ -28,8 +28,8 @@ export interface ResilientProfile {
  *
  * The cache call is byte-identical to the one `ProfileSection` issues
  * (`['fundamental:profile', upper]`), so both share one `unstable_cache` entry
- * (and `getProfile`'s React `cache()` dedups within a request) — wrapping it
- * here adds no extra FMP round-trip.
+ * (and the provider's `React.cache`-wrapped `getProfile` dedups within a request)
+ * — wrapping it here adds no extra FMP round-trip.
  */
 export async function getProfileResilient(
     upper: string

--- a/src/app/[symbol]/news/newsData.ts
+++ b/src/app/[symbol]/news/newsData.ts
@@ -2,14 +2,12 @@ import { cache } from 'react';
 import { getDatabaseClient } from '@/shared/db/client';
 import { DrizzleNewsRepository } from '@/entities/news-article';
 import { DrizzleEarningsReportsRepository } from '@/entities/earnings-report';
-import { FMP_FUNDAMENTAL_REVALIDATE_SECONDS } from '@/shared/api/fmp/fundamentalClient';
 import { getFundamentalDataProvider } from '@/shared/api/fmp/getFundamentalDataProvider';
 import {
     getFmpUserFacingMessage,
     isFmpPaymentRequiredError,
     logFmpPaymentRequiredError,
 } from '@/shared/api/fmp/fmpUserMessage';
-import { getOrSetCache } from '@/shared/cache/getOrSetCache';
 import { MS_PER_DAY } from '@/shared/config/time';
 import { NEWS_LOOKBACK_MS } from '@/entities/news-article';
 import type { NewsRow } from '@/entities/news-article';
@@ -30,20 +28,11 @@ export const getNewsList = cache(async (symbol: string): Promise<NewsRow[]> => {
     return repo.listBySymbol(symbol, NEWS_LOOKBACK_MS);
 });
 
-// 애널리스트 등급 이벤트는 펀더멘탈 데이터와 동일한 freshness 상수를 공유해 Redis에
-// cross-region 캐싱한다. 빈 배열도 캐싱한다 — getGrades는 FMP 장애 시 throw하므로
-// (getOptionalArray 미경유) 빈 배열은 "등급 이벤트 없음"이라는 정상·안정 결과다.
-//
-// Redis 키 `fundamental:grades:*`는 fundamentalData.ts가 소유한 `fundamental:*`
-// 네임스페이스를 공유한다. 키를 rename할 때는 두 파일을 함께 수정할 것.
-export const getGradeEvents = cache(
-    async (symbol: string): Promise<GradesEvent[]> =>
-        getOrSetCache(
-            `fundamental:grades:${symbol.toUpperCase()}`,
-            FMP_FUNDAMENTAL_REVALIDATE_SECONDS,
-            () => fundamentalClient.getGrades(symbol)
-        )
-);
+// 애널리스트 등급 이벤트는 CachedFundamentalProvider가 `fundamental:grades:<SYM>` 키로
+// 캐싱한다(페이지 fundamental 경로와 동일 키 공유). 빈 배열도 캐싱된다 — getGrades는
+// FMP 장애 시 throw하므로 빈 배열은 "등급 이벤트 없음"이라는 정상·안정 결과다.
+export const getGradeEvents = (symbol: string): Promise<GradesEvent[]> =>
+    fundamentalClient.getGrades(symbol);
 
 export async function getEarningsReportComparison(
     symbol: string,

--- a/src/entities/analysis/__tests__/submitFundamentalAnalysisAction.test.ts
+++ b/src/entities/analysis/__tests__/submitFundamentalAnalysisAction.test.ts
@@ -12,7 +12,10 @@ vi.mock('@y0ngha/siglens-core', async () => ({
     submitFundamentalAnalysis: vi.fn(),
 }));
 
-vi.mock('@/shared/api/fmp/fundamentalClient', () => ({
+vi.mock('@/shared/api/fmp/fundamentalClient', async importOriginal => ({
+    ...(await importOriginal<
+        typeof import('@/shared/api/fmp/fundamentalClient')
+    >()),
     FmpFundamentalClient: vi.fn().mockImplementation(function () {
         return {};
     }),

--- a/src/entities/analysis/__tests__/submitOverallAnalysisAction.test.ts
+++ b/src/entities/analysis/__tests__/submitOverallAnalysisAction.test.ts
@@ -18,7 +18,10 @@ vi.mock('@y0ngha/siglens-core', () => ({
     isEtRegularSessionOpen: vi.fn(),
 }));
 
-vi.mock('@/shared/api/fmp/fundamentalClient', () => ({
+vi.mock('@/shared/api/fmp/fundamentalClient', async importOriginal => ({
+    ...(await importOriginal<
+        typeof import('@/shared/api/fmp/fundamentalClient')
+    >()),
     FmpFundamentalClient: vi.fn().mockImplementation(function () {
         return {};
     }),

--- a/src/entities/earnings-report/__tests__/lib/nextEarningsReport.test.ts
+++ b/src/entities/earnings-report/__tests__/lib/nextEarningsReport.test.ts
@@ -21,7 +21,10 @@ vi.mock('@/entities/earnings-report', () => ({
     },
 }));
 
-vi.mock('@/shared/api/fmp/fundamentalClient', () => ({
+vi.mock('@/shared/api/fmp/fundamentalClient', async importOriginal => ({
+    ...(await importOriginal<
+        typeof import('@/shared/api/fmp/fundamentalClient')
+    >()),
     FmpFundamentalClient: class {
         getEarningsReports = mockGetEarningsReports;
     },

--- a/src/shared/api/fmp/CachedFundamentalProvider.ts
+++ b/src/shared/api/fmp/CachedFundamentalProvider.ts
@@ -3,7 +3,7 @@ import { cache } from 'react';
 import { getOrSetCache } from '@/shared/cache/getOrSetCache';
 import { FMP_FUNDAMENTAL_REVALIDATE_SECONDS } from './fundamentalClient';
 import type { FmpEarningsReportItem } from './fundamentalClient';
-import type { FundamentalProvider } from './getFundamentalDataProvider';
+import type { FundamentalProvider } from './fundamentalProvider.types';
 import type {
     EarningsReport,
     FundamentalAnalystEstimateInput,
@@ -51,25 +51,40 @@ export class CachedFundamentalProvider implements FundamentalProvider {
     /**
      * inner(`getValuationRaw`)는 FMP 장애 시 throw한다 — 그 throw는 getOrSetCache의
      * `set` 단계 전에 전파되므로 장애 결과가 캐싱되지 않는다(poison 방지). 바깥의
-     * `.catch(() => null)`이 throw를 graceful null로 변환해, ErrorBoundary 없이
-     * Suspense로만 감싼 `ValuationSection`(fundamental/page.tsx)과 분석 경로가
-     * 종전처럼 N/A를 렌더하게 한다. 에러는 fmpGet 경로의 logFmpPaymentRequiredError로
-     * 이미 로깅되므로 여기서 중복 로깅하지 않는다. 빈 200(데이터 없는 티커)은 정상
-     * null로 캐싱돼 롱테일 트래픽의 재호출을 막는다.
+     * `.catch`가 throw를 graceful null로 변환해, ErrorBoundary 없이 Suspense로만 감싼
+     * `ValuationSection`(fundamental/page.tsx)과 분석 경로가 종전처럼 N/A를 렌더하게 한다.
+     * 빈 200(데이터 없는 티커)은 정상 null로 캐싱돼 롱테일 트래픽의 재호출을 막는다.
+     *
+     * 에러는 여기서 직접 로깅한다. fmpGet 경로의 logFmpPaymentRequiredError는 HTTP 402만
+     * 처리하므로 5xx/429/timeout은 그 경로에서 로깅되지 않는다 — 로깅하지 않으면 일시적
+     * FMP 장애가 `.catch`에서 흔적 없이 사라진다. 캐싱 결정(throw=no-cache)은 inner가,
+     * 관측성(로깅)과 graceful null 변환은 이 데코레이터가 책임진다.
      */
     getKeyMetricsTtm = cache(
         (symbol: string): Promise<FundamentalValuationMetrics | null> =>
             getOrSetCache(`fundamental:key-metrics:${sym(symbol)}`, TTL, () =>
                 this.inner.getKeyMetricsTtm(symbol)
-            ).catch(() => null)
+            ).catch(error => {
+                console.error(
+                    '[CachedFundamentalProvider] key-metrics fetch failed (not cached):',
+                    error
+                );
+                return null;
+            })
     );
 
-    /** valuation 장애를 캐싱 없이 graceful null로 변환 — 사유는 getKeyMetricsTtm JSDoc 참고. */
+    /** valuation 장애를 로깅 후 캐싱 없이 graceful null로 변환 — 사유는 getKeyMetricsTtm JSDoc 참고. */
     getRatiosTtm = cache(
         (symbol: string): Promise<FundamentalRatiosInput | null> =>
             getOrSetCache(`fundamental:ratios:${sym(symbol)}`, TTL, () =>
                 this.inner.getRatiosTtm(symbol)
-            ).catch(() => null)
+            ).catch(error => {
+                console.error(
+                    '[CachedFundamentalProvider] ratios fetch failed (not cached):',
+                    error
+                );
+                return null;
+            })
     );
 
     getCashFlowStatement = cache(
@@ -142,23 +157,34 @@ export class CachedFundamentalProvider implements FundamentalProvider {
      * GET으로 돌려받고(peer당 round-trip 0), cold 호출만 enrich한다. per/psr은 캐싱된
      * getKeyMetricsTtm(`fundamental:key-metrics:<peer>`)에서 가져오며, 그 메서드는 FMP
      * 장애 시 throw하지 않고 null을 돌려주므로(catch→null) 한 peer 실패가 전체를 중단시키지
-     * 않는다. cold 캐시 시 peer당 동시 FMP 폭증(rate-limit)을 피해 순차 enrich하고, 비정상적
-     * 으로 큰 peer 목록은 PEER_LIMIT으로 제한한다.
+     * 않는다. cold 캐시 시 peer당 동시 FMP 폭증(rate-limit)을 피해 순차 enrich하고(await된
+     * accumulator를 잇는 async reduce — 다음 peer fetch는 직전 peer 완료 후에만 시작), 비정상
+     * 적으로 큰 peer 목록은 PEER_LIMIT으로 제한한다.
      */
     getStockPeers = cache(
         (symbol: string): Promise<FundamentalPeerInput[]> =>
             getOrSetCache(`fundamental:peers:${sym(symbol)}`, TTL, async () => {
                 const raw = await this.inner.getStockPeers(symbol);
-                const enriched: FundamentalPeerInput[] = [];
-                for (const peer of raw.slice(0, PEER_LIMIT)) {
-                    const metrics = await this.getKeyMetricsTtm(peer.symbol);
-                    enriched.push({
-                        ...peer,
-                        per: metrics?.peRatioTTM ?? null,
-                        psr: metrics?.priceToSalesRatioTTM ?? null,
-                    });
-                }
-                return enriched;
+                return raw.slice(0, PEER_LIMIT).reduce(
+                    async (
+                        accPromise: Promise<FundamentalPeerInput[]>,
+                        peer
+                    ) => {
+                        const acc = await accPromise;
+                        const metrics = await this.getKeyMetricsTtm(
+                            peer.symbol
+                        );
+                        return [
+                            ...acc,
+                            {
+                                ...peer,
+                                per: metrics?.peRatioTTM ?? null,
+                                psr: metrics?.priceToSalesRatioTTM ?? null,
+                            },
+                        ];
+                    },
+                    Promise.resolve([] as FundamentalPeerInput[])
+                );
             })
     );
 

--- a/src/shared/api/fmp/CachedFundamentalProvider.ts
+++ b/src/shared/api/fmp/CachedFundamentalProvider.ts
@@ -154,11 +154,16 @@ export class CachedFundamentalProvider implements FundamentalProvider {
         }
     );
 
-    // Task 4에서 캐싱으로 교체할 pass-through stub.
-    getSectorPerformanceSnapshot = (
-        date: string
-    ): Promise<FundamentalSectorPerformanceInput[]> =>
-        this.inner.getSectorPerformanceSnapshot(date);
+    /**
+     * 섹터 스냅샷은 날짜 단위 데이터이므로 키를 `<DATE>`로 잡는다(심볼 무관).
+     * 분석 경로에서만 호출되며 기존엔 무캐시였다 — 캐싱으로 분석마다의 FMP 호출을 막는다.
+     */
+    getSectorPerformanceSnapshot = cache(
+        (date: string): Promise<FundamentalSectorPerformanceInput[]> =>
+            getOrSetCache(`fundamental:sector-performance:${date}`, TTL, () =>
+                this.inner.getSectorPerformanceSnapshot(date)
+            )
+    );
 
     // pass-through (no-store + DB 영속 / 빈 stub)
     getHistoricalSectorPerformance = (

--- a/src/shared/api/fmp/CachedFundamentalProvider.ts
+++ b/src/shared/api/fmp/CachedFundamentalProvider.ts
@@ -1,0 +1,151 @@
+import 'server-only';
+import { cache } from 'react';
+import { getOrSetCache } from '@/shared/cache/getOrSetCache';
+import { FMP_FUNDAMENTAL_REVALIDATE_SECONDS } from './fundamentalClient';
+import type { FmpEarningsReportItem } from './fundamentalClient';
+import type { FundamentalProvider } from './getFundamentalDataProvider';
+import type {
+    EarningsReport,
+    FundamentalAnalystEstimateInput,
+    FundamentalCashFlowInput,
+    FundamentalFinancialScoresInput,
+    FundamentalGradesConsensusInput,
+    FundamentalGrowthInput,
+    FundamentalPeerInput,
+    FundamentalPriceTargetConsensusInput,
+    FundamentalPriceTargetSummaryInput,
+    FundamentalProfile,
+    FundamentalRatiosInput,
+    FundamentalSectorHistoricalInput,
+    FundamentalSectorPerformanceInput,
+    FundamentalValuationMetrics,
+    GradesEvent,
+} from '@y0ngha/siglens-core';
+
+const TTL = FMP_FUNDAMENTAL_REVALIDATE_SECONDS;
+const sym = (s: string): string => s.toUpperCase();
+
+/**
+ * `FundamentalProvider`를 감싸 메서드별 Redis 캐싱을 주입하는 데코레이터.
+ *
+ * 페이지 SSR(`fundamentalData.ts`)과 core 분석 경로(provider 주입)가 둘 다 이
+ * 데코레이터를 통과하므로 동일한 `fundamental:*` 캐시를 공유한다 — 한쪽이 워밍한
+ * 데이터를 다른 쪽이 재사용해 FMP 호출을 절감한다. 각 메서드는 `React.cache`로
+ * RSC 요청 스코프 dedup + `getOrSetCache`로 cross-request 캐싱을 적용한다
+ * (`barsDataCache`와 동일 형태). 키/TTL은 기존 `fundamentalData.ts`·`newsData.ts`
+ * 스킴을 그대로 따른다.
+ *
+ * earnings(no-store + DB 영속)와 historical-sector(빈 stub)는 pass-through한다.
+ */
+export class CachedFundamentalProvider implements FundamentalProvider {
+    constructor(private readonly inner: FundamentalProvider) {}
+
+    getProfile = cache(
+        (symbol: string): Promise<FundamentalProfile | null> =>
+            getOrSetCache(`fundamental:profile:${sym(symbol)}`, TTL, () =>
+                this.inner.getProfile(symbol)
+            )
+    );
+
+    getKeyMetricsTtm = cache(
+        (symbol: string): Promise<FundamentalValuationMetrics | null> =>
+            getOrSetCache(`fundamental:key-metrics:${sym(symbol)}`, TTL, () =>
+                this.inner.getKeyMetricsTtm(symbol)
+            )
+    );
+
+    getRatiosTtm = cache(
+        (symbol: string): Promise<FundamentalRatiosInput | null> =>
+            getOrSetCache(`fundamental:ratios:${sym(symbol)}`, TTL, () =>
+                this.inner.getRatiosTtm(symbol)
+            )
+    );
+
+    getCashFlowStatement = cache(
+        (symbol: string): Promise<FundamentalCashFlowInput | null> =>
+            getOrSetCache(`fundamental:cash-flow:${sym(symbol)}`, TTL, () =>
+                this.inner.getCashFlowStatement(symbol)
+            )
+    );
+
+    getIncomeStatementGrowth = cache(
+        (symbol: string): Promise<FundamentalGrowthInput | null> =>
+            getOrSetCache(`fundamental:growth:${sym(symbol)}`, TTL, () =>
+                this.inner.getIncomeStatementGrowth(symbol)
+            )
+    );
+
+    getFinancialScores = cache(
+        (symbol: string): Promise<FundamentalFinancialScoresInput | null> =>
+            getOrSetCache(`fundamental:scores:${sym(symbol)}`, TTL, () =>
+                this.inner.getFinancialScores(symbol)
+            )
+    );
+
+    getAnalystEstimates = cache(
+        (symbol: string): Promise<FundamentalAnalystEstimateInput | null> =>
+            getOrSetCache(`fundamental:estimates:${sym(symbol)}`, TTL, () =>
+                this.inner.getAnalystEstimates(symbol)
+            )
+    );
+
+    getGrades = cache(
+        (symbol: string): Promise<GradesEvent[]> =>
+            getOrSetCache(`fundamental:grades:${sym(symbol)}`, TTL, () =>
+                this.inner.getGrades(symbol)
+            )
+    );
+
+    getGradesConsensus = cache(
+        (symbol: string): Promise<FundamentalGradesConsensusInput | null> =>
+            getOrSetCache(
+                `fundamental:grades-consensus:${sym(symbol)}`,
+                TTL,
+                () => this.inner.getGradesConsensus(symbol)
+            )
+    );
+
+    getPriceTargetConsensus = cache(
+        (
+            symbol: string
+        ): Promise<FundamentalPriceTargetConsensusInput | null> =>
+            getOrSetCache(
+                `fundamental:price-target-consensus:${sym(symbol)}`,
+                TTL,
+                () => this.inner.getPriceTargetConsensus(symbol)
+            )
+    );
+
+    getPriceTargetSummary = cache(
+        (symbol: string): Promise<FundamentalPriceTargetSummaryInput | null> =>
+            getOrSetCache(
+                `fundamental:price-target-summary:${sym(symbol)}`,
+                TTL,
+                () => this.inner.getPriceTargetSummary(symbol)
+            )
+    );
+
+    // Task 3에서 캐싱+enrich로 교체할 pass-through stub.
+    getStockPeers = (symbol: string): Promise<FundamentalPeerInput[]> =>
+        this.inner.getStockPeers(symbol);
+
+    // Task 4에서 캐싱으로 교체할 pass-through stub.
+    getSectorPerformanceSnapshot = (
+        date: string
+    ): Promise<FundamentalSectorPerformanceInput[]> =>
+        this.inner.getSectorPerformanceSnapshot(date);
+
+    getHistoricalSectorPerformance = (
+        sector: string
+    ): Promise<FundamentalSectorHistoricalInput[]> =>
+        this.inner.getHistoricalSectorPerformance(sector);
+
+    getEarningsReport = (symbol: string): Promise<EarningsReport | null> =>
+        this.inner.getEarningsReport(symbol);
+
+    getEarningsReports = (
+        symbol: string,
+        limit?: number
+    ): Promise<FmpEarningsReportItem[]> =>
+        this.inner.getEarningsReports(symbol, limit);
+}

--- a/src/shared/api/fmp/CachedFundamentalProvider.ts
+++ b/src/shared/api/fmp/CachedFundamentalProvider.ts
@@ -55,6 +55,11 @@ export class CachedFundamentalProvider implements FundamentalProvider {
      * `ValuationSection`(fundamental/page.tsx)과 분석 경로가 종전처럼 N/A를 렌더하게 한다.
      * 빈 200(데이터 없는 티커)은 정상 null로 캐싱돼 롱테일 트래픽의 재호출을 막는다.
      *
+     * Redis 인프라 장애(get/set)는 이 `.catch`에 도달하지 않는다 — `getOrSetCache`가
+     * Redis get/set 에러를 내부에서 catch해 graceful fallback(fetcher 직접 호출 또는
+     * fresh 값 그대로 반환)하므로, `getOrSetCache`는 오직 fetcher(inner FMP)가 throw할
+     * 때만 throw한다. 따라서 이 `.catch`는 내부 FMP 장애만 처리한다.
+     *
      * 에러는 여기서 직접 로깅한다. fmpGet 경로의 logFmpPaymentRequiredError는 HTTP 402만
      * 처리하므로 5xx/429/timeout은 그 경로에서 로깅되지 않는다 — 로깅하지 않으면 일시적
      * FMP 장애가 `.catch`에서 흔적 없이 사라진다. 캐싱 결정(throw=no-cache)은 inner가,
@@ -165,26 +170,28 @@ export class CachedFundamentalProvider implements FundamentalProvider {
         (symbol: string): Promise<FundamentalPeerInput[]> =>
             getOrSetCache(`fundamental:peers:${sym(symbol)}`, TTL, async () => {
                 const raw = await this.inner.getStockPeers(symbol);
-                return raw.slice(0, PEER_LIMIT).reduce(
-                    async (
-                        accPromise: Promise<FundamentalPeerInput[]>,
-                        peer
-                    ) => {
-                        const acc = await accPromise;
-                        const metrics = await this.getKeyMetricsTtm(
-                            peer.symbol
-                        );
-                        return [
-                            ...acc,
-                            {
-                                ...peer,
-                                per: metrics?.peRatioTTM ?? null,
-                                psr: metrics?.priceToSalesRatioTTM ?? null,
-                            },
-                        ];
-                    },
-                    Promise.resolve([] as FundamentalPeerInput[])
-                );
+                return raw
+                    .slice(0, PEER_LIMIT)
+                    .reduce(
+                        async (
+                            accPromise: Promise<FundamentalPeerInput[]>,
+                            peer
+                        ) => {
+                            const acc = await accPromise;
+                            const metrics = await this.getKeyMetricsTtm(
+                                peer.symbol
+                            );
+                            return [
+                                ...acc,
+                                {
+                                    ...peer,
+                                    per: metrics?.peRatioTTM ?? null,
+                                    psr: metrics?.priceToSalesRatioTTM ?? null,
+                                },
+                            ];
+                        },
+                        Promise.resolve<FundamentalPeerInput[]>([])
+                    );
             })
     );
 

--- a/src/shared/api/fmp/CachedFundamentalProvider.ts
+++ b/src/shared/api/fmp/CachedFundamentalProvider.ts
@@ -47,18 +47,28 @@ export class CachedFundamentalProvider implements FundamentalProvider {
             )
     );
 
+    /**
+     * inner(`getValuationRaw`)는 FMP 장애 시 throw한다 — 그 throw는 getOrSetCache의
+     * `set` 단계 전에 전파되므로 장애 결과가 캐싱되지 않는다(poison 방지). 바깥의
+     * `.catch(() => null)`이 throw를 graceful null로 변환해, ErrorBoundary 없이
+     * Suspense로만 감싼 `ValuationSection`(fundamental/page.tsx)과 분석 경로가
+     * 종전처럼 N/A를 렌더하게 한다. 에러는 fmpGet 경로의 logFmpPaymentRequiredError로
+     * 이미 로깅되므로 여기서 중복 로깅하지 않는다. 빈 200(데이터 없는 티커)은 정상
+     * null로 캐싱돼 롱테일 트래픽의 재호출을 막는다.
+     */
     getKeyMetricsTtm = cache(
         (symbol: string): Promise<FundamentalValuationMetrics | null> =>
             getOrSetCache(`fundamental:key-metrics:${sym(symbol)}`, TTL, () =>
                 this.inner.getKeyMetricsTtm(symbol)
-            )
+            ).catch(() => null)
     );
 
+    /** valuation 장애를 캐싱 없이 graceful null로 변환 — 사유는 getKeyMetricsTtm JSDoc 참고. */
     getRatiosTtm = cache(
         (symbol: string): Promise<FundamentalRatiosInput | null> =>
             getOrSetCache(`fundamental:ratios:${sym(symbol)}`, TTL, () =>
                 this.inner.getRatiosTtm(symbol)
-            )
+            ).catch(() => null)
     );
 
     getCashFlowStatement = cache(

--- a/src/shared/api/fmp/CachedFundamentalProvider.ts
+++ b/src/shared/api/fmp/CachedFundamentalProvider.ts
@@ -23,7 +23,7 @@ import type {
 } from '@y0ngha/siglens-core';
 
 const TTL = FMP_FUNDAMENTAL_REVALIDATE_SECONDS;
-const PEER_LIMIT = 10;
+export const PEER_LIMIT = 10;
 const sym = (s: string): string => s.toUpperCase();
 
 /**
@@ -199,20 +199,19 @@ export class CachedFundamentalProvider implements FundamentalProvider {
             )
     );
 
-    // pass-through (no-store + DB 영속 / 빈 stub)
-    getHistoricalSectorPerformance = (
-        sector: string
-    ): Promise<FundamentalSectorHistoricalInput[]> =>
-        this.inner.getHistoricalSectorPerformance(sector);
-
-    // pass-through (no-store + DB 영속 / 빈 stub)
+    // earnings: DB-영속이라 Redis 캐시 대상 아님
     getEarningsReport = (symbol: string): Promise<EarningsReport | null> =>
         this.inner.getEarningsReport(symbol);
 
-    // pass-through (no-store + DB 영속 / 빈 stub)
     getEarningsReports = (
         symbol: string,
         limit?: number
     ): Promise<FmpEarningsReportItem[]> =>
         this.inner.getEarningsReports(symbol, limit);
+
+    // historical-sector: 현재 빈 stub이라 캐싱 불필요
+    getHistoricalSectorPerformance = (
+        sector: string
+    ): Promise<FundamentalSectorHistoricalInput[]> =>
+        this.inner.getHistoricalSectorPerformance(sector);
 }

--- a/src/shared/api/fmp/CachedFundamentalProvider.ts
+++ b/src/shared/api/fmp/CachedFundamentalProvider.ts
@@ -23,6 +23,7 @@ import type {
 } from '@y0ngha/siglens-core';
 
 const TTL = FMP_FUNDAMENTAL_REVALIDATE_SECONDS;
+const PEER_LIMIT = 10;
 const sym = (s: string): string => s.toUpperCase();
 
 /**
@@ -136,32 +137,29 @@ export class CachedFundamentalProvider implements FundamentalProvider {
     );
 
     /**
-     * raw peer 목록을 `fundamental:peers:<SYM>`에 캐싱한 뒤, 각 peer를 캐싱된
-     * `getKeyMetricsTtm`으로 enrich해 per/psr을 채운다. 페이지·분석이 동일한
-     * enrich된 peer를 받아 core 프롬프트의 PER/PSR이 정상 채워진다(기존엔 분석
-     * 경로가 enrich되지 않은 raw peer를 받아 PER/PSR이 N/A였다).
-     *
-     * enrich는 콜드 캐시 시 peer당 동시 FMP 요청 폭증(rate-limit)을 피하려 순차
-     * 실행한다 — warm 캐시에서는 getKeyMetricsTtm(Redis) 히트로 비용이 낮다.
+     * peer 목록을 fetch→top-N cap→per/psr enrich한 결과 전체를 `fundamental:peers:<SYM>`에
+     * 캐싱한다. enrich를 캐시 fetcher 안에 두므로 warm 호출은 enriched 목록을 단일 Redis
+     * GET으로 돌려받고(peer당 round-trip 0), cold 호출만 enrich한다. per/psr은 캐싱된
+     * getKeyMetricsTtm(`fundamental:key-metrics:<peer>`)에서 가져오며, 그 메서드는 FMP
+     * 장애 시 throw하지 않고 null을 돌려주므로(catch→null) 한 peer 실패가 전체를 중단시키지
+     * 않는다. cold 캐시 시 peer당 동시 FMP 폭증(rate-limit)을 피해 순차 enrich하고, 비정상적
+     * 으로 큰 peer 목록은 PEER_LIMIT으로 제한한다.
      */
     getStockPeers = cache(
-        async (symbol: string): Promise<FundamentalPeerInput[]> => {
-            const peers = await getOrSetCache(
-                `fundamental:peers:${sym(symbol)}`,
-                TTL,
-                () => this.inner.getStockPeers(symbol)
-            );
-            const enriched: FundamentalPeerInput[] = [];
-            for (const peer of peers) {
-                const metrics = await this.getKeyMetricsTtm(peer.symbol);
-                enriched.push({
-                    ...peer,
-                    per: metrics?.peRatioTTM ?? null,
-                    psr: metrics?.priceToSalesRatioTTM ?? null,
-                });
-            }
-            return enriched;
-        }
+        (symbol: string): Promise<FundamentalPeerInput[]> =>
+            getOrSetCache(`fundamental:peers:${sym(symbol)}`, TTL, async () => {
+                const raw = await this.inner.getStockPeers(symbol);
+                const enriched: FundamentalPeerInput[] = [];
+                for (const peer of raw.slice(0, PEER_LIMIT)) {
+                    const metrics = await this.getKeyMetricsTtm(peer.symbol);
+                    enriched.push({
+                        ...peer,
+                        per: metrics?.peRatioTTM ?? null,
+                        psr: metrics?.priceToSalesRatioTTM ?? null,
+                    });
+                }
+                return enriched;
+            })
     );
 
     /**

--- a/src/shared/api/fmp/CachedFundamentalProvider.ts
+++ b/src/shared/api/fmp/CachedFundamentalProvider.ts
@@ -125,9 +125,34 @@ export class CachedFundamentalProvider implements FundamentalProvider {
             )
     );
 
-    // Task 3에서 캐싱+enrich로 교체할 pass-through stub.
-    getStockPeers = (symbol: string): Promise<FundamentalPeerInput[]> =>
-        this.inner.getStockPeers(symbol);
+    /**
+     * raw peer 목록을 `fundamental:peers:<SYM>`에 캐싱한 뒤, 각 peer를 캐싱된
+     * `getKeyMetricsTtm`으로 enrich해 per/psr을 채운다. 페이지·분석이 동일한
+     * enrich된 peer를 받아 core 프롬프트의 PER/PSR이 정상 채워진다(기존엔 분석
+     * 경로가 enrich되지 않은 raw peer를 받아 PER/PSR이 N/A였다).
+     *
+     * enrich는 콜드 캐시 시 peer당 동시 FMP 요청 폭증(rate-limit)을 피하려 순차
+     * 실행한다 — warm 캐시에서는 getKeyMetricsTtm(Redis) 히트로 비용이 낮다.
+     */
+    getStockPeers = cache(
+        async (symbol: string): Promise<FundamentalPeerInput[]> => {
+            const peers = await getOrSetCache(
+                `fundamental:peers:${sym(symbol)}`,
+                TTL,
+                () => this.inner.getStockPeers(symbol)
+            );
+            const enriched: FundamentalPeerInput[] = [];
+            for (const peer of peers) {
+                const metrics = await this.getKeyMetricsTtm(peer.symbol);
+                enriched.push({
+                    ...peer,
+                    per: metrics?.peRatioTTM ?? null,
+                    psr: metrics?.priceToSalesRatioTTM ?? null,
+                });
+            }
+            return enriched;
+        }
+    );
 
     // Task 4에서 캐싱으로 교체할 pass-through stub.
     getSectorPerformanceSnapshot = (
@@ -135,14 +160,17 @@ export class CachedFundamentalProvider implements FundamentalProvider {
     ): Promise<FundamentalSectorPerformanceInput[]> =>
         this.inner.getSectorPerformanceSnapshot(date);
 
+    // pass-through (no-store + DB 영속 / 빈 stub)
     getHistoricalSectorPerformance = (
         sector: string
     ): Promise<FundamentalSectorHistoricalInput[]> =>
         this.inner.getHistoricalSectorPerformance(sector);
 
+    // pass-through (no-store + DB 영속 / 빈 stub)
     getEarningsReport = (symbol: string): Promise<EarningsReport | null> =>
         this.inner.getEarningsReport(symbol);
 
+    // pass-through (no-store + DB 영속 / 빈 stub)
     getEarningsReports = (
         symbol: string,
         limit?: number

--- a/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
+++ b/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
@@ -1,23 +1,35 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CachedFundamentalProvider } from '@/shared/api/fmp/CachedFundamentalProvider';
+import type { FundamentalProvider } from '@/shared/api/fmp/fundamentalProvider.types';
+import type { FundamentalPeerInput } from '@y0ngha/siglens-core';
 
 // 인메모리 fake Redis. envelope 포맷({data})을 그대로 저장/반환.
 // NOTE: react는 mock하지 않는다 — vitest에서 React.cache는 pass-through이므로
 // 두 번째 호출도 실제로 getOrSetCache에 재진입해 fake redis 히트를 검증하게 된다.
-const store = new Map<string, unknown>();
-const fakeRedis = {
-    get: vi.fn(async (key: string) => (store.has(key) ? store.get(key) : null)),
-    set: vi.fn(async (key: string, value: unknown) => {
-        store.set(key, value);
-    }),
-};
+const { store, fakeRedis } = vi.hoisted(() => {
+    const store = new Map<string, unknown>();
+    const fakeRedis = {
+        get: vi.fn(async (key: string) =>
+            store.has(key) ? store.get(key) : null
+        ),
+        set: vi.fn(async (key: string, value: unknown) => {
+            store.set(key, value);
+        }),
+    };
+    return { store, fakeRedis };
+});
+// `let` because tests reassign it; the mock factory closes over the mutable binding.
 let redisEnabled = true;
 vi.mock('@/shared/cache/redisClient', () => ({
     getRedisClient: () => (redisEnabled ? fakeRedis : null),
 }));
 
-import { CachedFundamentalProvider } from '@/shared/api/fmp/CachedFundamentalProvider';
-import type { FundamentalProvider } from '@/shared/api/fmp/getFundamentalDataProvider';
-import type { FundamentalPeerInput } from '@y0ngha/siglens-core';
+function resetSharedState() {
+    store.clear();
+    redisEnabled = true;
+    fakeRedis.get.mockClear();
+    fakeRedis.set.mockClear();
+}
 
 function makeInner(
     overrides: Partial<FundamentalProvider> = {}
@@ -59,14 +71,9 @@ function makeInner(
     } as FundamentalProvider;
 }
 
-beforeEach(() => {
-    store.clear();
-    redisEnabled = true;
-    fakeRedis.get.mockClear();
-    fakeRedis.set.mockClear();
-});
-
 describe('CachedFundamentalProvider — simple cached methods', () => {
+    beforeEach(resetSharedState);
+
     it('caches getProfile under fundamental:profile:<SYM> and uppercases symbol', async () => {
         const inner = makeInner();
         const provider = new CachedFundamentalProvider(inner);
@@ -182,6 +189,8 @@ describe('CachedFundamentalProvider — simple cached methods', () => {
 });
 
 describe('CachedFundamentalProvider — getStockPeers enrich', () => {
+    beforeEach(resetSharedState);
+
     it('caches the ENRICHED list as a whole; warm call does zero round-trips', async () => {
         const inner = makeInner({
             getStockPeers: vi.fn(async () => [
@@ -362,6 +371,8 @@ describe('CachedFundamentalProvider — getStockPeers enrich', () => {
 });
 
 describe('CachedFundamentalProvider — sector + pass-through', () => {
+    beforeEach(resetSharedState);
+
     it('caches sector performance under fundamental:sector-performance:<DATE>', async () => {
         const inner = makeInner({
             getSectorPerformanceSnapshot: vi.fn(async () => [

--- a/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
+++ b/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
@@ -181,7 +181,7 @@ describe('CachedFundamentalProvider — simple cached methods', () => {
 });
 
 describe('CachedFundamentalProvider — getStockPeers enrich', () => {
-    it('caches raw peers and enriches per/psr from getKeyMetricsTtm', async () => {
+    it('caches the ENRICHED list as a whole; warm call does zero round-trips', async () => {
         const inner = makeInner({
             getStockPeers: vi.fn(async () => [
                 { symbol: 'MSFT', companyName: 'Microsoft', marketCap: 2e12 },
@@ -204,6 +204,7 @@ describe('CachedFundamentalProvider — getStockPeers enrich', () => {
 
         const peers = await provider.getStockPeers('AAPL');
 
+        // MSFT has metrics → per/psr set; GOOG has null metrics → per/psr null
         expect(peers).toEqual([
             {
                 symbol: 'MSFT',
@@ -220,10 +221,31 @@ describe('CachedFundamentalProvider — getStockPeers enrich', () => {
                 psr: null,
             },
         ]);
-        expect(store.has('fundamental:peers:AAPL')).toBe(true);
-        // raw peer 목록 캐싱: 두 번째 호출 시 inner.getStockPeers 재호출 없음
-        await provider.getStockPeers('AAPL');
-        expect(inner.getStockPeers).toHaveBeenCalledTimes(1);
+
+        // the ENRICHED list (incl. per/psr) is what's cached under the peers key,
+        // not the raw peer list — the cached envelope carries per/psr.
+        const cached = store.get('fundamental:peers:AAPL') as {
+            data: typeof peers;
+        };
+        expect(cached.data).toEqual(peers);
+
+        const innerStockPeers = inner.getStockPeers as ReturnType<typeof vi.fn>;
+        const innerKeyMetrics = inner.getKeyMetricsTtm as ReturnType<
+            typeof vi.fn
+        >;
+        const stockPeersCallsAfterCold = innerStockPeers.mock.calls.length;
+        const keyMetricsCallsAfterCold = innerKeyMetrics.mock.calls.length;
+
+        // warm call: single Redis GET on the peers key, zero per-peer round-trips
+        const second = await provider.getStockPeers('AAPL');
+        expect(second).toEqual(peers);
+        expect(innerStockPeers.mock.calls.length).toBe(
+            stockPeersCallsAfterCold
+        );
+        expect(innerKeyMetrics.mock.calls.length).toBe(
+            keyMetricsCallsAfterCold
+        );
+        expect(innerStockPeers).toHaveBeenCalledTimes(1);
     });
 
     it('returns empty array for a symbol with no peers (worst case)', async () => {
@@ -254,6 +276,83 @@ describe('CachedFundamentalProvider — getStockPeers enrich', () => {
         expect(inner.getKeyMetricsTtm).toHaveBeenCalledTimes(1);
         expect(peers).toHaveLength(2);
         expect(peers[0].per).toBe(30);
+    });
+
+    it('caps the peer list to PEER_LIMIT (10) before enriching', async () => {
+        const rawPeers = Array.from({ length: 12 }, (_, i) => ({
+            symbol: `P${i}`,
+            companyName: `Company ${i}`,
+            marketCap: 1e9,
+        }));
+        const inner = makeInner({
+            getStockPeers: vi.fn(async () => rawPeers),
+            getKeyMetricsTtm: vi.fn(async () => ({
+                peRatioTTM: 15,
+                priceToSalesRatioTTM: 4,
+                pbRatioTTM: null,
+                pegRatioTTM: null,
+                enterpriseValueOverEBITDATTM: null,
+                epsTTM: null,
+            })),
+        });
+        const provider = new CachedFundamentalProvider(inner);
+
+        const peers = await provider.getStockPeers('AAPL');
+
+        // 12 raw peers → capped to 10
+        expect(peers).toHaveLength(10);
+        expect(peers.map(p => p.symbol)).toEqual(
+            rawPeers.slice(0, 10).map(p => p.symbol)
+        );
+        // each enriched peer carries per/psr from getKeyMetricsTtm
+        expect(peers.every(p => p.per === 15 && p.psr === 4)).toBe(true);
+        // enrich loop runs at most PEER_LIMIT (10) times, distinct symbols → 10 inner calls
+        expect(
+            (inner.getKeyMetricsTtm as ReturnType<typeof vi.fn>).mock.calls
+                .length
+        ).toBeLessThanOrEqual(10);
+        expect(inner.getKeyMetricsTtm).toHaveBeenCalledTimes(10);
+    });
+
+    it('one peer with null metrics does NOT break enrichment of the rest', async () => {
+        const inner = makeInner({
+            getStockPeers: vi.fn(async () => [
+                { symbol: 'MSFT', companyName: 'Microsoft', marketCap: 2e12 },
+                { symbol: 'BAD', companyName: 'Broken', marketCap: 1e9 },
+                { symbol: 'GOOG', companyName: 'Alphabet', marketCap: 1.5e12 },
+            ]),
+            // BAD returns null (e.g. getKeyMetricsTtm caught an FMP failure → null)
+            getKeyMetricsTtm: vi.fn(async (s: string) =>
+                s === 'BAD'
+                    ? null
+                    : {
+                          peRatioTTM: 20,
+                          priceToSalesRatioTTM: 5,
+                          pbRatioTTM: null,
+                          pegRatioTTM: null,
+                          enterpriseValueOverEBITDATTM: null,
+                          epsTTM: null,
+                      }
+            ),
+        });
+        const provider = new CachedFundamentalProvider(inner);
+
+        const peers = await provider.getStockPeers('AAPL');
+
+        expect(peers).toHaveLength(3);
+        // the null-metrics peer just gets per/psr null
+        expect(peers[1]).toEqual({
+            symbol: 'BAD',
+            companyName: 'Broken',
+            marketCap: 1e9,
+            per: null,
+            psr: null,
+        });
+        // the rest still enrich normally
+        expect(peers[0].per).toBe(20);
+        expect(peers[0].psr).toBe(5);
+        expect(peers[2].per).toBe(20);
+        expect(peers[2].psr).toBe(5);
     });
 });
 

--- a/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
+++ b/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
@@ -150,3 +150,80 @@ describe('CachedFundamentalProvider — simple cached methods', () => {
         expect(store.has('fundamental:price-target-summary:AAPL')).toBe(true);
     });
 });
+
+describe('CachedFundamentalProvider — getStockPeers enrich', () => {
+    it('caches raw peers and enriches per/psr from getKeyMetricsTtm', async () => {
+        const inner = makeInner({
+            getStockPeers: vi.fn(async () => [
+                { symbol: 'MSFT', companyName: 'Microsoft', marketCap: 2e12 },
+                { symbol: 'GOOG', companyName: 'Alphabet', marketCap: 1.5e12 },
+            ]),
+            getKeyMetricsTtm: vi.fn(async (s: string) =>
+                s === 'MSFT'
+                    ? {
+                          peRatioTTM: 30,
+                          priceToSalesRatioTTM: 11,
+                          pbRatioTTM: null,
+                          pegRatioTTM: null,
+                          enterpriseValueOverEBITDATTM: null,
+                          epsTTM: null,
+                      }
+                    : null
+            ),
+        });
+        const provider = new CachedFundamentalProvider(inner);
+
+        const peers = await provider.getStockPeers('AAPL');
+
+        expect(peers).toEqual([
+            {
+                symbol: 'MSFT',
+                companyName: 'Microsoft',
+                marketCap: 2e12,
+                per: 30,
+                psr: 11,
+            },
+            {
+                symbol: 'GOOG',
+                companyName: 'Alphabet',
+                marketCap: 1.5e12,
+                per: null,
+                psr: null,
+            },
+        ]);
+        expect(store.has('fundamental:peers:AAPL')).toBe(true);
+        // raw peer 목록 캐싱: 두 번째 호출 시 inner.getStockPeers 재호출 없음
+        await provider.getStockPeers('AAPL');
+        expect(inner.getStockPeers).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns empty array for a symbol with no peers (worst case)', async () => {
+        const inner = makeInner({ getStockPeers: vi.fn(async () => []) });
+        const provider = new CachedFundamentalProvider(inner);
+        expect(await provider.getStockPeers('NONE')).toEqual([]);
+    });
+
+    it('enriches each peer sequentially via cached getKeyMetricsTtm', async () => {
+        const inner = makeInner({
+            getStockPeers: vi.fn(async () => [
+                { symbol: 'MSFT', companyName: 'Microsoft', marketCap: 2e12 },
+                { symbol: 'MSFT', companyName: 'Microsoft', marketCap: 2e12 },
+            ]),
+            getKeyMetricsTtm: vi.fn(async () => ({
+                peRatioTTM: 30,
+                priceToSalesRatioTTM: 11,
+                pbRatioTTM: null,
+                pegRatioTTM: null,
+                enterpriseValueOverEBITDATTM: null,
+                epsTTM: null,
+            })),
+        });
+        const provider = new CachedFundamentalProvider(inner);
+        const peers = await provider.getStockPeers('AAPL');
+        // 동일 peer 심볼 → getKeyMetricsTtm 결과가 Redis(fundamental:key-metrics:MSFT)로 캐싱돼
+        // 두 번째 peer는 캐시 히트(inner.getKeyMetricsTtm 1회)
+        expect(inner.getKeyMetricsTtm).toHaveBeenCalledTimes(1);
+        expect(peers).toHaveLength(2);
+        expect(peers[0].per).toBe(30);
+    });
+});

--- a/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
+++ b/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// 인메모리 fake Redis. envelope 포맷({data})을 그대로 저장/반환.
+// NOTE: react는 mock하지 않는다 — vitest에서 React.cache는 pass-through이므로
+// 두 번째 호출도 실제로 getOrSetCache에 재진입해 fake redis 히트를 검증하게 된다.
+const store = new Map<string, unknown>();
+const fakeRedis = {
+    get: vi.fn(async (key: string) => (store.has(key) ? store.get(key) : null)),
+    set: vi.fn(async (key: string, value: unknown) => {
+        store.set(key, value);
+    }),
+};
+let redisEnabled = true;
+vi.mock('@/shared/cache/redisClient', () => ({
+    getRedisClient: () => (redisEnabled ? fakeRedis : null),
+}));
+
+import { CachedFundamentalProvider } from '@/shared/api/fmp/CachedFundamentalProvider';
+import type { FundamentalProvider } from '@/shared/api/fmp/getFundamentalDataProvider';
+
+function makeInner(
+    overrides: Partial<FundamentalProvider> = {}
+): FundamentalProvider {
+    return {
+        getProfile: vi.fn(async (s: string) => ({
+            symbol: s.toUpperCase(),
+            companyName: 'X',
+            sector: 'Tech',
+            industry: 'SW',
+            marketCap: 1e12,
+            ceo: 'A',
+            website: 'w',
+            description: 'd',
+        })),
+        getKeyMetricsTtm: vi.fn(async () => ({
+            peRatioTTM: 10,
+            priceToSalesRatioTTM: 3,
+            pbRatioTTM: null,
+            pegRatioTTM: null,
+            enterpriseValueOverEBITDATTM: null,
+            epsTTM: null,
+        })),
+        getRatiosTtm: vi.fn(async () => null),
+        getCashFlowStatement: vi.fn(async () => null),
+        getIncomeStatementGrowth: vi.fn(async () => null),
+        getFinancialScores: vi.fn(async () => null),
+        getStockPeers: vi.fn(async () => []),
+        getAnalystEstimates: vi.fn(async () => null),
+        getGrades: vi.fn(async () => []),
+        getGradesConsensus: vi.fn(async () => null),
+        getPriceTargetConsensus: vi.fn(async () => null),
+        getPriceTargetSummary: vi.fn(async () => null),
+        getSectorPerformanceSnapshot: vi.fn(async () => []),
+        getHistoricalSectorPerformance: vi.fn(async () => []),
+        getEarningsReport: vi.fn(async () => null),
+        getEarningsReports: vi.fn(async () => []),
+        ...overrides,
+    } as FundamentalProvider;
+}
+
+beforeEach(() => {
+    store.clear();
+    redisEnabled = true;
+    fakeRedis.get.mockClear();
+    fakeRedis.set.mockClear();
+});
+
+describe('CachedFundamentalProvider — simple cached methods', () => {
+    it('caches getProfile under fundamental:profile:<SYM> and uppercases symbol', async () => {
+        const inner = makeInner();
+        const provider = new CachedFundamentalProvider(inner);
+
+        const first = await provider.getProfile('aapl');
+        expect(first?.symbol).toBe('AAPL');
+        expect(inner.getProfile).toHaveBeenCalledTimes(1);
+        expect(store.has('fundamental:profile:AAPL')).toBe(true);
+
+        const second = await provider.getProfile('aapl');
+        expect(second?.symbol).toBe('AAPL');
+        expect(inner.getProfile).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches null result (no-data ticker) so it is not refetched', async () => {
+        const inner = makeInner({
+            getCashFlowStatement: vi.fn(async () => null),
+        });
+        const provider = new CachedFundamentalProvider(inner);
+
+        expect(await provider.getCashFlowStatement('NODATA')).toBeNull();
+        expect(await provider.getCashFlowStatement('NODATA')).toBeNull();
+        expect(inner.getCashFlowStatement).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches empty array result for getGrades under fundamental:grades:<SYM>', async () => {
+        const inner = makeInner({ getGrades: vi.fn(async () => []) });
+        const provider = new CachedFundamentalProvider(inner);
+
+        expect(await provider.getGrades('EMPTY')).toEqual([]);
+        expect(await provider.getGrades('EMPTY')).toEqual([]);
+        expect(inner.getGrades).toHaveBeenCalledTimes(1);
+        expect(store.has('fundamental:grades:EMPTY')).toBe(true);
+    });
+
+    it('propagates inner errors WITHOUT caching them (worst case)', async () => {
+        const boom = vi.fn(async () => {
+            throw new Error('FMP 502');
+        });
+        const inner = makeInner({ getFinancialScores: boom });
+        const provider = new CachedFundamentalProvider(inner);
+
+        await expect(provider.getFinancialScores('ERR')).rejects.toThrow(
+            'FMP 502'
+        );
+        expect(store.has('fundamental:scores:ERR')).toBe(false);
+        await expect(provider.getFinancialScores('ERR')).rejects.toThrow(
+            'FMP 502'
+        );
+        expect(boom).toHaveBeenCalledTimes(2);
+    });
+
+    it('falls back to inner when Redis is unavailable (worst case)', async () => {
+        redisEnabled = false;
+        const inner = makeInner();
+        const provider = new CachedFundamentalProvider(inner);
+
+        const profile = await provider.getProfile('TSLA');
+        expect(profile?.symbol).toBe('TSLA');
+        expect(inner.getProfile).toHaveBeenCalledTimes(1);
+        expect(store.size).toBe(0);
+    });
+
+    it('caches keyMetrics/ratios/growth/estimates/gradesConsensus/priceTarget under their keys', async () => {
+        const inner = makeInner();
+        const provider = new CachedFundamentalProvider(inner);
+
+        await provider.getKeyMetricsTtm('aapl');
+        await provider.getRatiosTtm('aapl');
+        await provider.getIncomeStatementGrowth('aapl');
+        await provider.getAnalystEstimates('aapl');
+        await provider.getGradesConsensus('aapl');
+        await provider.getPriceTargetConsensus('aapl');
+        await provider.getPriceTargetSummary('aapl');
+
+        expect(store.has('fundamental:key-metrics:AAPL')).toBe(true);
+        expect(store.has('fundamental:ratios:AAPL')).toBe(true);
+        expect(store.has('fundamental:growth:AAPL')).toBe(true);
+        expect(store.has('fundamental:estimates:AAPL')).toBe(true);
+        expect(store.has('fundamental:grades-consensus:AAPL')).toBe(true);
+        expect(store.has('fundamental:price-target-consensus:AAPL')).toBe(true);
+        expect(store.has('fundamental:price-target-summary:AAPL')).toBe(true);
+    });
+});

--- a/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
+++ b/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { CachedFundamentalProvider } from '@/shared/api/fmp/CachedFundamentalProvider';
+import {
+    CachedFundamentalProvider,
+    PEER_LIMIT,
+} from '@/shared/api/fmp/CachedFundamentalProvider';
 import type { FundamentalProvider } from '@/shared/api/fmp/fundamentalProvider.types';
 import type { FundamentalPeerInput } from '@y0ngha/siglens-core';
 
@@ -309,10 +312,10 @@ describe('CachedFundamentalProvider — getStockPeers enrich', () => {
 
         const peers = await provider.getStockPeers('AAPL');
 
-        // 12 raw peers → capped to 10
-        expect(peers).toHaveLength(10);
+        // 12 raw peers → capped to PEER_LIMIT
+        expect(peers).toHaveLength(PEER_LIMIT);
         expect(peers.map((p: FundamentalPeerInput) => p.symbol)).toEqual(
-            rawPeers.slice(0, 10).map(p => p.symbol)
+            rawPeers.slice(0, PEER_LIMIT).map(p => p.symbol)
         );
         // each enriched peer carries per/psr from getKeyMetricsTtm
         expect(
@@ -320,12 +323,12 @@ describe('CachedFundamentalProvider — getStockPeers enrich', () => {
                 (p: FundamentalPeerInput) => p.per === 15 && p.psr === 4
             )
         ).toBe(true);
-        // enrich loop runs at most PEER_LIMIT (10) times, distinct symbols → 10 inner calls
+        // enrich loop runs at most PEER_LIMIT times, distinct symbols → PEER_LIMIT inner calls
         expect(
             (inner.getKeyMetricsTtm as ReturnType<typeof vi.fn>).mock.calls
                 .length
-        ).toBeLessThanOrEqual(10);
-        expect(inner.getKeyMetricsTtm).toHaveBeenCalledTimes(10);
+        ).toBeLessThanOrEqual(PEER_LIMIT);
+        expect(inner.getKeyMetricsTtm).toHaveBeenCalledTimes(PEER_LIMIT);
     });
 
     it('one peer with null metrics does NOT break enrichment of the rest', async () => {

--- a/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
+++ b/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
@@ -118,6 +118,35 @@ describe('CachedFundamentalProvider — simple cached methods', () => {
         expect(boom).toHaveBeenCalledTimes(2);
     });
 
+    it('getKeyMetricsTtm: inner throw → null, NOT cached (valuation poison fix)', async () => {
+        const boom = vi.fn(async () => {
+            throw new Error('FMP 503');
+        });
+        const inner = makeInner({ getKeyMetricsTtm: boom });
+        const provider = new CachedFundamentalProvider(inner);
+
+        // decorator catches the throw and returns graceful null
+        expect(await provider.getKeyMetricsTtm('ERR')).toBeNull();
+        // the failure is NOT cached
+        expect(store.has('fundamental:key-metrics:ERR')).toBe(false);
+        // 2nd call re-invokes inner (no poisoned null served from cache)
+        expect(await provider.getKeyMetricsTtm('ERR')).toBeNull();
+        expect(boom).toHaveBeenCalledTimes(2);
+    });
+
+    it('getRatiosTtm: inner throw → null, NOT cached (valuation poison fix)', async () => {
+        const boom = vi.fn(async () => {
+            throw new Error('FMP 503');
+        });
+        const inner = makeInner({ getRatiosTtm: boom });
+        const provider = new CachedFundamentalProvider(inner);
+
+        expect(await provider.getRatiosTtm('ERR')).toBeNull();
+        expect(store.has('fundamental:ratios:ERR')).toBe(false);
+        expect(await provider.getRatiosTtm('ERR')).toBeNull();
+        expect(boom).toHaveBeenCalledTimes(2);
+    });
+
     it('falls back to inner when Redis is unavailable (worst case)', async () => {
         redisEnabled = false;
         const inner = makeInner();

--- a/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
+++ b/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
@@ -227,3 +227,67 @@ describe('CachedFundamentalProvider — getStockPeers enrich', () => {
         expect(peers[0].per).toBe(30);
     });
 });
+
+describe('CachedFundamentalProvider — sector + pass-through', () => {
+    it('caches sector performance under fundamental:sector-performance:<DATE>', async () => {
+        const inner = makeInner({
+            getSectorPerformanceSnapshot: vi.fn(async () => [
+                { sector: 'Technology', changesPercentage: 1.2 },
+            ]),
+        });
+        const provider = new CachedFundamentalProvider(inner);
+
+        const out = await provider.getSectorPerformanceSnapshot('2026-06-04');
+        expect(out).toEqual([{ sector: 'Technology', changesPercentage: 1.2 }]);
+        expect(store.has('fundamental:sector-performance:2026-06-04')).toBe(
+            true
+        );
+
+        await provider.getSectorPerformanceSnapshot('2026-06-04');
+        expect(inner.getSectorPerformanceSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    it('keys sector snapshot by date, not symbol (different dates miss separately)', async () => {
+        const inner = makeInner({
+            getSectorPerformanceSnapshot: vi.fn(async () => [
+                { sector: 'Energy', changesPercentage: -0.5 },
+            ]),
+        });
+        const provider = new CachedFundamentalProvider(inner);
+        await provider.getSectorPerformanceSnapshot('2026-06-04');
+        await provider.getSectorPerformanceSnapshot('2026-06-05');
+        expect(inner.getSectorPerformanceSnapshot).toHaveBeenCalledTimes(2);
+        expect(store.has('fundamental:sector-performance:2026-06-04')).toBe(
+            true
+        );
+        expect(store.has('fundamental:sector-performance:2026-06-05')).toBe(
+            true
+        );
+    });
+
+    it('does NOT cache earnings (pass-through, fresh each call)', async () => {
+        const inner = makeInner({
+            getEarningsReports: vi.fn(async () => []),
+            getEarningsReport: vi.fn(async () => null),
+        });
+        const provider = new CachedFundamentalProvider(inner);
+
+        await provider.getEarningsReports('AAPL', 5);
+        await provider.getEarningsReports('AAPL', 5);
+        await provider.getEarningsReport('AAPL');
+        await provider.getEarningsReport('AAPL');
+
+        expect(inner.getEarningsReports).toHaveBeenCalledTimes(2);
+        expect(inner.getEarningsReport).toHaveBeenCalledTimes(2);
+        expect(store.size).toBe(0);
+    });
+
+    it('passes through historical sector performance without caching', async () => {
+        const inner = makeInner();
+        const provider = new CachedFundamentalProvider(inner);
+        expect(
+            await provider.getHistoricalSectorPerformance('Technology')
+        ).toEqual([]);
+        expect(store.size).toBe(0);
+    });
+});

--- a/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
+++ b/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/shared/cache/redisClient', () => ({
 
 import { CachedFundamentalProvider } from '@/shared/api/fmp/CachedFundamentalProvider';
 import type { FundamentalProvider } from '@/shared/api/fmp/getFundamentalDataProvider';
+import type { FundamentalPeerInput } from '@y0ngha/siglens-core';
 
 function makeInner(
     overrides: Partial<FundamentalProvider> = {}
@@ -301,11 +302,15 @@ describe('CachedFundamentalProvider — getStockPeers enrich', () => {
 
         // 12 raw peers → capped to 10
         expect(peers).toHaveLength(10);
-        expect(peers.map(p => p.symbol)).toEqual(
+        expect(peers.map((p: FundamentalPeerInput) => p.symbol)).toEqual(
             rawPeers.slice(0, 10).map(p => p.symbol)
         );
         // each enriched peer carries per/psr from getKeyMetricsTtm
-        expect(peers.every(p => p.per === 15 && p.psr === 4)).toBe(true);
+        expect(
+            peers.every(
+                (p: FundamentalPeerInput) => p.per === 15 && p.psr === 4
+            )
+        ).toBe(true);
         // enrich loop runs at most PEER_LIMIT (10) times, distinct symbols → 10 inner calls
         expect(
             (inner.getKeyMetricsTtm as ReturnType<typeof vi.fn>).mock.calls

--- a/src/shared/api/fmp/__tests__/fundamentalClient.test.ts
+++ b/src/shared/api/fmp/__tests__/fundamentalClient.test.ts
@@ -240,18 +240,19 @@ describe('FmpFundamentalClient', () => {
 
     describe('getRatiosTtm', () => {
         it('returns mapped TTM ratios', async () => {
+            // getValuationRaw fetches key-metrics-ttm first, then ratios-ttm.
+            mockOk([
+                {
+                    returnOnEquityTTM: 1.47,
+                    returnOnAssetsTTM: 0.28,
+                },
+            ]);
             mockOk([
                 {
                     operatingProfitMarginTTM: 0.3,
                     netProfitMarginTTM: 0.25,
                     debtToAssetsRatioTTM: 0.31,
                     currentRatioTTM: 0.94,
-                },
-            ]);
-            mockOk([
-                {
-                    returnOnEquityTTM: 1.47,
-                    returnOnAssetsTTM: 0.28,
                 },
             ]);
             const client = new FmpFundamentalClient();
@@ -269,6 +270,8 @@ describe('FmpFundamentalClient', () => {
         });
 
         it('uses ratios when key metrics fallback request fails', async () => {
+            // getValuationRaw fetches key-metrics-ttm first (errors), then ratios-ttm.
+            mockError(400);
             mockOk([
                 {
                     returnOnEquityTTM: 1.47,
@@ -279,7 +282,6 @@ describe('FmpFundamentalClient', () => {
                     currentRatioTTM: 0.94,
                 },
             ]);
-            mockError(400);
             const client = new FmpFundamentalClient();
             expect(await client.getRatiosTtm('AAPL')).toEqual({
                 returnOnEquityTTM: 1.47,

--- a/src/shared/api/fmp/__tests__/fundamentalClient.test.ts
+++ b/src/shared/api/fmp/__tests__/fundamentalClient.test.ts
@@ -66,11 +66,13 @@ describe('FmpFundamentalClient', () => {
             await expect(client.getProfile('AAPL')).rejects.toThrow('404');
         });
 
-        it('getKeyMetricsTtm returns null when both optional endpoints fail', async () => {
+        it('getKeyMetricsTtm THROWS when an endpoint fails (poison fix: no swallow-to-null)', async () => {
             mockError(400);
             mockError(400);
             const client = new FmpFundamentalClient();
-            await expect(client.getKeyMetricsTtm('AAPL')).resolves.toBeNull();
+            await expect(client.getKeyMetricsTtm('AAPL')).rejects.toThrow(
+                '400'
+            );
         });
     });
 
@@ -210,7 +212,11 @@ describe('FmpFundamentalClient', () => {
             expect(await client.getKeyMetricsTtm('X')).toBeNull();
         });
 
-        it('uses key metrics when ratios fallback request fails', async () => {
+        it('THROWS when the ratios endpoint fails even if key-metrics succeeds (poison fix: no partial swallow)', async () => {
+            // key-metrics-ttm OK, ratios-ttm errors. Previously getOptionalArray
+            // swallowed the ratios error → key-metrics data was used. Now the
+            // Promise.all rejects so a transient FMP failure propagates instead of
+            // being cached as partial valuation by the Redis decorator.
             mockOk([
                 {
                     peRatioTTM: 28.5,
@@ -223,14 +229,9 @@ describe('FmpFundamentalClient', () => {
             ]);
             mockError(400);
             const client = new FmpFundamentalClient();
-            expect(await client.getKeyMetricsTtm('AAPL')).toEqual({
-                peRatioTTM: 28.5,
-                priceToSalesRatioTTM: 7.2,
-                pbRatioTTM: 45.1,
-                pegRatioTTM: 2.3,
-                enterpriseValueOverEBITDATTM: 22,
-                epsTTM: 6.11,
-            });
+            await expect(client.getKeyMetricsTtm('AAPL')).rejects.toThrow(
+                '400'
+            );
         });
     });
 
@@ -269,8 +270,10 @@ describe('FmpFundamentalClient', () => {
             expect(await client.getRatiosTtm('X')).toBeNull();
         });
 
-        it('uses ratios when key metrics fallback request fails', async () => {
-            // getValuationRaw fetches key-metrics-ttm first (errors), then ratios-ttm.
+        it('THROWS when the key-metrics endpoint fails even if ratios succeeds (poison fix: no partial swallow)', async () => {
+            // key-metrics-ttm errors, ratios-ttm OK. Previously the key-metrics
+            // error was swallowed and ratios data was used; now the Promise.all
+            // rejects so the transient failure propagates (decorator → null, uncached).
             mockError(400);
             mockOk([
                 {
@@ -283,14 +286,7 @@ describe('FmpFundamentalClient', () => {
                 },
             ]);
             const client = new FmpFundamentalClient();
-            expect(await client.getRatiosTtm('AAPL')).toEqual({
-                returnOnEquityTTM: 1.47,
-                returnOnAssetsTTM: 0.28,
-                operatingProfitMarginTTM: 0.3,
-                netProfitMarginTTM: 0.25,
-                debtRatioTTM: 0.31,
-                currentRatioTTM: 0.94,
-            });
+            await expect(client.getRatiosTtm('AAPL')).rejects.toThrow('400');
         });
 
         it('currentRatioTTM falls back to metrics when ratios row omits it', async () => {

--- a/src/shared/api/fmp/__tests__/fundamentalClient.test.ts
+++ b/src/shared/api/fmp/__tests__/fundamentalClient.test.ts
@@ -294,22 +294,23 @@ describe('FmpFundamentalClient', () => {
         });
 
         it('currentRatioTTM falls back to metrics when ratios row omits it', async () => {
+            // getValuationRaw fetches key-metrics-ttm FIRST, then ratios-ttm.
             // ratios row has no currentRatioTTM → `ratios?.currentRatioTTM` is
             // undefined → the ?? right-hand branch reads metrics?.currentRatioTTM.
             mockOk([
                 {
-                    // ratios-ttm row — omits currentRatioTTM
+                    // key-metrics-ttm row (consumed first) — provides currentRatioTTM
+                    currentRatioTTM: 1.85,
+                },
+            ]);
+            mockOk([
+                {
+                    // ratios-ttm row (consumed second) — omits currentRatioTTM
                     returnOnEquityTTM: 1.0,
                     returnOnAssetsTTM: 0.2,
                     operatingProfitMarginTTM: 0.3,
                     netProfitMarginTTM: 0.25,
                     debtToAssetsRatioTTM: 0.31,
-                },
-            ]);
-            mockOk([
-                {
-                    // key-metrics-ttm row — provides currentRatioTTM
-                    currentRatioTTM: 1.85,
                 },
             ]);
             const client = new FmpFundamentalClient();

--- a/src/shared/api/fmp/__tests__/fundamentalClient.valuation.test.ts
+++ b/src/shared/api/fmp/__tests__/fundamentalClient.valuation.test.ts
@@ -55,14 +55,26 @@ describe('FmpFundamentalClient valuation fetch sharing', () => {
         const client = new FmpFundamentalClient();
         await client.getKeyMetricsTtm('AAPL'); // completes, clears in-flight
         await client.getRatiosTtm('AAPL'); // fresh fetch
-        expect(fmpGet.mock.calls.filter(c => c[0] === 'key-metrics-ttm')).toHaveLength(2);
+        expect(
+            fmpGet.mock.calls.filter(c => c[0] === 'key-metrics-ttm')
+        ).toHaveLength(2);
     });
 
-    it('returns null when both endpoints are empty (worst case)', async () => {
+    it('returns null when both endpoints are empty (no throw on empty 200)', async () => {
         fmpGet.mockResolvedValue([]);
         const client = new FmpFundamentalClient();
         expect(await client.getKeyMetricsTtm('ZZZZ')).toBeNull();
         expect(await client.getRatiosTtm('ZZZZ')).toBeNull();
+    });
+
+    it('propagates (throws) FMP errors instead of swallowing to null (poison fix)', async () => {
+        fmpGet.mockRejectedValue(new Error('FMP 503'));
+        const client = new FmpFundamentalClient();
+        await expect(client.getKeyMetricsTtm('AAPL')).rejects.toThrow(
+            'FMP 503'
+        );
+        // 새 in-flight(finally로 제거됨)로 다시 fetch → 동일하게 throw
+        await expect(client.getRatiosTtm('AAPL')).rejects.toThrow('FMP 503');
     });
 
     it('falls back to key-metrics fields when ratios endpoint is empty', async () => {

--- a/src/shared/api/fmp/__tests__/fundamentalClient.valuation.test.ts
+++ b/src/shared/api/fmp/__tests__/fundamentalClient.valuation.test.ts
@@ -77,6 +77,35 @@ describe('FmpFundamentalClient valuation fetch sharing', () => {
         await expect(client.getRatiosTtm('AAPL')).rejects.toThrow('FMP 503');
     });
 
+    it('mixed-case concurrent calls share the same in-flight fetch (uppercase key coalesces)', async () => {
+        fmpGet.mockImplementation((path: string) => {
+            if (path === 'key-metrics-ttm')
+                return Promise.resolve([{ peRatioTTM: 20 }]);
+            if (path === 'ratios-ttm')
+                return Promise.resolve([{ netProfitMarginTTM: 0.25 }]);
+            return Promise.resolve([]);
+        });
+
+        const client = new FmpFundamentalClient();
+        // 'aapl' and 'AAPL' must coalesce to a single in-flight entry
+        const [km, ratios] = await Promise.all([
+            client.getKeyMetricsTtm('aapl'),
+            client.getRatiosTtm('AAPL'),
+        ]);
+
+        expect(km?.peRatioTTM).toBe(20);
+        expect(ratios?.netProfitMarginTTM).toBe(0.25);
+
+        // Each FMP endpoint must have been fetched exactly once despite the mixed
+        // case — proving the uppercase key coalesced the two concurrent callers.
+        expect(
+            fmpGet.mock.calls.filter(c => c[0] === 'key-metrics-ttm')
+        ).toHaveLength(1);
+        expect(
+            fmpGet.mock.calls.filter(c => c[0] === 'ratios-ttm')
+        ).toHaveLength(1);
+    });
+
     it('falls back to key-metrics fields when ratios endpoint is empty', async () => {
         fmpGet.mockImplementation((path: string) =>
             path === 'key-metrics-ttm'

--- a/src/shared/api/fmp/__tests__/fundamentalClient.valuation.test.ts
+++ b/src/shared/api/fmp/__tests__/fundamentalClient.valuation.test.ts
@@ -1,22 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// React.cache를 동기 메모이즈 stub으로 대체 — 비-RSC(vitest) 컨텍스트에서도
-// same-request dedup을 검증하기 위함. 인스턴스별 격리는 각 it()에서 새 client로 보장.
-vi.mock('react', async importOriginal => {
-    const actual = await importOriginal<typeof import('react')>();
-    return {
-        ...actual,
-        cache: <A extends unknown[], R>(fn: (...args: A) => R) => {
-            const store = new Map<string, R>();
-            return (...args: A): R => {
-                const key = JSON.stringify(args);
-                if (!store.has(key)) store.set(key, fn(...args));
-                return store.get(key) as R;
-            };
-        },
-    };
-});
-
 const fmpGet = vi.fn();
 vi.mock('@/shared/api/fmp/httpClient', () => ({
     fmpGet: (...args: unknown[]) => fmpGet(...args),
@@ -59,6 +42,20 @@ describe('FmpFundamentalClient valuation fetch sharing', () => {
         const rCalls = fmpGet.mock.calls.filter(c => c[0] === 'ratios-ttm');
         expect(kmCalls).toHaveLength(1);
         expect(rCalls).toHaveLength(1);
+    });
+
+    it('sequential calls do not share in-flight (cross-request is Redis job)', async () => {
+        fmpGet.mockImplementation((path: string) => {
+            if (path === 'key-metrics-ttm')
+                return Promise.resolve([{ peRatioTTM: 10 }]);
+            if (path === 'ratios-ttm')
+                return Promise.resolve([{ netProfitMarginTTM: 0.15 }]);
+            return Promise.resolve([]);
+        });
+        const client = new FmpFundamentalClient();
+        await client.getKeyMetricsTtm('AAPL'); // completes, clears in-flight
+        await client.getRatiosTtm('AAPL'); // fresh fetch
+        expect(fmpGet.mock.calls.filter(c => c[0] === 'key-metrics-ttm')).toHaveLength(2);
     });
 
     it('returns null when both endpoints are empty (worst case)', async () => {

--- a/src/shared/api/fmp/__tests__/fundamentalClient.valuation.test.ts
+++ b/src/shared/api/fmp/__tests__/fundamentalClient.valuation.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// React.cache를 동기 메모이즈 stub으로 대체 — 비-RSC(vitest) 컨텍스트에서도
+// same-request dedup을 검증하기 위함. 인스턴스별 격리는 각 it()에서 새 client로 보장.
+vi.mock('react', async importOriginal => {
+    const actual = await importOriginal<typeof import('react')>();
+    return {
+        ...actual,
+        cache: <A extends unknown[], R>(fn: (...args: A) => R) => {
+            const store = new Map<string, R>();
+            return (...args: A): R => {
+                const key = JSON.stringify(args);
+                if (!store.has(key)) store.set(key, fn(...args));
+                return store.get(key) as R;
+            };
+        },
+    };
+});
+
+const fmpGet = vi.fn();
+vi.mock('@/shared/api/fmp/httpClient', () => ({
+    fmpGet: (...args: unknown[]) => fmpGet(...args),
+    FMP_STABLE_BASE: 'https://example.test/stable',
+}));
+
+import { FmpFundamentalClient } from '@/shared/api/fmp/fundamentalClient';
+
+beforeEach(() => {
+    fmpGet.mockReset();
+});
+
+describe('FmpFundamentalClient valuation fetch sharing', () => {
+    it('getKeyMetricsTtm + getRatiosTtm in same request fetch each endpoint once', async () => {
+        fmpGet.mockImplementation((path: string) => {
+            if (path === 'key-metrics-ttm')
+                return Promise.resolve([
+                    { peRatioTTM: 10, returnOnEquityTTM: 0.2 },
+                ]);
+            if (path === 'ratios-ttm')
+                return Promise.resolve([
+                    { priceToSalesRatioTTM: 3, netProfitMarginTTM: 0.15 },
+                ]);
+            return Promise.resolve([]);
+        });
+
+        const client = new FmpFundamentalClient();
+        const [km, ratios] = await Promise.all([
+            client.getKeyMetricsTtm('AAPL'),
+            client.getRatiosTtm('AAPL'),
+        ]);
+
+        expect(km?.peRatioTTM).toBe(10);
+        expect(km?.priceToSalesRatioTTM).toBe(3);
+        expect(ratios?.netProfitMarginTTM).toBe(0.15);
+
+        const kmCalls = fmpGet.mock.calls.filter(
+            c => c[0] === 'key-metrics-ttm'
+        );
+        const rCalls = fmpGet.mock.calls.filter(c => c[0] === 'ratios-ttm');
+        expect(kmCalls).toHaveLength(1);
+        expect(rCalls).toHaveLength(1);
+    });
+
+    it('returns null when both endpoints are empty (worst case)', async () => {
+        fmpGet.mockResolvedValue([]);
+        const client = new FmpFundamentalClient();
+        expect(await client.getKeyMetricsTtm('ZZZZ')).toBeNull();
+        expect(await client.getRatiosTtm('ZZZZ')).toBeNull();
+    });
+
+    it('falls back to key-metrics fields when ratios endpoint is empty', async () => {
+        fmpGet.mockImplementation((path: string) =>
+            path === 'key-metrics-ttm'
+                ? Promise.resolve([
+                      { peRatioTTM: 12, pbRatioTTM: 2, returnOnEquityTTM: 0.3 },
+                  ])
+                : Promise.resolve([])
+        );
+        const client = new FmpFundamentalClient();
+        const km = await client.getKeyMetricsTtm('MSFT');
+        expect(km?.peRatioTTM).toBe(12);
+        expect(km?.pbRatioTTM).toBe(2);
+        const ratios = await client.getRatiosTtm('MSFT');
+        expect(ratios?.returnOnEquityTTM).toBe(0.3);
+    });
+});

--- a/src/shared/api/fmp/__tests__/fundamentalClient.valuation.test.ts
+++ b/src/shared/api/fmp/__tests__/fundamentalClient.valuation.test.ts
@@ -1,18 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FmpFundamentalClient } from '@/shared/api/fmp/fundamentalClient';
 
-const fmpGet = vi.fn();
+const fmpGet = vi.hoisted(() => vi.fn());
 vi.mock('@/shared/api/fmp/httpClient', () => ({
     fmpGet: (...args: unknown[]) => fmpGet(...args),
     FMP_STABLE_BASE: 'https://example.test/stable',
 }));
 
-import { FmpFundamentalClient } from '@/shared/api/fmp/fundamentalClient';
-
-beforeEach(() => {
-    fmpGet.mockReset();
-});
-
 describe('FmpFundamentalClient valuation fetch sharing', () => {
+    beforeEach(() => {
+        fmpGet.mockReset();
+    });
+
     it('getKeyMetricsTtm + getRatiosTtm in same request fetch each endpoint once', async () => {
         fmpGet.mockImplementation((path: string) => {
             if (path === 'key-metrics-ttm')

--- a/src/shared/api/fmp/__tests__/getFundamentalDataProvider.test.ts
+++ b/src/shared/api/fmp/__tests__/getFundamentalDataProvider.test.ts
@@ -2,11 +2,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/shared/api/e2eEnv', () => ({ isE2E: () => false }));
 
-afterEach(() => {
-    vi.resetModules();
-});
-
 describe('getFundamentalDataProvider (prod)', () => {
+    afterEach(() => {
+        vi.resetModules();
+    });
+
     it('returns a CachedFundamentalProvider instance in prod', async () => {
         const { getFundamentalDataProvider } =
             await import('@/shared/api/fmp/getFundamentalDataProvider');

--- a/src/shared/api/fmp/__tests__/getFundamentalDataProvider.test.ts
+++ b/src/shared/api/fmp/__tests__/getFundamentalDataProvider.test.ts
@@ -1,32 +1,25 @@
-import { describe, it, expect } from 'vitest';
-import { getFundamentalDataProvider } from '../getFundamentalDataProvider';
-import { FmpFundamentalClient } from '../fundamentalClient';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-/**
- * Branch + singleton tests for getFundamentalDataProvider, mirroring the
- * established getMarketDataProvider.test.ts precedent.
- *
- * The E2E_TEST=1 branch `require('./FakeFundamentalDataProvider')`s the fake to
- * keep it out of the production bundle. vitest's node module runner cannot
- * resolve a relative CJS `require` of a source module (it throws "Cannot find
- * module" — vi.mock does not intercept require either), so that branch is
- * exercised by the E2E suite, not here. These unit tests cover the prod path:
- * the real FMP instance is returned and cached as a singleton.
- */
-describe('getFundamentalDataProvider', () => {
-    it('returns a singleton (same instance across calls)', () => {
-        expect(getFundamentalDataProvider()).toBe(getFundamentalDataProvider());
-    });
+vi.mock('@/shared/api/e2eEnv', () => ({ isE2E: () => false }));
 
-    it('returns the real FmpFundamentalClient when E2E_TEST is unset', () => {
+afterEach(() => {
+    vi.resetModules();
+});
+
+describe('getFundamentalDataProvider (prod)', () => {
+    it('returns a CachedFundamentalProvider instance in prod', async () => {
+        const { getFundamentalDataProvider } =
+            await import('@/shared/api/fmp/getFundamentalDataProvider');
+        const { CachedFundamentalProvider } =
+            await import('@/shared/api/fmp/CachedFundamentalProvider');
         expect(getFundamentalDataProvider()).toBeInstanceOf(
-            FmpFundamentalClient
+            CachedFundamentalProvider
         );
     });
 
-    it('exposes the siglens-specific extras the FundamentalProvider surface requires', () => {
-        const provider = getFundamentalDataProvider();
-        expect(typeof provider.getGrades).toBe('function');
-        expect(typeof provider.getEarningsReports).toBe('function');
+    it('returns the same singleton across calls', async () => {
+        const { getFundamentalDataProvider } =
+            await import('@/shared/api/fmp/getFundamentalDataProvider');
+        expect(getFundamentalDataProvider()).toBe(getFundamentalDataProvider());
     });
 });

--- a/src/shared/api/fmp/fundamentalClient.ts
+++ b/src/shared/api/fmp/fundamentalClient.ts
@@ -57,6 +57,12 @@ const ANALYST_ESTIMATES_PAGE = '0';
 const ANALYST_ESTIMATES_LIMIT = '10';
 const EARNINGS_REPORT_LIMIT = 5;
 
+/** Raw TTM valuation pair fetched together (key-metrics-ttm + ratios-ttm); either side may be `null`. */
+interface ValuationRaw {
+    metrics: RawFmpKeyMetricsTtm | null;
+    ratios: RawFmpRatiosTtm | null;
+}
+
 export interface FmpEarningsReportItem {
     symbol: string;
     earningsDate: string;
@@ -121,13 +127,7 @@ export class FmpFundamentalClient implements FundamentalDataProvider {
      * 들어온 호출"만 합쳐진다. cross-request 캐싱은 CachedFundamentalProvider(Redis)가
      * 담당한다.
      */
-    private valuationInflight = new Map<
-        string,
-        Promise<{
-            metrics: RawFmpKeyMetricsTtm | null;
-            ratios: RawFmpRatiosTtm | null;
-        }>
-    >();
+    private valuationInflight = new Map<string, Promise<ValuationRaw>>();
 
     /**
      * key-metrics-ttm + ratios-ttm을 한 번에 fetch해 raw 쌍을 반환한다.
@@ -150,10 +150,7 @@ export class FmpFundamentalClient implements FundamentalDataProvider {
      * 캐싱하지 못한다(빈 200 → `[]` → null 캐싱은 정상 동작으로 유지). 데코레이터가
      * 이 throw를 catch해 graceful null로 변환하는 책임을 진다.
      */
-    private getValuationRaw(symbol: string): Promise<{
-        metrics: RawFmpKeyMetricsTtm | null;
-        ratios: RawFmpRatiosTtm | null;
-    }> {
+    private getValuationRaw(symbol: string): Promise<ValuationRaw> {
         const key = symbol.toUpperCase();
         const inflight = this.valuationInflight.get(key);
         if (inflight !== undefined) return inflight;

--- a/src/shared/api/fmp/fundamentalClient.ts
+++ b/src/shared/api/fmp/fundamentalClient.ts
@@ -137,6 +137,11 @@ export class FmpFundamentalClient implements FundamentalDataProvider {
      * 인스턴스 in-flight 맵을 쓴다. Next Data Cache(fmpGet revalidate)는 cross-request
      * 2차 방어선이지만 region/배포마다 초기화되므로 신선도 보장에 의존하지 않는다.
      *
+     * in-flight 맵 키는 대문자로 정규화한다(예: 'aapl' → 'AAPL'). Redis 계층은
+     * 이미 대문자 키를 사용하며, 혼합 케이스 동시 호출('aapl' + 'AAPL')이 각각 별도
+     * in-flight 항목으로 취급되는 중복 fetch 결함을 방지한다. 실제 FMP fetch에는 원래
+     * `symbol` 인수를 그대로 전달한다(FMP는 케이스 무관).
+     *
      * FMP 장애(429/5xx/timeout)는 `fmpGet`을 통해 그대로 throw된다 — 다른 9개
      * 메서드와 동일한 계약. 이전엔 `getOptionalArray`로 에러를 `[]`로 삼켜 null을
      * 반환했는데, 그 null이 Redis 데코레이터(CachedFundamentalProvider)에 1h TTL로
@@ -149,7 +154,8 @@ export class FmpFundamentalClient implements FundamentalDataProvider {
         metrics: RawFmpKeyMetricsTtm | null;
         ratios: RawFmpRatiosTtm | null;
     }> {
-        const inflight = this.valuationInflight.get(symbol);
+        const key = symbol.toUpperCase();
+        const inflight = this.valuationInflight.get(key);
         if (inflight !== undefined) return inflight;
 
         const pending = (async () => {
@@ -163,13 +169,13 @@ export class FmpFundamentalClient implements FundamentalDataProvider {
             };
         })();
 
-        this.valuationInflight.set(symbol, pending);
+        this.valuationInflight.set(key, pending);
         // 정리(in-flight 제거)는 성공·실패 모두에서 수행한다. `pending`이 reject되면
         // 이 derived 체인도 reject되는데, 호출부는 반환된 `pending`을 직접 await/catch하지
         // 이 정리 체인을 관찰하지 않으므로 .catch(() => {})로 별도 흡수해 unhandled
         // rejection을 막는다(실제 에러는 호출부가 그대로 받는다).
         void pending
-            .finally(() => this.valuationInflight.delete(symbol))
+            .finally(() => this.valuationInflight.delete(key))
             .catch(() => {});
         return pending;
     }

--- a/src/shared/api/fmp/fundamentalClient.ts
+++ b/src/shared/api/fmp/fundamentalClient.ts
@@ -94,17 +94,6 @@ function toEarningsDate(value: RawFmpEarningsReport): string | null {
           : null;
 }
 
-async function getOptionalArray<T>(
-    path: string,
-    query: Record<string, string>
-): Promise<T[]> {
-    try {
-        return await fmpGet<T[]>(path, query);
-    } catch {
-        return [];
-    }
-}
-
 /** FMP adapter implementing `FundamentalDataProvider`. Uses `fmpGet` for all HTTP calls. */
 export class FmpFundamentalClient implements FundamentalDataProvider {
     /** Fetch company profile; returns `null` when FMP returns an empty array. */
@@ -147,6 +136,14 @@ export class FmpFundamentalClient implements FundamentalDataProvider {
      * RSC 렌더 스코프 전용이라 Server Action(분석 경로)에서는 dedup되지 않으므로
      * 인스턴스 in-flight 맵을 쓴다. Next Data Cache(fmpGet revalidate)는 cross-request
      * 2차 방어선이지만 region/배포마다 초기화되므로 신선도 보장에 의존하지 않는다.
+     *
+     * FMP 장애(429/5xx/timeout)는 `fmpGet`을 통해 그대로 throw된다 — 다른 9개
+     * 메서드와 동일한 계약. 이전엔 `getOptionalArray`로 에러를 `[]`로 삼켜 null을
+     * 반환했는데, 그 null이 Redis 데코레이터(CachedFundamentalProvider)에 1h TTL로
+     * 캐싱돼 일시적 blip이 "valuation 데이터 없음"으로 fleet-wide 고정되는 cache
+     * poisoning 버그가 있었다. 이제 throw가 전파되므로 getOrSetCache가 장애 결과를
+     * 캐싱하지 못한다(빈 200 → `[]` → null 캐싱은 정상 동작으로 유지). 데코레이터가
+     * 이 throw를 catch해 graceful null로 변환하는 책임을 진다.
      */
     private getValuationRaw(symbol: string): Promise<{
         metrics: RawFmpKeyMetricsTtm | null;
@@ -157,10 +154,8 @@ export class FmpFundamentalClient implements FundamentalDataProvider {
 
         const pending = (async () => {
             const [metricsArr, ratiosArr] = await Promise.all([
-                getOptionalArray<RawFmpKeyMetricsTtm>('key-metrics-ttm', {
-                    symbol,
-                }),
-                getOptionalArray<RawFmpRatiosTtm>('ratios-ttm', { symbol }),
+                fmpGet<RawFmpKeyMetricsTtm[]>('key-metrics-ttm', { symbol }),
+                fmpGet<RawFmpRatiosTtm[]>('ratios-ttm', { symbol }),
             ]);
             return {
                 metrics: metricsArr[0] ?? null,
@@ -169,7 +164,13 @@ export class FmpFundamentalClient implements FundamentalDataProvider {
         })();
 
         this.valuationInflight.set(symbol, pending);
-        void pending.finally(() => this.valuationInflight.delete(symbol));
+        // 정리(in-flight 제거)는 성공·실패 모두에서 수행한다. `pending`이 reject되면
+        // 이 derived 체인도 reject되는데, 호출부는 반환된 `pending`을 직접 await/catch하지
+        // 이 정리 체인을 관찰하지 않으므로 .catch(() => {})로 별도 흡수해 unhandled
+        // rejection을 막는다(실제 에러는 호출부가 그대로 받는다).
+        void pending
+            .finally(() => this.valuationInflight.delete(symbol))
+            .catch(() => {});
         return pending;
     }
 

--- a/src/shared/api/fmp/fundamentalClient.ts
+++ b/src/shared/api/fmp/fundamentalClient.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import { fmpGet as fmpGetRaw } from './httpClient';
 import { SECONDS_PER_HOUR } from '@/shared/config/time';
 import type {
@@ -126,18 +127,34 @@ export class FmpFundamentalClient implements FundamentalDataProvider {
         };
     }
 
+    /**
+     * key-metrics-ttm + ratios-ttm을 한 번에 fetch해 raw 쌍을 반환한다.
+     * `React.cache`로 요청 스코프 메모이즈하므로, 같은 요청에서 getKeyMetricsTtm과
+     * getRatiosTtm이 모두 호출돼도(분석 Promise.all) 각 엔드포인트 fetch는 1회로
+     * 수렴한다. 두 메서드가 서로의 필드를 fallback으로 쓰므로 raw 쌍을 공유한다.
+     */
+    private getValuationRaw = cache(
+        async (
+            symbol: string
+        ): Promise<{
+            metrics: RawFmpKeyMetricsTtm | null;
+            ratios: RawFmpRatiosTtm | null;
+        }> => {
+            const [arr, ratiosArr] = await Promise.all([
+                getOptionalArray<RawFmpKeyMetricsTtm>('key-metrics-ttm', {
+                    symbol,
+                }),
+                getOptionalArray<RawFmpRatiosTtm>('ratios-ttm', { symbol }),
+            ]);
+            return { metrics: arr[0] ?? null, ratios: ratiosArr[0] ?? null };
+        }
+    );
+
     /** Fetch TTM key metrics (valuation multiples + EPS); returns `null` when unavailable. */
     async getKeyMetricsTtm(
         symbol: string
     ): Promise<FundamentalValuationMetrics | null> {
-        const [arr, ratiosArr] = await Promise.all([
-            getOptionalArray<RawFmpKeyMetricsTtm>('key-metrics-ttm', {
-                symbol,
-            }),
-            getOptionalArray<RawFmpRatiosTtm>('ratios-ttm', { symbol }),
-        ]);
-        const metrics = arr[0] ?? null;
-        const ratios = ratiosArr[0] ?? null;
+        const { metrics, ratios } = await this.getValuationRaw(symbol);
         if (metrics === null && ratios === null) return null;
         return {
             peRatioTTM: toFiniteNumber(
@@ -165,14 +182,7 @@ export class FmpFundamentalClient implements FundamentalDataProvider {
 
     /** Fetch TTM profitability and financial health ratios; returns `null` when unavailable. */
     async getRatiosTtm(symbol: string): Promise<FundamentalRatiosInput | null> {
-        const [arr, metricsArr] = await Promise.all([
-            getOptionalArray<RawFmpRatiosTtm>('ratios-ttm', { symbol }),
-            getOptionalArray<RawFmpKeyMetricsTtm>('key-metrics-ttm', {
-                symbol,
-            }),
-        ]);
-        const ratios = arr[0] ?? null;
-        const metrics = metricsArr[0] ?? null;
+        const { metrics, ratios } = await this.getValuationRaw(symbol);
         if (ratios === null && metrics === null) return null;
         return {
             returnOnEquityTTM: toFiniteNumber(

--- a/src/shared/api/fmp/fundamentalClient.ts
+++ b/src/shared/api/fmp/fundamentalClient.ts
@@ -150,21 +150,20 @@ export class FmpFundamentalClient implements FundamentalDataProvider {
      * 캐싱하지 못한다(빈 200 → `[]` → null 캐싱은 정상 동작으로 유지). 데코레이터가
      * 이 throw를 catch해 graceful null로 변환하는 책임을 진다.
      */
+    private async fetchValuationFromFmp(symbol: string): Promise<ValuationRaw> {
+        const [metricsArr, ratiosArr] = await Promise.all([
+            fmpGet<RawFmpKeyMetricsTtm[]>('key-metrics-ttm', { symbol }),
+            fmpGet<RawFmpRatiosTtm[]>('ratios-ttm', { symbol }),
+        ]);
+        return { metrics: metricsArr[0] ?? null, ratios: ratiosArr[0] ?? null };
+    }
+
     private getValuationRaw(symbol: string): Promise<ValuationRaw> {
         const key = symbol.toUpperCase();
         const inflight = this.valuationInflight.get(key);
         if (inflight !== undefined) return inflight;
 
-        const pending = (async () => {
-            const [metricsArr, ratiosArr] = await Promise.all([
-                fmpGet<RawFmpKeyMetricsTtm[]>('key-metrics-ttm', { symbol }),
-                fmpGet<RawFmpRatiosTtm[]>('ratios-ttm', { symbol }),
-            ]);
-            return {
-                metrics: metricsArr[0] ?? null,
-                ratios: ratiosArr[0] ?? null,
-            };
-        })();
+        const pending = this.fetchValuationFromFmp(symbol);
 
         this.valuationInflight.set(key, pending);
         // 정리(in-flight 제거)는 성공·실패 모두에서 수행한다. `pending`이 reject되면

--- a/src/shared/api/fmp/fundamentalClient.ts
+++ b/src/shared/api/fmp/fundamentalClient.ts
@@ -1,4 +1,3 @@
-import { cache } from 'react';
 import { fmpGet as fmpGetRaw } from './httpClient';
 import { SECONDS_PER_HOUR } from '@/shared/config/time';
 import type {
@@ -128,27 +127,51 @@ export class FmpFundamentalClient implements FundamentalDataProvider {
     }
 
     /**
-     * key-metrics-ttm + ratios-ttm을 한 번에 fetch해 raw 쌍을 반환한다.
-     * `React.cache`로 요청 스코프 메모이즈하므로, 같은 요청에서 getKeyMetricsTtm과
-     * getRatiosTtm이 모두 호출돼도(분석 Promise.all) 각 엔드포인트 fetch는 1회로
-     * 수렴한다. 두 메서드가 서로의 필드를 fallback으로 쓰므로 raw 쌍을 공유한다.
+     * 진행 중인 valuation fetch를 심볼별로 공유하는 in-flight 메모이즈 맵.
+     * 완료(성공·실패) 시 finally로 제거하므로 누수 없이 "같은 요청에서 동시에
+     * 들어온 호출"만 합쳐진다. cross-request 캐싱은 CachedFundamentalProvider(Redis)가
+     * 담당한다.
      */
-    private getValuationRaw = cache(
-        async (
-            symbol: string
-        ): Promise<{
+    private valuationInflight = new Map<
+        string,
+        Promise<{
             metrics: RawFmpKeyMetricsTtm | null;
             ratios: RawFmpRatiosTtm | null;
-        }> => {
-            const [arr, ratiosArr] = await Promise.all([
+        }>
+    >();
+
+    /**
+     * key-metrics-ttm + ratios-ttm을 한 번에 fetch해 raw 쌍을 반환한다.
+     * getKeyMetricsTtm과 getRatiosTtm이 같은 요청에서 동시에 호출돼도(core의
+     * Promise.all) in-flight 공유로 각 엔드포인트 fetch가 1회로 수렴한다. React.cache는
+     * RSC 렌더 스코프 전용이라 Server Action(분석 경로)에서는 dedup되지 않으므로
+     * 인스턴스 in-flight 맵을 쓴다. Next Data Cache(fmpGet revalidate)는 cross-request
+     * 2차 방어선이지만 region/배포마다 초기화되므로 신선도 보장에 의존하지 않는다.
+     */
+    private getValuationRaw(symbol: string): Promise<{
+        metrics: RawFmpKeyMetricsTtm | null;
+        ratios: RawFmpRatiosTtm | null;
+    }> {
+        const inflight = this.valuationInflight.get(symbol);
+        if (inflight !== undefined) return inflight;
+
+        const pending = (async () => {
+            const [metricsArr, ratiosArr] = await Promise.all([
                 getOptionalArray<RawFmpKeyMetricsTtm>('key-metrics-ttm', {
                     symbol,
                 }),
                 getOptionalArray<RawFmpRatiosTtm>('ratios-ttm', { symbol }),
             ]);
-            return { metrics: arr[0] ?? null, ratios: ratiosArr[0] ?? null };
-        }
-    );
+            return {
+                metrics: metricsArr[0] ?? null,
+                ratios: ratiosArr[0] ?? null,
+            };
+        })();
+
+        this.valuationInflight.set(symbol, pending);
+        void pending.finally(() => this.valuationInflight.delete(symbol));
+        return pending;
+    }
 
     /** Fetch TTM key metrics (valuation multiples + EPS); returns `null` when unavailable. */
     async getKeyMetricsTtm(

--- a/src/shared/api/fmp/fundamentalProvider.types.ts
+++ b/src/shared/api/fmp/fundamentalProvider.types.ts
@@ -1,0 +1,22 @@
+import type { FundamentalDataProvider } from '@y0ngha/siglens-core';
+import type { FmpEarningsReportItem } from './fundamentalClient';
+
+/**
+ * App-facing fundamental provider surface: the core `FundamentalDataProvider`
+ * port plus the two siglens-specific extras that some injection points call
+ * directly (`getGrades` is widened from the port's optional method to required,
+ * and `getEarningsReports` is not on the port at all). Both the real
+ * `FmpFundamentalClient` and the E2E `FakeFundamentalDataProvider` satisfy it.
+ *
+ * Lives in its own module (not `getFundamentalDataProvider.ts`) so the
+ * `CachedFundamentalProvider` class can `import type` it without forming a
+ * type-level cycle with `getFundamentalDataProvider.ts` (which imports the
+ * `CachedFundamentalProvider` class at runtime).
+ */
+export interface FundamentalProvider extends FundamentalDataProvider {
+    getGrades: NonNullable<FundamentalDataProvider['getGrades']>;
+    getEarningsReports(
+        symbol: string,
+        limit?: number
+    ): Promise<FmpEarningsReportItem[]>;
+}

--- a/src/shared/api/fmp/getFundamentalDataProvider.ts
+++ b/src/shared/api/fmp/getFundamentalDataProvider.ts
@@ -3,6 +3,7 @@ import {
     FmpFundamentalClient,
     type FmpEarningsReportItem,
 } from './fundamentalClient';
+import { CachedFundamentalProvider } from './CachedFundamentalProvider';
 import { isE2E } from '@/shared/api/e2eEnv';
 
 /**
@@ -34,6 +35,6 @@ export function getFundamentalDataProvider(): FundamentalProvider {
         cached = new FakeFundamentalDataProvider();
         return cached;
     }
-    cached = new FmpFundamentalClient();
+    cached = new CachedFundamentalProvider(new FmpFundamentalClient());
     return cached;
 }

--- a/src/shared/api/fmp/getFundamentalDataProvider.ts
+++ b/src/shared/api/fmp/getFundamentalDataProvider.ts
@@ -1,25 +1,12 @@
-import type { FundamentalDataProvider } from '@y0ngha/siglens-core';
-import {
-    FmpFundamentalClient,
-    type FmpEarningsReportItem,
-} from './fundamentalClient';
+import { FmpFundamentalClient } from './fundamentalClient';
 import { CachedFundamentalProvider } from './CachedFundamentalProvider';
+import type { FundamentalProvider } from './fundamentalProvider.types';
 import { isE2E } from '@/shared/api/e2eEnv';
 
-/**
- * App-facing fundamental provider surface: the core `FundamentalDataProvider`
- * port plus the two siglens-specific extras that some injection points call
- * directly (`getGrades` is widened from the port's optional method to required,
- * and `getEarningsReports` is not on the port at all). Both the real
- * `FmpFundamentalClient` and the E2E `FakeFundamentalDataProvider` satisfy it.
- */
-export interface FundamentalProvider extends FundamentalDataProvider {
-    getGrades: NonNullable<FundamentalDataProvider['getGrades']>;
-    getEarningsReports(
-        symbol: string,
-        limit?: number
-    ): Promise<FmpEarningsReportItem[]>;
-}
+// Re-exported so existing importers (`@/shared/api/fmp/getFundamentalDataProvider`)
+// keep resolving; the interface itself lives in `fundamentalProvider.types` to
+// avoid a type-level cycle with the `CachedFundamentalProvider` class import above.
+export type { FundamentalProvider } from './fundamentalProvider.types';
 
 let cached: FundamentalProvider | null = null;
 


### PR DESCRIPTION
## 배경
FMP API 사용량 점검에서 `key-metrics-ttm`·`ratios-ttm`이 시간당 각각 ~2,000회(합 ~4,000회) 호출되는 이상을 확인. 원인 두 가지:
1. **분석 경로(submitFundamentalAnalysis / submitOverallAnalysis)가 Redis를 우회** — core가 raw `FmpFundamentalClient`를 직접 호출, 페이지 SSR만 캐싱.
2. **key-metrics/ratios 이중 fetch** — 두 메서드가 각각 두 엔드포인트를 모두 fetch.
부수 발견: 분석 프롬프트의 peer PER/PSR이 항상 N/A(enrich가 페이지에만 존재).

## 변경
- **`CachedFundamentalProvider` 데코레이터** 신설 — `getFundamentalDataProvider()` 팩토리가 raw client를 감싸 반환. 분석·페이지가 동일 `fundamental:*` 캐시 공유(키/TTL 기존과 동일, core 변경 0).
- **`getValuationRaw`** — km/ratios raw fetch를 in-flight Promise 메모이즈로 1회로 합침(이중 fetch 제거).
- **peer enrich를 데코레이터로 통일** — 분석 프롬프트 PER/PSR 누락 정상화. enrich 결과 전체 캐싱(warm 시 round-trip 0) + top-N cap.
- **sector-performance 신규 캐싱**(date 키), earnings는 no-store + DB 영속 유지.
- 페이지/뉴스 데이터 파일은 thin delegation으로 축소.

## 감사 (모두 Opus 4.8, fresh context)
코드 품질 / 배포 안정성(아키) / 배포 준비(롤아웃) / SEO / 테스트 — 5종 감사 수행. 발견된 항목 모두 수정:
- **HIGH(포이즌)**: transient FMP 에러가 valuation에서 1h 캐싱되던 문제 — inner가 에러 throw(캐싱 안 됨), 데코레이터가 catch→null로 페이지/분석 graceful 유지.
- peer fan-out cap, in-flight 키 uppercase 정규화, delegation unit test 추가.

## 검증
- 전체 4885 tests 통과, `yarn lint`/`tsc --noEmit`/`yarn build` 모두 green.
- 핵심 파일(`CachedFundamentalProvider.ts`, `fundamentalClient.ts`) 100% 라인/브랜치 커버리지.
- **ISR 실증**: prod build + runtime에서 `/[symbol]/fundamental` = `●`(SSG), DSU 0, `x-nextjs-cache` MISS→HIT, `s-maxage=3600` 확인.

설계: `docs/superpowers/specs/2026-06-04-fmp-fundamental-cache-adapter-design.md`
플랜: `docs/superpowers/plans/2026-06-04-fmp-fundamental-cache-adapter.md`

Generated with [Claude Code](https://claude.com/claude-code)