### PR TITLE
fix(notice): 긴 공지 본문 모달 overflow 처리 (max-h + 본문 스크롤)

### DIFF
--- a/e2e/specs/notice-popup.spec.ts
+++ b/e2e/specs/notice-popup.spec.ts
@@ -26,12 +26,26 @@ const GLOBAL_NOTICE_ID = '11111111-e2e1-4000-8000-000000000001';
 const PATH_NOTICE_ID = '22222222-e2e2-4000-8000-000000000002';
 const LONG_NOTICE_ID = '66666666-e2e6-4000-8000-000000000006';
 
+/** 시드 공지를 실 공지보다 항상 먼저 띄우기 위한 높은 우선순위. */
+const E2E_HIGH_PRIORITY = 99;
+/** 85dvh를 확실히 초과시키는 섹션 수 — 본문이 모달 높이를 넘겨 회귀를 재현할 만큼 길어야 한다. */
+const LONG_BODY_SECTION_COUNT = 40;
+/**
+ * 모달 높이가 뷰포트 대비 이 비율 이하인지 본다. CSS 제약은 `max-h-[85dvh]`(0.85)이지만,
+ * `dvh`(동적 뷰포트)와 `window.innerHeight`의 의미가 모바일에서 달라(주소창 노출 시 dvh <
+ * innerHeight) 0.85로 단언하면 거짓 실패가 날 수 있다. 약간의 버퍼(0.87)로 "뷰포트를 넘지
+ * 않는다"는 본질을 안정적으로 검증한다.
+ */
+const VIEWPORT_FIT_RATIO = 0.87;
+/** scrollHeight > clientHeight 판정 시 서브픽셀 반올림 오차를 흡수하는 임계값(px). */
+const SCROLL_THRESHOLD_PX = 5;
+
 /**
  * 85dvh를 확실히 초과하도록 충분히 긴 마크다운 본문(헤딩/단락/리스트/코드 반복).
  * 이 길이가 핵심 — 본문이 모달 높이를 넘겨 푸터가 밀려나는 회귀를 재현할 수 있어야 한다.
  */
 const LONG_BODY = Array.from(
-    { length: 40 },
+    { length: LONG_BODY_SECTION_COUNT },
     (_, i) =>
         `### 섹션 ${i + 1}\n\n매우 긴 공지 본문의 ${i + 1}번째 문단입니다. 본문만 스크롤되고 푸터 버튼은 고정되어야 합니다.\n\n- 항목 A-${i + 1}\n- 항목 B-${i + 1}\n\n\`code-${i + 1}\``
 ).join('\n\n');
@@ -63,7 +77,7 @@ test.describe('공지 팝업', () => {
                     title: 'E2E 공지 테스트 제목',
                     body: 'E2E 공지 본문입니다.',
                     pathPattern: null, // 전역
-                    priority: 99,
+                    priority: E2E_HIGH_PRIORITY,
                 },
             ]);
         });
@@ -96,7 +110,7 @@ test.describe('공지 팝업', () => {
                     title: 'E2E 공지 테스트 제목',
                     body: 'E2E 공지 본문입니다.',
                     pathPattern: null,
-                    priority: 99,
+                    priority: E2E_HIGH_PRIORITY,
                 },
             ]);
         });
@@ -148,7 +162,7 @@ test.describe('공지 팝업', () => {
                     title: 'E2E 공지 테스트 제목',
                     body: 'E2E 공지 본문입니다.',
                     pathPattern: null,
-                    priority: 99,
+                    priority: E2E_HIGH_PRIORITY,
                 },
             ]);
         });
@@ -202,7 +216,7 @@ test.describe('공지 팝업', () => {
                     title: 'E2E 마켓 전용 공지',
                     body: '마켓 페이지에서만 보이는 공지입니다.',
                     pathPattern: '/market',
-                    priority: 99,
+                    priority: E2E_HIGH_PRIORITY,
                 },
             ]);
         });
@@ -256,7 +270,7 @@ test.describe('공지 팝업', () => {
                     title: 'E2E 비활성 공지',
                     body: '비활성 공지입니다.',
                     pathPattern: null,
-                    priority: 99,
+                    priority: E2E_HIGH_PRIORITY,
                     isActive: false,
                 },
             ]);
