### PR TITLE
feat(chart): render Keltner/Donchian price overlays (group A-bands)

### DIFF
--- a/docs/superpowers/plans/2026-06-07-render-group-a-bands.md
+++ b/docs/superpowers/plans/2026-06-07-render-group-a-bands.md
@@ -1,0 +1,481 @@
+# 그룹 A-밴드 (Keltner·Donchian 오버레이) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keltner·Donchian 채널 2종을 가격 차트 오버레이(Pane 0)로 렌더한다. keltner는 부드러운 곡선 3선, donchian은 계단형(WithSteps) 3선 + 점선 middle.
+
+**Architecture:** `useBollingerOverlay`의 overlay 메커니즘(자체 `useState(isVisible)`+toggle, Pane 0에 3시리즈)을 복제한다. keltner/donchian은 bollinger와 동일한 `{upper,middle,lower}` 구조라 `buildSeriesData` 제네릭을 재사용한다. 레지스트리 kind:`'overlay'` 메타 추가 → 모달 자동 노출. `useIndicatorVisibility`(pane 전용)·paneIndex는 무관.
+
+**Tech Stack:** Next.js 16 / React 19 (`'use client'`), lightweight-charts 5.1.0 (AreaSeries·LineSeries·LineType·LineStyle), `@y0ngha/siglens-core`(IndicatorResult), vitest + RTL, Playwright.
+
+**작업 위치:** 워크트리 `/Users/y0ngha/Project/siglens-group-a`, 브랜치 `feat/render-group-a-bands` (base `feat/render-group-c-simple`=#580). 스펙: `docs/superpowers/specs/2026-06-07-render-group-a-bands-design.md`.
+
+**커밋 규칙:** 커밋은 `git-agent`에 위임. `--no-verify` 금지.
+
+---
+
+## File Structure
+
+**신규**
+- `src/widgets/chart/hooks/useKeltnerOverlay.ts` + 테스트
+- `src/widgets/chart/hooks/useDonchianOverlay.ts` + 테스트
+
+**수정**
+- `src/widgets/chart/model/indicatorRegistry.ts` — IndicatorKey +2, INDICATOR_REGISTRY +2 (overlay)
+- `src/shared/lib/chartColors.ts` — 8색 (keltner/donchian × upper/middle/lower/background)
+- `src/widgets/chart/utils/overlayLabelUtils.ts` — keltnerVisible/donchianVisible params + KC/DC config
+- `src/widgets/chart/StockChart.tsx` — 2 훅 호출 + binding 24→26 + overlayLabelConfigs params
+- 각 테스트(registry·overlayLabelUtils·StockChart)
+- `e2e/specs/chart-indicators.spec.ts`
+
+**불변 (회귀 위험 0)**
+- 기존 overlay 훅(bollinger/MA/EMA/ichimoku/VP), pane 훅(13종), `useIndicatorVisibility`, `IndicatorSettingsModal`, `buildSeriesData`
+
+---
+
+## Task 0: 워크트리 node_modules
+
+- [ ] **Step 1**: `cp -al /Users/y0ngha/Project/siglens/node_modules /Users/y0ngha/Project/siglens-group-a/node_modules && rm -rf /Users/y0ngha/Project/siglens-group-a/node_modules/node_modules` (에러 없음)
+- [ ] **Step 2**: `cd /Users/y0ngha/Project/siglens-group-a && yarn test src/widgets/chart/__tests__/model/indicatorRegistry.test.ts 2>&1 | tail -6` (기존 24 지표 PASS)
+
+---
+
+## Task 1: 레지스트리 2 overlay 메타
+
+**Files:** Modify `src/widgets/chart/model/indicatorRegistry.ts`, `src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`
+
+- [ ] **Step 1: 테스트 갱신 (실패 유도)**
+
+count 26으로, overlay 검증 추가:
+```ts
+it('registers exactly the 26 modal-target indicators', () => {
+    expect(INDICATOR_REGISTRY).toHaveLength(26);
+});
+
+it('registers keltner/donchian as volatility overlays', () => {
+    expect(INDICATOR_META.keltnerChannel).toMatchObject({ category: 'volatility', kind: 'overlay' });
+    expect(INDICATOR_META.donchianChannel).toMatchObject({ category: 'volatility', kind: 'overlay' });
+});
+```
+(기존 "registers exactly the 24" → 26.)
+
+- [ ] **Step 2: Run → 실패** `cd /Users/y0ngha/Project/siglens-group-a && yarn test src/widgets/chart/__tests__/model/indicatorRegistry.test.ts` (length 24≠26)
+
+- [ ] **Step 3: 구현**
+
+`indicatorRegistry.ts`:
+1. `IndicatorKey` union에 `'keltnerChannel' | 'donchianChannel'` 추가.
+2. `INDICATOR_REGISTRY` 끝에:
+```ts
+    { key: 'keltnerChannel', label: 'Keltner', category: 'volatility', kind: 'overlay' },
+    { key: 'donchianChannel', label: 'Donchian', category: 'volatility', kind: 'overlay' },
+```
+(카테고리 union·CATEGORY_LABELS 무변경. 이 두 키는 kind:'overlay'라 useIndicatorVisibility의 pane 필터에서 자동 제외됨.)
+
+> 주의: `makePaneIndices` 헬퍼(paneLabelUtils.test)가 `satisfies PaneIndices`(=Record<IndicatorKey,number>)라 키 2개 추가 시 비충족. `paneLabelUtils.test.ts`의 makePaneIndices base에 `keltnerChannel: INACTIVE_PANE_INDEX, donchianChannel: INACTIVE_PANE_INDEX` 추가(buildPaneLabels는 overlay 키 안 읽으므로 INACTIVE로 무방).
+
+- [ ] **Step 4: Run → 통과** `yarn test src/widgets/chart/__tests__/model/indicatorRegistry.test.ts src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts && npx tsc --noEmit 2>&1 | tail -2`
+
+- [ ] **Step 5: Commit (git-agent)** — `feat(chart): register Keltner/Donchian overlay indicators`
+
+---
+
+## Task 2: 색상 8개 + 중복 검증
+
+**Files:** Modify `src/shared/lib/chartColors.ts`
+
+- [ ] **Step 1: 색 추가**
+
+`CHART_COLORS`에 추가 (섹션 레이블 주석 없이):
+```ts
+    keltnerUpper: '#5eead4',
+    keltnerMiddle: '#14b8a6',
+    keltnerLower: '#5eead4',
+    keltnerBackground: '#5eead420',
+    donchianUpper: '#fcd34d',
+    donchianMiddle: '#d97706',
+    donchianLower: '#fcd34d',
+    donchianBackground: '#fcd34d20',
+```
+> keltner는 teal 계열(upper/lower 동일 색 + middle 진한 teal), donchian은 amber 계열. bollinger와 동일하게 upper/lower 같은 색 + middle 구분색 패턴.
+
+- [ ] **Step 2: 라인색 중복 검증**
+
+```bash
+cd /Users/y0ngha/Project/siglens-group-a
+grep -oE "#[0-9a-fA-F]{6}" src/shared/lib/chartColors.ts | sort | uniq -d
+```
+Expected: keltnerUpper/Lower(#5eead4)·donchianUpper/Lower(#fcd34d)는 의도적 쌍이라 중복으로 나옴 — 이건 허용(bollinger도 upper/lower 동일). 그 외에 **다른 지표 라인색과 겹치는 hex가 나오면** 교체. 확인: `grep -oE "#[0-9a-fA-F]{6}" src/shared/lib/chartColors.ts | sort | uniq -c | sort -rn | head` 로 #5eead4·#fcd34d·#14b8a6·#d97706가 기존 다른 키와 안 겹치는지(각 2회 이하, 신규 keltner/donchian 내부 쌍만) 확인. 겹치면 미사용 hex로 교체.
+
+- [ ] **Step 3: tsc + lint** `npx tsc --noEmit 2>&1 | tail -2; echo TSC=$? && yarn lint 2>&1 | tail -3` (clean)
+
+- [ ] **Step 4: Commit (git-agent)** — `feat(chart): add Keltner/Donchian overlay colors`
+
+---
+
+## Task 3: useKeltnerOverlay 훅 (bollinger 복제)
+
+**Files:** Create `src/widgets/chart/hooks/useKeltnerOverlay.ts`, test
+
+- [ ] **Step 1: 테스트 작성 (실패 유도)**
+
+먼저 `src/widgets/chart/__tests__/hooks/useBollingerOverlay.test.ts`를 읽어 mock 구조(addSeries/removeSeries/setData spy)를 따른다. Create `useKeltnerOverlay.test.ts`를 그 복제로: indicators fixture `{ ...EMPTY, keltnerChannel: [{upper:11,middle:10,lower:9}, ...] }`, 검증 — toggle()로 isVisible true→addSeries 3회(upper/middle/lower), false→removeSeries, 데이터 sync(setData 3회), worst-case(`keltnerChannel: []`→setData 미호출). useBollingerOverlay.test의 케이스를 1:1 키 치환(bollinger→keltnerChannel).
+
+- [ ] **Step 2: Run → 실패** `cd /Users/y0ngha/Project/siglens-group-a && yarn test src/widgets/chart/__tests__/hooks/useKeltnerOverlay.test.ts` (모듈 없음)
+
+- [ ] **Step 3: 구현**
+
+Create `src/widgets/chart/hooks/useKeltnerOverlay.ts` (useBollingerOverlay 복제, 색·키 치환):
+```ts
+'use client';
+
+import type { RefObject } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useEffectEvent,
+    useRef,
+    useState,
+} from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import { AreaSeries, LineSeries } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { buildSeriesData } from '../utils/seriesDataUtils';
+
+interface UseKeltnerOverlayParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+}
+
+interface UseKeltnerOverlayReturn {
+    isVisible: boolean;
+    toggle: () => void;
+}
+
+export function useKeltnerOverlay({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+}: UseKeltnerOverlayParams): UseKeltnerOverlayReturn {
+    const [isVisible, setIsVisible] = useState(false);
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const upperSeriesRef = useRef<ISeriesApi<'Area'> | null>(null);
+    const middleSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+    const lowerSeriesRef = useRef<ISeriesApi<'Area'> | null>(null);
+
+    const toggle = useCallback(() => {
+        setIsVisible(prev => !prev);
+    }, []);
+
+    // chart 인스턴스 교체 시 ref만 초기화 (removeSeries 불필요 — 이전 chart는 부모가 소멸)
+    const clearSeriesRefs = useEffectEvent(() => {
+        upperSeriesRef.current = null;
+        middleSeriesRef.current = null;
+        lowerSeriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (upperSeriesRef.current) {
+            chart.removeSeries(upperSeriesRef.current);
+            upperSeriesRef.current = null;
+        }
+        if (middleSeriesRef.current) {
+            chart.removeSeries(middleSeriesRef.current);
+            middleSeriesRef.current = null;
+        }
+        if (lowerSeriesRef.current) {
+            chart.removeSeries(lowerSeriesRef.current);
+            lowerSeriesRef.current = null;
+        }
+    });
+
+    useEffect(() => {
+        const chart = chartRef.current;
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+        if (!chart) return;
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (!upperSeriesRef.current) {
+            upperSeriesRef.current = chart.addSeries(AreaSeries, {
+                topColor: CHART_COLORS.keltnerBackground,
+                bottomColor: CHART_COLORS.keltnerBackground,
+                lineColor: CHART_COLORS.keltnerUpper,
+                lineWidth,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        upperSeriesRef.current.applyOptions({ lineWidth });
+
+        if (!middleSeriesRef.current) {
+            middleSeriesRef.current = chart.addSeries(LineSeries, {
+                color: CHART_COLORS.keltnerMiddle,
+                lineWidth,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        middleSeriesRef.current.applyOptions({ lineWidth });
+
+        if (!lowerSeriesRef.current) {
+            lowerSeriesRef.current = chart.addSeries(AreaSeries, {
+                topColor: CHART_COLORS.background,
+                bottomColor: CHART_COLORS.background,
+                lineColor: CHART_COLORS.keltnerLower,
+                lineWidth,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        lowerSeriesRef.current.applyOptions({ lineWidth });
+    }, [chartRef, isVisible, lineWidth]);
+
+    useEffect(() => {
+        if (!isVisible) return;
+        const { keltnerChannel } = indicators;
+        if (!keltnerChannel.length) return;
+        if (
+            !upperSeriesRef.current ||
+            !middleSeriesRef.current ||
+            !lowerSeriesRef.current
+        )
+            return;
+        upperSeriesRef.current.setData(
+            buildSeriesData(bars, keltnerChannel, 'upper')
+        );
+        middleSeriesRef.current.setData(
+            buildSeriesData(bars, keltnerChannel, 'middle')
+        );
+        lowerSeriesRef.current.setData(
+            buildSeriesData(bars, keltnerChannel, 'lower')
+        );
+    }, [indicators, bars, isVisible]);
+
+    return { isVisible, toggle };
+}
+```
+> `CHART_COLORS.background`는 lower Area의 채움 제거용(bollinger와 동일 — upper만 채우고 lower는 투명). 기존 bollinger 훅 코드와 정확히 일치하는지 확인.
+
+- [ ] **Step 4: Run → 통과** `yarn test src/widgets/chart/__tests__/hooks/useKeltnerOverlay.test.ts`
+
+- [ ] **Step 5: Commit (git-agent)** — `feat(chart): add useKeltnerOverlay (curved 3-band overlay)`
+
+---
+
+## Task 4: useDonchianOverlay 훅 (keltner 복제 + 계단형)
+
+**Files:** Create `src/widgets/chart/hooks/useDonchianOverlay.ts`, test
+
+- [ ] **Step 1: 테스트 작성 (실패 유도)**
+
+`useKeltnerOverlay.test.ts`를 복제해 키만 `donchianChannel`로. 추가로 **WithSteps 검증**: upper/lower `addSeries` 호출 옵션에 `lineType: LineType.WithSteps`, middle에 `lineStyle: LineStyle.Dashed`가 포함됐는지 단언(`expect(mockAddSeries).toHaveBeenCalledWith(AreaSeries, expect.objectContaining({ lineType: ... }))` — lightweight-charts mock의 LineType/LineStyle enum 값에 맞춤). 나머지 케이스(3시리즈 생성/제거/데이터/빈배열)는 keltner와 동일.
+
+- [ ] **Step 2: Run → 실패** `yarn test src/widgets/chart/__tests__/hooks/useDonchianOverlay.test.ts`
+
+- [ ] **Step 3: 구현**
+
+`useKeltnerOverlay.ts`를 복사해 Create `useDonchianOverlay.ts`. 변경점:
+- 함수명 `useDonchianOverlay`, 인터페이스명 `UseDonchianOverlay*`.
+- import에 `LineType, LineStyle` 추가: `import { AreaSeries, LineSeries, LineType, LineStyle } from 'lightweight-charts';`
+- 데이터 accessor: `indicators.donchianChannel`.
+- 색: `donchianUpper/donchianMiddle/donchianLower/donchianBackground`.
+- **upper(Area) addSeries 옵션에 `lineType: LineType.WithSteps` 추가**:
+```ts
+            upperSeriesRef.current = chart.addSeries(AreaSeries, {
+                topColor: CHART_COLORS.donchianBackground,
+                bottomColor: CHART_COLORS.donchianBackground,
+                lineColor: CHART_COLORS.donchianUpper,
+                lineType: LineType.WithSteps,
+                lineWidth,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+```
+- **middle(Line) 옵션에 `lineType: LineType.WithSteps` + `lineStyle: LineStyle.Dashed`**:
+```ts
+            middleSeriesRef.current = chart.addSeries(LineSeries, {
+                color: CHART_COLORS.donchianMiddle,
+                lineType: LineType.WithSteps,
+                lineStyle: LineStyle.Dashed,
+                lineWidth,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+```
+- **lower(Area) 옵션에 `lineType: LineType.WithSteps`** (topColor/bottomColor=background, lineColor=donchianLower).
+- 데이터 sync effect는 `buildSeriesData(bars, donchianChannel, 'upper'|'middle'|'lower')`.
+
+- [ ] **Step 4: Run → 통과** `yarn test src/widgets/chart/__tests__/hooks/useDonchianOverlay.test.ts && npx tsc --noEmit 2>&1 | tail -2`
+
+- [ ] **Step 5: Commit (git-agent)** — `feat(chart): add useDonchianOverlay (stepped 3-band overlay)`
+
+---
+
+## Task 5: overlayLabelUtils — KC/DC legend
+
+**Files:** Modify `src/widgets/chart/utils/overlayLabelUtils.ts`, test
+
+- [ ] **Step 1: 테스트 추가 (실패 유도)**
+
+`overlayLabelUtils.test.ts`(있으면)에, 없으면 생성, 검증:
+```ts
+it('builds Keltner/Donchian legend configs when visible', () => {
+    const configs = buildOverlayLabelConfigs({
+        maVisiblePeriods: [], emaVisiblePeriods: [],
+        bollingerVisible: false, ichimokuVisible: false, vpVisible: false,
+        keltnerVisible: true, donchianVisible: true,
+    });
+    const names = configs.map(c => c.name);
+    expect(names).toEqual(expect.arrayContaining([
+        'KC Upper', 'KC Middle', 'KC Lower', 'DC Upper', 'DC Middle', 'DC Lower',
+    ]));
+    const ind = { keltnerChannel: [{ upper: 11, middle: 10, lower: 9 }], donchianChannel: [{ upper: 21, middle: 20, lower: 19 }] } as unknown as Parameters<typeof configs[0]['getValue']>[0];
+    const kcUpper = configs.find(c => c.name === 'KC Upper');
+    expect(kcUpper?.getValue(ind, 0)).toBe(11);
+});
+```
+> 기존 테스트가 params 5개를 넘기면 keltnerVisible/donchianVisible 누락으로 타입 에러 → Step 3 후 그 테스트들도 두 flag(false) 추가 갱신 필요.
+
+- [ ] **Step 2: Run → 실패** `yarn test src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts`
+
+- [ ] **Step 3: 구현**
+
+`overlayLabelUtils.ts`:
+1. `BuildOverlayLabelConfigsParams`에 `keltnerVisible: boolean; donchianVisible: boolean;` 추가.
+2. 함수 destructure에 `keltnerVisible, donchianVisible` 추가.
+3. bollingerConfigs 패턴 따라 추가:
+```ts
+    const keltnerConfigs: OverlayLabelConfig[] = keltnerVisible
+        ? [
+              { name: 'KC Upper', color: CHART_COLORS.keltnerUpper, getValue: (ind, i) => ind.keltnerChannel[i]?.upper ?? null },
+              { name: 'KC Middle', color: CHART_COLORS.keltnerMiddle, getValue: (ind, i) => ind.keltnerChannel[i]?.middle ?? null },
+              { name: 'KC Lower', color: CHART_COLORS.keltnerLower, getValue: (ind, i) => ind.keltnerChannel[i]?.lower ?? null },
+          ]
+        : [];
+    const donchianConfigs: OverlayLabelConfig[] = donchianVisible
+        ? [
+              { name: 'DC Upper', color: CHART_COLORS.donchianUpper, getValue: (ind, i) => ind.donchianChannel[i]?.upper ?? null },
+              { name: 'DC Middle', color: CHART_COLORS.donchianMiddle, getValue: (ind, i) => ind.donchianChannel[i]?.middle ?? null },
+              { name: 'DC Lower', color: CHART_COLORS.donchianLower, getValue: (ind, i) => ind.donchianChannel[i]?.lower ?? null },
+          ]
+        : [];
+```
+(타입 주석은 파일의 기존 `(ind: IndicatorResult, i: number): number | null` 형태에 맞춤.)
+4. return 배열에 `...keltnerConfigs, ...donchianConfigs` 추가.
+
+- [ ] **Step 4: 기존 테스트 params 갱신** — overlayLabelUtils.test의 기존 buildOverlayLabelConfigs 호출에 `keltnerVisible: false, donchianVisible: false` 추가(타입 충족).
+
+- [ ] **Step 5: Run → 통과** `yarn test src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts && npx tsc --noEmit 2>&1 | tail -2`
+
+- [ ] **Step 6: Commit (git-agent)** — `feat(chart): add Keltner/Donchian overlay legend configs`
+
+---
+
+## Task 6: StockChart 통합 (2 훅 + binding 24→26 + legend params)
+
+**Files:** Modify `src/widgets/chart/StockChart.tsx`, `src/widgets/chart/__tests__/StockChart.test.tsx`
+
+- [ ] **Step 1: StockChart.test data-count·keys 갱신 (실패 유도)**
+
+`data-count` → 26: `expect(modal).toHaveAttribute('data-count', '26');`
+`data-keys` 순서 단언 있으면 끝에 `,keltnerChannel,donchianChannel` 추가.
+StockChart.test가 overlay 훅을 mock하는 방식 확인 — bollinger 훅 mock 패턴 따라 useKeltnerOverlay/useDonchianOverlay mock 추가(`() => ({ isVisible: false, toggle: vi.fn() })`).
+
+- [ ] **Step 2: Run → 실패** `yarn test src/widgets/chart/__tests__/StockChart.test.tsx` (data-count 24≠26)
+
+- [ ] **Step 3: StockChart import + 훅 호출**
+
+import 추가:
+```ts
+import { useKeltnerOverlay } from './hooks/useKeltnerOverlay';
+import { useDonchianOverlay } from './hooks/useDonchianOverlay';
+```
+bollinger 훅 호출(L194 근처) 뒤에:
+```ts
+const { isVisible: keltnerVisible, toggle: toggleKeltner } =
+    useKeltnerOverlay(commonHookParams);
+const { isVisible: donchianVisible, toggle: toggleDonchian } =
+    useDonchianOverlay(commonHookParams);
+```
+
+- [ ] **Step 4: overlayLabelConfigs params + deps**
+
+`buildOverlayLabelConfigs({...})` 호출에 `keltnerVisible, donchianVisible` 추가, useMemo deps에도 `keltnerVisible, donchianVisible` 추가.
+
+- [ ] **Step 5: binding 2개 추가 (24→26)**
+
+`indicatorBindings`에 추가:
+```ts
+{ meta: INDICATOR_META.keltnerChannel, active: keltnerVisible, onToggle: toggleKeltner },
+{ meta: INDICATOR_META.donchianChannel, active: donchianVisible, onToggle: toggleDonchian },
+```
+binding useMemo deps에 `keltnerVisible, donchianVisible, toggleKeltner, toggleDonchian` 추가(bollingerVisible/toggleBollinger가 개별로 들어가 있는 패턴 따름).
+
+- [ ] **Step 6: Run → 통과 + 전체 차트** `yarn test src/widgets/chart/__tests__/StockChart.test.tsx && npx tsc --noEmit 2>&1 | tail -2 && yarn test src/widgets/chart 2>&1 | tail -5`
+Expected: data-count=26, tsc 0, 전체 PASS.
+
+- [ ] **Step 7: Commit (git-agent)** — `feat(chart): wire Keltner/Donchian overlays into StockChart`
+
+---
+
+## Task 7: E2E
+
+**Files:** Modify `e2e/specs/chart-indicators.spec.ts`
+
+- [ ] **Step 1: 시나리오 추가**
+
+overlay는 pane label(`.pane-indicator-label`)이 아니라 OverlayLegend로 표시된다. 기존 spec에서 overlay(bollinger 등) 검증 패턴이 있으면 따르고, 없으면 모달 체크 상태 + OverlayLegend 텍스트로 검증:
+```ts
+test('toggles Keltner channel overlay via the modal', async ({ page }) => {
+    await page.goto('/AAPL');
+    await page.getByRole('button', { name: GEAR }).click();
+    const dialog = page.getByRole('dialog');
+    const kc = dialog.getByRole('checkbox', { name: 'Keltner', exact: true });
+    await kc.check();
+    await expect(kc).toBeChecked();
+});
+```
+> overlay 차트 반영을 안정적으로 검증하기 어려우면(crosshair 필요) 모달 체크 상태로 검증. OverlayLegend 텍스트(`KC Upper` 등)는 crosshair hover 시에만 나오므로 E2E에선 모달 토글 검증이 안정적.
+
+- [ ] **Step 2: --list 확인** `cd /Users/y0ngha/Project/siglens-group-a && npx playwright test e2e/specs/chart-indicators.spec.ts --list 2>&1 | tail -10`
+
+- [ ] **Step 3: Commit (git-agent)** — `test(e2e): cover Keltner overlay toggle`
+
+---
+
+## Task 8: 최종 검증
+
+- [ ] **Step 1: Lint** `cd /Users/y0ngha/Project/siglens-group-a && yarn lint 2>&1 | tail -5`
+- [ ] **Step 2: 신규 2훅 커버리지 90%+**
+```bash
+npx vitest run --coverage \
+  --coverage.include='src/widgets/chart/hooks/useKeltnerOverlay.ts' \
+  --coverage.include='src/widgets/chart/hooks/useDonchianOverlay.ts' \
+  --coverage.thresholds.lines=0 --coverage.thresholds.functions=0 --coverage.thresholds.branches=0 --coverage.thresholds.statements=0 \
+  src/widgets/chart/__tests__ 2>&1 | grep -E "All files|Stmts|----" | head
+```
+Expected: 90%+ (미달 시 worst-case 보강).
+- [ ] **Step 3: 전체 유닛** `yarn test 2>&1 | tail -12` (전부 PASS)
+- [ ] **Step 4: 빌드** `yarn build > /tmp/groupa-build.log 2>&1; echo "EXIT=$?"` (EXIT=0)
+- [ ] **Step 5: review-agent 라우팅** — CLAUDE.md 워크플로우(review-agent Opus 4.8 → mistake-managing → git-agent push/PR).
+
+---
+
+## Self-Review (작성자 점검 결과)
+
+- **스펙 커버리지**: §2(자료조사 렌더)=Task 3·4, §5.1(2훅)=Task 3·4, §5.2(레지스트리)=Task 1, §5.3(색)=Task 2, §5.4(legend)=Task 5, §5.5(StockChart)=Task 6, §7(테스트)=각 Task+8. 전부 매핑.
+- **Placeholder**: 없음. useKeltnerOverlay 풀코드 + useDonchianOverlay 정확한 치환점(WithSteps/Dashed 3시리즈). 색은 후보 hex + Task 2 중복 검증 단계.
+- **타입 일관성**: `keltnerChannel`/`donchianChannel` 키, `CHART_COLORS.keltner*`/`donchian*`, `keltnerVisible`/`toggleKeltner`, binding `INDICATOR_META.keltnerChannel` — Task 1·2·3·4 정의와 Task 5·6 사용처 일치.
+- **순서 의존**: 1(레지스트리)→2(색)→3(keltner 훅)→4(donchian 훅, keltner 복제)→5(legend)→6(StockChart)→7(E2E). makePaneIndices fallout은 Task 1에서 처리.
+- **회귀**: 기존 overlay/pane 훅·useIndicatorVisibility·모달 무변경. StockChart binding 24→26 + overlayLabelConfigs params 확장으로 기존 테스트(data-count) 갱신.

--- a/docs/superpowers/specs/2026-06-07-render-group-a-bands-design.md
+++ b/docs/superpowers/specs/2026-06-07-render-group-a-bands-design.md
@@ -1,0 +1,110 @@
+# 미사용 보조지표 렌더링 — 4차: 그룹 A-밴드 (Keltner·Donchian 가격 오버레이)
+
+- **작성일**: 2026-06-07
+- **상태**: 설계 승인됨, 구현 계획 대기
+- **브랜치**: `feat/render-group-a-bands` (base: `feat/render-group-c-simple` = PR #580)
+
+## 1. 배경
+
+미사용 보조지표 렌더링 4차. group-B(#577, bounded pane 7종)·group-C-simple(#580, unbounded pane 6종)에 이어, **가격 오버레이(Pane 0 겹침) 채널 2종**(Keltner·Donchian)을 추가한다. pane 지표와 달리 가격 차트 위에 직접 그려지며, `useBollingerOverlay`/`useMAOverlay`의 overlay 메커니즘을 재사용한다(`useIndicatorVisibility`·paneIndex 무관).
+
+계산은 `@y0ngha/siglens-core`에 있으므로 추가 작업은 siglens 차트 렌더링뿐.
+
+## 2. 자료조사 / 이미지 확인 결과
+
+웹 자료조사(TradingView·StockCharts·Alchemy 등) + 이미지 확인으로 표준 렌더 방식을 확정:
+
+- **Keltner Channel** `{upper, middle, lower}`: middle=EMA, upper/lower=EMA±ATR×배수. **부드러운 곡선 3선** — bollinger와 시각적으로 동일(부드러운 envelope).
+- **Donchian Channel** `{upper, middle, lower}`: upper=N기간 최고가, lower=N기간 최저가, middle=중앙값. **계단형(step line) 3선** — 평평하다 새 고/저점에 점프하는 계단 모양이 표준(이미지 확인). 중간선은 통상 점선. 옅은 밴드 채움.
+
+→ **핵심 렌더 차이**: donchian만 `lineType: LineType.WithSteps`(계단형), keltner는 기본 곡선. 둘 다 bollinger의 3시리즈(upper/middle/lower) 구조를 그대로 복제.
+
+## 3. 목표 / 비목표
+
+### 목표
+- Keltner·Donchian 채널을 가격 오버레이로 렌더(useBollingerOverlay 패턴 복제).
+- donchian은 계단형(WithSteps) + 점선 middle로 표준 모양 구현.
+- 레지스트리 kind:`'overlay'` 메타 추가 → 모달 자동 노출, OverlayLegend에 crosshair 값 표시.
+
+### 비목표 (별도 스펙)
+- 그룹 A 나머지 3종: supertrend(trend 색 라인)·chandelierExit(stop 라인+trend)·parabolicSar(점 마커) — trend 방향 처리·마커 렌더 별도.
+- C-복합 3종(elderRay·squeezeMomentum·regression), 그룹 D(elderImpulse·smc).
+
+## 4. 핵심 결정사항
+
+| 항목 | 결정 | 근거 |
+|---|---|---|
+| 1차 범위 | A-밴드 2종(keltner·donchian) | bollinger 3밴드 복제로 가장 쉬움 (사용자 선택) |
+| 훅 구조 | useBollingerOverlay 복제 (overlay, 자체 isVisible/toggle) | overlay는 pane과 메커니즘 다름; bollinger가 검증된 레퍼런스 |
+| keltner 렌더 | 곡선 3선 (upper Area + middle Line + lower Area) | bollinger와 동일 시각 |
+| donchian 렌더 | 3시리즈 `lineType: WithSteps` + middle 점선 | N기간 최고/최저라 계단형이 표준(이미지 확인) |
+| 카테고리 | 둘 다 `volatility` | 채널/변동성 지표 |
+| 데이터 추출 | `buildSeriesData(bars, <channelArray>, 'upper'\|'middle'\|'lower')` 재사용 | keltner/donchian이 bollinger와 동일 `{upper,middle,lower}` 구조 |
+
+## 5. 아키텍처 (overlay 메커니즘 — pane 아님)
+
+### 5.1 2 overlay 훅
+**`hooks/useKeltnerOverlay.ts`** — `useBollingerOverlay` 복제:
+- 3 시리즈: upper(`AreaSeries`, 채움색=keltnerBackground, lineColor=keltnerUpper), middle(`LineSeries`, keltnerMiddle), lower(`AreaSeries`, lineColor=keltnerLower).
+- 데이터: `buildSeriesData(bars, indicators.keltnerChannel, 'upper'|'middle'|'lower')`.
+- 자체 `useState(isVisible)` + `toggle` 반환.
+
+**`hooks/useDonchianOverlay.ts`** — keltner 복제 + 계단형:
+- 3 시리즈 모두 `lineType: LineType.WithSteps`. middle은 `lineStyle: LineStyle.Dashed`.
+- 데이터: `buildSeriesData(bars, indicators.donchianChannel, ...)`.
+
+### 5.2 레지스트리 (`model/indicatorRegistry.ts`)
+- `IndicatorKey` union +2 (`keltnerChannel`·`donchianChannel`).
+- `INDICATOR_REGISTRY` +2: `{ key:'keltnerChannel', label:'Keltner', category:'volatility', kind:'overlay' }`, `{ key:'donchianChannel', label:'Donchian', category:'volatility', kind:'overlay' }`.
+- 카테고리 union·CATEGORY_LABELS 무변경.
+- **paneIndex 무관**: `useIndicatorVisibility`는 kind:'pane'만 추리므로 overlay 키는 자동 제외 — 무변경 확인.
+
+### 5.3 색상 (`shared/lib/chartColors.ts`)
+- keltner: keltnerUpper/keltnerMiddle/keltnerLower/keltnerBackground.
+- donchian: donchianUpper/donchianMiddle/donchianLower/donchianBackground.
+- bollinger 색(#818cf8 계열)·기존 팔레트와 **라인색 중복 회피**(구현 시 grep 검증).
+
+### 5.4 OverlayLegend (`utils/overlayLabelUtils.ts`)
+- `buildOverlayLabelConfigs` params에 `keltnerVisible`·`donchianVisible` 추가.
+- KC Upper/Middle/Lower, DC Upper/Middle/Lower config (`getValue: ind.keltnerChannel[i]?.upper ?? null` 등).
+
+### 5.5 StockChart (`StockChart.tsx`)
+- `useKeltnerOverlay`·`useDonchianOverlay` 호출 → `{ isVisible, toggle }`.
+- `buildOverlayLabelConfigs` 호출에 keltnerVisible/donchianVisible 전달 + deps.
+- `indicatorBindings`에 2 overlay binding 추가(24→26): `{ meta: INDICATOR_META.keltnerChannel, active: keltnerVisible, onToggle: toggleKeltner }`.
+
+## 6. 데이터 흐름
+```
+indicatorRegistry (keltnerChannel·donchianChannel = kind:'overlay')
+        │
+StockChart: useKeltnerOverlay/useDonchianOverlay (자체 visible state) 호출
+        │
+binding 조립(26개) → IndicatorSettingsModal 자동 노출(무수정)
+        │
+체크 → toggle → 훅이 Pane 0에 3시리즈 생성/제거
+        │
+OverlayLegend: crosshair 시 KC/DC upper/middle/lower 값 표시
+```
+
+## 7. 테스트 전략 (vitest + RTL, 커버리지 90%+, happy + worst)
+
+### 7.1 단위
+- **useKeltnerOverlay·useDonchianOverlay**: bollinger 훅 테스트 복제 — 3 시리즈 생성(isVisible)/제거(toggle off), 데이터 세팅, **worst-case**(빈 배열 → setData 미호출). donchian은 `addSeries` 옵션에 `lineType: WithSteps` 포함 검증.
+- **레지스트리**: 26개 등록, keltner/donchian이 kind:'overlay'·category:'volatility', 키 중복 없음.
+- **overlayLabelUtils**: keltnerVisible/donchianVisible 시 KC/DC 6개 config 생성, getValue 정확.
+
+### 7.2 통합 / E2E
+- E2E(`chart-indicators.spec.ts` 확장): 모달에서 Keltner 체크 → OverlayLegend 또는 차트 반영 확인. (overlay는 pane label이 아니라 OverlayLegend — 셀렉터는 기존 overlay E2E 패턴 따름. 없으면 모달 체크 상태로 검증.)
+
+### 7.3 회귀
+- 기존 overlay 훅(bollinger/MA/EMA/ichimoku/VP)·pane 훅·`useIndicatorVisibility` 무변경. StockChart binding 추가(24→26) + overlayLabelConfigs params 확장으로 인한 기존 테스트(data-count) 갱신.
+
+## 8. 확장성 검증
+- supertrend/chandelier/parabolicSar(그룹 A 나머지) 추가 시: overlay 훅 + 레지스트리 + binding. 단 trend 색·마커는 새 설계.
+
+## 9. FSD 준수
+- 훅·레지스트리·색·legend: `widgets/chart` 내부 + `shared/lib/chartColors`. core import(IndicatorResult). 레이어 정상. core 무변경.
+
+## 10. 후속 (별도 스펙)
+- 그룹 A 나머지 3종(supertrend·chandelier·parabolicSar — trend/마커)
+- C-복합 3종, 그룹 D(elderImpulse·smc), 전송 페이로드 슬림화

--- a/e2e/specs/chart-indicators.spec.ts
+++ b/e2e/specs/chart-indicators.spec.ts
@@ -94,4 +94,22 @@ test.describe('chart indicator settings modal', () => {
             page.locator('.pane-indicator-label').filter({ hasText: 'ATR' })
         ).toBeVisible();
     });
+
+    test('toggles the Keltner channel overlay via the modal', async ({
+        page,
+    }) => {
+        await page.goto('/AAPL');
+        await page.getByRole('button', { name: GEAR }).click();
+        const dialog = page.getByRole('dialog');
+        // Keltner는 가격 OVERLAY(페인 아님) — OverlayLegend 라벨이 crosshair
+        // hover에만 나타나 E2E에서 fragile하다. 안정적인 모달 체크박스 상태로
+        // 검증한다. 'Keltner'는 변동성 카테고리 체크박스이며 exact로 substring
+        // 충돌을 피한다.
+        const keltner = dialog.getByRole('checkbox', {
+            name: 'Keltner',
+            exact: true,
+        });
+        await keltner.check();
+        await expect(keltner).toBeChecked();
+    });
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,6 +43,14 @@
     /* Chart — 볼린저 밴드 */
     --color-chart-bollinger: #818cf8;
 
+    /* Chart — 켈트너 채널 */
+    --color-chart-keltner-upper: #5eead4;
+    --color-chart-keltner-middle: #14b8a6;
+
+    /* Chart — 돈치안 채널 */
+    --color-chart-donchian-upper: #fcd34d;
+    --color-chart-donchian-middle: #d97706;
+
     /* Chart — MACD */
     --color-chart-macd: #3b82f6;
     --color-chart-signal: #f59e0b;

--- a/src/shared/lib/chartColors.ts
+++ b/src/shared/lib/chartColors.ts
@@ -27,6 +27,15 @@ export const CHART_COLORS = {
     bollingerLower: '#818cf8',
     bollingerBackground: '#818cf820',
 
+    keltnerUpper: '#5eead4',
+    keltnerMiddle: '#14b8a6',
+    keltnerLower: '#5eead4',
+    keltnerBackground: '#5eead420',
+    donchianUpper: '#fcd34d',
+    donchianMiddle: '#d97706',
+    donchianLower: '#fcd34d',
+    donchianBackground: '#fcd34d20',
+
     // MACD
     macdLine: '#3b82f6',
     macdSignal: '#f59e0b',

--- a/src/widgets/chart/StockChart.tsx
+++ b/src/widgets/chart/StockChart.tsx
@@ -21,6 +21,8 @@ import { getTimeFormatter } from '@/shared/lib/timeFormat';
 import { useMAOverlay } from './hooks/useMAOverlay';
 import { useEMAOverlay } from './hooks/useEMAOverlay';
 import { useBollingerOverlay } from './hooks/useBollingerOverlay';
+import { useKeltnerOverlay } from './hooks/useKeltnerOverlay';
+import { useDonchianOverlay } from './hooks/useDonchianOverlay';
 import { useMACDChart } from './hooks/useMACDChart';
 import { useRSIChart } from './hooks/useRSIChart';
 import { useDMIChart } from './hooks/useDMIChart';
@@ -194,6 +196,12 @@ export function StockChart({
     const { isVisible: bollingerVisible, toggle: toggleBollinger } =
         useBollingerOverlay(commonHookParams);
 
+    const { isVisible: keltnerVisible, toggle: toggleKeltner } =
+        useKeltnerOverlay(commonHookParams);
+
+    const { isVisible: donchianVisible, toggle: toggleDonchian } =
+        useDonchianOverlay(commonHookParams);
+
     const { isVisible: vpVisible, toggle: toggleVP } =
         useVolumeProfileOverlay(commonHookParams);
 
@@ -365,6 +373,8 @@ export function StockChart({
                 bollingerVisible,
                 ichimokuVisible,
                 vpVisible,
+                keltnerVisible,
+                donchianVisible,
             }),
         [
             maVisiblePeriods,
@@ -372,6 +382,8 @@ export function StockChart({
             bollingerVisible,
             ichimokuVisible,
             vpVisible,
+            keltnerVisible,
+            donchianVisible,
         ]
     );
 
@@ -519,8 +531,18 @@ export function StockChart({
                 active: visible.ewmaVolatility,
                 onToggle: () => toggle('ewmaVolatility'),
             },
+            {
+                meta: INDICATOR_META.keltnerChannel,
+                active: keltnerVisible,
+                onToggle: toggleKeltner,
+            },
+            {
+                meta: INDICATOR_META.donchianChannel,
+                active: donchianVisible,
+                onToggle: toggleDonchian,
+            },
         ],
-        // deps에 visible 객체 전체를 둔다 — 한 지표 토글 시 24개 binding 전체가 재조립되지만
+        // deps에 visible 객체 전체를 둔다 — 한 지표 토글 시 26개 binding 전체가 재조립되지만
         // 항목 수가 적어 비용은 무시할 만하며, 개별 visible 키를 나열하는 것보다 명료하다.
         [
             maVisiblePeriods,
@@ -530,11 +552,15 @@ export function StockChart({
             toggle,
             bollingerVisible,
             vpVisible,
+            keltnerVisible,
+            donchianVisible,
             toggleMAPeriod,
             toggleEMAPeriod,
             toggleIchimoku,
             toggleBollinger,
             toggleVP,
+            toggleKeltner,
+            toggleDonchian,
         ]
     );
 

--- a/src/widgets/chart/__tests__/StockChart.test.tsx
+++ b/src/widgets/chart/__tests__/StockChart.test.tsx
@@ -213,6 +213,20 @@ vi.mock('@/widgets/chart/hooks/useIchimokuOverlay', () => ({
     }),
 }));
 
+vi.mock('@/widgets/chart/hooks/useKeltnerOverlay', () => ({
+    useKeltnerOverlay: () => ({
+        isVisible: false,
+        toggle: vi.fn(),
+    }),
+}));
+
+vi.mock('@/widgets/chart/hooks/useDonchianOverlay', () => ({
+    useDonchianOverlay: () => ({
+        isVisible: false,
+        toggle: vi.fn(),
+    }),
+}));
+
 vi.mock('@/widgets/chart/hooks/useCandlePatternMarkers', () => ({
     useCandlePatternMarkers: vi.fn(),
 }));
@@ -394,13 +408,13 @@ describe('StockChart', () => {
         );
     });
 
-    it('renders IndicatorSettingsModal with 24 indicator bindings', () => {
+    it('renders IndicatorSettingsModal with 26 indicator bindings', () => {
         render(<StockChart bars={mockBars} timeframe="1Day" />);
         const modal = screen.getByTestId('indicator-settings-modal');
-        expect(modal).toHaveAttribute('data-count', '24');
+        expect(modal).toHaveAttribute('data-count', '26');
         expect(modal).toHaveAttribute(
             'data-keys',
-            'ma,ema,ichimoku,rsi,macd,dmi,stochastic,stochRsi,cci,bollinger,volumeProfile,mfi,williamsR,connorsRsi,cmf,bollingerPercentB,hurst,varianceRatio,macdV,forceIndex,obv,atr,yangZhang,ewmaVolatility'
+            'ma,ema,ichimoku,rsi,macd,dmi,stochastic,stochRsi,cci,bollinger,volumeProfile,mfi,williamsR,connorsRsi,cmf,bollingerPercentB,hurst,varianceRatio,macdV,forceIndex,obv,atr,yangZhang,ewmaVolatility,keltnerChannel,donchianChannel'
         );
     });
 

--- a/src/widgets/chart/__tests__/hooks/useDonchianOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useDonchianOverlay.test.ts
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { LineStyle, LineType } from 'lightweight-charts';
+import { useDonchianOverlay } from '../../hooks/useDonchianOverlay';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(
+    (_definition: unknown, _options: Record<string, unknown>) => ({
+        setData: mockSetData,
+        applyOptions: mockApplyOptions,
+    })
+);
+
+vi.mock('lightweight-charts', () => ({
+    AreaSeries: 'AreaSeries',
+    LineSeries: 'LineSeries',
+    // Donchian renders as stepped lines (middle dashed). Mirror the real
+    // enum values so option assertions match production behavior.
+    LineType: { Simple: 0, WithSteps: 1, Curved: 2 },
+    LineStyle: {
+        Solid: 0,
+        Dotted: 1,
+        Dashed: 2,
+        LargeDashed: 3,
+        SparseDotted: 4,
+    },
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useDonchianOverlay
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = {
+    donchianChannel: [],
+} as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    donchianChannel: [{ upper: 21, middle: 20, lower: 19 }],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useDonchianOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns isVisible false initially', () => {
+        const { result } = renderHook(() =>
+            useDonchianOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('toggles isVisible when toggle is called', () => {
+        const { result } = renderHook(() =>
+            useDonchianOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+        expect(result.current.isVisible).toBe(true);
+
+        act(() => {
+            result.current.toggle();
+        });
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useDonchianOverlay({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates three series (upper, middle, lower) when visible and chart exists', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useDonchianOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockAddSeries).toHaveBeenCalledTimes(3);
+    });
+
+    it('removes series when toggled off', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useDonchianOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+
+    it('sets data on three series when visible with data', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useDonchianOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockSetData).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not set data when donchianChannel is empty', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useDonchianOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('creates all three series as stepped lines', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useDonchianOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockAddSeries).toHaveBeenCalledTimes(3);
+        for (const call of mockAddSeries.mock.calls) {
+            expect(call[1]).toEqual(
+                expect.objectContaining({ lineType: LineType.WithSteps })
+            );
+        }
+    });
+
+    it('renders the middle line as a dashed stepped line', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useDonchianOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockAddSeries).toHaveBeenCalledWith(
+            'LineSeries',
+            expect.objectContaining({
+                lineType: LineType.WithSteps,
+                lineStyle: LineStyle.Dashed,
+            })
+        );
+    });
+
+    it('provides stable toggle function reference', () => {
+        const { result, rerender } = renderHook(() =>
+            useDonchianOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+
+        const firstToggle = result.current.toggle;
+        rerender();
+        expect(result.current.toggle).toBe(firstToggle);
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useDonchianOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useDonchianOverlay.test.ts
@@ -138,7 +138,7 @@ describe('useDonchianOverlay', () => {
             result.current.toggle();
         });
 
-        expect(mockRemoveSeries).toHaveBeenCalled();
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(3);
     });
 
     it('sets data on three series when visible with data', () => {

--- a/src/widgets/chart/__tests__/hooks/useKeltnerOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useKeltnerOverlay.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useKeltnerOverlay } from '../../hooks/useKeltnerOverlay';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    AreaSeries: 'AreaSeries',
+    LineSeries: 'LineSeries',
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useKeltnerOverlay
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = {
+    keltnerChannel: [],
+} as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    keltnerChannel: [{ upper: 11, middle: 10, lower: 9 }],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useKeltnerOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns isVisible false initially', () => {
+        const { result } = renderHook(() =>
+            useKeltnerOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('toggles isVisible when toggle is called', () => {
+        const { result } = renderHook(() =>
+            useKeltnerOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+        expect(result.current.isVisible).toBe(true);
+
+        act(() => {
+            result.current.toggle();
+        });
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useKeltnerOverlay({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates three series (upper, middle, lower) when visible and chart exists', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useKeltnerOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockAddSeries).toHaveBeenCalledTimes(3);
+    });
+
+    it('removes series when toggled off', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useKeltnerOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+
+    it('sets data on three series when visible with data', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useKeltnerOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockSetData).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not set data when keltnerChannel is empty', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useKeltnerOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+
+        act(() => {
+            result.current.toggle();
+        });
+
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('provides stable toggle function reference', () => {
+        const { result, rerender } = renderHook(() =>
+            useKeltnerOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+
+        const firstToggle = result.current.toggle;
+        rerender();
+        expect(result.current.toggle).toBe(firstToggle);
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useKeltnerOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useKeltnerOverlay.test.ts
@@ -125,7 +125,7 @@ describe('useKeltnerOverlay', () => {
             result.current.toggle();
         });
 
-        expect(mockRemoveSeries).toHaveBeenCalled();
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(3);
     });
 
     it('sets data on three series when visible with data', () => {

--- a/src/widgets/chart/__tests__/model/indicatorRegistry.test.ts
+++ b/src/widgets/chart/__tests__/model/indicatorRegistry.test.ts
@@ -14,8 +14,19 @@ function bindingFor(key: IndicatorKey, active = false): IndicatorBinding {
 }
 
 describe('indicatorRegistry', () => {
-    it('registers exactly the 24 modal-target indicators', () => {
-        expect(INDICATOR_REGISTRY).toHaveLength(24);
+    it('registers exactly the 26 modal-target indicators', () => {
+        expect(INDICATOR_REGISTRY).toHaveLength(26);
+    });
+
+    it('registers keltner/donchian as volatility overlays', () => {
+        expect(INDICATOR_META.keltnerChannel).toMatchObject({
+            category: 'volatility',
+            kind: 'overlay',
+        });
+        expect(INDICATOR_META.donchianChannel).toMatchObject({
+            category: 'volatility',
+            kind: 'overlay',
+        });
     });
 
     it('has no duplicate keys', () => {

--- a/src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts
@@ -66,6 +66,8 @@ describe('buildOverlayLabelConfigs', () => {
                 bollingerVisible: false,
                 ichimokuVisible: false,
                 vpVisible: false,
+                keltnerVisible: false,
+                donchianVisible: false,
             });
 
             expect(result).toEqual([]);
@@ -80,6 +82,8 @@ describe('buildOverlayLabelConfigs', () => {
                 bollingerVisible: false,
                 ichimokuVisible: false,
                 vpVisible: false,
+                keltnerVisible: false,
+                donchianVisible: false,
             });
 
             expect(result).toHaveLength(2);
@@ -96,6 +100,8 @@ describe('buildOverlayLabelConfigs', () => {
                 bollingerVisible: false,
                 ichimokuVisible: false,
                 vpVisible: false,
+                keltnerVisible: false,
+                donchianVisible: false,
             });
 
             expect(result).toHaveLength(1);
@@ -111,6 +117,8 @@ describe('buildOverlayLabelConfigs', () => {
                 bollingerVisible: true,
                 ichimokuVisible: false,
                 vpVisible: false,
+                keltnerVisible: false,
+                donchianVisible: false,
             });
 
             expect(result).toHaveLength(3);
@@ -128,6 +136,8 @@ describe('buildOverlayLabelConfigs', () => {
                 bollingerVisible: false,
                 ichimokuVisible: true,
                 vpVisible: false,
+                keltnerVisible: false,
+                donchianVisible: false,
             });
 
             expect(result).toHaveLength(5);
@@ -147,6 +157,8 @@ describe('buildOverlayLabelConfigs', () => {
                 bollingerVisible: false,
                 ichimokuVisible: false,
                 vpVisible: true,
+                keltnerVisible: false,
+                donchianVisible: false,
             });
 
             expect(result).toHaveLength(3);
@@ -164,6 +176,8 @@ describe('buildOverlayLabelConfigs', () => {
                 bollingerVisible: true,
                 ichimokuVisible: false,
                 vpVisible: false,
+                keltnerVisible: false,
+                donchianVisible: false,
             });
 
             expect(result).toHaveLength(4);
@@ -182,6 +196,8 @@ describe('buildOverlayLabelConfigs', () => {
                 bollingerVisible: false,
                 ichimokuVisible: false,
                 vpVisible: false,
+                keltnerVisible: false,
+                donchianVisible: false,
             });
 
             expect(result[0].color).toBe(getPeriodColor(5));
@@ -194,10 +210,45 @@ describe('buildOverlayLabelConfigs', () => {
                 bollingerVisible: true,
                 ichimokuVisible: false,
                 vpVisible: false,
+                keltnerVisible: false,
+                donchianVisible: false,
             });
 
             expect(result[0].color).toBe(CHART_COLORS.bollingerUpper);
         });
+    });
+
+    it('builds Keltner/Donchian legend configs when visible', () => {
+        const configs = buildOverlayLabelConfigs({
+            maVisiblePeriods: [],
+            emaVisiblePeriods: [],
+            bollingerVisible: false,
+            ichimokuVisible: false,
+            vpVisible: false,
+            keltnerVisible: true,
+            donchianVisible: true,
+        });
+        const names = configs.map(c => c.name);
+        expect(names).toEqual(
+            expect.arrayContaining([
+                'KC Upper',
+                'KC Middle',
+                'KC Lower',
+                'DC Upper',
+                'DC Middle',
+                'DC Lower',
+            ])
+        );
+        const ind = {
+            keltnerChannel: [{ upper: 11, middle: 10, lower: 9 }],
+            donchianChannel: [{ upper: 21, middle: 20, lower: 19 }],
+        } as unknown as Parameters<(typeof configs)[number]['getValue']>[0];
+        expect(configs.find(c => c.name === 'KC Upper')?.getValue(ind, 0)).toBe(
+            11
+        );
+        expect(configs.find(c => c.name === 'DC Lower')?.getValue(ind, 0)).toBe(
+            19
+        );
     });
 });
 
@@ -249,6 +300,8 @@ describe('resolveOverlayValues', () => {
         bollingerVisible: true,
         ichimokuVisible: false,
         vpVisible: false,
+        keltnerVisible: false,
+        donchianVisible: false,
     });
 
     describe('barIndex가 -1일 때', () => {
@@ -334,6 +387,8 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             bollingerVisible: false,
             ichimokuVisible: false,
             vpVisible: false,
+            keltnerVisible: false,
+            donchianVisible: false,
         });
 
         expect(configs[0].getValue(mockIndicators, 0)).toBe(100);
@@ -348,6 +403,8 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             bollingerVisible: false,
             ichimokuVisible: false,
             vpVisible: false,
+            keltnerVisible: false,
+            donchianVisible: false,
         });
 
         expect(configs[0].getValue(mockIndicators, 0)).toBeNull();
@@ -360,6 +417,8 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             bollingerVisible: true,
             ichimokuVisible: false,
             vpVisible: false,
+            keltnerVisible: false,
+            donchianVisible: false,
         });
 
         expect(configs[0].getValue(mockIndicators, 0)).toBe(105);
@@ -375,6 +434,8 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             bollingerVisible: false,
             ichimokuVisible: true,
             vpVisible: false,
+            keltnerVisible: false,
+            donchianVisible: false,
         });
 
         expect(configs[0].getValue(mockIndicators, 0)).toBe(101); // tenkan
@@ -392,6 +453,8 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             bollingerVisible: false,
             ichimokuVisible: false,
             vpVisible: true,
+            keltnerVisible: false,
+            donchianVisible: false,
         });
 
         expect(configs[0].getValue(mockIndicators, 0)).toBe(100); // poc
@@ -411,6 +474,8 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             bollingerVisible: false,
             ichimokuVisible: false,
             vpVisible: true,
+            keltnerVisible: false,
+            donchianVisible: false,
         });
 
         expect(configs[0].getValue(emptyIndicators, 0)).toBeNull();

--- a/src/widgets/chart/__tests__/utils/overlayLabelUtilsBranches.test.ts
+++ b/src/widgets/chart/__tests__/utils/overlayLabelUtilsBranches.test.ts
@@ -64,6 +64,8 @@ describe('overlayLabelUtils — branch coverage', () => {
                 bollingerVisible: true,
                 ichimokuVisible: false,
                 vpVisible: false,
+                keltnerVisible: false,
+                donchianVisible: false,
             });
 
             expect(configs[0].getValue(indicators, 0)).toBeNull(); // upper
@@ -84,6 +86,8 @@ describe('overlayLabelUtils — branch coverage', () => {
                 bollingerVisible: false,
                 ichimokuVisible: true,
                 vpVisible: false,
+                keltnerVisible: false,
+                donchianVisible: false,
             });
 
             expect(configs[0].getValue(indicators, 0)).toBeNull(); // tenkan
@@ -108,6 +112,8 @@ describe('overlayLabelUtils — branch coverage', () => {
                 bollingerVisible: false,
                 ichimokuVisible: false,
                 vpVisible: true,
+                keltnerVisible: false,
+                donchianVisible: false,
             });
 
             expect(configs[0].getValue(indicators, 0)).toBeNull(); // poc

--- a/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
@@ -18,8 +18,8 @@ import {
 import type { PaneIndices } from '@/widgets/chart/types';
 import { INACTIVE_PANE_INDEX } from '@/widgets/chart/constants';
 
-// PaneIndices는 모든 IndicatorKey(24개)를 가진 Record다. buildPaneLabels가
-// 읽는 건 13개 pane 키뿐이므로, 나머지 overlay 키(ma·ema·ichimoku·bollinger·volumeProfile)와
+// PaneIndices는 모든 IndicatorKey(26개)를 가진 Record다. buildPaneLabels가
+// 읽는 건 13개 pane 키뿐이므로, 나머지 overlay 키(ma·ema·ichimoku·bollinger·volumeProfile·keltnerChannel·donchianChannel)와
 // 아직 렌더되지 않는 group-C pane 키를 INACTIVE로 채운 base에 해당 pane 키만 덮어쓴다.
 function makePaneIndices(overrides: Partial<PaneIndices> = {}): PaneIndices {
     const base = {
@@ -47,6 +47,8 @@ function makePaneIndices(overrides: Partial<PaneIndices> = {}): PaneIndices {
         atr: INACTIVE_PANE_INDEX,
         yangZhang: INACTIVE_PANE_INDEX,
         ewmaVolatility: INACTIVE_PANE_INDEX,
+        keltnerChannel: INACTIVE_PANE_INDEX,
+        donchianChannel: INACTIVE_PANE_INDEX,
     } satisfies PaneIndices;
     return { ...base, ...overrides };
 }

--- a/src/widgets/chart/hooks/useDonchianOverlay.ts
+++ b/src/widgets/chart/hooks/useDonchianOverlay.ts
@@ -55,7 +55,6 @@ export function useDonchianOverlay({
         lowerSeriesRef.current = null;
     });
 
-    // isVisible false 시 시리즈 제거 및 ref 초기화
     const removeAllSeries = useEffectEvent((chart: IChartApi) => {
         if (upperSeriesRef.current) {
             chart.removeSeries(upperSeriesRef.current);
@@ -71,7 +70,6 @@ export function useDonchianOverlay({
         }
     });
 
-    // 시리즈 lifecycle 관리 (생성/제거)
     // bars, indicators는 의존하지 않음 — 데이터 세팅은 아래 effect가 단독 담당
     // StockChart의 차트 생성 effect가 선언 순서상 앞에 있으므로
     // 이 effect 실행 시점에 chartRef.current는 이미 설정된 상태
@@ -130,7 +128,6 @@ export function useDonchianOverlay({
         lowerSeriesRef.current.applyOptions({ lineWidth });
     }, [chartRef, isVisible, lineWidth]);
 
-    // 데이터 동기화: 시리즈가 보이는 동안 bars/indicators 변경 시 업데이트
     // isVisible이 true로 바뀔 때도 실행되어 새로 생성된 시리즈에 초기 데이터를 세팅함
     useEffect(() => {
         if (!isVisible) return;

--- a/src/widgets/chart/hooks/useDonchianOverlay.ts
+++ b/src/widgets/chart/hooks/useDonchianOverlay.ts
@@ -1,0 +1,158 @@
+'use client';
+
+import type { RefObject } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useEffectEvent,
+    useRef,
+    useState,
+} from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import {
+    AreaSeries,
+    LineSeries,
+    LineStyle,
+    LineType,
+} from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { buildSeriesData } from '../utils/seriesDataUtils';
+
+interface UseDonchianOverlayParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+}
+
+interface UseDonchianOverlayReturn {
+    isVisible: boolean;
+    toggle: () => void;
+}
+
+export function useDonchianOverlay({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+}: UseDonchianOverlayParams): UseDonchianOverlayReturn {
+    const [isVisible, setIsVisible] = useState(false);
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const upperSeriesRef = useRef<ISeriesApi<'Area'> | null>(null);
+    const middleSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+    const lowerSeriesRef = useRef<ISeriesApi<'Area'> | null>(null);
+
+    const toggle = useCallback(() => {
+        setIsVisible(prev => !prev);
+    }, []);
+
+    // chart 인스턴스 교체 시 ref만 초기화 (removeSeries 불필요 — 이전 chart는 부모가 소멸)
+    const clearSeriesRefs = useEffectEvent(() => {
+        upperSeriesRef.current = null;
+        middleSeriesRef.current = null;
+        lowerSeriesRef.current = null;
+    });
+
+    // isVisible false 시 시리즈 제거 및 ref 초기화
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (upperSeriesRef.current) {
+            chart.removeSeries(upperSeriesRef.current);
+            upperSeriesRef.current = null;
+        }
+        if (middleSeriesRef.current) {
+            chart.removeSeries(middleSeriesRef.current);
+            middleSeriesRef.current = null;
+        }
+        if (lowerSeriesRef.current) {
+            chart.removeSeries(lowerSeriesRef.current);
+            lowerSeriesRef.current = null;
+        }
+    });
+
+    // 시리즈 lifecycle 관리 (생성/제거)
+    // bars, indicators는 의존하지 않음 — 데이터 세팅은 아래 effect가 단독 담당
+    // StockChart의 차트 생성 effect가 선언 순서상 앞에 있으므로
+    // 이 effect 실행 시점에 chartRef.current는 이미 설정된 상태
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        // Donchian 채널은 N-period 최고/최저가의 계단(stepped) 라인으로 렌더링한다.
+        if (!upperSeriesRef.current) {
+            upperSeriesRef.current = chart.addSeries(AreaSeries, {
+                topColor: CHART_COLORS.donchianBackground,
+                bottomColor: CHART_COLORS.donchianBackground,
+                lineColor: CHART_COLORS.donchianUpper,
+                lineType: LineType.WithSteps,
+                lineWidth,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        upperSeriesRef.current.applyOptions({ lineWidth });
+
+        if (!middleSeriesRef.current) {
+            middleSeriesRef.current = chart.addSeries(LineSeries, {
+                color: CHART_COLORS.donchianMiddle,
+                lineType: LineType.WithSteps,
+                lineStyle: LineStyle.Dashed,
+                lineWidth,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        middleSeriesRef.current.applyOptions({ lineWidth });
+
+        if (!lowerSeriesRef.current) {
+            lowerSeriesRef.current = chart.addSeries(AreaSeries, {
+                topColor: CHART_COLORS.background,
+                bottomColor: CHART_COLORS.background,
+                lineColor: CHART_COLORS.donchianLower,
+                lineType: LineType.WithSteps,
+                lineWidth,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        lowerSeriesRef.current.applyOptions({ lineWidth });
+    }, [chartRef, isVisible, lineWidth]);
+
+    // 데이터 동기화: 시리즈가 보이는 동안 bars/indicators 변경 시 업데이트
+    // isVisible이 true로 바뀔 때도 실행되어 새로 생성된 시리즈에 초기 데이터를 세팅함
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { donchianChannel } = indicators;
+        if (!donchianChannel.length) return;
+
+        if (
+            !upperSeriesRef.current ||
+            !middleSeriesRef.current ||
+            !lowerSeriesRef.current
+        )
+            return;
+
+        const upperData = buildSeriesData(bars, donchianChannel, 'upper');
+        const middleData = buildSeriesData(bars, donchianChannel, 'middle');
+        const lowerData = buildSeriesData(bars, donchianChannel, 'lower');
+
+        upperSeriesRef.current.setData(upperData);
+        middleSeriesRef.current.setData(middleData);
+        lowerSeriesRef.current.setData(lowerData);
+    }, [indicators, bars, isVisible]);
+
+    return { isVisible, toggle };
+}

--- a/src/widgets/chart/hooks/useKeltnerOverlay.ts
+++ b/src/widgets/chart/hooks/useKeltnerOverlay.ts
@@ -1,0 +1,148 @@
+'use client';
+
+import type { RefObject } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useEffectEvent,
+    useRef,
+    useState,
+} from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import { AreaSeries, LineSeries } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { buildSeriesData } from '../utils/seriesDataUtils';
+
+interface UseKeltnerOverlayParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+}
+
+interface UseKeltnerOverlayReturn {
+    isVisible: boolean;
+    toggle: () => void;
+}
+
+export function useKeltnerOverlay({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+}: UseKeltnerOverlayParams): UseKeltnerOverlayReturn {
+    const [isVisible, setIsVisible] = useState(false);
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const upperSeriesRef = useRef<ISeriesApi<'Area'> | null>(null);
+    const middleSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+    const lowerSeriesRef = useRef<ISeriesApi<'Area'> | null>(null);
+
+    const toggle = useCallback(() => {
+        setIsVisible(prev => !prev);
+    }, []);
+
+    // chart 인스턴스 교체 시 ref만 초기화 (removeSeries 불필요 — 이전 chart는 부모가 소멸)
+    const clearSeriesRefs = useEffectEvent(() => {
+        upperSeriesRef.current = null;
+        middleSeriesRef.current = null;
+        lowerSeriesRef.current = null;
+    });
+
+    // isVisible false 시 시리즈 제거 및 ref 초기화
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (upperSeriesRef.current) {
+            chart.removeSeries(upperSeriesRef.current);
+            upperSeriesRef.current = null;
+        }
+        if (middleSeriesRef.current) {
+            chart.removeSeries(middleSeriesRef.current);
+            middleSeriesRef.current = null;
+        }
+        if (lowerSeriesRef.current) {
+            chart.removeSeries(lowerSeriesRef.current);
+            lowerSeriesRef.current = null;
+        }
+    });
+
+    // 시리즈 lifecycle 관리 (생성/제거)
+    // bars, indicators는 의존하지 않음 — 데이터 세팅은 아래 effect가 단독 담당
+    // StockChart의 차트 생성 effect가 선언 순서상 앞에 있으므로
+    // 이 effect 실행 시점에 chartRef.current는 이미 설정된 상태
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (!upperSeriesRef.current) {
+            upperSeriesRef.current = chart.addSeries(AreaSeries, {
+                topColor: CHART_COLORS.keltnerBackground,
+                bottomColor: CHART_COLORS.keltnerBackground,
+                lineColor: CHART_COLORS.keltnerUpper,
+                lineWidth,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        upperSeriesRef.current.applyOptions({ lineWidth });
+
+        if (!middleSeriesRef.current) {
+            middleSeriesRef.current = chart.addSeries(LineSeries, {
+                color: CHART_COLORS.keltnerMiddle,
+                lineWidth,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        middleSeriesRef.current.applyOptions({ lineWidth });
+
+        if (!lowerSeriesRef.current) {
+            lowerSeriesRef.current = chart.addSeries(AreaSeries, {
+                topColor: CHART_COLORS.background,
+                bottomColor: CHART_COLORS.background,
+                lineColor: CHART_COLORS.keltnerLower,
+                lineWidth,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        lowerSeriesRef.current.applyOptions({ lineWidth });
+    }, [chartRef, isVisible, lineWidth]);
+
+    // 데이터 동기화: 시리즈가 보이는 동안 bars/indicators 변경 시 업데이트
+    // isVisible이 true로 바뀔 때도 실행되어 새로 생성된 시리즈에 초기 데이터를 세팅함
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { keltnerChannel } = indicators;
+        if (!keltnerChannel.length) return;
+
+        if (
+            !upperSeriesRef.current ||
+            !middleSeriesRef.current ||
+            !lowerSeriesRef.current
+        )
+            return;
+
+        const upperData = buildSeriesData(bars, keltnerChannel, 'upper');
+        const middleData = buildSeriesData(bars, keltnerChannel, 'middle');
+        const lowerData = buildSeriesData(bars, keltnerChannel, 'lower');
+
+        upperSeriesRef.current.setData(upperData);
+        middleSeriesRef.current.setData(middleData);
+        lowerSeriesRef.current.setData(lowerData);
+    }, [indicators, bars, isVisible]);
+
+    return { isVisible, toggle };
+}

--- a/src/widgets/chart/hooks/useKeltnerOverlay.ts
+++ b/src/widgets/chart/hooks/useKeltnerOverlay.ts
@@ -50,7 +50,6 @@ export function useKeltnerOverlay({
         lowerSeriesRef.current = null;
     });
 
-    // isVisible false 시 시리즈 제거 및 ref 초기화
     const removeAllSeries = useEffectEvent((chart: IChartApi) => {
         if (upperSeriesRef.current) {
             chart.removeSeries(upperSeriesRef.current);
@@ -66,7 +65,6 @@ export function useKeltnerOverlay({
         }
     });
 
-    // 시리즈 lifecycle 관리 (생성/제거)
     // bars, indicators는 의존하지 않음 — 데이터 세팅은 아래 effect가 단독 담당
     // StockChart의 차트 생성 effect가 선언 순서상 앞에 있으므로
     // 이 effect 실행 시점에 chartRef.current는 이미 설정된 상태
@@ -120,7 +118,6 @@ export function useKeltnerOverlay({
         lowerSeriesRef.current.applyOptions({ lineWidth });
     }, [chartRef, isVisible, lineWidth]);
 
-    // 데이터 동기화: 시리즈가 보이는 동안 bars/indicators 변경 시 업데이트
     // isVisible이 true로 바뀔 때도 실행되어 새로 생성된 시리즈에 초기 데이터를 세팅함
     useEffect(() => {
         if (!isVisible) return;

--- a/src/widgets/chart/model/indicatorRegistry.ts
+++ b/src/widgets/chart/model/indicatorRegistry.ts
@@ -41,7 +41,9 @@ export type IndicatorKey =
     | 'obv'
     | 'atr'
     | 'yangZhang'
-    | 'ewmaVolatility';
+    | 'ewmaVolatility'
+    | 'keltnerChannel'
+    | 'donchianChannel';
 
 export interface IndicatorMeta {
     key: IndicatorKey;
@@ -162,6 +164,18 @@ export const INDICATOR_REGISTRY: readonly IndicatorMeta[] = [
         label: 'EWMA Vol',
         category: 'volatility',
         kind: 'pane',
+    },
+    {
+        key: 'keltnerChannel',
+        label: 'Keltner',
+        category: 'volatility',
+        kind: 'overlay',
+    },
+    {
+        key: 'donchianChannel',
+        label: 'Donchian',
+        category: 'volatility',
+        kind: 'overlay',
     },
 ];
 

--- a/src/widgets/chart/utils/overlayLabelUtils.ts
+++ b/src/widgets/chart/utils/overlayLabelUtils.ts
@@ -12,6 +12,8 @@ interface BuildOverlayLabelConfigsParams {
     bollingerVisible: boolean;
     ichimokuVisible: boolean;
     vpVisible: boolean;
+    keltnerVisible: boolean;
+    donchianVisible: boolean;
 }
 
 export function buildOverlayLabelConfigs({
@@ -20,6 +22,8 @@ export function buildOverlayLabelConfigs({
     bollingerVisible,
     ichimokuVisible,
     vpVisible,
+    keltnerVisible,
+    donchianVisible,
 }: BuildOverlayLabelConfigsParams): OverlayLabelConfig[] {
     const maConfigs: OverlayLabelConfig[] = maVisiblePeriods.map(period => ({
         name: `MA(${period})`,
@@ -116,12 +120,60 @@ export function buildOverlayLabelConfigs({
           ]
         : [];
 
+    const keltnerConfigs: OverlayLabelConfig[] = keltnerVisible
+        ? [
+              {
+                  name: 'KC Upper',
+                  color: CHART_COLORS.keltnerUpper,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.keltnerChannel[i]?.upper ?? null,
+              },
+              {
+                  name: 'KC Middle',
+                  color: CHART_COLORS.keltnerMiddle,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.keltnerChannel[i]?.middle ?? null,
+              },
+              {
+                  name: 'KC Lower',
+                  color: CHART_COLORS.keltnerLower,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.keltnerChannel[i]?.lower ?? null,
+              },
+          ]
+        : [];
+
+    const donchianConfigs: OverlayLabelConfig[] = donchianVisible
+        ? [
+              {
+                  name: 'DC Upper',
+                  color: CHART_COLORS.donchianUpper,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.donchianChannel[i]?.upper ?? null,
+              },
+              {
+                  name: 'DC Middle',
+                  color: CHART_COLORS.donchianMiddle,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.donchianChannel[i]?.middle ?? null,
+              },
+              {
+                  name: 'DC Lower',
+                  color: CHART_COLORS.donchianLower,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.donchianChannel[i]?.lower ?? null,
+              },
+          ]
+        : [];
+
     return [
         ...maConfigs,
         ...emaConfigs,
         ...bollingerConfigs,
         ...ichimokuConfigs,
         ...vpConfigs,
+        ...keltnerConfigs,
+        ...donchianConfigs,
     ];
 }
 


### PR DESCRIPTION
## 요약
미사용 보조지표 렌더링 4차. Keltner·Donchian 채널 2종을 가격 차트 오버레이(Pane 0)로 렌더한다.

> ⚠️ Stacked PR — base가 `feat/render-group-c-simple`(#580)입니다. 스택: #575 ← #577 ← #580 ← 이 PR. 하위 PR 머지 후 base를 순차 변경하세요.

## 변경 내용
- 레지스트리 +2 메타(keltnerChannel·donchianChannel → 변동성, kind:overlay).
- useKeltnerOverlay: useBollingerOverlay 복제, 부드러운 곡선 3밴드(upper Area + middle Line + lower Area).
- useDonchianOverlay: keltner 복제 + 3시리즈 모두 lineType:WithSteps(계단형) + middle lineStyle:Dashed. (자료조사·이미지로 표준 모양 확인.)
- 색 8종(keltner teal / donchian amber, upper=lower 페어는 bollinger 관례).
- overlayLabelUtils에 KC/DC Upper/Middle/Lower legend.
- StockChart 2 overlay 훅 호출 + binding 24→26. useIndicatorVisibility(pane 전용)·모달 무변경.
- E2E: Keltner 오버레이 토글(overlay라 모달 체크 상태로 검증).

## 검증
- 신규 2훅 커버리지 98.24% stmts / 100% func / 98.11% lines / 85.71% branch (= useBollingerOverlay와 byte-identical; 미커버는 도달 불가 방어 guard, review-agent가 baseline 동등으로 승인)
- 전체 unit 5162 pass, tsc clean, lint clean, build exit 0
- review-agent approved (round 1, findings 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)