### PR TITLE
feat(chart): render Elder Impulse via per-bar candle paint

### DIFF
--- a/docs/superpowers/plans/2026-06-07-render-elder-impulse.md
+++ b/docs/superpowers/plans/2026-06-07-render-elder-impulse.md
@@ -1,0 +1,470 @@
+# Elder Impulse (candle-paint) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recolor the main candlestick series per-bar by Elder Impulse momentum (green/red/blue) when the indicator is toggled on.
+
+**Architecture:** Elder Impulse is NOT a separate series — it injects per-bar `color`/`borderColor`/`wickColor` into the existing main `CandlestickSeries` data. The inline OHLC map in StockChart's candle setData effect is extracted into a pure `buildCandlestickData(bars, elderImpulse, isActive)` helper so the injection logic is testable in isolation. A new registry kind `candle-paint` (not a pane, not a separate overlay series) carries it; visibility uses `useIndicatorVisibility`'s `visible.elderImpulse` / `toggle('elderImpulse')`. Computation is in `@y0ngha/siglens-core` (unchanged).
+
+**Tech Stack:** TypeScript, React 19, lightweight-charts 5.2.0 (`CandlestickData` per-point color), Vitest + RTL, Playwright (E2E).
+
+**Spec:** `docs/superpowers/specs/2026-06-07-render-elder-impulse-design.md`
+**Branch:** `feat/render-elder-impulse` (base: `feat/render-c-complex` = PR #585)
+**Worktree:** `/Users/y0ngha/Project/siglens-elder-impulse`
+
+**Data shape (siglens-core):** `type ImpulseColor = 'green' | 'red' | 'blue'`; `IndicatorResult.elderImpulse: (ImpulseColor | null)[]`.
+
+**Key existing code:**
+- StockChart candle setData effect (StockChart.tsx ~179–194), deps `[bars]`:
+  ```ts
+  seriesRef.current.setData(bars.map(({ time, open, high, low, close }) => ({ time: time as UTCTimestamp, open, high, low, close })));
+  chartRef.current.timeScale().fitContent();
+  ```
+- `useIndicatorVisibility()` at StockChart.tsx:117 (provides `visible`, `toggle`) — BEFORE the candle effect, so `visible.elderImpulse` is in scope.
+- `IndicatorKind = 'overlay' | 'pane'` (indicatorRegistry.ts:18). `CHART_COLORS` ends after `regressionDown` (chartColors.ts:161). globals.css regression tokens at 73–74.
+
+---
+
+## File Structure
+
+- `src/shared/lib/chartColors.ts` + `src/app/globals.css` — 3 impulse colors + @theme tokens (modify).
+- `src/widgets/chart/utils/candlestickDataUtils.ts` (+ test) — `impulseColor` + `buildCandlestickData` (create).
+- `src/widgets/chart/model/indicatorRegistry.ts` (+ tests, + paneLabelUtils test) — `IndicatorKind` += candle-paint, `IndicatorKey` += elderImpulse, 32→33 (modify).
+- `src/widgets/chart/StockChart.tsx` (+ test) — candle effect uses helper, +1 binding (modify).
+- `e2e/specs/chart-indicators.spec.ts` — modal-checkbox toggle test (modify).
+
+---
+
+## Task 0: Worktree node_modules verify
+
+**Files:** none
+
+- [ ] **Step 1:** Run:
+```bash
+cd /Users/y0ngha/Project/siglens-elder-impulse
+[ -e node_modules/.bin/vitest ] && [ ! -L node_modules ] && echo "OK" || echo "MISSING"
+```
+Expected `OK`. If MISSING: `cp -al /Users/y0ngha/Project/siglens/node_modules ./node_modules && rm -rf node_modules/node_modules`.
+
+- [ ] **Step 2:** `cd /Users/y0ngha/Project/siglens-elder-impulse && yarn vitest run src/widgets/chart/__tests__/model/indicatorRegistry.test.ts` → PASS.
+
+---
+
+## Task 1: Add impulse colors
+
+**Files:**
+- Modify: `src/shared/lib/chartColors.ts`
+- Modify: `src/app/globals.css`
+
+- [ ] **Step 1: Collision guard**
+
+```bash
+cd /Users/y0ngha/Project/siglens-elder-impulse
+grep -rn "impulseBullish\|impulseBearish\|impulseNeutral" src/ || echo "KEYS UNUSED — safe"
+```
+Expected: `KEYS UNUSED — safe`.
+
+- [ ] **Step 2:** In `src/shared/lib/chartColors.ts`, immediately AFTER `regressionDown: '#ef5350',` (the last entry before `} as const;`), add:
+```ts
+    // Elder Impulse (캔들 per-bar 색) — DESIGN.md teal/red + Elder blue 관례
+    impulseBullish: '#26a69a', // green — EMA↑ & MACD-hist↑
+    impulseBearish: '#ef5350', // red — 둘 다 ↓
+    impulseNeutral: '#3b82f6', // blue — 혼조/전환
+```
+
+- [ ] **Step 3:** In `src/app/globals.css`, AFTER `--color-chart-regression-down: #ef5350;`, add:
+```css
+    /* Chart — Elder Impulse (캔들 색) */
+    --color-chart-impulse-bullish: #26a69a;
+    --color-chart-impulse-bearish: #ef5350;
+    --color-chart-impulse-neutral: #3b82f6;
+```
+
+- [ ] **Step 4:** Verify:
+```bash
+cd /Users/y0ngha/Project/siglens-elder-impulse && yarn lint src/shared/lib/chartColors.ts && npx prettier --check src/shared/lib/chartColors.ts src/app/globals.css
+```
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/shared/lib/chartColors.ts src/app/globals.css
+git commit -m "feat(chart): add Elder Impulse candle colors"
+```
+
+---
+
+## Task 2: `buildCandlestickData` + `impulseColor` utils
+
+**Files:**
+- Create: `src/widgets/chart/utils/candlestickDataUtils.ts`
+- Test: `src/widgets/chart/__tests__/utils/candlestickDataUtils.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/widgets/chart/__tests__/utils/candlestickDataUtils.test.ts`:
+```ts
+import { describe, expect, it } from 'vitest';
+import type { Bar, ImpulseColor } from '@y0ngha/siglens-core';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import {
+    buildCandlestickData,
+    impulseColor,
+} from '@/widgets/chart/utils/candlestickDataUtils';
+
+function bar(time: number, close = 10): Bar {
+    return { time, open: 9, high: 11, low: 8, close, volume: 100 };
+}
+
+describe('impulseColor', () => {
+    it('maps green/red/blue to the impulse palette', () => {
+        expect(impulseColor('green')).toBe(CHART_COLORS.impulseBullish);
+        expect(impulseColor('red')).toBe(CHART_COLORS.impulseBearish);
+        expect(impulseColor('blue')).toBe(CHART_COLORS.impulseNeutral);
+    });
+});
+
+describe('buildCandlestickData', () => {
+    const bars: Bar[] = [bar(1), bar(2), bar(3)];
+
+    it('returns plain OHLC (no color fields) when impulse is inactive', () => {
+        const out = buildCandlestickData(
+            bars,
+            ['green', 'red', 'blue'],
+            false
+        );
+        expect(out).toEqual([
+            { time: 1, open: 9, high: 11, low: 8, close: 10 },
+            { time: 2, open: 9, high: 11, low: 8, close: 10 },
+            { time: 3, open: 9, high: 11, low: 8, close: 10 },
+        ]);
+        out.forEach(p => expect('color' in p).toBe(false));
+    });
+
+    it('injects color/borderColor/wickColor when active and color present', () => {
+        const out = buildCandlestickData([bar(1)], ['green'], true);
+        expect(out[0]).toEqual({
+            time: 1,
+            open: 9,
+            high: 11,
+            low: 8,
+            close: 10,
+            color: CHART_COLORS.impulseBullish,
+            borderColor: CHART_COLORS.impulseBullish,
+            wickColor: CHART_COLORS.impulseBullish,
+        });
+    });
+
+    it('leaves a bar plain when active but its impulse is null (warm-up)', () => {
+        const out = buildCandlestickData([bar(1), bar(2)], [null, 'red'], true);
+        expect('color' in out[0]).toBe(false);
+        expect(out[1].color).toBe(CHART_COLORS.impulseBearish);
+    });
+
+    it('leaves bars plain when the impulse array is shorter than bars', () => {
+        const out = buildCandlestickData([bar(1), bar(2)], ['green'], true);
+        expect(out[0].color).toBe(CHART_COLORS.impulseBullish);
+        expect('color' in out[1]).toBe(false); // index 1 → undefined → plain
+    });
+
+    it('returns [] for empty bars', () => {
+        expect(buildCandlestickData([], [], true)).toEqual([]);
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+`cd /Users/y0ngha/Project/siglens-elder-impulse && yarn vitest run src/widgets/chart/__tests__/utils/candlestickDataUtils.test.ts` → FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+Create `src/widgets/chart/utils/candlestickDataUtils.ts`:
+```ts
+import type { CandlestickData, UTCTimestamp } from 'lightweight-charts';
+import type { Bar, ImpulseColor } from '@y0ngha/siglens-core';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+
+/** Elder Impulse 색 매핑: green=강세(teal), red=약세(red), blue=혼조(blue). */
+export function impulseColor(c: ImpulseColor): string {
+    if (c === 'green') return CHART_COLORS.impulseBullish;
+    if (c === 'red') return CHART_COLORS.impulseBearish;
+    return CHART_COLORS.impulseNeutral;
+}
+
+/**
+ * 메인 캔들스틱 시리즈 데이터를 만든다. Elder Impulse가 활성이고 해당 bar의 색이
+ * 있으면 per-bar color/borderColor/wickColor를 주입해 시리즈 기본 bull/bear 색을
+ * override한다. 비활성이거나 warm-up(null)·배열 범위 밖이면 plain OHLC를 반환해
+ * 시리즈 기본 색이 그대로 적용되게 한다.
+ */
+export function buildCandlestickData(
+    bars: Bar[],
+    elderImpulse: (ImpulseColor | null)[],
+    isImpulseActive: boolean
+): CandlestickData<UTCTimestamp>[] {
+    return bars.map(bar => {
+        const base: CandlestickData<UTCTimestamp> = {
+            // Bar.time은 epoch seconds 정수 — LWC UTCTimestamp(branded number)와 런타임 형태 동일.
+            time: bar.time as UTCTimestamp,
+            open: bar.open,
+            high: bar.high,
+            low: bar.low,
+            close: bar.close,
+        };
+        return base;
+    }).map((base, i) => {
+        if (!isImpulseActive) return base;
+        const impulse = elderImpulse[i];
+        if (impulse == null) return base;
+        const color = impulseColor(impulse);
+        return { ...base, color, borderColor: color, wickColor: color };
+    });
+}
+```
+NOTE: the two-`.map` split keeps the base build and the color-inject pass readable; a single map is also acceptable. If the reviewer prefers one map, that's fine — keep it pure and branch-covered.
+
+- [ ] **Step 4: Run + tsc + lint**
+```bash
+cd /Users/y0ngha/Project/siglens-elder-impulse
+npx tsc --noEmit
+yarn vitest run src/widgets/chart/__tests__/utils/candlestickDataUtils.test.ts
+yarn lint src/widgets/chart/utils/candlestickDataUtils.ts src/widgets/chart/__tests__/utils/candlestickDataUtils.test.ts
+```
+Expected: all clean/PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/widgets/chart/utils/candlestickDataUtils.ts src/widgets/chart/__tests__/utils/candlestickDataUtils.test.ts
+git commit -m "feat(chart): add buildCandlestickData + impulseColor (Elder Impulse paint)"
+```
+
+---
+
+## Task 3: Register elderImpulse (new `candle-paint` kind)
+
+**Files:**
+- Modify: `src/widgets/chart/model/indicatorRegistry.ts`
+- Modify: `src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`
+- Modify: `src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts`
+
+- [ ] **Step 1: Write the failing registry test**
+
+In `src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`: change `toHaveLength(32)` → `toHaveLength(33)`, and add:
+```ts
+it('registers elderImpulse as a candle-paint indicator', () => {
+    const meta = INDICATOR_REGISTRY.find(m => m.key === 'elderImpulse');
+    expect(meta).toBeDefined();
+    expect(meta?.category).toBe('momentum');
+    expect(meta?.kind).toBe('candle-paint');
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+`cd /Users/y0ngha/Project/siglens-elder-impulse && yarn vitest run src/widgets/chart/__tests__/model/indicatorRegistry.test.ts` → FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `src/widgets/chart/model/indicatorRegistry.ts`:
+(a) Extend the kind union (line 18):
+```ts
+export type IndicatorKind = 'overlay' | 'pane' | 'candle-paint';
+```
+(b) In `IndicatorKey`, after `| 'regression'`, change the terminator to:
+```ts
+    | 'regression'
+    | 'elderImpulse';
+```
+(c) In `INDICATOR_REGISTRY`, after the `regression` entry (last element, before `];`), add:
+```ts
+    {
+        key: 'elderImpulse',
+        label: 'Elder Impulse',
+        category: 'momentum',
+        kind: 'candle-paint',
+    },
+```
+
+- [ ] **Step 4: Verify registry test PASS**
+
+`cd /Users/y0ngha/Project/siglens-elder-impulse && yarn vitest run src/widgets/chart/__tests__/model/indicatorRegistry.test.ts` → PASS.
+
+- [ ] **Step 5: Fix makePaneIndices fallout**
+
+In `src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts`, inside `makePaneIndices`, after `regression: INACTIVE_PANE_INDEX,`, add:
+```ts
+        elderImpulse: INACTIVE_PANE_INDEX,
+```
+
+- [ ] **Step 6: tsc + tests**
+```bash
+cd /Users/y0ngha/Project/siglens-elder-impulse
+npx tsc --noEmit
+yarn vitest run src/widgets/chart/__tests__/model/indicatorRegistry.test.ts src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts src/widgets/chart/__tests__/hooks/useIndicatorVisibility.test.ts
+```
+Expected: tsc clean; all PASS. tsc may flag OTHER `Record<IndicatorKey>` objects (e.g. in useIndicatorVisibility or its test) needing the `elderImpulse` key — fix each (add `elderImpulse` with the appropriate default; for visibility `false`, for pane indices INACTIVE) and report which files. Also: `useIndicatorVisibility` filters `kind === 'pane'`, so `candle-paint` is naturally excluded from pane allocation — confirm its test still passes and that `visible.elderImpulse` initializes to `false`.
+
+- [ ] **Step 7: Lint**
+```bash
+cd /Users/y0ngha/Project/siglens-elder-impulse && yarn lint src/widgets/chart/model/indicatorRegistry.ts src/widgets/chart/__tests__/model/indicatorRegistry.test.ts src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+```
+
+- [ ] **Step 8: Commit**
+```bash
+git add src/widgets/chart/model/indicatorRegistry.ts src/widgets/chart/__tests__/model/indicatorRegistry.test.ts src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+git commit -m "feat(chart): register elderImpulse (candle-paint kind)"
+```
+
+---
+
+## Task 4: Wire into StockChart
+
+**Files:**
+- Modify: `src/widgets/chart/StockChart.tsx`
+- Modify: `src/widgets/chart/__tests__/StockChart.test.tsx`
+
+- [ ] **Step 1: Import the helper**
+
+In `src/widgets/chart/StockChart.tsx`, add near the other util imports:
+```ts
+import { buildCandlestickData } from './utils/candlestickDataUtils';
+```
+
+- [ ] **Step 2: Use the helper in the candle setData effect**
+
+Replace the candle setData effect body (the `seriesRef.current.setData(bars.map(...))` call, ~lines 182–191) with:
+```ts
+        seriesRef.current.setData(
+            buildCandlestickData(
+                bars,
+                indicators.elderImpulse,
+                visible.elderImpulse
+            )
+        );
+```
+Update that effect's deps array from `[bars]` to:
+```ts
+    }, [bars, indicators.elderImpulse, visible.elderImpulse]);
+```
+(`fitContent()` call stays. `indicators` and `visible` are already in scope — `useIndicatorVisibility` is at line 117, this effect is at ~179.)
+
+- [ ] **Step 3: Add the binding (32→33)**
+
+In the `indicatorBindings` useMemo, after the last existing binding (e.g. `regression`), add:
+```ts
+            {
+                meta: INDICATOR_META.elderImpulse,
+                active: visible.elderImpulse,
+                onToggle: () => toggle('elderImpulse'),
+            },
+```
+`visible` and `toggle` are already in that useMemo's deps — confirm; if not, add them.
+
+- [ ] **Step 4: tsc + chart suite**
+```bash
+cd /Users/y0ngha/Project/siglens-elder-impulse
+npx tsc --noEmit
+yarn vitest run src/widgets/chart
+```
+Expected: tsc clean; tests PASS. In `src/widgets/chart/__tests__/StockChart.test.tsx`:
+- Update the binding-count test (name + `data-count`) from 32 to 33 and append `,elderImpulse` to the expected `data-keys` string (after `regression`).
+- If StockChart.test mocks `useIndicatorVisibility`, its `visible` object needs `elderImpulse: false` (and any INACTIVE_PANES-style list does NOT include it since it is not a pane — confirm the candle setData path renders without error). 
+- If a candle-render assertion exists, ensure it still holds (default toggle off → plain OHLC, unchanged behavior).
+Report exactly what you changed.
+
+- [ ] **Step 5: Lint**
+```bash
+cd /Users/y0ngha/Project/siglens-elder-impulse && yarn lint src/widgets/chart/StockChart.tsx
+```
+
+- [ ] **Step 6: Commit**
+```bash
+git add src/widgets/chart/StockChart.tsx src/widgets/chart/__tests__/StockChart.test.tsx
+git commit -m "feat(chart): wire Elder Impulse candle-paint into StockChart (33 bindings)"
+```
+
+---
+
+## Task 5: E2E modal toggle
+
+**Files:**
+- Modify: `e2e/specs/chart-indicators.spec.ts`
+
+- [ ] **Step 1: Add the toggle test**
+
+Elder Impulse paints the main candles — it has no pane label and no overlay legend, so verify via the modal checkbox state (the Keltner/Supertrend overlay pattern). Add, immediately after the last existing test in the `test.describe('chart indicator settings modal', ...)` block (and before the describe's closing `});`):
+```ts
+
+    test('toggles the Elder Impulse candle paint via the modal', async ({
+        page,
+    }) => {
+        await page.goto('/AAPL');
+        await page.getByRole('button', { name: GEAR }).click();
+        const dialog = page.getByRole('dialog');
+        // Elder Impulse는 메인 캔들을 재색칠(candle-paint) — pane/overlay 라벨이 없어
+        // 모달 체크박스 상태로 검증한다. exact로 substring 충돌 방지.
+        const impulse = dialog.getByRole('checkbox', {
+            name: 'Elder Impulse',
+            exact: true,
+        });
+        await expect(impulse).not.toBeChecked();
+        await impulse.check();
+        await expect(impulse).toBeChecked();
+    });
+```
+READ the file first to find the last test + the describe-closing `});`; `GEAR` is the const at the top of the describe.
+
+- [ ] **Step 2: Lint + tsc**
+```bash
+cd /Users/y0ngha/Project/siglens-elder-impulse && yarn lint e2e/specs/chart-indicators.spec.ts && npx tsc --noEmit
+```
+Expected: clean. (Do NOT run Playwright locally — shared docker backend; CI is the gate.)
+
+- [ ] **Step 3: Commit**
+```bash
+git add e2e/specs/chart-indicators.spec.ts
+git commit -m "test(e2e): toggle Elder Impulse candle paint from settings modal"
+```
+
+---
+
+## Task 6: Final verification + review handoff
+
+**Files:** none
+
+- [ ] **Step 1: Full coverage suite**
+
+`cd /Users/y0ngha/Project/siglens-elder-impulse && yarn test-coverage > /tmp/elder-cov.log 2>&1; echo "EXIT=$?"; tail -8 /tmp/elder-cov.log`
+Expected: `EXIT=0`, thresholds (90%+) met.
+
+- [ ] **Step 2: Lint + format (whole repo)**
+
+`cd /Users/y0ngha/Project/siglens-elder-impulse && yarn lint && npx prettier --check .`
+Expected: no errors.
+
+- [ ] **Step 3: Production build (capture exit code directly)**
+
+`cd /Users/y0ngha/Project/siglens-elder-impulse && yarn build > /tmp/elder-build.log 2>&1; echo "EXIT=$?"; tail -12 /tmp/elder-build.log`
+Expected: `EXIT=0`.
+
+- [ ] **Step 4: Hand off to review**
+
+Per CLAUDE.md routing: invoke `review-agent` (Opus 4.8) on branch `feat/render-elder-impulse`, then `mistake-managing-agent`, then `git-agent` to push and open the PR stacked on `feat/render-c-complex` (#585). Do not merge before APPROVED.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3.1 buildCandlestickData → Task 2. ✓
+- §3.2 impulseColor → Task 2. ✓
+- §3.3 colors + @theme → Task 1. ✓
+- §3.4 registry (candle-paint kind, 32→33, makePaneIndices, useIndicatorVisibility fallout) → Task 3. ✓
+- §3.5 StockChart wiring (candle effect + binding) → Task 4. ✓
+- §5.4 E2E → Task 5. ✓
+- §5 test strategy (90%+, happy + worst) → Task 2 covers inactive/active/null/short-array/empty; Task 3 covers candle-paint kind; Task 4 covers binding + toggle. ✓
+
+**Placeholder scan:** No TBD/TODO. Task 3 Step 6 and Task 4 Step 4 instruct fixing tsc-flagged `Record<IndicatorKey>` fallout sites "as flagged" — this is unavoidable discovery (the exact set depends on which objects enumerate all keys), but the fix per site is fully specified (add `elderImpulse` with the documented default).
+
+**Type consistency:** `buildCandlestickData(bars, elderImpulse, isActive)` and `impulseColor(c)` signatures consistent across Task 2 (def) and Task 4 (call). Color keys `impulseBullish/Bearish/Neutral` consistent across Tasks 1/2. Registry count 32→33 consistent Tasks 3/4. `candle-paint` kind consistent Tasks 3/4. ✓

--- a/docs/superpowers/specs/2026-06-07-render-elder-impulse-design.md
+++ b/docs/superpowers/specs/2026-06-07-render-elder-impulse-design.md
@@ -1,0 +1,138 @@
+# 미사용 보조지표 렌더링 — 8차(그룹 D-1): elderImpulse (캔들 per-bar 색칠)
+
+- **작성일**: 2026-06-07
+- **상태**: 설계 승인됨, 구현 계획 대기
+- **브랜치**: `feat/render-elder-impulse` (base: `feat/render-c-complex` = PR #585)
+
+## 1. 배경
+
+미사용 보조지표 렌더링 8차. 그룹 D(elderImpulse·smc zone)는 렌더 메커니즘이 완전히 disjoint하여 **2개 PR로 분리**한다(사용자 선택). 이 스펙은 그 첫 번째 **elderImpulse**만 다룬다(smc zone은 별도 스펙/PR).
+
+elderImpulse는 지금까지의 작업(별도 overlay/pane 시리즈 추가)과 달리 **기존 메인 캔들스틱 시리즈를 per-bar로 재색칠**하는 신규 메커니즘이다. Elder Impulse System: green=EMA↑ AND MACD 히스토그램↑(강세 모멘텀), red=둘 다↓(약세), blue=혼조(중립). 계산은 `@y0ngha/siglens-core`에 있어 추가 작업은 siglens 렌더링뿐.
+
+## 2. 자료조사 / 렌더 표준
+
+- **Elder Impulse System**: 가격 캔들 자체를 모멘텀에 따라 3색으로 칠한다(별도 패널/오버레이 아님). green=상승 모멘텀, red=하락 모멘텀, blue=중립/전환. core JSDoc과 일치.
+- LWC `CandlestickData`는 per-point `color`·`borderColor`·`wickColor` 필드로 시리즈 기본 up/down 색을 override한다 → 메인 시리즈 데이터에 색을 주입하는 방식으로 구현.
+
+데이터(siglens-core `domain/types.d.ts`):
+```ts
+type ImpulseColor = 'green' | 'red' | 'blue';
+// IndicatorResult.elderImpulse: (ImpulseColor | null)[]  // 한 bar당 한 색, warm-up은 null
+```
+
+현재 메인 캔들 setData(StockChart.tsx):
+```ts
+seriesRef.current.setData(
+    bars.map(({ time, open, high, low, close }) => ({ time: time as UTCTimestamp, open, high, low, close }))
+);
+```
+
+## 3. 핵심 설계 결정
+
+### 3.1 `buildCandlestickData` 순수 헬퍼 (침투 격리)
+메인 캔들 effect의 인라인 map을 순수 헬퍼로 추출해, elderImpulse 색 주입 로직을 테스트 가능하게 격리한다:
+```ts
+// utils/candlestickDataUtils.ts
+import type { Bar, ImpulseColor } from '@y0ngha/siglens-core';
+import type { CandlestickData, UTCTimestamp } from 'lightweight-charts';
+
+export function buildCandlestickData(
+    bars: Bar[],
+    elderImpulse: (ImpulseColor | null)[],
+    isImpulseActive: boolean
+): CandlestickData<UTCTimestamp>[] {
+    return bars.map((bar, i) => {
+        const base = {
+            time: bar.time as UTCTimestamp,
+            open: bar.open,
+            high: bar.high,
+            low: bar.low,
+            close: bar.close,
+        };
+        if (!isImpulseActive) return base;
+        const impulse = elderImpulse[i];
+        if (impulse == null) return base; // warm-up: 기본 bull/bear 색 유지
+        const color = impulseColor(impulse);
+        return { ...base, color, borderColor: color, wickColor: color };
+    });
+}
+```
+- `isImpulseActive=false`(토글 off) 또는 `elderImpulse[i]`가 null(warm-up)이면 plain OHLC → 시리즈 기본 bull/bear 색 적용(자동 복원).
+- 활성 + 색 있으면 body/border/wick 모두 impulse 색으로 통일.
+
+### 3.2 `impulseColor` 순수 함수 (`utils/candlestickDataUtils.ts` 동거)
+```ts
+export function impulseColor(c: ImpulseColor): string {
+    if (c === 'green') return CHART_COLORS.impulseBullish;
+    if (c === 'red') return CHART_COLORS.impulseBearish;
+    return CHART_COLORS.impulseNeutral; // 'blue'
+}
+```
+
+### 3.3 색상 (`shared/lib/chartColors.ts` + `globals.css`)
+DESIGN.md 추세 고정값 + Elder blue 관례:
+```ts
+impulseBullish: '#26a69a', // green — EMA↑ & MACD-hist↑
+impulseBearish: '#ef5350', // red — 둘 다 ↓
+impulseNeutral: '#3b82f6', // blue — 혼조/전환 (Elder 관례)
+```
+globals.css @theme: 세 토큰 미러(`--color-chart-impulse-bullish/bearish/neutral`).
+
+### 3.4 레지스트리 (신규 kind `candle-paint`)
+- `IndicatorKind` += `'candle-paint'` (레지스트리 헤더 주석이 이미 예고한 kind).
+- `IndicatorKey` += `'elderImpulse'`.
+- `INDICATOR_REGISTRY` += `{ key: 'elderImpulse', label: 'Elder Impulse', category: 'momentum', kind: 'candle-paint' }`. 32→33.
+- `candle-paint`은 pane이 아니므로 `useIndicatorVisibility`의 `kind === 'pane'` 필터에 안 걸려 pane index를 받지 않는다(기존 로직 그대로). 가시성은 `visible.elderImpulse` + `toggle('elderImpulse')`(useIndicatorVisibility가 모든 레지스트리 키를 초기화).
+- 모달은 kind 무관이라 무수정(자동 노출).
+- makePaneIndices(paneLabelUtils.test) fallout: `elderImpulse: INACTIVE_PANE_INDEX` +1.
+
+### 3.5 StockChart 배선
+- candle setData effect를 `seriesRef.current.setData(buildCandlestickData(bars, indicators.elderImpulse, visible.elderImpulse))`로 변경. effect deps에 `indicators`(또는 `indicators.elderImpulse`)·`visible.elderImpulse` 추가(현재는 `[bars]` 류).
+- `indicatorBindings` += `{ meta: INDICATOR_META.elderImpulse, active: visible.elderImpulse, onToggle: () => toggle('elderImpulse') }` (32→33). deps의 `visible`/`toggle`는 이미 포함.
+- 범례·pane 라벨 없음(캔들 자체가 표현).
+
+## 4. 데이터 흐름
+```
+indicatorRegistry (elderImpulse = kind:'candle-paint')
+        │
+useIndicatorVisibility → visible.elderImpulse (pane index 없음)
+        │
+binding(33개) → IndicatorSettingsModal 자동 노출(무수정)
+        │
+체크 → toggle('elderImpulse') → visible.elderImpulse=true
+        │
+candle setData effect 재실행 → buildCandlestickData(bars, indicators.elderImpulse, true)
+        │
+메인 캔들이 green/red/blue per-bar 색으로 재렌더 (off 시 기본 bull/bear 복원)
+```
+
+## 5. 테스트 전략 (vitest + RTL, 90%+, happy + worst)
+
+### 5.1 단위 — 순수 함수
+- **`impulseColor`**: green→impulseBullish, red→impulseBearish, blue→impulseNeutral.
+- **`buildCandlestickData`**:
+  - isImpulseActive=false → 모든 bar plain OHLC(색 필드 없음).
+  - active + 색 있음 → color/borderColor/wickColor 모두 impulse 색.
+  - active + 색 null(warm-up) → 해당 bar plain OHLC.
+  - active + 일부 null 혼재 → 섞여 반환.
+  - 빈 bars → [].
+  - elderImpulse 배열이 bars보다 짧음(worst): 인덱스 초과 bar는 plain(undefined→plain).
+
+### 5.2 StockChart 통합
+- elderImpulse 토글 시 `seriesRef.setData`가 색 포함 데이터로 호출되는지(setData mock 인자 캡처 또는 buildCandlestickData spy). 토글 off 시 plain OHLC로 호출.
+- (StockChart.test는 시리즈/차트 mock 구조이므로 기존 candle setData 검증 패턴에 맞춰 확장.)
+
+### 5.3 레지스트리
+- 레지스트리 33, elderImpulse가 momentum·candle-paint, 중복 없음.
+- `candle-paint` kind가 pane index 미할당(useIndicatorVisibility.test에서 paneIndices에 elderImpulse 없음/INACTIVE 확인).
+
+### 5.4 E2E
+- `chart-indicators.spec.ts` 확장: 모달에서 'Elder Impulse' 체크 → candle-paint은 pane/overlay 라벨이 없으므로 **모달 체크박스 상태로 검증**(initial unchecked → check → checked, group-A overlay 패턴, exact 매처).
+
+## 6. FSD 준수
+- 헬퍼·색·순수함수: `widgets/chart` 내부 + `shared/lib/chartColors`. core import(ImpulseColor/Bar). 레이어 정상. core 무변경.
+
+## 7. 후속 (별도 스펙)
+- 그룹 D-2: smc zone(premium/discount/equilibrium 가격 밴드, 신규 `zone` kind + 렌더 방식 결정 priceLine vs primitive). 별도 brainstorming→spec→plan→PR.
+- 이후: 전송 페이로드 슬림화.

--- a/e2e/specs/chart-indicators.spec.ts
+++ b/e2e/specs/chart-indicators.spec.ts
@@ -201,4 +201,21 @@ test.describe('chart indicator settings modal', () => {
         await chandelier.check();
         await expect(chandelier).toBeChecked();
     });
+
+    test('toggles the Elder Impulse candle paint via the modal', async ({
+        page,
+    }) => {
+        await page.goto('/AAPL');
+        await page.getByRole('button', { name: GEAR }).click();
+        const dialog = page.getByRole('dialog');
+        // Elder Impulse는 메인 캔들을 재색칠(candle-paint) — pane/overlay 라벨이 없어
+        // 모달 체크박스 상태로 검증한다. exact로 substring 충돌 방지.
+        const impulse = dialog.getByRole('checkbox', {
+            name: 'Elder Impulse',
+            exact: true,
+        });
+        await expect(impulse).not.toBeChecked();
+        await impulse.check();
+        await expect(impulse).toBeChecked();
+    });
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -72,6 +72,10 @@
     /* Chart — Regression */
     --color-chart-regression-up: #26a69a;
     --color-chart-regression-down: #ef5350;
+    /* Chart — Elder Impulse (캔들 색) */
+    --color-chart-impulse-bullish: #26a69a;
+    --color-chart-impulse-bearish: #ef5350;
+    --color-chart-impulse-neutral: #3b82f6;
 
     /* Chart — MACD */
     --color-chart-macd: #3b82f6;

--- a/src/shared/lib/chartColors.ts
+++ b/src/shared/lib/chartColors.ts
@@ -162,7 +162,7 @@ export const CHART_COLORS = {
     // Elder Impulse (캔들 per-bar 색) — DESIGN.md teal/red + Elder blue 관례
     impulseBullish: '#26a69a', // green — EMA↑ & MACD-hist↑
     impulseBearish: '#ef5350', // red — 둘 다 ↓
-    impulseNeutral: '#3b82f6', // blue — 혼조/전환
+    impulseNeutral: '#3b82f6', // blue — 혼조/전환; Elder 원저자 관례. macdLine과 같은 값이나 별 pane이라 공간상 겹치지 않음
 } as const;
 
 const PERIOD_COLOR_MAP: Record<number, string> = {

--- a/src/shared/lib/chartColors.ts
+++ b/src/shared/lib/chartColors.ts
@@ -159,6 +159,10 @@ export const CHART_COLORS = {
     // Regression (alpha는 r2로 런타임 계산)
     regressionUp: '#26a69a',
     regressionDown: '#ef5350',
+    // Elder Impulse (캔들 per-bar 색) — DESIGN.md teal/red + Elder blue 관례
+    impulseBullish: '#26a69a', // green — EMA↑ & MACD-hist↑
+    impulseBearish: '#ef5350', // red — 둘 다 ↓
+    impulseNeutral: '#3b82f6', // blue — 혼조/전환
 } as const;
 
 const PERIOD_COLOR_MAP: Record<number, string> = {

--- a/src/widgets/chart/StockChart.tsx
+++ b/src/widgets/chart/StockChart.tsx
@@ -59,6 +59,7 @@ import { useIndicatorVisibility } from './hooks/useIndicatorVisibility';
 import { OverlayLegend } from './OverlayLegend';
 import { buildPaneLabels } from './utils/paneLabelUtils';
 import { buildOverlayLabelConfigs } from './utils/overlayLabelUtils';
+import { buildCandlestickData } from './utils/candlestickDataUtils';
 import {
     EMA_DEFAULT_PERIODS,
     EMPTY_INDICATOR_RESULT,
@@ -180,18 +181,15 @@ export function StockChart({
         if (!seriesRef.current || !chartRef.current) return;
 
         seriesRef.current.setData(
-            bars.map(({ time, open, high, low, close }) => ({
-                // Bar.time은 number이지만 LWC setData는 UTCTimestamp(branded number)를 요구한다.
-                time: time as UTCTimestamp,
-                open,
-                high,
-                low,
-                close,
-            }))
+            buildCandlestickData(
+                bars,
+                indicators.elderImpulse,
+                visible.elderImpulse
+            )
         );
 
         chartRef.current.timeScale().fitContent();
-    }, [bars]);
+    }, [bars, indicators.elderImpulse, visible.elderImpulse]);
 
     const { visiblePeriods: maVisiblePeriods, togglePeriod: toggleMAPeriod } =
         useMAOverlay(commonHookParams);
@@ -609,6 +607,11 @@ export function StockChart({
                 meta: INDICATOR_META.regression,
                 active: visible.regression,
                 onToggle: () => toggle('regression'),
+            },
+            {
+                meta: INDICATOR_META.elderImpulse,
+                active: visible.elderImpulse,
+                onToggle: () => toggle('elderImpulse'),
             },
         ],
         // deps에 visible 객체 전체를 둔다 — 한 지표 토글 시 전체 binding이 재조립되지만

--- a/src/widgets/chart/StockChart.tsx
+++ b/src/widgets/chart/StockChart.tsx
@@ -178,7 +178,7 @@ export function StockChart({
     }, [timeframe]);
 
     useEffect(() => {
-        if (!seriesRef.current || !chartRef.current) return;
+        if (!seriesRef.current) return;
 
         seriesRef.current.setData(
             buildCandlestickData(
@@ -187,9 +187,13 @@ export function StockChart({
                 visible.elderImpulse
             )
         );
-
-        chartRef.current.timeScale().fitContent();
     }, [bars, indicators.elderImpulse, visible.elderImpulse]);
+
+    // fitContent는 bars(데이터 로드/심볼·타임프레임 변경) 변화에만 호출 — Elder Impulse 토글로
+    // setData가 재실행돼도 사용자의 줌/스크롤 상태가 초기화되지 않도록 의존성을 분리한다.
+    useEffect(() => {
+        chartRef.current?.timeScale().fitContent();
+    }, [bars]);
 
     const { visiblePeriods: maVisiblePeriods, togglePeriod: toggleMAPeriod } =
         useMAOverlay(commonHookParams);

--- a/src/widgets/chart/StockChart.tsx
+++ b/src/widgets/chart/StockChart.tsx
@@ -178,7 +178,7 @@ export function StockChart({
     }, [timeframe]);
 
     useEffect(() => {
-        if (!seriesRef.current) return;
+        if (!seriesRef.current || !chartRef.current) return;
 
         seriesRef.current.setData(
             buildCandlestickData(

--- a/src/widgets/chart/__tests__/StockChart.test.tsx
+++ b/src/widgets/chart/__tests__/StockChart.test.tsx
@@ -288,6 +288,7 @@ vi.mock('@/widgets/chart/hooks/useIndicatorVisibility', () => ({
             elderRay: false,
             squeezeMomentum: false,
             regression: false,
+            elderImpulse: false,
         },
         toggle: vi.fn(),
         paneIndices: INACTIVE_PANES,
@@ -341,6 +342,7 @@ vi.mock('@y0ngha/siglens-core', () => ({
         donchianChannel: [],
         squeezeMomentum: [],
         buySellVolume: [],
+        elderImpulse: [],
         smc: {
             orderBlocks: [],
             fairValueGaps: [],
@@ -426,13 +428,13 @@ describe('StockChart', () => {
         );
     });
 
-    it('renders IndicatorSettingsModal with 32 indicator bindings', () => {
+    it('renders IndicatorSettingsModal with 33 indicator bindings', () => {
         render(<StockChart bars={mockBars} timeframe="1Day" />);
         const modal = screen.getByTestId('indicator-settings-modal');
-        expect(modal).toHaveAttribute('data-count', '32');
+        expect(modal).toHaveAttribute('data-count', '33');
         expect(modal).toHaveAttribute(
             'data-keys',
-            'ma,ema,ichimoku,rsi,macd,dmi,stochastic,stochRsi,cci,bollinger,volumeProfile,mfi,williamsR,connorsRsi,cmf,bollingerPercentB,hurst,varianceRatio,macdV,forceIndex,obv,atr,yangZhang,ewmaVolatility,keltnerChannel,donchianChannel,supertrend,parabolicSar,chandelierExit,elderRay,squeezeMomentum,regression'
+            'ma,ema,ichimoku,rsi,macd,dmi,stochastic,stochRsi,cci,bollinger,volumeProfile,mfi,williamsR,connorsRsi,cmf,bollingerPercentB,hurst,varianceRatio,macdV,forceIndex,obv,atr,yangZhang,ewmaVolatility,keltnerChannel,donchianChannel,supertrend,parabolicSar,chandelierExit,elderRay,squeezeMomentum,regression,elderImpulse'
         );
     });
 

--- a/src/widgets/chart/__tests__/StockChart.test.tsx
+++ b/src/widgets/chart/__tests__/StockChart.test.tsx
@@ -32,6 +32,7 @@ const INACTIVE_PANES = Object.fromEntries(
         'elderRay',
         'squeezeMomentum',
         'regression',
+        'elderImpulse',
     ].map(k => [k, INACTIVE_PANE_INDEX])
 );
 

--- a/src/widgets/chart/__tests__/model/indicatorRegistry.test.ts
+++ b/src/widgets/chart/__tests__/model/indicatorRegistry.test.ts
@@ -14,8 +14,15 @@ function bindingFor(key: IndicatorKey, active = false): IndicatorBinding {
 }
 
 describe('indicatorRegistry', () => {
-    it('registers exactly the 32 modal-target indicators', () => {
-        expect(INDICATOR_REGISTRY).toHaveLength(32);
+    it('registers exactly the 33 modal-target indicators', () => {
+        expect(INDICATOR_REGISTRY).toHaveLength(33);
+    });
+
+    it('registers elderImpulse as a candle-paint indicator', () => {
+        const meta = INDICATOR_REGISTRY.find(m => m.key === 'elderImpulse');
+        expect(meta).toBeDefined();
+        expect(meta?.category).toBe('momentum');
+        expect(meta?.kind).toBe('candle-paint');
     });
 
     it('registers elderRay as a momentum pane', () => {

--- a/src/widgets/chart/__tests__/utils/candlestickDataUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/candlestickDataUtils.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type { Bar } from '@y0ngha/siglens-core';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import {
+    buildCandlestickData,
+    impulseColor,
+} from '@/widgets/chart/utils/candlestickDataUtils';
+
+function bar(time: number, close = 10): Bar {
+    return { time, open: 9, high: 11, low: 8, close, volume: 100 };
+}
+
+describe('impulseColor', () => {
+    it('maps green/red/blue to the impulse palette', () => {
+        expect(impulseColor('green')).toBe(CHART_COLORS.impulseBullish);
+        expect(impulseColor('red')).toBe(CHART_COLORS.impulseBearish);
+        expect(impulseColor('blue')).toBe(CHART_COLORS.impulseNeutral);
+    });
+});
+
+describe('buildCandlestickData', () => {
+    const bars: Bar[] = [bar(1), bar(2), bar(3)];
+
+    it('returns plain OHLC (no color fields) when impulse is inactive', () => {
+        const out = buildCandlestickData(bars, ['green', 'red', 'blue'], false);
+        expect(out).toEqual([
+            { time: 1, open: 9, high: 11, low: 8, close: 10 },
+            { time: 2, open: 9, high: 11, low: 8, close: 10 },
+            { time: 3, open: 9, high: 11, low: 8, close: 10 },
+        ]);
+        out.forEach(p => expect('color' in p).toBe(false));
+    });
+
+    it('injects color/borderColor/wickColor when active and color present', () => {
+        const out = buildCandlestickData([bar(1)], ['green'], true);
+        expect(out[0]).toEqual({
+            time: 1,
+            open: 9,
+            high: 11,
+            low: 8,
+            close: 10,
+            color: CHART_COLORS.impulseBullish,
+            borderColor: CHART_COLORS.impulseBullish,
+            wickColor: CHART_COLORS.impulseBullish,
+        });
+    });
+
+    it('leaves a bar plain when active but its impulse is null (warm-up)', () => {
+        const out = buildCandlestickData([bar(1), bar(2)], [null, 'red'], true);
+        expect('color' in out[0]).toBe(false);
+        expect(out[1].color).toBe(CHART_COLORS.impulseBearish);
+    });
+
+    it('leaves bars plain when the impulse array is shorter than bars', () => {
+        const out = buildCandlestickData([bar(1), bar(2)], ['green'], true);
+        expect(out[0].color).toBe(CHART_COLORS.impulseBullish);
+        expect('color' in out[1]).toBe(false); // index 1 → undefined → plain
+    });
+
+    it('returns [] for empty bars', () => {
+        expect(buildCandlestickData([], [], true)).toEqual([]);
+    });
+});

--- a/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
@@ -55,6 +55,7 @@ function makePaneIndices(overrides: Partial<PaneIndices> = {}): PaneIndices {
         elderRay: INACTIVE_PANE_INDEX,
         squeezeMomentum: INACTIVE_PANE_INDEX,
         regression: INACTIVE_PANE_INDEX,
+        elderImpulse: INACTIVE_PANE_INDEX,
     } satisfies PaneIndices;
     return { ...base, ...overrides };
 }

--- a/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
@@ -18,9 +18,8 @@ import {
 import type { PaneIndices } from '@/widgets/chart/types';
 import { INACTIVE_PANE_INDEX } from '@/widgets/chart/constants';
 
-// PaneIndices는 모든 IndicatorKey(26개)를 가진 Record다. buildPaneLabels가
-// 읽는 건 13개 pane 키뿐이므로, 나머지 overlay 키(ma·ema·ichimoku·bollinger·volumeProfile·keltnerChannel·donchianChannel)와
-// 아직 렌더되지 않는 group-C pane 키를 INACTIVE로 채운 base에 해당 pane 키만 덮어쓴다.
+// PaneIndices는 모든 IndicatorKey를 가진 Record다. buildPaneLabels가 읽는 건 pane 키뿐이므로,
+// 나머지 overlay·candle-paint 키를 INACTIVE로 채운 base에 해당 pane 키만 덮어쓴다.
 function makePaneIndices(overrides: Partial<PaneIndices> = {}): PaneIndices {
     const base = {
         ma: INACTIVE_PANE_INDEX,

--- a/src/widgets/chart/model/indicatorRegistry.ts
+++ b/src/widgets/chart/model/indicatorRegistry.ts
@@ -15,7 +15,7 @@ export type IndicatorCategory =
     | 'statistical'
     | 'smc';
 
-export type IndicatorKind = 'overlay' | 'pane';
+export type IndicatorKind = 'overlay' | 'pane' | 'candle-paint';
 
 export type IndicatorKey =
     | 'ma'
@@ -49,7 +49,8 @@ export type IndicatorKey =
     | 'chandelierExit'
     | 'elderRay'
     | 'squeezeMomentum'
-    | 'regression';
+    | 'regression'
+    | 'elderImpulse';
 
 export interface IndicatorMeta {
     key: IndicatorKey;
@@ -213,6 +214,12 @@ export const INDICATOR_REGISTRY: readonly IndicatorMeta[] = [
         label: 'Regression',
         category: 'statistical',
         kind: 'pane',
+    },
+    {
+        key: 'elderImpulse',
+        label: 'Elder Impulse',
+        category: 'momentum',
+        kind: 'candle-paint',
     },
 ];
 

--- a/src/widgets/chart/utils/candlestickDataUtils.ts
+++ b/src/widgets/chart/utils/candlestickDataUtils.ts
@@ -20,23 +20,18 @@ export function buildCandlestickData(
     elderImpulse: (ImpulseColor | null)[],
     isImpulseActive: boolean
 ): CandlestickData<UTCTimestamp>[] {
-    return bars
-        .map(bar => {
-            const base: CandlestickData<UTCTimestamp> = {
-                // Bar.time은 epoch seconds 정수 — LWC UTCTimestamp(branded number)와 런타임 형태 동일.
-                time: bar.time as UTCTimestamp,
-                open: bar.open,
-                high: bar.high,
-                low: bar.low,
-                close: bar.close,
-            };
-            return base;
-        })
-        .map((base, i) => {
-            if (!isImpulseActive) return base;
-            const impulse = elderImpulse[i];
-            if (impulse == null) return base;
-            const color = impulseColor(impulse);
-            return { ...base, color, borderColor: color, wickColor: color };
-        });
+    return bars.map((bar, i) => {
+        const base: CandlestickData<UTCTimestamp> = {
+            // Bar.time은 epoch seconds 정수 — LWC UTCTimestamp(branded number)와 런타임 형태 동일.
+            time: bar.time as UTCTimestamp,
+            open: bar.open,
+            high: bar.high,
+            low: bar.low,
+            close: bar.close,
+        };
+        const impulse = isImpulseActive ? elderImpulse[i] : null;
+        if (impulse == null) return base; // 비활성·warm-up·범위 밖 → 시리즈 기본 bull/bear 색
+        const color = impulseColor(impulse);
+        return { ...base, color, borderColor: color, wickColor: color };
+    });
 }

--- a/src/widgets/chart/utils/candlestickDataUtils.ts
+++ b/src/widgets/chart/utils/candlestickDataUtils.ts
@@ -1,0 +1,42 @@
+import type { CandlestickData, UTCTimestamp } from 'lightweight-charts';
+import type { Bar, ImpulseColor } from '@y0ngha/siglens-core';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+
+/** Elder Impulse 색 매핑: green=강세(teal), red=약세(red), blue=혼조(blue). */
+export function impulseColor(c: ImpulseColor): string {
+    if (c === 'green') return CHART_COLORS.impulseBullish;
+    if (c === 'red') return CHART_COLORS.impulseBearish;
+    return CHART_COLORS.impulseNeutral;
+}
+
+/**
+ * 메인 캔들스틱 시리즈 데이터를 만든다. Elder Impulse가 활성이고 해당 bar의 색이
+ * 있으면 per-bar color/borderColor/wickColor를 주입해 시리즈 기본 bull/bear 색을
+ * override한다. 비활성이거나 warm-up(null)·배열 범위 밖이면 plain OHLC를 반환해
+ * 시리즈 기본 색이 그대로 적용되게 한다.
+ */
+export function buildCandlestickData(
+    bars: Bar[],
+    elderImpulse: (ImpulseColor | null)[],
+    isImpulseActive: boolean
+): CandlestickData<UTCTimestamp>[] {
+    return bars
+        .map(bar => {
+            const base: CandlestickData<UTCTimestamp> = {
+                // Bar.time은 epoch seconds 정수 — LWC UTCTimestamp(branded number)와 런타임 형태 동일.
+                time: bar.time as UTCTimestamp,
+                open: bar.open,
+                high: bar.high,
+                low: bar.low,
+                close: bar.close,
+            };
+            return base;
+        })
+        .map((base, i) => {
+            if (!isImpulseActive) return base;
+            const impulse = elderImpulse[i];
+            if (impulse == null) return base;
+            const color = impulseColor(impulse);
+            return { ...base, color, borderColor: color, wickColor: color };
+        });
+}

--- a/src/widgets/chart/utils/candlestickDataUtils.ts
+++ b/src/widgets/chart/utils/candlestickDataUtils.ts
@@ -2,11 +2,20 @@ import type { CandlestickData, UTCTimestamp } from 'lightweight-charts';
 import type { Bar, ImpulseColor } from '@y0ngha/siglens-core';
 import { CHART_COLORS } from '@/shared/lib/chartColors';
 
-/** Elder Impulse 색 매핑: green=강세(teal), red=약세(red), blue=혼조(blue). */
+/**
+ * Elder Impulse 색 매핑: green=강세(teal), red=약세(red), blue=혼조(blue).
+ * switch로 exhaustive하게 둬, core가 ImpulseColor 유니온을 확장하면 컴파일타임에
+ * "not all paths return"으로 잡히게 한다(조용한 neutral fallthrough 방지).
+ */
 export function impulseColor(c: ImpulseColor): string {
-    if (c === 'green') return CHART_COLORS.impulseBullish;
-    if (c === 'red') return CHART_COLORS.impulseBearish;
-    return CHART_COLORS.impulseNeutral;
+    switch (c) {
+        case 'green':
+            return CHART_COLORS.impulseBullish;
+        case 'red':
+            return CHART_COLORS.impulseBearish;
+        case 'blue':
+            return CHART_COLORS.impulseNeutral;
+    }
 }
 
 /**


### PR DESCRIPTION
## 요약
미사용 보조지표 렌더링 8차(그룹 D-1). **elderImpulse**를 메인 캔들스틱 시리즈의 per-bar 색(green/red/blue)으로 렌더한다. 지금까지의 작업(별도 overlay/pane 시리즈)과 달리, 기존 캔들 시리즈 데이터에 per-bar `color`/`borderColor`/`wickColor`를 주입하는 신규 메커니즘(레지스트리 kind `candle-paint`)이다. green=EMA↑&MACD-hist↑(강세), red=둘 다↓(약세), blue=혼조.

계산은 `@y0ngha/siglens-core`에 있어 코어 변경 없음. 그룹 D 나머지(smc zone)는 렌더 메커니즘이 disjoint하여 별도 PR로 진행한다.

## 변경 사항
- `utils/candlestickDataUtils.ts`: `impulseColor`(green/red/blue→팔레트) + `buildCandlestickData`(활성+색→per-bar 색 주입, 비활성·warm-up null·범위 밖→plain OHLC로 기본 bull/bear 복원)
- `model/indicatorRegistry.ts`: 신규 kind `candle-paint` + elderImpulse 등록(32→33). candle-paint은 pane index 미할당
- `shared/lib/chartColors.ts` + `globals.css`: impulseBullish/Bearish/Neutral + @theme
- `StockChart.tsx`: 캔들 setData를 `buildCandlestickData(bars, indicators.elderImpulse, visible.elderImpulse)`로 변경 + binding 1개(33)
- `e2e/specs/chart-indicators.spec.ts`: 모달 토글 E2E

## 검증
- vitest 전체 커버리지 게이트 통과(branches 91.33%, lines 96.18%)
- lint / prettier --check / production build 전부 통과
- 내부 review-agent(Opus): round 1 recommended 2건(단일 map 리팩터·주석 key-count drift) 반영 → round 2 APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)