@@ -276,7 +290,7 @@ test.describe('공지 팝업', () => {
                     title: 'E2E 미래 시작 공지',
                     body: '아직 시작 전인 공지입니다.',
                     pathPattern: null,
-                    priority: 99,
+                    priority: E2E_HIGH_PRIORITY,
                     startsAt: new Date(Date.now() + 86400000).toISOString(),
                 },
             ]);
@@ -296,7 +310,7 @@ test.describe('공지 팝업', () => {
                     title: 'E2E 만료된 공지',
                     body: '이미 종료된 공지입니다.',
                     pathPattern: null,
-                    priority: 99,
+                    priority: E2E_HIGH_PRIORITY,
                     endsAt: new Date(Date.now() - 86400000).toISOString(),
                 },
             ]);
@@ -325,7 +339,7 @@ test.describe('공지 팝업', () => {
                     title: 'E2E 긴 공지',
                     body: LONG_BODY,
                     pathPattern: null,
-                    priority: 99,
+                    priority: E2E_HIGH_PRIORITY,
                 },
             ]);
         });
@@ -345,20 +359,22 @@ test.describe('공지 팝업', () => {
             await expect(modal).toBeVisible();
 
             // 1) 본문이 아무리 길어도 모달은 뷰포트(85dvh 제약)를 넘지 않는다.
-            const fitsViewport = await modal.evaluate(el => {
+            const fitsViewport = await modal.evaluate((el, ratio) => {
                 const r = el.getBoundingClientRect();
                 return (
-                    r.height <= window.innerHeight * 0.87 &&
+                    r.height <= window.innerHeight * ratio &&
                     r.top >= -1 &&
                     r.bottom <= window.innerHeight + 1
                 );
-            });
+            }, VIEWPORT_FIT_RATIO);
             expect(fitsViewport).toBe(true);
 
             // 2) 본문 스크롤 영역이 내부적으로 스크롤 가능하다(콘텐츠가 잘리지 않고 스크롤로 접근).
             const scroller = page.getByTestId('notice-body-scroller');
             const canScrollBody = await scroller.evaluate(
-                el => el.scrollHeight > el.clientHeight + 5
+                (el, threshold) =>
+                    el.scrollHeight > el.clientHeight + threshold,
+                SCROLL_THRESHOLD_PX
             );
             expect(canScrollBody).toBe(true);
 

--- a/e2e/specs/notice-popup.spec.ts
+++ b/e2e/specs/notice-popup.spec.ts
@@ -24,6 +24,17 @@ import { seedNotices } from '../support/noticeSeeder';
 /** 테스트 UUID — 실제 공지와 충돌하지 않을 임의 고정값. */
 const GLOBAL_NOTICE_ID = '11111111-e2e1-4000-8000-000000000001';
 const PATH_NOTICE_ID = '22222222-e2e2-4000-8000-000000000002';
+const LONG_NOTICE_ID = '66666666-e2e6-4000-8000-000000000006';
+
+/**
+ * 85dvh를 확실히 초과하도록 충분히 긴 마크다운 본문(헤딩/단락/리스트/코드 반복).
+ * 이 길이가 핵심 — 본문이 모달 높이를 넘겨 푸터가 밀려나는 회귀를 재현할 수 있어야 한다.
+ */
+const LONG_BODY = Array.from(
+    { length: 40 },
+    (_, i) =>
+        `### 섹션 ${i + 1}\n\n매우 긴 공지 본문의 ${i + 1}번째 문단입니다. 본문만 스크롤되고 푸터 버튼은 고정되어야 합니다.\n\n- 항목 A-${i + 1}\n- 항목 B-${i + 1}\n\n\`code-${i + 1}\``
+).join('\n\n');
 
 /**
  * Matches DISMISSED_NOTICES_STORAGE_KEY in src/widgets/notice-popup/utils/noticeStorage.ts.
@@ -294,6 +305,68 @@ test.describe('공지 팝업', () => {
             await expect(
                 page.getByTestId('notice-modal-content')
             ).not.toBeVisible();
+        });
+    });
+
+    /**
+     * 6. 긴 본문 오버플로우 — 본문이 모달 높이를 초과해도 모달은 뷰포트(85dvh)를 넘지 않고,
+     *    본문(notice-body-scroller)만 내부 스크롤되며, 푸터("닫기") 버튼은 화면 밖으로
+     *    밀리지 않고 뷰포트 안에 남아야 한다(PR #562 회귀 가드).
+     *    jsdom은 레이아웃/overflow를 측정하지 못하므로 이 시각적 동작은 여기(Playwright)에서만
+     *    검증된다 — 단위 테스트(NoticePopup.test.tsx)는 구조 불변식만 단언한다.
+     */
+    test.describe('@webkit 긴 본문 오버플로우 — 본문만 스크롤, 푸터 버튼 고정', () => {
+        let cleanup: () => Promise<void>;
+
+        test.beforeEach(async () => {
+            cleanup = await seedNotices([
+                {
+                    id: LONG_NOTICE_ID,
+                    title: 'E2E 긴 공지',
+                    body: LONG_BODY,
+                    pathPattern: null,
+                    priority: 99,
+                },
+            ]);
+        });
+
+        test.afterEach(async () => {
+            await cleanup?.();
+        });
+
+        // @webkit은 describe와 test 제목 양쪽에 둔다 — webkit 프로젝트가 grep: /@webkit/로
+        // 전체 제목을 매칭하기 때문(데스크톱 Chrome + iPhone14 모바일 Safari 양쪽 실행).
+        test('@webkit 긴 본문 공지에서 모달은 뷰포트를 넘지 않고, 본문만 스크롤되며, "닫기" 버튼이 뷰포트 안에 보인다', async ({
+            page,
+        }) => {
+            await page.goto('/');
+
+            const modal = page.getByTestId('notice-modal-content');
+            await expect(modal).toBeVisible();
+
+            // 1) 본문이 아무리 길어도 모달은 뷰포트(85dvh 제약)를 넘지 않는다.
+            const fitsViewport = await modal.evaluate(el => {
+                const r = el.getBoundingClientRect();
+                return (
+                    r.height <= window.innerHeight * 0.87 &&
+                    r.top >= -1 &&
+                    r.bottom <= window.innerHeight + 1
+                );
+            });
+            expect(fitsViewport).toBe(true);
+
+            // 2) 본문 스크롤 영역이 내부적으로 스크롤 가능하다(콘텐츠가 잘리지 않고 스크롤로 접근).
+            const scroller = page.getByTestId('notice-body-scroller');
+            const canScrollBody = await scroller.evaluate(
+                el => el.scrollHeight > el.clientHeight + 5
+            );
+            expect(canScrollBody).toBe(true);
+
+            // 3) 핵심 회귀: 긴 본문이 푸터를 밀어내지 않아 "닫기" 버튼이 뷰포트 안에 보인다.
+            //    name 부분일치로 X 버튼(aria-label="팝업 닫기")까지 잡히므로 exact로 하단 버튼만 겨냥.
+            await expect(
+                page.getByRole('button', { name: '닫기', exact: true })
+            ).toBeInViewport();
         });
     });
 });

