### PR TITLE
feat(chart): render group-C-simple (6 unbounded single-line panes)

### DIFF
--- a/docs/superpowers/plans/2026-06-07-render-group-c-simple.md
+++ b/docs/superpowers/plans/2026-06-07-render-group-c-simple.md
@@ -1,0 +1,525 @@
+# 그룹 C-단순 (unbounded 단일-라인 pane 6종) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** unbounded 단일-라인 보조지표 6종(atr·obv·macdV·forceIndex·yangZhang·ewmaVolatility)을 차트 pane으로 렌더한다. macdV·forceIndex는 0 기준선, 나머지 4종은 기준선 없음.
+
+**Architecture:** group-B(PR #577)의 pane 훅 패턴·레지스트리·paneIndex 일반화 인프라를 그대로 재사용한다. 6개 신규 pane 훅은 `useRSIChart`/group-B 훅을 복제하고, 레지스트리에 6 메타를 추가하면 `useIndicatorVisibility`(레지스트리 기반)·`IndicatorSettingsModal`이 자동으로 새 pane을 배정·노출한다. 기존 13개 pane 훅·visibility·모달은 무변경.
+
+**Tech Stack:** Next.js 16 / React 19 (`'use client'`), lightweight-charts 5.1.0, `@y0ngha/siglens-core`(IndicatorResult), vitest + RTL, Playwright.
+
+**작업 위치:** 워크트리 `/Users/y0ngha/Project/siglens-group-c`, 브랜치 `feat/render-group-c-simple` (base `feat/render-unused-indicators`=#577). 스펙: `docs/superpowers/specs/2026-06-07-render-group-c-simple-design.md`.
+
+**커밋 규칙:** 커밋은 `git-agent`에 위임(CLAUDE.md). 각 Task 끝 commit은 git-agent로. `--no-verify` 금지.
+
+---
+
+## File Structure
+
+**신규**
+- `src/widgets/chart/hooks/useMacdVChart.ts` 외 5개(`useForceIndexChart`·`useObvChart`·`useAtrChart`·`useYangZhangChart`·`useEwmaVolatilityChart`) + 각 colocated 테스트
+
+**수정**
+- `src/widgets/chart/model/indicatorRegistry.ts` — `IndicatorKey` +6, `INDICATOR_REGISTRY` +6 (카테고리 union 무변경)
+- `src/widgets/chart/constants/indicatorLevels.ts` — `MACD_V_ZERO_LEVEL`·`FORCE_INDEX_ZERO_LEVEL`
+- `src/shared/lib/chartColors.ts` — 6 라인색 + zero선 색
+- `src/widgets/chart/utils/paneLabelUtils.ts` — 6 pane label
+- `src/widgets/chart/StockChart.tsx` — 6 훅 호출 + binding 18→24
+- `src/widgets/chart/__tests__/StockChart.test.tsx` — data-count 18→24, data-keys +6
+- 각 테스트 파일(레지스트리·상수·paneLabel)
+- `e2e/specs/chart-indicators.spec.ts`
+
+**불변 (회귀 위험 0)**
+- 기존 13개 pane 훅(useRSIChart~useCCIChart, group-B 7종), `useIndicatorVisibility`, `IndicatorSettingsModal`, `buildSinglePaneLabel`, `buildSeriesDataFromValues`
+
+---
+
+## Task 0: 워크트리 node_modules 준비
+
+- [ ] **Step 1: 하드링크 복제**
+
+Run:
+```bash
+cp -al /Users/y0ngha/Project/siglens/node_modules /Users/y0ngha/Project/siglens-group-c/node_modules
+rm -rf /Users/y0ngha/Project/siglens-group-c/node_modules/node_modules
+```
+Expected: 에러 없음.
+
+- [ ] **Step 2: 러너 확인**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-c && yarn test src/widgets/chart/__tests__/model/indicatorRegistry.test.ts 2>&1 | tail -6`
+Expected: 기존 레지스트리 테스트 PASS (현재 18 지표).
+
+---
+
+## Task 1: 레지스트리 6 메타 추가
+
+**Files:**
+- Modify: `src/widgets/chart/model/indicatorRegistry.ts`
+- Modify: `src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`
+
+- [ ] **Step 1: 테스트 갱신 (실패 유도)**
+
+`indicatorRegistry.test.ts`에서 등록 수를 24로, 그룹 C 카테고리 검증 추가:
+```ts
+it('registers exactly the 24 modal-target indicators', () => {
+    expect(INDICATOR_REGISTRY).toHaveLength(24);
+});
+
+it('places group-C-simple indicators in the right categories', () => {
+    const byKey = Object.fromEntries(
+        INDICATOR_REGISTRY.map(m => [m.key, m.category])
+    );
+    expect(byKey.macdV).toBe('momentum');
+    expect(byKey.forceIndex).toBe('momentum');
+    expect(byKey.obv).toBe('volume');
+    expect(byKey.atr).toBe('volatility');
+    expect(byKey.yangZhang).toBe('volatility');
+    expect(byKey.ewmaVolatility).toBe('volatility');
+});
+
+it('all group-C-simple indicators are pane kind', () => {
+    const groupC = ['macdV', 'forceIndex', 'obv', 'atr', 'yangZhang', 'ewmaVolatility'];
+    expect(
+        groupC.every(key => INDICATOR_META[key as IndicatorKey].kind === 'pane')
+    ).toBe(true);
+});
+```
+> 기존 "registers exactly the N" 테스트가 18이면 24로 변경. `type IndicatorKey`는 이미 import됨.
+
+- [ ] **Step 2: Run → 실패**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-c && yarn test src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`
+Expected: FAIL (length 18≠24).
+
+- [ ] **Step 3: 레지스트리 구현**
+
+`indicatorRegistry.ts`:
+1. `IndicatorKey` union에 6키 추가:
+```ts
+    | 'macdV' | 'forceIndex' | 'obv' | 'atr' | 'yangZhang' | 'ewmaVolatility';
+```
+(기존 union 끝에 이어서. 멤버만 정확하면 됨.)
+2. `INDICATOR_REGISTRY` 끝에 6 메타 추가:
+```ts
+    { key: 'macdV', label: 'MACD-V', category: 'momentum', kind: 'pane' },
+    { key: 'forceIndex', label: 'Force Index', category: 'momentum', kind: 'pane' },
+    { key: 'obv', label: 'OBV', category: 'volume', kind: 'pane' },
+    { key: 'atr', label: 'ATR', category: 'volatility', kind: 'pane' },
+    { key: 'yangZhang', label: 'Yang-Zhang', category: 'volatility', kind: 'pane' },
+    { key: 'ewmaVolatility', label: 'EWMA Vol', category: 'volatility', kind: 'pane' },
+```
+(`IndicatorCategory`·`CATEGORY_LABELS` 무변경 — 전부 기존 카테고리.)
+
+- [ ] **Step 4: Run → 통과**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-c && yarn test src/widgets/chart/__tests__/model/indicatorRegistry.test.ts && npx tsc --noEmit 2>&1 | tail -2`
+Expected: PASS, tsc 0 errors.
+
+- [ ] **Step 5: Commit (git-agent)** — `feat(chart): register group-C-simple indicators`
+
+---
+
+## Task 2: 0선 상수 + 색상
+
+**Files:**
+- Modify: `src/widgets/chart/constants/indicatorLevels.ts`
+- Modify: `src/widgets/chart/__tests__/constants/indicatorLevels.test.ts`
+- Modify: `src/shared/lib/chartColors.ts`
+
+- [ ] **Step 1: 상수 테스트 추가 (실패 유도)**
+
+`indicatorLevels.test.ts`에 추가:
+```ts
+it('group-C zero levels', () => {
+    expect(MACD_V_ZERO_LEVEL).toBe(0);
+    expect(FORCE_INDEX_ZERO_LEVEL).toBe(0);
+});
+```
+그리고 import 라인에 `MACD_V_ZERO_LEVEL, FORCE_INDEX_ZERO_LEVEL` 추가.
+
+- [ ] **Step 2: Run → 실패**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-c && yarn test src/widgets/chart/__tests__/constants/indicatorLevels.test.ts`
+Expected: FAIL (상수 없음).
+
+- [ ] **Step 3: 상수 구현**
+
+`indicatorLevels.ts` 끝에 추가:
+```ts
+// MACD-V: 0선 교차가 강세/약세 기준 (volatility-normalized MACD, 부호 있음).
+export const MACD_V_ZERO_LEVEL = 0;
+
+// Force Index: 0선 교차가 매수/매도 압력 전환 기준.
+export const FORCE_INDEX_ZERO_LEVEL = 0;
+```
+
+- [ ] **Step 4: 색상 추가 + 중복 검증**
+
+`src/shared/lib/chartColors.ts`의 `CHART_COLORS`에 추가 (group-C 그룹 주석 없이 — #577 리뷰에서 섹션 레이블 주석이 지적됐으므로 단순 키만 추가):
+```ts
+    macdVLine: '#2dd4bf',
+    macdVZero: '#94a3b860',
+    forceIndexLine: '#fb7185',
+    forceIndexZero: '#94a3b860',
+    obvLine: '#7dd3fc',
+    atrLine: '#fdba74',
+    yangZhangLine: '#d8b4fe',
+    ewmaVolatilityLine: '#6ee7b7',
+```
+> 6 라인색(#2dd4bf·#fb7185·#7dd3fc·#fdba74·#d8b4fe·#6ee7b7)은 기존 팔레트 미사용으로 확인됨. zero선은 회색 #94a3b860 공유(reference선이라 라인색 중복 규칙 무관).
+
+- [ ] **Step 5: 라인색 중복 없음 검증**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-group-c && grep -oE "Line: '#[0-9a-f]{6}'" src/shared/lib/chartColors.ts | sort | uniq -d
+```
+Expected: 출력 없음(라인색 전부 유니크). 중복이 나오면 해당 group-C 색을 다른 미사용 hex로 교체.
+
+- [ ] **Step 6: Run → 통과**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-c && yarn test src/widgets/chart/__tests__/constants/indicatorLevels.test.ts && npx tsc --noEmit 2>&1 | tail -2`
+Expected: PASS, tsc 0.
+
+- [ ] **Step 7: Commit (git-agent)** — `feat(chart): add group-C-simple levels and colors`
+
+---
+
+## Task 3: 6 pane 훅 (RSI/group-B 복제)
+
+**Files:**
+- Create: `src/widgets/chart/hooks/useMacdVChart.ts` 외 5개
+- Test: 각 `src/widgets/chart/__tests__/hooks/use<Name>Chart.test.ts`
+
+대표로 `useMacdVChart`(0선 1개) 전체를 제시. 나머지 5개는 치환 명세.
+
+- [ ] **Step 1: useMacdVChart 테스트 작성 (실패 유도)**
+
+먼저 group-B의 `useMfiChart.test.ts`를 읽어 mock 구조를 그대로 따른다. Create `src/widgets/chart/__tests__/hooks/useMacdVChart.test.ts`를 그 패턴으로 작성: indicators fixture `{ ...EMPTY, macdV: [-1, 0.5, 2] }`, 검증 — isVisible true→addSeries 호출, false→removeSeries, paneIndex 변경→재생성, 데이터 sync(setData가 macdV로 호출), **worst-case**(`macdV: []`→setData 미호출). useMfiChart.test.ts의 케이스를 1:1 대응해 키만 macdV로 치환.
+
+- [ ] **Step 2: Run → 실패**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-c && yarn test src/widgets/chart/__tests__/hooks/useMacdVChart.test.ts`
+Expected: FAIL (모듈 없음).
+
+- [ ] **Step 3: useMacdVChart 구현**
+
+Create `src/widgets/chart/hooks/useMacdVChart.ts`:
+```ts
+'use client';
+
+import type { RefObject } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import { LineSeries, LineStyle } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { MACD_V_ZERO_LEVEL } from '../constants/indicatorLevels';
+import { buildSeriesDataFromValues } from '../utils/seriesDataUtils';
+
+interface UseMacdVChartParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+    isVisible: boolean;
+    paneIndex: number;
+}
+
+export function useMacdVChart({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+    isVisible,
+    paneIndex,
+}: UseMacdVChartParams): void {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const prevPaneIndexRef = useRef<number>(paneIndex);
+    const seriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+    // 이전 chart는 부모가 소멸시키므로 removeSeries 없이 ref만 초기화하면 충분.
+    const clearSeriesRefs = useEffectEvent(() => {
+        seriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (seriesRef.current) {
+            chart.removeSeries(seriesRef.current);
+            seriesRef.current = null;
+        }
+    });
+
+    // 데이터 세팅은 아래 effect에서 단독 처리하므로 이 effect는 lifecycle(생성·제거)만 담당.
+    useEffect(() => {
+        const chart = chartRef.current;
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+        if (!chart) return;
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+        if (prevPaneIndexRef.current !== paneIndex && seriesRef.current) {
+            removeAllSeries(chart);
+        }
+        prevPaneIndexRef.current = paneIndex;
+
+        if (!seriesRef.current) {
+            seriesRef.current = chart.addSeries(
+                LineSeries,
+                {
+                    color: CHART_COLORS.macdVLine,
+                    lineWidth,
+                    priceLineVisible: false,
+                    lastValueVisible: false,
+                },
+                paneIndex
+            );
+            seriesRef.current.createPriceLine({
+                price: MACD_V_ZERO_LEVEL,
+                color: CHART_COLORS.macdVZero,
+                lineWidth,
+                lineStyle: LineStyle.Dashed,
+                axisLabelVisible: false,
+                title: '',
+            });
+        }
+        seriesRef.current.applyOptions({ lineWidth });
+    }, [chartRef, isVisible, lineWidth, paneIndex]);
+
+    useEffect(() => {
+        if (!isVisible) return;
+        const { macdV } = indicators;
+        if (!macdV.length) return;
+        if (!seriesRef.current) return;
+        seriesRef.current.setData(buildSeriesDataFromValues(bars, macdV));
+    }, [indicators, bars, isVisible, paneIndex]);
+}
+```
+
+- [ ] **Step 4: Run → 통과**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-c && yarn test src/widgets/chart/__tests__/hooks/useMacdVChart.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: 나머지 5개 훅 + 테스트 (useMacdVChart 복제 + 치환)**
+
+각 훅은 useMacdVChart.ts를 복사해 치환. 각 훅마다 대응 테스트(useMacdVChart.test 복제, 키·fixture 치환)도 작성. 데이터 accessor는 모두 `const { <key> } = indicators;` + `buildSeriesDataFromValues(bars, <key>)`.
+
+| 파일 | 함수 | key (accessor) | 라인색 | 기준선 (createPriceLine) |
+|---|---|---|---|---|
+| `useForceIndexChart.ts` | `useForceIndexChart` | `forceIndex` | `forceIndexLine` | 1개: `FORCE_INDEX_ZERO_LEVEL`(색 `forceIndexZero`), import from `../constants/indicatorLevels` |
+| `useObvChart.ts` | `useObvChart` | `obv` | `obvLine` | **없음** (createPriceLine 블록 전체 제거) |
+| `useAtrChart.ts` | `useAtrChart` | `atr` | `atrLine` | **없음** |
+| `useYangZhangChart.ts` | `useYangZhangChart` | `yangZhang` | `yangZhangLine` | **없음** |
+| `useEwmaVolatilityChart.ts` | `useEwmaVolatilityChart` | `ewmaVolatility` | `ewmaVolatilityLine` | **없음** |
+
+**기준선 없는 4종**(obv/atr/yangZhang/ewmaVolatility): `if (!seriesRef.current) { ... addSeries ... }` 안의 `createPriceLine(...)` 호출을 통째로 제거하고 `addSeries` + `applyOptions`만 남긴다. import에서 `LineStyle`·indicatorLevels 상수 불필요 → 제거(LineStyle은 createPriceLine에서만 쓰임).
+
+`useForceIndexChart`만 useMacdVChart와 동일하게 0선 1개(`FORCE_INDEX_ZERO_LEVEL`/`forceIndexZero`, `LineStyle.Dashed` 유지).
+
+> 테스트도 기준선 없는 4종은 "createPriceLine 호출 안 함"을 검증할 필요는 없다(addSeries만 확인). macdV/forceIndex 테스트는 group-B의 priceLine 검증 방식이 있으면 따르고, 없으면 addSeries 호출 검증으로 충분.
+
+- [ ] **Step 6: Run → 6개 훅 테스트 전부 통과**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-c && yarn test src/widgets/chart/__tests__/hooks/ 2>&1 | tail -8`
+Expected: 6 신규 + 기존 훅 테스트 PASS.
+
+- [ ] **Step 7: Commit (git-agent)** — `feat(chart): add 6 group-C-simple pane hooks`
+
+---
+
+## Task 4: paneLabel 6종
+
+**Files:**
+- Modify: `src/widgets/chart/utils/paneLabelUtils.ts`
+- Modify: `src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts`
+
+- [ ] **Step 1: 테스트 추가 (실패 유도)**
+
+`paneLabelUtils.test.ts`에 group-C label 검증 추가(기존 `makePaneIndices` 헬퍼 + `buildSinglePaneLabel` 검증 패턴 따름):
+```ts
+it('builds single-subLabel labels for each group-C-simple pane', () => {
+    const cases: Array<[keyof PaneIndices, string, string]> = [
+        ['macdV', 'MACD-V', CHART_COLORS.macdVLine],
+        ['forceIndex', 'Force Index', CHART_COLORS.forceIndexLine],
+        ['obv', 'OBV', CHART_COLORS.obvLine],
+        ['atr', 'ATR', CHART_COLORS.atrLine],
+        ['yangZhang', 'Yang-Zhang', CHART_COLORS.yangZhangLine],
+        ['ewmaVolatility', 'EWMA Vol', CHART_COLORS.ewmaVolatilityLine],
+    ];
+    for (const [key, name, color] of cases) {
+        const labels = buildPaneLabels(makePaneIndices({ [key]: 1 }));
+        expect(labels).toHaveLength(1);
+        expect(labels[0].subLabels).toEqual([{ name, color }]);
+    }
+});
+```
+> 파일의 실제 `makePaneIndices` 시그니처·label/color 단언 형태에 맞춘다(group-B 테스트와 동일 방식). `CHART_COLORS` import가 없으면 추가.
+
+- [ ] **Step 2: Run → 실패**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-c && yarn test src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts`
+Expected: FAIL (group-C label 없음).
+
+- [ ] **Step 3: buildPaneLabels에 6 label 추가**
+
+`paneLabelUtils.ts`의 `buildPaneLabels`에서 기존 `buildSinglePaneLabel` 호출 패턴을 따라 6종 추가:
+```ts
+const macdVLabel = buildSinglePaneLabel(paneIndices.macdV, 'MACD-V', CHART_COLORS.macdVLine);
+const forceIndexLabel = buildSinglePaneLabel(paneIndices.forceIndex, 'Force Index', CHART_COLORS.forceIndexLine);
+const obvLabel = buildSinglePaneLabel(paneIndices.obv, 'OBV', CHART_COLORS.obvLine);
+const atrLabel = buildSinglePaneLabel(paneIndices.atr, 'ATR', CHART_COLORS.atrLine);
+const yangZhangLabel = buildSinglePaneLabel(paneIndices.yangZhang, 'Yang-Zhang', CHART_COLORS.yangZhangLine);
+const ewmaVolatilityLabel = buildSinglePaneLabel(paneIndices.ewmaVolatility, 'EWMA Vol', CHART_COLORS.ewmaVolatilityLine);
+```
+그리고 return 배열 spread에 6개 추가(기존 마지막 뒤):
+```ts
+    ...macdVLabel, ...forceIndexLabel, ...obvLabel, ...atrLabel, ...yangZhangLabel, ...ewmaVolatilityLabel,
+```
+
+- [ ] **Step 4: Run → 통과**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-c && yarn test src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit (git-agent)** — `feat(chart): add pane labels for group-C-simple`
+
+---
+
+## Task 5: StockChart 6 훅 호출 + binding 18→24
+
+**Files:**
+- Modify: `src/widgets/chart/StockChart.tsx`
+- Modify: `src/widgets/chart/__tests__/StockChart.test.tsx`
+
+- [ ] **Step 1: StockChart.test data-count·keys 갱신 (실패 유도)**
+
+`StockChart.test.tsx`의 `data-count` 단언을 24로:
+```ts
+expect(modal).toHaveAttribute('data-count', '24');
+```
+`data-keys` 순서 단언이 있으면 기존 18키 뒤에 `,macdV,forceIndex,obv,atr,yangZhang,ewmaVolatility` 추가. mock의 visible/paneIndices 객체에 신규 6키가 빠져있으면 추가(이미 18키 mock이면 6키 추가, 값 false/-1).
+
+- [ ] **Step 2: Run → 실패**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-c && yarn test src/widgets/chart/__tests__/StockChart.test.tsx`
+Expected: FAIL (data-count 18≠24).
+
+- [ ] **Step 3: StockChart import + 6 훅 호출**
+
+import 추가:
+```ts
+import { useMacdVChart } from './hooks/useMacdVChart';
+import { useForceIndexChart } from './hooks/useForceIndexChart';
+import { useObvChart } from './hooks/useObvChart';
+import { useAtrChart } from './hooks/useAtrChart';
+import { useYangZhangChart } from './hooks/useYangZhangChart';
+import { useEwmaVolatilityChart } from './hooks/useEwmaVolatilityChart';
+```
+기존 pane 훅 호출 뒤에 6개 추가:
+```ts
+useMacdVChart({ ...commonHookParams, isVisible: visible.macdV, paneIndex: paneIndices.macdV });
+useForceIndexChart({ ...commonHookParams, isVisible: visible.forceIndex, paneIndex: paneIndices.forceIndex });
+useObvChart({ ...commonHookParams, isVisible: visible.obv, paneIndex: paneIndices.obv });
+useAtrChart({ ...commonHookParams, isVisible: visible.atr, paneIndex: paneIndices.atr });
+useYangZhangChart({ ...commonHookParams, isVisible: visible.yangZhang, paneIndex: paneIndices.yangZhang });
+useEwmaVolatilityChart({ ...commonHookParams, isVisible: visible.ewmaVolatility, paneIndex: paneIndices.ewmaVolatility });
+```
+(기존 6개 호출과 동일 shape.)
+
+- [ ] **Step 4: indicatorBindings에 6 binding 추가**
+
+`indicatorBindings` 배열 끝에 추가:
+```ts
+{ meta: INDICATOR_META.macdV, active: visible.macdV, onToggle: () => toggle('macdV') },
+{ meta: INDICATOR_META.forceIndex, active: visible.forceIndex, onToggle: () => toggle('forceIndex') },
+{ meta: INDICATOR_META.obv, active: visible.obv, onToggle: () => toggle('obv') },
+{ meta: INDICATOR_META.atr, active: visible.atr, onToggle: () => toggle('atr') },
+{ meta: INDICATOR_META.yangZhang, active: visible.yangZhang, onToggle: () => toggle('yangZhang') },
+{ meta: INDICATOR_META.ewmaVolatility, active: visible.ewmaVolatility, onToggle: () => toggle('ewmaVolatility') },
+```
+useMemo deps는 `visible`·`toggle`가 이미 포함되어 있으므로 무변경(확인).
+
+- [ ] **Step 5: Run → 통과 + tsc + 전체 차트**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-c && yarn test src/widgets/chart/__tests__/StockChart.test.tsx && npx tsc --noEmit 2>&1 | tail -2 && yarn test src/widgets/chart 2>&1 | tail -5`
+Expected: data-count=24 PASS, tsc 0, 전체 차트 PASS.
+
+- [ ] **Step 6: Commit (git-agent)** — `feat(chart): wire group-C-simple hooks and bindings into StockChart`
+
+---
+
+## Task 6: E2E
+
+**Files:**
+- Modify: `e2e/specs/chart-indicators.spec.ts`
+
+- [ ] **Step 1: E2E 시나리오 추가**
+
+기존 describe 블록에 추가(셀렉터는 #577 패턴 — `.pane-indicator-label` 스코프, exact 체크박스):
+```ts
+test('toggles ATR into a pane via the modal', async ({ page }) => {
+    await page.goto('/AAPL');
+    await page.getByRole('button', { name: '보조지표 설정' }).click();
+    const dialog = page.getByRole('dialog');
+    await dialog.getByRole('checkbox', { name: 'ATR', exact: true }).check();
+    await page.getByRole('button', { name: '닫기' }).click();
+    await expect(
+        page.locator('.pane-indicator-label').filter({ hasText: 'ATR' })
+    ).toBeVisible();
+});
+```
+> `GEAR` 상수가 파일에 있으면 사용. ATR은 volatility 카테고리 체크박스.
+
+- [ ] **Step 2: --list 로드 확인**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-c && npx playwright test e2e/specs/chart-indicators.spec.ts --list 2>&1 | tail -10`
+Expected: 신규 테스트 포함 로드, 에러 없음.
+
+- [ ] **Step 3: Commit (git-agent)** — `test(e2e): cover ATR pane toggle`
+
+> 풀 E2E는 pre-push/CI 담당.
+
+---
+
+## Task 7: 최종 검증
+
+- [ ] **Step 1: Lint** — `cd /Users/y0ngha/Project/siglens-group-c && yarn lint 2>&1 | tail -5` (에러 0)
+
+- [ ] **Step 2: 변경 영역 커버리지 90%+**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-group-c && npx vitest run --coverage \
+  --coverage.include='src/widgets/chart/hooks/useMacdVChart.ts' \
+  --coverage.include='src/widgets/chart/hooks/useForceIndexChart.ts' \
+  --coverage.include='src/widgets/chart/hooks/useObvChart.ts' \
+  --coverage.include='src/widgets/chart/hooks/useAtrChart.ts' \
+  --coverage.include='src/widgets/chart/hooks/useYangZhangChart.ts' \
+  --coverage.include='src/widgets/chart/hooks/useEwmaVolatilityChart.ts' \
+  --coverage.thresholds.lines=0 --coverage.thresholds.functions=0 --coverage.thresholds.branches=0 --coverage.thresholds.statements=0 \
+  src/widgets/chart/__tests__ 2>&1 | grep -E "All files|Stmts|----" | head
+```
+Expected: 신규 6 훅 90%+ (미달 시 worst-case 보강).
+
+- [ ] **Step 3: 전체 유닛 테스트** — `cd /Users/y0ngha/Project/siglens-group-c && yarn test 2>&1 | tail -12` (전부 PASS, 회귀 없음)
+
+- [ ] **Step 4: 빌드 (exit code 직접 캡처)** — `cd /Users/y0ngha/Project/siglens-group-c && yarn build > /tmp/groupc-build.log 2>&1; echo "EXIT=$?"` (EXIT=0)
+
+- [ ] **Step 5: review-agent 라우팅** — 메인 오케스트레이터가 `review-agent`(Opus 4.8) 호출 → findings 반영 → mistake-managing-agent → git-agent(push/PR). CLAUDE.md 워크플로우.
+
+---
+
+## Self-Review (작성자 점검 결과)
+
+- **스펙 커버리지**: §4(데이터/카테고리/기준선)=Task 1+2+3, §5.1(6훅)=Task 3, §5.2(레지스트리)=Task 1, §5.3(상수/색)=Task 2, §5.4(label/StockChart)=Task 4+5, §7(테스트)=각 Task+Task 7. 전부 매핑.
+- **Placeholder**: 없음. 대표 훅(useMacdVChart) 풀코드 + 나머지 5개 구체 치환표(key/색/기준선 전부 명시). 색은 미사용 검증된 hex + Task 2 Step 5에 중복 검증 단계.
+- **타입 일관성**: `IndicatorKey` 24키·`INDICATOR_META.<key>`·`visible.<key>`·`paneIndices.<key>`·`CHART_COLORS.<key>Line` 명칭이 Task 1·2 정의와 Task 3·4·5 사용처 일치.
+- **순서 의존**: Task 1(레지스트리)→2(상수/색)→3(훅, 1·2 의존)→4(label, 2 의존)→5(StockChart, 3 의존)→6(E2E). paneIndex 일반화·모달은 #577 완료라 무변경.
+- **회귀**: 기존 13 pane 훅·visibility·모달 불변. StockChart binding 추가로 인한 기존 테스트 mock(data-count 18→24) 갱신만.

--- a/docs/superpowers/specs/2026-06-07-render-group-c-simple-design.md
+++ b/docs/superpowers/specs/2026-06-07-render-group-c-simple-design.md
@@ -1,0 +1,105 @@
+# 미사용 보조지표 렌더링 — 2차: 그룹 C-단순 (unbounded 단일-라인 pane 6종)
+
+- **작성일**: 2026-06-07
+- **상태**: 설계 승인됨, 구현 계획 대기
+- **브랜치**: `feat/render-group-c-simple` (base: `feat/render-unused-indicators` = PR #577, group-B 완료)
+
+## 1. 배경
+
+`IndicatorResult`의 미사용 지표 렌더링 2차. 1차(group-B, PR #577)에서 bounded 오실레이터 7종을 pane으로 렌더하고 `useIndicatorVisibility`를 레지스트리 기반 N-pane으로 일반화했다. 본 작업은 **unbounded 단일-라인 pane 6종**(그룹 C 중 단순 부류)을 추가한다.
+
+계산은 이미 `@y0ngha/siglens-core`에 있으므로 추가 작업은 siglens 차트 렌더링뿐. paneIndex 일반화·레지스트리·모달·binding 인프라는 #577에서 완성됐다.
+
+## 2. 목표 / 비목표
+
+### 목표
+- unbounded 단일-라인 pane 6종(`atr`·`obv`·`macdV`·`forceIndex`·`yangZhang`·`ewmaVolatility`)을 group-B와 동일한 pane 훅 패턴으로 렌더.
+- 레지스트리·모달·paneIndex 일반화 인프라 재사용(무변경) — 레지스트리 메타 추가만으로 모달 자동 노출.
+
+### 비목표 (별도 스펙)
+- **C-복합 3종**: `elderRay`(히스토그램 2개), `squeezeMomentum`(히스토그램+상태 마커), `regression`(slope/r2 2값) — 새 렌더 메커니즘 필요.
+- 그룹 A(가격 오버레이 5종), 그룹 D(특수: elderImpulse·smc).
+- 전송 페이로드 슬림화(메모리 `project_indicator_payload_waste`).
+
+## 3. 핵심 결정사항
+
+| 항목 | 결정 | 근거 |
+|---|---|---|
+| 1차 범위 | C-단순 6종만 | RSI/group-B 복제로 가장 빠름·검증된 패턴 (사용자 선택) |
+| 훅 구조 | RSI/group-B 훅 복제 (개별 파일 6개) | 기존 pane 훅 패턴과 완전 일관 |
+| 기준선 | macdV·forceIndex만 0선, 4종 무기준선 | atr/obv/yangZhang/ewma는 양수 변동성·누적이라 over/under 개념 없음 |
+| 카테고리 | 기존 카테고리 재사용(신규 없음) | momentum/volume/volatility로 충분 |
+| paneIndex·모달 | #577 인프라 무변경 | 레지스트리 추가만으로 자동 배정·노출 |
+
+## 4. 데이터 형태 / 카테고리 / 기준선
+
+6종 모두 `IndicatorResult`에서 `(number | null)[]` (bar당 1값, warm-up은 null).
+
+| key | label | category | 기준선 | 상수 출처 |
+|---|---|---|---|---|
+| `macdV` | MACD-V | momentum | 0 (zero line) | chart 표시 상수 `MACD_V_ZERO_LEVEL = 0` |
+| `forceIndex` | Force Index | momentum | 0 (zero line) | chart 표시 상수 `FORCE_INDEX_ZERO_LEVEL = 0` |
+| `obv` | OBV | volume | 없음 | — |
+| `atr` | ATR | volatility | 없음 | — |
+| `yangZhang` | Yang-Zhang | volatility | 없음 | — |
+| `ewmaVolatility` | EWMA Vol | volatility | 없음 | — |
+
+> 0선 상수 2개는 시각화 임계라 `widgets/chart/constants/indicatorLevels.ts`에 로컬 정의(group-B의 williamsR·hurst 등과 동일 방침). atr/obv/yangZhang/ewmaVolatility는 기준선 없음 → 해당 훅은 `createPriceLine` 생략.
+
+## 5. 아키텍처 (group-B와 동일 메커니즘)
+
+### 5.1 6 pane 훅 (`hooks/useMacdVChart.ts` 등 — RSI 복제)
+각 훅은 `useRSIChart`/group-B 훅과 동일 구조(2 effects: 시리즈 lifecycle + 데이터 sync; 동일 ref/useEffectEvent 패턴). 차이:
+- 색: `CHART_COLORS.<key>Line`
+- 기준선: macdV·forceIndex는 `createPriceLine(0선)` 1개; 나머지 4종은 createPriceLine 없음
+- dataAccessor: `indicators.<key>` (단일 배열) → `buildSeriesDataFromValues(bars, <key>)`
+
+### 5.2 레지스트리 확장 (`model/indicatorRegistry.ts`)
+- `IndicatorKey` union에 6키 추가(`macdV`·`forceIndex`·`obv`·`atr`·`yangZhang`·`ewmaVolatility`).
+- `INDICATOR_REGISTRY`에 6 메타 추가(§4 표, 전부 `kind: 'pane'`).
+- `IndicatorCategory`·`CATEGORY_LABELS` 무변경(기존 momentum/volume/volatility 재사용).
+
+### 5.3 상수 + 색상
+- `constants/indicatorLevels.ts`: `MACD_V_ZERO_LEVEL = 0`, `FORCE_INDEX_ZERO_LEVEL = 0` 추가.
+- `shared/lib/chartColors.ts`: 6종 라인색 + 0선 색(zero) 추가. 기존·group-B 색과 **중복 회피**(구현 시 검증).
+
+### 5.4 pane label / StockChart
+- `paneLabelUtils.ts`: `buildSinglePaneLabel`(기존 헬퍼)로 6종 label 추가(MACD-V·Force Index·OBV·ATR·Yang-Zhang·EWMA Vol).
+- `StockChart.tsx`: 6 훅 호출 + binding **18→24**. `useIndicatorVisibility`(레지스트리 기반)·모달 무변경.
+
+## 6. 데이터 흐름 (#577과 동일)
+```
+indicatorRegistry (pane 키 = kind:'pane', 이제 19종)
+        │
+useIndicatorVisibility: 레지스트리 전체 키 visible Record + 동적 paneIndex (무변경)
+        │
+StockChart: 6 신규 pane 훅 호출 + binding 조립(24개)
+        │
+IndicatorSettingsModal: 카테고리 그룹핑 자동 노출 (무수정)
+        │
+체크 → toggle(key) → paneIndices 재계산 → 훅이 pane 생성/제거
+```
+
+## 7. 테스트 전략 (vitest + RTL, 커버리지 90%+, happy + worst)
+
+### 7.1 단위
+- **6 pane 훅** 각각: 시리즈 생성(visible)/제거(false), paneIndex 변경 재생성, 데이터 세팅, **worst-case**(빈 배열·전부 null). macdV/forceIndex는 0선 priceLine 생성 확인.
+- **레지스트리**: 24개 등록, 6 신규 키 카테고리·pane kind, 키 중복 없음.
+- **상수**: `MACD_V_ZERO_LEVEL`·`FORCE_INDEX_ZERO_LEVEL` 값 단언.
+
+### 7.2 통합 / E2E
+- E2E(`chart-indicators.spec.ts` 확장): 모달에서 ATR(또는 macdV) 체크 → pane label 차트 반영(`.pane-indicator-label` 스코프 — #577 교훈).
+
+### 7.3 회귀
+- 기존 pane 훅(group-B 7 + 기존 6)·`useIndicatorVisibility`는 코드 무변경. StockChart binding 추가로 인한 기존 테스트(StockChart.test data-count 18→24) mock·단언 갱신.
+
+## 8. 확장성 검증
+- C-복합 3종·그룹 A·D 추가 시: 레지스트리 메타 + 훅 + StockChart binding만. paneIndex 일반화·모달 무수정.
+
+## 9. FSD 준수
+- 훅·레지스트리·상수: `widgets/chart` 내부 + `shared/lib/chartColors`. core import(IndicatorResult). 레이어 방향 정상. core 무변경.
+
+## 10. 후속 (별도 스펙)
+- C-복합 3종(elderRay 히스토그램·squeezeMomentum 히스토+상태·regression 2값)
+- 그룹 A(가격 오버레이 5종), 그룹 D(elderImpulse 캔들 색칠·smc zone primitive)
+- 전송 페이로드 슬림화

--- a/e2e/specs/chart-indicators.spec.ts
+++ b/e2e/specs/chart-indicators.spec.ts
@@ -78,4 +78,20 @@ test.describe('chart indicator settings modal', () => {
             page.locator('.pane-indicator-label').filter({ hasText: 'MFI' })
         ).toBeVisible();
     });
+
+    test('toggles ATR into a pane via the modal', async ({ page }) => {
+        await page.goto('/AAPL');
+        await page.getByRole('button', { name: GEAR }).click();
+        const dialog = page.getByRole('dialog');
+        // ATR은 변동성 카테고리의 체크박스(label 'ATR'). exact로 다른 라벨 substring 회피.
+        await dialog
+            .getByRole('checkbox', { name: 'ATR', exact: true })
+            .check();
+        await page.getByRole('button', { name: '닫기' }).click();
+        // MFI 케이스와 동일하게 .pane-indicator-label로 스코프 — 대시보드 SignalBadge
+        // 등 차트 외부의 'ATR' substring과의 충돌을 피한다.
+        await expect(
+            page.locator('.pane-indicator-label').filter({ hasText: 'ATR' })
+        ).toBeVisible();
+    });
 });

--- a/src/shared/lib/chartColors.ts
+++ b/src/shared/lib/chartColors.ts
@@ -117,6 +117,15 @@ export const CHART_COLORS = {
     // Variance Ratio (CCI #fb923c와 구별되는 라임)
     varianceRatioLine: '#a3e635',
     varianceRatioReference: '#94a3b860',
+
+    macdVLine: '#2dd4bf',
+    macdVZero: '#94a3b860',
+    forceIndexLine: '#fb7185',
+    forceIndexZero: '#94a3b860',
+    obvLine: '#7dd3fc',
+    atrLine: '#fdba74',
+    yangZhangLine: '#d8b4fe',
+    ewmaVolatilityLine: '#6ee7b7',
 } as const;
 
 const PERIOD_COLOR_MAP: Record<number, string> = {

--- a/src/widgets/chart/StockChart.tsx
+++ b/src/widgets/chart/StockChart.tsx
@@ -34,6 +34,12 @@ import { useCmfChart } from './hooks/useCmfChart';
 import { useBollingerPercentBChart } from './hooks/useBollingerPercentBChart';
 import { useHurstChart } from './hooks/useHurstChart';
 import { useVarianceRatioChart } from './hooks/useVarianceRatioChart';
+import { useMacdVChart } from './hooks/useMacdVChart';
+import { useForceIndexChart } from './hooks/useForceIndexChart';
+import { useObvChart } from './hooks/useObvChart';
+import { useAtrChart } from './hooks/useAtrChart';
+import { useYangZhangChart } from './hooks/useYangZhangChart';
+import { useEwmaVolatilityChart } from './hooks/useEwmaVolatilityChart';
 import { useVolumeProfileOverlay } from './hooks/useVolumeProfileOverlay';
 import { useIchimokuOverlay } from './hooks/useIchimokuOverlay';
 import { useCandlePatternMarkers } from './hooks/useCandlePatternMarkers';
@@ -272,6 +278,42 @@ export function StockChart({
         paneIndex: paneIndices.varianceRatio,
     });
 
+    useMacdVChart({
+        ...commonHookParams,
+        isVisible: visible.macdV,
+        paneIndex: paneIndices.macdV,
+    });
+
+    useForceIndexChart({
+        ...commonHookParams,
+        isVisible: visible.forceIndex,
+        paneIndex: paneIndices.forceIndex,
+    });
+
+    useObvChart({
+        ...commonHookParams,
+        isVisible: visible.obv,
+        paneIndex: paneIndices.obv,
+    });
+
+    useAtrChart({
+        ...commonHookParams,
+        isVisible: visible.atr,
+        paneIndex: paneIndices.atr,
+    });
+
+    useYangZhangChart({
+        ...commonHookParams,
+        isVisible: visible.yangZhang,
+        paneIndex: paneIndices.yangZhang,
+    });
+
+    useEwmaVolatilityChart({
+        ...commonHookParams,
+        isVisible: visible.ewmaVolatility,
+        paneIndex: paneIndices.ewmaVolatility,
+    });
+
     useCandlePatternMarkers({ seriesRef, bars });
 
     useActionRecommendationOverlay({
@@ -447,8 +489,38 @@ export function StockChart({
                 active: visible.varianceRatio,
                 onToggle: () => toggle('varianceRatio'),
             },
+            {
+                meta: INDICATOR_META.macdV,
+                active: visible.macdV,
+                onToggle: () => toggle('macdV'),
+            },
+            {
+                meta: INDICATOR_META.forceIndex,
+                active: visible.forceIndex,
+                onToggle: () => toggle('forceIndex'),
+            },
+            {
+                meta: INDICATOR_META.obv,
+                active: visible.obv,
+                onToggle: () => toggle('obv'),
+            },
+            {
+                meta: INDICATOR_META.atr,
+                active: visible.atr,
+                onToggle: () => toggle('atr'),
+            },
+            {
+                meta: INDICATOR_META.yangZhang,
+                active: visible.yangZhang,
+                onToggle: () => toggle('yangZhang'),
+            },
+            {
+                meta: INDICATOR_META.ewmaVolatility,
+                active: visible.ewmaVolatility,
+                onToggle: () => toggle('ewmaVolatility'),
+            },
         ],
-        // deps에 visible 객체 전체를 둔다 — 한 지표 토글 시 18개 binding 전체가 재조립되지만
+        // deps에 visible 객체 전체를 둔다 — 한 지표 토글 시 24개 binding 전체가 재조립되지만
         // 항목 수가 적어 비용은 무시할 만하며, 개별 visible 키를 나열하는 것보다 명료하다.
         [
             maVisiblePeriods,

--- a/src/widgets/chart/__tests__/StockChart.test.tsx
+++ b/src/widgets/chart/__tests__/StockChart.test.tsx
@@ -23,6 +23,12 @@ const INACTIVE_PANES = Object.fromEntries(
         'bollingerPercentB',
         'hurst',
         'varianceRatio',
+        'macdV',
+        'forceIndex',
+        'obv',
+        'atr',
+        'yangZhang',
+        'ewmaVolatility',
     ].map(k => [k, INACTIVE_PANE_INDEX])
 );
 
@@ -169,6 +175,30 @@ vi.mock('@/widgets/chart/hooks/useVarianceRatioChart', () => ({
     useVarianceRatioChart: vi.fn(),
 }));
 
+vi.mock('@/widgets/chart/hooks/useMacdVChart', () => ({
+    useMacdVChart: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useForceIndexChart', () => ({
+    useForceIndexChart: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useObvChart', () => ({
+    useObvChart: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useAtrChart', () => ({
+    useAtrChart: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useYangZhangChart', () => ({
+    useYangZhangChart: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useEwmaVolatilityChart', () => ({
+    useEwmaVolatilityChart: vi.fn(),
+}));
+
 vi.mock('@/widgets/chart/hooks/useVolumeProfileOverlay', () => ({
     useVolumeProfileOverlay: () => ({
         isVisible: false,
@@ -220,6 +250,12 @@ vi.mock('@/widgets/chart/hooks/useIndicatorVisibility', () => ({
             bollingerPercentB: false,
             hurst: false,
             varianceRatio: false,
+            macdV: false,
+            forceIndex: false,
+            obv: false,
+            atr: false,
+            yangZhang: false,
+            ewmaVolatility: false,
         },
         toggle: vi.fn(),
         paneIndices: INACTIVE_PANES,
@@ -358,13 +394,13 @@ describe('StockChart', () => {
         );
     });
 
-    it('renders IndicatorSettingsModal with 18 indicator bindings', () => {
+    it('renders IndicatorSettingsModal with 24 indicator bindings', () => {
         render(<StockChart bars={mockBars} timeframe="1Day" />);
         const modal = screen.getByTestId('indicator-settings-modal');
-        expect(modal).toHaveAttribute('data-count', '18');
+        expect(modal).toHaveAttribute('data-count', '24');
         expect(modal).toHaveAttribute(
             'data-keys',
-            'ma,ema,ichimoku,rsi,macd,dmi,stochastic,stochRsi,cci,bollinger,volumeProfile,mfi,williamsR,connorsRsi,cmf,bollingerPercentB,hurst,varianceRatio'
+            'ma,ema,ichimoku,rsi,macd,dmi,stochastic,stochRsi,cci,bollinger,volumeProfile,mfi,williamsR,connorsRsi,cmf,bollingerPercentB,hurst,varianceRatio,macdV,forceIndex,obv,atr,yangZhang,ewmaVolatility'
         );
     });
 

--- a/src/widgets/chart/__tests__/constants/indicatorLevels.test.ts
+++ b/src/widgets/chart/__tests__/constants/indicatorLevels.test.ts
@@ -11,6 +11,8 @@ import {
     BOLLINGER_PERCENT_B_LOWER_LEVEL,
     HURST_RANDOM_WALK_LEVEL,
     VARIANCE_RATIO_RANDOM_WALK_LEVEL,
+    MACD_V_ZERO_LEVEL,
+    FORCE_INDEX_ZERO_LEVEL,
 } from '../../constants/indicatorLevels';
 
 describe('indicatorLevels', () => {
@@ -38,5 +40,9 @@ describe('indicatorLevels', () => {
     it('random-walk reference levels', () => {
         expect(HURST_RANDOM_WALK_LEVEL).toBe(0.5);
         expect(VARIANCE_RATIO_RANDOM_WALK_LEVEL).toBe(1);
+    });
+    it('group-C zero levels', () => {
+        expect(MACD_V_ZERO_LEVEL).toBe(0);
+        expect(FORCE_INDEX_ZERO_LEVEL).toBe(0);
     });
 });

--- a/src/widgets/chart/__tests__/hooks/useAtrChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useAtrChart.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useAtrChart } from '../../hooks/useAtrChart';
+import { INACTIVE_PANE_INDEX } from '../../constants';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockCreatePriceLine = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+    createPriceLine: mockCreatePriceLine,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+    LineStyle: { Dashed: 1 },
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesDataFromValues: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return {
+        current: chart,
+    } as Parameters<typeof useAtrChart>[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { atr: [] } as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    atr: [1.5, 2.3, 1.9],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useAtrChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns void', () => {
+        const { result } = renderHook(() =>
+            useAtrChart({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useAtrChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('does not create series when not visible', () => {
+        renderHook(() =>
+            useAtrChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates ATR series without a zero line when visible with chart', () => {
+        renderHook(() =>
+            useAtrChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalled();
+        expect(mockCreatePriceLine).not.toHaveBeenCalled();
+    });
+
+    it('sets data when visible with filled indicators', () => {
+        renderHook(() =>
+            useAtrChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockSetData).toHaveBeenCalled();
+    });
+
+    it('does not set data when indicator array is empty', () => {
+        renderHook(() =>
+            useAtrChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('recreates series when paneIndex changes', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ pane }) =>
+                useAtrChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: true,
+                    paneIndex: pane,
+                }),
+            { initialProps: { pane: 2 } }
+        );
+
+        rerender({ pane: 3 });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes series when visibility turns off', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ visible, pane }) =>
+                useAtrChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: visible,
+                    paneIndex: pane,
+                }),
+            { initialProps: { visible: true, pane: 2 } }
+        );
+
+        rerender({ visible: false, pane: INACTIVE_PANE_INDEX });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useAtrChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useAtrChart.test.ts
@@ -39,6 +39,10 @@ const FILLED_INDICATORS = {
     atr: [1.5, 2.3, 1.9],
 } as unknown as IndicatorResult;
 
+const ALL_NULL_INDICATORS = {
+    atr: [null, null, null],
+} as unknown as IndicatorResult;
+
 const FAKE_BARS: Bar[] = [
     { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
 ];
@@ -131,6 +135,21 @@ describe('useAtrChart', () => {
         );
 
         expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('sets data once when indicator array is all-null (length > 0 passes guard)', () => {
+        renderHook(() =>
+            useAtrChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: ALL_NULL_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalled();
+        expect(mockSetData).toHaveBeenCalledTimes(1);
     });
 
     it('recreates series when paneIndex changes', () => {

--- a/src/widgets/chart/__tests__/hooks/useEwmaVolatilityChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useEwmaVolatilityChart.test.ts
@@ -39,6 +39,10 @@ const FILLED_INDICATORS = {
     ewmaVolatility: [0.21, 0.25, 0.23],
 } as unknown as IndicatorResult;
 
+const ALL_NULL_INDICATORS = {
+    ewmaVolatility: [null, null, null],
+} as unknown as IndicatorResult;
+
 const FAKE_BARS: Bar[] = [
     { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
 ];
@@ -131,6 +135,21 @@ describe('useEwmaVolatilityChart', () => {
         );
 
         expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('sets data once when indicator array is all-null (length > 0 passes guard)', () => {
+        renderHook(() =>
+            useEwmaVolatilityChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: ALL_NULL_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalled();
+        expect(mockSetData).toHaveBeenCalledTimes(1);
     });
 
     it('recreates series when paneIndex changes', () => {

--- a/src/widgets/chart/__tests__/hooks/useEwmaVolatilityChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useEwmaVolatilityChart.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useEwmaVolatilityChart } from '../../hooks/useEwmaVolatilityChart';
+import { INACTIVE_PANE_INDEX } from '../../constants';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockCreatePriceLine = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+    createPriceLine: mockCreatePriceLine,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+    LineStyle: { Dashed: 1 },
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesDataFromValues: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return {
+        current: chart,
+    } as Parameters<typeof useEwmaVolatilityChart>[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { ewmaVolatility: [] } as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    ewmaVolatility: [0.21, 0.25, 0.23],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useEwmaVolatilityChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns void', () => {
+        const { result } = renderHook(() =>
+            useEwmaVolatilityChart({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useEwmaVolatilityChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('does not create series when not visible', () => {
+        renderHook(() =>
+            useEwmaVolatilityChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates EWMA volatility series without a zero line when visible with chart', () => {
+        renderHook(() =>
+            useEwmaVolatilityChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalled();
+        expect(mockCreatePriceLine).not.toHaveBeenCalled();
+    });
+
+    it('sets data when visible with filled indicators', () => {
+        renderHook(() =>
+            useEwmaVolatilityChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockSetData).toHaveBeenCalled();
+    });
+
+    it('does not set data when indicator array is empty', () => {
+        renderHook(() =>
+            useEwmaVolatilityChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('recreates series when paneIndex changes', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ pane }) =>
+                useEwmaVolatilityChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: true,
+                    paneIndex: pane,
+                }),
+            { initialProps: { pane: 2 } }
+        );
+
+        rerender({ pane: 3 });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes series when visibility turns off', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ visible, pane }) =>
+                useEwmaVolatilityChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: visible,
+                    paneIndex: pane,
+                }),
+            { initialProps: { visible: true, pane: 2 } }
+        );
+
+        rerender({ visible: false, pane: INACTIVE_PANE_INDEX });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useForceIndexChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useForceIndexChart.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useForceIndexChart } from '../../hooks/useForceIndexChart';
+import { INACTIVE_PANE_INDEX } from '../../constants';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockCreatePriceLine = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+    createPriceLine: mockCreatePriceLine,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+    LineStyle: { Dashed: 1 },
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesDataFromValues: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return {
+        current: chart,
+    } as Parameters<typeof useForceIndexChart>[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { forceIndex: [] } as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    forceIndex: [-500, 250, 1000],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useForceIndexChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns void', () => {
+        const { result } = renderHook(() =>
+            useForceIndexChart({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useForceIndexChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('does not create series when not visible', () => {
+        renderHook(() =>
+            useForceIndexChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates Force Index series with zero line when visible with chart', () => {
+        renderHook(() =>
+            useForceIndexChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalled();
+        expect(mockCreatePriceLine).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets data when visible with filled indicators', () => {
+        renderHook(() =>
+            useForceIndexChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockSetData).toHaveBeenCalled();
+    });
+
+    it('does not set data when indicator array is empty', () => {
+        renderHook(() =>
+            useForceIndexChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('recreates series when paneIndex changes', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ pane }) =>
+                useForceIndexChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: true,
+                    paneIndex: pane,
+                }),
+            { initialProps: { pane: 2 } }
+        );
+
+        rerender({ pane: 3 });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes series when visibility turns off', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ visible, pane }) =>
+                useForceIndexChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: visible,
+                    paneIndex: pane,
+                }),
+            { initialProps: { visible: true, pane: 2 } }
+        );
+
+        rerender({ visible: false, pane: INACTIVE_PANE_INDEX });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useForceIndexChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useForceIndexChart.test.ts
@@ -39,6 +39,10 @@ const FILLED_INDICATORS = {
     forceIndex: [-500, 250, 1000],
 } as unknown as IndicatorResult;
 
+const ALL_NULL_INDICATORS = {
+    forceIndex: [null, null, null],
+} as unknown as IndicatorResult;
+
 const FAKE_BARS: Bar[] = [
     { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
 ];
@@ -103,6 +107,9 @@ describe('useForceIndexChart', () => {
 
         expect(mockAddSeries).toHaveBeenCalled();
         expect(mockCreatePriceLine).toHaveBeenCalledTimes(1);
+        expect(mockCreatePriceLine).toHaveBeenCalledWith(
+            expect.objectContaining({ price: 0 })
+        );
     });
 
     it('sets data when visible with filled indicators', () => {
@@ -131,6 +138,21 @@ describe('useForceIndexChart', () => {
         );
 
         expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('sets data once when indicator array is all-null (length > 0 passes guard)', () => {
+        renderHook(() =>
+            useForceIndexChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: ALL_NULL_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalled();
+        expect(mockSetData).toHaveBeenCalledTimes(1);
     });
 
     it('recreates series when paneIndex changes', () => {

--- a/src/widgets/chart/__tests__/hooks/useMacdVChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useMacdVChart.test.ts
@@ -39,6 +39,10 @@ const FILLED_INDICATORS = {
     macdV: [-1, 0.5, 2],
 } as unknown as IndicatorResult;
 
+const ALL_NULL_INDICATORS = {
+    macdV: [null, null, null],
+} as unknown as IndicatorResult;
+
 const FAKE_BARS: Bar[] = [
     { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
 ];
@@ -103,6 +107,9 @@ describe('useMacdVChart', () => {
 
         expect(mockAddSeries).toHaveBeenCalled();
         expect(mockCreatePriceLine).toHaveBeenCalledTimes(1);
+        expect(mockCreatePriceLine).toHaveBeenCalledWith(
+            expect.objectContaining({ price: 0 })
+        );
     });
 
     it('sets data when visible with filled indicators', () => {
@@ -131,6 +138,21 @@ describe('useMacdVChart', () => {
         );
 
         expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('sets data once when indicator array is all-null (length > 0 passes guard)', () => {
+        renderHook(() =>
+            useMacdVChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: ALL_NULL_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalled();
+        expect(mockSetData).toHaveBeenCalledTimes(1);
     });
 
     it('recreates series when paneIndex changes', () => {

--- a/src/widgets/chart/__tests__/hooks/useMacdVChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useMacdVChart.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useMacdVChart } from '../../hooks/useMacdVChart';
+import { INACTIVE_PANE_INDEX } from '../../constants';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockCreatePriceLine = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+    createPriceLine: mockCreatePriceLine,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+    LineStyle: { Dashed: 1 },
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesDataFromValues: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return {
+        current: chart,
+    } as Parameters<typeof useMacdVChart>[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { macdV: [] } as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    macdV: [-1, 0.5, 2],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useMacdVChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns void', () => {
+        const { result } = renderHook(() =>
+            useMacdVChart({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useMacdVChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('does not create series when not visible', () => {
+        renderHook(() =>
+            useMacdVChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates MACD-V series with zero line when visible with chart', () => {
+        renderHook(() =>
+            useMacdVChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalled();
+        expect(mockCreatePriceLine).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets data when visible with filled indicators', () => {
+        renderHook(() =>
+            useMacdVChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockSetData).toHaveBeenCalled();
+    });
+
+    it('does not set data when indicator array is empty', () => {
+        renderHook(() =>
+            useMacdVChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('recreates series when paneIndex changes', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ pane }) =>
+                useMacdVChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: true,
+                    paneIndex: pane,
+                }),
+            { initialProps: { pane: 2 } }
+        );
+
+        rerender({ pane: 3 });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes series when visibility turns off', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ visible, pane }) =>
+                useMacdVChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: visible,
+                    paneIndex: pane,
+                }),
+            { initialProps: { visible: true, pane: 2 } }
+        );
+
+        rerender({ visible: false, pane: INACTIVE_PANE_INDEX });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useObvChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useObvChart.test.ts
@@ -39,6 +39,10 @@ const FILLED_INDICATORS = {
     obv: [100, 200, 150],
 } as unknown as IndicatorResult;
 
+const ALL_NULL_INDICATORS = {
+    obv: [null, null, null],
+} as unknown as IndicatorResult;
+
 const FAKE_BARS: Bar[] = [
     { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
 ];
@@ -131,6 +135,21 @@ describe('useObvChart', () => {
         );
 
         expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('sets data once when indicator array is all-null (length > 0 passes guard)', () => {
+        renderHook(() =>
+            useObvChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: ALL_NULL_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalled();
+        expect(mockSetData).toHaveBeenCalledTimes(1);
     });
 
     it('recreates series when paneIndex changes', () => {

--- a/src/widgets/chart/__tests__/hooks/useObvChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useObvChart.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useObvChart } from '../../hooks/useObvChart';
+import { INACTIVE_PANE_INDEX } from '../../constants';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockCreatePriceLine = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+    createPriceLine: mockCreatePriceLine,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+    LineStyle: { Dashed: 1 },
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesDataFromValues: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return {
+        current: chart,
+    } as Parameters<typeof useObvChart>[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { obv: [] } as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    obv: [100, 200, 150],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useObvChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns void', () => {
+        const { result } = renderHook(() =>
+            useObvChart({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useObvChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('does not create series when not visible', () => {
+        renderHook(() =>
+            useObvChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates OBV series without a zero line when visible with chart', () => {
+        renderHook(() =>
+            useObvChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalled();
+        expect(mockCreatePriceLine).not.toHaveBeenCalled();
+    });
+
+    it('sets data when visible with filled indicators', () => {
+        renderHook(() =>
+            useObvChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockSetData).toHaveBeenCalled();
+    });
+
+    it('does not set data when indicator array is empty', () => {
+        renderHook(() =>
+            useObvChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('recreates series when paneIndex changes', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ pane }) =>
+                useObvChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: true,
+                    paneIndex: pane,
+                }),
+            { initialProps: { pane: 2 } }
+        );
+
+        rerender({ pane: 3 });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes series when visibility turns off', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ visible, pane }) =>
+                useObvChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: visible,
+                    paneIndex: pane,
+                }),
+            { initialProps: { visible: true, pane: 2 } }
+        );
+
+        rerender({ visible: false, pane: INACTIVE_PANE_INDEX });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useYangZhangChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useYangZhangChart.test.ts
@@ -39,6 +39,10 @@ const FILLED_INDICATORS = {
     yangZhang: [0.12, 0.18, 0.15],
 } as unknown as IndicatorResult;
 
+const ALL_NULL_INDICATORS = {
+    yangZhang: [null, null, null],
+} as unknown as IndicatorResult;
+
 const FAKE_BARS: Bar[] = [
     { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
 ];
@@ -131,6 +135,21 @@ describe('useYangZhangChart', () => {
         );
 
         expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('sets data once when indicator array is all-null (length > 0 passes guard)', () => {
+        renderHook(() =>
+            useYangZhangChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: ALL_NULL_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalled();
+        expect(mockSetData).toHaveBeenCalledTimes(1);
     });
 
     it('recreates series when paneIndex changes', () => {

--- a/src/widgets/chart/__tests__/hooks/useYangZhangChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useYangZhangChart.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useYangZhangChart } from '../../hooks/useYangZhangChart';
+import { INACTIVE_PANE_INDEX } from '../../constants';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockCreatePriceLine = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+    createPriceLine: mockCreatePriceLine,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+    LineStyle: { Dashed: 1 },
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesDataFromValues: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return {
+        current: chart,
+    } as Parameters<typeof useYangZhangChart>[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { yangZhang: [] } as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    yangZhang: [0.12, 0.18, 0.15],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useYangZhangChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns void', () => {
+        const { result } = renderHook(() =>
+            useYangZhangChart({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useYangZhangChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('does not create series when not visible', () => {
+        renderHook(() =>
+            useYangZhangChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: false,
+                paneIndex: INACTIVE_PANE_INDEX,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates Yang-Zhang series without a zero line when visible with chart', () => {
+        renderHook(() =>
+            useYangZhangChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockAddSeries).toHaveBeenCalled();
+        expect(mockCreatePriceLine).not.toHaveBeenCalled();
+    });
+
+    it('sets data when visible with filled indicators', () => {
+        renderHook(() =>
+            useYangZhangChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockSetData).toHaveBeenCalled();
+    });
+
+    it('does not set data when indicator array is empty', () => {
+        renderHook(() =>
+            useYangZhangChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+                isVisible: true,
+                paneIndex: 2,
+            })
+        );
+
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('recreates series when paneIndex changes', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ pane }) =>
+                useYangZhangChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: true,
+                    paneIndex: pane,
+                }),
+            { initialProps: { pane: 2 } }
+        );
+
+        rerender({ pane: 3 });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes series when visibility turns off', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(
+            ({ visible, pane }) =>
+                useYangZhangChart({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    isVisible: visible,
+                    paneIndex: pane,
+                }),
+            { initialProps: { visible: true, pane: 2 } }
+        );
+
+        rerender({ visible: false, pane: INACTIVE_PANE_INDEX });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+});

--- a/src/widgets/chart/__tests__/model/indicatorRegistry.test.ts
+++ b/src/widgets/chart/__tests__/model/indicatorRegistry.test.ts
@@ -95,21 +95,19 @@ describe('indicatorRegistry', () => {
         expect(byKey.ewmaVolatility).toBe('volatility');
     });
 
-    it('all group-C-simple indicators are pane kind', () => {
-        const groupC = [
-            'macdV',
-            'forceIndex',
-            'obv',
-            'atr',
-            'yangZhang',
-            'ewmaVolatility',
-        ];
-        expect(
-            groupC.every(
-                key => INDICATOR_META[key as IndicatorKey].kind === 'pane'
-            )
-        ).toBe(true);
-    });
+    it.each([
+        'macdV',
+        'forceIndex',
+        'obv',
+        'atr',
+        'yangZhang',
+        'ewmaVolatility',
+    ] as const satisfies readonly IndicatorKey[])(
+        '%s is a pane-kind indicator',
+        key => {
+            expect(INDICATOR_META[key].kind).toBe('pane');
+        }
+    );
 });
 
 describe('groupBindingsByCategory', () => {

--- a/src/widgets/chart/__tests__/model/indicatorRegistry.test.ts
+++ b/src/widgets/chart/__tests__/model/indicatorRegistry.test.ts
@@ -14,8 +14,8 @@ function bindingFor(key: IndicatorKey, active = false): IndicatorBinding {
 }
 
 describe('indicatorRegistry', () => {
-    it('registers exactly the 18 modal-target indicators', () => {
-        expect(INDICATOR_REGISTRY).toHaveLength(18);
+    it('registers exactly the 24 modal-target indicators', () => {
+        expect(INDICATOR_REGISTRY).toHaveLength(24);
     });
 
     it('has no duplicate keys', () => {
@@ -78,6 +78,34 @@ describe('indicatorRegistry', () => {
         ];
         expect(
             groupB.every(
+                key => INDICATOR_META[key as IndicatorKey].kind === 'pane'
+            )
+        ).toBe(true);
+    });
+
+    it('places group-C-simple indicators in the right categories', () => {
+        const byKey = Object.fromEntries(
+            INDICATOR_REGISTRY.map(m => [m.key, m.category])
+        );
+        expect(byKey.macdV).toBe('momentum');
+        expect(byKey.forceIndex).toBe('momentum');
+        expect(byKey.obv).toBe('volume');
+        expect(byKey.atr).toBe('volatility');
+        expect(byKey.yangZhang).toBe('volatility');
+        expect(byKey.ewmaVolatility).toBe('volatility');
+    });
+
+    it('all group-C-simple indicators are pane kind', () => {
+        const groupC = [
+            'macdV',
+            'forceIndex',
+            'obv',
+            'atr',
+            'yangZhang',
+            'ewmaVolatility',
+        ];
+        expect(
+            groupC.every(
                 key => INDICATOR_META[key as IndicatorKey].kind === 'pane'
             )
         ).toBe(true);

--- a/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
@@ -18,9 +18,9 @@ import {
 import type { PaneIndices } from '@/widgets/chart/types';
 import { INACTIVE_PANE_INDEX } from '@/widgets/chart/constants';
 
-// PaneIndices는 모든 IndicatorKey(18개)를 가진 Record다. buildPaneLabels가
-// 읽는 건 13개 pane 키뿐이므로, 나머지 overlay 키(ma·ema·ichimoku·bollinger·volumeProfile)를
-// INACTIVE로 채운 base에 해당 pane 키만 덮어쓴다.
+// PaneIndices는 모든 IndicatorKey(24개)를 가진 Record다. buildPaneLabels가
+// 읽는 건 13개 pane 키뿐이므로, 나머지 overlay 키(ma·ema·ichimoku·bollinger·volumeProfile)와
+// 아직 렌더되지 않는 group-C pane 키를 INACTIVE로 채운 base에 해당 pane 키만 덮어쓴다.
 function makePaneIndices(overrides: Partial<PaneIndices> = {}): PaneIndices {
     const base = {
         ma: INACTIVE_PANE_INDEX,
@@ -41,6 +41,12 @@ function makePaneIndices(overrides: Partial<PaneIndices> = {}): PaneIndices {
         bollingerPercentB: INACTIVE_PANE_INDEX,
         hurst: INACTIVE_PANE_INDEX,
         varianceRatio: INACTIVE_PANE_INDEX,
+        macdV: INACTIVE_PANE_INDEX,
+        forceIndex: INACTIVE_PANE_INDEX,
+        obv: INACTIVE_PANE_INDEX,
+        atr: INACTIVE_PANE_INDEX,
+        yangZhang: INACTIVE_PANE_INDEX,
+        ewmaVolatility: INACTIVE_PANE_INDEX,
     } satisfies PaneIndices;
     return { ...base, ...overrides };
 }

--- a/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
@@ -367,22 +367,20 @@ describe('buildPaneLabels', () => {
     });
 
     describe('group-C-simple pane가 활성일 때', () => {
-        it('builds single-subLabel labels for each group-C-simple pane', () => {
-            const cases: Array<[keyof PaneIndices, string, string]> = [
-                ['macdV', 'MACD-V', CHART_COLORS.macdVLine],
-                ['forceIndex', 'Force Index', CHART_COLORS.forceIndexLine],
-                ['obv', 'OBV', CHART_COLORS.obvLine],
-                ['atr', 'ATR', CHART_COLORS.atrLine],
-                ['yangZhang', 'Yang-Zhang', CHART_COLORS.yangZhangLine],
-                ['ewmaVolatility', 'EWMA Vol', CHART_COLORS.ewmaVolatilityLine],
-            ];
+        it.each([
+            ['macdV', 'MACD-V', CHART_COLORS.macdVLine],
+            ['forceIndex', 'Force Index', CHART_COLORS.forceIndexLine],
+            ['obv', 'OBV', CHART_COLORS.obvLine],
+            ['atr', 'ATR', CHART_COLORS.atrLine],
+            ['yangZhang', 'Yang-Zhang', CHART_COLORS.yangZhangLine],
+            ['ewmaVolatility', 'EWMA Vol', CHART_COLORS.ewmaVolatilityLine],
+        ] as const satisfies ReadonlyArray<
+            [keyof PaneIndices, string, string]
+        >)('builds %s pane label', (key, name, color) => {
+            const labels = buildPaneLabels(makePaneIndices({ [key]: 1 }));
 
-            for (const [key, name, color] of cases) {
-                const labels = buildPaneLabels(makePaneIndices({ [key]: 1 }));
-
-                expect(labels).toHaveLength(1);
-                expect(labels[0].subLabels).toEqual([{ name, color }]);
-            }
+            expect(labels).toHaveLength(1);
+            expect(labels[0].subLabels).toEqual([{ name, color }]);
         });
     });
 

--- a/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
@@ -366,6 +366,26 @@ describe('buildPaneLabels', () => {
         });
     });
 
+    describe('group-C-simple pane가 활성일 때', () => {
+        it('builds single-subLabel labels for each group-C-simple pane', () => {
+            const cases: Array<[keyof PaneIndices, string, string]> = [
+                ['macdV', 'MACD-V', CHART_COLORS.macdVLine],
+                ['forceIndex', 'Force Index', CHART_COLORS.forceIndexLine],
+                ['obv', 'OBV', CHART_COLORS.obvLine],
+                ['atr', 'ATR', CHART_COLORS.atrLine],
+                ['yangZhang', 'Yang-Zhang', CHART_COLORS.yangZhangLine],
+                ['ewmaVolatility', 'EWMA Vol', CHART_COLORS.ewmaVolatilityLine],
+            ];
+
+            for (const [key, name, color] of cases) {
+                const labels = buildPaneLabels(makePaneIndices({ [key]: 1 }));
+
+                expect(labels).toHaveLength(1);
+                expect(labels[0].subLabels).toEqual([{ name, color }]);
+            }
+        });
+    });
+
     describe('CCI만 활성일 때', () => {
         const CCI_PANE_INDEX = 1;
         const paneIndices = makePaneIndices({ cci: CCI_PANE_INDEX });

--- a/src/widgets/chart/constants/indicatorLevels.ts
+++ b/src/widgets/chart/constants/indicatorLevels.ts
@@ -33,3 +33,9 @@ export const HURST_RANDOM_WALK_LEVEL = 0.5;
 
 // Variance Ratio: 1.0 = 랜덤워크 기준(>1 추세, <1 평균회귀).
 export const VARIANCE_RATIO_RANDOM_WALK_LEVEL = 1;
+
+// MACD-V: 0선 교차가 강세/약세 기준 (volatility-normalized MACD, 부호 있음).
+export const MACD_V_ZERO_LEVEL = 0;
+
+// Force Index: 0선 교차가 매수/매도 압력 전환 기준.
+export const FORCE_INDEX_ZERO_LEVEL = 0;

--- a/src/widgets/chart/hooks/useAtrChart.ts
+++ b/src/widgets/chart/hooks/useAtrChart.ts
@@ -1,0 +1,91 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import { LineSeries } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { buildSeriesDataFromValues } from '../utils/seriesDataUtils';
+
+interface UseAtrChartParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+    isVisible: boolean;
+    paneIndex: number;
+}
+
+export function useAtrChart({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+    isVisible,
+    paneIndex,
+}: UseAtrChartParams): void {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const prevPaneIndexRef = useRef<number>(paneIndex);
+    const seriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+    // 이전 chart는 부모가 소멸시키므로 removeSeries 없이 ref만 초기화하면 충분.
+    const clearSeriesRefs = useEffectEvent(() => {
+        seriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (seriesRef.current) {
+            chart.removeSeries(seriesRef.current);
+            seriesRef.current = null;
+        }
+    });
+
+    // 데이터 세팅은 아래 effect에서 단독 처리하므로 이 effect는 lifecycle(생성·제거)만 담당.
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (prevPaneIndexRef.current !== paneIndex && seriesRef.current) {
+            removeAllSeries(chart);
+        }
+        prevPaneIndexRef.current = paneIndex;
+
+        if (!seriesRef.current) {
+            seriesRef.current = chart.addSeries(
+                LineSeries,
+                {
+                    color: CHART_COLORS.atrLine,
+                    lineWidth,
+                    priceLineVisible: false,
+                    lastValueVisible: false,
+                },
+                paneIndex
+            );
+        }
+        seriesRef.current.applyOptions({ lineWidth });
+    }, [chartRef, isVisible, lineWidth, paneIndex]);
+
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { atr } = indicators;
+        if (!atr.length) return;
+
+        if (!seriesRef.current) return;
+
+        seriesRef.current.setData(buildSeriesDataFromValues(bars, atr));
+    }, [indicators, bars, isVisible, paneIndex]);
+}

--- a/src/widgets/chart/hooks/useEwmaVolatilityChart.ts
+++ b/src/widgets/chart/hooks/useEwmaVolatilityChart.ts
@@ -1,0 +1,93 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import { LineSeries } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { buildSeriesDataFromValues } from '../utils/seriesDataUtils';
+
+interface UseEwmaVolatilityChartParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+    isVisible: boolean;
+    paneIndex: number;
+}
+
+export function useEwmaVolatilityChart({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+    isVisible,
+    paneIndex,
+}: UseEwmaVolatilityChartParams): void {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const prevPaneIndexRef = useRef<number>(paneIndex);
+    const seriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+    // 이전 chart는 부모가 소멸시키므로 removeSeries 없이 ref만 초기화하면 충분.
+    const clearSeriesRefs = useEffectEvent(() => {
+        seriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (seriesRef.current) {
+            chart.removeSeries(seriesRef.current);
+            seriesRef.current = null;
+        }
+    });
+
+    // 데이터 세팅은 아래 effect에서 단독 처리하므로 이 effect는 lifecycle(생성·제거)만 담당.
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (prevPaneIndexRef.current !== paneIndex && seriesRef.current) {
+            removeAllSeries(chart);
+        }
+        prevPaneIndexRef.current = paneIndex;
+
+        if (!seriesRef.current) {
+            seriesRef.current = chart.addSeries(
+                LineSeries,
+                {
+                    color: CHART_COLORS.ewmaVolatilityLine,
+                    lineWidth,
+                    priceLineVisible: false,
+                    lastValueVisible: false,
+                },
+                paneIndex
+            );
+        }
+        seriesRef.current.applyOptions({ lineWidth });
+    }, [chartRef, isVisible, lineWidth, paneIndex]);
+
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { ewmaVolatility } = indicators;
+        if (!ewmaVolatility.length) return;
+
+        if (!seriesRef.current) return;
+
+        seriesRef.current.setData(
+            buildSeriesDataFromValues(bars, ewmaVolatility)
+        );
+    }, [indicators, bars, isVisible, paneIndex]);
+}

--- a/src/widgets/chart/hooks/useForceIndexChart.ts
+++ b/src/widgets/chart/hooks/useForceIndexChart.ts
@@ -1,0 +1,101 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import { LineSeries, LineStyle } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { FORCE_INDEX_ZERO_LEVEL } from '../constants/indicatorLevels';
+import { buildSeriesDataFromValues } from '../utils/seriesDataUtils';
+
+interface UseForceIndexChartParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+    isVisible: boolean;
+    paneIndex: number;
+}
+
+export function useForceIndexChart({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+    isVisible,
+    paneIndex,
+}: UseForceIndexChartParams): void {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const prevPaneIndexRef = useRef<number>(paneIndex);
+    const seriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+    // 이전 chart는 부모가 소멸시키므로 removeSeries 없이 ref만 초기화하면 충분.
+    const clearSeriesRefs = useEffectEvent(() => {
+        seriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (seriesRef.current) {
+            chart.removeSeries(seriesRef.current);
+            seriesRef.current = null;
+        }
+    });
+
+    // 데이터 세팅은 아래 effect에서 단독 처리하므로 이 effect는 lifecycle(생성·제거)만 담당.
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (prevPaneIndexRef.current !== paneIndex && seriesRef.current) {
+            removeAllSeries(chart);
+        }
+        prevPaneIndexRef.current = paneIndex;
+
+        if (!seriesRef.current) {
+            seriesRef.current = chart.addSeries(
+                LineSeries,
+                {
+                    color: CHART_COLORS.forceIndexLine,
+                    lineWidth,
+                    priceLineVisible: false,
+                    lastValueVisible: false,
+                },
+                paneIndex
+            );
+
+            seriesRef.current.createPriceLine({
+                price: FORCE_INDEX_ZERO_LEVEL,
+                color: CHART_COLORS.forceIndexZero,
+                lineWidth,
+                lineStyle: LineStyle.Dashed,
+                axisLabelVisible: false,
+                title: '',
+            });
+        }
+        seriesRef.current.applyOptions({ lineWidth });
+    }, [chartRef, isVisible, lineWidth, paneIndex]);
+
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { forceIndex } = indicators;
+        if (!forceIndex.length) return;
+
+        if (!seriesRef.current) return;
+
+        seriesRef.current.setData(buildSeriesDataFromValues(bars, forceIndex));
+    }, [indicators, bars, isVisible, paneIndex]);
+}

--- a/src/widgets/chart/hooks/useMacdVChart.ts
+++ b/src/widgets/chart/hooks/useMacdVChart.ts
@@ -1,0 +1,101 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import { LineSeries, LineStyle } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { MACD_V_ZERO_LEVEL } from '../constants/indicatorLevels';
+import { buildSeriesDataFromValues } from '../utils/seriesDataUtils';
+
+interface UseMacdVChartParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+    isVisible: boolean;
+    paneIndex: number;
+}
+
+export function useMacdVChart({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+    isVisible,
+    paneIndex,
+}: UseMacdVChartParams): void {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const prevPaneIndexRef = useRef<number>(paneIndex);
+    const seriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+    // 이전 chart는 부모가 소멸시키므로 removeSeries 없이 ref만 초기화하면 충분.
+    const clearSeriesRefs = useEffectEvent(() => {
+        seriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (seriesRef.current) {
+            chart.removeSeries(seriesRef.current);
+            seriesRef.current = null;
+        }
+    });
+
+    // 데이터 세팅은 아래 effect에서 단독 처리하므로 이 effect는 lifecycle(생성·제거)만 담당.
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (prevPaneIndexRef.current !== paneIndex && seriesRef.current) {
+            removeAllSeries(chart);
+        }
+        prevPaneIndexRef.current = paneIndex;
+
+        if (!seriesRef.current) {
+            seriesRef.current = chart.addSeries(
+                LineSeries,
+                {
+                    color: CHART_COLORS.macdVLine,
+                    lineWidth,
+                    priceLineVisible: false,
+                    lastValueVisible: false,
+                },
+                paneIndex
+            );
+
+            seriesRef.current.createPriceLine({
+                price: MACD_V_ZERO_LEVEL,
+                color: CHART_COLORS.macdVZero,
+                lineWidth,
+                lineStyle: LineStyle.Dashed,
+                axisLabelVisible: false,
+                title: '',
+            });
+        }
+        seriesRef.current.applyOptions({ lineWidth });
+    }, [chartRef, isVisible, lineWidth, paneIndex]);
+
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { macdV } = indicators;
+        if (!macdV.length) return;
+
+        if (!seriesRef.current) return;
+
+        seriesRef.current.setData(buildSeriesDataFromValues(bars, macdV));
+    }, [indicators, bars, isVisible, paneIndex]);
+}

--- a/src/widgets/chart/hooks/useObvChart.ts
+++ b/src/widgets/chart/hooks/useObvChart.ts
@@ -1,0 +1,91 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import { LineSeries } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { buildSeriesDataFromValues } from '../utils/seriesDataUtils';
+
+interface UseObvChartParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+    isVisible: boolean;
+    paneIndex: number;
+}
+
+export function useObvChart({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+    isVisible,
+    paneIndex,
+}: UseObvChartParams): void {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const prevPaneIndexRef = useRef<number>(paneIndex);
+    const seriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+    // 이전 chart는 부모가 소멸시키므로 removeSeries 없이 ref만 초기화하면 충분.
+    const clearSeriesRefs = useEffectEvent(() => {
+        seriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (seriesRef.current) {
+            chart.removeSeries(seriesRef.current);
+            seriesRef.current = null;
+        }
+    });
+
+    // 데이터 세팅은 아래 effect에서 단독 처리하므로 이 effect는 lifecycle(생성·제거)만 담당.
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (prevPaneIndexRef.current !== paneIndex && seriesRef.current) {
+            removeAllSeries(chart);
+        }
+        prevPaneIndexRef.current = paneIndex;
+
+        if (!seriesRef.current) {
+            seriesRef.current = chart.addSeries(
+                LineSeries,
+                {
+                    color: CHART_COLORS.obvLine,
+                    lineWidth,
+                    priceLineVisible: false,
+                    lastValueVisible: false,
+                },
+                paneIndex
+            );
+        }
+        seriesRef.current.applyOptions({ lineWidth });
+    }, [chartRef, isVisible, lineWidth, paneIndex]);
+
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { obv } = indicators;
+        if (!obv.length) return;
+
+        if (!seriesRef.current) return;
+
+        seriesRef.current.setData(buildSeriesDataFromValues(bars, obv));
+    }, [indicators, bars, isVisible, paneIndex]);
+}

--- a/src/widgets/chart/hooks/useYangZhangChart.ts
+++ b/src/widgets/chart/hooks/useYangZhangChart.ts
@@ -1,0 +1,91 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import { LineSeries } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { buildSeriesDataFromValues } from '../utils/seriesDataUtils';
+
+interface UseYangZhangChartParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+    isVisible: boolean;
+    paneIndex: number;
+}
+
+export function useYangZhangChart({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+    isVisible,
+    paneIndex,
+}: UseYangZhangChartParams): void {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const prevPaneIndexRef = useRef<number>(paneIndex);
+    const seriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+    // 이전 chart는 부모가 소멸시키므로 removeSeries 없이 ref만 초기화하면 충분.
+    const clearSeriesRefs = useEffectEvent(() => {
+        seriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (seriesRef.current) {
+            chart.removeSeries(seriesRef.current);
+            seriesRef.current = null;
+        }
+    });
+
+    // 데이터 세팅은 아래 effect에서 단독 처리하므로 이 effect는 lifecycle(생성·제거)만 담당.
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (prevPaneIndexRef.current !== paneIndex && seriesRef.current) {
+            removeAllSeries(chart);
+        }
+        prevPaneIndexRef.current = paneIndex;
+
+        if (!seriesRef.current) {
+            seriesRef.current = chart.addSeries(
+                LineSeries,
+                {
+                    color: CHART_COLORS.yangZhangLine,
+                    lineWidth,
+                    priceLineVisible: false,
+                    lastValueVisible: false,
+                },
+                paneIndex
+            );
+        }
+        seriesRef.current.applyOptions({ lineWidth });
+    }, [chartRef, isVisible, lineWidth, paneIndex]);
+
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { yangZhang } = indicators;
+        if (!yangZhang.length) return;
+
+        if (!seriesRef.current) return;
+
+        seriesRef.current.setData(buildSeriesDataFromValues(bars, yangZhang));
+    }, [indicators, bars, isVisible, paneIndex]);
+}

--- a/src/widgets/chart/model/indicatorRegistry.ts
+++ b/src/widgets/chart/model/indicatorRegistry.ts
@@ -35,7 +35,13 @@ export type IndicatorKey =
     | 'cmf'
     | 'bollingerPercentB'
     | 'hurst'
-    | 'varianceRatio';
+    | 'varianceRatio'
+    | 'macdV'
+    | 'forceIndex'
+    | 'obv'
+    | 'atr'
+    | 'yangZhang'
+    | 'ewmaVolatility';
 
 export interface IndicatorMeta {
     key: IndicatorKey;
@@ -134,6 +140,27 @@ export const INDICATOR_REGISTRY: readonly IndicatorMeta[] = [
         key: 'varianceRatio',
         label: 'VR',
         category: 'statistical',
+        kind: 'pane',
+    },
+    { key: 'macdV', label: 'MACD-V', category: 'momentum', kind: 'pane' },
+    {
+        key: 'forceIndex',
+        label: 'Force Index',
+        category: 'momentum',
+        kind: 'pane',
+    },
+    { key: 'obv', label: 'OBV', category: 'volume', kind: 'pane' },
+    { key: 'atr', label: 'ATR', category: 'volatility', kind: 'pane' },
+    {
+        key: 'yangZhang',
+        label: 'Yang-Zhang',
+        category: 'volatility',
+        kind: 'pane',
+    },
+    {
+        key: 'ewmaVolatility',
+        label: 'EWMA Vol',
+        category: 'volatility',
         kind: 'pane',
     },
 ];

--- a/src/widgets/chart/utils/paneLabelUtils.ts
+++ b/src/widgets/chart/utils/paneLabelUtils.ts
@@ -171,6 +171,42 @@ export function buildPaneLabels(paneIndices: PaneIndices): PaneLabelConfig[] {
         CHART_COLORS.varianceRatioLine
     );
 
+    const macdVLabel = buildSinglePaneLabel(
+        paneIndices.macdV,
+        'MACD-V',
+        CHART_COLORS.macdVLine
+    );
+
+    const forceIndexLabel = buildSinglePaneLabel(
+        paneIndices.forceIndex,
+        'Force Index',
+        CHART_COLORS.forceIndexLine
+    );
+
+    const obvLabel = buildSinglePaneLabel(
+        paneIndices.obv,
+        'OBV',
+        CHART_COLORS.obvLine
+    );
+
+    const atrLabel = buildSinglePaneLabel(
+        paneIndices.atr,
+        'ATR',
+        CHART_COLORS.atrLine
+    );
+
+    const yangZhangLabel = buildSinglePaneLabel(
+        paneIndices.yangZhang,
+        'Yang-Zhang',
+        CHART_COLORS.yangZhangLine
+    );
+
+    const ewmaVolatilityLabel = buildSinglePaneLabel(
+        paneIndices.ewmaVolatility,
+        'EWMA Vol',
+        CHART_COLORS.ewmaVolatilityLine
+    );
+
     return [
         ...rsiLabel,
         ...macdLabel,
@@ -185,5 +221,11 @@ export function buildPaneLabels(paneIndices: PaneIndices): PaneLabelConfig[] {
         ...bollingerPercentBLabel,
         ...hurstLabel,
         ...varianceRatioLabel,
+        ...macdVLabel,
+        ...forceIndexLabel,
+        ...obvLabel,
+        ...atrLabel,
+        ...yangZhangLabel,
+        ...ewmaVolatilityLabel,
     ];
 }


### PR DESCRIPTION
## 요약
미사용 보조지표 렌더링 3차. unbounded 단일-라인 오실레이터 6종(MACD-V·Force Index·OBV·ATR·Yang-Zhang·EWMA Vol)을 차트 pane으로 렌더한다.

> ⚠️ Stacked PR — base가 `feat/render-unused-indicators`(#577)입니다. #577 머지 후 base를 master로 변경하세요. (#577은 다시 #575 위에 stacked.)

## 변경 내용
- 레지스트리 +6 메타(macdV·forceIndex→모멘텀, obv→볼륨, atr·yangZhang·ewmaVolatility→변동성). 신규 카테고리 없음.
- 6 pane 훅: group-B useMfiChart 패턴 복제. macdV·forceIndex는 0 기준선, 나머지 4종은 기준선 없음(양수 변동성/누적).
- 기준선 상수 2개(MACD_V/FORCE_INDEX zero) + 색 6종(전부 미사용 hex, 중복 검증).
- pane label 6종(buildSinglePaneLabel 재사용), StockChart binding 18→24.
- paneIndex 일반화·모달·기존 13개 pane 훅 무변경.
- E2E: ATR pane 토글(.pane-indicator-label 스코프).

## 검증
- 신규 6훅 커버리지 100% stmts / 95% branch / 100% func / 100% lines
- 전체 unit 5126 pass, tsc clean, lint clean, build exit 0
- E2E --list 6 tests 로드(풀 실행은 pre-push/CI)
- review-agent approved (round 1, findings 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)