### PR TITLE
fix(analysis): /news와 /overall news axis cache 공유

### DIFF
--- a/src/entities/analysis/__tests__/submitOverallAnalysisAction.test.ts
+++ b/src/entities/analysis/__tests__/submitOverallAnalysisAction.test.ts
@@ -82,7 +82,10 @@ import {
     type EarningsCalendarItem,
 } from '@y0ngha/siglens-core';
 import { headers } from 'next/headers';
-import { DrizzleNewsRepository } from '@/entities/news-article';
+import {
+    DrizzleNewsRepository,
+    MAX_AGGREGATE_NEWS_ITEMS,
+} from '@/entities/news-article';
 import { getNextEarningsReport } from '@/entities/earnings-report';
 import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 import { resolveTierAndByok } from '@/shared/lib/byokGate';
@@ -250,14 +253,16 @@ describe('submitOverallAnalysisAction 함수는', () => {
         expect(item.card.titleKo).toBe('애플 실적 예상치 상회');
     });
 
-    it('news input은 buildAnalysisNewsItems pipeline을 거쳐 cap 25개로 제한된다', async () => {
-        // 30개 row를 보내도 buildAnalysisNewsItems가 25개로 cap.
+    it('news input은 buildAnalysisNewsItems pipeline을 거쳐 MAX_AGGREGATE_NEWS_ITEMS로 cap된다', async () => {
         // pipeline 자체 검증은 buildAnalysisNewsItems.test.ts에서 망라.
         // 여기는 통합 — overall action이 그 함수를 통과시키는지만 확인.
-        const rows = Array.from({ length: 30 }, (_, i) => ({
-            ...ANALYZED_ROW,
-            id: `id-${i}`,
-        }));
+        const rows = Array.from(
+            { length: MAX_AGGREGATE_NEWS_ITEMS + 5 },
+            (_, i) => ({
+                ...ANALYZED_ROW,
+                id: `id-${i}`,
+            })
+        );
         mockListBySymbol.mockResolvedValue(rows);
         mockSubmitOverallAnalysis.mockResolvedValueOnce(SUBMITTED_RESULT);
 
@@ -269,7 +274,7 @@ describe('submitOverallAnalysisAction 함수는', () => {
         );
 
         const callArg = mockSubmitOverallAnalysis.mock.calls[0]?.[0];
-        expect(callArg?.newsItems).toHaveLength(25);
+        expect(callArg?.newsItems).toHaveLength(MAX_AGGREGATE_NEWS_ITEMS);
     });
 
     it('다음 실적 발표가 있으면 upcomingCalendar에 포함한다', async () => {

--- a/src/entities/analysis/__tests__/submitOverallAnalysisAction.test.ts
+++ b/src/entities/analysis/__tests__/submitOverallAnalysisAction.test.ts
@@ -250,6 +250,28 @@ describe('submitOverallAnalysisAction 함수는', () => {
         expect(item.card.titleKo).toBe('애플 실적 예상치 상회');
     });
 
+    it('news input은 buildAnalysisNewsItems pipeline을 거쳐 cap 25개로 제한된다', async () => {
+        // 30개 row를 보내도 buildAnalysisNewsItems가 25개로 cap.
+        // pipeline 자체 검증은 buildAnalysisNewsItems.test.ts에서 망라.
+        // 여기는 통합 — overall action이 그 함수를 통과시키는지만 확인.
+        const rows = Array.from({ length: 30 }, (_, i) => ({
+            ...ANALYZED_ROW,
+            id: `id-${i}`,
+        }));
+        mockListBySymbol.mockResolvedValue(rows);
+        mockSubmitOverallAnalysis.mockResolvedValueOnce(SUBMITTED_RESULT);
+
+        await submitOverallAnalysisAction(
+            'AAPL',
+            'Apple Inc.',
+            '1Day',
+            MODEL_ID
+        );
+
+        const callArg = mockSubmitOverallAnalysis.mock.calls[0]?.[0];
+        expect(callArg?.newsItems).toHaveLength(25);
+    });
+
     it('다음 실적 발표가 있으면 upcomingCalendar에 포함한다', async () => {
         mockGetNextEarningsReport.mockResolvedValue(NEXT_EARNINGS);
         mockSubmitOverallAnalysis.mockResolvedValueOnce(SUBMITTED_RESULT);

--- a/src/entities/analysis/actions/submitOverallAnalysisAction.ts
+++ b/src/entities/analysis/actions/submitOverallAnalysisAction.ts
@@ -17,8 +17,7 @@ import { getDatabaseClient } from '@/shared/db/client';
 import {
     DrizzleNewsRepository,
     NEWS_ANALYSIS_LOOKBACK_MS,
-    isEnrichedRow,
-    toEnrichedNewsItem,
+    buildAnalysisNewsItems,
 } from '@/entities/news-article';
 import { getNextEarningsReport } from '@/entities/earnings-report';
 import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
@@ -100,9 +99,12 @@ export async function submitOverallAnalysisAction(
             optionsSnapshotPromise,
         ]);
 
-        const enrichedNews: ReadonlyArray<EnrichedNewsItem> = rows
-            .filter(isEnrichedRow)
-            .map(toEnrichedNewsItem);
+        // Overall news axis는 core 안에서 동일한 `submitNewsAnalysis`를 호출한다
+        // (dependencyResolver → submitNewsAnalysis). `/news` 페이지의 호출과 동일한
+        // news input을 보내야 cache key가 일치해 axis 분석을 그대로 hit한다 —
+        // 두 호출자 모두 `buildAnalysisNewsItems`를 통과해 input pipeline을 통일한다.
+        const enrichedNews: ReadonlyArray<EnrichedNewsItem> =
+            buildAnalysisNewsItems(rows);
 
         // 정규장 시간대에는 OI=0 비율이 높아도 stale로 보지 않는다 — deep OTM strike
         // OI 0이 흔하므로 false positive 위험. 정규장 외에서만 stale 휴리스틱 적용.

--- a/src/entities/news-article/__tests__/lib/buildAnalysisNewsItems.test.ts
+++ b/src/entities/news-article/__tests__/lib/buildAnalysisNewsItems.test.ts
@@ -1,0 +1,149 @@
+/**
+ * buildAnalysisNewsItems — AI 분석 axis가 공통으로 받는 news input pipeline 검증.
+ *
+ * /news (submitNewsAnalysisAction) + /overall (submitOverallAnalysisAction news axis)이
+ * 같은 함수를 호출해 동일 `news IDs hash` cache key를 만들어야 axis 분석이 공유된다.
+ *
+ * - filter: titleKo/bodyKo/priceImpact 등 분석 결과 누락된 row 제거
+ * - map: NewsRow → EnrichedNewsItem 변환
+ * - cap: priceImpact 우선 top 25 (MAX_AGGREGATE_NEWS_ITEMS)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    buildAnalysisNewsItems,
+    MAX_AGGREGATE_NEWS_ITEMS,
+} from '@/entities/news-article';
+import type { NewsRow } from '@/entities/news-article/api';
+import type { NewsImpact } from '@y0ngha/siglens-core';
+
+function makeAnalyzedRow(
+    id: string,
+    priceImpact: NewsImpact = 'medium'
+): NewsRow {
+    return {
+        id,
+        symbol: 'AAPL',
+        source: 'Reuters',
+        url: `https://reuters.com/${id}`,
+        publishedAt: '2025-07-01T10:00:00.000Z',
+        titleEn: 'Apple news',
+        bodyEn: 'body',
+        titleKo: '애플 뉴스',
+        bodyKo: '본문',
+        summaryKo: '요약',
+        sentiment: 'bullish',
+        priceImpact,
+        category: 'earnings',
+        analyzedAt: new Date('2025-07-01T11:00:00.000Z'),
+    } as unknown as NewsRow;
+}
+
+function makeUnanalyzedRow(id: string): NewsRow {
+    return {
+        ...makeAnalyzedRow(id),
+        titleKo: null,
+        bodyKo: null,
+        summaryKo: null,
+        priceImpact: null,
+        sentiment: null,
+        category: null,
+        analyzedAt: null,
+    } as unknown as NewsRow;
+}
+
+describe('buildAnalysisNewsItems', () => {
+    it('Happy: 분석 완료된 row만 변환해 EnrichedNewsItem 배열을 반환한다', () => {
+        const rows = [
+            makeAnalyzedRow('a1'),
+            makeAnalyzedRow('a2'),
+            makeAnalyzedRow('a3'),
+        ];
+        const items = buildAnalysisNewsItems(rows);
+        expect(items).toHaveLength(3);
+        expect(items.map(i => i.id).sort()).toEqual(['a1', 'a2', 'a3']);
+    });
+
+    it('미분석 row(titleKo=null)는 필터링한다', () => {
+        const rows = [
+            makeAnalyzedRow('a1'),
+            makeUnanalyzedRow('u1'),
+            makeAnalyzedRow('a2'),
+            makeUnanalyzedRow('u2'),
+        ];
+        const items = buildAnalysisNewsItems(rows);
+        expect(items).toHaveLength(2);
+        expect(items.map(i => i.id).sort()).toEqual(['a1', 'a2']);
+    });
+
+    it('30개 row → MAX_AGGREGATE_NEWS_ITEMS(25)로 cap', () => {
+        const rows = Array.from({ length: 30 }, (_, i) =>
+            makeAnalyzedRow(`id-${i}`)
+        );
+        const items = buildAnalysisNewsItems(rows);
+        expect(items).toHaveLength(MAX_AGGREGATE_NEWS_ITEMS);
+        expect(items).toHaveLength(25);
+    });
+
+    it('priceImpact 우선: high > medium > low > negligible 순서로 cap', () => {
+        const rows = [
+            ...Array.from({ length: 10 }, (_, i) =>
+                makeAnalyzedRow(`neg-${i}`, 'negligible')
+            ),
+            ...Array.from({ length: 10 }, (_, i) =>
+                makeAnalyzedRow(`low-${i}`, 'low')
+            ),
+            ...Array.from({ length: 5 }, (_, i) =>
+                makeAnalyzedRow(`med-${i}`, 'medium')
+            ),
+            ...Array.from({ length: 5 }, (_, i) =>
+                makeAnalyzedRow(`high-${i}`, 'high')
+            ),
+        ];
+        const items = buildAnalysisNewsItems(rows);
+        expect(items).toHaveLength(25);
+        // 상위 5개: high, 다음 5개: medium, 다음 10개: low, 마지막 5개: negligible(10개 중 5개만 들어감)
+        expect(
+            items.slice(0, 5).every(i => i.card.priceImpact === 'high')
+        ).toBe(true);
+        expect(
+            items.slice(5, 10).every(i => i.card.priceImpact === 'medium')
+        ).toBe(true);
+        expect(
+            items.slice(10, 20).every(i => i.card.priceImpact === 'low')
+        ).toBe(true);
+        expect(
+            items.slice(20, 25).every(i => i.card.priceImpact === 'negligible')
+        ).toBe(true);
+    });
+
+    it('동일 input → 동일 output 순서 (cache 공유 결정성)', () => {
+        // /news + /overall이 동일 rows를 받으면 결과 항목 순서까지 같아야
+        // sorted news IDs hash가 동일 → cache key 동일.
+        const rows = [
+            makeAnalyzedRow('a', 'medium'),
+            makeAnalyzedRow('b', 'high'),
+            makeAnalyzedRow('c', 'low'),
+            makeAnalyzedRow('d', 'high'),
+            makeAnalyzedRow('e', 'medium'),
+        ];
+        const r1 = buildAnalysisNewsItems(rows);
+        const r2 = buildAnalysisNewsItems(rows);
+        expect(r1.map(i => i.id)).toEqual(r2.map(i => i.id));
+        // input이 변이되지 않았는지 (sample IDs 보존)
+        expect(rows.map(r => r.id)).toEqual(['a', 'b', 'c', 'd', 'e']);
+    });
+
+    it('빈 배열 input → 빈 배열 output (throw 없음)', () => {
+        expect(buildAnalysisNewsItems([])).toEqual([]);
+    });
+
+    it('모든 row가 미분석이면 빈 배열 (filter 후 0개)', () => {
+        const rows = [
+            makeUnanalyzedRow('u1'),
+            makeUnanalyzedRow('u2'),
+            makeUnanalyzedRow('u3'),
+        ];
+        expect(buildAnalysisNewsItems(rows)).toEqual([]);
+    });
+});

--- a/src/entities/news-article/__tests__/lib/buildAnalysisNewsItems.test.ts
+++ b/src/entities/news-article/__tests__/lib/buildAnalysisNewsItems.test.ts
@@ -76,13 +76,13 @@ describe('buildAnalysisNewsItems', () => {
         expect(items.map(i => i.id).sort()).toEqual(['a1', 'a2']);
     });
 
-    it('30개 row → MAX_AGGREGATE_NEWS_ITEMS(25)로 cap', () => {
-        const rows = Array.from({ length: 30 }, (_, i) =>
-            makeAnalyzedRow(`id-${i}`)
+    it('MAX_AGGREGATE_NEWS_ITEMS 초과 row는 그 값까지 cap', () => {
+        const rows = Array.from(
+            { length: MAX_AGGREGATE_NEWS_ITEMS + 5 },
+            (_, i) => makeAnalyzedRow(`id-${i}`)
         );
         const items = buildAnalysisNewsItems(rows);
         expect(items).toHaveLength(MAX_AGGREGATE_NEWS_ITEMS);
-        expect(items).toHaveLength(25);
     });
 
     it('priceImpact 우선: high > medium > low > negligible 순서로 cap', () => {
@@ -101,7 +101,7 @@ describe('buildAnalysisNewsItems', () => {
             ),
         ];
         const items = buildAnalysisNewsItems(rows);
-        expect(items).toHaveLength(25);
+        expect(items).toHaveLength(MAX_AGGREGATE_NEWS_ITEMS);
         // 상위 5개: high, 다음 5개: medium, 다음 10개: low, 마지막 5개: negligible(10개 중 5개만 들어감)
         expect(
             items.slice(0, 5).every(i => i.card.priceImpact === 'high')

--- a/src/entities/news-article/actions/submitNewsAnalysisAction.ts
+++ b/src/entities/news-article/actions/submitNewsAnalysisAction.ts
@@ -11,8 +11,7 @@ import {
 import { getDatabaseClient } from '@/shared/db/client';
 import { DrizzleNewsRepository } from '@/entities/news-article';
 import { NEWS_ANALYSIS_LOOKBACK_MS } from '../lib/newsLookback';
-import { isEnrichedRow, toEnrichedNewsItem } from '../lib/newsEnrichment';
-import { selectAggregateNewsItems } from '../lib/newsAnalysisSelection';
+import { buildAnalysisNewsItems } from '../lib/buildAnalysisNewsItems';
 import { getNextEarningsReport } from '@/entities/earnings-report';
 import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 import { resolveTierAndByok, buildGateError } from '@/shared/lib/byokGate';
@@ -62,12 +61,11 @@ export async function submitNewsAnalysisAction(
             getNextEarningsReport(symbol, db),
         ]);
 
-        // The per-card stage and 30-day window above are untouched — this only
-        // bounds what the aggregate prompt sees.
+        // The per-card stage and 30-day window above are untouched — buildAnalysisNewsItems
+        // bounds what the aggregate prompt sees(top 25 by priceImpact). 동일 pipeline을
+        // submitOverallAnalysisAction이 공유해 news axis cache가 같은 키로 hit한다.
         const enrichedNews: ReadonlyArray<EnrichedNewsItem> =
-            selectAggregateNewsItems(
-                rows.filter(isEnrichedRow).map(toEnrichedNewsItem)
-            );
+            buildAnalysisNewsItems(rows);
 
         return await submitNewsAnalysis({
             symbol,

--- a/src/entities/news-article/index.ts
+++ b/src/entities/news-article/index.ts
@@ -11,10 +11,9 @@ export {
     NEWS_LOOKBACK_MS,
     NEWS_ANALYSIS_LOOKBACK_MS,
 } from './lib/newsLookback';
-export {
-    selectAggregateNewsItems,
-    MAX_AGGREGATE_NEWS_ITEMS,
-} from './lib/newsAnalysisSelection';
+// MAX_AGGREGATE_NEWS_ITEMS는 테스트가 expected length 단언에 import해 사용한다.
+// selectAggregateNewsItems는 buildAnalysisNewsItems 안에서 캡슐화되어 외부 노출 불필요.
+export { MAX_AGGREGATE_NEWS_ITEMS } from './lib/newsAnalysisSelection';
 export { buildAnalysisNewsItems } from './lib/buildAnalysisNewsItems';
 
 // actions are imported from @/entities/news-article/actions

--- a/src/entities/news-article/index.ts
+++ b/src/entities/news-article/index.ts
@@ -11,5 +11,10 @@ export {
     NEWS_LOOKBACK_MS,
     NEWS_ANALYSIS_LOOKBACK_MS,
 } from './lib/newsLookback';
+export {
+    selectAggregateNewsItems,
+    MAX_AGGREGATE_NEWS_ITEMS,
+} from './lib/newsAnalysisSelection';
+export { buildAnalysisNewsItems } from './lib/buildAnalysisNewsItems';
 
 // actions are imported from @/entities/news-article/actions

--- a/src/entities/news-article/lib/buildAnalysisNewsItems.ts
+++ b/src/entities/news-article/lib/buildAnalysisNewsItems.ts
@@ -1,0 +1,32 @@
+import type { EnrichedNewsItem } from '@y0ngha/siglens-core';
+import type { NewsRow } from '../api';
+import { isEnrichedRow, toEnrichedNewsItem } from './newsEnrichment';
+import { selectAggregateNewsItems } from './newsAnalysisSelection';
+
+/**
+ * AI 분석 axis가 input으로 받을 표준 news items를 만든다.
+ *
+ * 1. 미분석/번역 누락 row 필터 (`isEnrichedRow`)
+ * 2. shape 변환 (`toEnrichedNewsItem`)
+ * 3. priceImpact 우선 top-N cap (`selectAggregateNewsItems`)
+ *
+ * **왜 단일 함수로 묶나** — `submitNewsAnalysisAction`(`/news` 페이지)과
+ * `submitOverallAnalysisAction`(`/overall` 페이지 news axis)이 core 안에서 동일한
+ * `submitNewsAnalysis` 함수를 호출한다(`dependencyResolver` → `submitNewsAnalysis`).
+ * 두 호출자가 같은 news input을 보내야 `symbol+modelId+hash(sorted news IDs)` 캐시
+ * 키가 일치해 `/news`에서 한 분석이 `/overall` news axis로 그대로 hit한다. 호출자별로
+ * 변환 파이프라인을 직접 짜면 한쪽이 step을 빼먹는 순간 cache miss로 종합 분석이
+ * ~1분 대기 상태에 빠진다.
+ *
+ * 미래에 news를 input으로 받는 axis가 추가되면(예: 뉴스+옵션 결합 axis) 이 함수를
+ * 재사용해 cache 공유를 자동으로 보장한다.
+ *
+ * 순수 함수 — 입력 배열을 변이하지 않는다(`selectAggregateNewsItems`가 `toSorted`).
+ */
+export function buildAnalysisNewsItems(
+    rows: ReadonlyArray<NewsRow>
+): EnrichedNewsItem[] {
+    return selectAggregateNewsItems(
+        rows.filter(isEnrichedRow).map(toEnrichedNewsItem)
+    );
+}


### PR DESCRIPTION
## Summary

- `/AAPL/overall`의 "AI 종합 분석"이 첫 클릭에서 1분+ 대기. `/AAPL/news`에서 이미 같은 모델로 뉴스 분석 cache hit인데도 overall news axis가 miss로 재분석 enqueue.
- 원인: core(`dependencyResolver`)는 동일 `submitNewsAnalysis`를 호출하지만, siglens 호출자가 보내는 news input이 달라 `sorted news IDs hash` 캐시 키 불일치.
- `submitNewsAnalysisAction`: `selectAggregateNewsItems(top 25 by priceImpact)`
- `submitOverallAnalysisAction`: 30일 전체 rows (필터·cap 없음)
- 해결: 새 공통 함수 `buildAnalysisNewsItems(rows)`로 input pipeline 통일. 두 action이 같은 함수 호출 → 동일 input → 동일 cache key → axis hit. 미래 axis 추가 시 동일 함수 재사용해 cache 공유 자동 보장 (DRY).

## Test plan

- [x] `buildAnalysisNewsItems.test.ts` 7 케이스 (Happy + 미분석 필터 + cap 25 + priceImpact 정렬 + 결정성 + 빈 배열 + 전부 미분석)
- [x] `submitOverallAnalysisAction.test.ts` 통합 케이스 1개 (pipeline 통과 검증)
- [x] 32 파일 265 테스트 모두 통과
- [ ] 배포 후 /AAPL/overall 첫 클릭 시간이 즉시 응답으로 단축되는지 (news axis 이미 cached일 때) 실측

🤖 Generated with [Claude Code](https://claude.com/claude-code)