--- a/src/widgets/notice-popup/__tests__/NoticePopup.test.tsx
+++ b/src/widgets/notice-popup/__tests__/NoticePopup.test.tsx
@@ -55,24 +55,38 @@ describe('NoticePopup', () => {
 
     it('푸터 버튼은 스크롤 본문(overflow-y-auto) 밖에 위치한다 — 긴 본문에도 버튼 고정', async () => {
         mockedAction.mockResolvedValue([notice()]);
-        const { container } = render(<NoticePopup />);
+        render(<NoticePopup />);
         await screen.findByText('긴급 점검 안내');
-        const scroller = container.querySelector('.overflow-y-auto');
-        expect(scroller).not.toBeNull();
+        // CSS 클래스가 아니라 data-testid로 조회한다: 스크롤 구현(overflow-y-auto 클래스)을
+        // 바꿔도 이 구조 불변식 검증이 무음으로 깨지지 않도록.
+        const scroller = screen.getByTestId('notice-body-scroller');
         // 푸터가 스크롤 영역의 자손이 되면(=footer가 스크롤 안으로 들어가면) 긴 본문에서
         // 버튼이 화면 밖으로 밀리는 원래 버그가 재발한다. 항상 스크롤 밖(sibling)이어야 한다.
         // (overflow의 실제 동작/높이는 jsdom이 측정 못 하므로 Playwright로 검증 — 여기서는
         //  회귀를 잡는 구조 불변식만 단언한다.)
         expect(
-            scroller?.contains(
+            scroller.contains(
                 screen.getByRole('button', { name: '다시 보지 않기' })
             )
         ).toBe(false);
         expect(
-            scroller?.contains(screen.getByRole('button', { name: '닫기' }))
+            scroller.contains(screen.getByRole('button', { name: '닫기' }))
         ).toBe(false);
-        // 모달 content는 뷰포트 초과를 막는 max-h 제약을 가진다.
-        expect(screen.getByRole('dialog').className).toContain('max-h-');
+        // 모달 content는 뷰포트 초과를 막는 max-h 제약을 가진다. 적용 값은 max-h-[85dvh]로
+        // 고정(deterministic)이므로 정확히 단언한다(max-h-* 아무거나 통과하는 것을 방지).
+        expect(screen.getByRole('dialog').className).toContain('max-h-[85dvh]');
+    });
+
+    it('스크롤 본문은 키보드 포커스 가능하다 — 링크 없는 본문도 방향키로 스크롤(WCAG 2.1.1)', async () => {
+        mockedAction.mockResolvedValue([notice()]);
+        render(<NoticePopup />);
+        await screen.findByText('긴급 점검 안내');
+        const scroller = screen.getByTestId('notice-body-scroller');
+        // 본문에 포커스 가능한 자손(링크)이 없을 때도 키보드 사용자가 스크롤 영역에 진입해
+        // 방향키/PageUp·Down으로 스크롤할 수 있어야 한다.
+        expect(scroller).toHaveAttribute('tabindex', '0');
+        expect(scroller).toHaveAttribute('role', 'region');
+        expect(scroller).toHaveAccessibleName('공지 본문');
     });
 
     it('linkUrl이 있으면 링크를 렌더하고, label이 없으면 url을 표시한다', async () => {

--- a/src/widgets/notice-popup/__tests__/NoticePopup.test.tsx
+++ b/src/widgets/notice-popup/__tests__/NoticePopup.test.tsx
@@ -62,8 +62,9 @@ describe('NoticePopup', () => {
         const scroller = screen.getByTestId('notice-body-scroller');
         // 푸터가 스크롤 영역의 자손이 되면(=footer가 스크롤 안으로 들어가면) 긴 본문에서
         // 버튼이 화면 밖으로 밀리는 원래 버그가 재발한다. 항상 스크롤 밖(sibling)이어야 한다.
-        // (overflow의 실제 동작/높이는 jsdom이 측정 못 하므로 Playwright로 검증 — 여기서는
-        //  회귀를 잡는 구조 불변식만 단언한다.)
+        // (overflow의 실제 시각 동작/높이는 jsdom이 측정 못 하므로 여기서는 회귀를 잡는 구조
+        //  불변식만 단언한다. 모달이 뷰포트를 넘지 않고 본문만 스크롤되며 푸터가 뷰포트에 남는
+        //  실제 동작은 e2e/specs/notice-popup.spec.ts "긴 본문 오버플로우" 케이스에서 검증한다.)
         expect(
             scroller.contains(
                 screen.getByRole('button', { name: '다시 보지 않기' })

--- a/src/widgets/notice-popup/__tests__/NoticePopup.test.tsx
+++ b/src/widgets/notice-popup/__tests__/NoticePopup.test.tsx
@@ -53,6 +53,28 @@ describe('NoticePopup', () => {
         expect(screen.getByText('2026.06.03 작성')).toBeInTheDocument();
     });
 
+    it('푸터 버튼은 스크롤 본문(overflow-y-auto) 밖에 위치한다 — 긴 본문에도 버튼 고정', async () => {
+        mockedAction.mockResolvedValue([notice()]);
+        const { container } = render(<NoticePopup />);
+        await screen.findByText('긴급 점검 안내');
+        const scroller = container.querySelector('.overflow-y-auto');
+        expect(scroller).not.toBeNull();
+        // 푸터가 스크롤 영역의 자손이 되면(=footer가 스크롤 안으로 들어가면) 긴 본문에서
+        // 버튼이 화면 밖으로 밀리는 원래 버그가 재발한다. 항상 스크롤 밖(sibling)이어야 한다.
+        // (overflow의 실제 동작/높이는 jsdom이 측정 못 하므로 Playwright로 검증 — 여기서는
+        //  회귀를 잡는 구조 불변식만 단언한다.)
+        expect(
+            scroller?.contains(
+                screen.getByRole('button', { name: '다시 보지 않기' })
+            )
+        ).toBe(false);
+        expect(
+            scroller?.contains(screen.getByRole('button', { name: '닫기' }))
+        ).toBe(false);
+        // 모달 content는 뷰포트 초과를 막는 max-h 제약을 가진다.
+        expect(screen.getByRole('dialog').className).toContain('max-h-');
+    });
+
     it('linkUrl이 있으면 링크를 렌더하고, label이 없으면 url을 표시한다', async () => {
         mockedAction.mockResolvedValue([
             notice({ linkUrl: 'https://siglens.io/blog', linkLabel: null }),

--- a/src/widgets/notice-popup/__tests__/NoticePopup.test.tsx
+++ b/src/widgets/notice-popup/__tests__/NoticePopup.test.tsx
@@ -186,6 +186,11 @@ describe('NoticePopup', () => {
         ]);
         render(<NoticePopup />);
         expect(await screen.findByText('첫 번째')).toBeInTheDocument();
+        // useEscapeKey의 keydown 리스너는 passive effect로 등록된다(버튼 클릭과 달리 직접
+        // 핸들러가 아니다). CI(vmThreads + 부하)에서는 모달 렌더 직후 리스너 부착 전에 keyDown이
+        // 발사되면 Esc가 유실돼 다음 공지로 넘어가지 않는다. dialog 포커스는 같은 effect 배치에서
+        // 실행되므로, 포커스를 기다리면 리스너 부착이 보장된다 — 그 후 Esc를 발사한다.
+        await waitFor(() => expect(screen.getByRole('dialog')).toHaveFocus());
         fireEvent.keyDown(document, { key: 'Escape' });
         expect(await screen.findByText('두 번째')).toBeInTheDocument();
     });

--- a/src/widgets/notice-popup/ui/NoticePopup.tsx
+++ b/src/widgets/notice-popup/ui/NoticePopup.tsx
@@ -49,10 +49,10 @@ export function NoticePopup() {
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby={MODAL_TITLE_ID}
-                className="border-secondary-700 bg-secondary-800 w-full max-w-md rounded-2xl border p-5"
+                className="border-secondary-700 bg-secondary-800 flex max-h-[85dvh] w-full max-w-md flex-col rounded-2xl border p-5"
                 onClick={e => e.stopPropagation()}
             >
-                <div className="mb-3 flex items-start justify-between gap-3">
+                <div className="mb-3 flex shrink-0 items-start justify-between gap-3">
                     <h2
                         id={MODAL_TITLE_ID}
                         className="text-secondary-100 text-base font-bold"
@@ -67,23 +67,28 @@ export function NoticePopup() {
                         ✕
                     </button>
                 </div>
-                <p className="text-secondary-500 mb-3 text-xs">
-                    {formatNoticeDate(current.createdAt)}
-                </p>
-                <MarkdownText className="text-secondary-300 text-sm">
-                    {current.body}
-                </MarkdownText>
-                {safeLinkUrl !== null && (
-                    <a
-                        href={safeLinkUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="bg-primary-600 hover:bg-primary-500 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-800 mt-4 inline-block rounded-lg px-4 py-2 text-sm font-semibold text-white transition-colors focus-visible:ring-1 focus-visible:ring-offset-2 focus-visible:outline-none"
-                    >
-                        {current.linkLabel ?? safeLinkUrl}
-                    </a>
-                )}
-                <div className="mt-5 flex items-center justify-end gap-3">
+                {/* 긴 마크다운이 푸터(버튼)를 화면 밖으로 밀지 않도록 본문만 스크롤시킨다.
+                    min-h-0은 flex 자식이 기본 min-height:auto여서, 없으면 overflow가 동작하지
+                    않아(자식이 콘텐츠 높이만큼 늘어남) 반드시 필요하다. */}
+                <div className="-mr-2 min-h-0 flex-1 overflow-y-auto pr-2">
+                    <p className="text-secondary-500 mb-3 text-xs">
+                        {formatNoticeDate(current.createdAt)}
+                    </p>
+                    <MarkdownText className="text-secondary-300 text-sm">
+                        {current.body}
+                    </MarkdownText>
+                    {safeLinkUrl !== null && (
+                        <a
+                            href={safeLinkUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="bg-primary-600 hover:bg-primary-500 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-800 mt-4 inline-block rounded-lg px-4 py-2 text-sm font-semibold text-white transition-colors focus-visible:ring-1 focus-visible:ring-offset-2 focus-visible:outline-none"
+                        >
+                            {current.linkLabel ?? safeLinkUrl}
+                        </a>
+                    )}
+                </div>
+                <div className="mt-5 flex shrink-0 items-center justify-end gap-3">
                     <button
                         onClick={dontShowAgain}
                         className="text-secondary-400 hover:text-secondary-200 focus-visible:ring-primary-500 text-sm transition-colors focus-visible:ring-1 focus-visible:outline-none"

--- a/src/widgets/notice-popup/ui/NoticePopup.tsx
+++ b/src/widgets/notice-popup/ui/NoticePopup.tsx
@@ -69,8 +69,17 @@ export function NoticePopup() {
                 </div>
                 {/* 긴 마크다운이 푸터(버튼)를 화면 밖으로 밀지 않도록 본문만 스크롤시킨다.
                     min-h-0은 flex 자식이 기본 min-height:auto여서, 없으면 overflow가 동작하지
-                    않아(자식이 콘텐츠 높이만큼 늘어남) 반드시 필요하다. */}
-                <div className="-mr-2 min-h-0 flex-1 overflow-y-auto pr-2">
+                    않아(자식이 콘텐츠 높이만큼 늘어남) 반드시 필요하다.
+                    tabIndex/role/aria-label은 키보드 접근성용: 본문에 포커스 가능한 자손(링크)이
+                    없으면 키보드 사용자가 스크롤 영역에 진입할 수 없어 방향키/PageUp·Down으로
+                    긴 본문을 스크롤할 수 없다(WCAG 2.1.1). 컨테이너를 포커스 가능하게 만든다. */}
+                <div
+                    tabIndex={0}
+                    role="region"
+                    aria-label="공지 본문"
+                    data-testid="notice-body-scroller"
+                    className="focus-visible:ring-primary-500 -mr-2 min-h-0 flex-1 overflow-y-auto rounded pr-2 focus-visible:ring-1 focus-visible:outline-none"
+                >
                     <p className="text-secondary-500 mb-3 text-xs">
                         {formatNoticeDate(current.createdAt)}
                     </p>


### PR DESCRIPTION
## 배경
공지 팝업 본문은 `MarkdownText`로 렌더된다. 모달 content에 높이 제한/overflow가 없어, **긴 마크다운 공지**(실측: 6404자 본문)가 들어오면 모달이 뷰포트보다 커지며 **푸터 버튼("다시 보지 않기"/"닫기")이 화면 밖으로 밀리고 스크롤도 안 돼** 사용성이 깨졌다(특히 모바일).

## 수정
- 모달 content를 `flex flex-col max-h-[85dvh]`로 제한(모바일 주소창 대응 위해 `vh` 아닌 `dvh`).
- 헤더(제목·X)·푸터(버튼)는 `shrink-0`으로 고정.
- 본문(날짜·마크다운·링크)만 `min-h-0 flex-1 overflow-y-auto`로 **내부 스크롤**.

## 검증 (실증)
docker DB에 마크다운 공지(짧은 것 + 6404자 긴 것)를 seed하고 prod build + Playwright **Chrome/Safari × desktop/mobile 24/24 PASS**:
- 긴 마크다운에도 모달 높이 ≤ 85dvh, 본문 내부 스크롤(scrollH 4828~6077 > clientH), **닫기 버튼 항상 뷰포트 내**.
- 마크다운 렌더(strong/em/ul/ol/li/code/link) 정상, 가로 오버플로우 없음.
- 단위 31 passed(푸터가 스크롤 영역 밖이라는 구조 불변식 + max-h 클래스 검증 추가), lint/tsc/build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)