### PR TITLE
feat(chart): render Elder Ray + Squeeze Momentum + Regression panes (finish group C)

### DIFF
--- a/docs/superpowers/plans/2026-06-07-render-c-complex.md
+++ b/docs/superpowers/plans/2026-06-07-render-c-complex.md
@@ -1,0 +1,1630 @@
+# C-Complex Panes (Elder Ray + Squeeze Momentum + Regression) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render `elderRay`, `squeezeMomentum`, and `regression` as separate-pane indicators with histograms, zero-line state dots, and r²-modulated opacity.
+
+**Architecture:** Reuse the established pane-hook pattern (`useMACDChart`): each hook takes a `paneIndex` from `useIndicatorVisibility`, manages series lifecycle + data-sync in two effects, and recreates series on paneIndex change. Histograms color per-bar via a row-aware `buildSeriesData` colorFn. Squeeze state dots use a new `buildZeroLineDots` builder. Color decisions live in pure functions. Computation is in `@y0ngha/siglens-core` (unchanged); this is pure siglens rendering.
+
+**Tech Stack:** TypeScript, React 19 (`useEffectEvent`), lightweight-charts 5.2.0 (`HistogramSeries`, `pointMarkersVisible`), Vitest + RTL, Playwright (E2E).
+
+**Spec:** `docs/superpowers/specs/2026-06-07-render-c-complex-design.md`
+**Branch:** `feat/render-c-complex` (base: `feat/render-group-a-rest` = PR #584)
+**Worktree:** `/Users/y0ngha/Project/siglens-c-complex`
+
+**Data shapes (siglens-core `domain/types.d.ts`):**
+```ts
+interface ElderRayResult { bullPower: number | null; bearPower: number | null; }
+interface SqueezeMomentumResult { momentum: number | null; sqzOn: boolean | null; sqzOff: boolean | null; noSqz: boolean | null; increasing: boolean | null; }
+interface RegressionResult { slope: number | null; r2: number | null; }
+// IndicatorResult.elderRay / squeezeMomentum / regression: each []
+```
+
+**Reference files (read before implementing):**
+- `src/widgets/chart/hooks/useMACDChart.ts` — histogram pane hook skeleton (paneIndex lifecycle + data-sync + per-bar colorFn)
+- `src/widgets/chart/__tests__/hooks/useAtrChart.test.ts` — pane hook test template
+- `src/widgets/chart/utils/paneLabelUtils.ts` — `buildSinglePaneLabel` + MACD-style inline multi-sublabel
+- `e2e/specs/chart-indicators.spec.ts` — existing MFI/ATR "toggles into a pane" tests (`.pane-indicator-label`)
+
+---
+
+## File Structure
+
+- `src/widgets/chart/utils/seriesDataUtils.ts` (+ test) — row-aware `buildSeriesData` colorFn + new `buildZeroLineDots` (modify).
+- `src/widgets/chart/utils/histogramColorUtils.ts` (+ test) — `squeezeMomentumColor` / `squeezeStateColor` / `regressionBarColor` pure fns (create).
+- `src/shared/lib/chartColors.ts` + `src/app/globals.css` — new colors + @theme tokens (modify).
+- `src/widgets/chart/model/indicatorRegistry.ts` (+ tests, + paneLabelUtils test) — `IndicatorKey` +3, registry +3 (modify).
+- `src/widgets/chart/hooks/useElderRayChart.ts` (+ test) — 2 histograms (create).
+- `src/widgets/chart/hooks/useSqueezeMomentumChart.ts` (+ test) — histogram + state dots (create).
+- `src/widgets/chart/hooks/useRegressionChart.ts` (+ test) — slope histogram + r² opacity (create).
+- `src/widgets/chart/utils/paneLabelUtils.ts` (+ test) — 3 pane labels (modify).
+- `src/widgets/chart/StockChart.tsx` (+ test) — 3 hooks, 3 bindings (32) (modify).
+- `e2e/specs/chart-indicators.spec.ts` — 3 pane-toggle tests (modify).
+
+---
+
+## Task 0: Worktree node_modules verify
+
+**Files:** none
+
+- [ ] **Step 1: Verify real node_modules**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-c-complex
+[ -e node_modules/.bin/vitest ] && [ ! -L node_modules ] && echo "OK" || echo "MISSING"
+```
+Expected: `OK`. If MISSING: `cp -al /Users/y0ngha/Project/siglens/node_modules ./node_modules && rm -rf node_modules/node_modules`.
+
+- [ ] **Step 2: Sanity-check**
+
+Run: `cd /Users/y0ngha/Project/siglens-c-complex && yarn vitest run src/widgets/chart/__tests__/hooks/useMACDChart.test.ts`
+Expected: PASS.
+
+---
+
+## Task 1: Row-aware `buildSeriesData` colorFn + `buildZeroLineDots`
+
+**Files:**
+- Modify: `src/widgets/chart/utils/seriesDataUtils.ts`
+- Modify: `src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts` a new describe + extend the import to include `buildZeroLineDots`:
+```ts
+describe('buildSeriesData colorFn row arg', () => {
+    const bars: Bar[] = [bar(1), bar(2)];
+    const data = [
+        { v: 5, flag: true },
+        { v: -3, flag: false },
+    ];
+
+    it('passes (value, row, index) to colorFn', () => {
+        const seen: Array<[number, unknown, number]> = [];
+        buildSeriesData(bars, data, 'v', (value, row, index) => {
+            seen.push([value, row, index]);
+            return '#fff';
+        });
+        expect(seen[0]).toEqual([5, { v: 5, flag: true }, 0]);
+        expect(seen[1]).toEqual([-3, { v: -3, flag: false }, 1]);
+    });
+
+    it('still supports a value-only colorFn (backward compatible)', () => {
+        const out = buildSeriesData(bars, data, 'v', value =>
+            value >= 0 ? '#0f0' : '#f00'
+        );
+        expect(out).toEqual([
+            { time: 1, value: 5, color: '#0f0' },
+            { time: 2, value: -3, color: '#f00' },
+        ]);
+    });
+});
+
+describe('buildZeroLineDots', () => {
+    const bars: Bar[] = [bar(1), bar(2), bar(3)];
+
+    it('emits a zero-value point with the colorFn color per row', () => {
+        const data = [{ s: 'a' }, { s: 'b' }, { s: 'c' }];
+        const out = buildZeroLineDots(bars, data, row =>
+            row.s === 'b' ? '#abc' : null
+        );
+        expect(out).toEqual([{ time: 1 }, { time: 2, value: 0, color: '#abc' }, { time: 3 }]);
+    });
+
+    it('emits whitespace when the row is null/undefined', () => {
+        const data = [null, { s: 'x' }] as unknown as Array<{ s: string }>;
+        const out = buildZeroLineDots(bars.slice(0, 2), data, () => '#fff');
+        expect(out).toEqual([{ time: 1 }, { time: 2, value: 0, color: '#fff' }]);
+    });
+
+    it('clamps to the shorter length and returns [] for empty inputs', () => {
+        expect(buildZeroLineDots([], [], () => '#fff')).toEqual([]);
+        expect(
+            buildZeroLineDots(bars, [{ s: 'a' }], () => '#fff')
+        ).toEqual([{ time: 1, value: 0, color: '#fff' }]);
+    });
+});
+```
+Update the existing top import to add `buildZeroLineDots`:
+```ts
+import {
+    buildSeriesData,
+    buildSeriesDataFromValues,
+    buildTrendSplitData,
+    buildZeroLineDots,
+} from '@/widgets/chart/utils/seriesDataUtils';
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/y0ngha/Project/siglens-c-complex && yarn vitest run src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts`
+Expected: FAIL (colorFn arity / `buildZeroLineDots` not exported).
+
+- [ ] **Step 3: Widen the colorFn type**
+
+In `src/widgets/chart/utils/seriesDataUtils.ts`, change the `buildSeriesData` colorFn param type and the call site:
+```ts
+    colorFn?: (value: number, row: T, index: number) => string
+```
+and inside the colored branch:
+```ts
+        if (colorFn !== undefined) {
+            point.color = colorFn(value, indicatorData[i] as T, i);
+        }
+```
+
+- [ ] **Step 4: Add `buildZeroLineDots`**
+
+Append to `src/widgets/chart/utils/seriesDataUtils.ts`:
+```ts
+/**
+ * 각 bar에 0(zero)라인 위 점({ time, value: 0, color })을 만든다. colorFn이 null을
+ * 반환하거나 행이 없으면 해당 bar는 whitespace(점 없음). Squeeze 상태 점처럼 값과
+ * 무관하게 0라인에 상태 색을 찍는 용도.
+ */
+export function buildZeroLineDots<T>(
+    bars: Bar[],
+    data: T[],
+    colorFn: (row: T) => string | null
+): SeriesPoint[] {
+    const count = Math.min(bars.length, data.length);
+    return bars.slice(0, count).map((bar, i) => {
+        const row = data[i];
+        const color = row == null ? null : colorFn(row);
+        if (color === null) {
+            return { time: bar.time as UTCTimestamp };
+        }
+        return { time: bar.time as UTCTimestamp, value: 0, color };
+    });
+}
+```
+
+- [ ] **Step 5: Run tests + tsc + lint**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-c-complex
+npx tsc --noEmit
+yarn vitest run src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts
+yarn lint src/widgets/chart/utils/seriesDataUtils.ts src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts
+```
+Expected: tsc clean (MACD's existing `value => ...` colorFn still type-checks); tests PASS; lint clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/widgets/chart/utils/seriesDataUtils.ts src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts
+git commit -m "feat(chart): row-aware buildSeriesData colorFn + buildZeroLineDots"
+```
+
+---
+
+## Task 2: Add colors
+
+**Files:**
+- Modify: `src/shared/lib/chartColors.ts`
+- Modify: `src/app/globals.css`
+
+- [ ] **Step 1: Collision guard**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-c-complex
+grep -rn "elderBullPower\|elderBearPower\|squeezeMomentumUp\|squeezeMomentumDown\|squeezeOn\|squeezeOff\|squeezeNone\|regressionUp\|regressionDown" src/ || echo "KEYS UNUSED — safe"
+```
+Expected: `KEYS UNUSED — safe`.
+
+- [ ] **Step 2: Add to `CHART_COLORS`**
+
+In `src/shared/lib/chartColors.ts`, after the `chandelierShort: '#ef5350',` line, add:
+```ts
+    // Elder Ray (bull/bear power 히스토그램)
+    elderBullPower: '#26a69a',
+    elderBearPower: '#ef5350',
+    // Squeeze Momentum 히스토그램 (강=solid, 약=50% alpha) — DESIGN.md teal/red 기반
+    squeezeMomentumUp: '#26a69a',
+    squeezeMomentumUpWeak: '#26a69a80',
+    squeezeMomentumDown: '#ef5350',
+    squeezeMomentumDownWeak: '#ef535080',
+    // Squeeze 상태 점 (추세 무관 상태 팔레트)
+    squeezeOn: '#fbbf24',
+    squeezeOff: '#94a3b8',
+    squeezeNone: '#3b82f6',
+    // Regression (alpha는 r2로 런타임 계산)
+    regressionUp: '#26a69a',
+    regressionDown: '#ef5350',
+```
+
+- [ ] **Step 3: Mirror solid tokens in `@theme`**
+
+In `src/app/globals.css`, after the `--color-chart-chandelier-short: #ef5350;` line, add:
+```css
+    /* Chart — Elder Ray */
+    --color-chart-elder-bull-power: #26a69a;
+    --color-chart-elder-bear-power: #ef5350;
+    /* Chart — Squeeze Momentum / 상태 점 */
+    --color-chart-squeeze-momentum-up: #26a69a;
+    --color-chart-squeeze-momentum-down: #ef5350;
+    --color-chart-squeeze-on: #fbbf24;
+    --color-chart-squeeze-off: #94a3b8;
+    --color-chart-squeeze-none: #3b82f6;
+    /* Chart — Regression */
+    --color-chart-regression-up: #26a69a;
+    --color-chart-regression-down: #ef5350;
+```
+(alpha 변형 `...Weak`는 JS 전용이라 미러하지 않는다.)
+
+- [ ] **Step 4: Verify**
+
+Run: `cd /Users/y0ngha/Project/siglens-c-complex && yarn lint src/shared/lib/chartColors.ts && npx prettier --check src/shared/lib/chartColors.ts src/app/globals.css`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/lib/chartColors.ts src/app/globals.css
+git commit -m "feat(chart): add elderRay + squeeze + regression colors"
+```
+
+---
+
+## Task 3: Histogram color pure functions
+
+**Files:**
+- Create: `src/widgets/chart/utils/histogramColorUtils.ts`
+- Test: `src/widgets/chart/__tests__/utils/histogramColorUtils.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/widgets/chart/__tests__/utils/histogramColorUtils.test.ts`:
+```ts
+import { describe, expect, it } from 'vitest';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import {
+    regressionBarColor,
+    squeezeMomentumColor,
+    squeezeStateColor,
+} from '@/widgets/chart/utils/histogramColorUtils';
+
+describe('squeezeMomentumColor', () => {
+    it('positive + increasing → strong up', () => {
+        expect(squeezeMomentumColor(5, true)).toBe(CHART_COLORS.squeezeMomentumUp);
+    });
+    it('positive + not increasing → weak up', () => {
+        expect(squeezeMomentumColor(5, false)).toBe(CHART_COLORS.squeezeMomentumUpWeak);
+    });
+    it('negative + increasing → weak down (recovering)', () => {
+        expect(squeezeMomentumColor(-5, true)).toBe(CHART_COLORS.squeezeMomentumDownWeak);
+    });
+    it('negative + not increasing → strong down', () => {
+        expect(squeezeMomentumColor(-5, false)).toBe(CHART_COLORS.squeezeMomentumDown);
+    });
+    it('zero counts as non-positive (weak/strong down by increasing)', () => {
+        expect(squeezeMomentumColor(0, true)).toBe(CHART_COLORS.squeezeMomentumDownWeak);
+        expect(squeezeMomentumColor(0, false)).toBe(CHART_COLORS.squeezeMomentumDown);
+    });
+    it('null increasing treated as not increasing', () => {
+        expect(squeezeMomentumColor(5, null)).toBe(CHART_COLORS.squeezeMomentumUpWeak);
+    });
+});
+
+describe('squeezeStateColor', () => {
+    it('noSqz → squeezeNone (highest priority)', () => {
+        expect(
+            squeezeStateColor({ noSqz: true, sqzOn: true, sqzOff: false })
+        ).toBe(CHART_COLORS.squeezeNone);
+    });
+    it('sqzOn → squeezeOn', () => {
+        expect(
+            squeezeStateColor({ noSqz: false, sqzOn: true, sqzOff: false })
+        ).toBe(CHART_COLORS.squeezeOn);
+    });
+    it('sqzOff → squeezeOff', () => {
+        expect(
+            squeezeStateColor({ noSqz: false, sqzOn: false, sqzOff: true })
+        ).toBe(CHART_COLORS.squeezeOff);
+    });
+    it('all false/null → null (no dot)', () => {
+        expect(
+            squeezeStateColor({ noSqz: false, sqzOn: false, sqzOff: false })
+        ).toBeNull();
+        expect(
+            squeezeStateColor({ noSqz: null, sqzOn: null, sqzOff: null })
+        ).toBeNull();
+    });
+});
+
+describe('regressionBarColor', () => {
+    it('positive slope → teal rgba with r2 alpha', () => {
+        expect(regressionBarColor(2, 0.8)).toBe('rgba(38, 166, 154, 0.8)');
+    });
+    it('negative slope → red rgba with r2 alpha', () => {
+        expect(regressionBarColor(-2, 0.5)).toBe('rgba(239, 83, 80, 0.5)');
+    });
+    it('clamps r2 into [0,1]', () => {
+        expect(regressionBarColor(1, 1.7)).toBe('rgba(38, 166, 154, 1)');
+        expect(regressionBarColor(1, -0.4)).toBe('rgba(38, 166, 154, 0)');
+    });
+    it('null r2 → fallback alpha 0.25', () => {
+        expect(regressionBarColor(1, null)).toBe('rgba(38, 166, 154, 0.25)');
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/y0ngha/Project/siglens-c-complex && yarn vitest run src/widgets/chart/__tests__/utils/histogramColorUtils.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+Create `src/widgets/chart/utils/histogramColorUtils.ts`:
+```ts
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+
+/** Regression alpha 기본값 — r2가 null(신뢰도 미확정)일 때 흐릿하게. */
+const REGRESSION_FALLBACK_ALPHA = 0.25;
+/** Regression 막대 RGB(투명도만 r2로 변조) — DESIGN.md teal/red 고정값의 RGB 분해. */
+const REGRESSION_UP_RGB = '38, 166, 154'; // #26a69a
+const REGRESSION_DOWN_RGB = '239, 83, 80'; // #ef5350
+
+/**
+ * Squeeze 모멘텀 히스토그램 4색: 부호(상승/하락) × increasing(강/약).
+ * value > 0: increasing이면 강한 상승, 아니면 약화. value ≤ 0: increasing이면
+ * 회복(약한 하락), 아니면 강한 하락. (LazyBear 표준)
+ */
+export function squeezeMomentumColor(
+    value: number,
+    increasing: boolean | null
+): string {
+    if (value > 0) {
+        return increasing
+            ? CHART_COLORS.squeezeMomentumUp
+            : CHART_COLORS.squeezeMomentumUpWeak;
+    }
+    return increasing
+        ? CHART_COLORS.squeezeMomentumDownWeak
+        : CHART_COLORS.squeezeMomentumDown;
+}
+
+/**
+ * Squeeze 상태 점 색: noSqz > sqzOn > sqzOff 우선순위. 어느 상태도 아니면 null(점 없음).
+ */
+export function squeezeStateColor(row: {
+    noSqz: boolean | null;
+    sqzOn: boolean | null;
+    sqzOff: boolean | null;
+}): string | null {
+    if (row.noSqz) return CHART_COLORS.squeezeNone;
+    if (row.sqzOn) return CHART_COLORS.squeezeOn;
+    if (row.sqzOff) return CHART_COLORS.squeezeOff;
+    return null;
+}
+
+/**
+ * Regression slope 막대 색: 부호로 teal/red, 투명도 = r2(적합도) 클램프.
+ * r2 null이면 fallback alpha로 "신뢰도 미확정"을 흐리게 표현.
+ */
+export function regressionBarColor(slope: number, r2: number | null): string {
+    const alpha =
+        r2 === null ? REGRESSION_FALLBACK_ALPHA : Math.min(1, Math.max(0, r2));
+    const rgb = slope >= 0 ? REGRESSION_UP_RGB : REGRESSION_DOWN_RGB;
+    return `rgba(${rgb}, ${alpha})`;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes + tsc + lint**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-c-complex
+npx tsc --noEmit
+yarn vitest run src/widgets/chart/__tests__/utils/histogramColorUtils.test.ts
+yarn lint src/widgets/chart/utils/histogramColorUtils.ts src/widgets/chart/__tests__/utils/histogramColorUtils.test.ts
+```
+Expected: tsc clean; tests PASS; lint clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets/chart/utils/histogramColorUtils.ts src/widgets/chart/__tests__/utils/histogramColorUtils.test.ts
+git commit -m "feat(chart): add squeeze/regression histogram color functions"
+```
+
+---
+
+## Task 4: Register the 3 indicators
+
+**Files:**
+- Modify: `src/widgets/chart/model/indicatorRegistry.ts`
+- Modify: `src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`
+- Modify: `src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts`
+
+- [ ] **Step 1: Write the failing registry tests**
+
+In `src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`: change the length assertion `toHaveLength(29)` → `toHaveLength(32)`, and add:
+```ts
+it('registers elderRay as a momentum pane', () => {
+    const meta = INDICATOR_REGISTRY.find(m => m.key === 'elderRay');
+    expect(meta).toBeDefined();
+    expect(meta?.category).toBe('momentum');
+    expect(meta?.kind).toBe('pane');
+});
+
+it('registers squeezeMomentum as a momentum pane', () => {
+    const meta = INDICATOR_REGISTRY.find(m => m.key === 'squeezeMomentum');
+    expect(meta).toBeDefined();
+    expect(meta?.category).toBe('momentum');
+    expect(meta?.kind).toBe('pane');
+});
+
+it('registers regression as a statistical pane', () => {
+    const meta = INDICATOR_REGISTRY.find(m => m.key === 'regression');
+    expect(meta).toBeDefined();
+    expect(meta?.category).toBe('statistical');
+    expect(meta?.kind).toBe('pane');
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/y0ngha/Project/siglens-c-complex && yarn vitest run src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Add union members + registry entries**
+
+In `src/widgets/chart/model/indicatorRegistry.ts`:
+(a) In `IndicatorKey`, after `| 'chandelierExit'`, change the terminator to:
+```ts
+    | 'chandelierExit'
+    | 'elderRay'
+    | 'squeezeMomentum'
+    | 'regression';
+```
+(b) In `INDICATOR_REGISTRY`, after the `chandelierExit` entry (last element, before `];`), add:
+```ts
+    { key: 'elderRay', label: 'Elder Ray', category: 'momentum', kind: 'pane' },
+    {
+        key: 'squeezeMomentum',
+        label: 'Squeeze',
+        category: 'momentum',
+        kind: 'pane',
+    },
+    {
+        key: 'regression',
+        label: 'Regression',
+        category: 'statistical',
+        kind: 'pane',
+    },
+```
+
+- [ ] **Step 4: Verify registry test passes**
+
+Run: `cd /Users/y0ngha/Project/siglens-c-complex && yarn vitest run src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Fix makePaneIndices fallout**
+
+In `src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts`, inside the `makePaneIndices` base object, after `chandelierExit: INACTIVE_PANE_INDEX,`, add:
+```ts
+        elderRay: INACTIVE_PANE_INDEX,
+        squeezeMomentum: INACTIVE_PANE_INDEX,
+        regression: INACTIVE_PANE_INDEX,
+```
+
+- [ ] **Step 6: tsc + both tests**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-c-complex
+npx tsc --noEmit
+yarn vitest run src/widgets/chart/__tests__/model/indicatorRegistry.test.ts src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+```
+Expected: tsc clean; both PASS. If tsc flags other `Record<IndicatorKey>` objects missing the 3 keys, fix each and report.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/widgets/chart/model/indicatorRegistry.ts src/widgets/chart/__tests__/model/indicatorRegistry.test.ts src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+git commit -m "feat(chart): register elderRay + squeezeMomentum + regression panes"
+```
+
+---
+
+## Task 5: `useElderRayChart` hook
+
+**Files:**
+- Create: `src/widgets/chart/hooks/useElderRayChart.ts`
+- Test: `src/widgets/chart/__tests__/hooks/useElderRayChart.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/widgets/chart/__tests__/hooks/useElderRayChart.test.ts`:
+```ts
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useElderRayChart } from '../../hooks/useElderRayChart';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    HistogramSeries: 'HistogramSeries',
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useElderRayChart
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { elderRay: [] } as unknown as IndicatorResult;
+const FILLED_INDICATORS = {
+    elderRay: [{ bullPower: 2, bearPower: -1 }],
+} as unknown as IndicatorResult;
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 1, high: 2, low: 0, close: 1, volume: 10 },
+];
+
+describe('useElderRayChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useElderRayChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates two histogram series when visible', () => {
+        renderHook(() =>
+            useElderRayChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes both series when not visible', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(props => useElderRayChart(props), {
+            initialProps: {
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            },
+        });
+        rerender({
+            chartRef: makeChartRef(chart),
+            bars: FAKE_BARS,
+            indicators: FILLED_INDICATORS,
+            isVisible: false,
+            paneIndex: 1,
+        });
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('sets data on both series when visible with data', () => {
+        renderHook(() =>
+            useElderRayChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockSetData).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not set data when elderRay is empty', () => {
+        renderHook(() =>
+            useElderRayChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('recreates series when paneIndex changes', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(props => useElderRayChart(props), {
+            initialProps: {
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            },
+        });
+        rerender({
+            chartRef: makeChartRef(chart),
+            bars: FAKE_BARS,
+            indicators: FILLED_INDICATORS,
+            isVisible: true,
+            paneIndex: 2,
+        });
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(2);
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/y0ngha/Project/siglens-c-complex && yarn vitest run src/widgets/chart/__tests__/hooks/useElderRayChart.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement the hook**
+
+Create `src/widgets/chart/hooks/useElderRayChart.ts` (cloned from useMACDChart skeleton, 2 histograms):
+```ts
+'use client';
+
+import type { RefObject } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { IChartApi, ISeriesApi } from 'lightweight-charts';
+import { HistogramSeries } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { buildSeriesData } from '../utils/seriesDataUtils';
+
+interface UseElderRayChartParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    isVisible: boolean;
+    paneIndex: number;
+}
+
+export function useElderRayChart({
+    chartRef,
+    bars,
+    indicators,
+    isVisible,
+    paneIndex,
+}: UseElderRayChartParams): void {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const prevPaneIndexRef = useRef<number>(paneIndex);
+    const bullSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null);
+    const bearSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null);
+
+    const clearSeriesRefs = useEffectEvent(() => {
+        bullSeriesRef.current = null;
+        bearSeriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (bullSeriesRef.current) {
+            chart.removeSeries(bullSeriesRef.current);
+            bullSeriesRef.current = null;
+        }
+        if (bearSeriesRef.current) {
+            chart.removeSeries(bearSeriesRef.current);
+            bearSeriesRef.current = null;
+        }
+    });
+
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (prevPaneIndexRef.current !== paneIndex && bullSeriesRef.current) {
+            removeAllSeries(chart);
+        }
+        prevPaneIndexRef.current = paneIndex;
+
+        if (!bullSeriesRef.current) {
+            bullSeriesRef.current = chart.addSeries(
+                HistogramSeries,
+                { priceLineVisible: false, lastValueVisible: false },
+                paneIndex
+            );
+        }
+        if (!bearSeriesRef.current) {
+            bearSeriesRef.current = chart.addSeries(
+                HistogramSeries,
+                { priceLineVisible: false, lastValueVisible: false },
+                paneIndex
+            );
+        }
+    }, [chartRef, isVisible, paneIndex]);
+
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { elderRay } = indicators;
+        if (!elderRay.length) return;
+
+        if (!bullSeriesRef.current || !bearSeriesRef.current) return;
+
+        bullSeriesRef.current.setData(
+            buildSeriesData(bars, elderRay, 'bullPower', value =>
+                value >= 0 ? CHART_COLORS.elderBullPower : CHART_COLORS.neutral
+            )
+        );
+        bearSeriesRef.current.setData(
+            buildSeriesData(bars, elderRay, 'bearPower', value =>
+                value <= 0 ? CHART_COLORS.elderBearPower : CHART_COLORS.neutral
+            )
+        );
+    }, [indicators, bars, isVisible, paneIndex]);
+}
+```
+
+- [ ] **Step 4: Run to verify it passes + tsc + lint**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-c-complex
+npx tsc --noEmit
+yarn vitest run src/widgets/chart/__tests__/hooks/useElderRayChart.test.ts
+yarn lint src/widgets/chart/hooks/useElderRayChart.ts src/widgets/chart/__tests__/hooks/useElderRayChart.test.ts
+```
+Expected: all clean/PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets/chart/hooks/useElderRayChart.ts src/widgets/chart/__tests__/hooks/useElderRayChart.test.ts
+git commit -m "feat(chart): add useElderRayChart hook (bull/bear power histograms)"
+```
+
+---
+
+## Task 6: `useSqueezeMomentumChart` hook
+
+**Files:**
+- Create: `src/widgets/chart/hooks/useSqueezeMomentumChart.ts`
+- Test: `src/widgets/chart/__tests__/hooks/useSqueezeMomentumChart.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/widgets/chart/__tests__/hooks/useSqueezeMomentumChart.test.ts`:
+```ts
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useSqueezeMomentumChart } from '../../hooks/useSqueezeMomentumChart';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    HistogramSeries: 'HistogramSeries',
+    LineSeries: 'LineSeries',
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesData: vi.fn(() => []),
+    buildZeroLineDots: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useSqueezeMomentumChart
+    >[0]['chartRef'];
+}
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { squeezeMomentum: [] } as unknown as IndicatorResult;
+const FILLED_INDICATORS = {
+    squeezeMomentum: [
+        { momentum: 3, sqzOn: true, sqzOff: false, noSqz: false, increasing: true },
+    ],
+} as unknown as IndicatorResult;
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 1, high: 2, low: 0, close: 1, volume: 10 },
+];
+
+describe('useSqueezeMomentumChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useSqueezeMomentumChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates histogram + state-dots series when visible', () => {
+        renderHook(() =>
+            useSqueezeMomentumChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes both series when not visible', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(p => useSqueezeMomentumChart(p), {
+            initialProps: {
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            },
+        });
+        rerender({
+            chartRef: makeChartRef(chart),
+            bars: FAKE_BARS,
+            indicators: FILLED_INDICATORS,
+            isVisible: false,
+            paneIndex: 1,
+        });
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('sets data on both series when visible with data', () => {
+        renderHook(() =>
+            useSqueezeMomentumChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockSetData).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not set data when squeezeMomentum is empty', () => {
+        renderHook(() =>
+            useSqueezeMomentumChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('recreates series when paneIndex changes', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(p => useSqueezeMomentumChart(p), {
+            initialProps: {
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            },
+        });
+        rerender({
+            chartRef: makeChartRef(chart),
+            bars: FAKE_BARS,
+            indicators: FILLED_INDICATORS,
+            isVisible: true,
+            paneIndex: 2,
+        });
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(2);
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/y0ngha/Project/siglens-c-complex && yarn vitest run src/widgets/chart/__tests__/hooks/useSqueezeMomentumChart.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `src/widgets/chart/hooks/useSqueezeMomentumChart.ts`:
+```ts
+'use client';
+
+import type { RefObject } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { IChartApi, ISeriesApi } from 'lightweight-charts';
+import { HistogramSeries, LineSeries } from 'lightweight-charts';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_POINT_MARKERS_RADIUS } from '../constants';
+import { buildSeriesData, buildZeroLineDots } from '../utils/seriesDataUtils';
+import {
+    squeezeMomentumColor,
+    squeezeStateColor,
+} from '../utils/histogramColorUtils';
+
+interface UseSqueezeMomentumChartParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    isVisible: boolean;
+    paneIndex: number;
+}
+
+export function useSqueezeMomentumChart({
+    chartRef,
+    bars,
+    indicators,
+    isVisible,
+    paneIndex,
+}: UseSqueezeMomentumChartParams): void {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const prevPaneIndexRef = useRef<number>(paneIndex);
+    const momentumSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null);
+    const stateDotsSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+    const clearSeriesRefs = useEffectEvent(() => {
+        momentumSeriesRef.current = null;
+        stateDotsSeriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (momentumSeriesRef.current) {
+            chart.removeSeries(momentumSeriesRef.current);
+            momentumSeriesRef.current = null;
+        }
+        if (stateDotsSeriesRef.current) {
+            chart.removeSeries(stateDotsSeriesRef.current);
+            stateDotsSeriesRef.current = null;
+        }
+    });
+
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (
+            prevPaneIndexRef.current !== paneIndex &&
+            momentumSeriesRef.current
+        ) {
+            removeAllSeries(chart);
+        }
+        prevPaneIndexRef.current = paneIndex;
+
+        if (!momentumSeriesRef.current) {
+            momentumSeriesRef.current = chart.addSeries(
+                HistogramSeries,
+                { priceLineVisible: false, lastValueVisible: false },
+                paneIndex
+            );
+        }
+        if (!stateDotsSeriesRef.current) {
+            stateDotsSeriesRef.current = chart.addSeries(
+                LineSeries,
+                {
+                    lineVisible: false,
+                    pointMarkersVisible: true,
+                    pointMarkersRadius: DEFAULT_POINT_MARKERS_RADIUS,
+                    priceLineVisible: false,
+                    lastValueVisible: false,
+                },
+                paneIndex
+            );
+        }
+    }, [chartRef, isVisible, paneIndex]);
+
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { squeezeMomentum } = indicators;
+        if (!squeezeMomentum.length) return;
+
+        if (!momentumSeriesRef.current || !stateDotsSeriesRef.current) return;
+
+        momentumSeriesRef.current.setData(
+            buildSeriesData(bars, squeezeMomentum, 'momentum', (value, row) =>
+                squeezeMomentumColor(value, row.increasing)
+            )
+        );
+        stateDotsSeriesRef.current.setData(
+            buildZeroLineDots(bars, squeezeMomentum, squeezeStateColor)
+        );
+    }, [indicators, bars, isVisible, paneIndex]);
+}
+```
+
+- [ ] **Step 4: Run to verify it passes + tsc + lint**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-c-complex
+npx tsc --noEmit
+yarn vitest run src/widgets/chart/__tests__/hooks/useSqueezeMomentumChart.test.ts
+yarn lint src/widgets/chart/hooks/useSqueezeMomentumChart.ts src/widgets/chart/__tests__/hooks/useSqueezeMomentumChart.test.ts
+```
+Expected: all clean/PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets/chart/hooks/useSqueezeMomentumChart.ts src/widgets/chart/__tests__/hooks/useSqueezeMomentumChart.test.ts
+git commit -m "feat(chart): add useSqueezeMomentumChart hook (4-color histogram + state dots)"
+```
+
+---
+
+## Task 7: `useRegressionChart` hook
+
+**Files:**
+- Create: `src/widgets/chart/hooks/useRegressionChart.ts`
+- Test: `src/widgets/chart/__tests__/hooks/useRegressionChart.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/widgets/chart/__tests__/hooks/useRegressionChart.test.ts`:
+```ts
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useRegressionChart } from '../../hooks/useRegressionChart';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    HistogramSeries: 'HistogramSeries',
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useRegressionChart
+    >[0]['chartRef'];
+}
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { regression: [] } as unknown as IndicatorResult;
+const FILLED_INDICATORS = {
+    regression: [{ slope: 0.4, r2: 0.8 }],
+} as unknown as IndicatorResult;
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 1, high: 2, low: 0, close: 1, volume: 10 },
+];
+
+describe('useRegressionChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useRegressionChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates one histogram series when visible', () => {
+        renderHook(() =>
+            useRegressionChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockAddSeries).toHaveBeenCalledTimes(1);
+    });
+
+    it('removes the series when not visible', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(p => useRegressionChart(p), {
+            initialProps: {
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            },
+        });
+        rerender({
+            chartRef: makeChartRef(chart),
+            bars: FAKE_BARS,
+            indicators: FILLED_INDICATORS,
+            isVisible: false,
+            paneIndex: 1,
+        });
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets data when visible with data', () => {
+        renderHook(() =>
+            useRegressionChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockSetData).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not set data when regression is empty', () => {
+        renderHook(() =>
+            useRegressionChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('recreates the series when paneIndex changes', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(p => useRegressionChart(p), {
+            initialProps: {
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            },
+        });
+        rerender({
+            chartRef: makeChartRef(chart),
+            bars: FAKE_BARS,
+            indicators: FILLED_INDICATORS,
+            isVisible: true,
+            paneIndex: 2,
+        });
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(1);
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/y0ngha/Project/siglens-c-complex && yarn vitest run src/widgets/chart/__tests__/hooks/useRegressionChart.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `src/widgets/chart/hooks/useRegressionChart.ts`:
+```ts
+'use client';
+
+import type { RefObject } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { IChartApi, ISeriesApi } from 'lightweight-charts';
+import { HistogramSeries } from 'lightweight-charts';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { buildSeriesData } from '../utils/seriesDataUtils';
+import { regressionBarColor } from '../utils/histogramColorUtils';
+
+interface UseRegressionChartParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    isVisible: boolean;
+    paneIndex: number;
+}
+
+export function useRegressionChart({
+    chartRef,
+    bars,
+    indicators,
+    isVisible,
+    paneIndex,
+}: UseRegressionChartParams): void {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const prevPaneIndexRef = useRef<number>(paneIndex);
+    const slopeSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null);
+
+    const clearSeriesRefs = useEffectEvent(() => {
+        slopeSeriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (slopeSeriesRef.current) {
+            chart.removeSeries(slopeSeriesRef.current);
+            slopeSeriesRef.current = null;
+        }
+    });
+
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (prevPaneIndexRef.current !== paneIndex && slopeSeriesRef.current) {
+            removeAllSeries(chart);
+        }
+        prevPaneIndexRef.current = paneIndex;
+
+        if (!slopeSeriesRef.current) {
+            slopeSeriesRef.current = chart.addSeries(
+                HistogramSeries,
+                { priceLineVisible: false, lastValueVisible: false },
+                paneIndex
+            );
+        }
+    }, [chartRef, isVisible, paneIndex]);
+
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { regression } = indicators;
+        if (!regression.length) return;
+
+        if (!slopeSeriesRef.current) return;
+
+        slopeSeriesRef.current.setData(
+            buildSeriesData(bars, regression, 'slope', (value, row) =>
+                regressionBarColor(value, row.r2)
+            )
+        );
+    }, [indicators, bars, isVisible, paneIndex]);
+}
+```
+
+- [ ] **Step 4: Run to verify it passes + tsc + lint**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-c-complex
+npx tsc --noEmit
+yarn vitest run src/widgets/chart/__tests__/hooks/useRegressionChart.test.ts
+yarn lint src/widgets/chart/hooks/useRegressionChart.ts src/widgets/chart/__tests__/hooks/useRegressionChart.test.ts
+```
+Expected: all clean/PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets/chart/hooks/useRegressionChart.ts src/widgets/chart/__tests__/hooks/useRegressionChart.test.ts
+git commit -m "feat(chart): add useRegressionChart hook (slope histogram + r2 opacity)"
+```
+
+---
+
+## Task 8: Pane labels
+
+**Files:**
+- Modify: `src/widgets/chart/utils/paneLabelUtils.ts`
+- Modify: `src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts`
+
+- [ ] **Step 1: Write failing label tests**
+
+In `src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts`, add (inside the existing top-level describe for `buildPaneLabels`):
+```ts
+it('builds Elder Ray sub-labels (Bull Power, Bear Power) when active', () => {
+    const labels = buildPaneLabels(makePaneIndices({ elderRay: 2 }));
+    const elder = labels.find(l => l.paneIndex === 2);
+    expect(elder?.subLabels.map(s => s.name)).toEqual([
+        'Bull Power',
+        'Bear Power',
+    ]);
+});
+
+it('builds a Squeeze pane label when active', () => {
+    const labels = buildPaneLabels(makePaneIndices({ squeezeMomentum: 3 }));
+    expect(labels.find(l => l.paneIndex === 3)?.subLabels[0].name).toBe(
+        'Squeeze'
+    );
+});
+
+it('builds a Regression pane label when active', () => {
+    const labels = buildPaneLabels(makePaneIndices({ regression: 4 }));
+    expect(labels.find(l => l.paneIndex === 4)?.subLabels[0].name).toBe(
+        'Regression'
+    );
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/y0ngha/Project/siglens-c-complex && yarn vitest run src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts`
+Expected: FAIL (labels not present).
+
+- [ ] **Step 3: Implement the labels**
+
+In `src/widgets/chart/utils/paneLabelUtils.ts`, add three label configs (place them next to the other single/multi-label definitions, before the `return [...]`). For Elder Ray (MACD-style inline, 2 sub-labels):
+```ts
+    const elderRayLabel: PaneLabelConfig[] =
+        paneIndices.elderRay !== INACTIVE_PANE_INDEX
+            ? [
+                  {
+                      paneIndex: paneIndices.elderRay,
+                      subLabels: [
+                          {
+                              name: 'Bull Power',
+                              color: CHART_COLORS.elderBullPower,
+                          },
+                          {
+                              name: 'Bear Power',
+                              color: CHART_COLORS.elderBearPower,
+                          },
+                      ],
+                  },
+              ]
+            : [];
+```
+For Squeeze and Regression (single label via the existing helper):
+```ts
+    const squeezeLabel = buildSinglePaneLabel(
+        paneIndices.squeezeMomentum,
+        'Squeeze',
+        CHART_COLORS.squeezeMomentumUp
+    );
+    const regressionLabel = buildSinglePaneLabel(
+        paneIndices.regression,
+        'Regression',
+        CHART_COLORS.regressionUp
+    );
+```
+Then add `...elderRayLabel`, `...squeezeLabel`, `...regressionLabel` to the `return [...]` array. (Confirm the exact spread/style matches how the file currently composes its return — match the existing pattern.)
+
+- [ ] **Step 4: Run + tsc + lint**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-c-complex
+npx tsc --noEmit
+yarn vitest run src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+yarn lint src/widgets/chart/utils/paneLabelUtils.ts src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+```
+Expected: all clean/PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets/chart/utils/paneLabelUtils.ts src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+git commit -m "feat(chart): add Elder Ray / Squeeze / Regression pane labels"
+```
+
+---
+
+## Task 9: Wire into StockChart
+
+**Files:**
+- Modify: `src/widgets/chart/StockChart.tsx`
+- Modify: `src/widgets/chart/__tests__/StockChart.test.tsx`
+
+- [ ] **Step 1: Add imports + hook calls**
+
+In `src/widgets/chart/StockChart.tsx`, add imports near the other pane-hook imports (e.g. after `useAtrChart`):
+```ts
+import { useElderRayChart } from './hooks/useElderRayChart';
+import { useSqueezeMomentumChart } from './hooks/useSqueezeMomentumChart';
+import { useRegressionChart } from './hooks/useRegressionChart';
+```
+Add three hook calls alongside the other pane hook calls (match the `useAtrChart({ chartRef, bars, indicators, isVisible: visible.atr, paneIndex: paneIndices.atr })` shape):
+```ts
+    useElderRayChart({
+        chartRef,
+        bars,
+        indicators,
+        isVisible: visible.elderRay,
+        paneIndex: paneIndices.elderRay,
+    });
+    useSqueezeMomentumChart({
+        chartRef,
+        bars,
+        indicators,
+        isVisible: visible.squeezeMomentum,
+        paneIndex: paneIndices.squeezeMomentum,
+    });
+    useRegressionChart({
+        chartRef,
+        bars,
+        indicators,
+        isVisible: visible.regression,
+        paneIndex: paneIndices.regression,
+    });
+```
+(Use the exact param object shape the sibling pane hooks use in this file — read `useAtrChart(...)` call and mirror it, including whether `bars`/`indicators` come from local vars.)
+
+- [ ] **Step 2: Add 3 bindings (29→32)**
+
+In the `indicatorBindings` useMemo, after the existing pane bindings (e.g. near `atr`/`yangZhang`/`ewmaVolatility`), add:
+```ts
+            {
+                meta: INDICATOR_META.elderRay,
+                active: visible.elderRay,
+                onToggle: () => toggle('elderRay'),
+            },
+            {
+                meta: INDICATOR_META.squeezeMomentum,
+                active: visible.squeezeMomentum,
+                onToggle: () => toggle('squeezeMomentum'),
+            },
+            {
+                meta: INDICATOR_META.regression,
+                active: visible.regression,
+                onToggle: () => toggle('regression'),
+            },
+```
+The `indicatorBindings` deps array already contains `visible` and `toggle` (the binding deps comment notes the whole `visible` object is a dep) — no per-key dep additions needed. Confirm `visible` and `toggle` are already in that deps array; if not, add them.
+
+- [ ] **Step 3: tsc + chart suite**
+
+Run:
+```bash
+cd /Users/y0ngha/Project/siglens-c-complex
+npx tsc --noEmit
+yarn vitest run src/widgets/chart
+```
+Expected: tsc clean; tests PASS. In `src/widgets/chart/__tests__/StockChart.test.tsx`, update the binding count test (name + `data-count`) from 29 to 32 and append `,elderRay,squeezeMomentum,regression` to the expected `data-keys` string (in that order — they are appended after chandelierExit). Report what you changed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/widgets/chart/StockChart.tsx src/widgets/chart/__tests__/StockChart.test.tsx
+git commit -m "feat(chart): wire elderRay + squeeze + regression panes into StockChart (32 bindings)"
+```
+
+---
+
+## Task 10: E2E pane toggles
+
+**Files:**
+- Modify: `e2e/specs/chart-indicators.spec.ts`
+
+- [ ] **Step 1: Read the existing pane-toggle test (MFI/ATR)**
+
+Run: `cd /Users/y0ngha/Project/siglens-c-complex && grep -n "into a pane\|pane-indicator-label\|닫기\|GEAR" e2e/specs/chart-indicators.spec.ts`
+Expected: shows the "toggles MFI into a pane" / "toggles ATR into a pane" test shape (open modal → check checkbox → close modal → assert `.pane-indicator-label` contains the name).
+
+- [ ] **Step 2: Add three pane-toggle tests**
+
+In `e2e/specs/chart-indicators.spec.ts`, add three tests mirroring the EXACT structure of the existing ATR/MFI "toggles … into a pane" test (open modal via `GEAR`, check the checkbox with `exact: true`, close modal via the `닫기` button, assert the pane label is visible). Use checkbox names `'Elder Ray'`, `'Squeeze'`, `'Regression'` and assert their pane labels (`Bull Power` / `Squeeze` / `Regression`) appear in `.pane-indicator-label`. Copy the ATR test body verbatim and substitute the names — do NOT invent a different structure. If the ATR test asserts a specific label string in `.pane-indicator-label`, mirror that assertion style for:
+- Elder Ray → label text `Bull Power` (first sub-label)
+- Squeeze → label text `Squeeze`
+- Regression → label text `Regression`
+
+- [ ] **Step 3: Lint + tsc**
+
+Run: `cd /Users/y0ngha/Project/siglens-c-complex && yarn lint e2e/specs/chart-indicators.spec.ts && npx tsc --noEmit`
+Expected: clean. (Do NOT run the Playwright suite locally — shared docker backend; CI is the gate.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/specs/chart-indicators.spec.ts
+git commit -m "test(e2e): toggle Elder Ray / Squeeze / Regression panes from settings modal"
+```
+
+---
+
+## Task 11: Final verification + review handoff
+
+**Files:** none
+
+- [ ] **Step 1: Full coverage suite**
+
+Run: `cd /Users/y0ngha/Project/siglens-c-complex && yarn test-coverage > /tmp/c-complex-cov.log 2>&1; echo "EXIT=$?"; tail -8 /tmp/c-complex-cov.log`
+Expected: `EXIT=0`, thresholds (90%+) met.
+
+- [ ] **Step 2: Lint + format (whole repo)**
+
+Run: `cd /Users/y0ngha/Project/siglens-c-complex && yarn lint && npx prettier --check .`
+Expected: no errors.
+
+- [ ] **Step 3: Production build (capture exit code directly)**
+
+Run: `cd /Users/y0ngha/Project/siglens-c-complex && yarn build > /tmp/c-complex-build.log 2>&1; echo "EXIT=$?"; tail -12 /tmp/c-complex-build.log`
+Expected: `EXIT=0`.
+
+- [ ] **Step 4: Hand off to review**
+
+Per CLAUDE.md routing: invoke `review-agent` (Opus 4.8) on branch `feat/render-c-complex`, then `mistake-managing-agent`, then `git-agent` to push and open the PR stacked on `feat/render-group-a-rest` (#584). Do not merge before APPROVED.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3.1 row-aware buildSeriesData colorFn → Task 1. ✓
+- §3.2 buildZeroLineDots → Task 1. ✓
+- §4.1 useElderRayChart (2 histograms) → Task 5. ✓
+- §4.2 useSqueezeMomentumChart (histogram + state dots) → Task 6. ✓ (color fns Task 3)
+- §4.3 useRegressionChart (slope histogram + r2 opacity) → Task 7. ✓ (regressionBarColor Task 3)
+- §5 colors + @theme → Task 2. ✓
+- §6.1 registry +3 (29→32, makePaneIndices, StockChart.test) → Task 4 + Task 9. ✓
+- §6.2 pane labels → Task 8. ✓
+- §6.3 StockChart wiring → Task 9. ✓
+- §8.4 E2E ×3 → Task 10. ✓
+- §8 test strategy (90%+, happy + worst) → Tasks 1/3/5/6/7 cover null rows, empty, length mismatch, 4-color branches, state priority, r2 clamp/null, paneIndex change. ✓
+
+**Placeholder scan:** No TBD/TODO. Task 8 (paneLabelUtils return composition) and Task 9/10 (matching sibling shape) instruct reading the exact existing pattern rather than guessing — the code to add is fully specified; only the insertion-into-existing-array style is "match existing", which is unavoidable without duplicating the whole file.
+
+**Type consistency:** `buildSeriesData(bars, data, key, (value, row, index) => string)` signature consistent across Tasks 1/5/6/7. `buildZeroLineDots(bars, data, (row) => string|null)` consistent Tasks 1/6. Color fns `squeezeMomentumColor(value, increasing)`, `squeezeStateColor(row)`, `regressionBarColor(slope, r2)` consistent between Task 3 defs and Task 6/7 calls. Registry count 29→32 consistent Tasks 4/9. Pane keys `elderRay`/`squeezeMomentum`/`regression` consistent throughout. `DEFAULT_POINT_MARKERS_RADIUS` reused from constants (added in #584). ✓

--- a/docs/superpowers/specs/2026-06-07-render-c-complex-design.md
+++ b/docs/superpowers/specs/2026-06-07-render-c-complex-design.md
@@ -1,0 +1,157 @@
+# 미사용 보조지표 렌더링 — 7차: C-복합 3종 (elderRay · squeezeMomentum · regression)
+
+- **작성일**: 2026-06-07
+- **상태**: 설계 승인됨, 구현 계획 대기
+- **브랜치**: `feat/render-c-complex` (base: `feat/render-group-a-rest` = PR #584)
+
+## 1. 배경
+
+미사용 보조지표 렌더링 7차. C-복합 3종(elderRay·squeezeMomentum·regression)을 **별도 Pane** 지표(`kind:'pane'`)로 렌더한다. C-simple(단일 라인 오실레이터)과 달리 히스토그램·상태 점·다값(투명도 인코딩) 등 복합 렌더 요소가 들어간다. 한 spec/PR로 묶되 지표별 task로 분해한다(사용자 선택). 계산은 `@y0ngha/siglens-core`에 있어 추가 작업은 siglens 차트 렌더링뿐.
+
+## 2. 자료조사 / 렌더 표준
+
+웹 자료조사(TradingView LazyBear, gocharting, TradingTechnologies) 결과:
+- **Squeeze Momentum (LazyBear)**: 모멘텀 히스토그램을 4색으로 — 양수&증가=밝은 초록(강한 상승), 양수&감소=어두운 초록(약화), 음수&증가=어두운 빨강(회복), 음수&감소=밝은 빨강(강한 하락). 0(mid)라인 위에 squeeze 상태 점 — squeeze ON(압축 형성)/OFF(해제)/none(없음)을 색으로 구분.
+- **Elder Ray**: bullPower(High−EMA13, 양수 우세)·bearPower(Low−EMA13, 음수 우세)를 **2개 히스토그램**으로 한 pane에서 0라인 기준 표시. bullPower 양수=초록, bearPower 음수=빨강, 반대 부호 막대는 회색(중립).
+- **Regression**: 표준 단일 렌더 없음. slope(추세 방향/강도)와 r2(적합도 0~1)는 스케일이 달라 한 축 공유 불가 → **slope 히스토그램(부호 색) + 막대 투명도=r2**(신뢰도 낮으면 흐릿)로 단일 pane에 압축 표현(사용자 선택).
+
+데이터(siglens-core `domain/types.d.ts`):
+```ts
+interface ElderRayResult { bullPower: number | null; bearPower: number | null; }
+interface SqueezeMomentumResult {
+    momentum: number | null;
+    sqzOn: boolean | null; sqzOff: boolean | null; noSqz: boolean | null;
+    increasing: boolean | null;
+}
+interface RegressionResult { slope: number | null; r2: number | null; }
+// IndicatorResult.elderRay/squeezeMomentum/regression: 각 []
+```
+
+기존 `useMACDChart`가 히스토그램 pane + per-bar colorFn 레퍼런스. pane 지표는 `useIndicatorVisibility`가 `kind:'pane'`을 필터해 paneIndex를 자동 배정하고 StockChart가 `paneIndices.<key>`를 전달한다.
+
+## 3. 공통 인프라 (소규모 일반화)
+
+### 3.1 `buildSeriesData` colorFn 행(row) 인지 확장
+현재 `colorFn?: (value: number) => string`은 값만 받아, squeeze 4색(`increasing` 필요)·regression 투명도(`r2` 필요)를 결정할 수 없다. **하위호환 확장**:
+```ts
+export function buildSeriesData<K extends string, T extends Record<K, number | null | undefined>>(
+    bars: Bar[],
+    indicatorData: T[],
+    key: K,
+    colorFn?: (value: number, row: T, index: number) => string
+): SeriesPoint[]
+```
+- 구현: 색 분기에서 `colorFn(value, indicatorData[i] as T, i)` 호출(이 분기는 `value !== null`이므로 행 존재).
+- MACD의 `value => value >= 0 ? ... : ...`는 인자 수가 적어도 그대로 유효(하위호환). 기존 호출부 무변경.
+
+### 3.2 `buildZeroLineDots` 신규 빌더 (squeeze 상태 점)
+```ts
+// 각 bar에 0라인 위 점({ time, value: 0, color }), 행이 null이면 whitespace.
+export function buildZeroLineDots<T>(
+    bars: Bar[],
+    data: T[],
+    colorFn: (row: T) => string | null
+): SeriesPoint[]
+```
+- `colorFn(row)`이 null 반환 시 해당 bar는 whitespace(점 없음).
+
+## 4. 지표별 렌더
+
+### 4.1 `useElderRayChart` (pane) — `hooks/useElderRayChart.ts`
+- MACD 훅 골격(paneIndex, prevPaneIndexRef, 2-effect lifecycle/data-sync, paneIndex 변경 시 재생성).
+- 2 HistogramSeries(`bullSeriesRef`, `bearSeriesRef`), 둘 다 `paneIndex` 지정.
+- 데이터: `buildSeriesData(bars, elderRay, 'bullPower', v => v >= 0 ? CHART_COLORS.elderBullPower : CHART_COLORS.neutral)`, bear는 `'bearPower', v => v <= 0 ? CHART_COLORS.elderBearPower : CHART_COLORS.neutral`.
+
+### 4.2 `useSqueezeMomentumChart` (pane) — `hooks/useSqueezeMomentumChart.ts`
+- MACD 훅 골격 + 시리즈 2개: `momentumSeriesRef`(HistogramSeries), `stateDotsSeriesRef`(LineSeries, `lineVisible:false`+`pointMarkersVisible:true`+`pointMarkersRadius: DEFAULT_POINT_MARKERS_RADIUS`).
+- 모멘텀: `buildSeriesData(bars, squeezeMomentum, 'momentum', (v, row) => squeezeMomentumColor(v, row.increasing))`.
+- 상태 점: `buildZeroLineDots(bars, squeezeMomentum, squeezeStateColor)`.
+- 순수 함수(별도 util):
+  - `squeezeMomentumColor(value, increasing)`: v>0 → increasing ? `squeezeMomentumUp` : `squeezeMomentumUpWeak`; v≤0 → increasing ? `squeezeMomentumDownWeak` : `squeezeMomentumDown`.
+  - `squeezeStateColor(row)`: `noSqz` → `squeezeNone`; `sqzOn` → `squeezeOn`; `sqzOff` → `squeezeOff`; 모두 false/null → null(점 없음).
+
+### 4.3 `useRegressionChart` (pane) — `hooks/useRegressionChart.ts`
+- MACD 훅 골격 + 1 HistogramSeries(`slopeSeriesRef`).
+- 데이터: `buildSeriesData(bars, regression, 'slope', (v, row) => regressionBarColor(v, row.r2))`.
+- 순수 함수 `regressionBarColor(slope, r2)`: 부호로 teal(`regressionUp`)/red(`regressionDown`) 선택, alpha = clamp(r2 ?? FALLBACK, 0, 1). teal/red의 RGB는 util 상수로(`#26a69a`=38,166,154 / `#ef5350`=239,83,80), `rgba(r,g,b,alpha)` 반환. r2 null → 낮은 기본 alpha(예 0.25)로 "신뢰도 미확정".
+
+## 5. 색상 (`shared/lib/chartColors.ts` + `globals.css` @theme)
+
+DESIGN.md 추세 고정값(teal `#26a69a` / red `#ef5350`) 기반, 강/약은 alpha 변형. 상태 점은 추세 무관 상태 팔레트.
+```ts
+// Elder Ray
+elderBullPower: '#26a69a',
+elderBearPower: '#ef5350',
+// Squeeze Momentum 히스토그램 (강=solid, 약=50% alpha)
+squeezeMomentumUp: '#26a69a',
+squeezeMomentumUpWeak: '#26a69a80',
+squeezeMomentumDown: '#ef5350',
+squeezeMomentumDownWeak: '#ef535080',
+// Squeeze 상태 점 (상태 팔레트 — 추세 무관)
+squeezeOn: '#fbbf24',   // 압축 형성(에너지 축적)
+squeezeOff: '#94a3b8',  // 해제(발화)
+squeezeNone: '#3b82f6', // 스퀴즈 없음
+// Regression (alpha는 r2로 런타임 계산)
+regressionUp: '#26a69a',
+regressionDown: '#ef5350',
+```
+globals.css @theme: solid 항목을 `--color-chart-*` 토큰으로 미러(group-A 선례). alpha 변형(`#...80`)·런타임 alpha는 JS 전용이라 미러 불필요.
+
+## 6. 레지스트리 / pane 라벨 / StockChart
+
+### 6.1 레지스트리 (`model/indicatorRegistry.ts`)
+- `IndicatorKey` +3 (`elderRay`, `squeezeMomentum`, `regression`).
+- `INDICATOR_REGISTRY` +3: elderRay `{ category:'momentum', kind:'pane' }`, squeezeMomentum `{ category:'momentum', kind:'pane' }`, regression `{ category:'statistical', kind:'pane' }`. 라벨 `Elder Ray` / `Squeeze` / `Regression`.
+- 29→32. makePaneIndices(paneLabelUtils.test) fallout +3(기본 INACTIVE). StockChart.test binding 29→32 + data-keys.
+
+### 6.2 pane 라벨 (`utils/paneLabelUtils.ts`)
+- elderRay: 2 sub-label(`Bull Power`=elderBullPower, `Bear Power`=elderBearPower) — MACD식 인라인.
+- squeezeMomentum: 1 sub-label(`Squeeze`=squeezeMomentumUp) — `buildSinglePaneLabel`.
+- regression: 1 sub-label(`Regression`=regressionUp) — `buildSinglePaneLabel`.
+- `buildPaneLabels` 반환 배열에 3개 추가.
+
+### 6.3 StockChart (`StockChart.tsx`)
+- `useElderRayChart`/`useSqueezeMomentumChart`/`useRegressionChart` 호출, 각 `paneIndex: paneIndices.<key>`.
+- `indicatorBindings` +3 (29→32): `INDICATOR_META.<key>` + active(`visible.<key>`) + `onToggle: () => toggle('<key>')` (pane 지표는 useIndicatorVisibility의 visible/toggle 사용, group-A overlay와 달리).
+
+## 7. 데이터 흐름
+```
+indicatorRegistry (3종 = kind:'pane')
+        │
+useIndicatorVisibility → visible{...}, paneIndices{elderRay, squeezeMomentum, regression}
+        │
+StockChart: use<X>Chart({ paneIndex: paneIndices.<x> })
+        │
+binding(32개) → IndicatorSettingsModal 자동 노출(무수정)
+        │
+체크 → toggle → 해당 paneIndex에:
+  - ElderRay: bull/bear 2 HistogramSeries(0라인 기준 색)
+  - Squeeze: 모멘텀 4색 Histogram + 0라인 상태 점(3색)
+  - Regression: slope Histogram(부호 색 + r2 투명도)
+buildSeriesData(row 인지 colorFn) / buildZeroLineDots로 데이터 생성
+```
+
+## 8. 테스트 전략 (vitest + RTL, 90%+, happy + worst)
+
+### 8.1 단위 — 유틸/순수 함수
+- **`buildSeriesData` colorFn row 인자**: colorFn이 (value, row, index)를 받는지, 기존 (value)=>... 하위호환 유지, null→whitespace.
+- **`buildZeroLineDots`**: value=0 점·색, colorFn null 반환 시 whitespace, null 행 whitespace, 길이 불일치.
+- **`squeezeMomentumColor`**: 4분기(양수/음수 × increasing T/F) 정확 + 0 경계.
+- **`squeezeStateColor`**: noSqz/sqzOn/sqzOff 우선순위, 전부 false/null→null.
+- **`regressionBarColor`**: 부호별 hue, alpha=r2 클램프, r2 null→기본 alpha, rgba 포맷.
+
+### 8.2 단위 — 훅 (use<X>Chart)
+- 각 훅: isVisible 토글, chart null 미생성, true→시리즈 생성(elderRay 2·squeeze 2·regression 1 addSeries), false→removeSeries, paneIndex 변경 시 재생성, setData(색 분기 인자 포함), 빈 배열→미호출, bars 변경 재싱크. (group-A에서 확립한 항목 망라)
+
+### 8.3 레지스트리/라벨
+- 레지스트리 32, 3종 category·kind·중복 없음.
+- paneLabelUtils: 각 지표 활성 시 sub-label·색 정확(elderRay 2개).
+
+### 8.4 E2E
+- `chart-indicators.spec.ts` 확장: 모달에서 'Elder Ray'·'Squeeze'·'Regression' 각각 체크 → pane 지표이므로 `.pane-indicator-label` 노출 검증(MFI/ATR 패턴, exact 매처).
+
+## 9. FSD 준수
+- 훅·레지스트리·색·라벨·빌더·순수함수: `widgets/chart` 내부 + `shared/lib/chartColors`. core import(ElderRayResult/SqueezeMomentumResult/RegressionResult/IndicatorResult). 레이어 정상. core 무변경.
+
+## 10. 후속 (별도 스펙)
+- C 전체 완료. 다음: 그룹 D(elderImpulse 캔들 색, smc zone primitive), 전송 페이로드 슬림화.

--- a/e2e/specs/chart-indicators.spec.ts
+++ b/e2e/specs/chart-indicators.spec.ts
@@ -103,7 +103,6 @@ test.describe('chart indicator settings modal', () => {
             .getByRole('checkbox', { name: 'Elder Ray', exact: true })
             .check();
         await page.getByRole('button', { name: '닫기' }).click();
-        // Elder Ray pane의 첫 sub-label은 'Bull Power'. .pane-indicator-label로 스코프.
         await expect(
             page
                 .locator('.pane-indicator-label')

--- a/e2e/specs/chart-indicators.spec.ts
+++ b/e2e/specs/chart-indicators.spec.ts
@@ -95,6 +95,50 @@ test.describe('chart indicator settings modal', () => {
         ).toBeVisible();
     });
 
+    test('toggles Elder Ray into a pane via the modal', async ({ page }) => {
+        await page.goto('/AAPL');
+        await page.getByRole('button', { name: GEAR }).click();
+        const dialog = page.getByRole('dialog');
+        await dialog
+            .getByRole('checkbox', { name: 'Elder Ray', exact: true })
+            .check();
+        await page.getByRole('button', { name: '닫기' }).click();
+        // Elder Ray pane의 첫 sub-label은 'Bull Power'. .pane-indicator-label로 스코프.
+        await expect(
+            page
+                .locator('.pane-indicator-label')
+                .filter({ hasText: 'Bull Power' })
+        ).toBeVisible();
+    });
+
+    test('toggles Squeeze into a pane via the modal', async ({ page }) => {
+        await page.goto('/AAPL');
+        await page.getByRole('button', { name: GEAR }).click();
+        const dialog = page.getByRole('dialog');
+        await dialog
+            .getByRole('checkbox', { name: 'Squeeze', exact: true })
+            .check();
+        await page.getByRole('button', { name: '닫기' }).click();
+        await expect(
+            page.locator('.pane-indicator-label').filter({ hasText: 'Squeeze' })
+        ).toBeVisible();
+    });
+
+    test('toggles Regression into a pane via the modal', async ({ page }) => {
+        await page.goto('/AAPL');
+        await page.getByRole('button', { name: GEAR }).click();
+        const dialog = page.getByRole('dialog');
+        await dialog
+            .getByRole('checkbox', { name: 'Regression', exact: true })
+            .check();
+        await page.getByRole('button', { name: '닫기' }).click();
+        await expect(
+            page
+                .locator('.pane-indicator-label')
+                .filter({ hasText: 'Regression' })
+        ).toBeVisible();
+    });
+
     test('toggles the Keltner channel overlay via the modal', async ({
         page,
     }) => {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -60,6 +60,18 @@
     /* Chart — Chandelier Exit (추세 색 점선 stop) */
     --color-chart-chandelier-long: #26a69a;
     --color-chart-chandelier-short: #ef5350;
+    /* Chart — Elder Ray */
+    --color-chart-elder-bull-power: #26a69a;
+    --color-chart-elder-bear-power: #ef5350;
+    /* Chart — Squeeze Momentum / 상태 점 */
+    --color-chart-squeeze-momentum-up: #26a69a;
+    --color-chart-squeeze-momentum-down: #ef5350;
+    --color-chart-squeeze-on: #fbbf24;
+    --color-chart-squeeze-off: #94a3b8;
+    --color-chart-squeeze-none: #3b82f6;
+    /* Chart — Regression */
+    --color-chart-regression-up: #26a69a;
+    --color-chart-regression-down: #ef5350;
 
     /* Chart — MACD */
     --color-chart-macd: #3b82f6;

--- a/src/shared/lib/chartColors.ts
+++ b/src/shared/lib/chartColors.ts
@@ -144,6 +144,21 @@ export const CHART_COLORS = {
     // Chandelier Exit (trend 색 점선 stop) — DESIGN.md 추세 고정값 재사용
     chandelierLong: '#26a69a',
     chandelierShort: '#ef5350',
+    // Elder Ray (bull/bear power 히스토그램)
+    elderBullPower: '#26a69a',
+    elderBearPower: '#ef5350',
+    // Squeeze Momentum 히스토그램 (강=solid, 약=50% alpha) — DESIGN.md teal/red 기반
+    squeezeMomentumUp: '#26a69a',
+    squeezeMomentumUpWeak: '#26a69a80',
+    squeezeMomentumDown: '#ef5350',
+    squeezeMomentumDownWeak: '#ef535080',
+    // Squeeze 상태 점 (추세 무관 상태 팔레트)
+    squeezeOn: '#fbbf24',
+    squeezeOff: '#94a3b8',
+    squeezeNone: '#3b82f6',
+    // Regression (alpha는 r2로 런타임 계산)
+    regressionUp: '#26a69a',
+    regressionDown: '#ef5350',
 } as const;
 
 const PERIOD_COLOR_MAP: Record<number, string> = {

--- a/src/widgets/chart/StockChart.tsx
+++ b/src/widgets/chart/StockChart.tsx
@@ -45,6 +45,9 @@ import { useObvChart } from './hooks/useObvChart';
 import { useAtrChart } from './hooks/useAtrChart';
 import { useYangZhangChart } from './hooks/useYangZhangChart';
 import { useEwmaVolatilityChart } from './hooks/useEwmaVolatilityChart';
+import { useElderRayChart } from './hooks/useElderRayChart';
+import { useSqueezeMomentumChart } from './hooks/useSqueezeMomentumChart';
+import { useRegressionChart } from './hooks/useRegressionChart';
 import { useVolumeProfileOverlay } from './hooks/useVolumeProfileOverlay';
 import { useIchimokuOverlay } from './hooks/useIchimokuOverlay';
 import { useCandlePatternMarkers } from './hooks/useCandlePatternMarkers';
@@ -334,6 +337,24 @@ export function StockChart({
         paneIndex: paneIndices.ewmaVolatility,
     });
 
+    useElderRayChart({
+        ...commonHookParams,
+        isVisible: visible.elderRay,
+        paneIndex: paneIndices.elderRay,
+    });
+
+    useSqueezeMomentumChart({
+        ...commonHookParams,
+        isVisible: visible.squeezeMomentum,
+        paneIndex: paneIndices.squeezeMomentum,
+    });
+
+    useRegressionChart({
+        ...commonHookParams,
+        isVisible: visible.regression,
+        paneIndex: paneIndices.regression,
+    });
+
     useCandlePatternMarkers({ seriesRef, bars });
 
     useActionRecommendationOverlay({
@@ -573,6 +594,21 @@ export function StockChart({
                 meta: INDICATOR_META.chandelierExit,
                 active: chandelierVisible,
                 onToggle: toggleChandelier,
+            },
+            {
+                meta: INDICATOR_META.elderRay,
+                active: visible.elderRay,
+                onToggle: () => toggle('elderRay'),
+            },
+            {
+                meta: INDICATOR_META.squeezeMomentum,
+                active: visible.squeezeMomentum,
+                onToggle: () => toggle('squeezeMomentum'),
+            },
+            {
+                meta: INDICATOR_META.regression,
+                active: visible.regression,
+                onToggle: () => toggle('regression'),
             },
         ],
         // deps에 visible 객체 전체를 둔다 — 한 지표 토글 시 전체 binding이 재조립되지만

--- a/src/widgets/chart/__tests__/StockChart.test.tsx
+++ b/src/widgets/chart/__tests__/StockChart.test.tsx
@@ -29,6 +29,9 @@ const INACTIVE_PANES = Object.fromEntries(
         'atr',
         'yangZhang',
         'ewmaVolatility',
+        'elderRay',
+        'squeezeMomentum',
+        'regression',
     ].map(k => [k, INACTIVE_PANE_INDEX])
 );
 
@@ -199,6 +202,18 @@ vi.mock('@/widgets/chart/hooks/useEwmaVolatilityChart', () => ({
     useEwmaVolatilityChart: vi.fn(),
 }));
 
+vi.mock('@/widgets/chart/hooks/useElderRayChart', () => ({
+    useElderRayChart: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useSqueezeMomentumChart', () => ({
+    useSqueezeMomentumChart: vi.fn(),
+}));
+
+vi.mock('@/widgets/chart/hooks/useRegressionChart', () => ({
+    useRegressionChart: vi.fn(),
+}));
+
 vi.mock('@/widgets/chart/hooks/useVolumeProfileOverlay', () => ({
     useVolumeProfileOverlay: () => ({
         isVisible: false,
@@ -270,6 +285,9 @@ vi.mock('@/widgets/chart/hooks/useIndicatorVisibility', () => ({
             atr: false,
             yangZhang: false,
             ewmaVolatility: false,
+            elderRay: false,
+            squeezeMomentum: false,
+            regression: false,
         },
         toggle: vi.fn(),
         paneIndices: INACTIVE_PANES,
@@ -408,13 +426,13 @@ describe('StockChart', () => {
         );
     });
 
-    it('renders IndicatorSettingsModal with 29 indicator bindings', () => {
+    it('renders IndicatorSettingsModal with 32 indicator bindings', () => {
         render(<StockChart bars={mockBars} timeframe="1Day" />);
         const modal = screen.getByTestId('indicator-settings-modal');
-        expect(modal).toHaveAttribute('data-count', '29');
+        expect(modal).toHaveAttribute('data-count', '32');
         expect(modal).toHaveAttribute(
             'data-keys',
-            'ma,ema,ichimoku,rsi,macd,dmi,stochastic,stochRsi,cci,bollinger,volumeProfile,mfi,williamsR,connorsRsi,cmf,bollingerPercentB,hurst,varianceRatio,macdV,forceIndex,obv,atr,yangZhang,ewmaVolatility,keltnerChannel,donchianChannel,supertrend,parabolicSar,chandelierExit'
+            'ma,ema,ichimoku,rsi,macd,dmi,stochastic,stochRsi,cci,bollinger,volumeProfile,mfi,williamsR,connorsRsi,cmf,bollingerPercentB,hurst,varianceRatio,macdV,forceIndex,obv,atr,yangZhang,ewmaVolatility,keltnerChannel,donchianChannel,supertrend,parabolicSar,chandelierExit,elderRay,squeezeMomentum,regression'
         );
     });
 

--- a/src/widgets/chart/__tests__/hooks/useElderRayChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useElderRayChart.test.ts
@@ -117,7 +117,6 @@ describe('useElderRayChart', () => {
         const calls = vi.mocked(buildSeriesData).mock.calls;
         const bullColorFn = calls.find(c => c[2] === 'bullPower')?.[3];
         const bearColorFn = calls.find(c => c[2] === 'bearPower')?.[3];
-        // buildSeriesData colorFn signature: (value, row, index). row/index은 색 결정과 무관.
         expect(bullColorFn?.(2, {} as never, 0)).toBe(
             CHART_COLORS.elderBullPower
         );

--- a/src/widgets/chart/__tests__/hooks/useElderRayChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useElderRayChart.test.ts
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
 import { renderHook } from '@testing-library/react';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
 import { useElderRayChart } from '../../hooks/useElderRayChart';
+import { buildSeriesData } from '../../utils/seriesDataUtils';
 
 const mockSetData = vi.fn();
 const mockApplyOptions = vi.fn();
@@ -100,6 +102,30 @@ describe('useElderRayChart', () => {
             })
         );
         expect(mockSetData).toHaveBeenCalledTimes(2);
+    });
+
+    it('wires bull/bear colorFns that color the dominant side and neutralize the other', () => {
+        renderHook(() =>
+            useElderRayChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        const calls = vi.mocked(buildSeriesData).mock.calls;
+        const bullColorFn = calls.find(c => c[2] === 'bullPower')?.[3];
+        const bearColorFn = calls.find(c => c[2] === 'bearPower')?.[3];
+        // buildSeriesData colorFn signature: (value, row, index). row/index은 색 결정과 무관.
+        expect(bullColorFn?.(2, {} as never, 0)).toBe(
+            CHART_COLORS.elderBullPower
+        );
+        expect(bullColorFn?.(-2, {} as never, 0)).toBe(CHART_COLORS.neutral);
+        expect(bearColorFn?.(-2, {} as never, 0)).toBe(
+            CHART_COLORS.elderBearPower
+        );
+        expect(bearColorFn?.(2, {} as never, 0)).toBe(CHART_COLORS.neutral);
     });
 
     it('does not set data when elderRay is empty', () => {

--- a/src/widgets/chart/__tests__/hooks/useElderRayChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useElderRayChart.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useElderRayChart } from '../../hooks/useElderRayChart';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    HistogramSeries: 'HistogramSeries',
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useElderRayChart
+    >[0]['chartRef'];
+}
+
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { elderRay: [] } as unknown as IndicatorResult;
+const FILLED_INDICATORS = {
+    elderRay: [{ bullPower: 2, bearPower: -1 }],
+} as unknown as IndicatorResult;
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 1, high: 2, low: 0, close: 1, volume: 10 },
+];
+
+describe('useElderRayChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useElderRayChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates two histogram series when visible', () => {
+        renderHook(() =>
+            useElderRayChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes both series when not visible', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(props => useElderRayChart(props), {
+            initialProps: {
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            },
+        });
+        rerender({
+            chartRef: makeChartRef(chart),
+            bars: FAKE_BARS,
+            indicators: FILLED_INDICATORS,
+            isVisible: false,
+            paneIndex: 1,
+        });
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('sets data on both series when visible with data', () => {
+        renderHook(() =>
+            useElderRayChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockSetData).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not set data when elderRay is empty', () => {
+        renderHook(() =>
+            useElderRayChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('recreates series when paneIndex changes', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(props => useElderRayChart(props), {
+            initialProps: {
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            },
+        });
+        rerender({
+            chartRef: makeChartRef(chart),
+            bars: FAKE_BARS,
+            indicators: FILLED_INDICATORS,
+            isVisible: true,
+            paneIndex: 2,
+        });
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useRegressionChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useRegressionChart.test.ts
@@ -2,6 +2,8 @@
 import { renderHook } from '@testing-library/react';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
 import { useRegressionChart } from '../../hooks/useRegressionChart';
+import { buildSeriesData } from '../../utils/seriesDataUtils';
+import { regressionBarColor } from '../../utils/histogramColorUtils';
 
 const mockSetData = vi.fn();
 const mockApplyOptions = vi.fn();
@@ -99,6 +101,27 @@ describe('useRegressionChart', () => {
             })
         );
         expect(mockSetData).toHaveBeenCalledTimes(1);
+    });
+
+    it('wires the slope colorFn to regressionBarColor(value, row.r2)', () => {
+        renderHook(() =>
+            useRegressionChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        const colorFn = vi
+            .mocked(buildSeriesData)
+            .mock.calls.find(c => c[2] === 'slope')?.[3];
+        expect(colorFn?.(0.4, { r2: 0.8 } as never, 0)).toBe(
+            regressionBarColor(0.4, 0.8)
+        );
+        expect(colorFn?.(-0.4, { r2: null } as never, 0)).toBe(
+            regressionBarColor(-0.4, null)
+        );
     });
 
     it('does not set data when regression is empty', () => {

--- a/src/widgets/chart/__tests__/hooks/useRegressionChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useRegressionChart.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useRegressionChart } from '../../hooks/useRegressionChart';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    HistogramSeries: 'HistogramSeries',
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesData: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useRegressionChart
+    >[0]['chartRef'];
+}
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { regression: [] } as unknown as IndicatorResult;
+const FILLED_INDICATORS = {
+    regression: [{ slope: 0.4, r2: 0.8 }],
+} as unknown as IndicatorResult;
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 1, high: 2, low: 0, close: 1, volume: 10 },
+];
+
+describe('useRegressionChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useRegressionChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates one histogram series when visible', () => {
+        renderHook(() =>
+            useRegressionChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockAddSeries).toHaveBeenCalledTimes(1);
+    });
+
+    it('removes the series when not visible', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(p => useRegressionChart(p), {
+            initialProps: {
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            },
+        });
+        rerender({
+            chartRef: makeChartRef(chart),
+            bars: FAKE_BARS,
+            indicators: FILLED_INDICATORS,
+            isVisible: false,
+            paneIndex: 1,
+        });
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets data when visible with data', () => {
+        renderHook(() =>
+            useRegressionChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockSetData).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not set data when regression is empty', () => {
+        renderHook(() =>
+            useRegressionChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('recreates the series when paneIndex changes', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(p => useRegressionChart(p), {
+            initialProps: {
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            },
+        });
+        rerender({
+            chartRef: makeChartRef(chart),
+            bars: FAKE_BARS,
+            indicators: FILLED_INDICATORS,
+            isVisible: true,
+            paneIndex: 2,
+        });
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useSqueezeMomentumChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useSqueezeMomentumChart.test.ts
@@ -127,7 +127,6 @@ describe('useSqueezeMomentumChart', () => {
                 paneIndex: 1,
             })
         );
-        // 모멘텀 colorFn은 row.increasing을 squeezeMomentumColor로 forward해야 한다.
         const momentumColorFn = vi
             .mocked(buildSeriesData)
             .mock.calls.find(c => c[2] === 'momentum')?.[3];

--- a/src/widgets/chart/__tests__/hooks/useSqueezeMomentumChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useSqueezeMomentumChart.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { useSqueezeMomentumChart } from '../../hooks/useSqueezeMomentumChart';
+
+const mockSetData = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockRemoveSeries = vi.fn();
+const mockAddSeries = vi.fn(() => ({
+    setData: mockSetData,
+    applyOptions: mockApplyOptions,
+}));
+
+vi.mock('lightweight-charts', () => ({
+    HistogramSeries: 'HistogramSeries',
+    LineSeries: 'LineSeries',
+}));
+
+vi.mock('../../utils/seriesDataUtils', () => ({
+    buildSeriesData: vi.fn(() => []),
+    buildZeroLineDots: vi.fn(() => []),
+}));
+
+function makeChartRef(chart: unknown = null) {
+    return { current: chart } as Parameters<
+        typeof useSqueezeMomentumChart
+    >[0]['chartRef'];
+}
+function makeChart() {
+    return { addSeries: mockAddSeries, removeSeries: mockRemoveSeries };
+}
+
+const EMPTY_INDICATORS = { squeezeMomentum: [] } as unknown as IndicatorResult;
+const FILLED_INDICATORS = {
+    squeezeMomentum: [
+        {
+            momentum: 3,
+            sqzOn: true,
+            sqzOff: false,
+            noSqz: false,
+            increasing: true,
+        },
+    ],
+} as unknown as IndicatorResult;
+const FAKE_BARS: Bar[] = [
+    { time: 1000, open: 1, high: 2, low: 0, close: 1, volume: 10 },
+];
+
+describe('useSqueezeMomentumChart', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('does not create series when chart is null', () => {
+        renderHook(() =>
+            useSqueezeMomentumChart({
+                chartRef: makeChartRef(null),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockAddSeries).not.toHaveBeenCalled();
+    });
+
+    it('creates histogram + state-dots series when visible', () => {
+        renderHook(() =>
+            useSqueezeMomentumChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockAddSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes both series when not visible', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(p => useSqueezeMomentumChart(p), {
+            initialProps: {
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            },
+        });
+        rerender({
+            chartRef: makeChartRef(chart),
+            bars: FAKE_BARS,
+            indicators: FILLED_INDICATORS,
+            isVisible: false,
+            paneIndex: 1,
+        });
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(2);
+    });
+
+    it('sets data on both series when visible with data', () => {
+        renderHook(() =>
+            useSqueezeMomentumChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockSetData).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not set data when squeezeMomentum is empty', () => {
+        renderHook(() =>
+            useSqueezeMomentumChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: EMPTY_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('recreates series when paneIndex changes', () => {
+        const chart = makeChart();
+        const { rerender } = renderHook(p => useSqueezeMomentumChart(p), {
+            initialProps: {
+                chartRef: makeChartRef(chart),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            },
+        });
+        rerender({
+            chartRef: makeChartRef(chart),
+            bars: FAKE_BARS,
+            indicators: FILLED_INDICATORS,
+            isVisible: true,
+            paneIndex: 2,
+        });
+        expect(mockRemoveSeries).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/widgets/chart/__tests__/hooks/useSqueezeMomentumChart.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useSqueezeMomentumChart.test.ts
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 import { renderHook } from '@testing-library/react';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
 import { useSqueezeMomentumChart } from '../../hooks/useSqueezeMomentumChart';
+import {
+    buildSeriesData,
+    buildZeroLineDots,
+} from '../../utils/seriesDataUtils';
+import { squeezeStateColor } from '../../utils/histogramColorUtils';
 
 const mockSetData = vi.fn();
 const mockApplyOptions = vi.fn();
@@ -109,6 +115,32 @@ describe('useSqueezeMomentumChart', () => {
             })
         );
         expect(mockSetData).toHaveBeenCalledTimes(2);
+    });
+
+    it('wires momentum colorFn to row.increasing and passes squeezeStateColor for dots', () => {
+        renderHook(() =>
+            useSqueezeMomentumChart({
+                chartRef: makeChartRef(makeChart()),
+                bars: FAKE_BARS,
+                indicators: FILLED_INDICATORS,
+                isVisible: true,
+                paneIndex: 1,
+            })
+        );
+        // 모멘텀 colorFn은 row.increasing을 squeezeMomentumColor로 forward해야 한다.
+        const momentumColorFn = vi
+            .mocked(buildSeriesData)
+            .mock.calls.find(c => c[2] === 'momentum')?.[3];
+        expect(momentumColorFn?.(3, { increasing: true } as never, 0)).toBe(
+            CHART_COLORS.squeezeMomentumUp
+        );
+        expect(momentumColorFn?.(3, { increasing: false } as never, 0)).toBe(
+            CHART_COLORS.squeezeMomentumUpWeak
+        );
+        // 상태 점은 squeezeStateColor 함수 자체를 buildZeroLineDots에 넘긴다.
+        expect(vi.mocked(buildZeroLineDots).mock.calls[0][2]).toBe(
+            squeezeStateColor
+        );
     });
 
     it('does not set data when squeezeMomentum is empty', () => {

--- a/src/widgets/chart/__tests__/model/indicatorRegistry.test.ts
+++ b/src/widgets/chart/__tests__/model/indicatorRegistry.test.ts
@@ -14,8 +14,29 @@ function bindingFor(key: IndicatorKey, active = false): IndicatorBinding {
 }
 
 describe('indicatorRegistry', () => {
-    it('registers exactly the 29 modal-target indicators', () => {
-        expect(INDICATOR_REGISTRY).toHaveLength(29);
+    it('registers exactly the 32 modal-target indicators', () => {
+        expect(INDICATOR_REGISTRY).toHaveLength(32);
+    });
+
+    it('registers elderRay as a momentum pane', () => {
+        const meta = INDICATOR_REGISTRY.find(m => m.key === 'elderRay');
+        expect(meta).toBeDefined();
+        expect(meta?.category).toBe('momentum');
+        expect(meta?.kind).toBe('pane');
+    });
+
+    it('registers squeezeMomentum as a momentum pane', () => {
+        const meta = INDICATOR_REGISTRY.find(m => m.key === 'squeezeMomentum');
+        expect(meta).toBeDefined();
+        expect(meta?.category).toBe('momentum');
+        expect(meta?.kind).toBe('pane');
+    });
+
+    it('registers regression as a statistical pane', () => {
+        const meta = INDICATOR_REGISTRY.find(m => m.key === 'regression');
+        expect(meta).toBeDefined();
+        expect(meta?.category).toBe('statistical');
+        expect(meta?.kind).toBe('pane');
     });
 
     it('registers parabolicSar as a trend overlay', () => {

--- a/src/widgets/chart/__tests__/utils/histogramColorUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/histogramColorUtils.test.ts
@@ -89,11 +89,17 @@ describe('regressionBarColor', () => {
     it('negative slope → red rgba with r2 alpha', () => {
         expect(regressionBarColor(-2, 0.5)).toBe('rgba(239, 83, 80, 0.5)');
     });
+    it('zero slope counts as non-negative → teal', () => {
+        expect(regressionBarColor(0, 0.5)).toBe('rgba(38, 166, 154, 0.5)');
+    });
     it('clamps r2 into [0,1]', () => {
         expect(regressionBarColor(1, 1.7)).toBe('rgba(38, 166, 154, 1)');
         expect(regressionBarColor(1, -0.4)).toBe('rgba(38, 166, 154, 0)');
     });
-    it('null r2 → fallback alpha 0.25', () => {
+    it('null or undefined r2 → fallback alpha 0.25 (no NaN)', () => {
         expect(regressionBarColor(1, null)).toBe('rgba(38, 166, 154, 0.25)');
+        expect(regressionBarColor(1, undefined)).toBe(
+            'rgba(38, 166, 154, 0.25)'
+        );
     });
 });

--- a/src/widgets/chart/__tests__/utils/histogramColorUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/histogramColorUtils.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import {
+    regressionBarColor,
+    squeezeMomentumColor,
+    squeezeStateColor,
+} from '@/widgets/chart/utils/histogramColorUtils';
+
+describe('squeezeMomentumColor', () => {
+    it('positive + increasing → strong up', () => {
+        expect(squeezeMomentumColor(5, true)).toBe(
+            CHART_COLORS.squeezeMomentumUp
+        );
+    });
+    it('positive + not increasing → weak up', () => {
+        expect(squeezeMomentumColor(5, false)).toBe(
+            CHART_COLORS.squeezeMomentumUpWeak
+        );
+    });
+    it('negative + increasing → weak down (recovering)', () => {
+        expect(squeezeMomentumColor(-5, true)).toBe(
+            CHART_COLORS.squeezeMomentumDownWeak
+        );
+    });
+    it('negative + not increasing → strong down', () => {
+        expect(squeezeMomentumColor(-5, false)).toBe(
+            CHART_COLORS.squeezeMomentumDown
+        );
+    });
+    it('zero counts as non-positive', () => {
+        expect(squeezeMomentumColor(0, true)).toBe(
+            CHART_COLORS.squeezeMomentumDownWeak
+        );
+        expect(squeezeMomentumColor(0, false)).toBe(
+            CHART_COLORS.squeezeMomentumDown
+        );
+    });
+    it('null increasing treated as not increasing', () => {
+        expect(squeezeMomentumColor(5, null)).toBe(
+            CHART_COLORS.squeezeMomentumUpWeak
+        );
+    });
+});
+
+describe('squeezeStateColor', () => {
+    it('noSqz → squeezeNone (highest priority)', () => {
+        expect(
+            squeezeStateColor({ noSqz: true, sqzOn: true, sqzOff: false })
+        ).toBe(CHART_COLORS.squeezeNone);
+    });
+    it('sqzOn → squeezeOn', () => {
+        expect(
+            squeezeStateColor({ noSqz: false, sqzOn: true, sqzOff: false })
+        ).toBe(CHART_COLORS.squeezeOn);
+    });
+    it('sqzOff → squeezeOff', () => {
+        expect(
+            squeezeStateColor({ noSqz: false, sqzOn: false, sqzOff: true })
+        ).toBe(CHART_COLORS.squeezeOff);
+    });
+    it('all false/null → null (no dot)', () => {
+        expect(
+            squeezeStateColor({ noSqz: false, sqzOn: false, sqzOff: false })
+        ).toBeNull();
+        expect(
+            squeezeStateColor({ noSqz: null, sqzOn: null, sqzOff: null })
+        ).toBeNull();
+    });
+});
+
+describe('regressionBarColor', () => {
+    it('positive slope → teal rgba with r2 alpha', () => {
+        expect(regressionBarColor(2, 0.8)).toBe('rgba(38, 166, 154, 0.8)');
+    });
+    it('negative slope → red rgba with r2 alpha', () => {
+        expect(regressionBarColor(-2, 0.5)).toBe('rgba(239, 83, 80, 0.5)');
+    });
+    it('clamps r2 into [0,1]', () => {
+        expect(regressionBarColor(1, 1.7)).toBe('rgba(38, 166, 154, 1)');
+        expect(regressionBarColor(1, -0.4)).toBe('rgba(38, 166, 154, 0)');
+    });
+    it('null r2 → fallback alpha 0.25', () => {
+        expect(regressionBarColor(1, null)).toBe('rgba(38, 166, 154, 0.25)');
+    });
+});

--- a/src/widgets/chart/__tests__/utils/histogramColorUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/histogramColorUtils.test.ts
@@ -1,10 +1,24 @@
 import { describe, expect, it } from 'vitest';
 import { CHART_COLORS } from '@/shared/lib/chartColors';
 import {
+    elderRayBarColor,
     regressionBarColor,
     squeezeMomentumColor,
     squeezeStateColor,
 } from '@/widgets/chart/utils/histogramColorUtils';
+
+describe('elderRayBarColor', () => {
+    it('bull side: positive (incl. 0) → bull color, negative → neutral', () => {
+        expect(elderRayBarColor(2, 'bull')).toBe(CHART_COLORS.elderBullPower);
+        expect(elderRayBarColor(0, 'bull')).toBe(CHART_COLORS.elderBullPower);
+        expect(elderRayBarColor(-2, 'bull')).toBe(CHART_COLORS.neutral);
+    });
+    it('bear side: negative (incl. 0) → bear color, positive → neutral', () => {
+        expect(elderRayBarColor(-2, 'bear')).toBe(CHART_COLORS.elderBearPower);
+        expect(elderRayBarColor(0, 'bear')).toBe(CHART_COLORS.elderBearPower);
+        expect(elderRayBarColor(2, 'bear')).toBe(CHART_COLORS.neutral);
+    });
+});
 
 describe('squeezeMomentumColor', () => {
     it('positive + increasing → strong up', () => {

--- a/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
@@ -392,6 +392,33 @@ describe('buildPaneLabels', () => {
         });
     });
 
+    describe('group-C-complex pane가 활성일 때', () => {
+        it('builds Elder Ray sub-labels (Bull Power, Bear Power) when active', () => {
+            const labels = buildPaneLabels(makePaneIndices({ elderRay: 2 }));
+            const elder = labels.find(l => l.paneIndex === 2);
+            expect(elder?.subLabels.map(s => s.name)).toEqual([
+                'Bull Power',
+                'Bear Power',
+            ]);
+        });
+
+        it('builds a Squeeze pane label when active', () => {
+            const labels = buildPaneLabels(
+                makePaneIndices({ squeezeMomentum: 3 })
+            );
+            expect(labels.find(l => l.paneIndex === 3)?.subLabels[0].name).toBe(
+                'Squeeze'
+            );
+        });
+
+        it('builds a Regression pane label when active', () => {
+            const labels = buildPaneLabels(makePaneIndices({ regression: 4 }));
+            expect(labels.find(l => l.paneIndex === 4)?.subLabels[0].name).toBe(
+                'Regression'
+            );
+        });
+    });
+
     describe('CCI만 활성일 때', () => {
         const CCI_PANE_INDEX = 1;
         const paneIndices = makePaneIndices({ cci: CCI_PANE_INDEX });

--- a/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
@@ -52,6 +52,9 @@ function makePaneIndices(overrides: Partial<PaneIndices> = {}): PaneIndices {
         supertrend: INACTIVE_PANE_INDEX,
         parabolicSar: INACTIVE_PANE_INDEX,
         chandelierExit: INACTIVE_PANE_INDEX,
+        elderRay: INACTIVE_PANE_INDEX,
+        squeezeMomentum: INACTIVE_PANE_INDEX,
+        regression: INACTIVE_PANE_INDEX,
     } satisfies PaneIndices;
     return { ...base, ...overrides };
 }

--- a/src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/seriesDataUtils.test.ts
@@ -4,6 +4,7 @@ import {
     buildSeriesData,
     buildSeriesDataFromValues,
     buildTrendSplitData,
+    buildZeroLineDots,
 } from '@/widgets/chart/utils/seriesDataUtils';
 
 const mockBars: Bar[] = [
@@ -203,5 +204,65 @@ describe('buildTrendSplitData', () => {
         expect(
             buildTrendSplitData(longBars, ch, 'short', r => r.shortStop)
         ).toEqual([{ time: 1 }, { time: 2, value: 111 }]);
+    });
+});
+
+describe('buildSeriesData colorFn row arg', () => {
+    const bars: Bar[] = [bar(1), bar(2)];
+    const data = [
+        { v: 5, flag: true },
+        { v: -3, flag: false },
+    ];
+
+    it('passes (value, row, index) to colorFn', () => {
+        const seen: Array<[number, unknown, number]> = [];
+        buildSeriesData(bars, data, 'v', (value, row, index) => {
+            seen.push([value, row, index]);
+            return '#fff';
+        });
+        expect(seen[0]).toEqual([5, { v: 5, flag: true }, 0]);
+        expect(seen[1]).toEqual([-3, { v: -3, flag: false }, 1]);
+    });
+
+    it('still supports a value-only colorFn (backward compatible)', () => {
+        const out = buildSeriesData(bars, data, 'v', value =>
+            value >= 0 ? '#0f0' : '#f00'
+        );
+        expect(out).toEqual([
+            { time: 1, value: 5, color: '#0f0' },
+            { time: 2, value: -3, color: '#f00' },
+        ]);
+    });
+});
+
+describe('buildZeroLineDots', () => {
+    const bars: Bar[] = [bar(1), bar(2), bar(3)];
+
+    it('emits a zero-value point with the colorFn color per row', () => {
+        const data = [{ s: 'a' }, { s: 'b' }, { s: 'c' }];
+        const out = buildZeroLineDots(bars, data, row =>
+            row.s === 'b' ? '#abc' : null
+        );
+        expect(out).toEqual([
+            { time: 1 },
+            { time: 2, value: 0, color: '#abc' },
+            { time: 3 },
+        ]);
+    });
+
+    it('emits whitespace when the row is null/undefined', () => {
+        const data = [null, { s: 'x' }] as unknown as Array<{ s: string }>;
+        const out = buildZeroLineDots(bars.slice(0, 2), data, () => '#fff');
+        expect(out).toEqual([
+            { time: 1 },
+            { time: 2, value: 0, color: '#fff' },
+        ]);
+    });
+
+    it('clamps to the shorter length and returns [] for empty inputs', () => {
+        expect(buildZeroLineDots([], [], () => '#fff')).toEqual([]);
+        expect(buildZeroLineDots(bars, [{ s: 'a' }], () => '#fff')).toEqual([
+            { time: 1, value: 0, color: '#fff' },
+        ]);
     });
 });

--- a/src/widgets/chart/hooks/useElderRayChart.ts
+++ b/src/widgets/chart/hooks/useElderRayChart.ts
@@ -4,9 +4,9 @@ import type { RefObject } from 'react';
 import { useEffect, useEffectEvent, useRef } from 'react';
 import type { IChartApi, ISeriesApi } from 'lightweight-charts';
 import { HistogramSeries } from 'lightweight-charts';
-import { CHART_COLORS } from '@/shared/lib/chartColors';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
 import { buildSeriesData } from '../utils/seriesDataUtils';
+import { elderRayBarColor } from '../utils/histogramColorUtils';
 
 interface UseElderRayChartParams {
     chartRef: RefObject<IChartApi | null>;
@@ -90,12 +90,12 @@ export function useElderRayChart({
 
         bullSeriesRef.current.setData(
             buildSeriesData(bars, elderRay, 'bullPower', value =>
-                value >= 0 ? CHART_COLORS.elderBullPower : CHART_COLORS.neutral
+                elderRayBarColor(value, 'bull')
             )
         );
         bearSeriesRef.current.setData(
             buildSeriesData(bars, elderRay, 'bearPower', value =>
-                value <= 0 ? CHART_COLORS.elderBearPower : CHART_COLORS.neutral
+                elderRayBarColor(value, 'bear')
             )
         );
     }, [indicators, bars, isVisible, paneIndex]);

--- a/src/widgets/chart/hooks/useElderRayChart.ts
+++ b/src/widgets/chart/hooks/useElderRayChart.ts
@@ -1,0 +1,102 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { IChartApi, ISeriesApi } from 'lightweight-charts';
+import { HistogramSeries } from 'lightweight-charts';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { buildSeriesData } from '../utils/seriesDataUtils';
+
+interface UseElderRayChartParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    isVisible: boolean;
+    paneIndex: number;
+}
+
+export function useElderRayChart({
+    chartRef,
+    bars,
+    indicators,
+    isVisible,
+    paneIndex,
+}: UseElderRayChartParams): void {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const prevPaneIndexRef = useRef<number>(paneIndex);
+    const bullSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null);
+    const bearSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null);
+
+    const clearSeriesRefs = useEffectEvent(() => {
+        bullSeriesRef.current = null;
+        bearSeriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (bullSeriesRef.current) {
+            chart.removeSeries(bullSeriesRef.current);
+            bullSeriesRef.current = null;
+        }
+        if (bearSeriesRef.current) {
+            chart.removeSeries(bearSeriesRef.current);
+            bearSeriesRef.current = null;
+        }
+    });
+
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (prevPaneIndexRef.current !== paneIndex && bullSeriesRef.current) {
+            removeAllSeries(chart);
+        }
+        prevPaneIndexRef.current = paneIndex;
+
+        if (!bullSeriesRef.current) {
+            bullSeriesRef.current = chart.addSeries(
+                HistogramSeries,
+                { priceLineVisible: false, lastValueVisible: false },
+                paneIndex
+            );
+        }
+        if (!bearSeriesRef.current) {
+            bearSeriesRef.current = chart.addSeries(
+                HistogramSeries,
+                { priceLineVisible: false, lastValueVisible: false },
+                paneIndex
+            );
+        }
+    }, [chartRef, isVisible, paneIndex]);
+
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { elderRay } = indicators;
+        if (!elderRay.length) return;
+
+        if (!bullSeriesRef.current || !bearSeriesRef.current) return;
+
+        bullSeriesRef.current.setData(
+            buildSeriesData(bars, elderRay, 'bullPower', value =>
+                value >= 0 ? CHART_COLORS.elderBullPower : CHART_COLORS.neutral
+            )
+        );
+        bearSeriesRef.current.setData(
+            buildSeriesData(bars, elderRay, 'bearPower', value =>
+                value <= 0 ? CHART_COLORS.elderBearPower : CHART_COLORS.neutral
+            )
+        );
+    }, [indicators, bars, isVisible, paneIndex]);
+}

--- a/src/widgets/chart/hooks/useRegressionChart.ts
+++ b/src/widgets/chart/hooks/useRegressionChart.ts
@@ -1,0 +1,84 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { IChartApi, ISeriesApi } from 'lightweight-charts';
+import { HistogramSeries } from 'lightweight-charts';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { buildSeriesData } from '../utils/seriesDataUtils';
+import { regressionBarColor } from '../utils/histogramColorUtils';
+
+interface UseRegressionChartParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    isVisible: boolean;
+    paneIndex: number;
+}
+
+export function useRegressionChart({
+    chartRef,
+    bars,
+    indicators,
+    isVisible,
+    paneIndex,
+}: UseRegressionChartParams): void {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const prevPaneIndexRef = useRef<number>(paneIndex);
+    const slopeSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null);
+
+    const clearSeriesRefs = useEffectEvent(() => {
+        slopeSeriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (slopeSeriesRef.current) {
+            chart.removeSeries(slopeSeriesRef.current);
+            slopeSeriesRef.current = null;
+        }
+    });
+
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (prevPaneIndexRef.current !== paneIndex && slopeSeriesRef.current) {
+            removeAllSeries(chart);
+        }
+        prevPaneIndexRef.current = paneIndex;
+
+        if (!slopeSeriesRef.current) {
+            slopeSeriesRef.current = chart.addSeries(
+                HistogramSeries,
+                { priceLineVisible: false, lastValueVisible: false },
+                paneIndex
+            );
+        }
+    }, [chartRef, isVisible, paneIndex]);
+
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { regression } = indicators;
+        if (!regression.length) return;
+
+        if (!slopeSeriesRef.current) return;
+
+        slopeSeriesRef.current.setData(
+            buildSeriesData(bars, regression, 'slope', (value, row) =>
+                regressionBarColor(value, row.r2)
+            )
+        );
+    }, [indicators, bars, isVisible, paneIndex]);
+}

--- a/src/widgets/chart/hooks/useSqueezeMomentumChart.ts
+++ b/src/widgets/chart/hooks/useSqueezeMomentumChart.ts
@@ -1,0 +1,113 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { IChartApi, ISeriesApi } from 'lightweight-charts';
+import { HistogramSeries, LineSeries } from 'lightweight-charts';
+import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { DEFAULT_POINT_MARKERS_RADIUS } from '../constants';
+import { buildSeriesData, buildZeroLineDots } from '../utils/seriesDataUtils';
+import {
+    squeezeMomentumColor,
+    squeezeStateColor,
+} from '../utils/histogramColorUtils';
+
+interface UseSqueezeMomentumChartParams {
+    chartRef: RefObject<IChartApi | null>;
+    bars: Bar[];
+    indicators: IndicatorResult;
+    isVisible: boolean;
+    paneIndex: number;
+}
+
+export function useSqueezeMomentumChart({
+    chartRef,
+    bars,
+    indicators,
+    isVisible,
+    paneIndex,
+}: UseSqueezeMomentumChartParams): void {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const prevPaneIndexRef = useRef<number>(paneIndex);
+    const momentumSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null);
+    const stateDotsSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+    const clearSeriesRefs = useEffectEvent(() => {
+        momentumSeriesRef.current = null;
+        stateDotsSeriesRef.current = null;
+    });
+
+    const removeAllSeries = useEffectEvent((chart: IChartApi) => {
+        if (momentumSeriesRef.current) {
+            chart.removeSeries(momentumSeriesRef.current);
+            momentumSeriesRef.current = null;
+        }
+        if (stateDotsSeriesRef.current) {
+            chart.removeSeries(stateDotsSeriesRef.current);
+            stateDotsSeriesRef.current = null;
+        }
+    });
+
+    useEffect(() => {
+        const chart = chartRef.current;
+
+        if (prevChartRef.current !== chart) {
+            clearSeriesRefs();
+            prevChartRef.current = chart;
+        }
+
+        if (!chart) return;
+
+        if (!isVisible) {
+            removeAllSeries(chart);
+            return;
+        }
+
+        if (
+            prevPaneIndexRef.current !== paneIndex &&
+            momentumSeriesRef.current
+        ) {
+            removeAllSeries(chart);
+        }
+        prevPaneIndexRef.current = paneIndex;
+
+        if (!momentumSeriesRef.current) {
+            momentumSeriesRef.current = chart.addSeries(
+                HistogramSeries,
+                { priceLineVisible: false, lastValueVisible: false },
+                paneIndex
+            );
+        }
+        if (!stateDotsSeriesRef.current) {
+            stateDotsSeriesRef.current = chart.addSeries(
+                LineSeries,
+                {
+                    lineVisible: false,
+                    pointMarkersVisible: true,
+                    pointMarkersRadius: DEFAULT_POINT_MARKERS_RADIUS,
+                    priceLineVisible: false,
+                    lastValueVisible: false,
+                },
+                paneIndex
+            );
+        }
+    }, [chartRef, isVisible, paneIndex]);
+
+    useEffect(() => {
+        if (!isVisible) return;
+
+        const { squeezeMomentum } = indicators;
+        if (!squeezeMomentum.length) return;
+
+        if (!momentumSeriesRef.current || !stateDotsSeriesRef.current) return;
+
+        momentumSeriesRef.current.setData(
+            buildSeriesData(bars, squeezeMomentum, 'momentum', (value, row) =>
+                squeezeMomentumColor(value, row.increasing)
+            )
+        );
+        stateDotsSeriesRef.current.setData(
+            buildZeroLineDots(bars, squeezeMomentum, squeezeStateColor)
+        );
+    }, [indicators, bars, isVisible, paneIndex]);
+}

--- a/src/widgets/chart/model/indicatorRegistry.ts
+++ b/src/widgets/chart/model/indicatorRegistry.ts
@@ -46,7 +46,10 @@ export type IndicatorKey =
     | 'donchianChannel'
     | 'supertrend'
     | 'parabolicSar'
-    | 'chandelierExit';
+    | 'chandelierExit'
+    | 'elderRay'
+    | 'squeezeMomentum'
+    | 'regression';
 
 export interface IndicatorMeta {
     key: IndicatorKey;
@@ -197,6 +200,19 @@ export const INDICATOR_REGISTRY: readonly IndicatorMeta[] = [
         label: 'Chandelier',
         category: 'trend',
         kind: 'overlay',
+    },
+    { key: 'elderRay', label: 'Elder Ray', category: 'momentum', kind: 'pane' },
+    {
+        key: 'squeezeMomentum',
+        label: 'Squeeze',
+        category: 'momentum',
+        kind: 'pane',
+    },
+    {
+        key: 'regression',
+        label: 'Regression',
+        category: 'statistical',
+        kind: 'pane',
     },
 ];
 

--- a/src/widgets/chart/utils/histogramColorUtils.ts
+++ b/src/widgets/chart/utils/histogramColorUtils.ts
@@ -1,0 +1,51 @@
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+
+/** Regression alpha 기본값 — r2가 null(신뢰도 미확정)일 때 흐릿하게. */
+const REGRESSION_FALLBACK_ALPHA = 0.25;
+/** Regression 막대 RGB(투명도만 r2로 변조) — DESIGN.md teal/red 고정값의 RGB 분해. */
+const REGRESSION_UP_RGB = '38, 166, 154'; // #26a69a
+const REGRESSION_DOWN_RGB = '239, 83, 80'; // #ef5350
+
+/**
+ * Squeeze 모멘텀 히스토그램 4색: 부호(상승/하락) × increasing(강/약).
+ * value > 0: increasing이면 강한 상승, 아니면 약화. value ≤ 0: increasing이면
+ * 회복(약한 하락), 아니면 강한 하락. (LazyBear 표준)
+ */
+export function squeezeMomentumColor(
+    value: number,
+    increasing: boolean | null
+): string {
+    if (value > 0) {
+        return increasing
+            ? CHART_COLORS.squeezeMomentumUp
+            : CHART_COLORS.squeezeMomentumUpWeak;
+    }
+    return increasing
+        ? CHART_COLORS.squeezeMomentumDownWeak
+        : CHART_COLORS.squeezeMomentumDown;
+}
+
+/**
+ * Squeeze 상태 점 색: noSqz > sqzOn > sqzOff 우선순위. 어느 상태도 아니면 null(점 없음).
+ */
+export function squeezeStateColor(row: {
+    noSqz: boolean | null;
+    sqzOn: boolean | null;
+    sqzOff: boolean | null;
+}): string | null {
+    if (row.noSqz) return CHART_COLORS.squeezeNone;
+    if (row.sqzOn) return CHART_COLORS.squeezeOn;
+    if (row.sqzOff) return CHART_COLORS.squeezeOff;
+    return null;
+}
+
+/**
+ * Regression slope 막대 색: 부호로 teal/red, 투명도 = r2(적합도) 클램프.
+ * r2 null이면 fallback alpha로 "신뢰도 미확정"을 흐리게 표현.
+ */
+export function regressionBarColor(slope: number, r2: number | null): string {
+    const alpha =
+        r2 === null ? REGRESSION_FALLBACK_ALPHA : Math.min(1, Math.max(0, r2));
+    const rgb = slope >= 0 ? REGRESSION_UP_RGB : REGRESSION_DOWN_RGB;
+    return `rgba(${rgb}, ${alpha})`;
+}

--- a/src/widgets/chart/utils/histogramColorUtils.ts
+++ b/src/widgets/chart/utils/histogramColorUtils.ts
@@ -1,5 +1,16 @@
 import { CHART_COLORS } from '@/shared/lib/chartColors';
 
+/**
+ * Elder Ray 막대 색: 해당 side의 우세 방향(bull=양수, bear=음수)일 때만 색을 입히고,
+ * 반대 부호 막대는 neutral(회색)로 죽인다 — bull/bear power를 한 pane에 겹쳐도 우세 쪽만 부각.
+ */
+export function elderRayBarColor(value: number, side: 'bull' | 'bear'): string {
+    if (side === 'bull') {
+        return value >= 0 ? CHART_COLORS.elderBullPower : CHART_COLORS.neutral;
+    }
+    return value <= 0 ? CHART_COLORS.elderBearPower : CHART_COLORS.neutral;
+}
+
 /** Regression alpha 기본값 — r2가 null(신뢰도 미확정)일 때 흐릿하게. */
 const REGRESSION_FALLBACK_ALPHA = 0.25;
 /** Regression 막대 RGB(투명도만 r2로 변조) — DESIGN.md teal/red 고정값의 RGB 분해. */

--- a/src/widgets/chart/utils/histogramColorUtils.ts
+++ b/src/widgets/chart/utils/histogramColorUtils.ts
@@ -52,11 +52,14 @@ export function squeezeStateColor(row: {
 
 /**
  * Regression slope 막대 색: 부호로 teal/red, 투명도 = r2(적합도) 클램프.
- * r2 null이면 fallback alpha로 "신뢰도 미확정"을 흐리게 표현.
+ * r2 null/undefined이면 fallback alpha로 "신뢰도 미확정"을 흐리게 표현(`== null`로 둘 다 방어 → NaN alpha 방지).
  */
-export function regressionBarColor(slope: number, r2: number | null): string {
+export function regressionBarColor(
+    slope: number,
+    r2: number | null | undefined
+): string {
     const alpha =
-        r2 === null ? REGRESSION_FALLBACK_ALPHA : Math.min(1, Math.max(0, r2));
+        r2 == null ? REGRESSION_FALLBACK_ALPHA : Math.min(1, Math.max(0, r2));
     const rgb = slope >= 0 ? REGRESSION_UP_RGB : REGRESSION_DOWN_RGB;
     return `rgba(${rgb}, ${alpha})`;
 }

--- a/src/widgets/chart/utils/paneLabelUtils.ts
+++ b/src/widgets/chart/utils/paneLabelUtils.ts
@@ -207,6 +207,37 @@ export function buildPaneLabels(paneIndices: PaneIndices): PaneLabelConfig[] {
         CHART_COLORS.ewmaVolatilityLine
     );
 
+    const elderRayLabel: PaneLabelConfig[] =
+        paneIndices.elderRay !== INACTIVE_PANE_INDEX
+            ? [
+                  {
+                      paneIndex: paneIndices.elderRay,
+                      subLabels: [
+                          {
+                              name: 'Bull Power',
+                              color: CHART_COLORS.elderBullPower,
+                          },
+                          {
+                              name: 'Bear Power',
+                              color: CHART_COLORS.elderBearPower,
+                          },
+                      ],
+                  },
+              ]
+            : [];
+
+    const squeezeLabel = buildSinglePaneLabel(
+        paneIndices.squeezeMomentum,
+        'Squeeze',
+        CHART_COLORS.squeezeMomentumUp
+    );
+
+    const regressionLabel = buildSinglePaneLabel(
+        paneIndices.regression,
+        'Regression',
+        CHART_COLORS.regressionUp
+    );
+
     return [
         ...rsiLabel,
         ...macdLabel,
@@ -227,5 +258,8 @@ export function buildPaneLabels(paneIndices: PaneIndices): PaneLabelConfig[] {
         ...atrLabel,
         ...yangZhangLabel,
         ...ewmaVolatilityLabel,
+        ...elderRayLabel,
+        ...squeezeLabel,
+        ...regressionLabel,
     ];
 }

--- a/src/widgets/chart/utils/seriesDataUtils.ts
+++ b/src/widgets/chart/utils/seriesDataUtils.ts
@@ -18,7 +18,7 @@ export function buildSeriesData<
     bars: Bar[],
     indicatorData: T[],
     key: K,
-    colorFn?: (value: number) => string
+    colorFn?: (value: number, row: T, index: number) => string
 ): SeriesPoint[] {
     const count = Math.min(bars.length, indicatorData.length);
     return bars.slice(0, count).map((bar, i) => {
@@ -31,7 +31,7 @@ export function buildSeriesData<
             value,
         };
         if (colorFn !== undefined) {
-            point.color = colorFn(value);
+            point.color = colorFn(value, indicatorData[i] as T, i);
         }
         return point;
     });
@@ -82,5 +82,26 @@ export function buildTrendSplitData<
             }
         }
         return { time: bar.time as UTCTimestamp };
+    });
+}
+
+/**
+ * 각 bar에 0(zero)라인 위 점({ time, value: 0, color })을 만든다. colorFn이 null을
+ * 반환하거나 행이 없으면 해당 bar는 whitespace(점 없음). Squeeze 상태 점처럼 값과
+ * 무관하게 0라인에 상태 색을 찍는 용도.
+ */
+export function buildZeroLineDots<T>(
+    bars: Bar[],
+    data: T[],
+    colorFn: (row: T) => string | null
+): SeriesPoint[] {
+    const count = Math.min(bars.length, data.length);
+    return bars.slice(0, count).map((bar, i) => {
+        const row = data[i];
+        const color = row == null ? null : colorFn(row);
+        if (color === null) {
+            return { time: bar.time as UTCTimestamp };
+        }
+        return { time: bar.time as UTCTimestamp, value: 0, color };
     });
 }

--- a/src/widgets/chart/utils/seriesDataUtils.ts
+++ b/src/widgets/chart/utils/seriesDataUtils.ts
@@ -31,7 +31,7 @@ export function buildSeriesData<
             value,
         };
         if (colorFn !== undefined) {
-            point.color = colorFn(value, indicatorData[i] as T, i);
+            point.color = colorFn(value, indicatorData[i], i);
         }
         return point;
     });


### PR DESCRIPTION
## 요약
미사용 보조지표 렌더링 7차이자 그룹 C 마무리. **elderRay**·**squeezeMomentum**·**regression**을 별도 Pane 지표로 렌더한다. 히스토그램·상태 점·투명도 인코딩 등 복합 렌더 요소가 들어간다.

- **Elder Ray**: bull/bear power를 2 HistogramSeries로 0라인 기준 표시(우세 쪽만 색, 반대 부호는 neutral).
- **Squeeze Momentum (LazyBear)**: 모멘텀 4색 히스토그램(부호 × increasing) + 0라인 squeeze 상태 점(on/off/none 3색).
- **Regression**: slope 히스토그램(부호 색) + 막대 투명도 = r2(적합도 낮으면 흐릿).

공통 인프라: `buildSeriesData` colorFn을 row 인지(`(value, row, index)`)로 하위호환 확장, 신규 `buildZeroLineDots`(0라인 상태 점), 색 분기 순수함수(`squeezeMomentumColor`/`squeezeStateColor`/`regressionBarColor`/`elderRayBarColor`). 코어 변경 없음.

## 변경 사항
- `utils/seriesDataUtils.ts`: row 인지 colorFn + `buildZeroLineDots`
- `utils/histogramColorUtils.ts`: 4개 색 분기 순수함수
- `hooks/useElderRayChart.ts` / `useSqueezeMomentumChart.ts` / `useRegressionChart.ts`: pane 훅 3개
- `model/indicatorRegistry.ts`: 3종 등록(pane, 29→32)
- `shared/lib/chartColors.ts` + `globals.css`: 색 11개(solid만 @theme 미러)
- `utils/paneLabelUtils.ts`: pane 라벨 3개
- `StockChart.tsx`: 훅 3개 + binding 3개(32)
- `e2e/specs/chart-indicators.spec.ts`: pane 토글 E2E 3개

## 검증
- vitest 전체 커버리지 게이트 통과(branches 91.54%, lines 95.77%)
- lint / prettier --check / production build 전부 통과
- 내부 review-agent(Opus): round 1 recommended 2건 반영 → round 2 APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)