### PR TITLE
feat(chart): render Parabolic SAR + Chandelier Exit overlays (finish group A)

### DIFF
--- a/docs/superpowers/plans/2026-06-07-render-group-a-rest.md
+++ b/docs/superpowers/plans/2026-06-07-render-group-a-rest.md
@@ -1,0 +1,1384 @@
+# Group A Remaining (Chandelier Exit + Parabolic SAR) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render `chandelierExit` (trend-colored dashed trailing-stop line) and `parabolicSar` (trend-colored dots) as price-pane overlays, finishing group A.
+
+**Architecture:** Reuse the established overlay-hook pattern (`useSupertrendOverlay`/`useKeltnerOverlay`). Both indicators are trend-direction overlays drawn with two `LineSeries` (one per direction) because lightweight-charts has no per-point color. Generalize the existing `buildTrendSplitData` helper with a value-selector + generic trend literal so supertrend, parabolicSar, and chandelier all share it. Computation lives in `@y0ngha/siglens-core` (unchanged); this is pure siglens rendering.
+
+**Tech Stack:** TypeScript, React 19 (`useEffectEvent`), lightweight-charts 5.2.0 (`pointMarkersVisible`, `LineStyle.Dashed`), Vitest + React Testing Library, Playwright (E2E).
+
+**Spec:** `docs/superpowers/specs/2026-06-07-render-group-a-rest-design.md`
+**Branch:** `feat/render-group-a-rest` (base: `feat/render-supertrend` = PR #582)
+**Worktree:** `/Users/y0ngha/Project/siglens-group-a-rest`
+
+**Data shapes (siglens-core `domain/types.d.ts`):**
+```ts
+interface ParabolicSARResult { sar: number | null; trend: TrendDirection; }      // 'up' | 'down' | null
+interface ChandelierResult  { longStop: number | null; shortStop: number | null; trend: ChandelierTrend | null; } // 'long' | 'short'
+// IndicatorResult.parabolicSar: ParabolicSARResult[]
+// IndicatorResult.chandelierExit: ChandelierResult[]
+```
+
+**Reference files (read before implementing):**
+- `src/widgets/chart/hooks/useSupertrendOverlay.ts` — 2-series overlay hook skeleton (closest analog)
+- `src/widgets/chart/hooks/useDonchianOverlay.ts` — `LineStyle.Dashed` import/usage example
+- `src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts` — hook test pattern
+
+---
+
+## File Structure
+
+- `src/widgets/chart/utils/seriesDataUtils.ts` — generalize `buildTrendSplitData` (selector + generic Dir) (modify).
+- `src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts` — update existing buildTrendSplitData tests for new signature + add long/short cases (modify).
+- `src/widgets/chart/hooks/useSupertrendOverlay.ts` — update 2 call sites to pass selector (modify).
+- `src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts` — update `toHaveBeenCalledWith` for 4th arg (modify).
+- `src/shared/lib/chartColors.ts` + `src/app/globals.css` — 4 new colors + @theme tokens (modify).
+- `src/widgets/chart/model/indicatorRegistry.ts` — `IndicatorKey` +2, registry +2 (modify).
+- `src/widgets/chart/__tests__/model/indicatorRegistry.test.ts` — 27→29 + 2 assertions (modify).
+- `src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts` — makePaneIndices +2 (modify).
+- `src/widgets/chart/hooks/useParabolicSarOverlay.ts` (+ test) — dots hook (create).
+- `src/widgets/chart/hooks/useChandelierOverlay.ts` (+ test) — dashed stop hook (create).
+- `src/widgets/chart/utils/overlayLabelUtils.ts` (+ tests) — 2 params + 2 configs with getColor (modify).
+- `src/widgets/chart/StockChart.tsx` (+ test) — 2 hooks, 2 bindings, label-config params (modify).
+- `e2e/specs/chart-indicators.spec.ts` — 2 modal-toggle tests (modify).
+
+---
+
+## Task 0: Worktree node_modules verify
+
+**Files:** none (environment only)
+
+- [ ] **Step 1: Verify the worktree has a real node_modules**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-group-a-rest
+[ -e node_modules/.bin/vitest ] && [ ! -L node_modules ] && echo "OK: real node_modules present" || echo "MISSING"
+```
+Expected: `OK: real node_modules present`. If MISSING, run:
+```bash
+cp -al /Users/y0ngha/Project/siglens/node_modules ./node_modules && rm -rf node_modules/node_modules
+```
+
+- [ ] **Step 2: Sanity-check the toolchain**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn vitest run src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts`
+Expected: PASS (9 tests).
+
+---
+
+## Task 1: Generalize `buildTrendSplitData`
+
+**Files:**
+- Modify: `src/widgets/chart/utils/seriesDataUtils.ts`
+- Modify: `src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts`
+- Modify: `src/widgets/chart/hooks/useSupertrendOverlay.ts`
+- Modify: `src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts`
+
+- [ ] **Step 1: Update the existing buildTrendSplitData tests to the new signature (test-first)**
+
+In `src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts`, the `describe('buildTrendSplitData', ...)` block currently calls `buildTrendSplitData(bars, data, 'up')`. Add a 4th selector arg to every call and add long/short coverage. Replace the entire `describe('buildTrendSplitData', () => { ... })` block (lines ~142–192) with:
+
+```ts
+describe('buildTrendSplitData', () => {
+    const bars: Bar[] = [bar(1), bar(2), bar(3)];
+    const data: SupertrendResult[] = [
+        { supertrend: 10, trend: 'up' },
+        { supertrend: 11, trend: 'down' },
+        { supertrend: null, trend: null },
+    ];
+    const getSt = (r: SupertrendResult): number | null => r.supertrend;
+
+    it("returns value only on bars whose trend matches 'up', whitespace otherwise", () => {
+        expect(buildTrendSplitData(bars, data, 'up', getSt)).toEqual([
+            { time: 1, value: 10 },
+            { time: 2 },
+            { time: 3 },
+        ]);
+    });
+
+    it("returns value only on bars whose trend matches 'down', whitespace otherwise", () => {
+        expect(buildTrendSplitData(bars, data, 'down', getSt)).toEqual([
+            { time: 1 },
+            { time: 2, value: 11 },
+            { time: 3 },
+        ]);
+    });
+
+    it('up and down outputs are complementary on matched bars (never both have value)', () => {
+        const up = buildTrendSplitData(bars, data, 'up', getSt);
+        const down = buildTrendSplitData(bars, data, 'down', getSt);
+        up.forEach((u, i) => {
+            const bothHaveValue = 'value' in u && 'value' in down[i];
+            expect(bothHaveValue).toBe(false);
+        });
+    });
+
+    it('emits whitespace when the selected value is null even if trend matches dir', () => {
+        const nullVal: SupertrendResult[] = [{ supertrend: null, trend: 'up' }];
+        expect(buildTrendSplitData([bar(1)], nullVal, 'up', getSt)).toEqual([
+            { time: 1 },
+        ]);
+    });
+
+    it('clamps to the shorter of bars / data length (worst case)', () => {
+        const longBars = [bar(1), bar(2), bar(3), bar(4)];
+        const shortData: SupertrendResult[] = [{ supertrend: 5, trend: 'up' }];
+        const out = buildTrendSplitData(longBars, shortData, 'up', getSt);
+        expect(out).toEqual([{ time: 1, value: 5 }]);
+    });
+
+    it('returns empty array for empty inputs', () => {
+        expect(buildTrendSplitData([], [], 'up', getSt)).toEqual([]);
+    });
+
+    it("supports a 'long'/'short' trend literal with a per-side selector (chandelier shape)", () => {
+        const ch = [
+            { longStop: 90, shortStop: 110, trend: 'long' as const },
+            { longStop: 91, shortStop: 111, trend: 'short' as const },
+        ];
+        const longBars = [bar(1), bar(2)];
+        expect(
+            buildTrendSplitData(longBars, ch, 'long', r => r.longStop)
+        ).toEqual([{ time: 1, value: 90 }, { time: 2 }]);
+        expect(
+            buildTrendSplitData(longBars, ch, 'short', r => r.shortStop)
+        ).toEqual([{ time: 1 }, { time: 2, value: 111 }]);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails (compile/signature mismatch)**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn vitest run src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts`
+Expected: FAIL — the 4-arg calls don't match the current 3-arg signature (TS/runtime error), and the new long/short test fails.
+
+- [ ] **Step 3: Generalize the helper**
+
+In `src/widgets/chart/utils/seriesDataUtils.ts`, replace the entire `buildTrendSplitData` function (the JSDoc block + function, lines ~67–later) with:
+
+```ts
+/**
+ * trend 방향이 dir과 일치하는 bar만 getValue(r) 값을, 나머지는 WhitespaceData({ time })를 반환한다.
+ * 추세별 색 라인을 up/down(또는 long/short) 2개 LineSeries로 표현하기 위함(LineSeries는 per-point 색 미지원).
+ * getValue 선택자와 제네릭 Dir로 supertrend·parabolicSar(단일 값 필드)와 chandelier(추세별 longStop/shortStop)를 모두 지원한다.
+ */
+export function buildTrendSplitData<Dir extends string, T extends { trend: Dir | null }>(
+    bars: Bar[],
+    data: T[],
+    dir: Dir,
+    getValue: (r: T) => number | null
+): SeriesPoint[] {
+    const count = Math.min(bars.length, data.length);
+    return bars.slice(0, count).map((bar, i) => {
+        const r = data[i];
+        if (r && r.trend === dir) {
+            const value = getValue(r);
+            // Bar.time은 epoch seconds 정수 — LWC UTCTimestamp(branded number)와 런타임 형태 동일하므로 safe-cast.
+            if (value !== null) {
+                return { time: bar.time as UTCTimestamp, value };
+            }
+        }
+        return { time: bar.time as UTCTimestamp };
+    });
+}
+```
+
+The now-unused `SupertrendResult` import and `TrendDir` type alias in this file: leave them ONLY if still referenced. After this change `buildTrendSplitData` no longer references `SupertrendResult` or `TrendDir`. Remove `SupertrendResult` from the core import line and delete the `type TrendDir = Exclude<TrendDirection, null>;` line and its JSDoc — UNLESS `TrendDirection`/`SupertrendResult` are used elsewhere in the file (they are not). The core import becomes: `import type { Bar } from '@y0ngha/siglens-core';`. (tsc/lint in Step 5 will confirm no unused imports remain.)
+
+- [ ] **Step 4: Update the supertrend hook call sites**
+
+In `src/widgets/chart/hooks/useSupertrendOverlay.ts`, the data-sync effect calls `buildTrendSplitData(bars, supertrend, 'up')` / `'down'`. Update both to pass the selector:
+
+```ts
+        upSeriesRef.current.setData(
+            buildTrendSplitData(bars, supertrend, 'up', r => r.supertrend)
+        );
+        downSeriesRef.current.setData(
+            buildTrendSplitData(bars, supertrend, 'down', r => r.supertrend)
+        );
+```
+
+- [ ] **Step 5: Update the supertrend hook test assertions**
+
+In `src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts`, the two blocks asserting `toHaveBeenCalledWith(FAKE_BARS, ..., 'up')` / `'down'` now receive a 4th argument (the selector function). Update each `toHaveBeenCalledWith(...)` to append `expect.any(Function)`:
+
+```ts
+        expect(splitMock).toHaveBeenCalledWith(
+            FAKE_BARS,
+            FILLED_INDICATORS.supertrend,
+            'up',
+            expect.any(Function)
+        );
+        expect(splitMock).toHaveBeenCalledWith(
+            FAKE_BARS,
+            FILLED_INDICATORS.supertrend,
+            'down',
+            expect.any(Function)
+        );
+```
+Apply the same 4th-arg addition to BOTH occurrences (the 'sets data on both series' test and the 're-sets data ... when bars change' test — there are two `toHaveBeenCalledWith(...,'up'...)` and two `...'down'...`; note the second test uses `newBars` not `FAKE_BARS` as the first arg — keep that, only add `expect.any(Function)`).
+
+- [ ] **Step 6: Run the affected tests + tsc**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-group-a-rest
+npx tsc --noEmit
+yarn vitest run src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts
+```
+Expected: tsc clean; both files PASS (seriesDataUtils 7 buildTrendSplitData cases, useSupertrendOverlay 9 cases).
+
+- [ ] **Step 7: Lint**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn lint src/widgets/chart/utils/seriesDataUtils.ts src/widgets/chart/hooks/useSupertrendOverlay.ts src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts`
+Expected: no errors (no unused imports).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/widgets/chart/utils/seriesDataUtils.ts src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts src/widgets/chart/hooks/useSupertrendOverlay.ts src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts
+git commit -m "refactor(chart): generalize buildTrendSplitData with value selector + generic trend"
+```
+
+---
+
+## Task 2: Add colors
+
+**Files:**
+- Modify: `src/shared/lib/chartColors.ts`
+- Modify: `src/app/globals.css`
+
+- [ ] **Step 1: Collision guard**
+
+The new colors reuse the project trend palette (`#26a69a` teal / `#ef5350` red), consistent with existing semantic aliases (`supertrendUp`, `trendlineAscending`, `supportLine`, `dmiPlus` all = `#26a69a`). Confirm the new KEY names are unused:
+```bash
+cd /Users/y0ngha/Project/siglens-group-a-rest
+grep -rn "parabolicSarUp\|parabolicSarDown\|chandelierLong\|chandelierShort" src/ || echo "KEYS UNUSED — safe"
+```
+Expected: `KEYS UNUSED — safe`.
+
+- [ ] **Step 2: Add the colors to `CHART_COLORS`**
+
+In `src/shared/lib/chartColors.ts`, immediately AFTER the `supertrendDown: '#ef5350',` line, add:
+```ts
+    // Parabolic SAR (trend 색 점) — DESIGN.md 추세 고정값 재사용
+    parabolicSarUp: '#26a69a',
+    parabolicSarDown: '#ef5350',
+    // Chandelier Exit (trend 색 점선 stop) — DESIGN.md 추세 고정값 재사용
+    chandelierLong: '#26a69a',
+    chandelierShort: '#ef5350',
+```
+
+- [ ] **Step 3: Mirror as @theme tokens**
+
+In `src/app/globals.css`, AFTER the `--color-chart-supertrend-down: #ef5350;` line, add:
+```css
+    /* Chart — Parabolic SAR (추세 색 점) */
+    --color-chart-parabolic-sar-up: #26a69a;
+    --color-chart-parabolic-sar-down: #ef5350;
+    /* Chart — Chandelier Exit (추세 색 점선 stop) */
+    --color-chart-chandelier-long: #26a69a;
+    --color-chart-chandelier-short: #ef5350;
+```
+
+- [ ] **Step 4: Verify lint + format**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn lint src/shared/lib/chartColors.ts && npx prettier --check src/shared/lib/chartColors.ts src/app/globals.css`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/lib/chartColors.ts src/app/globals.css
+git commit -m "feat(chart): add parabolicSar + chandelier trend colors"
+```
+
+---
+
+## Task 3: Register both indicators
+
+**Files:**
+- Modify: `src/widgets/chart/model/indicatorRegistry.ts`
+- Modify: `src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`
+- Modify: `src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts`
+
+- [ ] **Step 1: Write the failing registry tests**
+
+In `src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`: change the length assertion from `toHaveLength(27)` to `toHaveLength(29)`, and add inside the top-level describe:
+```ts
+it('registers parabolicSar as a trend overlay', () => {
+    const meta = INDICATOR_REGISTRY.find(m => m.key === 'parabolicSar');
+    expect(meta).toBeDefined();
+    expect(meta?.category).toBe('trend');
+    expect(meta?.kind).toBe('overlay');
+    expect(meta?.hasPeriods).toBeUndefined();
+});
+
+it('registers chandelierExit as a trend overlay', () => {
+    const meta = INDICATOR_REGISTRY.find(m => m.key === 'chandelierExit');
+    expect(meta).toBeDefined();
+    expect(meta?.category).toBe('trend');
+    expect(meta?.kind).toBe('overlay');
+    expect(meta?.hasPeriods).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn vitest run src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`
+Expected: FAIL (length 27 ≠ 29; metas undefined).
+
+- [ ] **Step 3: Add union members + registry entries**
+
+In `src/widgets/chart/model/indicatorRegistry.ts`:
+(a) In `IndicatorKey`, after `| 'supertrend'`, change the terminator so it reads:
+```ts
+    | 'supertrend'
+    | 'parabolicSar'
+    | 'chandelierExit';
+```
+(b) In `INDICATOR_REGISTRY`, after the `supertrend` entry (currently the last element, before the closing `];`), add:
+```ts
+    {
+        key: 'parabolicSar',
+        label: 'Parabolic SAR',
+        category: 'trend',
+        kind: 'overlay',
+    },
+    {
+        key: 'chandelierExit',
+        label: 'Chandelier',
+        category: 'trend',
+        kind: 'overlay',
+    },
+```
+
+- [ ] **Step 4: Verify registry test passes**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn vitest run src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Fix makePaneIndices fallout**
+
+In `src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts`, inside the `makePaneIndices` base object, after `supertrend: INACTIVE_PANE_INDEX,`, add:
+```ts
+        parabolicSar: INACTIVE_PANE_INDEX,
+        chandelierExit: INACTIVE_PANE_INDEX,
+```
+
+- [ ] **Step 6: tsc + both tests**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-group-a-rest
+npx tsc --noEmit
+yarn vitest run src/widgets/chart/__tests__/model/indicatorRegistry.test.ts src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+```
+Expected: tsc clean; both PASS. If tsc flags other `Record<IndicatorKey>` objects missing the new keys, fix each (add `parabolicSar`/`chandelierExit`) and report.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/widgets/chart/model/indicatorRegistry.ts src/widgets/chart/__tests__/model/indicatorRegistry.test.ts src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+git commit -m "feat(chart): register parabolicSar + chandelierExit as trend overlays"
+```
+
+---
+
+## Task 4: `useParabolicSarOverlay` hook (dots)
+
+**Files:**
+- Create: `src/widgets/chart/hooks/useParabolicSarOverlay.ts`
+- Test: `src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts` (cloned from useSupertrendOverlay.test.ts, adapted to `parabolicSar` + `r => r.sar`):
+```ts
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useParabolicSarOverlay } from '../../hooks/useParabolicSarOverlay';
+import { buildTrendSplitData } from '../../utils/seriesDataUtils';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildTrendSplitData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useParabolicSarOverlay
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = {
+    parabolicSar: [],
+} as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    parabolicSar: [{ sar: 99, trend: 'up' }],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useParabolicSarOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns isVisible false initially', () => {
+        const { result } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('toggles isVisible when toggle is called', () => {
+        const { result } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(result.current.isVisible).toBe(true);
+        act(() => result.current.toggle());
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates two LineSeries (up, down) when visible and chart exists', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes both series when toggled off', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        act(() => result.current.toggle());
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('sets data on both series with up/down direction and sar selector', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockSetData).toHaveBeenCalledTimes(2);
+        const splitMock = vi.mocked(buildTrendSplitData);
+        expect(splitMock).toHaveBeenCalledWith(
+            FAKE_BARS,
+            FILLED_INDICATORS.parabolicSar,
+            'up',
+            expect.any(Function)
+        );
+        expect(splitMock).toHaveBeenCalledWith(
+            FAKE_BARS,
+            FILLED_INDICATORS.parabolicSar,
+            'down',
+            expect.any(Function)
+        );
+    });
+
+    it('does not set data when parabolicSar is empty', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('provides stable toggle function reference', () => {
+        const { result, rerender } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        const firstToggle = result.current.toggle;
+        rerender();
+        expect(result.current.toggle).toBe(firstToggle);
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn vitest run src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Create the hook**
+
+Create `src/widgets/chart/hooks/useParabolicSarOverlay.ts`:
+```ts
+'use client';
+
+import type { RefObject } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useEffectEvent,
+    useRef,
+    useState,
+} from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import { LineSeries } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { buildTrendSplitData } from '../utils/seriesDataUtils';
+
+interface UseParabolicSarOverlayParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+}
+
+interface UseParabolicSarOverlayReturn {
+    isVisible: boolean;
+    toggle: () => void;
+}
+
+export function useParabolicSarOverlay({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+}: UseParabolicSarOverlayParams): UseParabolicSarOverlayReturn {
+    const [isVisible, setIsVisible] = useState(false);
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const upSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+    const downSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+    const toggle = useCallback(() => {
+        setIsVisible(prev => !prev);
+    }, []);
+
+    const clearSeriesRefs = useEffectEvent(() => {
+        upSeriesRef.current = null;
+        downSeriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (upSeriesRef.current) {
+            chart.removeSeries(upSeriesRef.current);
+            upSeriesRef.current = null;
+        }
+        if (downSeriesRef.current) {
+            chart.removeSeries(downSeriesRef.current);
+            downSeriesRef.current = null;
+        }
+    });
+
+    // bars, indicators는 의존하지 않음 — 데이터 세팅은 아래 effect가 단독 담당.
+    // 가격 위/아래 점(dot)만 렌더하므로 lineVisible:false + pointMarkersVisible:true.
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (!upSeriesRef.current) {
+            upSeriesRef.current = chart.addSeries(LineSeries, {
+                color: CHART_COLORS.parabolicSarUp,
+                lineVisible: false,
+                pointMarkersVisible: true,
+                pointMarkersRadius: 2,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+
+        if (!downSeriesRef.current) {
+            downSeriesRef.current = chart.addSeries(LineSeries, {
+                color: CHART_COLORS.parabolicSarDown,
+                lineVisible: false,
+                pointMarkersVisible: true,
+                pointMarkersRadius: 2,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+    }, [chartRef, isVisible, lineWidth]);
+
+    // isVisible이 true로 바뀔 때도 실행되어 새로 생성된 시리즈에 초기 데이터를 세팅함
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { parabolicSar } = indicators;
+        if (!parabolicSar.length) return;
+
+        if (!upSeriesRef.current || !downSeriesRef.current) return;
+
+        upSeriesRef.current.setData(
+            buildTrendSplitData(bars, parabolicSar, 'up', r => r.sar)
+        );
+        downSeriesRef.current.setData(
+            buildTrendSplitData(bars, parabolicSar, 'down', r => r.sar)
+        );
+    }, [indicators, bars, isVisible]);
+
+    return { isVisible, toggle };
+}
+```
+NOTE: `lineWidth` is kept in the lifecycle effect deps for parity with the sibling overlay hooks even though point markers do not draw a line; this keeps the hook shape identical and avoids an exhaustive-deps lint exception. Do not remove it.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn vitest run src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: tsc + lint**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && npx tsc --noEmit && yarn lint src/widgets/chart/hooks/useParabolicSarOverlay.ts src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts`
+Expected: clean. (If `lineWidth` triggers an unused-var lint error because point markers don't use it, reference it harmlessly is NOT needed — it IS passed in deps; confirm clean. If lint flags it as unused, the cleanest fix is to keep `lineWidth` in the param + deps as written; report any lint output.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/widgets/chart/hooks/useParabolicSarOverlay.ts src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts
+git commit -m "feat(chart): add useParabolicSarOverlay hook (trend-colored dots)"
+```
+
+---
+
+## Task 5: `useChandelierOverlay` hook (dashed stop)
+
+**Files:**
+- Create: `src/widgets/chart/hooks/useChandelierOverlay.ts`
+- Test: `src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts`:
+```ts
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useChandelierOverlay } from '../../hooks/useChandelierOverlay';
+import { buildTrendSplitData } from '../../utils/seriesDataUtils';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+    LineStyle: { Dashed: 2 },
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildTrendSplitData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useChandelierOverlay
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = {
+    chandelierExit: [],
+} as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    chandelierExit: [{ longStop: 90, shortStop: 110, trend: 'long' }],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useChandelierOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns isVisible false initially', () => {
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('toggles isVisible when toggle is called', () => {
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(result.current.isVisible).toBe(true);
+        act(() => result.current.toggle());
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates two LineSeries (long, short) when visible and chart exists', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes both series when toggled off', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        act(() => result.current.toggle());
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('sets data with long/short direction and longStop/shortStop selectors', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockSetData).toHaveBeenCalledTimes(2);
+        const splitMock = vi.mocked(buildTrendSplitData);
+        expect(splitMock).toHaveBeenCalledWith(
+            FAKE_BARS,
+            FILLED_INDICATORS.chandelierExit,
+            'long',
+            expect.any(Function)
+        );
+        expect(splitMock).toHaveBeenCalledWith(
+            FAKE_BARS,
+            FILLED_INDICATORS.chandelierExit,
+            'short',
+            expect.any(Function)
+        );
+    });
+
+    it('long selector reads longStop, short selector reads shortStop', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        const calls = vi.mocked(buildTrendSplitData).mock.calls;
+        const longCall = calls.find(c => c[2] === 'long');
+        const shortCall = calls.find(c => c[2] === 'short');
+        const row = { longStop: 90, shortStop: 110, trend: 'long' as const };
+        expect(longCall?.[3](row)).toBe(90);
+        expect(shortCall?.[3](row)).toBe(110);
+    });
+
+    it('does not set data when chandelierExit is empty', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('provides stable toggle function reference', () => {
+        const { result, rerender } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        const firstToggle = result.current.toggle;
+        rerender();
+        expect(result.current.toggle).toBe(firstToggle);
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn vitest run src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Create the hook**
+
+Create `src/widgets/chart/hooks/useChandelierOverlay.ts`:
+```ts
+'use client';
+
+import type { RefObject } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useEffectEvent,
+    useRef,
+    useState,
+} from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import { LineSeries, LineStyle } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { buildTrendSplitData } from '../utils/seriesDataUtils';
+
+interface UseChandelierOverlayParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+}
+
+interface UseChandelierOverlayReturn {
+    isVisible: boolean;
+    toggle: () => void;
+}
+
+export function useChandelierOverlay({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+}: UseChandelierOverlayParams): UseChandelierOverlayReturn {
+    const [isVisible, setIsVisible] = useState(false);
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const longSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+    const shortSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+    const toggle = useCallback(() => {
+        setIsVisible(prev => !prev);
+    }, []);
+
+    const clearSeriesRefs = useEffectEvent(() => {
+        longSeriesRef.current = null;
+        shortSeriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (longSeriesRef.current) {
+            chart.removeSeries(longSeriesRef.current);
+            longSeriesRef.current = null;
+        }
+        if (shortSeriesRef.current) {
+            chart.removeSeries(shortSeriesRef.current);
+            shortSeriesRef.current = null;
+        }
+    });
+
+    // bars, indicators는 의존하지 않음 — 데이터 세팅은 아래 effect가 단독 담당.
+    // supertrend(solid)와 구분되도록 LineStyle.Dashed로 그린다.
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (!longSeriesRef.current) {
+            longSeriesRef.current = chart.addSeries(LineSeries, {
+                color: CHART_COLORS.chandelierLong,
+                lineWidth,
+                lineStyle: LineStyle.Dashed,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        longSeriesRef.current.applyOptions({ lineWidth });
+
+        if (!shortSeriesRef.current) {
+            shortSeriesRef.current = chart.addSeries(LineSeries, {
+                color: CHART_COLORS.chandelierShort,
+                lineWidth,
+                lineStyle: LineStyle.Dashed,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        shortSeriesRef.current.applyOptions({ lineWidth });
+    }, [chartRef, isVisible, lineWidth]);
+
+    // isVisible이 true로 바뀔 때도 실행되어 새로 생성된 시리즈에 초기 데이터를 세팅함
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { chandelierExit } = indicators;
+        if (!chandelierExit.length) return;
+
+        if (!longSeriesRef.current || !shortSeriesRef.current) return;
+
+        longSeriesRef.current.setData(
+            buildTrendSplitData(bars, chandelierExit, 'long', r => r.longStop)
+        );
+        shortSeriesRef.current.setData(
+            buildTrendSplitData(bars, chandelierExit, 'short', r => r.shortStop)
+        );
+    }, [indicators, bars, isVisible]);
+
+    return { isVisible, toggle };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn vitest run src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: tsc + lint**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && npx tsc --noEmit && yarn lint src/widgets/chart/hooks/useChandelierOverlay.ts src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/widgets/chart/hooks/useChandelierOverlay.ts src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts
+git commit -m "feat(chart): add useChandelierOverlay hook (dashed trend-colored stop)"
+```
+
+---
+
+## Task 6: OverlayLegend configs
+
+**Files:**
+- Modify: `src/widgets/chart/utils/overlayLabelUtils.ts`
+- Test: `src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts`: FIRST add `parabolicSarVisible: false,` and `chandelierVisible: false,` to EVERY existing `buildOverlayLabelConfigs({...})` call object in BOTH this file and `overlayLabelUtilsBranches.test.ts` (run tsc in Step 5 to catch any you miss). THEN add these tests inside the top-level describe:
+```ts
+it('includes a PSAR config (value + trend getColor) when parabolicSarVisible', () => {
+    const configs = buildOverlayLabelConfigs({
+        maVisiblePeriods: [],
+        emaVisiblePeriods: [],
+        bollingerVisible: false,
+        ichimokuVisible: false,
+        vpVisible: false,
+        keltnerVisible: false,
+        donchianVisible: false,
+        supertrendVisible: false,
+        parabolicSarVisible: true,
+        chandelierVisible: false,
+    });
+    const psar = configs.find(c => c.name === 'PSAR');
+    expect(psar).toBeDefined();
+    const ind = {
+        parabolicSar: [
+            { sar: 99, trend: 'up' },
+            { sar: 98, trend: 'down' },
+        ],
+    } as never;
+    expect(psar?.getValue(ind, 0)).toBe(99);
+    expect(psar?.getValue(ind, 9)).toBeNull();
+    expect(psar?.getColor?.(ind, 0)).toBe(CHART_COLORS.parabolicSarUp);
+    expect(psar?.getColor?.(ind, 1)).toBe(CHART_COLORS.parabolicSarDown);
+    expect(psar?.getColor?.(ind, 9)).toBe(CHART_COLORS.neutral);
+});
+
+it('includes a Chandelier config (active stop by trend + trend getColor) when chandelierVisible', () => {
+    const configs = buildOverlayLabelConfigs({
+        maVisiblePeriods: [],
+        emaVisiblePeriods: [],
+        bollingerVisible: false,
+        ichimokuVisible: false,
+        vpVisible: false,
+        keltnerVisible: false,
+        donchianVisible: false,
+        supertrendVisible: false,
+        parabolicSarVisible: false,
+        chandelierVisible: true,
+    });
+    const ch = configs.find(c => c.name === 'Chandelier');
+    expect(ch).toBeDefined();
+    const ind = {
+        chandelierExit: [
+            { longStop: 90, shortStop: 110, trend: 'long' },
+            { longStop: 91, shortStop: 111, trend: 'short' },
+            { longStop: null, shortStop: null, trend: null },
+        ],
+    } as never;
+    expect(ch?.getValue(ind, 0)).toBe(90); // long → longStop
+    expect(ch?.getValue(ind, 1)).toBe(111); // short → shortStop
+    expect(ch?.getValue(ind, 2)).toBeNull();
+    expect(ch?.getColor?.(ind, 0)).toBe(CHART_COLORS.chandelierLong);
+    expect(ch?.getColor?.(ind, 1)).toBe(CHART_COLORS.chandelierShort);
+    expect(ch?.getColor?.(ind, 2)).toBe(CHART_COLORS.neutral);
+});
+
+it('omits PSAR and Chandelier configs when their flags are false', () => {
+    const configs = buildOverlayLabelConfigs({
+        maVisiblePeriods: [],
+        emaVisiblePeriods: [],
+        bollingerVisible: false,
+        ichimokuVisible: false,
+        vpVisible: false,
+        keltnerVisible: false,
+        donchianVisible: false,
+        supertrendVisible: false,
+        parabolicSarVisible: false,
+        chandelierVisible: false,
+    });
+    expect(configs.find(c => c.name === 'PSAR')).toBeUndefined();
+    expect(configs.find(c => c.name === 'Chandelier')).toBeUndefined();
+});
+```
+Ensure `CHART_COLORS` is imported at the top of the test file (it is already used in the supertrend tests).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn vitest run src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts`
+Expected: FAIL — unknown params / configs not found.
+
+- [ ] **Step 3: Add params + config blocks**
+
+In `src/widgets/chart/utils/overlayLabelUtils.ts`:
+(a) In `BuildOverlayLabelConfigsParams`, after `supertrendVisible: boolean;`, add:
+```ts
+    parabolicSarVisible: boolean;
+    chandelierVisible: boolean;
+```
+(b) In the destructured params, after `supertrendVisible,`, add `parabolicSarVisible,` and `chandelierVisible,`.
+(c) After the `supertrendConfigs` block, add:
+```ts
+    const parabolicSarConfigs: OverlayLabelConfig[] = parabolicSarVisible
+        ? [
+              {
+                  name: 'PSAR',
+                  color: CHART_COLORS.parabolicSarUp,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.parabolicSar[i]?.sar ?? null,
+                  getColor: (ind: IndicatorResult, i: number): string => {
+                      const trend = ind.parabolicSar[i]?.trend;
+                      if (trend === 'down')
+                          return CHART_COLORS.parabolicSarDown;
+                      if (trend === 'up') return CHART_COLORS.parabolicSarUp;
+                      return CHART_COLORS.neutral;
+                  },
+              },
+          ]
+        : [];
+
+    const chandelierConfigs: OverlayLabelConfig[] = chandelierVisible
+        ? [
+              {
+                  name: 'Chandelier',
+                  color: CHART_COLORS.chandelierLong,
+                  // active stop만 표시: long 추세→longStop, short 추세→shortStop.
+                  getValue: (ind: IndicatorResult, i: number): number | null => {
+                      const r = ind.chandelierExit[i];
+                      if (r?.trend === 'long') return r.longStop;
+                      if (r?.trend === 'short') return r.shortStop;
+                      return null;
+                  },
+                  getColor: (ind: IndicatorResult, i: number): string => {
+                      const trend = ind.chandelierExit[i]?.trend;
+                      if (trend === 'short') return CHART_COLORS.chandelierShort;
+                      if (trend === 'long') return CHART_COLORS.chandelierLong;
+                      return CHART_COLORS.neutral;
+                  },
+              },
+          ]
+        : [];
+```
+(d) In the returned array, after `...supertrendConfigs,`, add `...parabolicSarConfigs,` and `...chandelierConfigs,`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn vitest run src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts src/widgets/chart/__tests__/utils/overlayLabelUtilsBranches.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: tsc (catches StockChart caller missing the 2 new params — EXPECTED, leave StockChart for Task 7)**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && npx tsc --noEmit`
+Expected: the ONLY remaining tsc error is in `StockChart.tsx` (its `buildOverlayLabelConfigs` call now misses `parabolicSarVisible`/`chandelierVisible`). Confirm no other errors. Do NOT edit StockChart.tsx here — Task 7 wires it. Fix any test-file callers that tsc flags.
+
+- [ ] **Step 6: Lint**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn lint src/widgets/chart/utils/overlayLabelUtils.ts src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts src/widgets/chart/__tests__/utils/overlayLabelUtilsBranches.test.ts`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/widgets/chart/utils/overlayLabelUtils.ts src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts src/widgets/chart/__tests__/utils/overlayLabelUtilsBranches.test.ts
+git commit -m "feat(chart): add parabolicSar + chandelier overlay legend configs"
+```
+
+---
+
+## Task 7: Wire both into StockChart
+
+**Files:**
+- Modify: `src/widgets/chart/StockChart.tsx`
+
+- [ ] **Step 1: Add imports + hook calls**
+
+In `src/widgets/chart/StockChart.tsx`, after the `import { useSupertrendOverlay } from './hooks/useSupertrendOverlay';` line (~line 26), add:
+```ts
+import { useParabolicSarOverlay } from './hooks/useParabolicSarOverlay';
+import { useChandelierOverlay } from './hooks/useChandelierOverlay';
+```
+After the `useSupertrendOverlay(commonHookParams)` destructure (~line 207), add:
+```ts
+    const { isVisible: parabolicSarVisible, toggle: toggleParabolicSar } =
+        useParabolicSarOverlay(commonHookParams);
+
+    const { isVisible: chandelierVisible, toggle: toggleChandelier } =
+        useChandelierOverlay(commonHookParams);
+```
+
+- [ ] **Step 2: Pass to buildOverlayLabelConfigs**
+
+In the `overlayLabelConfigs` useMemo, add `parabolicSarVisible,` and `chandelierVisible,` to BOTH the call object (after `supertrendVisible,`) AND the dependency array (after `supertrendVisible,`).
+
+- [ ] **Step 3: Add 2 bindings (27→29)**
+
+In the `indicatorBindings` useMemo, after the `supertrend` binding object (the last entry, before the `],` closing the array), add:
+```ts
+            {
+                meta: INDICATOR_META.parabolicSar,
+                active: parabolicSarVisible,
+                onToggle: toggleParabolicSar,
+            },
+            {
+                meta: INDICATOR_META.chandelierExit,
+                active: chandelierVisible,
+                onToggle: toggleChandelier,
+            },
+```
+Then add to the useMemo dependency array: `parabolicSarVisible,`, `chandelierVisible,`, `toggleParabolicSar,`, `toggleChandelier,`.
+
+- [ ] **Step 4: tsc + chart suite**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-group-a-rest
+npx tsc --noEmit
+yarn vitest run src/widgets/chart
+```
+Expected: tsc fully clean (StockChart error gone). All chart tests PASS. If `StockChart.test.tsx` asserts a binding count of 27 (or a `data-keys` string), update it to 29 and append `,parabolicSar,chandelierExit` to the expected keys (report it).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets/chart/StockChart.tsx src/widgets/chart/__tests__/StockChart.test.tsx
+git commit -m "feat(chart): wire parabolicSar + chandelier overlays into StockChart (29 bindings)"
+```
+
+---
+
+## Task 8: E2E modal toggles
+
+**Files:**
+- Modify: `e2e/specs/chart-indicators.spec.ts`
+
+- [ ] **Step 1: Add two overlay-toggle tests**
+
+In `e2e/specs/chart-indicators.spec.ts`, immediately after the Supertrend test's closing `});` and BEFORE the `});` that closes the `test.describe('chart indicator settings modal', ...)` block, insert:
+```ts
+
+    test('toggles the Parabolic SAR overlay via the modal', async ({ page }) => {
+        await page.goto('/AAPL');
+        await page.getByRole('button', { name: GEAR }).click();
+        const dialog = page.getByRole('dialog');
+        // Parabolic SAR는 가격 OVERLAY(점 마커) — Keltner/Supertrend와 동일하게
+        // 모달 체크박스 상태로 검증한다. exact로 substring 충돌 방지.
+        const psar = dialog.getByRole('checkbox', {
+            name: 'Parabolic SAR',
+            exact: true,
+        });
+        await expect(psar).not.toBeChecked();
+        await psar.check();
+        await expect(psar).toBeChecked();
+    });
+
+    test('toggles the Chandelier overlay via the modal', async ({ page }) => {
+        await page.goto('/AAPL');
+        await page.getByRole('button', { name: GEAR }).click();
+        const dialog = page.getByRole('dialog');
+        const chandelier = dialog.getByRole('checkbox', {
+            name: 'Chandelier',
+            exact: true,
+        });
+        await expect(chandelier).not.toBeChecked();
+        await chandelier.check();
+        await expect(chandelier).toBeChecked();
+    });
+```
+`GEAR` is the const already at the top of the describe — reuse it.
+
+- [ ] **Step 2: Lint + tsc**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn lint e2e/specs/chart-indicators.spec.ts && npx tsc --noEmit`
+Expected: clean. (Do NOT run the full Playwright suite locally — it uses the shared docker-compose backend; CI's `e2e` job is the gate.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/specs/chart-indicators.spec.ts
+git commit -m "test(e2e): toggle Parabolic SAR + Chandelier overlays from settings modal"
+```
+
+---
+
+## Task 9: Final verification + review handoff
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full coverage suite (CI-equivalent gate)**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn test-coverage > /tmp/group-a-rest-cov.log 2>&1; echo "EXIT=$?"; tail -8 /tmp/group-a-rest-cov.log`
+Expected: `EXIT=0`, all global thresholds (90%+) met.
+
+- [ ] **Step 2: Lint + format (whole repo)**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn lint && npx prettier --check .`
+Expected: no errors. (Use `npx prettier --check .`, not `yarn format --cache`.)
+
+- [ ] **Step 3: Production build (capture exit code directly, no pipe)**
+
+Run: `cd /Users/y0ngha/Project/siglens-group-a-rest && yarn build > /tmp/group-a-rest-build.log 2>&1; echo "EXIT=$?"; tail -12 /tmp/group-a-rest-build.log`
+Expected: `EXIT=0`.
+
+- [ ] **Step 4: Hand off to review**
+
+Implementation complete. Per CLAUDE.md routing: invoke `review-agent` (Opus 4.8) on branch `feat/render-group-a-rest`, then `mistake-managing-agent`, then `git-agent` to push and open the PR stacked on `feat/render-supertrend` (#582). Do not merge before APPROVED.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3.1 generalize `buildTrendSplitData` (+ supertrend call/test update) → Task 1. ✓
+- §3.2 `useParabolicSarOverlay` (dots) → Task 4. ✓
+- §3.3 `useChandelierOverlay` (dashed, long/short) → Task 5. ✓
+- §3.4 registry +2 (27→29, makePaneIndices, StockChart.test count) → Task 3 + Task 7 Step 4. ✓
+- §3.5 colors + @theme → Task 2. ✓
+- §3.6 overlayLabelUtils +2 configs with getColor → Task 6. ✓
+- §3.7 StockChart wiring → Task 7. ✓
+- §5.2 E2E ×2 → Task 8. ✓
+- §5 test strategy (90%+, happy + worst) → Tasks 1/4/5/6 cover null trend, null value, length mismatch, empty inputs, off-range index, long/short selectors, bars-change re-sync. ✓
+
+**Placeholder scan:** No TBD/TODO. Every code step has complete code.
+
+**Type consistency:** `buildTrendSplitData<Dir, T>(bars, data, dir, getValue)` signature identical across Tasks 1/4/5/6. `parabolicSarVisible`/`chandelierVisible` booleans threaded identically through Tasks 6/7. Color keys `parabolicSarUp/Down`, `chandelierLong/Short` consistent across Tasks 2/4/5/6. Registry count 27→29 consistent across Tasks 3/7. `PSAR`/`Chandelier` legend names consistent between Task 6 config and tests. ✓

--- a/docs/superpowers/specs/2026-06-07-render-group-a-rest-design.md
+++ b/docs/superpowers/specs/2026-06-07-render-group-a-rest-design.md
@@ -1,0 +1,132 @@
+# 미사용 보조지표 렌더링 — 6차: 그룹 A 나머지 (chandelierExit · parabolicSar)
+
+- **작성일**: 2026-06-07
+- **상태**: 설계 승인됨, 구현 계획 대기
+- **브랜치**: `feat/render-group-a-rest` (base: `feat/render-supertrend` = PR #582)
+
+## 1. 배경
+
+미사용 보조지표 렌더링 6차이자 그룹 A(가격 오버레이) 마무리. supertrend(#582)에 이어 **chandelierExit·parabolicSar** 2종을 가격 오버레이(Pane 0)로 렌더한다. 한 spec/PR로 묶되 지표별 task로 분해한다(사용자 선택). 계산은 `@y0ngha/siglens-core`에 있으므로 추가 작업은 siglens 차트 렌더링뿐.
+
+## 2. 자료조사 / 렌더 표준
+
+웹 자료조사(StockCharts ChartSchool, TradingView) 결과:
+- **Chandelier Exit**: 추세 따라 한쪽에만 나타나는 **단일 trailing stop 라인**. 상승 추세(long)엔 가격 **아래**(longStop = 기간고 − ATR×승수), 하락 추세(short)엔 가격 **위**(shortStop = 기간저 + ATR×승수). 가격이 active stop을 깨면 반대편으로 **flip**한다. → supertrend와 동일한 "추세별 색 + flip" 구조이나 **값 소스가 추세별로 다름**(long→longStop, short→shortStop).
+- **Parabolic SAR**: 가격 위/아래 **점(dot) 시리즈**. 상승 추세엔 가격 아래(초록 점), 하락 추세엔 가격 위(빨강 점). SAR 정확값 위치에 점을 찍고 추세 반전 시 점이 반대편으로 이동.
+
+데이터(siglens-core `domain/types.d.ts`):
+```ts
+interface ParabolicSARResult { sar: number | null; trend: TrendDirection; }      // 'up' | 'down' | null
+interface ChandelierResult  { longStop: number | null; shortStop: number | null; trend: ChandelierTrend | null; } // 'long' | 'short'
+// IndicatorResult.parabolicSar: ParabolicSARResult[]
+// IndicatorResult.chandelierExit: ChandelierResult[]
+```
+
+LWC 5.2.0 API 확인:
+- `LineSeries` 옵션에 `pointMarkersVisible: boolean` + `pointMarkersRadius?: number` 존재 → `lineVisible:false`와 조합하면 각 데이터 포인트 **정확값 위치에 점**만 렌더. parabolicSar 점에 적합.
+- `lineStyle: LineStyle.Dashed` → chandelier 점선.
+
+## 3. 핵심 설계 결정
+
+### 3.1 `buildTrendSplitData` 일반화 (값 선택자 + 제네릭 추세)
+세 지표(supertrend·sar·chandelier)가 "추세 일치 막대만 값, 나머지 whitespace"의 2-시리즈 분리를 공유한다. 현재 헬퍼는 `r.supertrend` 필드와 `SupertrendResult`에 하드코딩돼 있다. **값 선택자(getValue)와 추세 리터럴(Dir)을 제네릭화**해 셋 모두 재사용한다:
+
+```ts
+export function buildTrendSplitData<Dir extends string, T extends { trend: Dir | null }>(
+    bars: Bar[],
+    data: T[],
+    dir: Dir,
+    getValue: (r: T) => number | null
+): SeriesPoint[] {
+    const count = Math.min(bars.length, data.length);
+    return bars.slice(0, count).map((bar, i) => {
+        const r = data[i];
+        if (r && r.trend === dir) {
+            const value = getValue(r);
+            // Bar.time은 epoch seconds 정수 — LWC UTCTimestamp(branded number)와 런타임 형태 동일하므로 safe-cast.
+            if (value !== null) {
+                return { time: bar.time as UTCTimestamp, value };
+            }
+        }
+        return { time: bar.time as UTCTimestamp };
+    });
+}
+```
+- supertrend: `buildTrendSplitData(bars, st, 'up'|'down', r => r.supertrend)`
+- parabolicSar: `buildTrendSplitData(bars, sar, 'up'|'down', r => r.sar)`
+- chandelier long 시리즈: `buildTrendSplitData(bars, ch, 'long', r => r.longStop)`
+- chandelier short 시리즈: `buildTrendSplitData(bars, ch, 'short', r => r.shortStop)`
+
+| 항목 | 결정 | 근거 |
+|---|---|---|
+| 헬퍼 | 제네릭 일반화(값 선택자) | 3지표 공유, near-duplicate 방지 |
+| supertrend 영향 | 호출부 1줄×2 + 헬퍼 테스트(getValue 인자) + useSupertrendOverlay 테스트 `toHaveBeenCalledWith`(`expect.any(Function)`) 갱신 | 일반화의 불가피한 churn, 전부 기계적 |
+
+**기존 supertrend 호출부 변경(필수)**: `useSupertrendOverlay`의 두 `buildTrendSplitData(bars, supertrend, 'up'|'down')` → `(bars, supertrend, 'up'|'down', r => r.supertrend)`. 그리고 그 훅 테스트의 `toHaveBeenCalledWith(FAKE_BARS, ..., 'up')`는 4번째 인자(함수)가 추가되므로 `expect.any(Function)`을 덧붙인다.
+
+### 3.2 `useParabolicSarOverlay` (점 마커)
+- supertrend 훅 골격(자체 `useState(isVisible)`+toggle, prevChartRef, clearSeriesRefs/removeAllSeries useEffectEvent, 2-effect lifecycle/data-sync).
+- 시리즈 2개: `upSeriesRef`(LineSeries, color=parabolicSarUp), `downSeriesRef`(color=parabolicSarDown). **둘 다 `lineVisible:false, pointMarkersVisible:true, pointMarkersRadius:2`** → 라인 없이 점만.
+- 데이터: `upSeriesRef.setData(buildTrendSplitData(bars, parabolicSar, 'up', r => r.sar))`, down도 'down'. guard `if (!indicators.parabolicSar.length) return`.
+
+### 3.3 `useChandelierOverlay` (점선 trailing stop)
+- supertrend 훅 골격 복제.
+- 시리즈 2개: `longSeriesRef`(LineSeries, color=chandelierLong), `shortSeriesRef`(color=chandelierShort). **둘 다 `lineStyle:LineStyle.Dashed`** (supertrend solid과 구분).
+- 데이터: `longSeriesRef.setData(buildTrendSplitData(bars, chandelierExit, 'long', r => r.longStop))`, `shortSeriesRef.setData(buildTrendSplitData(bars, chandelierExit, 'short', r => r.shortStop))`. guard `if (!indicators.chandelierExit.length) return`.
+
+### 3.4 레지스트리 (`model/indicatorRegistry.ts`)
+- `IndicatorKey` +2 (`parabolicSar`, `chandelierExit`).
+- `INDICATOR_REGISTRY` +2: 둘 다 `{ category: 'trend', kind: 'overlay' }`. 라벨 `Parabolic SAR` / `Chandelier`.
+- makePaneIndices(paneLabelUtils.test) fallout: 두 키 모두 `INACTIVE_PANE_INDEX`(overlay).
+- StockChart.test의 binding 카운트 27→29, data-keys에 두 키 추가.
+
+### 3.5 색상 (`shared/lib/chartColors.ts` + `globals.css` @theme)
+DESIGN.md 추세 고정값(bullish teal `#26a69a` / bearish red `#ef5350`) 재사용 — 코드베이스 시맨틱 alias 관례(trendlineAscending/supportLine/dmiPlus/supertrendUp 등) 준수:
+- `parabolicSarUp: '#26a69a'`, `parabolicSarDown: '#ef5350'`
+- `chandelierLong: '#26a69a'`, `chandelierShort: '#ef5350'`
+- globals.css @theme: `--color-chart-parabolic-sar-up/down`, `--color-chart-chandelier-long/short`
+
+### 3.6 OverlayLegend (`utils/overlayLabelUtils.ts`)
+- params +`parabolicSarVisible: boolean`, `chandelierVisible: boolean`.
+- parabolicSar config: `{ name: 'PSAR', color: parabolicSarUp, getValue: (ind,i) => ind.parabolicSar[i]?.sar ?? null, getColor: (ind,i) => trend==='down'?down:trend==='up'?up:neutral }` (supertrend의 per-bar getColor 패턴).
+- chandelier config: `{ name: 'Chandelier', color: chandelierLong, getValue: (ind,i) => { const r=ind.chandelierExit[i]; return r?.trend==='long'?r.longStop:r?.trend==='short'?r.shortStop:null; }, getColor: (ind,i) => trend==='long'?long:trend==='short'?short:neutral }`.
+
+### 3.7 StockChart (`StockChart.tsx`)
+- `useParabolicSarOverlay(commonHookParams)`, `useChandelierOverlay(commonHookParams)` 호출.
+- `buildOverlayLabelConfigs`에 `parabolicSarVisible`/`chandelierVisible` 전달 + deps.
+- `indicatorBindings` +2 (27→29): `INDICATOR_META.parabolicSar`/`.chandelierExit` + 각 active/onToggle + deps.
+
+## 4. 데이터 흐름
+```
+indicatorRegistry (parabolicSar·chandelierExit = kind:'overlay', trend)
+        │
+StockChart: useParabolicSarOverlay / useChandelierOverlay (각자 visible state)
+        │
+binding(29개) → IndicatorSettingsModal 자동 노출(무수정)
+        │
+체크 → toggle → Pane 0에:
+  - PSAR: up/down 2 LineSeries(lineVisible:false, pointMarkers) = 추세별 색 점
+  - Chandelier: long/short 2 LineSeries(dashed) = 추세별 색 stop 라인
+buildTrendSplitData(일반화, 값 선택자)로 분리 데이터 생성
+```
+
+## 5. 테스트 전략 (vitest + RTL, 90%+, happy + worst)
+
+### 5.1 단위
+- **일반화된 `buildTrendSplitData`**: getValue 선택자 동작, Dir 'up'/'down'·'long'/'short' 모두, 불일치/null trend/null value → whitespace, 길이 불일치, 빈 입력. (supertrend 기존 6케이스 + chandelier longStop/shortStop 선택, sar 선택)
+- **`useParabolicSarOverlay`**: isVisible 토글, chart null 시 미생성, true→2 LineSeries(addSeries 2회), false→removeSeries 2회, setData 2회 + up/down 방향+선택자 인자 명시(`toHaveBeenCalledWith(..., 'up', expect.any(Function))`), 빈 배열→미호출, bars 변경 재싱크, 안정 toggle 참조.
+- **`useChandelierOverlay`**: 동일 패턴, 'long'/'short' 방향 + longStop/shortStop 선택자.
+- **레지스트리**: 29개, 두 키가 trend·overlay, 중복 없음.
+- **overlayLabelUtils**: parabolicSarVisible/chandelierVisible 시 config, getValue/getColor 정확(추세별 색·현재값).
+
+### 5.2 E2E
+- `chart-indicators.spec.ts` 확장: 모달에서 'Parabolic SAR'·'Chandelier' 각각 체크 → 초기 unchecked 검증 후 체크 상태 검증(overlay, #582 supertrend 패턴, exact 매처).
+
+### 5.3 회귀
+- supertrend 호출부/테스트 갱신(§3.1) 외 기존 overlay/pane 훅·useIndicatorVisibility·모달 무변경. StockChart binding 27→29, overlayLabelConfigs params 확장으로 기존 테스트 갱신.
+
+## 6. FSD 준수
+- 훅·레지스트리·색·legend·헬퍼: `widgets/chart` 내부 + `shared/lib/chartColors`. core import(ParabolicSARResult/ChandelierResult/IndicatorResult/TrendDirection/ChandelierTrend). 레이어 정상. core 무변경.
+
+## 7. 후속 (별도 스펙)
+- 그룹 A 완료. 다음: C-복합 3종(elderRay histogram, squeezeMomentum histo+state, regression 2-value), 그룹 D(elderImpulse candle coloring, smc zone primitive), 전송 페이로드 슬림화.

--- a/e2e/specs/chart-indicators.spec.ts
+++ b/e2e/specs/chart-indicators.spec.ts
@@ -128,4 +128,34 @@ test.describe('chart indicator settings modal', () => {
         await supertrend.check();
         await expect(supertrend).toBeChecked();
     });
+
+    test('toggles the Parabolic SAR overlay via the modal', async ({
+        page,
+    }) => {
+        await page.goto('/AAPL');
+        await page.getByRole('button', { name: GEAR }).click();
+        const dialog = page.getByRole('dialog');
+        // Parabolic SAR는 가격 OVERLAY(점 마커) — Keltner/Supertrend와 동일하게
+        // 모달 체크박스 상태로 검증한다. exact로 substring 충돌 방지.
+        const psar = dialog.getByRole('checkbox', {
+            name: 'Parabolic SAR',
+            exact: true,
+        });
+        await expect(psar).not.toBeChecked();
+        await psar.check();
+        await expect(psar).toBeChecked();
+    });
+
+    test('toggles the Chandelier overlay via the modal', async ({ page }) => {
+        await page.goto('/AAPL');
+        await page.getByRole('button', { name: GEAR }).click();
+        const dialog = page.getByRole('dialog');
+        const chandelier = dialog.getByRole('checkbox', {
+            name: 'Chandelier',
+            exact: true,
+        });
+        await expect(chandelier).not.toBeChecked();
+        await chandelier.check();
+        await expect(chandelier).toBeChecked();
+    });
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -54,6 +54,12 @@
     /* Chart — Supertrend (추세 색 고정값: bullish teal / bearish red) */
     --color-chart-supertrend-up: #26a69a;
     --color-chart-supertrend-down: #ef5350;
+    /* Chart — Parabolic SAR (추세 색 점) */
+    --color-chart-parabolic-sar-up: #26a69a;
+    --color-chart-parabolic-sar-down: #ef5350;
+    /* Chart — Chandelier Exit (추세 색 점선 stop) */
+    --color-chart-chandelier-long: #26a69a;
+    --color-chart-chandelier-short: #ef5350;
 
     /* Chart — MACD */
     --color-chart-macd: #3b82f6;

--- a/src/shared/lib/chartColors.ts
+++ b/src/shared/lib/chartColors.ts
@@ -138,6 +138,12 @@ export const CHART_COLORS = {
     // Supertrend (trend 색 라인 — up/down) — DESIGN.md 추세 색 고정값(bullish teal / bearish red) 재사용
     supertrendUp: '#26a69a',
     supertrendDown: '#ef5350',
+    // Parabolic SAR (trend 색 점) — DESIGN.md 추세 고정값 재사용
+    parabolicSarUp: '#26a69a',
+    parabolicSarDown: '#ef5350',
+    // Chandelier Exit (trend 색 점선 stop) — DESIGN.md 추세 고정값 재사용
+    chandelierLong: '#26a69a',
+    chandelierShort: '#ef5350',
 } as const;
 
 const PERIOD_COLOR_MAP: Record<number, string> = {

--- a/src/widgets/chart/StockChart.tsx
+++ b/src/widgets/chart/StockChart.tsx
@@ -24,6 +24,8 @@ import { useBollingerOverlay } from './hooks/useBollingerOverlay';
 import { useKeltnerOverlay } from './hooks/useKeltnerOverlay';
 import { useDonchianOverlay } from './hooks/useDonchianOverlay';
 import { useSupertrendOverlay } from './hooks/useSupertrendOverlay';
+import { useParabolicSarOverlay } from './hooks/useParabolicSarOverlay';
+import { useChandelierOverlay } from './hooks/useChandelierOverlay';
 import { useMACDChart } from './hooks/useMACDChart';
 import { useRSIChart } from './hooks/useRSIChart';
 import { useDMIChart } from './hooks/useDMIChart';
@@ -206,6 +208,12 @@ export function StockChart({
     const { isVisible: supertrendVisible, toggle: toggleSupertrend } =
         useSupertrendOverlay(commonHookParams);
 
+    const { isVisible: parabolicSarVisible, toggle: toggleParabolicSar } =
+        useParabolicSarOverlay(commonHookParams);
+
+    const { isVisible: chandelierVisible, toggle: toggleChandelier } =
+        useChandelierOverlay(commonHookParams);
+
     const { isVisible: vpVisible, toggle: toggleVP } =
         useVolumeProfileOverlay(commonHookParams);
 
@@ -380,6 +388,8 @@ export function StockChart({
                 keltnerVisible,
                 donchianVisible,
                 supertrendVisible,
+                parabolicSarVisible,
+                chandelierVisible,
             }),
         [
             maVisiblePeriods,
@@ -390,6 +400,8 @@ export function StockChart({
             keltnerVisible,
             donchianVisible,
             supertrendVisible,
+            parabolicSarVisible,
+            chandelierVisible,
         ]
     );
 
@@ -552,8 +564,18 @@ export function StockChart({
                 active: supertrendVisible,
                 onToggle: toggleSupertrend,
             },
+            {
+                meta: INDICATOR_META.parabolicSar,
+                active: parabolicSarVisible,
+                onToggle: toggleParabolicSar,
+            },
+            {
+                meta: INDICATOR_META.chandelierExit,
+                active: chandelierVisible,
+                onToggle: toggleChandelier,
+            },
         ],
-        // deps에 visible 객체 전체를 둔다 — 한 지표 토글 시 27개 binding 전체가 재조립되지만
+        // deps에 visible 객체 전체를 둔다 — 한 지표 토글 시 29개 binding 전체가 재조립되지만
         // 항목 수가 적어 비용은 무시할 만하며, 개별 visible 키를 나열하는 것보다 명료하다.
         [
             maVisiblePeriods,
@@ -566,6 +588,8 @@ export function StockChart({
             keltnerVisible,
             donchianVisible,
             supertrendVisible,
+            parabolicSarVisible,
+            chandelierVisible,
             toggleMAPeriod,
             toggleEMAPeriod,
             toggleIchimoku,
@@ -574,6 +598,8 @@ export function StockChart({
             toggleKeltner,
             toggleDonchian,
             toggleSupertrend,
+            toggleParabolicSar,
+            toggleChandelier,
         ]
     );
 

--- a/src/widgets/chart/StockChart.tsx
+++ b/src/widgets/chart/StockChart.tsx
@@ -575,7 +575,7 @@ export function StockChart({
                 onToggle: toggleChandelier,
             },
         ],
-        // deps에 visible 객체 전체를 둔다 — 한 지표 토글 시 29개 binding 전체가 재조립되지만
+        // deps에 visible 객체 전체를 둔다 — 한 지표 토글 시 전체 binding이 재조립되지만
         // 항목 수가 적어 비용은 무시할 만하며, 개별 visible 키를 나열하는 것보다 명료하다.
         [
             maVisiblePeriods,

--- a/src/widgets/chart/__tests__/StockChart.test.tsx
+++ b/src/widgets/chart/__tests__/StockChart.test.tsx
@@ -408,13 +408,13 @@ describe('StockChart', () => {
         );
     });
 
-    it('renders IndicatorSettingsModal with 27 indicator bindings', () => {
+    it('renders IndicatorSettingsModal with 29 indicator bindings', () => {
         render(<StockChart bars={mockBars} timeframe="1Day" />);
         const modal = screen.getByTestId('indicator-settings-modal');
-        expect(modal).toHaveAttribute('data-count', '27');
+        expect(modal).toHaveAttribute('data-count', '29');
         expect(modal).toHaveAttribute(
             'data-keys',
-            'ma,ema,ichimoku,rsi,macd,dmi,stochastic,stochRsi,cci,bollinger,volumeProfile,mfi,williamsR,connorsRsi,cmf,bollingerPercentB,hurst,varianceRatio,macdV,forceIndex,obv,atr,yangZhang,ewmaVolatility,keltnerChannel,donchianChannel,supertrend'
+            'ma,ema,ichimoku,rsi,macd,dmi,stochastic,stochRsi,cci,bollinger,volumeProfile,mfi,williamsR,connorsRsi,cmf,bollingerPercentB,hurst,varianceRatio,macdV,forceIndex,obv,atr,yangZhang,ewmaVolatility,keltnerChannel,donchianChannel,supertrend,parabolicSar,chandelierExit'
         );
     });
 

--- a/src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { act, renderHook } from '@testing-library/react';
+import type { LineWidth } from 'lightweight-charts';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
 import { useChandelierOverlay } from '../../hooks/useChandelierOverlay';
 import { buildTrendSplitData } from '../../utils/seriesDataUtils';
@@ -109,6 +110,27 @@ describe('useChandelierOverlay', () => {
         );
         act(() => result.current.toggle());
         // chandelier는 PSAR과 달리 lineWidth를 실제 반영한다(applyOptions). 계약을 고정한다.
+        expect(mockApplyOptions).toHaveBeenCalledWith({ lineWidth: 3 });
+        expect(mockApplyOptions).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-applies lineWidth when the lineWidth prop changes while visible', () => {
+        const chart = makeChart();
+        const { result, rerender } = renderHook(
+            ({ lineWidth }) =>
+                useChandelierOverlay({
+                    chartRef: makeChartRef(chart),
+                    bars: FAKE_BARS,
+                    indicators: FILLED_INDICATORS,
+                    lineWidth,
+                }),
+            { initialProps: { lineWidth: 1 as LineWidth } }
+        );
+        act(() => result.current.toggle());
+        vi.clearAllMocks();
+
+        // lifecycle effect deps에 lineWidth가 있어 prop 변경 시 재실행 → 두 시리즈에 applyOptions 재호출.
+        rerender({ lineWidth: 3 as LineWidth });
         expect(mockApplyOptions).toHaveBeenCalledWith({ lineWidth: 3 });
         expect(mockApplyOptions).toHaveBeenCalledTimes(2);
     });

--- a/src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts
@@ -155,6 +155,48 @@ describe('useChandelierOverlay', () => {
         expect(shortCall?.[3](row)).toBe(110);
     });
 
+    it('re-sets data on both series when bars change while visible', () => {
+        const chart = makeChart();
+        const { result, rerender } = renderHook(
+            ({ bars }) =>
+                useChandelierOverlay({
+                    chartRef: makeChartRef(chart),
+                    bars,
+                    indicators: FILLED_INDICATORS,
+                }),
+            { initialProps: { bars: FAKE_BARS } }
+        );
+        act(() => result.current.toggle());
+        vi.clearAllMocks();
+
+        const newBars: Bar[] = [
+            {
+                time: 2000,
+                open: 200,
+                high: 220,
+                low: 180,
+                close: 210,
+                volume: 2000,
+            },
+        ];
+        rerender({ bars: newBars });
+
+        expect(mockSetData).toHaveBeenCalledTimes(2);
+        const splitMock = vi.mocked(buildTrendSplitData);
+        expect(splitMock).toHaveBeenCalledWith(
+            newBars,
+            FILLED_INDICATORS.chandelierExit,
+            'long',
+            expect.any(Function)
+        );
+        expect(splitMock).toHaveBeenCalledWith(
+            newBars,
+            FILLED_INDICATORS.chandelierExit,
+            'short',
+            expect.any(Function)
+        );
+    });
+
     it('does not set data when chandelierExit is empty', () => {
         const chart = makeChart();
         const { result } = renderHook(() =>

--- a/src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useChandelierOverlay } from '../../hooks/useChandelierOverlay';
+import { buildTrendSplitData } from '../../utils/seriesDataUtils';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+    LineStyle: { Dashed: 2 },
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildTrendSplitData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useChandelierOverlay
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = {
+    chandelierExit: [],
+} as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    chandelierExit: [{ longStop: 90, shortStop: 110, trend: 'long' }],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useChandelierOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns isVisible false initially', () => {
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('toggles isVisible when toggle is called', () => {
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(result.current.isVisible).toBe(true);
+        act(() => result.current.toggle());
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates two LineSeries (long, short) when visible and chart exists', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes both series when toggled off', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        act(() => result.current.toggle());
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('sets data with long/short direction and longStop/shortStop selectors', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockSetData).toHaveBeenCalledTimes(2);
+        const splitMock = vi.mocked(buildTrendSplitData);
+        expect(splitMock).toHaveBeenCalledWith(
+            FAKE_BARS,
+            FILLED_INDICATORS.chandelierExit,
+            'long',
+            expect.any(Function)
+        );
+        expect(splitMock).toHaveBeenCalledWith(
+            FAKE_BARS,
+            FILLED_INDICATORS.chandelierExit,
+            'short',
+            expect.any(Function)
+        );
+    });
+
+    it('long selector reads longStop, short selector reads shortStop', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        const calls = vi.mocked(buildTrendSplitData).mock.calls;
+        const longCall = calls.find(c => c[2] === 'long');
+        const shortCall = calls.find(c => c[2] === 'short');
+        const row = { longStop: 90, shortStop: 110, trend: 'long' as const };
+        expect(longCall?.[3](row)).toBe(90);
+        expect(shortCall?.[3](row)).toBe(110);
+    });
+
+    it('does not set data when chandelierExit is empty', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('provides stable toggle function reference', () => {
+        const { result, rerender } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        const firstToggle = result.current.toggle;
+        rerender();
+        expect(result.current.toggle).toBe(firstToggle);
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts
@@ -97,6 +97,22 @@ describe('useChandelierOverlay', () => {
         expect(mockAddSeries).toHaveBeenCalledTimes(2);
     });
 
+    it('applies lineWidth to both series after creation', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                lineWidth: 3,
+            })
+        );
+        act(() => result.current.toggle());
+        // chandelier는 PSAR과 달리 lineWidth를 실제 반영한다(applyOptions). 계약을 고정한다.
+        expect(mockApplyOptions).toHaveBeenCalledWith({ lineWidth: 3 });
+        expect(mockApplyOptions).toHaveBeenCalledTimes(2);
+    });
+
     it('removes both series when toggled off', () => {
         const chart = makeChart();
         const { result } = renderHook(() =>

--- a/src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts
@@ -136,7 +136,7 @@ describe('useParabolicSarOverlay', () => {
         );
     });
 
-    it('both up and short selectors read r.sar', () => {
+    it('both up and down selectors read r.sar', () => {
         const chart = makeChart();
         const { result } = renderHook(() =>
             useParabolicSarOverlay({

--- a/src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts
@@ -136,6 +136,66 @@ describe('useParabolicSarOverlay', () => {
         );
     });
 
+    it('both up and short selectors read r.sar', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        const calls = vi.mocked(buildTrendSplitData).mock.calls;
+        const upCall = calls.find(c => c[2] === 'up');
+        const downCall = calls.find(c => c[2] === 'down');
+        const row = { sar: 99, trend: 'up' as const };
+        expect(upCall?.[3](row)).toBe(99);
+        expect(downCall?.[3](row)).toBe(99);
+    });
+
+    it('re-sets data on both series when bars change while visible', () => {
+        const chart = makeChart();
+        const { result, rerender } = renderHook(
+            ({ bars }) =>
+                useParabolicSarOverlay({
+                    chartRef: makeChartRef(chart),
+                    bars,
+                    indicators: FILLED_INDICATORS,
+                }),
+            { initialProps: { bars: FAKE_BARS } }
+        );
+        act(() => result.current.toggle());
+        vi.clearAllMocks();
+
+        const newBars: Bar[] = [
+            {
+                time: 2000,
+                open: 200,
+                high: 220,
+                low: 180,
+                close: 210,
+                volume: 2000,
+            },
+        ];
+        rerender({ bars: newBars });
+
+        expect(mockSetData).toHaveBeenCalledTimes(2);
+        const splitMock = vi.mocked(buildTrendSplitData);
+        expect(splitMock).toHaveBeenCalledWith(
+            newBars,
+            FILLED_INDICATORS.parabolicSar,
+            'up',
+            expect.any(Function)
+        );
+        expect(splitMock).toHaveBeenCalledWith(
+            newBars,
+            FILLED_INDICATORS.parabolicSar,
+            'down',
+            expect.any(Function)
+        );
+    });
+
     it('does not set data when parabolicSar is empty', () => {
         const chart = makeChart();
         const { result } = renderHook(() =>

--- a/src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useParabolicSarOverlay } from '../../hooks/useParabolicSarOverlay';
+import { buildTrendSplitData } from '../../utils/seriesDataUtils';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    LineSeries: 'LineSeries',
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildTrendSplitData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useParabolicSarOverlay
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = {
+    parabolicSar: [],
+} as unknown as IndicatorResult;
+
+const FILLED_INDICATORS = {
+    parabolicSar: [{ sar: 99, trend: 'up' }],
+} as unknown as IndicatorResult;
+
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 },
+];
+
+describe('useParabolicSarOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns isVisible false initially', () => {
+        const { result } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('toggles isVisible when toggle is called', () => {
+        const { result } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(result.current.isVisible).toBe(true);
+        act(() => result.current.toggle());
+        expect(result.current.isVisible).toBe(false);
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates two LineSeries (up, down) when visible and chart exists', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes both series when toggled off', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        act(() => result.current.toggle());
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('sets data on both series with up/down direction and sar selector', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockSetData).toHaveBeenCalledTimes(2);
+        const splitMock = vi.mocked(buildTrendSplitData);
+        expect(splitMock).toHaveBeenCalledWith(
+            FAKE_BARS,
+            FILLED_INDICATORS.parabolicSar,
+            'up',
+            expect.any(Function)
+        );
+        expect(splitMock).toHaveBeenCalledWith(
+            FAKE_BARS,
+            FILLED_INDICATORS.parabolicSar,
+            'down',
+            expect.any(Function)
+        );
+    });
+
+    it('does not set data when parabolicSar is empty', () => {
+        const chart = makeChart();
+        const { result } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => result.current.toggle());
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('provides stable toggle function reference', () => {
+        const { result, rerender } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        const firstToggle = result.current.toggle;
+        rerender();
+        expect(result.current.toggle).toBe(firstToggle);
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts
@@ -128,12 +128,14 @@ describe('useSupertrendOverlay', () => {
         expect(splitMock).toHaveBeenCalledWith(
             FAKE_BARS,
             FILLED_INDICATORS.supertrend,
-            'up'
+            'up',
+            expect.any(Function)
         );
         expect(splitMock).toHaveBeenCalledWith(
             FAKE_BARS,
             FILLED_INDICATORS.supertrend,
-            'down'
+            'down',
+            expect.any(Function)
         );
     });
 
@@ -170,12 +172,14 @@ describe('useSupertrendOverlay', () => {
         expect(splitMock).toHaveBeenCalledWith(
             newBars,
             FILLED_INDICATORS.supertrend,
-            'up'
+            'up',
+            expect.any(Function)
         );
         expect(splitMock).toHaveBeenCalledWith(
             newBars,
             FILLED_INDICATORS.supertrend,
-            'down'
+            'down',
+            expect.any(Function)
         );
     });
 

--- a/src/widgets/chart/__tests__/model/indicatorRegistry.test.ts
+++ b/src/widgets/chart/__tests__/model/indicatorRegistry.test.ts
@@ -14,8 +14,24 @@ function bindingFor(key: IndicatorKey, active = false): IndicatorBinding {
 }
 
 describe('indicatorRegistry', () => {
-    it('registers exactly the 27 modal-target indicators', () => {
-        expect(INDICATOR_REGISTRY).toHaveLength(27);
+    it('registers exactly the 29 modal-target indicators', () => {
+        expect(INDICATOR_REGISTRY).toHaveLength(29);
+    });
+
+    it('registers parabolicSar as a trend overlay', () => {
+        const meta = INDICATOR_REGISTRY.find(m => m.key === 'parabolicSar');
+        expect(meta).toBeDefined();
+        expect(meta?.category).toBe('trend');
+        expect(meta?.kind).toBe('overlay');
+        expect(meta?.hasPeriods).toBeUndefined();
+    });
+
+    it('registers chandelierExit as a trend overlay', () => {
+        const meta = INDICATOR_REGISTRY.find(m => m.key === 'chandelierExit');
+        expect(meta).toBeDefined();
+        expect(meta?.category).toBe('trend');
+        expect(meta?.kind).toBe('overlay');
+        expect(meta?.hasPeriods).toBeUndefined();
     });
 
     it('registers supertrend as a trend overlay', () => {

--- a/src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts
@@ -69,6 +69,8 @@ describe('buildOverlayLabelConfigs', () => {
                 keltnerVisible: false,
                 donchianVisible: false,
                 supertrendVisible: false,
+                parabolicSarVisible: false,
+                chandelierVisible: false,
             });
 
             expect(result).toEqual([]);
@@ -86,6 +88,8 @@ describe('buildOverlayLabelConfigs', () => {
                 keltnerVisible: false,
                 donchianVisible: false,
                 supertrendVisible: false,
+                parabolicSarVisible: false,
+                chandelierVisible: false,
             });
 
             expect(result).toHaveLength(2);
@@ -105,6 +109,8 @@ describe('buildOverlayLabelConfigs', () => {
                 keltnerVisible: false,
                 donchianVisible: false,
                 supertrendVisible: false,
+                parabolicSarVisible: false,
+                chandelierVisible: false,
             });
 
             expect(result).toHaveLength(1);
@@ -123,6 +129,8 @@ describe('buildOverlayLabelConfigs', () => {
                 keltnerVisible: false,
                 donchianVisible: false,
                 supertrendVisible: false,
+                parabolicSarVisible: false,
+                chandelierVisible: false,
             });
 
             expect(result).toHaveLength(3);
@@ -143,6 +151,8 @@ describe('buildOverlayLabelConfigs', () => {
                 keltnerVisible: false,
                 donchianVisible: false,
                 supertrendVisible: false,
+                parabolicSarVisible: false,
+                chandelierVisible: false,
             });
 
             expect(result).toHaveLength(5);
@@ -165,6 +175,8 @@ describe('buildOverlayLabelConfigs', () => {
                 keltnerVisible: false,
                 donchianVisible: false,
                 supertrendVisible: false,
+                parabolicSarVisible: false,
+                chandelierVisible: false,
             });
 
             expect(result).toHaveLength(3);
@@ -185,6 +197,8 @@ describe('buildOverlayLabelConfigs', () => {
                 keltnerVisible: false,
                 donchianVisible: false,
                 supertrendVisible: false,
+                parabolicSarVisible: false,
+                chandelierVisible: false,
             });
 
             expect(result).toHaveLength(4);
@@ -206,6 +220,8 @@ describe('buildOverlayLabelConfigs', () => {
                 keltnerVisible: false,
                 donchianVisible: false,
                 supertrendVisible: false,
+                parabolicSarVisible: false,
+                chandelierVisible: false,
             });
 
             expect(result[0].color).toBe(getPeriodColor(5));
@@ -221,6 +237,8 @@ describe('buildOverlayLabelConfigs', () => {
                 keltnerVisible: false,
                 donchianVisible: false,
                 supertrendVisible: false,
+                parabolicSarVisible: false,
+                chandelierVisible: false,
             });
 
             expect(result[0].color).toBe(CHART_COLORS.bollingerUpper);
@@ -237,6 +255,8 @@ describe('buildOverlayLabelConfigs', () => {
             keltnerVisible: true,
             donchianVisible: true,
             supertrendVisible: false,
+            parabolicSarVisible: false,
+            chandelierVisible: false,
         });
         const names = configs.map(c => c.name);
         expect(names).toEqual(
@@ -271,6 +291,8 @@ describe('buildOverlayLabelConfigs', () => {
             keltnerVisible: false,
             donchianVisible: false,
             supertrendVisible: true,
+            parabolicSarVisible: false,
+            chandelierVisible: false,
         });
         const st = configs.find(c => c.name === 'Supertrend');
         expect(st).toBeDefined();
@@ -290,6 +312,8 @@ describe('buildOverlayLabelConfigs', () => {
             keltnerVisible: false,
             donchianVisible: false,
             supertrendVisible: true,
+            parabolicSarVisible: false,
+            chandelierVisible: false,
         });
         const st = configs.find(c => c.name === 'Supertrend');
         expect(st?.getColor).toBeDefined();
@@ -317,8 +341,85 @@ describe('buildOverlayLabelConfigs', () => {
             keltnerVisible: false,
             donchianVisible: false,
             supertrendVisible: false,
+            parabolicSarVisible: false,
+            chandelierVisible: false,
         });
         expect(configs.find(c => c.name === 'Supertrend')).toBeUndefined();
+    });
+
+    it('includes a PSAR config (value + trend getColor) when parabolicSarVisible', () => {
+        const configs = buildOverlayLabelConfigs({
+            maVisiblePeriods: [],
+            emaVisiblePeriods: [],
+            bollingerVisible: false,
+            ichimokuVisible: false,
+            vpVisible: false,
+            keltnerVisible: false,
+            donchianVisible: false,
+            supertrendVisible: false,
+            parabolicSarVisible: true,
+            chandelierVisible: false,
+        });
+        const psar = configs.find(c => c.name === 'PSAR');
+        expect(psar).toBeDefined();
+        const ind = {
+            parabolicSar: [
+                { sar: 99, trend: 'up' },
+                { sar: 98, trend: 'down' },
+            ],
+        } as never;
+        expect(psar?.getValue(ind, 0)).toBe(99);
+        expect(psar?.getValue(ind, 9)).toBeNull();
+        expect(psar?.getColor?.(ind, 0)).toBe(CHART_COLORS.parabolicSarUp);
+        expect(psar?.getColor?.(ind, 1)).toBe(CHART_COLORS.parabolicSarDown);
+        expect(psar?.getColor?.(ind, 9)).toBe(CHART_COLORS.neutral);
+    });
+
+    it('includes a Chandelier config (active stop by trend + trend getColor) when chandelierVisible', () => {
+        const configs = buildOverlayLabelConfigs({
+            maVisiblePeriods: [],
+            emaVisiblePeriods: [],
+            bollingerVisible: false,
+            ichimokuVisible: false,
+            vpVisible: false,
+            keltnerVisible: false,
+            donchianVisible: false,
+            supertrendVisible: false,
+            parabolicSarVisible: false,
+            chandelierVisible: true,
+        });
+        const ch = configs.find(c => c.name === 'Chandelier');
+        expect(ch).toBeDefined();
+        const ind = {
+            chandelierExit: [
+                { longStop: 90, shortStop: 110, trend: 'long' },
+                { longStop: 91, shortStop: 111, trend: 'short' },
+                { longStop: null, shortStop: null, trend: null },
+            ],
+        } as never;
+        expect(ch?.getValue(ind, 0)).toBe(90);
+        expect(ch?.getValue(ind, 1)).toBe(111);
+        expect(ch?.getValue(ind, 2)).toBeNull();
+        expect(ch?.getColor?.(ind, 0)).toBe(CHART_COLORS.chandelierLong);
+        expect(ch?.getColor?.(ind, 1)).toBe(CHART_COLORS.chandelierShort);
+        expect(ch?.getColor?.(ind, 2)).toBe(CHART_COLORS.neutral);
+    });
+
+    it('omits PSAR and Chandelier configs when their flags are false', () => {
+        const configs = buildOverlayLabelConfigs({
+            maVisiblePeriods: [],
+            emaVisiblePeriods: [],
+            bollingerVisible: false,
+            ichimokuVisible: false,
+            vpVisible: false,
+            keltnerVisible: false,
+            donchianVisible: false,
+            supertrendVisible: false,
+            parabolicSarVisible: false,
+            chandelierVisible: false,
+        });
+        expect(configs.find(c => c.name === 'PSAR')).toBeUndefined();
+        expect(configs.find(c => c.name === 'Chandelier')).toBeUndefined();
     });
 });
 
@@ -373,6 +474,8 @@ describe('resolveOverlayValues', () => {
         keltnerVisible: false,
         donchianVisible: false,
         supertrendVisible: false,
+        parabolicSarVisible: false,
+        chandelierVisible: false,
     });
 
     describe('barIndex가 -1일 때', () => {
@@ -482,6 +585,8 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             keltnerVisible: false,
             donchianVisible: false,
             supertrendVisible: false,
+            parabolicSarVisible: false,
+            chandelierVisible: false,
         });
 
         expect(configs[0].getValue(mockIndicators, 0)).toBe(100);
@@ -499,6 +604,8 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             keltnerVisible: false,
             donchianVisible: false,
             supertrendVisible: false,
+            parabolicSarVisible: false,
+            chandelierVisible: false,
         });
 
         expect(configs[0].getValue(mockIndicators, 0)).toBeNull();
@@ -514,6 +621,8 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             keltnerVisible: false,
             donchianVisible: false,
             supertrendVisible: false,
+            parabolicSarVisible: false,
+            chandelierVisible: false,
         });
 
         expect(configs[0].getValue(mockIndicators, 0)).toBe(105);
@@ -532,6 +641,8 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             keltnerVisible: false,
             donchianVisible: false,
             supertrendVisible: false,
+            parabolicSarVisible: false,
+            chandelierVisible: false,
         });
 
         expect(configs[0].getValue(mockIndicators, 0)).toBe(101); // tenkan
@@ -552,6 +663,8 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             keltnerVisible: false,
             donchianVisible: false,
             supertrendVisible: false,
+            parabolicSarVisible: false,
+            chandelierVisible: false,
         });
 
         expect(configs[0].getValue(mockIndicators, 0)).toBe(100); // poc
@@ -574,6 +687,8 @@ describe('buildOverlayLabelConfigs — getValue 콜백', () => {
             keltnerVisible: false,
             donchianVisible: false,
             supertrendVisible: false,
+            parabolicSarVisible: false,
+            chandelierVisible: false,
         });
 
         expect(configs[0].getValue(emptyIndicators, 0)).toBeNull();

--- a/src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts
@@ -366,12 +366,15 @@ describe('buildOverlayLabelConfigs', () => {
             parabolicSar: [
                 { sar: 99, trend: 'up' },
                 { sar: 98, trend: 'down' },
+                { sar: null, trend: null },
             ],
         } as never;
         expect(psar?.getValue(ind, 0)).toBe(99);
+        expect(psar?.getValue(ind, 2)).toBeNull(); // warm-up 구간(sar null)
         expect(psar?.getValue(ind, 9)).toBeNull();
         expect(psar?.getColor?.(ind, 0)).toBe(CHART_COLORS.parabolicSarUp);
         expect(psar?.getColor?.(ind, 1)).toBe(CHART_COLORS.parabolicSarDown);
+        expect(psar?.getColor?.(ind, 2)).toBe(CHART_COLORS.neutral);
         expect(psar?.getColor?.(ind, 9)).toBe(CHART_COLORS.neutral);
     });
 

--- a/src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/overlayLabelUtils.test.ts
@@ -406,6 +406,13 @@ describe('buildOverlayLabelConfigs', () => {
         expect(ch?.getColor?.(ind, 0)).toBe(CHART_COLORS.chandelierLong);
         expect(ch?.getColor?.(ind, 1)).toBe(CHART_COLORS.chandelierShort);
         expect(ch?.getColor?.(ind, 2)).toBe(CHART_COLORS.neutral);
+        // 타입 경계: trend는 확정됐지만 stop 값이 아직 null인 warm-up 조합도 null 반환.
+        const trendOnly = {
+            chandelierExit: [
+                { longStop: null, shortStop: null, trend: 'long' },
+            ],
+        } as never;
+        expect(ch?.getValue(trendOnly, 0)).toBeNull();
     });
 
     it('omits PSAR and Chandelier configs when their flags are false', () => {

--- a/src/widgets/chart/__tests__/utils/overlayLabelUtilsBranches.test.ts
+++ b/src/widgets/chart/__tests__/utils/overlayLabelUtilsBranches.test.ts
@@ -67,6 +67,8 @@ describe('overlayLabelUtils — branch coverage', () => {
                 keltnerVisible: false,
                 donchianVisible: false,
                 supertrendVisible: false,
+                parabolicSarVisible: false,
+                chandelierVisible: false,
             });
 
             expect(configs[0].getValue(indicators, 0)).toBeNull(); // upper
@@ -90,6 +92,8 @@ describe('overlayLabelUtils — branch coverage', () => {
                 keltnerVisible: false,
                 donchianVisible: false,
                 supertrendVisible: false,
+                parabolicSarVisible: false,
+                chandelierVisible: false,
             });
 
             expect(configs[0].getValue(indicators, 0)).toBeNull(); // tenkan
@@ -117,6 +121,8 @@ describe('overlayLabelUtils — branch coverage', () => {
                 keltnerVisible: false,
                 donchianVisible: false,
                 supertrendVisible: false,
+                parabolicSarVisible: false,
+                chandelierVisible: false,
             });
 
             expect(configs[0].getValue(indicators, 0)).toBeNull(); // poc

--- a/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
@@ -50,6 +50,8 @@ function makePaneIndices(overrides: Partial<PaneIndices> = {}): PaneIndices {
         keltnerChannel: INACTIVE_PANE_INDEX,
         donchianChannel: INACTIVE_PANE_INDEX,
         supertrend: INACTIVE_PANE_INDEX,
+        parabolicSar: INACTIVE_PANE_INDEX,
+        chandelierExit: INACTIVE_PANE_INDEX,
     } satisfies PaneIndices;
     return { ...base, ...overrides };
 }

--- a/src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts
@@ -146,9 +146,10 @@ describe('buildTrendSplitData', () => {
         { supertrend: 11, trend: 'down' },
         { supertrend: null, trend: null },
     ];
+    const getSt = (r: SupertrendResult): number | null => r.supertrend;
 
     it("returns value only on bars whose trend matches 'up', whitespace otherwise", () => {
-        expect(buildTrendSplitData(bars, data, 'up')).toEqual([
+        expect(buildTrendSplitData(bars, data, 'up', getSt)).toEqual([
             { time: 1, value: 10 },
             { time: 2 },
             { time: 3 },
@@ -156,7 +157,7 @@ describe('buildTrendSplitData', () => {
     });
 
     it("returns value only on bars whose trend matches 'down', whitespace otherwise", () => {
-        expect(buildTrendSplitData(bars, data, 'down')).toEqual([
+        expect(buildTrendSplitData(bars, data, 'down', getSt)).toEqual([
             { time: 1 },
             { time: 2, value: 11 },
             { time: 3 },
@@ -164,17 +165,17 @@ describe('buildTrendSplitData', () => {
     });
 
     it('up and down outputs are complementary on matched bars (never both have value)', () => {
-        const up = buildTrendSplitData(bars, data, 'up');
-        const down = buildTrendSplitData(bars, data, 'down');
+        const up = buildTrendSplitData(bars, data, 'up', getSt);
+        const down = buildTrendSplitData(bars, data, 'down', getSt);
         up.forEach((u, i) => {
             const bothHaveValue = 'value' in u && 'value' in down[i];
             expect(bothHaveValue).toBe(false);
         });
     });
 
-    it('emits whitespace when supertrend is null even if trend matches dir', () => {
+    it('emits whitespace when the selected value is null even if trend matches dir', () => {
         const nullVal: SupertrendResult[] = [{ supertrend: null, trend: 'up' }];
-        expect(buildTrendSplitData([bar(1)], nullVal, 'up')).toEqual([
+        expect(buildTrendSplitData([bar(1)], nullVal, 'up', getSt)).toEqual([
             { time: 1 },
         ]);
     });
@@ -182,11 +183,25 @@ describe('buildTrendSplitData', () => {
     it('clamps to the shorter of bars / data length (worst case)', () => {
         const longBars = [bar(1), bar(2), bar(3), bar(4)];
         const shortData: SupertrendResult[] = [{ supertrend: 5, trend: 'up' }];
-        const out = buildTrendSplitData(longBars, shortData, 'up');
+        const out = buildTrendSplitData(longBars, shortData, 'up', getSt);
         expect(out).toEqual([{ time: 1, value: 5 }]);
     });
 
     it('returns empty array for empty inputs', () => {
-        expect(buildTrendSplitData([], [], 'up')).toEqual([]);
+        expect(buildTrendSplitData([], [], 'up', getSt)).toEqual([]);
+    });
+
+    it("supports a 'long'/'short' trend literal with a per-side selector (chandelier shape)", () => {
+        const ch = [
+            { longStop: 90, shortStop: 110, trend: 'long' as const },
+            { longStop: 91, shortStop: 111, trend: 'short' as const },
+        ];
+        const longBars = [bar(1), bar(2)];
+        expect(
+            buildTrendSplitData(longBars, ch, 'long', r => r.longStop)
+        ).toEqual([{ time: 1, value: 90 }, { time: 2 }]);
+        expect(
+            buildTrendSplitData(longBars, ch, 'short', r => r.shortStop)
+        ).toEqual([{ time: 1 }, { time: 2, value: 111 }]);
     });
 });

--- a/src/widgets/chart/constants.ts
+++ b/src/widgets/chart/constants.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_LINE_WIDTH = 1;
+export const DEFAULT_POINT_MARKERS_RADIUS = 2; // 점 마커(Parabolic SAR 등) 반지름
 export const INACTIVE_PANE_INDEX = -1;
 export const FIRST_INDICATOR_PANE_INDEX = 1;
 export const LABEL_SERIES_INDEX = 0; // 첫 번째 시리즈에만 label을 표시한다

--- a/src/widgets/chart/constants.ts
+++ b/src/widgets/chart/constants.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_LINE_WIDTH = 1;
-export const DEFAULT_POINT_MARKERS_RADIUS = 2; // 점 마커(Parabolic SAR 등) 반지름
+export const DEFAULT_POINT_MARKERS_RADIUS = 2;
 export const INACTIVE_PANE_INDEX = -1;
 export const FIRST_INDICATOR_PANE_INDEX = 1;
 export const LABEL_SERIES_INDEX = 0; // 첫 번째 시리즈에만 label을 표시한다

--- a/src/widgets/chart/hooks/useChandelierOverlay.ts
+++ b/src/widgets/chart/hooks/useChandelierOverlay.ts
@@ -1,0 +1,119 @@
+'use client';
+
+import type { RefObject } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useEffectEvent,
+    useRef,
+    useState,
+} from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import { LineSeries, LineStyle } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { buildTrendSplitData } from '../utils/seriesDataUtils';
+
+interface UseChandelierOverlayParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+}
+
+interface UseChandelierOverlayReturn {
+    isVisible: boolean;
+    toggle: () => void;
+}
+
+export function useChandelierOverlay({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+}: UseChandelierOverlayParams): UseChandelierOverlayReturn {
+    const [isVisible, setIsVisible] = useState(false);
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const longSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+    const shortSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+    const toggle = useCallback(() => {
+        setIsVisible(prev => !prev);
+    }, []);
+
+    const clearSeriesRefs = useEffectEvent(() => {
+        longSeriesRef.current = null;
+        shortSeriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (longSeriesRef.current) {
+            chart.removeSeries(longSeriesRef.current);
+            longSeriesRef.current = null;
+        }
+        if (shortSeriesRef.current) {
+            chart.removeSeries(shortSeriesRef.current);
+            shortSeriesRef.current = null;
+        }
+    });
+
+    // bars, indicators는 의존하지 않음 — 데이터 세팅은 아래 effect가 단독 담당.
+    // supertrend(solid)와 구분되도록 LineStyle.Dashed로 그린다.
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (!longSeriesRef.current) {
+            longSeriesRef.current = chart.addSeries(LineSeries, {
+                color: CHART_COLORS.chandelierLong,
+                lineWidth,
+                lineStyle: LineStyle.Dashed,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        longSeriesRef.current.applyOptions({ lineWidth });
+
+        if (!shortSeriesRef.current) {
+            shortSeriesRef.current = chart.addSeries(LineSeries, {
+                color: CHART_COLORS.chandelierShort,
+                lineWidth,
+                lineStyle: LineStyle.Dashed,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+        shortSeriesRef.current.applyOptions({ lineWidth });
+    }, [chartRef, isVisible, lineWidth]);
+
+    // isVisible이 true로 바뀔 때도 실행되어 새로 생성된 시리즈에 초기 데이터를 세팅함
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { chandelierExit } = indicators;
+        if (!chandelierExit.length) return;
+
+        if (!longSeriesRef.current || !shortSeriesRef.current) return;
+
+        longSeriesRef.current.setData(
+            buildTrendSplitData(bars, chandelierExit, 'long', r => r.longStop)
+        );
+        shortSeriesRef.current.setData(
+            buildTrendSplitData(bars, chandelierExit, 'short', r => r.shortStop)
+        );
+    }, [indicators, bars, isVisible]);
+
+    return { isVisible, toggle };
+}

--- a/src/widgets/chart/hooks/useParabolicSarOverlay.ts
+++ b/src/widgets/chart/hooks/useParabolicSarOverlay.ts
@@ -8,18 +8,17 @@ import {
     useRef,
     useState,
 } from 'react';
-import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import type { IChartApi, ISeriesApi } from 'lightweight-charts';
 import { LineSeries } from 'lightweight-charts';
 import { CHART_COLORS } from '@/shared/lib/chartColors';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
-import { DEFAULT_LINE_WIDTH } from '../constants';
+import { DEFAULT_POINT_MARKERS_RADIUS } from '../constants';
 import { buildTrendSplitData } from '../utils/seriesDataUtils';
 
 interface UseParabolicSarOverlayParams {
     chartRef: RefObject<IChartApi | null>;
     bars: Bar[];
     indicators: IndicatorResult;
-    lineWidth?: LineWidth;
 }
 
 interface UseParabolicSarOverlayReturn {
@@ -31,7 +30,6 @@ export function useParabolicSarOverlay({
     chartRef,
     bars,
     indicators,
-    lineWidth = DEFAULT_LINE_WIDTH,
 }: UseParabolicSarOverlayParams): UseParabolicSarOverlayReturn {
     const [isVisible, setIsVisible] = useState(false);
     const prevChartRef = useRef<IChartApi | null>(null);
@@ -80,7 +78,7 @@ export function useParabolicSarOverlay({
                 color: CHART_COLORS.parabolicSarUp,
                 lineVisible: false,
                 pointMarkersVisible: true,
-                pointMarkersRadius: 2,
+                pointMarkersRadius: DEFAULT_POINT_MARKERS_RADIUS,
                 priceLineVisible: false,
                 lastValueVisible: false,
             });
@@ -91,12 +89,12 @@ export function useParabolicSarOverlay({
                 color: CHART_COLORS.parabolicSarDown,
                 lineVisible: false,
                 pointMarkersVisible: true,
-                pointMarkersRadius: 2,
+                pointMarkersRadius: DEFAULT_POINT_MARKERS_RADIUS,
                 priceLineVisible: false,
                 lastValueVisible: false,
             });
         }
-    }, [chartRef, isVisible, lineWidth]);
+    }, [chartRef, isVisible]);
 
     // isVisible이 true로 바뀔 때도 실행되어 새로 생성된 시리즈에 초기 데이터를 세팅함
     useEffect(() => {

--- a/src/widgets/chart/hooks/useParabolicSarOverlay.ts
+++ b/src/widgets/chart/hooks/useParabolicSarOverlay.ts
@@ -1,0 +1,119 @@
+'use client';
+
+import type { RefObject } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useEffectEvent,
+    useRef,
+    useState,
+} from 'react';
+import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
+import { LineSeries } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { buildTrendSplitData } from '../utils/seriesDataUtils';
+
+interface UseParabolicSarOverlayParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    lineWidth?: LineWidth;
+}
+
+interface UseParabolicSarOverlayReturn {
+    isVisible: boolean;
+    toggle: () => void;
+}
+
+export function useParabolicSarOverlay({
+    chartRef,
+    bars,
+    indicators,
+    lineWidth = DEFAULT_LINE_WIDTH,
+}: UseParabolicSarOverlayParams): UseParabolicSarOverlayReturn {
+    const [isVisible, setIsVisible] = useState(false);
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const upSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+    const downSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+    const toggle = useCallback(() => {
+        setIsVisible(prev => !prev);
+    }, []);
+
+    const clearSeriesRefs = useEffectEvent(() => {
+        upSeriesRef.current = null;
+        downSeriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (upSeriesRef.current) {
+            chart.removeSeries(upSeriesRef.current);
+            upSeriesRef.current = null;
+        }
+        if (downSeriesRef.current) {
+            chart.removeSeries(downSeriesRef.current);
+            downSeriesRef.current = null;
+        }
+    });
+
+    // bars, indicators는 의존하지 않음 — 데이터 세팅은 아래 effect가 단독 담당.
+    // 가격 위/아래 점(dot)만 렌더하므로 lineVisible:false + pointMarkersVisible:true.
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (!upSeriesRef.current) {
+            upSeriesRef.current = chart.addSeries(LineSeries, {
+                color: CHART_COLORS.parabolicSarUp,
+                lineVisible: false,
+                pointMarkersVisible: true,
+                pointMarkersRadius: 2,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+
+        if (!downSeriesRef.current) {
+            downSeriesRef.current = chart.addSeries(LineSeries, {
+                color: CHART_COLORS.parabolicSarDown,
+                lineVisible: false,
+                pointMarkersVisible: true,
+                pointMarkersRadius: 2,
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+        }
+    }, [chartRef, isVisible, lineWidth]);
+
+    // isVisible이 true로 바뀔 때도 실행되어 새로 생성된 시리즈에 초기 데이터를 세팅함
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { parabolicSar } = indicators;
+        if (!parabolicSar.length) return;
+
+        if (!upSeriesRef.current || !downSeriesRef.current) return;
+
+        upSeriesRef.current.setData(
+            buildTrendSplitData(bars, parabolicSar, 'up', r => r.sar)
+        );
+        downSeriesRef.current.setData(
+            buildTrendSplitData(bars, parabolicSar, 'down', r => r.sar)
+        );
+    }, [indicators, bars, isVisible]);
+
+    return { isVisible, toggle };
+}

--- a/src/widgets/chart/hooks/useSupertrendOverlay.ts
+++ b/src/widgets/chart/hooks/useSupertrendOverlay.ts
@@ -107,10 +107,10 @@ export function useSupertrendOverlay({
         if (!upSeriesRef.current || !downSeriesRef.current) return;
 
         upSeriesRef.current.setData(
-            buildTrendSplitData(bars, supertrend, 'up')
+            buildTrendSplitData(bars, supertrend, 'up', r => r.supertrend)
         );
         downSeriesRef.current.setData(
-            buildTrendSplitData(bars, supertrend, 'down')
+            buildTrendSplitData(bars, supertrend, 'down', r => r.supertrend)
         );
     }, [indicators, bars, isVisible]);
 

--- a/src/widgets/chart/model/indicatorRegistry.ts
+++ b/src/widgets/chart/model/indicatorRegistry.ts
@@ -44,7 +44,9 @@ export type IndicatorKey =
     | 'ewmaVolatility'
     | 'keltnerChannel'
     | 'donchianChannel'
-    | 'supertrend';
+    | 'supertrend'
+    | 'parabolicSar'
+    | 'chandelierExit';
 
 export interface IndicatorMeta {
     key: IndicatorKey;
@@ -181,6 +183,18 @@ export const INDICATOR_REGISTRY: readonly IndicatorMeta[] = [
     {
         key: 'supertrend',
         label: 'Supertrend',
+        category: 'trend',
+        kind: 'overlay',
+    },
+    {
+        key: 'parabolicSar',
+        label: 'Parabolic SAR',
+        category: 'trend',
+        kind: 'overlay',
+    },
+    {
+        key: 'chandelierExit',
+        label: 'Chandelier',
         category: 'trend',
         kind: 'overlay',
     },

--- a/src/widgets/chart/utils/overlayLabelUtils.ts
+++ b/src/widgets/chart/utils/overlayLabelUtils.ts
@@ -220,7 +220,7 @@ export function buildOverlayLabelConfigs({
               {
                   name: 'Chandelier',
                   color: CHART_COLORS.chandelierLong,
-                  // active stop만 표시: long 추세→longStop, short 추세→shortStop.
+                  // long/short stop 두 값을 동시에 띄우면 범례가 혼란스럽다 — 현재 추세의 active stop 하나만 노출한다.
                   getValue: (
                       ind: IndicatorResult,
                       i: number

--- a/src/widgets/chart/utils/overlayLabelUtils.ts
+++ b/src/widgets/chart/utils/overlayLabelUtils.ts
@@ -21,6 +21,8 @@ interface BuildOverlayLabelConfigsParams {
     keltnerVisible: boolean;
     donchianVisible: boolean;
     supertrendVisible: boolean;
+    parabolicSarVisible: boolean;
+    chandelierVisible: boolean;
 }
 
 export function buildOverlayLabelConfigs({
@@ -32,6 +34,8 @@ export function buildOverlayLabelConfigs({
     keltnerVisible,
     donchianVisible,
     supertrendVisible,
+    parabolicSarVisible,
+    chandelierVisible,
 }: BuildOverlayLabelConfigsParams): OverlayLabelConfig[] {
     const maConfigs: OverlayLabelConfig[] = maVisiblePeriods.map(period => ({
         name: `MA(${period})`,
@@ -193,6 +197,50 @@ export function buildOverlayLabelConfigs({
           ]
         : [];
 
+    const parabolicSarConfigs: OverlayLabelConfig[] = parabolicSarVisible
+        ? [
+              {
+                  name: 'PSAR',
+                  color: CHART_COLORS.parabolicSarUp,
+                  getValue: (ind: IndicatorResult, i: number): number | null =>
+                      ind.parabolicSar[i]?.sar ?? null,
+                  getColor: (ind: IndicatorResult, i: number): string => {
+                      const trend = ind.parabolicSar[i]?.trend;
+                      if (trend === 'down')
+                          return CHART_COLORS.parabolicSarDown;
+                      if (trend === 'up') return CHART_COLORS.parabolicSarUp;
+                      return CHART_COLORS.neutral;
+                  },
+              },
+          ]
+        : [];
+
+    const chandelierConfigs: OverlayLabelConfig[] = chandelierVisible
+        ? [
+              {
+                  name: 'Chandelier',
+                  color: CHART_COLORS.chandelierLong,
+                  // active stop만 표시: long 추세→longStop, short 추세→shortStop.
+                  getValue: (
+                      ind: IndicatorResult,
+                      i: number
+                  ): number | null => {
+                      const r = ind.chandelierExit[i];
+                      if (r?.trend === 'long') return r.longStop;
+                      if (r?.trend === 'short') return r.shortStop;
+                      return null;
+                  },
+                  getColor: (ind: IndicatorResult, i: number): string => {
+                      const trend = ind.chandelierExit[i]?.trend;
+                      if (trend === 'short')
+                          return CHART_COLORS.chandelierShort;
+                      if (trend === 'long') return CHART_COLORS.chandelierLong;
+                      return CHART_COLORS.neutral;
+                  },
+              },
+          ]
+        : [];
+
     return [
         ...maConfigs,
         ...emaConfigs,
@@ -202,6 +250,8 @@ export function buildOverlayLabelConfigs({
         ...keltnerConfigs,
         ...donchianConfigs,
         ...supertrendConfigs,
+        ...parabolicSarConfigs,
+        ...chandelierConfigs,
     ];
 }
 

--- a/src/widgets/chart/utils/seriesDataUtils.ts
+++ b/src/widgets/chart/utils/seriesDataUtils.ts
@@ -1,12 +1,5 @@
-import type {
-    Bar,
-    SupertrendResult,
-    TrendDirection,
-} from '@y0ngha/siglens-core';
+import type { Bar } from '@y0ngha/siglens-core';
 import type { UTCTimestamp } from 'lightweight-charts';
-
-/** 추세 방향 중 확정된 값(warm-up의 null 제외). */
-type TrendDir = Exclude<TrendDirection, null>;
 
 export type SeriesPoint =
     | { time: UTCTimestamp; value: number; color?: string }
@@ -65,20 +58,28 @@ export function buildSeriesDataFromValues(
 }
 
 /**
- * trend 방향이 dir과 일치하는 bar만 supertrend 값을, 나머지는 WhitespaceData({ time })를 반환한다.
- * up/down 2개 LineSeries로 trend별 색을 표현하기 위함 (LineSeries는 per-point 색 미지원).
+ * trend 방향이 dir과 일치하는 bar만 getValue(r) 값을, 나머지는 WhitespaceData({ time })를 반환한다.
+ * 추세별 색 라인을 up/down(또는 long/short) 2개 LineSeries로 표현하기 위함(LineSeries는 per-point 색 미지원).
+ * getValue 선택자와 제네릭 Dir로 supertrend·parabolicSar(단일 값 필드)와 chandelier(추세별 longStop/shortStop)를 모두 지원한다.
  */
-export function buildTrendSplitData(
+export function buildTrendSplitData<
+    Dir extends string,
+    T extends { trend: string | null },
+>(
     bars: Bar[],
-    data: SupertrendResult[],
-    dir: TrendDir
+    data: T[],
+    dir: Dir,
+    getValue: (r: T) => number | null
 ): SeriesPoint[] {
     const count = Math.min(bars.length, data.length);
     return bars.slice(0, count).map((bar, i) => {
         const r = data[i];
-        // Bar.time은 epoch seconds 정수 — LWC UTCTimestamp(branded number)와 런타임 형태 동일하므로 safe-cast.
-        if (r && r.trend === dir && r.supertrend !== null) {
-            return { time: bar.time as UTCTimestamp, value: r.supertrend };
+        if (r && r.trend === dir) {
+            const value = getValue(r);
+            // Bar.time은 epoch seconds 정수 — LWC UTCTimestamp(branded number)와 런타임 형태 동일하므로 safe-cast.
+            if (value !== null) {
+                return { time: bar.time as UTCTimestamp, value };
+            }
         }
         return { time: bar.time as UTCTimestamp };
     });

--- a/src/widgets/chart/utils/seriesDataUtils.ts
+++ b/src/widgets/chart/utils/seriesDataUtils.ts
@@ -72,11 +72,11 @@ export function buildTrendSplitData<
     getValue: (r: T) => number | null
 ): SeriesPoint[] {
     const count = Math.min(bars.length, data.length);
+    // Bar.time은 epoch seconds 정수 — LWC UTCTimestamp(branded number)와 런타임 형태 동일하므로 아래 두 cast 모두 안전.
     return bars.slice(0, count).map((bar, i) => {
         const r = data[i];
         if (r && r.trend === dir) {
             const value = getValue(r);
-            // Bar.time은 epoch seconds 정수 — LWC UTCTimestamp(branded number)와 런타임 형태 동일하므로 safe-cast.
             if (value !== null) {
                 return { time: bar.time as UTCTimestamp, value };
             }


### PR DESCRIPTION
## 요약
미사용 보조지표 렌더링 6차이자 그룹 A(가격 오버레이) 마무리. **parabolicSar**(추세 색 점)와 **chandelierExit**(추세 색 점선 trailing stop)를 가격 페인 오버레이로 렌더한다.

- **Parabolic SAR**: 가격 위/아래 점(dot). LWC `LineSeries`에 `lineVisible:false`+`pointMarkersVisible:true`+`radius:2`로 SAR 정확값 위치에 점. 추세 색 2-시리즈(up=teal 점 / down=red 점).
- **Chandelier Exit**: 추세 따라 flip하는 단일 trailing stop. long→longStop(가격 아래), short→shortStop(가격 위). `LineStyle.Dashed`로 supertrend(solid)와 구분. 추세 색 2-시리즈.

`buildTrendSplitData` 헬퍼를 값 선택자(`getValue`) + 제네릭 추세(`Dir`)로 일반화해 supertrend·parabolicSar·chandelier 셋이 공유한다. 계산은 `@y0ngha/siglens-core`에 있어 코어 변경 없음.

## 변경 사항
- `utils/seriesDataUtils.ts`: `buildTrendSplitData` 일반화(`<Dir, T>(bars, data, dir, getValue)`) — supertrend 호출부/테스트 갱신 포함
- `hooks/useParabolicSarOverlay.ts`: 점 마커 오버레이 훅
- `hooks/useChandelierOverlay.ts`: 점선 trailing stop 오버레이 훅
- `model/indicatorRegistry.ts`: 2종 등록(overlay·trend, 27→29)
- `shared/lib/chartColors.ts` + `globals.css`: parabolicSar/chandelier 색(#26a69a/#ef5350, DESIGN.md 고정값) + @theme
- `utils/overlayLabelUtils.ts`: 2 config + per-bar `getColor`(범례 색이 현재 막대 추세를 따라 라인과 일치; chandelier는 active stop만 표시)
- `StockChart.tsx`: 훅 2개 + binding 2개(29)
- `e2e/specs/chart-indicators.spec.ts`: 모달 토글 E2E 2개

## 검증
- vitest 전체 커버리지 게이트 통과(branches 91.48%, lines 95.79%)
- lint / prettier --check / production build 전부 통과
- 내부 review-agent(Opus): round 1 recommended 2건(테스트 parity — bars 변경 재싱크·선택자 identity) 반영 → round 2 APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)