### PR TITLE
fix: QA audit follow-ups (round 2) — core 0.20.0 bump + E2E flag + error boundary + SEO links + coverage

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -1,4 +1,11 @@
 E2E_TEST=1
+# Client-side E2E flag (build-time inlined). E2E_TEST above is server-only; the
+# client bundle reads NEXT_PUBLIC_E2E_TEST via isE2EClient(). useMarketSummary
+# gates its force-partial refetch on this (staleTime:0 + refetchOnMount:'always'),
+# so the partial-data notice E2E (market.spec '...dismissible notice') is flaky
+# without it — the RSC-seeded (non-partial) summary is served instead of the
+# cookie-driven force-partial one. Must be present at BUILD time (NEXT_PUBLIC_* is inlined).
+NEXT_PUBLIC_E2E_TEST=1
 DATABASE_URL=postgres://siglens:siglens@localhost:5433/siglens_e2e
 UPSTASH_REDIS_REST_URL=http://localhost:8079
 UPSTASH_REDIS_REST_TOKEN=e2e-token

--- a/e2e/specs/market.spec.ts
+++ b/e2e/specs/market.spec.ts
@@ -30,10 +30,25 @@ test.describe('market overview', () => {
     });
 
     /**
+     * SSR 크롤 텍스트 보장. 인터랙티브 SectorSignalPanel은 useSearchParams CSR
+     * bailout이라 no-JS HTML이 비어 있다. SectorFactsSummary가 Suspense fallback에
+     * 같은 데이터를 서버 렌더하므로, JS 없이 받은 raw HTML에 섹션 헤딩이 있어야 한다.
+     */
+    test('SSR HTML exposes the SectorFactsSummary crawl-text (no-JS crawlers)', async ({
+        page,
+    }) => {
+        const res = await page.request.get('/market');
+        expect(res.status()).toBe(200);
+        const html = await res.text();
+        expect(html).toContain('섹터별 신호 모아보기');
+    });
+
+    /**
      * 부분 로드 실패 안내. FakeMarketProvider는 항상 비-0 시세를 주므로 안내가 뜨지
-     * 않는다 — force-partial 쿠키(E2E_TEST 한정, getMarketSummaryAction이 해석)로 첫
-     * 섹터 quote를 0으로 만들어 server action → useMarketSummary(hasMissingQuotes)
-     * → 패널 안내까지 전 경로를 결정적으로 검증한다. 닫으면(일시적) 사라진다.
+     * 않는다 — force-partial 쿠키(E2E_TEST 한정, getMarketSummaryClientAction이 해석;
+     * 클라는 NEXT_PUBLIC_E2E_TEST=1일 때 force-partial을 결정적으로 refetch)로 첫 섹터
+     * quote를 0으로 만들어 server action → useMarketSummary(hasMissingQuotes) → 패널
+     * 안내까지 전 경로를 결정적으로 검증한다. 닫으면(일시적) 사라진다.
      */
     test('partial data-load failure shows a dismissible notice', async ({
         page,

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "@upstash/redis": "^1.37.0",
         "@vercel/analytics": "^2.0.1",
         "@vercel/functions": "^3.4.3",
-        "@y0ngha/siglens-core": "0.19.1",
+        "@y0ngha/siglens-core": "0.20.0",
         "bcryptjs": "^3.0.3",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",

--- a/src/app/market/__tests__/error.test.tsx
+++ b/src/app/market/__tests__/error.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MarketError from '../error';
+
+describe('MarketError (/market route error boundary)', () => {
+    const error = Object.assign(new Error('boom'), { digest: 'deadbeef' });
+
+    it('renders exactly one h1 (single-h1 contract is preserved even on error)', () => {
+        const { container } = render(
+            <MarketError error={error} reset={vi.fn()} />
+        );
+        expect(container.querySelectorAll('h1')).toHaveLength(1);
+    });
+
+    it('wires the retry button to reset()', () => {
+        const reset = vi.fn();
+        render(<MarketError error={error} reset={reset} />);
+
+        screen.getByRole('button', { name: '다시 시도' }).click();
+
+        expect(reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('offers a working home link', () => {
+        render(<MarketError error={error} reset={vi.fn()} />);
+
+        expect(screen.getByRole('link', { name: /홈으로/ })).toHaveAttribute(
+            'href',
+            '/'
+        );
+    });
+
+    it('logs the error (with its digest) for server-side correlation', () => {
+        const errorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined);
+
+        render(<MarketError error={error} reset={vi.fn()} />);
+
+        expect(errorSpy).toHaveBeenCalledWith(
+            '[MarketRoute] render error:',
+            error
+        );
+        errorSpy.mockRestore();
+    });
+});

--- a/src/app/market/error.tsx
+++ b/src/app/market/error.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { SITE_NAME } from '@/shared/lib/seo';
+
+interface MarketErrorProps {
+    error: Error & { digest?: string };
+    reset: () => void;
+}
+
+/**
+ * Error boundary for the `/market` ISR route.
+ *
+ * `MarketContent` fans out to FMP (market summary / sector signals) + the
+ * briefing peek. Those paths degrade gracefully today (core returns null quotes
+ * / Promise.allSettled drops failures), so a thrown render is unlikely — but an
+ * unexpected throw during an uncached ISR cold-gen (DB/Redis client init, an
+ * unforeseen core error) would otherwise surface as a bare 500. This boundary
+ * contains that into a branded, retryable UI. `reset()` re-renders the segment,
+ * which on a transient outage typically succeeds on the next attempt. Mirrors
+ * `src/app/[symbol]/error.tsx`.
+ */
+export default function MarketError({ error, reset }: MarketErrorProps) {
+    useEffect(() => {
+        // `digest` ties this client log to the server-side error entry.
+        console.error('[MarketRoute] render error:', error);
+    }, [error]);
+
+    return (
+        <main className="flex flex-1 flex-col items-center px-6 py-20 text-center">
+            <p className="text-primary-400 font-mono text-sm tracking-widest">
+                일시 오류
+            </p>
+            <h1 className="text-secondary-100 mt-4 text-2xl font-bold sm:text-3xl">
+                시장 데이터를 불러오지 못했어요
+            </h1>
+            <p className="text-secondary-400 mt-3 max-w-md text-sm leading-relaxed">
+                외부 시세 제공처가 일시적으로 응답하지 않을 수 있어요. 잠시 후
+                다시 시도해 주세요.
+            </p>
+            <div className="mt-8 flex gap-3">
+                <button
+                    type="button"
+                    onClick={reset}
+                    className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-950 inline-flex min-h-11 items-center rounded-lg px-6 text-sm font-medium text-white transition-colors focus-visible:ring-1 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                    다시 시도
+                </button>
+                <Link
+                    href="/"
+                    className="text-secondary-200 hover:text-secondary-50 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-950 inline-flex min-h-11 items-center rounded-lg px-6 text-sm font-medium transition-colors focus-visible:ring-1 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                    {SITE_NAME} 홈으로
+                </Link>
+            </div>
+        </main>
+    );
+}

--- a/src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
+++ b/src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
@@ -84,6 +84,15 @@ describe('CachedMarketDataProvider', () => {
         expect(store.has('bars:raw:AAPL:1Day:2026-01-01::')).toBe(false);
     });
 
+    it('getBars: from/before/limit이 모두 undefined면 키에 빈 문자열로 채워진다 (?? 가드)', async () => {
+        const inner = makeInner();
+        const p = new CachedMarketDataProvider(inner);
+        await p.getBars(barsOpts({ from: undefined }));
+        expect(inner.getBars).toHaveBeenCalledTimes(1);
+        // from/before/limit 모두 미지정 → `?? ''`로 빈 문자열, 트레일링 콜론만 남는다.
+        expect(store.has('bars:raw:AAPL:1Day:::')).toBe(true);
+    });
+
     it('getBars: from/before가 다르면 키가 분리된다', async () => {
         const inner = makeInner();
         const p = new CachedMarketDataProvider(inner);

--- a/src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
+++ b/src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
@@ -89,7 +89,6 @@ describe('CachedMarketDataProvider', () => {
         const p = new CachedMarketDataProvider(inner);
         await p.getBars(barsOpts({ from: undefined }));
         expect(inner.getBars).toHaveBeenCalledTimes(1);
-        // from/before/limit 모두 미지정 → `?? ''`로 빈 문자열, 트레일링 콜론만 남는다.
         expect(store.has('bars:raw:AAPL:1Day:::')).toBe(true);
     });
 

--- a/src/shared/config/__tests__/dashboard-tickers.test.ts
+++ b/src/shared/config/__tests__/dashboard-tickers.test.ts
@@ -187,10 +187,10 @@ describe('SIGNAL_SECTORS', () => {
 });
 
 describe('isDashboardTimeframe', () => {
-    it('(Happy) 유효한 DashboardTimeframe이면 true', () => {
-        expect(isDashboardTimeframe('15Min')).toBe(true);
-        expect(isDashboardTimeframe('1Hour')).toBe(true);
-        expect(isDashboardTimeframe('1Day')).toBe(true);
+    it('(Happy) 모든 DASHBOARD_TIMEFRAMES 값에 대해 true (하드코딩 대신 모듈 export 순회)', () => {
+        for (const tf of DASHBOARD_TIMEFRAMES) {
+            expect(isDashboardTimeframe(tf)).toBe(true);
+        }
     });
 
     it('(Edge) 대소문자/미지원/빈값/non-string이면 false', () => {

--- a/src/shared/config/__tests__/dashboard-tickers.test.ts
+++ b/src/shared/config/__tests__/dashboard-tickers.test.ts
@@ -188,9 +188,9 @@ describe('SIGNAL_SECTORS', () => {
 
 describe('isDashboardTimeframe', () => {
     it('(Happy) 모든 DASHBOARD_TIMEFRAMES 값에 대해 true (하드코딩 대신 모듈 export 순회)', () => {
-        for (const tf of DASHBOARD_TIMEFRAMES) {
-            expect(isDashboardTimeframe(tf)).toBe(true);
-        }
+        DASHBOARD_TIMEFRAMES.forEach(tf =>
+            expect(isDashboardTimeframe(tf)).toBe(true)
+        );
     });
 
     it('(Edge) 대소문자/미지원/빈값/non-string이면 false', () => {

--- a/src/shared/config/__tests__/dashboard-tickers.test.ts
+++ b/src/shared/config/__tests__/dashboard-tickers.test.ts
@@ -2,6 +2,7 @@ import {
     DASHBOARD_TIMEFRAME_LABELS,
     DASHBOARD_TIMEFRAMES,
     DEFAULT_DASHBOARD_TIMEFRAME,
+    isDashboardTimeframe,
     MARKET_INDICES,
     MARKET_SUMMARY_FMP_SYMBOLS,
     SECTOR_ETFS,
@@ -182,5 +183,23 @@ describe('SIGNAL_SECTORS', () => {
         const quantum = SIGNAL_SECTORS.find(s => s.symbol === 'QNTM');
         expect(quantum).toBeDefined();
         expect(quantum!.sectorName).toBe('Quantum');
+    });
+});
+
+describe('isDashboardTimeframe', () => {
+    it('(Happy) 유효한 DashboardTimeframe이면 true', () => {
+        expect(isDashboardTimeframe('15Min')).toBe(true);
+        expect(isDashboardTimeframe('1Hour')).toBe(true);
+        expect(isDashboardTimeframe('1Day')).toBe(true);
+    });
+
+    it('(Edge) 대소문자/미지원/빈값/non-string이면 false', () => {
+        expect(isDashboardTimeframe('1day')).toBe(false); // 대소문자 구분
+        expect(isDashboardTimeframe('1Week')).toBe(false); // 미지원 tf
+        expect(isDashboardTimeframe('5Min')).toBe(false);
+        expect(isDashboardTimeframe('')).toBe(false);
+        expect(isDashboardTimeframe(null)).toBe(false);
+        expect(isDashboardTimeframe(undefined)).toBe(false);
+        expect(isDashboardTimeframe(123)).toBe(false);
     });
 });

--- a/src/widgets/dashboard/SectorFactsSummary.tsx
+++ b/src/widgets/dashboard/SectorFactsSummary.tsx
@@ -60,7 +60,7 @@ export function SectorFactsSummary({ data }: SectorFactsSummaryProps) {
                                                 {i > 0 && ', '}
                                                 <Link
                                                     href={`/${symbol}`}
-                                                    className="hover:text-secondary-300 focus-visible:ring-primary-500 rounded-sm underline-offset-2 hover:underline focus-visible:ring-1 focus-visible:outline-none"
+                                                    className="hover:text-secondary-300 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-950 rounded-sm underline-offset-2 hover:underline focus-visible:ring-1 focus-visible:ring-offset-2 focus-visible:outline-none"
                                                 >
                                                     {symbol}
                                                 </Link>

--- a/src/widgets/dashboard/SectorFactsSummary.tsx
+++ b/src/widgets/dashboard/SectorFactsSummary.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import type { SectorSignalsResult } from '@y0ngha/siglens-core';
 import { buildSectorFacts } from '@/entities/sector-signal';
 
@@ -18,6 +19,11 @@ interface SectorFactsSummaryProps {
  * On a no-signal snapshot (`facts` empty) it renders a minimal sentence instead
  * of `null`, so the prerendered HTML is never text-empty for crawlers (the
  * SSR crawl-text guarantee shouldn't be data-dependent).
+ *
+ * `topSymbols` render as real `<Link href="/{symbol}">` anchors (not plain text)
+ * so this server-rendered hub page passes crawlable internal links into the
+ * per-symbol pages — the interactive `SectorSignalPanel` (CSR) is invisible to
+ * crawlers, so without these this page would ship zero server-side `/{symbol}` links.
  */
 export function SectorFactsSummary({ data }: SectorFactsSummaryProps) {
     const facts = buildSectorFacts(data);
@@ -47,7 +53,19 @@ export function SectorFactsSummary({ data }: SectorFactsSummaryProps) {
                                 {fact.bearishCount}종목
                                 {fact.topSymbols.length > 0 && (
                                     <span className="text-secondary-500 ml-2">
-                                        ({fact.topSymbols.join(', ')})
+                                        (
+                                        {fact.topSymbols.map((symbol, i) => (
+                                            <span key={symbol}>
+                                                {i > 0 && ', '}
+                                                <Link
+                                                    href={`/${symbol}`}
+                                                    className="hover:text-secondary-300 underline-offset-2 hover:underline"
+                                                >
+                                                    {symbol}
+                                                </Link>
+                                            </span>
+                                        ))}
+                                        )
                                     </span>
                                 )}
                             </dd>

--- a/src/widgets/dashboard/SectorFactsSummary.tsx
+++ b/src/widgets/dashboard/SectorFactsSummary.tsx
@@ -53,19 +53,20 @@ export function SectorFactsSummary({ data }: SectorFactsSummaryProps) {
                                 {fact.bearishCount}종목
                                 {fact.topSymbols.length > 0 && (
                                     <span className="text-secondary-500 ml-2">
-                                        (
+                                        {/* parens as JSX expressions → no stray whitespace around them */}
+                                        {'('}
                                         {fact.topSymbols.map((symbol, i) => (
                                             <span key={symbol}>
                                                 {i > 0 && ', '}
                                                 <Link
                                                     href={`/${symbol}`}
-                                                    className="hover:text-secondary-300 underline-offset-2 hover:underline"
+                                                    className="hover:text-secondary-300 focus-visible:ring-primary-500 rounded-sm underline-offset-2 hover:underline focus-visible:ring-1 focus-visible:outline-none"
                                                 >
                                                     {symbol}
                                                 </Link>
                                             </span>
                                         ))}
-                                        )
+                                        {')'}
                                     </span>
                                 )}
                             </dd>

--- a/src/widgets/dashboard/__tests__/SectorFactsSummary.test.tsx
+++ b/src/widgets/dashboard/__tests__/SectorFactsSummary.test.tsx
@@ -102,6 +102,20 @@ describe('SectorFactsSummary', () => {
         expect(screen.getByText(/AAPL/)).toBeInTheDocument();
     });
 
+    it('(Happy) topSymbols가 /{symbol} href를 가진 크롤 가능 링크로 렌더된다', () => {
+        // SEO 회귀 가드: topSymbols가 일반 텍스트로 되돌아가거나 href 포맷이
+        // 바뀌면(이 PR 핵심 = 크롤러용 서버사이드 내부 링크) 이 단언이 깨진다.
+        render(
+            <SectorFactsSummary
+                data={makeResult([makeStock('AAPL', 'XLK', 'bullish')])}
+            />
+        );
+        expect(screen.getByRole('link', { name: 'AAPL' })).toHaveAttribute(
+            'href',
+            '/AAPL'
+        );
+    });
+
     it('(Happy) 여러 섹터가 모두 렌더된다', () => {
         const stocks = [
             makeStock('AAPL', 'XLK', 'bullish'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3467,14 +3467,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@y0ngha/siglens-core@npm:0.19.1":
-  version: 0.19.1
-  resolution: "@y0ngha/siglens-core@npm:0.19.1::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.19.1%2F39a5ceffedc532cbb0a7c49445622c29fb295f0b"
+"@y0ngha/siglens-core@npm:0.20.0":
+  version: 0.20.0
+  resolution: "@y0ngha/siglens-core@npm:0.20.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.20.0%2F90a045b16cd1208026848a95208a6b298508a759"
   dependencies:
     jsonrepair: "npm:^3.14.0"
   peerDependencies:
     "@upstash/redis": ^1.37.0
-  checksum: 10c0/3d994248f2b452fb06e7139c07701ffb095f6f29431f8647760e7164f56db740fd21c1a62b240678b8027faed905b487987c6be9333235dad5158f3118479196
+  checksum: 10c0/b6ed92ed14e46c4967a8dae80e2e4b623a58961eaf3b6fbaeceac8c2c24f413a798739e8de7ac05b57ce01ef51611f4ceb4fcd2b21c122b3a610418fce2a1d61
   languageName: node
   linkType: hard
 
@@ -10378,7 +10378,7 @@ __metadata:
     "@vercel/analytics": "npm:^2.0.1"
     "@vercel/functions": "npm:^3.4.3"
     "@vitest/coverage-v8": "npm:^4.1.7"
-    "@y0ngha/siglens-core": "npm:0.19.1"
+    "@y0ngha/siglens-core": "npm:0.20.0"
     babel-plugin-react-compiler: "npm:^1.0.0"
     bcryptjs: "npm:^3.0.3"
     clsx: "npm:^2.1.1"


### PR DESCRIPTION
## Summary

Two commits addressing QA audit findings and CI build stability:

1. **chore(deps): bump @y0ngha/siglens-core to 0.20.0**
   - Committing the 0.20.0 bump resolves the prior clean-CI/Vercel build failure (peekBriefingCache missing from 0.19.1)
   - Master imports peekBriefingCache, which the published 0.19.1 does not export
   - A clean CI/Vercel `yarn install` + build fails on the committed 0.19.1
   - 0.20.0 (published to GitHub Packages) exports it

2. **fix: QA audit follow-ups — E2E client flag, /market error boundary, SEO internal links, coverage**
   - `.env.e2e`: Add NEXT_PUBLIC_E2E_TEST=1. The #563 client-action split added isE2EClient() to gate useMarketSummary's force-partial refetch, but the flag was never set in the E2E build env → the partial-data-notice E2E was flaky/failing. Setting it makes the notice deterministic.
   - `src/app/market/error.tsx`: Add an error boundary for the /market ISR route so unexpected throws during cold-gen degrade to a branded retryable UI instead of a bare 500 (mirrors [symbol]/error.tsx).
   - `SectorFactsSummary`: Render topSymbols as real <Link href="/{symbol}"> anchors so this server-rendered hub page ships crawlable internal links into the symbol pages.
   - Tests: Direct isDashboardTimeframe unit test; CachedMarketDataProvider key test for from/before/limit all-undefined branch; market.spec SSR crawl-text assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)