### PR TITLE
fix(notice): Chrome 공지 팝업 starvation 수정 (startTransition → useMemo 파생)

### DIFF
--- a/docs/superpowers/specs/2026-06-04-notice-popup-testcases.md
+++ b/docs/superpowers/specs/2026-06-04-notice-popup-testcases.md
@@ -1,0 +1,60 @@
+# 공지 팝업(Notice Popup) 테스트 케이스 — #559
+
+> 변경사항: 운영 공지 팝업(`notices` 테이블 0016, `getActiveNoticesAction`, `useNoticePopup` 큐, `NoticePopup` 모달, `noticeStorage` localStorage, `matchPath` 경로 타겟).
+> 실증 환경: prod build + `next start` (실 동작), docker postgres에 공지 A–F seed.
+
+## 동작 모델 (코드 근거)
+- `getActiveNoticesAction` → `findActive()`: **active(now ∈ [starts_at, ends_at] AND is_active) 공지를 priority/최신순으로 모두 반환**.
+- `useNoticePopup`: 마운트 시 1회 fetch → `allNotices`. `pathname`/목록 변경 시 **큐 재구성** = `matchPath(pathPattern, pathname) && !dismissed(localStorage)` 필터. `queue[0]`만 표시.
+- `NoticePopup`: `current = queue[0]`. **X / 배경 / Esc / "닫기" = `advance`**(큐 slice(1), localStorage 미변경 → 새로고침 시 재노출). **"다시 보지 않기" = `dontShowAgain`**(`dismissNotice(id)` → localStorage `siglens_dismissed_notices`에 id 추가 + slice(1)).
+- `matchPath`: `null`·`/*`=전역, `/prefix/*`=접두 일치, 그 외 정확 일치.
+- 링크: `toSafeHttpUrl` — http(s)만 렌더, `javascript:`/`data:` 차단.
+
+## Seed (docker DB)
+| 공지 | path_pattern | priority | active | 비고 |
+|---|---|---|---|---|
+| A 전역 우선 | `/` | 100 | ✅ | link `/notice-a` |
+| B 전역 일반 | `/` | 50 | ✅ | link 없음 |
+| C AAPL 전용 | `/AAPL/*` | 80 | ✅ | |
+| D 만료 | `/` | 70 | ⛔ (ends_at 과거) | findActive 제외 |
+| E 비활성 | `/` | 60 | ⛔ (is_active=false) | findActive 제외 |
+| F 악성링크 | `/` | 40 | ✅ | link `javascript:alert(1)` |
+
+→ 홈(`/`) 매칭 active: **A(100) → B(50) → F(40)** 순. `/AAPL` 매칭: **C**. D/E는 어디서도 미표시.
+
+## 테스트 케이스
+
+| ID | 시나리오 | 절차 | 기대 결과 | 판정 |
+|---|---|---|---|---|
+| **N1** | 활성 공지 표시 + 우선순위 | 홈 접속 | priority 최상위 **A** 모달 표시(`queue[0]`) | |
+| **N2** | "닫기"=advance 순차 | 홈 → 닫기 → 닫기 → 닫기 | A → B → F 순차 표시, 3번째 닫기 후 모달 사라짐 | |
+| **N3** | "닫기" 후 새로고침 재노출 | 홈에서 A 닫기 → F5/재접속 | A 다시 표시(advance는 dismiss 아님) | |
+| **N4** | "다시 보지 않기" + 새로고침 | 홈 A "다시 보지 않기" → 새로고침 | A 미표시, **B** 표시. localStorage `siglens_dismissed_notices`=`[A.id]` | |
+| **N5** | 전부 dismiss + 새로고침 | A·B·F 모두 "다시 보지 않기" → 새로고침 | 아무 모달도 안 뜸. localStorage에 3 id | |
+| **N6** | path 타겟 표시 | `/AAPL` 접속 | **C** 표시(A/B/F는 `/` 정확매칭이라 미표시) | |
+| **N7** | path 격리(홈) | 홈 접속 | A/B/F만, **C 미표시**(`/AAPL/*`) | |
+| **N8** | 만료 공지 제외 | 어느 경로든 | **D 절대 미표시**(ends_at 과거) | |
+| **N9** | 비활성 공지 제외 | 어느 경로든 | **E 절대 미표시**(is_active=false) | |
+| **N10** | 악성 링크 차단 | F 표시 시 링크 영역 | `javascript:` 링크 버튼 **미렌더**(toSafeHttpUrl) | |
+| **N11** | dismiss는 id별 격리 | A만 dismiss 후 새로고침 | B·F는 정상 표시(A만 제외) | |
+| **N12** | 접근성 | 모달 표시 시 | `role=dialog` `aria-modal` focus-trap, Esc=닫기 | |
+
+## 모바일 환경 테스트 케이스 (뷰포트 ~390×844, iPhone)
+
+> 공지 모달은 `fixed inset-0 ... px-4` + `max-w-md`. 메모리: 이 레포는 iOS Safari fixed/overflow 회귀 이력이 있어 모바일에서 특히 확인.
+
+| ID | 시나리오 | 절차 | 기대 결과 | 판정 |
+|---|---|---|---|---|
+| **M1** | 모바일 공지 모달 | 모바일 뷰포트 + 홈 접속 | 모달이 화면 폭(px-4 여백) 안에 들어오고 가로 오버플로우 없음, 텍스트 잘림 없음 | |
+| **M2** | 모바일 버튼 탭 | 모바일에서 "다시 보지 않기"/"닫기"/✕ 탭 | 탭 타깃 정상 동작(advance/dismiss), 가림/겹침 없음 | |
+| **M3** | 모바일 dismiss + 새로고침 | 모바일 A "다시 보지 않기" → 새로고침 | A 미표시, B 표시 (desktop과 동일) | |
+| **M4** | 모바일 홈 렌더 | 모바일 홈 | 히어로/검색/섹터 인기종목 반응형, 가로 스크롤 없음 | |
+| **M5** | 모바일 /AAPL 차트 | 모바일 /AAPL | 차트·탭·지표요약 반응형 렌더, 콘솔 에러 0 | |
+| **M6** | 모바일 fundamental | 모바일 /AAPL/fundamental | 프로필·valuation·peers 테이블 반응형(가로 오버플로우 없음) | |
+| **M7** | 모바일 body 가로 스크롤 | 각 페이지 모바일 | `document.documentElement.scrollWidth ≤ clientWidth`(가로 스크롤 유발 원소 없음) | |
+
+## 검증 방법
+- Chrome DevTools로 각 경로 접속/새로고침, 모달 표시·버튼 클릭 관찰.
+- **모바일**: `resize_window`로 ~390×844 뷰포트 적용 후 동일 케이스(M1–M7). 가로 오버플로우는 `document.documentElement.scrollWidth`/`clientWidth` 비교로 정량 확인.
+- `localStorage.getItem('siglens_dismissed_notices')`를 javascript로 직접 조회해 dismiss 동작 확정.
+- 새로고침은 재접속(navigate)로 대체 가능(마운트 시 재fetch + 큐 재구성).

