### PR TITLE
feat(chart): render Supertrend as trend-colored overlay

### DIFF
--- a/docs/superpowers/plans/2026-06-07-render-supertrend.md
+++ b/docs/superpowers/plans/2026-06-07-render-supertrend.md
@@ -1,0 +1,860 @@
+# Supertrend (trend-colored overlay) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the `supertrend` indicator as a price-pane overlay whose line color flips between green (uptrend) and red (downtrend) by trend direction.
+
+**Architecture:** Reuse the established overlay-hook mechanism (`useKeltnerOverlay`/`useBollingerOverlay`). Because lightweight-charts `LineSeries` has no per-point color, trend coloring is achieved with **two `LineSeries`** (up = green, down = red); each receives the supertrend value only on bars matching its direction, whitespace otherwise. A new pure helper `buildTrendSplitData` produces that split. The registry gains one `kind: 'overlay'` entry so the settings modal exposes it automatically. Computation lives in `@y0ngha/siglens-core` (unchanged); this is pure siglens rendering.
+
+**Tech Stack:** TypeScript, React 19 (`useEffectEvent`), lightweight-charts 5.1.0, Vitest + React Testing Library, Playwright (E2E).
+
+**Spec:** `docs/superpowers/specs/2026-06-07-render-supertrend-design.md`
+**Branch:** `feat/render-supertrend` (base: `feat/render-group-a-bands` = PR #581)
+**Worktree:** `/Users/y0ngha/Project/siglens-supertrend`
+
+**Data shape (from siglens-core `domain/types.d.ts`):**
+```ts
+interface SupertrendResult { supertrend: number | null; trend: TrendDirection; }
+// TrendDirection = 'up' | 'down' | null
+// IndicatorResult.supertrend: SupertrendResult[]
+```
+
+---
+
+## File Structure
+
+- `src/shared/lib/chartColors.ts` — add `supertrendUp` / `supertrendDown` to `CHART_COLORS` (modify).
+- `src/app/globals.css` — mirror the two colors as `@theme` tokens (modify; matches #581 precedent).
+- `src/widgets/chart/utils/seriesDataUtils.ts` — add `buildTrendSplitData` helper (modify).
+- `src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts` — add helper tests (modify; create if absent).
+- `src/widgets/chart/model/indicatorRegistry.ts` — `IndicatorKey` + `INDICATOR_REGISTRY` gain `supertrend` (modify).
+- `src/widgets/chart/__tests__/model/indicatorRegistry.test.ts` — registry-count + supertrend assertions (modify).
+- `src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts` — `makePaneIndices` gains `supertrend: INACTIVE_PANE_INDEX` (modify).
+- `src/widgets/chart/hooks/useSupertrendOverlay.ts` — new overlay hook, two LineSeries (create).
+- `src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts` — hook tests (create).
+- `src/widgets/chart/utils/overlayLabelUtils.ts` — `supertrendVisible` param + config block (modify).
+- `src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts` — supertrend config assertions (modify).
+- `src/widgets/chart/StockChart.tsx` — call hook, wire `overlayLabelConfigs` + 27th binding (modify).
+- `e2e/specs/chart-indicators.spec.ts` — modal-checkbox toggle for Supertrend (modify).
+
+---
+
+## Task 0: Worktree node_modules setup
+
+**Files:** none (environment only)
+
+- [ ] **Step 1: Verify worktree node_modules exists and is usable**
+
+The worktree must have its own real `node_modules` (hardlink copy, NOT symlink — Turbopack rejects symlinks and a symlinked tree causes dual-React `useEffect` null failures).
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-supertrend
+[ -e node_modules/.bin/vitest ] && [ ! -L node_modules ] && echo "OK: real node_modules present" || echo "MISSING"
+```
+Expected: `OK: real node_modules present`
+
+- [ ] **Step 2: If MISSING, create a hardlink copy from the main checkout**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-supertrend
+cp -al /Users/y0ngha/Project/siglens/node_modules ./node_modules
+rm -rf node_modules/node_modules
+```
+Expected: completes silently. Re-run Step 1 to confirm `OK`.
+
+- [ ] **Step 3: Sanity-check the toolchain**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && yarn vitest run src/widgets/chart/__tests__/hooks/useKeltnerOverlay.test.ts`
+Expected: PASS (confirms vitest + jsdom + lightweight-charts mock resolve in the worktree).
+
+---
+
+## Task 1: Add supertrend colors
+
+**Files:**
+- Modify: `src/shared/lib/chartColors.ts`
+- Modify: `src/app/globals.css`
+
+- [ ] **Step 1: Verify the candidate hex values are unused (collision guard)**
+
+Standard supertrend uses a saturated green (up) and red (down). Candidates: `#16a34a` (green-600), `#dc2626` (red-600).
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-supertrend
+grep -rn "16a34a\|dc2626" src/ || echo "BOTH UNUSED — safe"
+```
+Expected: `BOTH UNUSED — safe`. If either collides, pick another saturated green/red not already in `CHART_COLORS` (e.g. `#15803d` / `#b91c1c`) and use it consistently below.
+
+- [ ] **Step 2: Add the two colors to `CHART_COLORS`**
+
+In `src/shared/lib/chartColors.ts`, immediately after the `ewmaVolatilityLine: '#6ee7b7',` line (last entry before the closing `} as const;`), add:
+```ts
+    // Supertrend (trend 색 라인 — up=초록, down=빨강)
+    supertrendUp: '#16a34a',
+    supertrendDown: '#dc2626',
+```
+
+- [ ] **Step 3: Mirror the colors as `@theme` tokens**
+
+In `src/app/globals.css`, after the `--color-chart-donchian-middle: #d97706;` block, add:
+```css
+    /* Chart — Supertrend */
+    --color-chart-supertrend-up: #16a34a;
+    --color-chart-supertrend-down: #dc2626;
+```
+(This matches the #581 precedent where overlay legend colors are mirrored in `@theme`.)
+
+- [ ] **Step 4: Verify lint + format pass for the changed files**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && yarn lint && npx prettier --check src/shared/lib/chartColors.ts src/app/globals.css`
+Expected: no errors.
+
+- [ ] **Step 5: Commit** (delegate to git-agent per CLAUDE.md — controller dispatches)
+
+```bash
+git add src/shared/lib/chartColors.ts src/app/globals.css
+git commit -m "feat(chart): add supertrend up/down colors"
+```
+
+---
+
+## Task 2: `buildTrendSplitData` helper
+
+**Files:**
+- Modify: `src/widgets/chart/utils/seriesDataUtils.ts`
+- Test: `src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts` (create the file with the standard import header if it does not exist):
+```ts
+import { describe, it, expect } from 'vitest';
+import type { Bar, SupertrendResult } from '@y0ngha/siglens-core';
+import { buildTrendSplitData } from '../../utils/seriesDataUtils';
+
+function bar(time: number): Bar {
+    return { time, open: 1, high: 2, low: 0, close: 1, volume: 10 };
+}
+
+describe('buildTrendSplitData', () => {
+    const bars: Bar[] = [bar(1), bar(2), bar(3)];
+    const data: SupertrendResult[] = [
+        { supertrend: 10, trend: 'up' },
+        { supertrend: 11, trend: 'down' },
+        { supertrend: null, trend: null },
+    ];
+
+    it("returns value only on bars whose trend matches 'up', whitespace otherwise", () => {
+        expect(buildTrendSplitData(bars, data, 'up')).toEqual([
+            { time: 1, value: 10 },
+            { time: 2 },
+            { time: 3 },
+        ]);
+    });
+
+    it("returns value only on bars whose trend matches 'down', whitespace otherwise", () => {
+        expect(buildTrendSplitData(bars, data, 'down')).toEqual([
+            { time: 1 },
+            { time: 2, value: 11 },
+            { time: 3 },
+        ]);
+    });
+
+    it('up and down outputs are complementary on matched bars (never both have value)', () => {
+        const up = buildTrendSplitData(bars, data, 'up');
+        const down = buildTrendSplitData(bars, data, 'down');
+        up.forEach((u, i) => {
+            const bothHaveValue = 'value' in u && 'value' in down[i];
+            expect(bothHaveValue).toBe(false);
+        });
+    });
+
+    it('emits whitespace when supertrend is null even if trend matches dir', () => {
+        const nullVal: SupertrendResult[] = [{ supertrend: null, trend: 'up' }];
+        expect(buildTrendSplitData([bar(1)], nullVal, 'up')).toEqual([
+            { time: 1 },
+        ]);
+    });
+
+    it('clamps to the shorter of bars / data length (worst case)', () => {
+        const longBars = [bar(1), bar(2), bar(3), bar(4)];
+        const shortData: SupertrendResult[] = [{ supertrend: 5, trend: 'up' }];
+        const out = buildTrendSplitData(longBars, shortData, 'up');
+        expect(out).toEqual([{ time: 1, value: 5 }]);
+    });
+
+    it('returns empty array for empty inputs', () => {
+        expect(buildTrendSplitData([], [], 'up')).toEqual([]);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && yarn vitest run src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts`
+Expected: FAIL with "buildTrendSplitData is not a function" / import error.
+
+- [ ] **Step 3: Implement the helper**
+
+In `src/widgets/chart/utils/seriesDataUtils.ts`, add the `SupertrendResult` import to the existing core import line:
+```ts
+import type { Bar, SupertrendResult } from '@y0ngha/siglens-core';
+```
+Then append at the end of the file:
+```ts
+/**
+ * trend 방향이 dir과 일치하는 bar만 supertrend 값을, 나머지는 WhitespaceData({ time })를 반환한다.
+ * up/down 2개 LineSeries로 trend별 색을 표현하기 위함 (LineSeries는 per-point 색 미지원).
+ */
+export function buildTrendSplitData(
+    bars: Bar[],
+    data: SupertrendResult[],
+    dir: 'up' | 'down'
+): SeriesPoint[] {
+    const count = Math.min(bars.length, data.length);
+    return bars.slice(0, count).map((bar, i) => {
+        const r = data[i];
+        if (r && r.trend === dir && r.supertrend !== null) {
+            return { time: bar.time as UTCTimestamp, value: r.supertrend };
+        }
+        return { time: bar.time as UTCTimestamp };
+    });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && yarn vitest run src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts`
+Expected: PASS (all 6 cases).
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && npx tsc --noEmit`
+Expected: no errors. (vitest only transpiles — `tsc` is the real type gate.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/widgets/chart/utils/seriesDataUtils.ts src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts
+git commit -m "feat(chart): add buildTrendSplitData helper for trend-colored series"
+```
+
+---
+
+## Task 3: Register supertrend in the indicator registry
+
+**Files:**
+- Modify: `src/widgets/chart/model/indicatorRegistry.ts`
+- Modify: `src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`
+- Modify: `src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts`
+
+- [ ] **Step 1: Write the failing registry test**
+
+In `src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`, update the count assertion (currently 26) to 27 and add a supertrend-specific assertion. Add this test inside the existing top-level `describe`:
+```ts
+it('registers supertrend as a trend overlay', () => {
+    const meta = INDICATOR_REGISTRY.find(m => m.key === 'supertrend');
+    expect(meta).toBeDefined();
+    expect(meta?.category).toBe('trend');
+    expect(meta?.kind).toBe('overlay');
+    expect(meta?.hasPeriods).toBeUndefined();
+});
+```
+If there is an existing assertion like `expect(INDICATOR_REGISTRY).toHaveLength(26)`, change `26` to `27`. If there is a "no duplicate keys" test, it will still pass — leave it.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && yarn vitest run src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`
+Expected: FAIL (length 26 ≠ 27 and/or supertrend meta undefined).
+
+- [ ] **Step 3: Add the registry entry and union member**
+
+In `src/widgets/chart/model/indicatorRegistry.ts`:
+
+(a) Add `| 'supertrend'` to the `IndicatorKey` union, after `| 'donchianChannel'`:
+```ts
+    | 'donchianChannel'
+    | 'supertrend';
+```
+
+(b) Add the meta to `INDICATOR_REGISTRY`, after the `donchianChannel` entry (the last array element, before the closing `];`):
+```ts
+    {
+        key: 'supertrend',
+        label: 'Supertrend',
+        category: 'trend',
+        kind: 'overlay',
+    },
+```
+
+- [ ] **Step 4: Run registry test to verify it passes**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && yarn vitest run src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Fix the `makePaneIndices` fallout (type-completeness)**
+
+Adding a key to `IndicatorKey` widens `PaneIndices` (a `Record<IndicatorKey, number>`), so the `satisfies PaneIndices` object in `paneLabelUtils.test.ts` now misses a key. In `src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts`, add to the `makePaneIndices` base object, after `donchianChannel: INACTIVE_PANE_INDEX,`:
+```ts
+        supertrend: INACTIVE_PANE_INDEX,
+```
+(supertrend is an overlay → never gets a pane index → always INACTIVE.)
+
+- [ ] **Step 6: Type-check + run both affected test files**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-supertrend
+npx tsc --noEmit
+yarn vitest run src/widgets/chart/__tests__/model/indicatorRegistry.test.ts src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+```
+Expected: tsc clean; both test files PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/widgets/chart/model/indicatorRegistry.ts src/widgets/chart/__tests__/model/indicatorRegistry.test.ts src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+git commit -m "feat(chart): register supertrend as trend overlay"
+```
+
+---
+
+## Task 4: `useSupertrendOverlay` hook
+
+**Files:**
+- Create: `src/widgets/chart/hooks/useSupertrendOverlay.ts`
+- Test: `src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts` (cloned from `useKeltnerOverlay.test.ts`, adapted to 2 series + supertrend data + `buildTrendSplitData` mock):
+```ts
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useSupertrendOverlay } from '../../hooks/useSupertrendOverlay';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildTrendSplitData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useSupertrendOverlay
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = {
+    supertrend: [],
+} as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    supertrend: [{ supertrend: 10, trend: 'up' }],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useSupertrendOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns isVisible false initially', () => {
+        const { result } = renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('toggles isVisible when toggle is called', () => {
+        const { result } = renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(result.current.isVisible).toBe(true);
+        act(() => result.current.toggle());
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates two LineSeries (up, down) when visible and chart exists', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes both series when toggled off', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        act(() => result.current.toggle());
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('sets data on both series when visible with data', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockSetData).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not set data when supertrend is empty', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('provides stable toggle function reference', () => {
+        const { result, rerender } = renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        const firstToggle = result.current.toggle;
+        rerender();
+        expect(result.current.toggle).toBe(firstToggle);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && yarn vitest run src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts`
+Expected: FAIL ("useSupertrendOverlay is not a function" / module not found).
+
+- [ ] **Step 3: Implement the hook**
+
+Create `src/widgets/chart/hooks/useSupertrendOverlay.ts`:
+```ts
+'use client';
+
+import type { RefObject } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useEffectEvent,
+    useRef,
+    useState,
+} from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import { LineSeries } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { buildTrendSplitData } from '../utils/seriesDataUtils';
+
+interface UseSupertrendOverlayParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+}
+
+interface UseSupertrendOverlayReturn {
+    isVisible: boolean;
+    toggle: () => void;
+}
+
+export function useSupertrendOverlay({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+}: UseSupertrendOverlayParams): UseSupertrendOverlayReturn {
+    const [isVisible, setIsVisible] = useState(false);
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const upSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+    const downSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+    const toggle = useCallback(() => {
+        setIsVisible(prev => !prev);
+    }, []);
+
+    const clearSeriesRefs = useEffectEvent(() => {
+        upSeriesRef.current = null;
+        downSeriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (upSeriesRef.current) {
+            chart.removeSeries(upSeriesRef.current);
+            upSeriesRef.current = null;
+        }
+        if (downSeriesRef.current) {
+            chart.removeSeries(downSeriesRef.current);
+            downSeriesRef.current = null;
+        }
+    });
+
+    // bars, indicators는 의존하지 않음 — 데이터 세팅은 아래 effect가 단독 담당.
+    // StockChart의 차트 생성 effect가 선언 순서상 앞에 있으므로
+    // 이 effect 실행 시점에 chartRef.current는 이미 설정된 상태.
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (!upSeriesRef.current) {
+            upSeriesRef.current = chart.addSeries(LineSeries, {
+                color: CHART_COLORS.supertrendUp,
+                lineWidth,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        upSeriesRef.current.applyOptions({ lineWidth });
+
+        if (!downSeriesRef.current) {
+            downSeriesRef.current = chart.addSeries(LineSeries, {
+                color: CHART_COLORS.supertrendDown,
+                lineWidth,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        downSeriesRef.current.applyOptions({ lineWidth });
+    }, [chartRef, isVisible, lineWidth]);
+
+    // isVisible이 true로 바뀔 때도 실행되어 새로 생성된 시리즈에 초기 데이터를 세팅함
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { supertrend } = indicators;
+        if (!supertrend.length) return;
+
+        if (!upSeriesRef.current || !downSeriesRef.current) return;
+
+        upSeriesRef.current.setData(buildTrendSplitData(bars, supertrend, 'up'));
+        downSeriesRef.current.setData(
+            buildTrendSplitData(bars, supertrend, 'down')
+        );
+    }, [indicators, bars, isVisible]);
+
+    return { isVisible, toggle };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && yarn vitest run src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts`
+Expected: PASS (all 8 cases).
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/widgets/chart/hooks/useSupertrendOverlay.ts src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts
+git commit -m "feat(chart): add useSupertrendOverlay hook (up/down 2 LineSeries)"
+```
+
+---
+
+## Task 5: OverlayLegend config for supertrend
+
+**Files:**
+- Modify: `src/widgets/chart/utils/overlayLabelUtils.ts`
+- Test: `src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts`, add (and update any existing calls to `buildOverlayLabelConfigs` so they keep compiling — see Step 3 note):
+```ts
+it('includes a Supertrend config when supertrendVisible is true', () => {
+    const configs = buildOverlayLabelConfigs({
+        maVisiblePeriods: [],
+        emaVisiblePeriods: [],
+        bollingerVisible: false,
+        ichimokuVisible: false,
+        vpVisible: false,
+        keltnerVisible: false,
+        donchianVisible: false,
+        supertrendVisible: true,
+    });
+    const st = configs.find(c => c.name === 'Supertrend');
+    expect(st).toBeDefined();
+    expect(st?.color).toBe(CHART_COLORS.supertrendUp);
+    const ind = { supertrend: [{ supertrend: 42, trend: 'up' }] } as never;
+    expect(st?.getValue(ind, 0)).toBe(42);
+    expect(st?.getValue(ind, 5)).toBeNull();
+});
+
+it('omits Supertrend config when supertrendVisible is false', () => {
+    const configs = buildOverlayLabelConfigs({
+        maVisiblePeriods: [],
+        emaVisiblePeriods: [],
+        bollingerVisible: false,
+        ichimokuVisible: false,
+        vpVisible: false,
+        keltnerVisible: false,
+        donchianVisible: false,
+        supertrendVisible: false,
+    });
+    expect(configs.find(c => c.name === 'Supertrend')).toBeUndefined();
+});
+```
+Ensure `CHART_COLORS` is imported at the top of the test file (it is used here): `import { CHART_COLORS } from '@/shared/lib/chartColors';` — add only if not already present.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && yarn vitest run src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts`
+Expected: FAIL — TS/runtime error on the unknown `supertrendVisible` property, or `Supertrend` config not found.
+
+- [ ] **Step 3: Add the param and config block**
+
+In `src/widgets/chart/utils/overlayLabelUtils.ts`:
+
+(a) Add `supertrendVisible: boolean;` to the `BuildOverlayLabelConfigsParams` interface (after `donchianVisible: boolean;`).
+
+(b) Add `supertrendVisible,` to the destructured params of `buildOverlayLabelConfigs` (after `donchianVisible,`).
+
+(c) After the `donchianConfigs` block, add:
+```ts
+    const supertrendConfigs: OverlayLabelConfig[] = supertrendVisible
+        ? [
+              {
+                  name: 'Supertrend',
+                  color: CHART_COLORS.supertrendUp,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.supertrend[i]?.supertrend ?? null,
+              },
+          ]
+        : [];
+```
+
+(d) Add `...supertrendConfigs,` to the returned array (after `...donchianConfigs,`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && yarn vitest run src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts`
+Expected: PASS. (If pre-existing tests in this file call `buildOverlayLabelConfigs` without `supertrendVisible`, add `supertrendVisible: false` to each — tsc will flag them in Step 5.)
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && npx tsc --noEmit`
+Expected: no errors. Fix any callers in the test file that now miss `supertrendVisible`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/widgets/chart/utils/overlayLabelUtils.ts src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts
+git commit -m "feat(chart): add supertrend overlay legend config"
+```
+
+---
+
+## Task 6: Wire supertrend into StockChart
+
+**Files:**
+- Modify: `src/widgets/chart/StockChart.tsx`
+
+- [ ] **Step 1: Call the hook**
+
+In `src/widgets/chart/StockChart.tsx`, add the import near the other overlay-hook imports (after the `useDonchianOverlay` import, line ~25):
+```ts
+import { useSupertrendOverlay } from './hooks/useSupertrendOverlay';
+```
+Then add the hook call immediately after the `useDonchianOverlay` call (line ~203):
+```ts
+    const { isVisible: supertrendVisible, toggle: toggleSupertrend } =
+        useSupertrendOverlay(commonHookParams);
+```
+
+- [ ] **Step 2: Pass `supertrendVisible` to `buildOverlayLabelConfigs`**
+
+In the `overlayLabelConfigs` `useMemo` (line ~368), add `supertrendVisible,` to both the call object (after `donchianVisible,`) and the dependency array (after `donchianVisible,`).
+
+- [ ] **Step 3: Add the 27th binding**
+
+In the `indicatorBindings` `useMemo` (line ~408), add after the `donchianChannel` binding object (the last entry, before the `],` that closes the array):
+```ts
+            {
+                meta: INDICATOR_META.supertrend,
+                active: supertrendVisible,
+                onToggle: toggleSupertrend,
+            },
+```
+Then add `supertrendVisible,` and `toggleSupertrend,` to the `useMemo` dependency array (after `donchianVisible,` and `toggleDonchian,` respectively).
+
+- [ ] **Step 4: Type-check + run the StockChart-adjacent suites**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-supertrend
+npx tsc --noEmit
+yarn vitest run src/widgets/chart
+```
+Expected: tsc clean; all chart widget tests PASS. (If a StockChart render test snapshots the binding count, update it to 27.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets/chart/StockChart.tsx
+git commit -m "feat(chart): wire supertrend overlay into StockChart (27th binding)"
+```
+
+---
+
+## Task 7: E2E — toggle Supertrend from the settings modal
+
+**Files:**
+- Modify: `e2e/specs/chart-indicators.spec.ts`
+
+- [ ] **Step 1: Read the existing keltner/donchian overlay E2E case**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && grep -n "Keltner\|Donchian\|checkbox\|getByRole" e2e/specs/chart-indicators.spec.ts | head -30`
+Expected: shows the modal-open + checkbox-toggle pattern for an overlay (overlays are verified by checkbox checked-state, not by a pane label).
+
+- [ ] **Step 2: Add a Supertrend toggle test mirroring the keltner overlay case**
+
+Add a test that: opens the settings modal (gear button), checks the `Supertrend` checkbox, and asserts it becomes checked. Use an exact-name matcher to avoid strict-mode collisions:
+```ts
+test('toggles Supertrend overlay from the settings modal', async ({ page }) => {
+    // (reuse the spec's existing modal-open helper / gear-button locator)
+    await openIndicatorModal(page); // or the inline gear-button click used by sibling tests
+    const supertrend = page.getByRole('checkbox', {
+        name: 'Supertrend',
+        exact: true,
+    });
+    await expect(supertrend).not.toBeChecked();
+    await supertrend.check();
+    await expect(supertrend).toBeChecked();
+});
+```
+Match the surrounding tests' exact structure (helper names, fixtures, `test.describe` block). Do not invent a helper that doesn't exist — copy the keltner/donchian test body and swap the name to `'Supertrend'`.
+
+- [ ] **Step 3: Note on local E2E**
+
+Full Playwright E2E uses the shared docker-compose backend and is NOT run inside worktrees (per project convention) — it runs in CI on the PR. Do a static/lint check only here:
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && yarn lint e2e/specs/chart-indicators.spec.ts`
+Expected: no lint errors. CI's `e2e` job is the real gate.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/specs/chart-indicators.spec.ts
+git commit -m "test(e2e): toggle Supertrend overlay from settings modal"
+```
+
+---
+
+## Task 8: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full unit suite + coverage for changed areas**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && yarn vitest run src/widgets/chart src/shared/lib --coverage`
+Expected: all PASS; the new helper/hook/config at 90%+ line+branch coverage (happy + worst cases are covered by Tasks 2/4/5).
+
+- [ ] **Step 2: Lint + format (whole repo, matches CI gate)**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && yarn lint && npx prettier --check .`
+Expected: no errors. (Use `npx prettier --check .`, not `yarn format --cache`, to avoid stale-cache false negatives — see memory.)
+
+- [ ] **Step 3: Production build (capture exit code directly, no pipe)**
+
+Run: `cd /Users/y0ngha/Project/siglens-supertrend && yarn build > /tmp/supertrend-build.log 2>&1; echo "EXIT=$?"`
+Expected: `EXIT=0`. (Piping to `tail` masks failures as exit 0 — capture directly. If exit ≠ 0, read the log.)
+
+- [ ] **Step 4: Hand off to review**
+
+Implementation complete. Per CLAUDE.md routing: invoke `review-agent` (Opus 4.8) on branch `feat/render-supertrend`, then `mistake-managing-agent`, then `git-agent` to push and open the PR stacked on `feat/render-group-a-bands` (#581). Do not merge before APPROVED.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §4.1 `buildTrendSplitData` → Task 2. ✓
+- §4.2 `useSupertrendOverlay` (2 LineSeries, trend split, bollinger skeleton) → Task 4. ✓
+- §4.3 registry (+IndicatorKey, +entry, makePaneIndices fallout) → Task 3. ✓
+- §4.4 colors `supertrendUp`/`supertrendDown` + grep collision → Task 1. ✓
+- §4.5 overlayLabelUtils `supertrendVisible` + config → Task 5. ✓
+- §4.6 StockChart (hook call, label configs, binding 26→27) → Task 6. ✓
+- §6.2 E2E modal toggle → Task 7. ✓
+- §6 test strategy (90%+, happy + worst) → Tasks 2/4/5 cover null trend, null supertrend, length mismatch, empty inputs, off-range index. ✓
+
+**Placeholder scan:** No TBD/TODO. The only deliberately non-literal spot is Task 7's modal-open helper, which must mirror the existing keltner/donchian E2E test (named explicitly so the implementer copies the real one rather than inventing).
+
+**Type consistency:** `buildTrendSplitData(bars, data, dir)` signature identical across Tasks 2/4; `SeriesPoint`/`UTCTimestamp` reused from `seriesDataUtils`; `supertrendVisible` boolean threaded identically through Tasks 5/6; `CHART_COLORS.supertrendUp`/`supertrendDown` names consistent across Tasks 1/4/5. Registry count 26→27 consistent across Tasks 3/6. ✓

--- a/docs/superpowers/specs/2026-06-07-render-supertrend-design.md
+++ b/docs/superpowers/specs/2026-06-07-render-supertrend-design.md
@@ -1,0 +1,113 @@
+# 미사용 보조지표 렌더링 — 5차: Supertrend (trend 색 오버레이)
+
+- **작성일**: 2026-06-07
+- **상태**: 설계 승인됨, 구현 계획 대기
+- **브랜치**: `feat/render-supertrend` (base: `feat/render-group-a-bands` = PR #581)
+
+## 1. 배경
+
+미사용 보조지표 렌더링 5차. 그룹 A 나머지(supertrend·chandelier·parabolicSar) 중 **supertrend** 1종을 가격 오버레이로 렌더한다. keltner/donchian(#581)에 이어 overlay 메커니즘을 쓰되, **trend 방향별 색**이라는 새 렌더 요소가 추가된다.
+
+계산은 `@y0ngha/siglens-core`에 있으므로 추가 작업은 siglens 차트 렌더링뿐.
+
+## 2. 자료조사 / 이미지 확인 결과
+
+웹 자료조사(TradingView·Mudrex 등) + 이미지 확인:
+- **Supertrend**: 가격 차트 위 **단일 연속 라인**으로, trend에 따라 색이 바뀐다. **trend up = 초록(가격 아래, 동적 지지)**, **trend down = 빨강(가격 위, 동적 저항)**. 추세 반전(flip) 시 라인 색이 전환되며 라인이 점프한다.
+- 데이터: `supertrend: SupertrendResult[]` where `{ supertrend: number | null, trend: 'up' | 'down' | null }`. trend는 `TrendDirection`(PriceTrend|null), warm-up은 null.
+
+## 3. 핵심 설계 결정
+
+### trend 색 라인 = up/down 2 LineSeries
+lightweight-charts `LineSeries`는 per-point 색을 지원하지 않는다(단색). 따라서 trend별 색을 표현하려면 **2개의 LineSeries**(up=초록, down=빨강)로 분리한다:
+- 각 bar에서 `trend === 'up'`이면 **up 시리즈**에 `supertrend` 값, down 시리즈에는 whitespace(`{ time }`만).
+- `trend === 'down'`이면 반대.
+- `trend === null`(warm-up) 또는 `supertrend === null`이면 양쪽 모두 whitespace.
+- flip 지점에서는 자연스럽게 한 시리즈가 끊기고 다른 시리즈가 시작 → 표준 supertrend의 "색 전환 + 라인 점프" 동작과 일치.
+
+| 항목 | 결정 | 근거 |
+|---|---|---|
+| 1차 범위 | supertrend 1종만 | trend 색 2시리즈 패턴 첫 도입, 검증 (사용자 선택) |
+| trend 색 | up/down 2 LineSeries + whitespace 분리 | LineSeries per-point 색 미지원; 표준 = 색 필수 |
+| 훅 구조 | overlay (자체 isVisible/toggle, Pane 0) | keltner/bollinger overlay 패턴 |
+| 카테고리 | `trend` | trend-following 지표(MA/EMA/ichimoku와 동류) |
+| 데이터 빌더 | 신규 `buildTrendSplitData` 헬퍼 | buildSeriesData(단순 키 추출)로는 trend 조건 분리 불가 |
+
+## 4. 아키텍처
+
+### 4.1 `utils/seriesDataUtils.ts` — `buildTrendSplitData` 헬퍼 (신규)
+```ts
+// trend 방향이 dir과 일치하는 bar만 supertrend 값을, 나머지는 whitespace를 반환.
+// up/down 2개 LineSeries로 trend별 색을 표현하기 위함(LineSeries는 per-point 색 미지원).
+export function buildTrendSplitData(
+    bars: Bar[],
+    data: SupertrendResult[],
+    dir: 'up' | 'down'
+): SeriesPoint[] {
+    const count = Math.min(bars.length, data.length);
+    return bars.slice(0, count).map((bar, i) => {
+        const r = data[i];
+        if (r && r.trend === dir && r.supertrend !== null) {
+            return { time: bar.time as UTCTimestamp, value: r.supertrend };
+        }
+        return { time: bar.time as UTCTimestamp };
+    });
+}
+```
+(seriesDataUtils의 SeriesPoint/UTCTimestamp 기존 import 재사용. SupertrendResult는 core import.)
+
+### 4.2 `hooks/useSupertrendOverlay.ts`
+- bollinger/keltner overlay 골격(자체 `useState(isVisible)`+toggle, prevChartRef, clearSeriesRefs/removeAllSeries useEffectEvent, 2-effect lifecycle/data-sync).
+- 시리즈 **2개**: `upSeriesRef`(LineSeries, color=supertrendUp), `downSeriesRef`(LineSeries, color=supertrendDown). (Area 아님 — 채움 없는 라인.)
+- 데이터 sync: `upSeriesRef.setData(buildTrendSplitData(bars, indicators.supertrend, 'up'))`, down도 'down'. guard `if (!indicators.supertrend.length) return`.
+- 반환 `{ isVisible, toggle }`.
+
+### 4.3 레지스트리 (`model/indicatorRegistry.ts`)
+- `IndicatorKey` +1 (`supertrend`).
+- `INDICATOR_REGISTRY` +1: `{ key: 'supertrend', label: 'Supertrend', category: 'trend', kind: 'overlay' }`.
+- 카테고리 union·CATEGORY_LABELS 무변경(`trend` 존재).
+- makePaneIndices(paneLabelUtils.test) fallout: `supertrend: INACTIVE_PANE_INDEX` 추가(overlay라 buildPaneLabels 미사용).
+
+### 4.4 색상 (`shared/lib/chartColors.ts`)
+- `supertrendUp`(초록 계열, 미사용 hex), `supertrendDown`(빨강 계열, 미사용 hex). 라인색 중복 grep 검증.
+
+### 4.5 OverlayLegend (`utils/overlayLabelUtils.ts`)
+- params +`supertrendVisible: boolean`.
+- config: `{ name: 'Supertrend', color: CHART_COLORS.supertrendUp, getValue: (ind, i) => ind.supertrend[i]?.supertrend ?? null }` (trend 무관 단일 현재값; 색은 up 색으로 대표).
+
+### 4.6 StockChart (`StockChart.tsx`)
+- `useSupertrendOverlay(commonHookParams)` 호출 → `{ isVisible: supertrendVisible, toggle: toggleSupertrend }`.
+- `buildOverlayLabelConfigs`에 `supertrendVisible` 전달 + deps.
+- `indicatorBindings` +1 (26→27): `{ meta: INDICATOR_META.supertrend, active: supertrendVisible, onToggle: toggleSupertrend }` + deps에 supertrendVisible/toggleSupertrend.
+
+## 5. 데이터 흐름
+```
+indicatorRegistry (supertrend = kind:'overlay', trend)
+        │
+StockChart: useSupertrendOverlay (자체 visible state)
+        │
+binding(27개) → IndicatorSettingsModal 자동 노출(무수정)
+        │
+체크 → toggle → Pane 0에 up/down 2 LineSeries 생성, buildTrendSplitData로 trend별 분리 데이터
+```
+
+## 6. 테스트 전략 (vitest + RTL, 90%+, happy + worst)
+
+### 6.1 단위
+- **`buildTrendSplitData`** 순수 함수: trend==='up'/'down' 일치 시 값, 불일치/null trend/null supertrend 시 whitespace. up/down 호출 시 상보적 분리 확인. bars/data 길이 불일치 worst-case.
+- **`useSupertrendOverlay`**: isVisible true→2 LineSeries 생성(addSeries 2회), false→removeSeries, 데이터 sync(up/down setData), worst-case(빈 배열→setData 미호출).
+- **레지스트리**: 27개, supertrend가 trend·overlay, 키 중복 없음.
+- **overlayLabelUtils**: supertrendVisible 시 'Supertrend' config, getValue 정확.
+
+### 6.2 E2E
+- `chart-indicators.spec.ts` 확장: 모달에서 Supertrend 체크 → 체크 상태 검증(overlay라 모달 상태로, #581 keltner 패턴).
+
+### 6.3 회귀
+- 기존 overlay/pane 훅·useIndicatorVisibility·모달 무변경. StockChart binding 26→27, overlayLabelConfigs params 확장으로 기존 테스트 갱신.
+
+## 7. FSD 준수
+- 훅·레지스트리·색·legend·헬퍼: `widgets/chart` 내부 + `shared/lib/chartColors`. core import(SupertrendResult/IndicatorResult). 레이어 정상. core 무변경.
+
+## 8. 후속 (별도 스펙)
+- chandelierExit(stop 라인+trend), parabolicSar(점 마커) — 그룹 A 나머지.
+- C-복합 3종, 그룹 D, 전송 페이로드 슬림화.

--- a/e2e/specs/chart-indicators.spec.ts
+++ b/e2e/specs/chart-indicators.spec.ts
@@ -124,6 +124,7 @@ test.describe('chart indicator settings modal', () => {
             name: 'Supertrend',
             exact: true,
         });
+        await expect(supertrend).not.toBeChecked();
         await supertrend.check();
         await expect(supertrend).toBeChecked();
     });

--- a/e2e/specs/chart-indicators.spec.ts
+++ b/e2e/specs/chart-indicators.spec.ts
@@ -112,4 +112,19 @@ test.describe('chart indicator settings modal', () => {
         await keltner.check();
         await expect(keltner).toBeChecked();
     });
+
+    test('toggles the Supertrend overlay via the modal', async ({ page }) => {
+        await page.goto('/AAPL');
+        await page.getByRole('button', { name: GEAR }).click();
+        const dialog = page.getByRole('dialog');
+        // Supertrend는 가격 OVERLAY(페인 아님) — Keltner와 동일하게 모달 체크박스
+        // 상태로 검증한다. 'Supertrend'는 추세 카테고리 체크박스이며 exact로
+        // substring 충돌을 피한다.
+        const supertrend = dialog.getByRole('checkbox', {
+            name: 'Supertrend',
+            exact: true,
+        });
+        await supertrend.check();
+        await expect(supertrend).toBeChecked();
+    });
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,9 +51,9 @@
     --color-chart-donchian-upper: #fcd34d;
     --color-chart-donchian-middle: #d97706;
 
-    /* Chart — Supertrend */
-    --color-chart-supertrend-up: #16a34a;
-    --color-chart-supertrend-down: #dc2626;
+    /* Chart — Supertrend (추세 색 고정값: bullish teal / bearish red) */
+    --color-chart-supertrend-up: #26a69a;
+    --color-chart-supertrend-down: #ef5350;
 
     /* Chart — MACD */
     --color-chart-macd: #3b82f6;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,6 +51,10 @@
     --color-chart-donchian-upper: #fcd34d;
     --color-chart-donchian-middle: #d97706;
 
+    /* Chart — Supertrend */
+    --color-chart-supertrend-up: #16a34a;
+    --color-chart-supertrend-down: #dc2626;
+
     /* Chart — MACD */
     --color-chart-macd: #3b82f6;
     --color-chart-signal: #f59e0b;

--- a/src/shared/lib/chartColors.ts
+++ b/src/shared/lib/chartColors.ts
@@ -135,9 +135,9 @@ export const CHART_COLORS = {
     atrLine: '#fdba74',
     yangZhangLine: '#d8b4fe',
     ewmaVolatilityLine: '#6ee7b7',
-    // Supertrend (trend 색 라인 — up=초록, down=빨강)
-    supertrendUp: '#16a34a',
-    supertrendDown: '#dc2626',
+    // Supertrend (trend 색 라인 — up/down) — DESIGN.md 추세 색 고정값(bullish teal / bearish red) 재사용
+    supertrendUp: '#26a69a',
+    supertrendDown: '#ef5350',
 } as const;
 
 const PERIOD_COLOR_MAP: Record<number, string> = {

--- a/src/shared/lib/chartColors.ts
+++ b/src/shared/lib/chartColors.ts
@@ -135,6 +135,9 @@ export const CHART_COLORS = {
     atrLine: '#fdba74',
     yangZhangLine: '#d8b4fe',
     ewmaVolatilityLine: '#6ee7b7',
+    // Supertrend (trend 색 라인 — up=초록, down=빨강)
+    supertrendUp: '#16a34a',
+    supertrendDown: '#dc2626',
 } as const;
 
 const PERIOD_COLOR_MAP: Record<number, string> = {

--- a/src/widgets/chart/StockChart.tsx
+++ b/src/widgets/chart/StockChart.tsx
@@ -23,6 +23,7 @@ import { useEMAOverlay } from './hooks/useEMAOverlay';
 import { useBollingerOverlay } from './hooks/useBollingerOverlay';
 import { useKeltnerOverlay } from './hooks/useKeltnerOverlay';
 import { useDonchianOverlay } from './hooks/useDonchianOverlay';
+import { useSupertrendOverlay } from './hooks/useSupertrendOverlay';
 import { useMACDChart } from './hooks/useMACDChart';
 import { useRSIChart } from './hooks/useRSIChart';
 import { useDMIChart } from './hooks/useDMIChart';
@@ -202,6 +203,9 @@ export function StockChart({
     const { isVisible: donchianVisible, toggle: toggleDonchian } =
         useDonchianOverlay(commonHookParams);
 
+    const { isVisible: supertrendVisible, toggle: toggleSupertrend } =
+        useSupertrendOverlay(commonHookParams);
+
     const { isVisible: vpVisible, toggle: toggleVP } =
         useVolumeProfileOverlay(commonHookParams);
 
@@ -375,6 +379,7 @@ export function StockChart({
                 vpVisible,
                 keltnerVisible,
                 donchianVisible,
+                supertrendVisible,
             }),
         [
             maVisiblePeriods,
@@ -384,6 +389,7 @@ export function StockChart({
             vpVisible,
             keltnerVisible,
             donchianVisible,
+            supertrendVisible,
         ]
     );
 
@@ -541,8 +547,13 @@ export function StockChart({
                 active: donchianVisible,
                 onToggle: toggleDonchian,
             },
+            {
+                meta: INDICATOR_META.supertrend,
+                active: supertrendVisible,
+                onToggle: toggleSupertrend,
+            },
         ],
-        // deps에 visible 객체 전체를 둔다 — 한 지표 토글 시 26개 binding 전체가 재조립되지만
+        // deps에 visible 객체 전체를 둔다 — 한 지표 토글 시 27개 binding 전체가 재조립되지만
         // 항목 수가 적어 비용은 무시할 만하며, 개별 visible 키를 나열하는 것보다 명료하다.
         [
             maVisiblePeriods,
@@ -554,6 +565,7 @@ export function StockChart({
             vpVisible,
             keltnerVisible,
             donchianVisible,
+            supertrendVisible,
             toggleMAPeriod,
             toggleEMAPeriod,
             toggleIchimoku,
@@ -561,6 +573,7 @@ export function StockChart({
             toggleVP,
             toggleKeltner,
             toggleDonchian,
+            toggleSupertrend,
         ]
     );
 

--- a/src/widgets/chart/__tests__/StockChart.test.tsx
+++ b/src/widgets/chart/__tests__/StockChart.test.tsx
@@ -408,13 +408,13 @@ describe('StockChart', () => {
         );
     });
 
-    it('renders IndicatorSettingsModal with 26 indicator bindings', () => {
+    it('renders IndicatorSettingsModal with 27 indicator bindings', () => {
         render(<StockChart bars={mockBars} timeframe="1Day" />);
         const modal = screen.getByTestId('indicator-settings-modal');
-        expect(modal).toHaveAttribute('data-count', '26');
+        expect(modal).toHaveAttribute('data-count', '27');
         expect(modal).toHaveAttribute(
             'data-keys',
-            'ma,ema,ichimoku,rsi,macd,dmi,stochastic,stochRsi,cci,bollinger,volumeProfile,mfi,williamsR,connorsRsi,cmf,bollingerPercentB,hurst,varianceRatio,macdV,forceIndex,obv,atr,yangZhang,ewmaVolatility,keltnerChannel,donchianChannel'
+            'ma,ema,ichimoku,rsi,macd,dmi,stochastic,stochRsi,cci,bollinger,volumeProfile,mfi,williamsR,connorsRsi,cmf,bollingerPercentB,hurst,varianceRatio,macdV,forceIndex,obv,atr,yangZhang,ewmaVolatility,keltnerChannel,donchianChannel,supertrend'
         );
     });
 

--- a/src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts
@@ -2,6 +2,7 @@
 import { act, renderHook } from '@testing-library/react';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
 import { useSupertrendOverlay } from '../../hooks/useSupertrendOverlay';
+import { buildTrendSplitData } from '../../utils/seriesDataUtils';
 
 const mockSetData = vi.fn();
 const mockApplyOptions = vi.fn();
@@ -120,6 +121,62 @@ describe('useSupertrendOverlay', () => {
         );
         act(() => result.current.toggle());
         expect(mockSetData).toHaveBeenCalledTimes(2);
+
+        // 두 시리즈가 각각 올바른 방향('up'/'down')으로 분리 호출되는지 명시 검증
+        // — 호출 횟수만 보면 둘 다 'up'으로 잘못 호출돼도 통과하므로 인자까지 고정한다.
+        const splitMock = vi.mocked(buildTrendSplitData);
+        expect(splitMock).toHaveBeenCalledWith(
+            FAKE_BARS,
+            FILLED_INDICATORS.supertrend,
+            'up'
+        );
+        expect(splitMock).toHaveBeenCalledWith(
+            FAKE_BARS,
+            FILLED_INDICATORS.supertrend,
+            'down'
+        );
+    });
+
+    it('re-sets data on both series when bars change while visible', () => {
+        const chart = makeChart();
+        const { result, rerender } = renderHook(
+            ({ bars }) =>
+                useSupertrendOverlay({
+                    chartRef: makeChartRef(chart),
+                    bars,
+                    indicators: FILLED_INDICATORS,
+                }),
+            { initialProps: { bars: FAKE_BARS } }
+        );
+        act(() => result.current.toggle());
+        vi.clearAllMocks();
+
+        const newBars: Bar[] = [
+            {
+                time: 2000,
+                open: 200,
+                high: 220,
+                low: 180,
+                close: 210,
+                volume: 2000,
+            },
+        ];
+        rerender({ bars: newBars });
+
+        // 데이터-싱크 effect 의존성([indicators, bars, isVisible])이 bars 변경에 반응해
+        // up/down 두 시리즈를 모두 다시 setData 하는지 검증.
+        expect(mockSetData).toHaveBeenCalledTimes(2);
+        const splitMock = vi.mocked(buildTrendSplitData);
+        expect(splitMock).toHaveBeenCalledWith(
+            newBars,
+            FILLED_INDICATORS.supertrend,
+            'up'
+        );
+        expect(splitMock).toHaveBeenCalledWith(
+            newBars,
+            FILLED_INDICATORS.supertrend,
+            'down'
+        );
     });
 
     it('does not set data when supertrend is empty', () => {

--- a/src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useSupertrendOverlay } from '../../hooks/useSupertrendOverlay';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildTrendSplitData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useSupertrendOverlay
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = {
+    supertrend: [],
+} as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    supertrend: [{ supertrend: 10, trend: 'up' }],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useSupertrendOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns isVisible false initially', () => {
+        const { result } = renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('toggles isVisible when toggle is called', () => {
+        const { result } = renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(result.current.isVisible).toBe(true);
+        act(() => result.current.toggle());
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates two LineSeries (up, down) when visible and chart exists', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes both series when toggled off', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        act(() => result.current.toggle());
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('sets data on both series when visible with data', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockSetData).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not set data when supertrend is empty', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('provides stable toggle function reference', () => {
+        const { result, rerender } = renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        const firstToggle = result.current.toggle;
+        rerender();
+        expect(result.current.toggle).toBe(firstToggle);
+    });
+});

--- a/src/widgets/chart/__tests__/model/indicatorRegistry.test.ts
+++ b/src/widgets/chart/__tests__/model/indicatorRegistry.test.ts
@@ -14,8 +14,16 @@ function bindingFor(key: IndicatorKey, active = false): IndicatorBinding {
 }
 
 describe('indicatorRegistry', () => {
-    it('registers exactly the 26 modal-target indicators', () => {
-        expect(INDICATOR_REGISTRY).toHaveLength(26);
+    it('registers exactly the 27 modal-target indicators', () => {
+        expect(INDICATOR_REGISTRY).toHaveLength(27);
+    });
+
+    it('registers supertrend as a trend overlay', () => {
+        const meta = INDICATOR_REGISTRY.find(m => m.key === 'supertrend');
+        expect(meta).toBeDefined();
+        expect(meta?.category).toBe('trend');
+        expect(meta?.kind).toBe('overlay');
+        expect(meta?.hasPeriods).toBeUndefined();
     });
 
     it('registers keltner/donchian as volatility overlays', () => {

--- a/src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts
@@ -280,6 +280,33 @@ describe('buildOverlayLabelConfigs', () => {
         expect(st?.getValue(ind, 5)).toBeNull();
     });
 
+    it('Supertrend getColor follows the bar trend (up=green, down=red, null=neutral)', () => {
+        const configs = buildOverlayLabelConfigs({
+            maVisiblePeriods: [],
+            emaVisiblePeriods: [],
+            bollingerVisible: false,
+            ichimokuVisible: false,
+            vpVisible: false,
+            keltnerVisible: false,
+            donchianVisible: false,
+            supertrendVisible: true,
+        });
+        const st = configs.find(c => c.name === 'Supertrend');
+        expect(st?.getColor).toBeDefined();
+        const ind = {
+            supertrend: [
+                { supertrend: 10, trend: 'up' },
+                { supertrend: 11, trend: 'down' },
+                { supertrend: null, trend: null },
+            ],
+        } as never;
+        expect(st?.getColor?.(ind, 0)).toBe(CHART_COLORS.supertrendUp);
+        expect(st?.getColor?.(ind, 1)).toBe(CHART_COLORS.supertrendDown);
+        expect(st?.getColor?.(ind, 2)).toBe(CHART_COLORS.neutral);
+        // 범위를 벗어난 인덱스(warm-up 이전)도 neutral로 안전 처리
+        expect(st?.getColor?.(ind, 9)).toBe(CHART_COLORS.neutral);
+    });
+
     it('omits Supertrend config when supertrendVisible is false', () => {
         const configs = buildOverlayLabelConfigs({
             maVisiblePeriods: [],
@@ -381,6 +408,27 @@ describe('resolveOverlayValues', () => {
             const result = resolveOverlayValues([], mockIndicators, 0);
 
             expect(result).toEqual([]);
+        });
+    });
+
+    describe('config.getColor가 있을 때', () => {
+        it('정적 color 대신 getColor(indicators, barIndex) 결과를 색으로 사용한다', () => {
+            const dynamicConfigs = [
+                {
+                    name: 'Dyn',
+                    color: '#000000',
+                    getValue: (): number | null => 1,
+                    getColor: (_i: never, barIndex: number): string =>
+                        barIndex === 0 ? '#111111' : '#222222',
+                },
+            ] as unknown as Parameters<typeof resolveOverlayValues>[0];
+
+            expect(
+                resolveOverlayValues(dynamicConfigs, mockIndicators, 0)[0].color
+            ).toBe('#111111');
+            expect(
+                resolveOverlayValues(dynamicConfigs, mockIndicators, 1)[0].color
+            ).toBe('#222222');
         });
     });
 });

--- a/src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts
@@ -68,6 +68,7 @@ describe('buildOverlayLabelConfigs', () => {
                 vpVisible: false,
                 keltnerVisible: false,
                 donchianVisible: false,
+                supertrendVisible: false,
             });
 
             expect(result).toEqual([]);
@@ -84,6 +85,7 @@ describe('buildOverlayLabelConfigs', () => {
                 vpVisible: false,
                 keltnerVisible: false,
                 donchianVisible: false,
+                supertrendVisible: false,
             });
 
             expect(result).toHaveLength(2);
@@ -102,6 +104,7 @@ describe('buildOverlayLabelConfigs', () => {
                 vpVisible: false,
                 keltnerVisible: false,
                 donchianVisible: false,
+                supertrendVisible: false,
             });
 
             expect(result).toHaveLength(1);
@@ -119,6 +122,7 @@ describe('buildOverlayLabelConfigs', () => {
                 vpVisible: false,
                 keltnerVisible: false,
                 donchianVisible: false,
+                supertrendVisible: false,
             });
 
             expect(result).toHaveLength(3);
@@ -138,6 +142,7 @@ describe('buildOverlayLabelConfigs', () => {
                 vpVisible: false,
                 keltnerVisible: false,
                 donchianVisible: false,
+                supertrendVisible: false,
             });
 
             expect(result).toHaveLength(5);
@@ -159,6 +164,7 @@ describe('buildOverlayLabelConfigs', () => {
                 vpVisible: true,
                 keltnerVisible: false,
                 donchianVisible: false,
+                supertrendVisible: false,
             });
 
             expect(result).toHaveLength(3);
@@ -178,6 +184,7 @@ describe('buildOverlayLabelConfigs', () => {
                 vpVisible: false,
                 keltnerVisible: false,
                 donchianVisible: false,
+                supertrendVisible: false,
             });
 
             expect(result).toHaveLength(4);
@@ -198,6 +205,7 @@ describe('buildOverlayLabelConfigs', () => {
                 vpVisible: false,
                 keltnerVisible: false,
                 donchianVisible: false,
+                supertrendVisible: false,
             });
 
             expect(result[0].color).toBe(getPeriodColor(5));
@@ -212,6 +220,7 @@ describe('buildOverlayLabelConfigs', () => {
                 vpVisible: false,
                 keltnerVisible: false,
                 donchianVisible: false,
+                supertrendVisible: false,
             });
 
             expect(result[0].color).toBe(CHART_COLORS.bollingerUpper);
@@ -227,6 +236,7 @@ describe('buildOverlayLabelConfigs', () => {
             vpVisible: false,
             keltnerVisible: true,
             donchianVisible: true,
+            supertrendVisible: false,
         });
         const names = configs.map(c => c.name);
         expect(names).toEqual(
@@ -249,6 +259,39 @@ describe('buildOverlayLabelConfigs', () => {
         expect(configs.find(c => c.name === 'DC Lower')?.getValue(ind, 0)).toBe(
             19
         );
+    });
+
+    it('includes a Supertrend config when supertrendVisible is true', () => {
+        const configs = buildOverlayLabelConfigs({
+            maVisiblePeriods: [],
+            emaVisiblePeriods: [],
+            bollingerVisible: false,
+            ichimokuVisible: false,
+            vpVisible: false,
+            keltnerVisible: false,
+            donchianVisible: false,
+            supertrendVisible: true,
+        });
+        const st = configs.find(c => c.name === 'Supertrend');
+        expect(st).toBeDefined();
+        expect(st?.color).toBe(CHART_COLORS.supertrendUp);
+        const ind = { supertrend: [{ supertrend: 42, trend: 'up' }] } as never;
+        expect(st?.getValue(ind, 0)).toBe(42);
+        expect(st?.getValue(ind, 5)).toBeNull();
+    });
+
+    it('omits Supertrend config when supertrendVisible is false', () => {
+        const configs = buildOverlayLabelConfigs({
+            maVisiblePeriods: [],
+            emaVisiblePeriods: [],
+            bollingerVisible: false,
+            ichimokuVisible: false,
+            vpVisible: false,
+            keltnerVisible: false,
+            donchianVisible: false,
+            supertrendVisible: false,
+        });
+        expect(configs.find(c => c.name === 'Supertrend')).toBeUndefined();
     });
 });
 
@@ -302,6 +345,7 @@ describe('resolveOverlayValues', () => {
         vpVisible: false,
         keltnerVisible: false,
         donchianVisible: false,
+        supertrendVisible: false,
     });
 
     describe('barIndex가 -1일 때', () => {
@@ -389,6 +433,7 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             vpVisible: false,
             keltnerVisible: false,
             donchianVisible: false,
+            supertrendVisible: false,
         });
 
         expect(configs[0].getValue(mockIndicators, 0)).toBe(100);
@@ -405,6 +450,7 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             vpVisible: false,
             keltnerVisible: false,
             donchianVisible: false,
+            supertrendVisible: false,
         });
 
         expect(configs[0].getValue(mockIndicators, 0)).toBeNull();
@@ -419,6 +465,7 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             vpVisible: false,
             keltnerVisible: false,
             donchianVisible: false,
+            supertrendVisible: false,
         });
 
         expect(configs[0].getValue(mockIndicators, 0)).toBe(105);
@@ -436,6 +483,7 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             vpVisible: false,
             keltnerVisible: false,
             donchianVisible: false,
+            supertrendVisible: false,
         });
 
         expect(configs[0].getValue(mockIndicators, 0)).toBe(101); // tenkan
@@ -455,6 +503,7 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             vpVisible: true,
             keltnerVisible: false,
             donchianVisible: false,
+            supertrendVisible: false,
         });
 
         expect(configs[0].getValue(mockIndicators, 0)).toBe(100); // poc
@@ -476,6 +525,7 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             vpVisible: true,
             keltnerVisible: false,
             donchianVisible: false,
+            supertrendVisible: false,
         });
 
         expect(configs[0].getValue(emptyIndicators, 0)).toBeNull();

--- a/src/widgets/chart/__tests__/utils/overlayLabelUtilsBranches.test.ts
+++ b/src/widgets/chart/__tests__/utils/overlayLabelUtilsBranches.test.ts
@@ -66,6 +66,7 @@ describe('overlayLabelUtils — branch coverage', () => {
                 vpVisible: false,
                 keltnerVisible: false,
                 donchianVisible: false,
+                supertrendVisible: false,
             });
 
             expect(configs[0].getValue(indicators, 0)).toBeNull(); // upper
@@ -88,6 +89,7 @@ describe('overlayLabelUtils — branch coverage', () => {
                 vpVisible: false,
                 keltnerVisible: false,
                 donchianVisible: false,
+                supertrendVisible: false,
             });
 
             expect(configs[0].getValue(indicators, 0)).toBeNull(); // tenkan
@@ -114,6 +116,7 @@ describe('overlayLabelUtils — branch coverage', () => {
                 vpVisible: true,
                 keltnerVisible: false,
                 donchianVisible: false,
+                supertrendVisible: false,
             });
 
             expect(configs[0].getValue(indicators, 0)).toBeNull(); // poc

--- a/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
@@ -49,6 +49,7 @@ function makePaneIndices(overrides: Partial<PaneIndices> = {}): PaneIndices {
         ewmaVolatility: INACTIVE_PANE_INDEX,
         keltnerChannel: INACTIVE_PANE_INDEX,
         donchianChannel: INACTIVE_PANE_INDEX,
+        supertrend: INACTIVE_PANE_INDEX,
     } satisfies PaneIndices;
     return { ...base, ...overrides };
 }

--- a/src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts
@@ -1,8 +1,10 @@
-import type { Bar } from '@y0ngha/siglens-core';
+import { describe, it, expect } from 'vitest';
+import type { Bar, SupertrendResult } from '@y0ngha/siglens-core';
 import type { UTCTimestamp } from 'lightweight-charts';
 import {
     buildSeriesData,
     buildSeriesDataFromValues,
+    buildTrendSplitData,
 } from '@/widgets/chart/utils/seriesDataUtils';
 
 const mockBars: Bar[] = [
@@ -131,5 +133,61 @@ describe('buildSeriesDataFromValues', () => {
         result.forEach(point => {
             expect(point).not.toHaveProperty('value');
         });
+    });
+});
+
+function bar(time: number): Bar {
+    return { time, open: 1, high: 2, low: 0, close: 1, volume: 10 };
+}
+
+describe('buildTrendSplitData', () => {
+    const bars: Bar[] = [bar(1), bar(2), bar(3)];
+    const data: SupertrendResult[] = [
+        { supertrend: 10, trend: 'up' },
+        { supertrend: 11, trend: 'down' },
+        { supertrend: null, trend: null },
+    ];
+
+    it("returns value only on bars whose trend matches 'up', whitespace otherwise", () => {
+        expect(buildTrendSplitData(bars, data, 'up')).toEqual([
+            { time: 1, value: 10 },
+            { time: 2 },
+            { time: 3 },
+        ]);
+    });
+
+    it("returns value only on bars whose trend matches 'down', whitespace otherwise", () => {
+        expect(buildTrendSplitData(bars, data, 'down')).toEqual([
+            { time: 1 },
+            { time: 2, value: 11 },
+            { time: 3 },
+        ]);
+    });
+
+    it('up and down outputs are complementary on matched bars (never both have value)', () => {
+        const up = buildTrendSplitData(bars, data, 'up');
+        const down = buildTrendSplitData(bars, data, 'down');
+        up.forEach((u, i) => {
+            const bothHaveValue = 'value' in u && 'value' in down[i];
+            expect(bothHaveValue).toBe(false);
+        });
+    });
+
+    it('emits whitespace when supertrend is null even if trend matches dir', () => {
+        const nullVal: SupertrendResult[] = [{ supertrend: null, trend: 'up' }];
+        expect(buildTrendSplitData([bar(1)], nullVal, 'up')).toEqual([
+            { time: 1 },
+        ]);
+    });
+
+    it('clamps to the shorter of bars / data length (worst case)', () => {
+        const longBars = [bar(1), bar(2), bar(3), bar(4)];
+        const shortData: SupertrendResult[] = [{ supertrend: 5, trend: 'up' }];
+        const out = buildTrendSplitData(longBars, shortData, 'up');
+        expect(out).toEqual([{ time: 1, value: 5 }]);
+    });
+
+    it('returns empty array for empty inputs', () => {
+        expect(buildTrendSplitData([], [], 'up')).toEqual([]);
     });
 });

--- a/src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from 'vitest';
 import type { Bar, SupertrendResult } from '@y0ngha/siglens-core';
 import type { UTCTimestamp } from 'lightweight-charts';
 import {

--- a/src/widgets/chart/hooks/useSupertrendOverlay.ts
+++ b/src/widgets/chart/hooks/useSupertrendOverlay.ts
@@ -1,0 +1,118 @@
+'use client';
+
+import type { RefObject } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useEffectEvent,
+    useRef,
+    useState,
+} from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import { LineSeries } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { buildTrendSplitData } from '../utils/seriesDataUtils';
+
+interface UseSupertrendOverlayParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+}
+
+interface UseSupertrendOverlayReturn {
+    isVisible: boolean;
+    toggle: () => void;
+}
+
+export function useSupertrendOverlay({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+}: UseSupertrendOverlayParams): UseSupertrendOverlayReturn {
+    const [isVisible, setIsVisible] = useState(false);
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const upSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+    const downSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+    const toggle = useCallback(() => {
+        setIsVisible(prev => !prev);
+    }, []);
+
+    const clearSeriesRefs = useEffectEvent(() => {
+        upSeriesRef.current = null;
+        downSeriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (upSeriesRef.current) {
+            chart.removeSeries(upSeriesRef.current);
+            upSeriesRef.current = null;
+        }
+        if (downSeriesRef.current) {
+            chart.removeSeries(downSeriesRef.current);
+            downSeriesRef.current = null;
+        }
+    });
+
+    // bars, indicators는 의존하지 않음 — 데이터 세팅은 아래 effect가 단독 담당.
+    // StockChart의 차트 생성 effect가 선언 순서상 앞에 있으므로
+    // 이 effect 실행 시점에 chartRef.current는 이미 설정된 상태.
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (!upSeriesRef.current) {
+            upSeriesRef.current = chart.addSeries(LineSeries, {
+                color: CHART_COLORS.supertrendUp,
+                lineWidth,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        upSeriesRef.current.applyOptions({ lineWidth });
+
+        if (!downSeriesRef.current) {
+            downSeriesRef.current = chart.addSeries(LineSeries, {
+                color: CHART_COLORS.supertrendDown,
+                lineWidth,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        downSeriesRef.current.applyOptions({ lineWidth });
+    }, [chartRef, isVisible, lineWidth]);
+
+    // isVisible이 true로 바뀔 때도 실행되어 새로 생성된 시리즈에 초기 데이터를 세팅함
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { supertrend } = indicators;
+        if (!supertrend.length) return;
+
+        if (!upSeriesRef.current || !downSeriesRef.current) return;
+
+        upSeriesRef.current.setData(
+            buildTrendSplitData(bars, supertrend, 'up')
+        );
+        downSeriesRef.current.setData(
+            buildTrendSplitData(bars, supertrend, 'down')
+        );
+    }, [indicators, bars, isVisible]);
+
+    return { isVisible, toggle };
+}

--- a/src/widgets/chart/model/indicatorRegistry.ts
+++ b/src/widgets/chart/model/indicatorRegistry.ts
@@ -43,7 +43,8 @@ export type IndicatorKey =
     | 'yangZhang'
     | 'ewmaVolatility'
     | 'keltnerChannel'
-    | 'donchianChannel';
+    | 'donchianChannel'
+    | 'supertrend';
 
 export interface IndicatorMeta {
     key: IndicatorKey;
@@ -175,6 +176,12 @@ export const INDICATOR_REGISTRY: readonly IndicatorMeta[] = [
         key: 'donchianChannel',
         label: 'Donchian',
         category: 'volatility',
+        kind: 'overlay',
+    },
+    {
+        key: 'supertrend',
+        label: 'Supertrend',
+        category: 'trend',
         kind: 'overlay',
     },
 ];

--- a/src/widgets/chart/utils/overlayLabelUtils.ts
+++ b/src/widgets/chart/utils/overlayLabelUtils.ts
@@ -14,6 +14,7 @@ interface BuildOverlayLabelConfigsParams {
     vpVisible: boolean;
     keltnerVisible: boolean;
     donchianVisible: boolean;
+    supertrendVisible: boolean;
 }
 
 export function buildOverlayLabelConfigs({
@@ -24,6 +25,7 @@ export function buildOverlayLabelConfigs({
     vpVisible,
     keltnerVisible,
     donchianVisible,
+    supertrendVisible,
 }: BuildOverlayLabelConfigsParams): OverlayLabelConfig[] {
     const maConfigs: OverlayLabelConfig[] = maVisiblePeriods.map(period => ({
         name: `MA(${period})`,
@@ -166,6 +168,17 @@ export function buildOverlayLabelConfigs({
           ]
         : [];
 
+    const supertrendConfigs: OverlayLabelConfig[] = supertrendVisible
+        ? [
+              {
+                  name: 'Supertrend',
+                  color: CHART_COLORS.supertrendUp,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.supertrend[i]?.supertrend ?? null,
+              },
+          ]
+        : [];
+
     return [
         ...maConfigs,
         ...emaConfigs,
@@ -174,6 +187,7 @@ export function buildOverlayLabelConfigs({
         ...vpConfigs,
         ...keltnerConfigs,
         ...donchianConfigs,
+        ...supertrendConfigs,
     ];
 }
 

--- a/src/widgets/chart/utils/overlayLabelUtils.ts
+++ b/src/widgets/chart/utils/overlayLabelUtils.ts
@@ -4,6 +4,12 @@ import type { OverlayItemBase, OverlayLegendItem } from '../types';
 
 export interface OverlayLabelConfig extends OverlayItemBase {
     getValue: (indicators: IndicatorResult, barIndex: number) => number | null;
+    /**
+     * 크로스헤어 막대마다 범례 점 색을 동적으로 결정한다(선택). 라인 색이 막대별로
+     * 바뀌는 지표(예: Supertrend는 추세별 초록/빨강)에서, 범례 색이 실제 그려진
+     * 라인 색과 어긋나지 않도록 한다. 미지정 시 정적 color를 사용한다.
+     */
+    getColor?: (indicators: IndicatorResult, barIndex: number) => string;
 }
 
 interface BuildOverlayLabelConfigsParams {
@@ -175,6 +181,14 @@ export function buildOverlayLabelConfigs({
                   color: CHART_COLORS.supertrendUp,
                   getValue: (ind: IndicatorResult, i: number): number | null =>
                       ind.supertrend[i]?.supertrend ?? null,
+                  // 라인은 추세별 초록(up)/빨강(down) — 범례 점도 현재 막대 추세를 따라간다.
+                  // 추세 미정(warm-up)은 neutral로, 라인과 어긋나지 않게 한다.
+                  getColor: (ind: IndicatorResult, i: number): string => {
+                      const trend = ind.supertrend[i]?.trend;
+                      if (trend === 'down') return CHART_COLORS.supertrendDown;
+                      if (trend === 'up') return CHART_COLORS.supertrendUp;
+                      return CHART_COLORS.neutral;
+                  },
               },
           ]
         : [];
@@ -229,7 +243,9 @@ export function resolveOverlayValues(
 
     return configs.map(config => ({
         name: config.name,
-        color: config.color,
+        color: config.getColor
+            ? config.getColor(indicators, barIndex)
+            : config.color,
         value: config.getValue(indicators, barIndex),
     }));
 }

--- a/src/widgets/chart/utils/seriesDataUtils.ts
+++ b/src/widgets/chart/utils/seriesDataUtils.ts
@@ -1,5 +1,12 @@
-import type { Bar, SupertrendResult } from '@y0ngha/siglens-core';
+import type {
+    Bar,
+    SupertrendResult,
+    TrendDirection,
+} from '@y0ngha/siglens-core';
 import type { UTCTimestamp } from 'lightweight-charts';
+
+/** 추세 방향 중 확정된 값(warm-up의 null 제외). buildTrendSplitData의 dir 인자에 사용. */
+type TrendDir = Exclude<TrendDirection, null>;
 
 export type SeriesPoint =
     | { time: UTCTimestamp; value: number; color?: string }
@@ -64,11 +71,12 @@ export function buildSeriesDataFromValues(
 export function buildTrendSplitData(
     bars: Bar[],
     data: SupertrendResult[],
-    dir: 'up' | 'down'
+    dir: TrendDir
 ): SeriesPoint[] {
     const count = Math.min(bars.length, data.length);
     return bars.slice(0, count).map((bar, i) => {
         const r = data[i];
+        // Bar.time은 epoch seconds 정수 — LWC UTCTimestamp(branded number)와 런타임 형태 동일하므로 safe-cast.
         if (r && r.trend === dir && r.supertrend !== null) {
             return { time: bar.time as UTCTimestamp, value: r.supertrend };
         }

--- a/src/widgets/chart/utils/seriesDataUtils.ts
+++ b/src/widgets/chart/utils/seriesDataUtils.ts
@@ -1,4 +1,4 @@
-import type { Bar } from '@y0ngha/siglens-core';
+import type { Bar, SupertrendResult } from '@y0ngha/siglens-core';
 import type { UTCTimestamp } from 'lightweight-charts';
 
 export type SeriesPoint =
@@ -54,5 +54,24 @@ export function buildSeriesDataFromValues(
             return { time: bar.time as UTCTimestamp };
         }
         return { time: bar.time as UTCTimestamp, value };
+    });
+}
+
+/**
+ * trend 방향이 dir과 일치하는 bar만 supertrend 값을, 나머지는 WhitespaceData({ time })를 반환한다.
+ * up/down 2개 LineSeries로 trend별 색을 표현하기 위함 (LineSeries는 per-point 색 미지원).
+ */
+export function buildTrendSplitData(
+    bars: Bar[],
+    data: SupertrendResult[],
+    dir: 'up' | 'down'
+): SeriesPoint[] {
+    const count = Math.min(bars.length, data.length);
+    return bars.slice(0, count).map((bar, i) => {
+        const r = data[i];
+        if (r && r.trend === dir && r.supertrend !== null) {
+            return { time: bar.time as UTCTimestamp, value: r.supertrend };
+        }
+        return { time: bar.time as UTCTimestamp };
     });
 }

--- a/src/widgets/chart/utils/seriesDataUtils.ts
+++ b/src/widgets/chart/utils/seriesDataUtils.ts
@@ -5,7 +5,7 @@ import type {
 } from '@y0ngha/siglens-core';
 import type { UTCTimestamp } from 'lightweight-charts';
 
-/** 추세 방향 중 확정된 값(warm-up의 null 제외). buildTrendSplitData의 dir 인자에 사용. */
+/** 추세 방향 중 확정된 값(warm-up의 null 제외). */
 type TrendDir = Exclude<TrendDirection, null>;
 
 export type SeriesPoint =


### PR DESCRIPTION
## 요약
미사용 보조지표 렌더링 5차. `supertrend` 지표를 가격 페인 오버레이로 렌더한다. 추세에 따라 라인 색이 바뀐다 — 상승(up)=초록, 하락(down)=빨강.

lightweight-charts `LineSeries`는 per-point 색을 지원하지 않으므로, **2개의 LineSeries**(up=초록, down=빨강)로 분리하고 각 시리즈에 해당 추세 막대만 값을 채운다(나머지는 whitespace). 신규 순수 헬퍼 `buildTrendSplitData`가 이 분리를 담당한다. 기존 `useKeltnerOverlay`/`useBollingerOverlay` overlay 패턴을 따른다. 계산은 `@y0ngha/siglens-core`에 있어 코어 변경 없음.

## 변경 사항
- `shared/lib/chartColors.ts` + `globals.css`: `supertrendUp`(#16a34a)/`supertrendDown`(#dc2626) 색 + @theme 토큰
- `utils/seriesDataUtils.ts`: `buildTrendSplitData` 헬퍼 (추세별 값/whitespace 분리)
- `model/indicatorRegistry.ts`: supertrend 레지스트리 등록 (overlay·trend, 26→27)
- `hooks/useSupertrendOverlay.ts`: 오버레이 훅 (up/down 2 LineSeries)
- `utils/overlayLabelUtils.ts`: OverlayLegend config + per-bar `getColor`(범례 점 색이 현재 막대 추세를 따라 라인과 일치)
- `StockChart.tsx`: 훅 배선 + 27번째 binding
- `e2e/specs/chart-indicators.spec.ts`: 모달 토글 E2E

## 검증
- vitest 전체 커버리지 게이트 통과 (branches 91.46%, lines 95.79%)
- lint / prettier --check / production build 전부 통과
- 내부 review-agent(Opus): round 1 recommended 1건(범례 색 정합) 수정 → round 2 APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)