--- a/docs/superpowers/specs/2026-06-04-v015-to-current-testcases.md
+++ b/docs/superpowers/specs/2026-06-04-v015-to-current-testcases.md
@@ -1,0 +1,199 @@
+# Test Cases — v0.15.0 → current HEAD verification
+
+> 작성: 2026-06-04 · 짝 Spec: `docs/superpowers/specs/2026-06-04-v015-to-current-verification-spec.md`
+> 범위: `v0.15.0..HEAD`(218 commits) 전체 + `v0.17.0..HEAD`(67 commits) 배포 안정성 부분집합(R 섹션)
+> 실행 전제: 프로덕션 빌드(`yarn build`) + `yarn start`(기본 `http://localhost:3000`). docker postgres + redis(env-shadow)는 §Spec 6.
+
+## 사용법
+- `$B` = base URL(기본 `http://localhost:3000`; 프로덕션 검증 시 실도메인).
+- 우선순위 **P0**=배포 차단 · **P1**=중요 · **P2**=nice.
+- ID 접두사: **C**=curl, **B**=browser(Chrome DevTools), **S**=SEO 전용, **D**=DB-dependent, **R**=배포 안정성(v0.17.0..HEAD).
+- "warm" 캐시 케이스는 같은 URL을 **2번 연속** 요청하고 2번째 응답을 본다.
+- ⚠️ E2E 환경 사실: FMP 키 없거나 미시드 종목 → degrade(200+noindex). `AAPL`만 시드 가정. invalid-format ticker → ISR에서 HTTP **200** + not-found 본문.
+
+전체 테스트 케이스 수: **80** (curl 35 · browser 22 · SEO 12 · DB 6 · deploy-stability 19; 일부 ID는 area-cross 카운트 — 합계는 섹션별 소계 기준).
+
+---
+
+## A. curl — 상태 코드 & 라우트 가용성 (C1–C10)
+
+| ID | P | 대상 | 명령 | 기대 / 합격 기준 |
+|----|---|------|------|------------------|
+| C1 | P0 | home | `curl -sS -o /dev/null -w '%{http_code}\n' $B/` | `200` |
+| C2 | P0 | chart | `curl -sS -o /dev/null -w '%{http_code}\n' $B/AAPL` | `200` |
+| C3 | P0 | 5 siblings | `for p in overall fundamental news options fear-greed; do curl -sS -o /dev/null -w "$p %{http_code}\n" $B/AAPL/$p; done` | 전부 `200` |
+| C4 | P0 | degrade 종목 | `curl -sS -o /dev/null -w '%{http_code}\n' $B/MSFT` | `200` (500/404 아님) |
+| C5 | P0 | invalid ticker | `curl -sS -o /dev/null -w '%{http_code}\n' $B/INVALIDTICKER1` | `200` + (C18에서 not-found 본문 확인) |
+| C6 | P1 | 소문자 redirect | `curl -sS -o /dev/null -w '%{http_code} %{redirect_url}\n' $B/aapl` | `301` → `…/AAPL` |
+| C7 | P1 | 보조 페이지 | `for p in market backtesting terms privacy; do curl -sS -o /dev/null -w "$p %{http_code}\n" $B/$p; done` | 전부 `200` (terms/privacy는 DB seed 전제 — D1) |
+| C8 | P1 | auth 페이지 | `for p in login signup reset-password forgot-password; do curl -sS -o /dev/null -w "$p %{http_code}\n" $B/$p; done` | 전부 `200` |
+| C9 | P0 | not-found | `curl -sS -o /dev/null -w '%{http_code}\n' $B/this-route-does-not-exist` | `404` |
+| C10 | P2 | account(미인증) | `curl -sS -o /dev/null -w '%{http_code} %{redirect_url}\n' $B/account` | `200`/redirect (proxy 역가드) — 콘솔/네트워크로 동작 확인은 B17 |
+
+## B-area curl — 메타/SEO 라우트 & 헤더 (C11–C22)
+
+| ID | P | 대상 | 명령 | 기대 / 합격 기준 |
+|----|---|------|------|------------------|
+| C11 | P0 | robots.txt | `curl -sS $B/robots.txt` | `200`, `text/plain`, `Disallow: /api/`, 패러사이트봇(AhrefsBot/SemrushBot/MJ12bot/DotBot/BLEXBot/DataForSeoBot) 각 `Disallow: /`, `Sitemap: …/sitemap.xml` 라인. 인증 페이지(`/login` 등) **Disallow 없음** |
+| C12 | P0 | sitemap index | `curl -sS -D- $B/sitemap.xml \| head -40` | `200`, `Content-Type: application/xml; charset=utf-8`, `<sitemapindex>`, `sitemap-static.xml`·`sitemap-popular.xml` 참조 |
+| C13 | P1 | sub-sitemaps | `for s in static popular longtail-1; do curl -sS -o /dev/null -w "$s %{http_code} %{content_type}\n" $B/sitemap-$s.xml; done` | static/popular `200 application/xml`; longtail-1은 데이터 있으면 200, 없으면 404 graceful |
+| C14 | P1 | manifest | `curl -sS -D- $B/manifest.webmanifest -o /dev/null` | `200`, content-type `manifest+json` 계열 |
+| C15 | P1 | OG images | `for p in "" /overall /fundamental /news /options /fear-greed; do curl -sS -o /dev/null -w "$p %{http_code} %{content_type}\n" $B/AAPL$p/opengraph-image; done` | 전부 `200 image/png` |
+| C16 | P1 | twitter image | `curl -sS -o /dev/null -w '%{http_code} %{content_type}\n' $B/AAPL/news/twitter-image` | `200 image/png` |
+| C17 | P2 | 보안 헤더 | `curl -sS -D- -o /dev/null $B/AAPL` | `x-content-type-options: nosniff`, `x-frame-options: DENY`, `referrer-policy: strict-origin-when-cross-origin`, `strict-transport-security: max-age=63072000; includeSubDomains; preload` |
+| C18 | P0 | invalid 본문 | `curl -sS $B/INVALIDTICKER1 \| grep -i "not.found\|404\|찾을 수"` | not-found 본문 마커 존재(HTTP 200이지만 본문은 not-found) |
+| C19 | P2 | api disallow 실재 | `curl -sS -o /dev/null -w '%{http_code}\n' $B/api/sitemap` | `200`(rewrite 소스는 동작) — robots는 색인 정책일 뿐 |
+
+## C-area curl — ISR 캐싱 헤더 (C20–C26)
+
+| ID | P | 대상 | 명령 | 기대 / 합격 기준 |
+|----|---|------|------|------------------|
+| C20 | P0 | chart warm cache | `curl -sS -D- -o /dev/null $B/AAPL; echo ---; curl -sS -D- -o /dev/null $B/AAPL \| grep -i 'x-nextjs-cache\|cache-control'` | 2번째 `x-nextjs-cache: HIT` + `cache-control` `s-maxage=3600` 계열 |
+| C21 | P0 | siblings warm cache | overall/fundamental/news/options/fear-greed 각 2회 요청 후 헤더 | 각 2번째 `x-nextjs-cache: HIT` |
+| C22 | P1 | degrade warm cache | `/MSFT` 2회 요청 | 2번째 `HIT`(degrade 결과도 ISR 캐시되되 noindex) |
+| C23 | P0 | DYNAMIC_SERVER_USAGE | `yarn start` 콘솔 로그 grep `DYNAMIC_SERVER_USAGE` (C20–C22 수행 중) | **0건** (축0/축1 위반 없음) |
+| C24 | P1 | OG static cache | `curl -sS -D- -o /dev/null $B/AAPL/opengraph-image \| grep -i cache-control` | 장기 캐시(30d/`s-maxage=2592000` 계열, force-static) |
+| C25 | P1 | home cache | `/` 2회 요청 헤더 | `x-nextjs-cache: HIT` 또는 정적 서빙 + `revalidate` 반영 |
+| C26 | P2 | sitemap cache | `curl -sS -D- -o /dev/null $B/sitemap.xml \| grep -i cache-control` | `public, max-age=3600, stale-while-revalidate=3600` |
+
+## D-area curl — SEO HTML 마커 (C27–C35) — SEO 케이스와 교차(§D-SEO)
+
+| ID | P | 대상 | 명령 | 기대 / 합격 기준 |
+|----|---|------|------|------------------|
+| C27 | P0 | canonical self | `curl -sS $B/AAPL \| grep -o '<link rel="canonical"[^>]*>'` | self·절대 URL·대문자 `…/AAPL` |
+| C28 | P0 | canonical 부재(degrade) | `curl -sS $B/MSFT \| grep -c '<link rel="canonical"'` | `0` (home `SITE_URL` 미상속) |
+| C29 | P0 | canonical 부재(invalid) | `curl -sS $B/INVALIDTICKER1 \| grep -c '<link rel="canonical"'` | `0` |
+| C30 | P0 | robots meta valid | `curl -sS $B/AAPL \| grep -o '<meta name="robots"[^>]*>'` | `index,follow` 포함(noindex 없음) |
+| C31 | P0 | robots meta degrade | `curl -sS $B/MSFT \| grep -o '<meta name="robots"[^>]*>'; curl -sS $B/INVALIDTICKER1 \| grep -o '<meta name="robots"[^>]*>'` | 둘 다 `noindex` 포함 |
+| C32 | P0 | single h1 | `for u in $B/AAPL $B/AAPL/fundamental $B/AAPL/news $B/AAPL/overall $B/AAPL/options $B/AAPL/fear-greed; do echo -n "$u "; curl -sS $u \| grep -o '<h1' \| wc -l; done` | 각 정확히 `1` |
+| C33 | P1 | JSON-LD | `curl -sS $B/AAPL \| grep -o 'application/ld+json'` 후 본문에서 `"@type":"WebPage"`·`"BreadcrumbList"`·`"FAQPage"` 존재 확인 | 3종 SSR HTML 내 존재, 유효 JSON |
+| C34 | P0 | placeholder 누출 | `for u in $B/AAPL $B/AAPL/fundamental $B/AAPL/news; do curl -sS $u \| grep -c '\[SYMBOL\]'; done` | 전부 `0` |
+| C35 | P1 | title 구체성 | `curl -sS $B/AAPL/fundamental \| grep -o '<title>[^<]*</title>'` | 종목·섹션 반영 + `| Siglens` 템플릿 |
+
+---
+
+## E. SEO 전용 (S1–S12)
+
+| ID | P | 영역 | 방법 | 기대 / 합격 기준 |
+|----|---|------|------|------------------|
+| S1 | P0 | metadata 완전성(home) | `curl -sS $B/ \| grep -o '<meta[^>]*og:[^>]*>'` | og:type/siteName/title/url/locale + twitter card, canonical=`SITE_URL` |
+| S2 | P0 | canonical/og:url 일치(auth) | `curl -sS $B/login \| grep -o '<link rel="canonical"[^>]*>\|og:url[^>]*'` | canonical=`…/login`, og:url=`…/login`(SITE_URL 미상속), robots `noindex,follow` |
+| S3 | P0 | noindex(account/auth) | `for u in login signup reset-password forgot-password account; do curl -sS $B/$u \| grep -o '<meta name="robots"[^>]*noindex[^>]*>'; done` | 각 `noindex` 존재 |
+| S4 | P0 | invalid → noindex+canonical 부재 | C29+C31 합산 | soft-404가 index+canonical 동시 미발생(둘 다 noindex·canonical 0) |
+| S5 | P1 | BreadcrumbList 정합 | `curl -sS $B/AAPL/fundamental` JSON-LD 파싱 | 3단계 `[Siglens, AAPL, 펀더멘털 분석]`(Siglens auto-prepend), chart는 2단계 |
+| S6 | P1 | Corporation about | `curl -sS $B/AAPL` WebPage JSON-LD | stock 분류 시 `about` Corporation 노드 존재; ETF/Index는 생략(검증: 한 ETF 티커로 about 부재) |
+| S7 | P1 | Article(news) | `curl -sS $B/AAPL/news` | Article JSON-LD 존재(있다면) 유효 |
+| S8 | P0 | robots.txt 정책 | C11 확장 | API disallow + 패러사이트봇 차단 + 인증페이지 미차단(noindex로 처리) 동시 성립 |
+| S9 | P0 | sitemap 유효성 | `curl -sS $B/sitemap.xml \| xmllint --noout - && echo OK` | well-formed XML, sitemapindex |
+| S10 | P1 | structured data 검증 | 각 라우트 JSON-LD를 Schema.org validator 또는 `python -c json.loads`로 파싱 | 파싱 오류 0, required 필드(@context/@type) 존재 |
+| S11 | P2 | CWV 스모크(LCP) | Chrome DevTools Performance/Lighthouse `$B/AAPL` | LCP 합리적(폰트 self-host로 text LCP 개선), CLS≈0(size-adjust 폰트) |
+| S12 | P2 | CWV 스모크(CLS) | Chrome DevTools Layout Shift `$B/AAPL/fundamental` | skeleton→data 교체 시 CLS 점프 없음(Suspense fallback 높이 예약) |
+
+---
+
+## F. Chrome DevTools — 렌더 & 인터랙션 (B1–B22)
+
+각 케이스: 페이지 로드 → **Console에 에러 0** 확인 → 명시 동작 관찰. UX 회귀는 v0.15.0 대비 감시.
+
+| ID | P | 영역 | 동작 | 관찰 / 합격 기준 |
+|----|---|------|------|------------------|
+| B1 | P0 | chart 렌더 | `$B/AAPL` 로드 | 차트 + AI 분석 패널 렌더, blank flash·CLS 없음, 콘솔 0에러 |
+| B2 | P0 | overall 렌더 | `$B/AAPL/overall` | 종합 결론 렌더, FactLayer SSR 텍스트 → 인터랙티브 교체 |
+| B3 | P0 | fundamental 렌더 | `$B/AAPL/fundamental` | 프로필/밸류에이션/peers/수익성/성장/건전성/미래방향 섹션, skeleton→data |
+| B4 | P0 | news 렌더 | `$B/AAPL/news` | 뉴스 카드 + AI 요약, 클라 분석 트리거 동작 |
+| B5 | P0 | options 렌더 | `$B/AAPL/options` | 옵션 스냅샷 렌더(hasOptions 분기) |
+| B6 | P0 | fear-greed 렌더 | `$B/AAPL/fear-greed` | 공포·탐욕 지수 + 히스토리컬 차트 |
+| B7 | P0 | 검색 | home 검색창에 `TSLA` 입력→선택 | `/TSLA`로 soft-nav, 결과 렌더 |
+| B8 | P0 | 탭 전환 | `/AAPL`에서 SymbolTabs로 6 탭 순회 | soft-nav, 헤더/breadcrumb 안정, 풀리로드·헤더 깜빡임 없음, 활성탭 정확 |
+| B9 | P1 | 분석 트리거 | chart에서 재분석/타임프레임 변경 | useAnalysis 트리거, 로딩→결과, job cancel 정상 |
+| B10 | P1 | 타임프레임 딥링크 | `$B/AAPL?tf=1D` 직접 로드 | 클라가 tf 읽어 해당 bars fetch, h1·차트 정상 |
+| B11 | P0 | 게스트 헤더 | 쿠키 없이 임의 라우트 로드 | 로그인/회원가입 표시, authed avatar flash **없음**, skeleton stuck 없음 |
+| B12 | P0 | hydration | 6 라우트 각 로드 | React hydration mismatch 경고 0(client-island 헤더 + CSR-bailout subtree) |
+| B13 | P1 | degrade UI | `$B/MSFT` 로드 | degrade 안내 렌더(에러 화면 아님), 콘솔 에러 없음 |
+| B14 | P1 | degrade fundamental | `$B/MSFT/fundamental` 로드 | `FundamentalDegraded` 렌더(200), full-crash 아님 |
+| B15 | P1 | network 워터폴 | `$B/AAPL` Network 탭 | FMP/redis 호출 합리적, 중복 fetch 없음, 4xx/5xx XHR 없음 |
+| B16 | P1 | auth flip(login) | login 폼 제출(시드 유저)→리다이렉트 | navigation refetch로 헤더 authed 전환(stuck 아님) — E2E `account-*.spec` 병행 |
+| B17 | P1 | auth flip(logout) | authed 상태에서 logout | 헤더 guest 전환, 보호 동작 정상 |
+| B18 | P2 | OAuth | OAuth start→consent→finalize(E2E fake) | consent 페이지 렌더, finalize 후 authed |
+| B19 | P2 | market 부분실패 | `$B/market` (일부 quote 0 상황) | `MarketDataErrorNotice` 안내, 패널 정상 |
+| B20 | P2 | backtesting | `$B/backtesting` | 백테스팅 UI 렌더, 콘솔 0에러 |
+| B21 | P2 | PWA | manifest/install 배너 | PwaBanner 동작, manifest 로드 |
+| B22 | P2 | 모바일 뷰포트 | DevTools device emulation으로 `/AAPL` | 모바일 bottom-sheet/탭 정상(Radix aria-hidden 이슈 없음) |
+
+---
+
+## G. DB-dependent (D1–D6) — docker postgres seed 필요
+
+> 기존 E2E 인프라(docker postgres + `.env.e2e` + `E2E_TEST=1` + fake email/oauth) 재사용 권장.
+
+| ID | P | 영역 | seed | 방법 | 기대 / 합격 기준 |
+|----|---|------|------|------|------------------|
+| D1 | P0 | terms/privacy 빌드 | active `terms`(tos/privacy) row | 빌드 전 seed; `curl -sS $B/terms`·`$B/privacy` | `200` + 약관 본문(빌드타임 DB 조회 — 미seed 시 **빌드 실패**) |
+| D2 | P0 | 공지 노출 | `notices` 1 active row(window 현재 포함, path_pattern `null` 또는 `/AAPL/*`) | 해당 경로 로드(Chrome) | 모달 노출, title/body 렌더 |
+| D3 | P1 | 공지 graceful | notices 미설정/장애 | 임의 라우트 로드 | 빈 큐, **페이지 정상**(에러 0) — R3와 교차 |
+| D4 | P1 | 공지 path 타게팅 | path_pattern=`/AAPL/*` row | `/AAPL`(노출) vs `/TSLA`(미노출) 비교 | 경로 매칭만 노출 |
+| D5 | P1 | auth 플로우 | users/sessions/verification | login/signup(email code)/reset(token) — E2E fake email | 각 플로우 완료, 세션 발급 |
+| D6 | P2 | account CRUD | authed user + api_key | `/account` api-key 추가/삭제, `/account/delete` | CRUD 동작(authed storageState) |
+
+---
+
+## H. 배포 안정성 — v0.17.0..HEAD 전용 (R1–R19)
+
+> 이번 over-deploy(현재 HEAD over 0.17.0)가 **깨면 안 되는** 표면. 67 commits 부분집합. 최우선.
+
+### R1–R6 · 공지 팝업 (#559)
+| ID | P | 방법 | 기대 / 합격 기준 |
+|----|---|------|------------------|
+| R1 | P0 | curl: `curl -sS $B/AAPL \| grep -ci notice-popup\|noticepopup` | SSR HTML에 **공지 마크업 부재**(`ssr:false` client-only) → 검색 인덱싱·hydration race 영향 0 |
+| R2 | P0 | Chrome: 활성 공지 seed(D2) 후 `/AAPL` 로드 | hydration 완료 **후** 모달 마운트, 콘솔 0에러, streaming race 없음 |
+| R3 | P0 | Chrome: notices DB 장애/미설정 상태로 임의 라우트 로드 | 페이지 **정상 렌더**(공지 실패가 페이지를 깨지 않음), `console.warn` 1줄 허용 |
+| R4 | P1 | Chrome: 모달에서 "다시 보지 않기"→새로고침 | localStorage 영구 저장, 재노출 안 됨 |
+| R5 | P1 | Chrome: 모달 Esc/배경 클릭/닫기→새로고침 | 임시 dismiss(다음 방문 재노출), focus-trap·Esc a11y 동작 |
+| R6 | P2 | Chrome: link_url에 `javascript:`/비http(s) seed | 링크 렌더 거부(safeUrl 가드) — XSS 차단 |
+
+### R7–R11 · Auth full-static (#557)
+| ID | P | 방법 | 기대 / 합격 기준 |
+|----|---|------|------------------|
+| R7 | P0 | 빌드 output 확인 | `/login` `/signup` `/reset-password`가 `○`(static) — `ƒ`(dynamic) 아님 |
+| R8 | P0 | curl: `curl -sS -D- -o /dev/null $B/login \| grep -i x-nextjs-cache` | 정적 서빙(HIT/prerender), 쿠키·DB 의존 누출 없음 |
+| R9 | P0 | Chrome: `$B/login?next=/AAPL` 로드 후 제출 | `?next` searchParams를 CSR(`LoginContent`)이 읽어 폼 동작, redirect target 반영 |
+| R10 | P1 | Chrome: `/reset-password?token=xxx` 로드 | token searchParams CSR 처리, AuthFormSkeleton fallback→폼 |
+| R11 | P1 | Chrome: `/signup?code=xxx`(oauth) | 쿼리 의존부 정상 렌더 |
+
+### R12–R16 · FMP fundamental 캐시 (#560)
+| ID | P | 방법 | 기대 / 합격 기준 |
+|----|---|------|------------------|
+| R12 | P0 | curl: `/AAPL/fundamental` 2회 warm | 2번째 `x-nextjs-cache: HIT`, FMP 재호출 없음(Network/로그) |
+| R13 | P0 | Chrome: FMP 장애 주입 후 `/<sym>/fundamental` 재시도 | 장애 시 N/A degrade, **다음 요청 재시도 성공**(poison 캐싱 없음) |
+| R14 | P1 | curl: 빈 200 종목(존재 안 함, well-formed) | null 캐싱으로 long-tail 재호출 차단(2번째 빠른 응답), noindex |
+| R15 | P1 | Chrome: `/AAPL/fundamental` peers 표 | PER/PSR 채워짐(#538), peer ≤ 10개 |
+| R16 | P2 | curl: 대소문자 키 | `/aapl/fundamental`(→301 /AAPL) 캐시 키 대문자 정규화로 일관 HIT |
+
+### R17–R19 · Market summary 부분실패(#556) + 기타
+| ID | P | 방법 | 기대 / 합격 기준 |
+|----|---|------|------------------|
+| R17 | P1 | Chrome: 일부 quote 0 상황 `/market` | `hasMissingQuotes` true → 안내 배너, 패널 정상 |
+| R18 | P1 | Chrome: 전 quote 정상 `/market` | false-positive 안내 **없음**, 캐시 가드가 정상 데이터만 캐싱 |
+| R19 | P2 | curl: skills/chat 회귀 | `/AAPL` h1 sr-only "보조지표 N종" 카운트 렌더(skill 로더 dedupe), dashboard bearish badge 라벨 표시 |
+
+---
+
+## I. 회귀 스모크 — v0.16 실패 모드 재발 방지 (G1–G4) — P0
+
+| ID | 방법 | 기대 / 합격 기준 |
+|----|------|------------------|
+| G1 | `grep -rn "cookies()\|headers()" src/app/layout.tsx src/app/_components/` | root layout/공유 셸에서 직접 호출 **0**(클라이언트화 유지, 축 0) |
+| G2 | C23(로그 `DYNAMIC_SERVER_USAGE` 0) + C20–C22(`x-nextjs-cache: HIT`) | ISR 정적화 유지(축 1) — cold-gen 500 재발 없음 |
+| G3 | C28/C29/C31(degrade·invalid canonical 부재 + noindex) | soft-404 robots 충돌 없음 |
+| G4 | `grep -rn "export const revalidate\|export const dynamic" src/app/**/page.tsx` | route segment config가 **리터럴**(상수/식 추출 아님) — Next 정적 분석 가능 |
+
+---
+
+## J. 실행 순서 권장
+1. **빌드** (env §Spec 6.2 확인) → 빌드 output에서 R7(auth ○) + 종목 라우트 SSG 표시 확인.
+2. **DB seed** (D1 terms 필수, D2 notices) → `yarn start`.
+3. **curl 배치** C1–C35, S1–S10 → 표 채움.
+4. **회귀 스모크** G1–G4 (정적 grep + 런타임 헤더/로그).
+5. **Chrome** B1–B22, S11–S12(CWV).
+6. **배포 안정성** R1–R19 (가장 마지막에 집중 검증, P0부터).
+7. 실패 1건이라도 P0면 **배포 차단**, 보고.

--- a/docs/superpowers/specs/2026-06-04-v015-to-current-verification-spec.md
+++ b/docs/superpowers/specs/2026-06-04-v015-to-current-verification-spec.md
@@ -1,0 +1,216 @@
+# Verification Spec — v0.15.0 → current HEAD (production-like)
+
+> 작성: 2026-06-04 · 작성자 컨텍스트: fresh-analysis of `verify-0.15-current` worktree
+> 대상: `git log v0.15.0..HEAD` = **218 commits** · 현재 `package.json` version = **0.17.0**
+> 짝 문서(Test Cases): `docs/superpowers/specs/2026-06-04-v015-to-current-testcases.md`
+> 선행 문서(이전 라운드, v0.16-era): `docs/superpowers/specs/2026-06-03-predeploy-verification.md`
+
+이 문서는 검증을 **설계**한다 — 빌드/기동/검증을 직접 수행하지 않는다. 실행은 짝 Test Cases 문서(C/B/S/D/R 번호)로 한다.
+
+---
+
+## 1. 목적 & 범위
+
+마지막 정상 배포는 **v0.17.0**(`2b44159e chore: release v0.17.0`). 현재 HEAD를 v0.17.0 위에 배포하기 전에, **v0.15.0 이후 누적된 전 변경**이 프로덕션처럼 빌드·기동된 상태에서 ① curl ② Chrome DevTools 양쪽으로 정상 동작하고 SEO·UX·배포 안정성 회귀가 없는지 실증한다.
+
+검증 범위는 두 겹이다:
+
+- **전체 범위 (Full scope):** `v0.15.0..HEAD` = **218 commits**. SEO/ISR 전면 전환, FSD 마이그레이션 후속, auth 클라이언트화, E2E 스위트, 봇/캐시 비용 최적화 등 누적분 전체.
+- **배포 안정성 부분집합 (Since last deploy):** `v0.17.0..HEAD` = **67 commits**. v0.17.0 배포 이후 master에 들어온 것 — 이번 배포가 **"0.17.0 위 over-deploy"**로서 깨면 안 되는 표면. 가장 회귀 위험이 높은 구간이며 §5와 Test Cases의 전용 섹션(R1~)에서 따로 다룬다.
+
+> ⚠️ 빌드 output의 `●`(SSG) 표시 ≠ 런타임 동작. ISR/캐시는 반드시 `prod build && start` 후 런타임 헤더(`x-nextjs-cache: HIT`)와 로그(`DYNAMIC_SERVER_USAGE` 0)로 실측한다 (`src/app/CLAUDE.md` ISR 4축 규약).
+
+---
+
+## 2. 변경 요약 (영역별, 커밋/경로 근거)
+
+### A. `[symbol]` 6-라우트 ISR/SEO 전면 전환 (#543~#549, #551, #553) — 전체범위
+- 라우트: `/[symbol]`(chart), `/[symbol]/overall`, `/[symbol]/fundamental`, `/[symbol]/news`, `/[symbol]/options`, `/[symbol]/fear-greed`.
+- 각 `page.tsx`: `export const revalidate = 3600` + `export async function generateStaticParams() { return [] }`(on-demand ISR). 동적 데이터는 `staticSymbolCache`(`unstable_cache`, 1h + `symbol:` tag)로 정적화. (근거: `src/app/[symbol]/page.tsx`, `…/fundamental/page.tsx`, `src/shared/cache/staticSymbolCache.ts`.)
+- **축 0 인증 클라이언트화** (`1f9ff95d`, `e4a66ce3`, #547): root layout이 `cookies()`를 직접 호출하지 않도록 헤더를 `AuthSessionHeaderClient`(client island)로 분리. navigation마다 `currentUser` 1회 refetch로 redirect-기반 인증 플로우 후 헤더 재동기화. (근거: `src/app/layout.tsx` L144, `src/app/_components/AuthSessionHeaderClient.tsx`.)
+- **FactLayer SSR**: `useSearchParams` CSR-bailout 밖으로 크롤 가능 텍스트를 Suspense fallback에 서버 컴포넌트로 박음(`TechnicalFactsSummary`/`OverallFactsSummary`). (근거: `src/app/[symbol]/page.tsx` L282~330.)
+- **News on-demand 무효화** (`39b0d7b7`): `headers()`(봇 판정) 제거 → 클라 트리거(`useNewsAnalysisTrigger`)로 이전, ingestion 후 `revalidateTag('news:${symbol}', 'max')`.
+
+### B. 인프라 실패 graceful degrade + soft-404 정합 (#545, #552, #555) — 전체범위
+- `getAssetInfoResilient` / `getProfileResilient`: FMP 인프라 장애 시 throw 대신 `{ degraded: true }` 반환 → 본문 200(degrade UI), `generateMetadata`는 `NOINDEX_SYMBOL_METADATA`(canonical:null). (근거: `src/entities/ticker`, `src/app/[symbol]/fundamental/getProfileResilient.ts`, `…/FundamentalDegraded.tsx`.)
+- `0a59e92a` (#549): `getAssetInfoResilient`에서 `connection()` 제거 → ISR cold-gen 시 FMP 장애가 500을 던지지 않게 함 (ISR cold-gen 500 회귀 픽스).
+- `a1368f38` (#555): symbol metadata soft-404에 noindex 누락 픽스 — `assetInfo === null`(형식 유효·실재 안 함)도 `NOINDEX_SYMBOL_METADATA`. (근거: `src/app/[symbol]/page.tsx` L68~70.)
+- `[symbol]/error.tsx`(#552): 전 sibling 라우트 throw 봉쇄 에러 바운더리.
+
+### C. FMP fundamental 캐시 데코레이터 (#560) — **배포 안정성 부분집합 (v0.17.0..HEAD)**
+- `CachedFundamentalProvider`: `FundamentalProvider`를 감싸 메서드별 Redis 캐싱(`fundamental:*` 키, `getOrSetCache`). 페이지 SSR과 core 분석 경로가 동일 캐시 공유. (근거: `src/shared/api/fmp/CachedFundamentalProvider.ts`.)
+- **Poison 방지**: FMP 장애(throw)는 `set` 전에 전파돼 캐싱 안 됨; 빈 200(존재하지 않는 티커)만 `null`로 캐싱. (근거: 같은 파일 L51~67.)
+- **Peer PER/PSR 보강** (#538, `fe91a378`): peer 목록을 cached key-metrics로 enrich, `PEER_LIMIT = 10`으로 cap. sector-performance를 날짜별 캐싱.
+
+### D. 운영 공지 팝업 (#559) — **배포 안정성 부분집합 (v0.17.0..HEAD)**
+- DB 테이블 `notices`(migration `0016_clear_rachel_grey.sql`): title/body/link_url/path_pattern/priority/is_active/starts_at/ends_at.
+- `getActiveNoticesAction`(server action, `'use server'`): DB 미설정/실패 시 `[]`로 graceful degrade. (근거: `src/entities/notice/actions/getActiveNoticesAction.ts`.)
+- `NoticePopupLoader`(client-only `dynamic({ ssr: false })`) → root layout 마운트. `useNoticePopup`: 마운트 1회 fetch + pathname 변경 시 `matchPath` 경로 매칭 + `localStorage` dismiss 필터. (근거: `src/app/layout.tsx` L141, `src/widgets/notice-popup/`.)
+- link_url은 http(s)만 허용(safeUrl 가드). "다시 보지 않기" = localStorage 영구, "닫기"/Esc/배경 = 임시. (근거: `docs/SERVICE.md` §운영 기능.)
+
+### E. Auth 페이지 full-static 전환 (#557) — **배포 안정성 부분집합 (v0.17.0..HEAD)**
+- `/login`, `/signup`, `/reset-password`: `searchParams` 읽기를 `*Content`('use client')로 격리 → 라우트가 full-static(○) prerender. shell/footer/metadata 정적, 쿼리 의존부만 Suspense 아래 CSR(`AuthFormSkeleton` fallback). (근거: `src/app/login/page.tsx` L20~52.)
+- 전부 `robots: { index: false, follow: true }` + self-canonical. (근거: 같은 파일 L12~18.)
+
+### F. Market summary 부분 실패 안내 (#556) — **배포 안정성 부분집합 (v0.17.0..HEAD)**
+- `hasMissingQuotes`(quote=0 = FMP fetch 실패 종목 존재) → `MarketDataErrorNotice` 안내, 캐시 가드 강화. (근거: `src/widgets/dashboard/hooks/useMarketSummary.ts` L68~71, `MarketDataErrorNotice`.)
+
+### G. Skills gating/tagging + chat prompt caching (#539, #541, #542) — 전체범위
+- 모든 skill frontmatter에 gating 블록(snake_case) 태깅, CI frontmatter 검증 게이트. `FileSkillsLoader` skill-name dedupe, `freeApiKey` 정책 삭제. siglens-core 0.19.x bump.
+- Anthropic multi-turn chat prompt caching(`withHistoryCacheBreakpoint`).
+- 압축 indicator core + candle primer skill, dashboard bearish signal badge.
+- ⚠️ 분석 로직 자체는 `@y0ngha/siglens-core` 소관 — siglens 측은 어댑터/로더만. 검증은 **렌더 결과** 기준.
+
+### H. Vercel transfer-cost 최적화 + 봇 차단 (#543, `b3c220dc`) — 전체범위
+- 봇 차단, page+OG ISR, FMP 404 안전성으로 Fast Origin/Data Transfer 절감. `popular tickers` 업데이트(`44a376fa`).
+
+### I. SEO 인프라: sitemap index 분할 + 보안 헤더 — 전체범위(v0.15.0 직후~)
+- `/sitemap.xml`(sitemapindex) → `/sitemap-static.xml`, `/sitemap-popular.xml`, `/sitemap-longtail-{n}.xml`. `next.config.ts` rewrites가 `/sitemap-*.xml` → `/api/sitemap/*` 매핑. (근거: `src/app/api/sitemap/route.ts`, `next.config.ts` L59~67.)
+- robots.txt: `/api/` Disallow + 패러사이트봇(Ahrefs/Semrush/MJ12/Dot/BLEX/DataForSeo) 전면 Disallow. 인증 페이지는 robots.txt가 아닌 page noindex로 처리. (근거: `src/app/robots.ts`.)
+- 전역 보안 헤더: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, `Strict-Transport-Security`. (근거: `next.config.ts` L69~92.)
+
+### J. E2E Playwright 스위트 (#531~#537) — 전체범위(검증 인프라, 런타임 비영향)
+- Tier 1~4 + resilience 23+ 스펙. fake OAuth/email 어댑터(`E2E_TEST=1`), 에러 주입 쿠키 seam, authed storageState. CI workers:1(DB-write 병렬 hang 회피). **런타임 코드 아님** — 회귀 안전망으로 참고.
+
+---
+
+## 3. 검증 대상 라우트 인벤토리 (App Router, 실재 확인)
+
+### 페이지 라우트
+| 경로 | 파일 | ISR/렌더 | 비고 |
+|---|---|---|---|
+| `/` | `src/app/page.tsx` | `revalidate=3600`, searchParams 미소비 | home, footer 포함 |
+| `/[symbol]` | `src/app/[symbol]/page.tsx` | on-demand ISR(`gSP=[]`+`revalidate=3600`) | chart + AI, FactLayer SSR |
+| `/[symbol]/overall` | `…/overall/page.tsx` | 동일 | 종합 결론, FactLayer SSR |
+| `/[symbol]/fundamental` | `…/fundamental/page.tsx` | 동일 | profile degrade/notFound 게이트 |
+| `/[symbol]/news` | `…/news/page.tsx` | 동일 + `news:${symbol}` on-demand 무효화 | 클라 분석 트리거 |
+| `/[symbol]/options` | `…/options/page.tsx` | 동일 | hasOptions/snapshot 정적 |
+| `/[symbol]/fear-greed` | `…/fear-greed/page.tsx` | 동일 | bars prefetch 정적 |
+| `/market` | `src/app/market/page.tsx` | — | 마켓 요약 + 부분실패 안내(#556) |
+| `/backtesting` | `src/app/backtesting/page.tsx` | — | |
+| `/login` `/signup` `/reset-password` | 각 `page.tsx` | **full-static(○)**(#557) | noindex + self-canonical |
+| `/forgot-password` | `src/app/forgot-password/page.tsx` | — | noindex |
+| `/signup/oauth/consent` | `…/oauth/consent/page.tsx` | — | OAuth 신규가입 동의 |
+| `/account` `/account/delete` | `src/app/account/…` | — | authed only, noindex |
+| `/terms` `/privacy` | 각 `page.tsx` | — | **빌드타임 DB 조회**(§6) |
+| `/login` error | `src/app/login/error.tsx` | — | |
+| `/[symbol]` error | `src/app/[symbol]/error.tsx` | — | sibling throw 봉쇄(#552) |
+| not-found | `src/app/not-found.tsx` | — | invalid ticker는 ISR에서 HTTP 200 + 본문 |
+
+### API / 메타 라우트
+| 경로 | 파일 | 출력 |
+|---|---|---|
+| `/robots.txt` | `src/app/robots.ts` | text/plain |
+| `/sitemap.xml` | rewrite → `src/app/api/sitemap/route.ts` | application/xml (sitemapindex) |
+| `/sitemap-static.xml` | → `api/sitemap/static/route.ts` | xml |
+| `/sitemap-popular.xml` | → `api/sitemap/popular/route.ts` | xml |
+| `/sitemap-longtail-{n}.xml` | → `api/sitemap/longtail/[page]/route.ts` | xml |
+| `/manifest.webmanifest` | `src/app/manifest.ts` | manifest+json (PWA) |
+| `/[symbol]{,/overall,/fundamental,/news,/options,/fear-greed}/opengraph-image` | 각 `opengraph-image.tsx` | `dynamic='force-static'`, `revalidate=2592000`(30d), image/png |
+| `/[symbol]/news/twitter-image` | `…/news/twitter-image.tsx` | image/png |
+| `/api/auth/[provider]/start` | `…/start/route.ts` | OAuth 시작 redirect |
+| `/api/auth/callback/[provider]` | `…/callback/route.ts` | OAuth 콜백 |
+| `/api/jobs/cancel` | `…/jobs/cancel/route.ts` | 분석 job 취소 |
+
+---
+
+## 4. 영역별 핵심 동작 & 불변식 ("올바름"의 정의)
+
+### 4.1 렌더링 / 상태 코드
+- `/`, 6×`/AAPL[/*]`, `/market`, `/backtesting`, legal, auth 페이지 → **HTTP 200**.
+- degrade 종목(FMP 미시드 well-formed, 예 `/MSFT`) → **200**(500/404 아님) + degrade UI.
+- invalid-format ticker(예 `/INVALIDTICKER1`) → ISR에서 **HTTP 200 + not-found 본문**(`notFound()`는 ISR 컨텍스트에서 200).
+- 소문자 ticker(`/aapl`) → **301** → `/AAPL`.
+- 어느 라우트도 hydration 에러 0 (client-island 헤더, CSR-bailout subtree).
+
+### 4.2 SEO 메타/구조화 데이터 (불변식)
+- **canonical**: 유효 종목 = self·절대 URL·대문자. degrade/invalid = **canonical 태그 부재**(home `SITE_URL` 미상속 — `NOINDEX_SYMBOL_METADATA`의 `alternates.canonical: null`).
+- **robots meta**: 유효 종목 `index,follow`; degrade/invalid `noindex,nofollow`; auth/account `noindex,follow`.
+- **single h1**: 전 라우트 정확히 1개. chart는 SSR sr-only h1(fallback) ↔ 가시 클라 h1이 hydration 시 교체(동시 미존재).
+- **`[SYMBOL]` placeholder 누출 0**: cacheComponents 비활성이라 fake-params prerender 없음 — generateMetadata가 실제 params로만 실행.
+- **JSON-LD**: WebPage(`@id#webpage`) + BreadcrumbList + FAQPage; chart에 Corporation(about, stock 분류 시만); news에 Article. 전부 SSR HTML 내 유효 JSON.
+- **title**: 라우트별 구체(`%s | Siglens` 템플릿).
+- **robots.txt**: `/api/` Disallow + 패러사이트봇 6종 Disallow + sitemap 라인. 인증 페이지는 Disallow 없음(page noindex로 처리).
+- **sitemap.xml**: 유효 sitemapindex XML, sub-sitemap(static/popular[/longtail-n]) 참조, `Content-Type: application/xml`.
+- **OG images**: 6 라우트 + news twitter — 200 `image/png`, `force-static`+30d.
+
+### 4.3 ISR 캐싱 (불변식)
+- 6 종목 라우트 warm 요청(2번째 hit): `x-nextjs-cache: HIT` + `Cache-Control: s-maxage=3600` 계열.
+- 런타임 로그 `DYNAMIC_SERVER_USAGE` = 0 (축 0/1 위반 없음).
+- auth 3페이지: 빌드 output `○`(full static), 런타임 정적 서빙.
+- home: `revalidate=3600` 반영.
+
+### 4.4 Auth 플로우 (불변식)
+- 게스트(쿠키 없음): 헤더에 로그인/회원가입, authed avatar flash 없음.
+- login/signup 성공(redirect) → navigation refetch로 헤더 authed 전환. logout → guest 전환. (이 "redirect 후 헤더 stuck"이 v0.16 실패 축 — E2E `account-logout.spec.ts`가 커버.)
+- OAuth start → callback → consent → finalize (E2E fake adapter로 CI 커버).
+
+### 4.5 운영 공지 팝업 (불변식, v0.17.0..HEAD)
+- 활성 공지 row가 있고 path_pattern 매칭 + 미dismiss → 모달 노출.
+- DB 미설정/조회 실패 → 빈 큐, **에러 없이 페이지 정상**(부가 기능 degrade).
+- "다시 보지 않기" → localStorage 영구 저장, 새로고침 후 미노출.
+- link_url non-http(s) → 렌더 거부(safeUrl 가드).
+- client-only(`ssr:false`)라 SSR HTML에 미포함 — hydration 후 마운트(streaming race 없음).
+
+### 4.6 FMP fundamental 캐시 (불변식, v0.17.0..HEAD)
+- 같은 종목 fundamental 2회 요청 → 2번째는 Redis HIT(FMP round-trip 없음, `x-nextjs-cache: HIT`로 간접 확인).
+- FMP 장애 → degrade(N/A 렌더) + **장애 결과 미캐싱**(다음 요청 재시도 가능); 빈 200(존재 안 함)만 null 캐싱.
+- peer 표 PER/PSR 채워짐(#538), peer ≤ 10.
+
+### 4.7 에러/degrade 처리 (불변식)
+- FMP/Redis/DB 인프라 장애가 어느 라우트도 **500으로 표면화하지 않음** — graceful degrade(200 + thin UI + noindex).
+- market summary 부분 실패 → 안내 배너, 페이지 정상.
+
+---
+
+## 5. 리스크 영역 / 회귀 가능성 (배포 안정성)
+
+### 5.1 v0.17.0..HEAD 부분집합 (이번 over-deploy가 깨면 안 되는 표면) — **최우선**
+1. **공지 팝업(#559)** — root layout에 새 client island 마운트. 위험: hydration race / 모든 라우트에 영향 / DB 장애 시 페이지 깨짐 / Esc·focus-trap a11y. **DB seed 필요**(notices row) 또는 빈 큐 graceful 둘 다 검증.
+2. **Auth full-static(#557)** — `/login` `/signup` `/reset-password`가 ○로 전환. 위험: searchParams(`?next=`, `?code=`) 의존부가 CSR로 안 올라오면 폼 동작 불가 / static prerender가 DB·쿠키 의존 누출로 빌드 실패.
+3. **FMP fundamental 캐시(#560)** — 캐시 데코레이터 신규. 위험: poison(장애 캐싱)으로 long-tail 종목 영구 N/A / 키 대소문자 불일치(`sym()` uppercase) / peer enrich N+1.
+4. **Market summary 부분실패(#556)** — 안내 로직. 위험: 정상 데이터에도 false-positive 안내 / 캐시 가드가 부분 데이터 캐싱.
+
+### 5.2 전체범위 고위험 (v0.16 실패 모드 — 근본 해결 확인)
+1. **루트 레이아웃 `cookies()` 재유입** — axis-0 위반 시 전 라우트 dynamic화 → ISR 붕괴 → cold-gen 500 (v0.16 롤백 원인). `src/app/layout.tsx`에 `cookies()`/`headers()` 직접 호출 0 확인.
+2. **ISR 미정적화 재유입** — 종목 라우트 데이터 fetch가 `staticSymbolCache` 우회 시 `DYNAMIC_SERVER_USAGE` → cold-gen 500.
+3. **soft-404 robots 충돌** — degrade/invalid에서 canonical 누출 또는 index+noindex 동시.
+4. **route segment config 리터럴 위반** — `revalidate`/`dynamic`을 상수/식으로 추출 시 Next가 조용히 무시 → ISR 깨짐 (`src/app/CLAUDE.md` 경고).
+
+---
+
+## 6. 환경 노트 (빌드/기동/검증)
+
+### 6.1 빌드 & 기동
+- 프로덕션 빌드 `yarn build` + `yarn start`. **`yarn`만**(npm/pnpm 금지).
+- 워크트리 node_modules는 **symlink 금지** — `cp -al` 하드링크 후 잔여 `node_modules/node_modules` 제거(Turbopack/dual-React 회피).
+- env-shadow: e2e DB+redis 기동, `.env.local` 키를 `.env.e2e`로 shadow(`dotenv -e .env.e2e -o`).
+- 빌드 exit code는 파이프 없이 직접 캡처(`> log 2>&1; echo $?`) — `| tail`은 실패를 exit 0으로 가림.
+
+### 6.2 필수 env (없으면 코드와 무관하게 빌드/런타임 실패)
+1. **`SIGLENS_GITHUB_TOKEN`** (read:packages) — `@y0ngha/siglens-core@0.19.1`(GitHub Packages) 설치. 없으면 `yarn install` 403. **CI(ci.yml)는 빌드 안 함 → 못 잡음**.
+2. **`DATABASE_URL` + `terms` 테이블(active `tos`/`privacy`)** — `/terms`·`/privacy`가 **빌드타임** DB 조회(try/catch 없음).
+3. **`DATABASE_URL` + `notices` 테이블(migration 0016 적용)** — 공지 팝업 server action 검증용. **미설정 시 `[]` graceful degrade라 빌드는 안 깨지나, 노출 검증엔 seed 필요.**
+4. **`NEXT_PUBLIC_SITE_URL`** — 빌드타임 인라인(canonical/OG/JSON-LD/sitemap). 프로덕션 도메인.
+5. **FMP API key** — 시드 종목(`AAPL`) 실데이터. 미설정/미시드 종목은 degrade(200+noindex)로 검증.
+6. **Upstash Redis(`UPSTASH_REDIS_REST_*`)** — ISR `staticSymbolCache`·`getOrSetCache`·FMP fundamental 캐시·분석 peek. 장애 시 graceful degrade 경로도 검증 대상.
+
+### 6.3 docker postgres가 필요한 케이스 (DB-backed)
+| 플로우 | DB 의존 | seed 필요 |
+|---|---|---|
+| `/terms` `/privacy` | **빌드타임** active terms row | **예** (없으면 빌드 실패) |
+| 공지 팝업 노출 | `notices` active row(+window+path) | **예**(노출 검증 시); 미시드면 빈 큐 graceful 검증 |
+| auth(login/signup/reset/oauth) | users/sessions/verification | **예**(플로우 검증 시) — E2E 인프라(`.env.e2e` + fake email/oauth) 재사용 권장 |
+| `/account` `/account/delete` | authed user + api_key | **예**(authed storageState) |
+| sitemap longtail | tickers DB | 선택(없으면 longtail 항목 생략 graceful) |
+
+> DB seed는 기존 E2E 인프라(docker postgres + `.env.e2e` + fake email/oauth 어댑터, `E2E_TEST=1`)를 그대로 재사용하는 것을 권장한다. 공지 검증을 위해 `notices`에 1 active row(path_pattern `null` 또는 `/AAPL/*`, window 현재 포함)를 INSERT.
+
+---
+
+## 7. 검증 방법 두 갈래
+
+- **① curl** — status code / 응답 헤더(`x-nextjs-cache`·`cache-control`·`content-type`·`x-robots-tag`·보안 4종) / HTML 마커(canonical·h1·JSON-LD·noindex·`[SYMBOL]` 누출) / robots.txt·sitemap XML·OG 엔드포인트.
+- **② Chrome DevTools** (claude-in-chrome) — 실제 렌더 / 콘솔(하이드레이션 0에러) / 헤더 게스트·authed 상태 / 인터랙션(검색·탭 전환·분석 트리거·auth·공지 팝업) / 네트워크 워터폴 / Core Web Vitals 스모크(LCP/CLS) / UX 회귀(vs 0.15.0).
+
+실행 절차·기대값은 짝 문서 `2026-06-04-v015-to-current-testcases.md`로 한다.

--- a/src/widgets/notice-popup/__tests__/useNoticePopup.test.ts
+++ b/src/widgets/notice-popup/__tests__/useNoticePopup.test.ts
@@ -47,6 +47,10 @@ describe('useNoticePopup', () => {
         act(() => result.current.advance());
         expect(result.current.queue).toHaveLength(1);
         expect(result.current.queue[0].id).toBe('b');
+        // advance("닫기")는 세션 한정 소비이므로 localStorage(dismissed)에 쓰지 않는다 —
+        // 새로고침/재접속 시 재노출된다. 영구 저장은 dontShowAgain만 수행하며, 이 분기가
+        // 본 변경의 핵심이다(회귀 시 advance가 잘못 영구 저장되는 것을 잡는다).
+        expect(localStorage.getItem(DISMISSED_NOTICES_STORAGE_KEY)).toBeNull();
     });
 
     it('dontShowAgain은 dismiss 저장 후 큐에서 제거한다', async () => {

--- a/src/widgets/notice-popup/hooks/useNoticePopup.ts
+++ b/src/widgets/notice-popup/hooks/useNoticePopup.ts
@@ -1,12 +1,6 @@
 'use client';
 
-import {
-    startTransition,
-    useCallback,
-    useEffect,
-    useEffectEvent,
-    useState,
-} from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { getActiveNoticesAction } from '@/entities/notice/actions';
 import { matchPath, type NoticeRecord } from '@/entities/notice';
 import { loadDismissedNoticeIds, dismissNotice } from '../utils/noticeStorage';
@@ -19,36 +13,59 @@ export interface UseNoticePopupResult {
 }
 
 /**
- * 공지 팝업 데이터 훅. 마운트 시 1회 활성 공지를 fetch하고, pathname 변경 또는
- * 공지 목록 갱신 시 경로 매칭 + localStorage dismiss 필터로 노출 큐를 재구성한다.
+ * 공지 팝업 데이터 훅. 마운트 시 1회 활성 공지를 fetch하고, 경로 매칭 + localStorage
+ * dismiss + 세션 내 소비(consumed) 필터로 노출 큐를 **렌더 중 파생**한다.
+ *
+ * 큐를 effect+setState가 아니라 `useMemo`로 파생하는 이유: 이전 구현은 effect에서
+ * `setQueue`를 호출했고, lint(`react-hooks/set-state-in-effect`)를 피하려 `startTransition`
+ * 으로 감쌌다. 그 낮은 우선순위 업데이트가 무거운 client 페이지(종목 차트/AI 스트리밍)의
+ * 렌더에 밀려 Chrome(Blink)에서 공지 노출이 ~10초+ 지연(starvation)되는 회귀가 있었다
+ * (Safari/WebKit은 즉시 — 실측 확인). 렌더 중 파생으로 urgent 반영 + effect-setState
+ * 제거를 동시에 달성한다.
+ *
+ * 큐 진행(advance/dontShowAgain)은 모두 세션 한정 `consumedIds`(state)로 일원화한다.
+ * "닫기"는 consumed만 추가(새로고침 시 리셋 → 재노출), "다시 보지 않기"는 추가로
+ * localStorage에 영구 dismiss한다(새로고침 후에도 제외).
  */
 export function useNoticePopup(pathname: string): UseNoticePopupResult {
     const [allNotices, setAllNotices] = useState<NoticeRecord[]>([]);
-    const [queue, setQueue] = useState<NoticeRecord[]>([]);
+    const [consumedIds, setConsumedIds] = useState<readonly string[]>([]);
 
-    const rebuildQueue = useEffectEvent(() => {
+    // consumedIds 변경 시 재계산되며, 그때 localStorage(dismissed)도 최신으로 재평가한다.
+    // dismissed는 deps에 없지만, 이 훅에서 dismissed에 쓰는 유일한 경로인 dontShowAgain이
+    // 항상 consumedIds를 함께 bump하므로(아래), consumedIds 변경 → 재계산 시 최신 dismissed를
+    // 다시 읽어 세션 내 stale이 불가능하다. advance는 localStorage를 건드리지 않으므로 재읽기가
+    // 불필요하다.
+    const queue = useMemo<NoticeRecord[]>(() => {
         const dismissed = loadDismissedNoticeIds();
-        startTransition(() => {
-            setQueue(
-                allNotices.filter(
-                    n =>
-                        matchPath(n.pathPattern, pathname) &&
-                        !dismissed.includes(n.id)
-                )
-            );
-        });
-    });
+        return allNotices.filter(
+            n =>
+                matchPath(n.pathPattern, pathname) &&
+                !dismissed.includes(n.id) &&
+                !consumedIds.includes(n.id)
+        );
+    }, [allNotices, pathname, consumedIds]);
 
-    const advance = useCallback(() => setQueue(prev => prev.slice(1)), []);
+    const consume = useCallback((id: string) => {
+        setConsumedIds(prev => (prev.includes(id) ? prev : [...prev, id]));
+    }, []);
 
-    // B1: setState 업데이터 내부에서 사이드이펙트(dismissNotice) 호출 금지.
-    // 업데이터 밖에서 현재 공지를 dismiss한 뒤 큐를 진행한다.
+    // X / 배경 클릭 / Esc / "닫기": 세션 한정 소비(다음 방문 시 재노출).
+    const advance = useCallback(() => {
+        const cur = queue[0];
+        if (cur !== undefined) consume(cur.id);
+    }, [queue, consume]);
+
+    // "다시 보지 않기": localStorage 영구 dismiss + 세션 소비.
     const dontShowAgain = useCallback(() => {
         const cur = queue[0];
-        if (cur) dismissNotice(cur.id);
-        setQueue(prev => prev.slice(1));
-    }, [queue]);
+        if (cur === undefined) return;
+        dismissNotice(cur.id);
+        consume(cur.id);
+    }, [queue, consume]);
 
+    // 활성 공지 fetch는 외부 시스템 동기화 effect. canonical hook order(effects last)에 따라
+    // useMemo/useCallback 뒤에 둔다. deps `[]` — 마운트 시 1회만 실행.
     useEffect(() => {
         let cancelled = false;
         getActiveNoticesAction()
@@ -63,13 +80,6 @@ export function useNoticePopup(pathname: string): UseNoticePopupResult {
             cancelled = true;
         };
     }, []);
-
-    // rebuildQueue는 useEffectEvent 결과(stable 참조)이므로 deps 배열에서 의도적으로
-    // 제외한다. react-hooks/exhaustive-deps가 이 패턴을 인식해 경고하지 않는다(lint 통과).
-    // MISTAKES.md Predictability §3.
-    useEffect(() => {
-        rebuildQueue();
-    }, [pathname, allNotices]);
 
     return { queue, advance, dontShowAgain };
 }

--- a/src/widgets/notice-popup/hooks/useNoticePopup.ts
+++ b/src/widgets/notice-popup/hooks/useNoticePopup.ts
@@ -13,9 +13,6 @@ export interface UseNoticePopupResult {
 }
 
 /**
- * 공지 팝업 데이터 훅. 마운트 시 1회 활성 공지를 fetch하고, 경로 매칭 + localStorage
- * dismiss + 세션 내 소비(consumed) 필터로 노출 큐를 **렌더 중 파생**한다.
- *
  * 큐를 effect+setState가 아니라 `useMemo`로 파생하는 이유: 이전 구현은 effect에서
  * `setQueue`를 호출했고, lint(`react-hooks/set-state-in-effect`)를 피하려 `startTransition`
  * 으로 감쌌다. 그 낮은 우선순위 업데이트가 무거운 client 페이지(종목 차트/AI 스트리밍)의
@@ -65,7 +62,7 @@ export function useNoticePopup(pathname: string): UseNoticePopupResult {
     }, [queue, consume]);
 
     // 활성 공지 fetch는 외부 시스템 동기화 effect. canonical hook order(effects last)에 따라
-    // useMemo/useCallback 뒤에 둔다. deps `[]` — 마운트 시 1회만 실행.
+    // useMemo/useCallback 뒤에 둔다.
     useEffect(() => {
         let cancelled = false;
         getActiveNoticesAction()


### PR DESCRIPTION
## 배경
0.17.0~현재 변경분의 프로덕션-유사 실증(prod build + Chrome/Safari × desktop/mobile) 중, 운영 공지 팝업(#559)이 **Chrome(Blink)에서 무거운 client 페이지(종목 차트/AI 스트리밍)에 진입하면 ~10초+ 지연 표시**되는 버그를 발견했다(16초 실측). Safari/WebKit은 즉시 표시.

## 원인
`useNoticePopup`이 노출 큐를 `useEffect` 안에서 `startTransition(() => setQueue(...))`로 재구성했다. `startTransition`은 lint(`react-hooks/set-state-in-effect`) 회피용이었으나, 그 낮은 우선순위 업데이트가 무거운 렌더에 밀려 Blink에서 starvation됐다.

## 수정
- 큐를 effect+setState가 아니라 **`useMemo`로 렌더 중 파생** → urgent 반영 + effect-setState 제거를 동시에 달성(startTransition 불필요).
- 큐 진행을 세션 한정 `consumedIds`(state)로 **일원화**: "닫기"(advance)는 세션 소비만(새로고침 시 재노출), "다시 보지 않기"(dontShowAgain)는 localStorage 영구 dismiss + 세션 소비.

## 검증 (실증)
- 실 Chrome /AAPL 공지 표시: **16초 → 4초**.
- Playwright **Chrome/Safari × desktop/mobile**: 표시·우선순위·"닫기" 순차·"다시 보지 않기"+새로고침·path 타겟팅·만료/비활성 제외·악성링크 차단 + 모바일 가로 오버플로우 — 핵심 케이스 전부 통과.
- 단위 50 passed, lint/tsc/build 모두 green.

## 문서
- 검증 spec/test case: `docs/superpowers/specs/2026-06-04-v015-to-current-*.md`, `2026-06-04-notice-popup-testcases.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)