### PR TITLE
feat(chart): render SMC premium/discount/equilibrium zones (finish unused-indicator rendering)

### DIFF
--- a/docs/superpowers/plans/2026-06-07-render-smc-zones.md
+++ b/docs/superpowers/plans/2026-06-07-render-smc-zones.md
@@ -1,0 +1,699 @@
+# SMC Zones (zone kind) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render SMC premium/discount/equilibrium price bands as price lines on the main candlestick series when toggled on.
+
+**Architecture:** SMC zones are drawn with `series.createPriceLine` on the existing candlestick series — mirroring `useActionRecommendationOverlay` (seriesRef + priceLinesRef[] + isVisible gating + remove-all-and-recreate on change). A pure `buildSmcZoneLines(smc)` helper converts the SMCResult zones into price-line specs (premium/discount as high+low bands, equilibrium as a single 50% midline). A new registry kind `zone` (not a pane, not a separate series) carries it. Computation is in `@y0ngha/siglens-core` (unchanged).
+
+**Tech Stack:** TypeScript, React 19, lightweight-charts 5.2.0 (`createPriceLine`/`removePriceLine`), Vitest + RTL, Playwright (E2E).
+
+**Spec:** `docs/superpowers/specs/2026-06-07-render-smc-zones-design.md`
+**Branch:** `feat/render-smc-zones` (base: `feat/render-elder-impulse` = PR #587)
+**Worktree:** `/Users/y0ngha/Project/siglens-smc-zones`
+
+**Data shapes (siglens-core):**
+```ts
+type SMCZoneType = 'premium' | 'discount' | 'equilibrium';
+interface SMCZone { high: number; low: number; type: SMCZoneType; }
+// SMCResult.premiumZone / discountZone / equilibriumZone: SMCZone | null
+// IndicatorResult.smc: SMCResult
+```
+
+**Reference / key existing code:**
+- `src/widgets/chart/hooks/useActionRecommendationOverlay.ts` — the createPriceLine pattern (seriesRef, priceLinesRef, isVisible, remove-all + recreate). EXACT template.
+- StockChart: `seriesRef` (candle series, line ~110); `useActionRecommendationOverlay({ seriesRef, ..., isVisible })` call at line ~362; `INDICATOR_META` imported (line 70); last binding `elderImpulse` (line ~615); `indicatorBindings` deps already include `visible`/`toggle`.
+- `CHART_COLORS` ends after `impulseNeutral` (chartColors.ts:165, `} as const` at 166). globals.css impulse tokens at 77–78.
+- `IndicatorKind = 'overlay' | 'pane' | 'candle-paint'` (indicatorRegistry.ts). `smc` category already in `CATEGORY_LABELS` ('SMC').
+
+---
+
+## File Structure
+
+- `src/shared/lib/chartColors.ts` + `src/app/globals.css` — 3 smc colors + @theme tokens (modify).
+- `src/widgets/chart/utils/smcZoneUtils.ts` (+ test) — `buildSmcZoneLines` (create).
+- `src/widgets/chart/model/indicatorRegistry.ts` (+ tests, + paneLabelUtils test) — IndicatorKind += 'zone', IndicatorKey += smc, 33→34 (modify).
+- `src/widgets/chart/hooks/useSmcZones.ts` (+ test) — price-line hook (create).
+- `src/widgets/chart/StockChart.tsx` (+ test) — useSmcZones call + 1 binding (34) (modify).
+- `e2e/specs/chart-indicators.spec.ts` — modal-checkbox toggle test (modify).
+
+---
+
+## Task 0: Worktree node_modules verify
+
+**Files:** none
+
+- [ ] **Step 1:** This worktree was clean-installed (NOT hardlinked) to match the pinned `@y0ngha/siglens-core@0.20.0`. Verify:
+```bash
+cd /Users/y0ngha/Project/siglens-smc-zones
+grep '"version"' node_modules/@y0ngha/siglens-core/package.json | head -1
+```
+Expected: `0.20.0`. If it shows `0.21.1` or node_modules is missing: `rm -rf node_modules && yarn install` (do NOT `cp -al` from the main repo — its core drifted to 0.21.1).
+
+- [ ] **Step 2:** `cd /Users/y0ngha/Project/siglens-smc-zones && yarn vitest run src/widgets/chart/__tests__/hooks/useActionRecommendationOverlay.test.ts` → PASS (confirms toolchain + the reference hook's test).
+
+---
+
+## Task 1: Add SMC zone colors
+
+**Files:**
+- Modify: `src/shared/lib/chartColors.ts`
+- Modify: `src/app/globals.css`
+
+- [ ] **Step 1: Collision guard**
+```bash
+cd /Users/y0ngha/Project/siglens-smc-zones
+grep -rn "smcPremium\|smcDiscount\|smcEquilibrium" src/ || echo "KEYS UNUSED — safe"
+```
+Expected: `KEYS UNUSED — safe`.
+
+- [ ] **Step 2:** In `src/shared/lib/chartColors.ts`, immediately AFTER the `impulseNeutral: ...` line (the last entry before `} as const;`), add:
+```ts
+    // SMC zones (가격 밴드 경계선) — DESIGN.md bearish/bullish/neutral 매핑
+    smcPremium: '#ef5350', // 매도/저항 상단
+    smcDiscount: '#26a69a', // 매수/지지 하단
+    smcEquilibrium: '#94a3b8', // 50% 공정가 (neutral)
+```
+
+- [ ] **Step 3:** In `src/app/globals.css`, AFTER the `--color-chart-impulse-neutral: #3b82f6;` line, add:
+```css
+    /* Chart — SMC zones */
+    --color-chart-smc-premium: #ef5350;
+    --color-chart-smc-discount: #26a69a;
+    --color-chart-smc-equilibrium: #94a3b8;
+```
+
+- [ ] **Step 4:** Verify:
+```bash
+cd /Users/y0ngha/Project/siglens-smc-zones && yarn lint src/shared/lib/chartColors.ts && npx prettier --check src/shared/lib/chartColors.ts src/app/globals.css
+```
+Expected: clean.
+
+- [ ] **Step 5: Commit** (DO NOT --no-verify; hook must pass)
+```bash
+git add src/shared/lib/chartColors.ts src/app/globals.css
+git commit -m "feat(chart): add SMC zone colors"
+```
+
+---
+
+## Task 2: `buildSmcZoneLines` helper
+
+**Files:**
+- Create: `src/widgets/chart/utils/smcZoneUtils.ts`
+- Test: `src/widgets/chart/__tests__/utils/smcZoneUtils.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/widgets/chart/__tests__/utils/smcZoneUtils.test.ts`:
+```ts
+import { describe, expect, it } from 'vitest';
+import type { SMCResult } from '@y0ngha/siglens-core';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import { buildSmcZoneLines } from '@/widgets/chart/utils/smcZoneUtils';
+
+function smc(overrides: Partial<SMCResult>): SMCResult {
+    return {
+        swingHighs: [],
+        swingLows: [],
+        orderBlocks: [],
+        fairValueGaps: [],
+        equalHighs: [],
+        equalLows: [],
+        premiumZone: null,
+        discountZone: null,
+        equilibriumZone: null,
+        structureBreaks: [],
+        ...overrides,
+    };
+}
+
+describe('buildSmcZoneLines', () => {
+    it('returns [] for undefined smc', () => {
+        expect(buildSmcZoneLines(undefined)).toEqual([]);
+    });
+
+    it('returns [] when all zones are null', () => {
+        expect(buildSmcZoneLines(smc({}))).toEqual([]);
+    });
+
+    it('builds 5 lines when all three zones present (premium/discount 2 each + equilibrium 1)', () => {
+        const out = buildSmcZoneLines(
+            smc({
+                premiumZone: { high: 110, low: 105, type: 'premium' },
+                discountZone: { high: 95, low: 90, type: 'discount' },
+                equilibriumZone: { high: 101, low: 99, type: 'equilibrium' },
+            })
+        );
+        expect(out).toEqual([
+            { price: 110, color: CHART_COLORS.smcPremium, title: 'Premium' },
+            { price: 105, color: CHART_COLORS.smcPremium, title: '' },
+            { price: 95, color: CHART_COLORS.smcDiscount, title: 'Discount' },
+            { price: 90, color: CHART_COLORS.smcDiscount, title: '' },
+            { price: 100, color: CHART_COLORS.smcEquilibrium, title: 'Equilibrium' },
+        ]);
+    });
+
+    it('equilibrium line uses the (high+low)/2 midpoint', () => {
+        const out = buildSmcZoneLines(
+            smc({ equilibriumZone: { high: 102, low: 98, type: 'equilibrium' } })
+        );
+        expect(out).toEqual([
+            { price: 100, color: CHART_COLORS.smcEquilibrium, title: 'Equilibrium' },
+        ]);
+    });
+
+    it('skips null zones independently (premium only)', () => {
+        const out = buildSmcZoneLines(
+            smc({ premiumZone: { high: 110, low: 105, type: 'premium' } })
+        );
+        expect(out).toEqual([
+            { price: 110, color: CHART_COLORS.smcPremium, title: 'Premium' },
+            { price: 105, color: CHART_COLORS.smcPremium, title: '' },
+        ]);
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+`cd /Users/y0ngha/Project/siglens-smc-zones && yarn vitest run src/widgets/chart/__tests__/utils/smcZoneUtils.test.ts` → FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+Create `src/widgets/chart/utils/smcZoneUtils.ts`:
+```ts
+import type { SMCResult } from '@y0ngha/siglens-core';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+
+export interface SmcZoneLine {
+    price: number;
+    color: string;
+    title: string;
+}
+
+/**
+ * SMC premium/discount/equilibrium 존을 가격선 스펙으로 변환한다.
+ * premium·discount는 high/low 밴드(2선, 대표 high선에만 title), equilibrium은 50% 공정가 1선.
+ * null 존은 스킵 — 최대 5선.
+ */
+export function buildSmcZoneLines(smc: SMCResult | undefined): SmcZoneLine[] {
+    if (!smc) return [];
+    const lines: SmcZoneLine[] = [];
+    const { premiumZone, discountZone, equilibriumZone } = smc;
+    if (premiumZone) {
+        lines.push({
+            price: premiumZone.high,
+            color: CHART_COLORS.smcPremium,
+            title: 'Premium',
+        });
+        lines.push({
+            price: premiumZone.low,
+            color: CHART_COLORS.smcPremium,
+            title: '',
+        });
+    }
+    if (discountZone) {
+        lines.push({
+            price: discountZone.high,
+            color: CHART_COLORS.smcDiscount,
+            title: 'Discount',
+        });
+        lines.push({
+            price: discountZone.low,
+            color: CHART_COLORS.smcDiscount,
+            title: '',
+        });
+    }
+    if (equilibriumZone) {
+        lines.push({
+            price: (equilibriumZone.high + equilibriumZone.low) / 2,
+            color: CHART_COLORS.smcEquilibrium,
+            title: 'Equilibrium',
+        });
+    }
+    return lines;
+}
+```
+
+- [ ] **Step 4: Run + tsc + lint**
+```bash
+cd /Users/y0ngha/Project/siglens-smc-zones
+npx tsc --noEmit
+yarn vitest run src/widgets/chart/__tests__/utils/smcZoneUtils.test.ts
+yarn lint src/widgets/chart/utils/smcZoneUtils.ts src/widgets/chart/__tests__/utils/smcZoneUtils.test.ts
+```
+Expected: all clean/PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/widgets/chart/utils/smcZoneUtils.ts src/widgets/chart/__tests__/utils/smcZoneUtils.test.ts
+git commit -m "feat(chart): add buildSmcZoneLines helper"
+```
+
+---
+
+## Task 3: Register smc (new `zone` kind)
+
+**Files:**
+- Modify: `src/widgets/chart/model/indicatorRegistry.ts`
+- Modify: `src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`
+- Modify: `src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts`
+
+- [ ] **Step 1: Write the failing registry tests**
+
+In `src/widgets/chart/__tests__/model/indicatorRegistry.test.ts`: change `toHaveLength(33)` → `toHaveLength(34)`; add:
+```ts
+it('registers smc as a zone indicator in the smc category', () => {
+    const meta = INDICATOR_REGISTRY.find(m => m.key === 'smc');
+    expect(meta).toBeDefined();
+    expect(meta?.category).toBe('smc');
+    expect(meta?.kind).toBe('zone');
+});
+
+it('groupBindingsByCategory surfaces the SMC group once an smc binding exists', () => {
+    const groups = groupBindingsByCategory([
+        { meta: INDICATOR_META.smc, active: false, onToggle: () => {} },
+    ]);
+    expect(groups.find(g => g.category === 'smc')?.label).toBe('SMC');
+});
+```
+(Ensure `groupBindingsByCategory` and `INDICATOR_META` are imported in this test file — add to the existing import if missing.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+`cd /Users/y0ngha/Project/siglens-smc-zones && yarn vitest run src/widgets/chart/__tests__/model/indicatorRegistry.test.ts` → FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `src/widgets/chart/model/indicatorRegistry.ts`:
+(a) Extend the kind union:
+```ts
+export type IndicatorKind = 'overlay' | 'pane' | 'candle-paint' | 'zone';
+```
+(b) In `IndicatorKey`, after `| 'elderImpulse'`, change the terminator to:
+```ts
+    | 'elderImpulse'
+    | 'smc';
+```
+(c) In `INDICATOR_REGISTRY`, after the `elderImpulse` entry (last, before `];`), add:
+```ts
+    { key: 'smc', label: 'SMC Zones', category: 'smc', kind: 'zone' },
+```
+
+- [ ] **Step 4: Verify registry test PASS**
+
+`cd /Users/y0ngha/Project/siglens-smc-zones && yarn vitest run src/widgets/chart/__tests__/model/indicatorRegistry.test.ts` → PASS.
+
+- [ ] **Step 5: Fix makePaneIndices fallout**
+
+In `src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts` `makePaneIndices` base object, after `elderImpulse: INACTIVE_PANE_INDEX,`, add:
+```ts
+        smc: INACTIVE_PANE_INDEX,
+```
+
+- [ ] **Step 6: tsc + tests**
+```bash
+cd /Users/y0ngha/Project/siglens-smc-zones
+npx tsc --noEmit
+yarn vitest run src/widgets/chart/__tests__/model/indicatorRegistry.test.ts src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts src/widgets/chart/__tests__/hooks/useIndicatorVisibility.test.ts
+```
+tsc clean; all PASS. If tsc flags OTHER `Record<IndicatorKey>` sites missing `smc`, fix each (report). Confirm `visible.smc` initializes false and `zone` gets no pane index.
+
+- [ ] **Step 7: Lint**
+```bash
+cd /Users/y0ngha/Project/siglens-smc-zones && yarn lint src/widgets/chart/model/indicatorRegistry.ts src/widgets/chart/__tests__/model/indicatorRegistry.test.ts src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+```
+
+- [ ] **Step 8: Commit**
+```bash
+git add src/widgets/chart/model/indicatorRegistry.ts src/widgets/chart/__tests__/model/indicatorRegistry.test.ts src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+git commit -m "feat(chart): register smc (zone kind, surfaces SMC modal group)"
+```
+
+---
+
+## Task 4: `useSmcZones` hook
+
+**Files:**
+- Create: `src/widgets/chart/hooks/useSmcZones.ts`
+- Test: `src/widgets/chart/__tests__/hooks/useSmcZones.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/widgets/chart/__tests__/hooks/useSmcZones.test.ts`:
+```ts
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { IndicatorResult, SMCResult } from '@y0ngha/siglens-core';
+import { useSmcZones } from '../../hooks/useSmcZones';
+import { buildSmcZoneLines } from '../../utils/smcZoneUtils';
+
+const mockCreatePriceLine = vi.fn(() => ({ id: 'pl' }));
+const mockRemovePriceLine = vi.fn();
+
+vi.mock('lightweight-charts', () => ({
+    LineStyle: { Dashed: 2 },
+}));
+
+function makeSeriesRef(series: unknown = makeSeries()) {
+    return { current: series } as Parameters<
+        typeof useSmcZones
+    >[0]['seriesRef'];
+}
+function makeSeries() {
+    return {
+        createPriceLine: mockCreatePriceLine,
+        removePriceLine: mockRemovePriceLine,
+    };
+}
+
+function smc(overrides: Partial<SMCResult>): SMCResult {
+    return {
+        swingHighs: [],
+        swingLows: [],
+        orderBlocks: [],
+        fairValueGaps: [],
+        equalHighs: [],
+        equalLows: [],
+        premiumZone: null,
+        discountZone: null,
+        equilibriumZone: null,
+        structureBreaks: [],
+        ...overrides,
+    };
+}
+
+const THREE_ZONES = smc({
+    premiumZone: { high: 110, low: 105, type: 'premium' },
+    discountZone: { high: 95, low: 90, type: 'discount' },
+    equilibriumZone: { high: 101, low: 99, type: 'equilibrium' },
+});
+
+describe('useSmcZones', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('does not create lines when series is null', () => {
+        renderHook(() =>
+            useSmcZones({
+                seriesRef: makeSeriesRef(null),
+                smc: THREE_ZONES,
+                isVisible: true,
+            })
+        );
+        expect(mockCreatePriceLine).not.toHaveBeenCalled();
+    });
+
+    it('creates 5 price lines for three zones when visible', () => {
+        renderHook(() =>
+            useSmcZones({
+                seriesRef: makeSeriesRef(),
+                smc: THREE_ZONES,
+                isVisible: true,
+            })
+        );
+        expect(mockCreatePriceLine).toHaveBeenCalledTimes(5);
+    });
+
+    it('does not create lines when not visible', () => {
+        renderHook(() =>
+            useSmcZones({
+                seriesRef: makeSeriesRef(),
+                smc: THREE_ZONES,
+                isVisible: false,
+            })
+        );
+        expect(mockCreatePriceLine).not.toHaveBeenCalled();
+    });
+
+    it('does not create lines when there are no zones', () => {
+        renderHook(() =>
+            useSmcZones({
+                seriesRef: makeSeriesRef(),
+                smc: smc({}),
+                isVisible: true,
+            })
+        );
+        expect(mockCreatePriceLine).not.toHaveBeenCalled();
+    });
+
+    it('removes existing lines when toggled off', () => {
+        const series = makeSeries();
+        const { rerender } = renderHook(props => useSmcZones(props), {
+            initialProps: {
+                seriesRef: makeSeriesRef(series),
+                smc: THREE_ZONES,
+                isVisible: true,
+            },
+        });
+        rerender({
+            seriesRef: makeSeriesRef(series),
+            smc: THREE_ZONES,
+            isVisible: false,
+        });
+        expect(mockRemovePriceLine).toHaveBeenCalledTimes(5);
+    });
+
+    it('passes the first line spec from buildSmcZoneLines to createPriceLine', () => {
+        renderHook(() =>
+            useSmcZones({
+                seriesRef: makeSeriesRef(),
+                smc: THREE_ZONES,
+                isVisible: true,
+            })
+        );
+        const expected = buildSmcZoneLines(THREE_ZONES)[0];
+        expect(mockCreatePriceLine).toHaveBeenCalledWith(
+            expect.objectContaining({
+                price: expected.price,
+                color: expected.color,
+                title: expected.title,
+            })
+        );
+    });
+});
+```
+NOTE: this test does NOT mock `../../utils/smcZoneUtils` — it uses the real `buildSmcZoneLines` so the wiring (line specs → createPriceLine args) is verified end-to-end. `IndicatorResult` import is only for typing if needed; remove it if unused to avoid a lint warning.
+
+- [ ] **Step 2: Run to verify it fails**
+
+`cd /Users/y0ngha/Project/siglens-smc-zones && yarn vitest run src/widgets/chart/__tests__/hooks/useSmcZones.test.ts` → FAIL.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `src/widgets/chart/hooks/useSmcZones.ts`:
+```ts
+'use client';
+
+import type { RefObject } from 'react';
+import { useEffect, useRef } from 'react';
+import type {
+    IPriceLine,
+    ISeriesApi,
+    LineWidth,
+    UTCTimestamp,
+} from 'lightweight-charts';
+import { LineStyle } from 'lightweight-charts';
+import type { SMCResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { buildSmcZoneLines } from '../utils/smcZoneUtils';
+
+interface UseSmcZonesParams {
+    seriesRef: RefObject<ISeriesApi<'Candlestick', UTCTimestamp> | null>;
+    smc: SMCResult | undefined;
+    isVisible: boolean;
+    lineWidth?: LineWidth;
+}
+
+export function useSmcZones({
+    seriesRef,
+    smc,
+    isVisible,
+    lineWidth = DEFAULT_LINE_WIDTH,
+}: UseSmcZonesParams): void {
+    const priceLinesRef = useRef<IPriceLine[]>([]);
+
+    useEffect(() => {
+        const series = seriesRef.current;
+
+        priceLinesRef.current.forEach(pl => series?.removePriceLine(pl));
+        priceLinesRef.current = [];
+
+        if (!series || !isVisible) return;
+
+        const lines = buildSmcZoneLines(smc);
+        if (lines.length === 0) return;
+
+        priceLinesRef.current = lines.map(line =>
+            series.createPriceLine({
+                price: line.price,
+                color: line.color,
+                lineWidth,
+                lineStyle: LineStyle.Dashed,
+                // 대표선(title 있음)만 축 라벨 표시 — 밴드 하단선 라벨 중복으로 축 혼잡해지는 것 방지.
+                axisLabelVisible: line.title !== '',
+                title: line.title,
+            })
+        );
+    }, [smc, isVisible, lineWidth, seriesRef]);
+}
+```
+
+- [ ] **Step 4: Run + tsc + lint**
+```bash
+cd /Users/y0ngha/Project/siglens-smc-zones
+npx tsc --noEmit
+yarn vitest run src/widgets/chart/__tests__/hooks/useSmcZones.test.ts
+yarn lint src/widgets/chart/hooks/useSmcZones.ts src/widgets/chart/__tests__/hooks/useSmcZones.test.ts
+```
+Expected: all clean/PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/widgets/chart/hooks/useSmcZones.ts src/widgets/chart/__tests__/hooks/useSmcZones.test.ts
+git commit -m "feat(chart): add useSmcZones hook (price-line bands)"
+```
+
+---
+
+## Task 5: Wire into StockChart
+
+**Files:**
+- Modify: `src/widgets/chart/StockChart.tsx`
+- Modify: `src/widgets/chart/__tests__/StockChart.test.tsx`
+
+- [ ] **Step 1: Import + call the hook**
+
+In `src/widgets/chart/StockChart.tsx`, add the import near other hook imports (after `useActionRecommendationOverlay`):
+```ts
+import { useSmcZones } from './hooks/useSmcZones';
+```
+Add the hook call right after the `useActionRecommendationOverlay({...})` call (~line 368):
+```ts
+    useSmcZones({
+        seriesRef,
+        smc: indicators.smc,
+        isVisible: visible.smc,
+    });
+```
+
+- [ ] **Step 2: Add the binding (33→34)**
+
+In the `indicatorBindings` useMemo, after the `elderImpulse` binding (last entry), add:
+```ts
+            {
+                meta: INDICATOR_META.smc,
+                active: visible.smc,
+                onToggle: () => toggle('smc'),
+            },
+```
+`visible`/`toggle` are already in the useMemo deps.
+
+- [ ] **Step 3: tsc + chart suite**
+```bash
+cd /Users/y0ngha/Project/siglens-smc-zones
+npx tsc --noEmit
+yarn vitest run src/widgets/chart
+```
+tsc clean; tests PASS. In `src/widgets/chart/__tests__/StockChart.test.tsx`:
+- Update the binding-count test (name + `data-count`) from 33 to 34, append `,smc` to expected `data-keys` (after `elderImpulse`).
+- Add `'smc'` to the `INACTIVE_PANES` array.
+- Add `smc: false` to the `useIndicatorVisibility` `visible` mock.
+- The mock `EMPTY_INDICATOR_RESULT` (or equivalent `indicators` mock) needs a `smc` field that is a valid SMCResult-shaped object (all-null zones) since `useSmcZones` reads `indicators.smc` — if the test's indicators mock lacks `smc`, add a minimal `smc: { swingHighs: [], swingLows: [], orderBlocks: [], fairValueGaps: [], equalHighs: [], equalLows: [], premiumZone: null, discountZone: null, equilibriumZone: null, structureBreaks: [] }`. (If the real `EMPTY_INDICATOR_RESULT` from core is used and already includes `smc`, nothing to add — confirm.)
+Report exactly what you changed.
+
+- [ ] **Step 4: Lint**
+```bash
+cd /Users/y0ngha/Project/siglens-smc-zones && yarn lint src/widgets/chart/StockChart.tsx
+```
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/widgets/chart/StockChart.tsx src/widgets/chart/__tests__/StockChart.test.tsx
+git commit -m "feat(chart): wire SMC zones into StockChart (34 bindings)"
+```
+
+---
+
+## Task 6: E2E modal toggle
+
+**Files:**
+- Modify: `e2e/specs/chart-indicators.spec.ts`
+
+- [ ] **Step 1: Add the toggle test**
+
+SMC zones are price lines (no pane label, no overlay legend) — verify via the modal checkbox state. Add immediately after the LAST existing test in the `test.describe('chart indicator settings modal', ...)` block, before its closing `});` (READ the file to locate it). `GEAR` is the const at the top of the describe.
+```ts
+
+    test('toggles SMC Zones via the modal', async ({ page }) => {
+        await page.goto('/AAPL');
+        await page.getByRole('button', { name: GEAR }).click();
+        const dialog = page.getByRole('dialog');
+        // SMC Zones는 가격선(zone) — pane/overlay 라벨이 없어 모달 체크박스 상태로 검증한다.
+        // 'SMC' 카테고리 그룹이 이 지표 등록으로 처음 모달에 노출된다.
+        await expect(dialog.getByText('SMC')).toBeVisible();
+        const smc = dialog.getByRole('checkbox', {
+            name: 'SMC Zones',
+            exact: true,
+        });
+        await expect(smc).not.toBeChecked();
+        await smc.check();
+        await expect(smc).toBeChecked();
+    });
+```
+
+- [ ] **Step 2: Lint + tsc**
+```bash
+cd /Users/y0ngha/Project/siglens-smc-zones && yarn lint e2e/specs/chart-indicators.spec.ts && npx tsc --noEmit
+```
+Expected: clean. (Do NOT run Playwright locally — shared docker backend; CI is the gate.)
+
+- [ ] **Step 3: Commit**
+```bash
+git add e2e/specs/chart-indicators.spec.ts
+git commit -m "test(e2e): toggle SMC Zones from settings modal"
+```
+
+---
+
+## Task 7: Final verification + review handoff
+
+**Files:** none
+
+- [ ] **Step 1: Full coverage suite**
+
+`cd /Users/y0ngha/Project/siglens-smc-zones && yarn test-coverage > /tmp/smc-cov.log 2>&1; echo "EXIT=$?"; tail -8 /tmp/smc-cov.log`
+Expected: `EXIT=0`, thresholds (90%+) met.
+
+- [ ] **Step 2: Lint + format (whole repo)**
+
+`cd /Users/y0ngha/Project/siglens-smc-zones && yarn lint && npx prettier --check .`
+Expected: no errors.
+
+- [ ] **Step 3: Production build (capture exit code directly)**
+
+`cd /Users/y0ngha/Project/siglens-smc-zones && yarn build > /tmp/smc-build.log 2>&1; echo "EXIT=$?"; tail -12 /tmp/smc-build.log`
+Expected: `EXIT=0`.
+
+- [ ] **Step 4: Hand off to review**
+
+Per CLAUDE.md routing: invoke `review-agent` (Opus 4.8) on branch `feat/render-smc-zones`, then `mistake-managing-agent`, then `git-agent` to push and open the PR stacked on `feat/render-elder-impulse` (#587). Do not merge before APPROVED.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3.1 buildSmcZoneLines → Task 2. ✓
+- §3.2 useSmcZones → Task 4. ✓
+- §3.3 colors + @theme → Task 1. ✓
+- §3.4 registry (zone kind, smc, 33→34, makePaneIndices, SMC group surfacing) → Task 3. ✓
+- §3.5 StockChart wiring → Task 5. ✓
+- §5.5 E2E → Task 6. ✓
+- §5 test strategy (90%+, happy + worst) → Task 2 (all-null/undefined/partial/midpoint), Task 4 (series-null/not-visible/no-zones/remove-on-off/wiring), Task 3 (group surfacing). ✓
+
+**Placeholder scan:** No TBD/TODO. Task 5 Step 3 instructs confirming/adding the `smc` field to the indicators mock "as flagged" — the exact mock shape depends on whether the test uses core's EMPTY_INDICATOR_RESULT (which includes smc) or a local mock; both fixes are fully specified.
+
+**Type consistency:** `buildSmcZoneLines(smc)` and `SmcZoneLine` consistent across Tasks 2/4. `useSmcZones({ seriesRef, smc, isVisible })` consistent Tasks 4/5. Color keys `smcPremium/Discount/Equilibrium` consistent Tasks 1/2. Registry count 33→34 consistent Tasks 3/5. `zone` kind consistent Tasks 3. ✓

--- a/docs/superpowers/specs/2026-06-07-render-smc-zones-design.md
+++ b/docs/superpowers/specs/2026-06-07-render-smc-zones-design.md
@@ -1,0 +1,164 @@
+# 미사용 보조지표 렌더링 — 9차(그룹 D-2, 마지막): smc zone (premium/discount/equilibrium 가격 밴드)
+
+- **작성일**: 2026-06-07
+- **상태**: 설계 승인됨, 구현 계획 대기
+- **브랜치**: `feat/render-smc-zones` (base: `feat/render-elder-impulse` = PR #587)
+
+## 1. 배경
+
+미사용 보조지표 렌더링 마지막 차수. 그룹 D-2 **smc zone**을 렌더한다. SMC(Smart Money Concepts)의 premium/discount/equilibrium **가격 밴드** 3개를 가격선으로 표시한다. SMC의 나머지(swingHighs/Lows, orderBlocks, fairValueGaps, equalHighs/Lows, structureBreaks)는 스코프 밖. 계산은 `@y0ngha/siglens-core`에 있어 추가 작업은 siglens 렌더링뿐. 이걸로 미사용 지표 렌더링 전체가 마무리된다.
+
+## 2. 자료조사 / 렌더 표준
+
+- **SMC zones**: premium=equilibrium 위(매도/저항 영역, 빨강), discount=equilibrium 아래(매수/지지 영역, 초록/teal), equilibrium=스윙 고저의 50% 공정가(중립 회색). TradingView SMC들은 배경 채움 박스로 그리나, 본 구현은 **렌더 방식으로 priceLine 경계선을 선택**(사용자 결정 — 단순·저위험, 기존 actionEntry 가격선과 동일 메커니즘).
+- DESIGN.md 매핑: premium=`#ef5350`(bearish), discount=`#26a69a`(bullish), equilibrium=`#94a3b8`(neutral).
+
+데이터(siglens-core `domain/types.d.ts`):
+```ts
+type SMCZoneType = 'premium' | 'discount' | 'equilibrium';
+interface SMCZone { high: number; low: number; type: SMCZoneType; }
+// SMCResult.premiumZone / discountZone / equilibriumZone: SMCZone | null
+// IndicatorResult.smc: SMCResult (객체형 — 시리즈 전체 요약)
+```
+
+기존 `useActionRecommendationOverlay`가 메인 캔들 시리즈에 `createPriceLine`으로 가격선을 그리는 정확한 레퍼런스다(`seriesRef` + `priceLinesRef: IPriceLine[]` 추적 + `isVisible` 게이팅 + 변경 시 전체 `removePriceLine` 후 재생성).
+
+## 3. 핵심 설계 결정
+
+### 3.1 `buildSmcZoneLines(smc)` 순수 헬퍼
+선택한 렌더(premium/discount = high·low 2선, equilibrium = 50% 중간선 1선)를 가격선 스펙으로 변환한다:
+```ts
+// utils/smcZoneUtils.ts
+import type { SMCResult } from '@y0ngha/siglens-core';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+
+export interface SmcZoneLine {
+    price: number;
+    color: string;
+    title: string;
+}
+
+export function buildSmcZoneLines(smc: SMCResult | undefined): SmcZoneLine[] {
+    if (!smc) return [];
+    const lines: SmcZoneLine[] = [];
+    const { premiumZone, discountZone, equilibriumZone } = smc;
+    if (premiumZone) {
+        lines.push({ price: premiumZone.high, color: CHART_COLORS.smcPremium, title: 'Premium' });
+        lines.push({ price: premiumZone.low, color: CHART_COLORS.smcPremium, title: '' });
+    }
+    if (discountZone) {
+        lines.push({ price: discountZone.high, color: CHART_COLORS.smcDiscount, title: 'Discount' });
+        lines.push({ price: discountZone.low, color: CHART_COLORS.smcDiscount, title: '' });
+    }
+    if (equilibriumZone) {
+        const mid = (equilibriumZone.high + equilibriumZone.low) / 2;
+        lines.push({ price: mid, color: CHART_COLORS.smcEquilibrium, title: 'Equilibrium' });
+    }
+    return lines;
+}
+```
+- null 존은 스킵. premium/discount는 밴드(2선, 대표 high선에만 title), equilibrium은 50% 공정가 1선. 최대 5선.
+
+### 3.2 `useSmcZones` 훅 (`hooks/useSmcZones.ts`)
+`useActionRecommendationOverlay` 골격 복제:
+```ts
+interface UseSmcZonesParams {
+    seriesRef: RefObject<ISeriesApi<'Candlestick', UTCTimestamp> | null>;
+    smc: SMCResult | undefined;
+    isVisible: boolean;
+    lineWidth?: LineWidth;
+}
+export function useSmcZones({ seriesRef, smc, isVisible, lineWidth = DEFAULT_LINE_WIDTH }: UseSmcZonesParams): void {
+    const priceLinesRef = useRef<IPriceLine[]>([]);
+    useEffect(() => {
+        const series = seriesRef.current;
+        priceLinesRef.current.forEach(pl => series?.removePriceLine(pl));
+        priceLinesRef.current = [];
+        if (!series || !isVisible) return;
+        const lines = buildSmcZoneLines(smc);
+        if (lines.length === 0) return;
+        priceLinesRef.current = lines.map(l =>
+            series.createPriceLine({
+                price: l.price,
+                color: l.color,
+                lineWidth,
+                lineStyle: LineStyle.Dashed,
+                axisLabelVisible: l.title !== '',
+                title: l.title,
+            })
+        );
+    }, [smc, isVisible, lineWidth, seriesRef]);
+}
+```
+- `lineStyle: LineStyle.Dashed`(action 가격선과 동일 톤). `axisLabelVisible`은 title 있는 대표선만 true(축 혼잡 완화).
+
+### 3.3 색상 (`shared/lib/chartColors.ts` + `globals.css`)
+DESIGN.md 시맨틱 매핑:
+```ts
+smcPremium: '#ef5350',     // 매도/저항 (bearish)
+smcDiscount: '#26a69a',    // 매수/지지 (bullish)
+smcEquilibrium: '#94a3b8', // 50% 공정가 (neutral)
+```
+globals.css @theme: `--color-chart-smc-premium/discount/equilibrium` 미러.
+
+### 3.4 레지스트리 (신규 kind `zone`)
+- `IndicatorKind` += `'zone'`(레지스트리 헤더 주석이 이미 예고).
+- `IndicatorKey` += `'smc'`.
+- `INDICATOR_REGISTRY` += `{ key: 'smc', label: 'SMC Zones', category: 'smc', kind: 'zone' }`. 33→34.
+- `smc` 카테고리는 `CATEGORY_LABELS`에 이미 존재('SMC'). 지금까지 항목이 0이라 `groupBindingsByCategory`가 숨겼으나, 이제 **모달에 'SMC' 그룹이 처음 표시**된다.
+- `zone`은 pane 아님 → `useIndicatorVisibility`의 `kind === 'pane'` 필터에 안 걸려 pane index 미할당. 가시성은 `visible.smc` + `toggle('smc')`(모든 키 초기화).
+- 모달은 kind 무관이라 무수정(SMC 그룹 자동 노출).
+- makePaneIndices(paneLabelUtils.test) fallout: `smc: INACTIVE_PANE_INDEX` +1.
+
+### 3.5 StockChart 배선
+- `useSmcZones({ seriesRef, smc: indicators.smc, isVisible: visible.smc })` 호출(`seriesRef`는 이미 StockChart에 존재 — useActionRecommendationOverlay에 전달 중).
+- `indicatorBindings` += `{ meta: INDICATOR_META.smc, active: visible.smc, onToggle: () => toggle('smc') }` (33→34). `visible`/`toggle`은 이미 deps에 포함.
+- 범례·pane 라벨 없음(가격선 + 축 라벨이 표현).
+
+## 4. 데이터 흐름
+```
+indicatorRegistry (smc = kind:'zone', category:'smc')
+        │
+useIndicatorVisibility → visible.smc (pane index 없음)
+        │
+binding(34개) → IndicatorSettingsModal에 'SMC' 그룹 처음 노출
+        │
+체크 → toggle('smc') → visible.smc=true
+        │
+useSmcZones effect → buildSmcZoneLines(indicators.smc) → 메인 캔들 시리즈에 createPriceLine(최대 5선)
+        │
+premium(빨강 high/low) · discount(teal high/low) · equilibrium(회색 50% 1선). off 시 removePriceLine 전부.
+```
+
+## 5. 테스트 전략 (vitest + RTL, 90%+, happy + worst)
+
+### 5.1 단위 — `buildSmcZoneLines`
+- 3존 모두 존재 → 5선(premium 2 + discount 2 + equilibrium 1), 색·title 정확.
+- equilibrium price = (high+low)/2 (midpoint) 검증.
+- null 존 스킵(premium만/discount만/equilibrium만/전부 null→[]).
+- smc undefined → [].
+- premium/discount는 high선 title 있음, low선 title ''(빈 문자열).
+
+### 5.2 단위 — `useSmcZones` (jsdom, lightweight-charts mock)
+- isVisible true + 3존 → createPriceLine 5회.
+- isVisible false → createPriceLine 미호출 + 기존 removePriceLine.
+- series null → 미생성.
+- 존 없음(smc undefined/전부 null) → 미생성.
+- smc 변경 시 기존 전부 removePriceLine 후 재생성(개수 갱신).
+- createPriceLine 인자(price/color/title/lineStyle Dashed/axisLabelVisible) 정확(인자 캡처).
+
+### 5.3 레지스트리/모달
+- 레지스트리 34, smc가 smc 카테고리·zone kind, 중복 없음.
+- `groupBindingsByCategory`: smc 바인딩 포함 시 'SMC' 그룹이 결과에 노출(이전엔 빈 그룹이라 제외).
+
+### 5.4 StockChart
+- binding 34 + data-keys에 smc 추가. INACTIVE_PANES에 smc 추가, visible mock에 smc:false.
+
+### 5.5 E2E
+- `chart-indicators.spec.ts` 확장: 모달에서 'SMC Zones' 체크 → zone은 pane/overlay 라벨이 없으므로 **모달 체크박스 상태로 검증**(initial unchecked → check → checked, exact 매처). 추가로 'SMC' 카테고리 그룹이 모달에 보이는지 검증 가능.
+
+## 6. FSD 준수
+- 헬퍼·훅·색: `widgets/chart` 내부 + `shared/lib/chartColors`. core import(SMCResult/SMCZone). 레이어 정상. core 무변경.
+
+## 7. 후속
+- **미사용 보조지표 렌더링 전체 완료.** SMC 나머지 요소(swing/orderBlock/FVG/structureBreak)는 스코프 밖 — 필요 시 별도 스펙.

--- a/e2e/specs/chart-indicators.spec.ts
+++ b/e2e/specs/chart-indicators.spec.ts
@@ -218,4 +218,20 @@ test.describe('chart indicator settings modal', () => {
         await impulse.check();
         await expect(impulse).toBeChecked();
     });
+
+    test('toggles SMC Zones via the modal', async ({ page }) => {
+        await page.goto('/AAPL');
+        await page.getByRole('button', { name: GEAR }).click();
+        const dialog = page.getByRole('dialog');
+        // SMC Zones는 가격선(zone) — pane/overlay 라벨이 없어 모달 체크박스 상태로 검증.
+        // smc 등록으로 'SMC' 카테고리 그룹이 모달에 처음 노출된다.
+        await expect(dialog.getByText('SMC')).toBeVisible();
+        const smc = dialog.getByRole('checkbox', {
+            name: 'SMC Zones',
+            exact: true,
+        });
+        await expect(smc).not.toBeChecked();
+        await smc.check();
+        await expect(smc).toBeChecked();
+    });
 });

--- a/e2e/specs/chart-indicators.spec.ts
+++ b/e2e/specs/chart-indicators.spec.ts
@@ -9,7 +9,7 @@ import { test, expect } from '../support/fixtures';
 test.describe('chart indicator settings modal', () => {
     const GEAR = '보조지표 설정';
 
-    test('opens the modal from the gear and shows category groups (no SMC)', async ({
+    test('opens the modal from the gear and shows category groups (incl. SMC)', async ({
         page,
     }) => {
         await page.goto('/AAPL');
@@ -23,7 +23,10 @@ test.describe('chart indicator settings modal', () => {
         await expect(dialog.getByText('모멘텀')).toBeVisible();
         await expect(dialog.getByText('변동성')).toBeVisible();
         await expect(dialog.getByText('볼륨')).toBeVisible();
-        await expect(dialog.getByText('SMC')).toHaveCount(0);
+        // smc 지표 등록으로 'SMC' 카테고리 그룹이 이제 모달에 노출된다(heading으로 'SMC Zones' 체크박스와 구별).
+        await expect(
+            dialog.getByRole('heading', { name: 'SMC' })
+        ).toBeVisible();
     });
 
     test('toggles the RSI checkbox on', async ({ page }) => {
@@ -224,8 +227,10 @@ test.describe('chart indicator settings modal', () => {
         await page.getByRole('button', { name: GEAR }).click();
         const dialog = page.getByRole('dialog');
         // SMC Zones는 가격선(zone) — pane/overlay 라벨이 없어 모달 체크박스 상태로 검증.
-        // smc 등록으로 'SMC' 카테고리 그룹이 모달에 처음 노출된다.
-        await expect(dialog.getByText('SMC')).toBeVisible();
+        // smc 등록으로 'SMC' 카테고리 그룹이 모달에 처음 노출된다('SMC Zones' 스팬과 구별 위해 heading).
+        await expect(
+            dialog.getByRole('heading', { name: 'SMC' })
+        ).toBeVisible();
         const smc = dialog.getByRole('checkbox', {
             name: 'SMC Zones',
             exact: true,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,6 +77,11 @@
     --color-chart-impulse-bearish: #ef5350;
     --color-chart-impulse-neutral: #3b82f6;
 
+    /* Chart — SMC zones */
+    --color-chart-smc-premium: #ef5350;
+    --color-chart-smc-discount: #26a69a;
+    --color-chart-smc-equilibrium: #94a3b8;
+
     /* Chart — MACD */
     --color-chart-macd: #3b82f6;
     --color-chart-signal: #f59e0b;

--- a/src/shared/lib/chartColors.ts
+++ b/src/shared/lib/chartColors.ts
@@ -163,6 +163,10 @@ export const CHART_COLORS = {
     impulseBullish: '#26a69a', // green — EMA↑ & MACD-hist↑
     impulseBearish: '#ef5350', // red — 둘 다 ↓
     impulseNeutral: '#3b82f6', // blue — 혼조/전환; Elder 원저자 관례. macdLine과 같은 값이나 별 pane이라 공간상 겹치지 않음
+    // SMC zones (가격 밴드 경계선) — DESIGN.md bearish/bullish/neutral 매핑
+    smcPremium: '#ef5350', // 매도/저항 상단
+    smcDiscount: '#26a69a', // 매수/지지 하단
+    smcEquilibrium: '#94a3b8', // 50% 공정가 (neutral)
 } as const;
 
 const PERIOD_COLOR_MAP: Record<number, string> = {

--- a/src/widgets/chart/StockChart.tsx
+++ b/src/widgets/chart/StockChart.tsx
@@ -52,6 +52,7 @@ import { useVolumeProfileOverlay } from './hooks/useVolumeProfileOverlay';
 import { useIchimokuOverlay } from './hooks/useIchimokuOverlay';
 import { useCandlePatternMarkers } from './hooks/useCandlePatternMarkers';
 import { useActionRecommendationOverlay } from './hooks/useActionRecommendationOverlay';
+import { useSmcZones } from './hooks/useSmcZones';
 import { usePaneLabels } from './hooks/usePaneLabels';
 import { useOverlayLegend } from './hooks/useOverlayLegend';
 import { DEFAULT_LINE_WIDTH } from './constants';
@@ -367,6 +368,12 @@ export function StockChart({
         lineWidth: DEFAULT_LINE_WIDTH,
     });
 
+    useSmcZones({
+        seriesRef,
+        smc: indicators.smc,
+        isVisible: visible.smc,
+    });
+
     // indicator 제거 시 LWC v5가 빈 pane DOM을 정리하지 않아 autoSize 토글로 layout invalidate를 강제한다.
     // 단, 첫 mount에서는 이 명시 resize를 skip한다 (`isInitialPaneRenderRef`) — hydration /
     // 첫 진입 시 layout 안정화 전에 wrapper.clientHeight를 측정하면 작은 값(예: 30px)이
@@ -616,6 +623,11 @@ export function StockChart({
                 meta: INDICATOR_META.elderImpulse,
                 active: visible.elderImpulse,
                 onToggle: () => toggle('elderImpulse'),
+            },
+            {
+                meta: INDICATOR_META.smc,
+                active: visible.smc,
+                onToggle: () => toggle('smc'),
             },
         ],
         // deps에 visible 객체 전체를 둔다 — 한 지표 토글 시 전체 binding이 재조립되지만

--- a/src/widgets/chart/__tests__/StockChart.test.tsx
+++ b/src/widgets/chart/__tests__/StockChart.test.tsx
@@ -33,6 +33,7 @@ const INACTIVE_PANES = Object.fromEntries(
         'squeezeMomentum',
         'regression',
         'elderImpulse',
+        'smc',
     ].map(k => [k, INACTIVE_PANE_INDEX])
 );
 
@@ -251,6 +252,10 @@ vi.mock('@/widgets/chart/hooks/useActionRecommendationOverlay', () => ({
     useActionRecommendationOverlay: vi.fn(),
 }));
 
+vi.mock('@/widgets/chart/hooks/useSmcZones', () => ({
+    useSmcZones: vi.fn(),
+}));
+
 vi.mock('@/widgets/chart/hooks/usePaneLabels', () => ({
     usePaneLabels: vi.fn(),
 }));
@@ -290,6 +295,7 @@ vi.mock('@/widgets/chart/hooks/useIndicatorVisibility', () => ({
             squeezeMomentum: false,
             regression: false,
             elderImpulse: false,
+            smc: false,
         },
         toggle: vi.fn(),
         paneIndices: INACTIVE_PANES,
@@ -429,13 +435,13 @@ describe('StockChart', () => {
         );
     });
 
-    it('renders IndicatorSettingsModal with 33 indicator bindings', () => {
+    it('renders IndicatorSettingsModal with 34 indicator bindings', () => {
         render(<StockChart bars={mockBars} timeframe="1Day" />);
         const modal = screen.getByTestId('indicator-settings-modal');
-        expect(modal).toHaveAttribute('data-count', '33');
+        expect(modal).toHaveAttribute('data-count', '34');
         expect(modal).toHaveAttribute(
             'data-keys',
-            'ma,ema,ichimoku,rsi,macd,dmi,stochastic,stochRsi,cci,bollinger,volumeProfile,mfi,williamsR,connorsRsi,cmf,bollingerPercentB,hurst,varianceRatio,macdV,forceIndex,obv,atr,yangZhang,ewmaVolatility,keltnerChannel,donchianChannel,supertrend,parabolicSar,chandelierExit,elderRay,squeezeMomentum,regression,elderImpulse'
+            'ma,ema,ichimoku,rsi,macd,dmi,stochastic,stochRsi,cci,bollinger,volumeProfile,mfi,williamsR,connorsRsi,cmf,bollingerPercentB,hurst,varianceRatio,macdV,forceIndex,obv,atr,yangZhang,ewmaVolatility,keltnerChannel,donchianChannel,supertrend,parabolicSar,chandelierExit,elderRay,squeezeMomentum,regression,elderImpulse,smc'
         );
     });
 

--- a/src/widgets/chart/__tests__/hooks/useSmcZones.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useSmcZones.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import type { SMCResult } from '@y0ngha/siglens-core';
+import { useSmcZones } from '../../hooks/useSmcZones';
+import { buildSmcZoneLines } from '../../utils/smcZoneUtils';
+
+const mockCreatePriceLine = vi.fn(() => ({ id: 'pl' }));
+const mockRemovePriceLine = vi.fn();
+
+vi.mock('lightweight-charts', () => ({
+    LineStyle: { Dashed: 2 },
+}));
+
+function makeSeriesRef(series: unknown = makeSeries()) {
+    return { current: series } as Parameters<
+        typeof useSmcZones
+    >[0]['seriesRef'];
+}
+function makeSeries() {
+    return {
+        createPriceLine: mockCreatePriceLine,
+        removePriceLine: mockRemovePriceLine,
+    };
+}
+
+function smc(overrides: Partial<SMCResult>): SMCResult {
+    return {
+        swingHighs: [],
+        swingLows: [],
+        orderBlocks: [],
+        fairValueGaps: [],
+        equalHighs: [],
+        equalLows: [],
+        premiumZone: null,
+        discountZone: null,
+        equilibriumZone: null,
+        structureBreaks: [],
+        ...overrides,
+    };
+}
+
+const THREE_ZONES = smc({
+    premiumZone: { high: 110, low: 105, type: 'premium' },
+    discountZone: { high: 95, low: 90, type: 'discount' },
+    equilibriumZone: { high: 101, low: 99, type: 'equilibrium' },
+});
+
+describe('useSmcZones', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('does not create lines when series is null', () => {
+        renderHook(() =>
+            useSmcZones({
+                seriesRef: makeSeriesRef(null),
+                smc: THREE_ZONES,
+                isVisible: true,
+            })
+        );
+        expect(mockCreatePriceLine).not.toHaveBeenCalled();
+    });
+
+    it('creates 5 price lines for three zones when visible', () => {
+        renderHook(() =>
+            useSmcZones({
+                seriesRef: makeSeriesRef(),
+                smc: THREE_ZONES,
+                isVisible: true,
+            })
+        );
+        expect(mockCreatePriceLine).toHaveBeenCalledTimes(5);
+    });
+
+    it('does not create lines when not visible', () => {
+        renderHook(() =>
+            useSmcZones({
+                seriesRef: makeSeriesRef(),
+                smc: THREE_ZONES,
+                isVisible: false,
+            })
+        );
+        expect(mockCreatePriceLine).not.toHaveBeenCalled();
+    });
+
+    it('does not create lines when there are no zones', () => {
+        renderHook(() =>
+            useSmcZones({
+                seriesRef: makeSeriesRef(),
+                smc: smc({}),
+                isVisible: true,
+            })
+        );
+        expect(mockCreatePriceLine).not.toHaveBeenCalled();
+    });
+
+    it('removes existing lines when toggled off', () => {
+        const series = makeSeries();
+        const { rerender } = renderHook(props => useSmcZones(props), {
+            initialProps: {
+                seriesRef: makeSeriesRef(series),
+                smc: THREE_ZONES,
+                isVisible: true,
+            },
+        });
+        rerender({
+            seriesRef: makeSeriesRef(series),
+            smc: THREE_ZONES,
+            isVisible: false,
+        });
+        expect(mockRemovePriceLine).toHaveBeenCalledTimes(5);
+    });
+
+    it('passes the first line spec from buildSmcZoneLines to createPriceLine', () => {
+        renderHook(() =>
+            useSmcZones({
+                seriesRef: makeSeriesRef(),
+                smc: THREE_ZONES,
+                isVisible: true,
+            })
+        );
+        const expected = buildSmcZoneLines(THREE_ZONES)[0];
+        expect(mockCreatePriceLine).toHaveBeenCalledWith(
+            expect.objectContaining({
+                price: expected.price,
+                color: expected.color,
+                title: expected.title,
+            })
+        );
+    });
+});

--- a/src/widgets/chart/__tests__/model/indicatorRegistry.test.ts
+++ b/src/widgets/chart/__tests__/model/indicatorRegistry.test.ts
@@ -14,8 +14,8 @@ function bindingFor(key: IndicatorKey, active = false): IndicatorBinding {
 }
 
 describe('indicatorRegistry', () => {
-    it('registers exactly the 33 modal-target indicators', () => {
-        expect(INDICATOR_REGISTRY).toHaveLength(33);
+    it('registers exactly the 34 modal-target indicators', () => {
+        expect(INDICATOR_REGISTRY).toHaveLength(34);
     });
 
     it('registers elderImpulse as a candle-paint indicator', () => {
@@ -171,6 +171,20 @@ describe('indicatorRegistry', () => {
             expect(INDICATOR_META[key].kind).toBe('pane');
         }
     );
+
+    it('registers smc as a zone indicator in the smc category', () => {
+        const meta = INDICATOR_REGISTRY.find(m => m.key === 'smc');
+        expect(meta).toBeDefined();
+        expect(meta?.category).toBe('smc');
+        expect(meta?.kind).toBe('zone');
+    });
+
+    it('groupBindingsByCategory surfaces the SMC group once an smc binding exists', () => {
+        const groups = groupBindingsByCategory([
+            { meta: INDICATOR_META.smc, active: false, onToggle: () => {} },
+        ]);
+        expect(groups.find(g => g.category === 'smc')?.label).toBe('SMC');
+    });
 });
 
 describe('groupBindingsByCategory', () => {

--- a/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/paneLabelUtils.test.ts
@@ -55,6 +55,7 @@ function makePaneIndices(overrides: Partial<PaneIndices> = {}): PaneIndices {
         squeezeMomentum: INACTIVE_PANE_INDEX,
         regression: INACTIVE_PANE_INDEX,
         elderImpulse: INACTIVE_PANE_INDEX,
+        smc: INACTIVE_PANE_INDEX,
     } satisfies PaneIndices;
     return { ...base, ...overrides };
 }

--- a/src/widgets/chart/__tests__/utils/smcZoneUtils.test.ts
+++ b/src/widgets/chart/__tests__/utils/smcZoneUtils.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { SMCResult } from '@y0ngha/siglens-core';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+import { buildSmcZoneLines } from '@/widgets/chart/utils/smcZoneUtils';
+
+function smc(overrides: Partial<SMCResult>): SMCResult {
+    return {
+        swingHighs: [],
+        swingLows: [],
+        orderBlocks: [],
+        fairValueGaps: [],
+        equalHighs: [],
+        equalLows: [],
+        premiumZone: null,
+        discountZone: null,
+        equilibriumZone: null,
+        structureBreaks: [],
+        ...overrides,
+    };
+}
+
+describe('buildSmcZoneLines', () => {
+    it('returns [] for undefined smc', () => {
+        expect(buildSmcZoneLines(undefined)).toEqual([]);
+    });
+
+    it('returns [] when all zones are null', () => {
+        expect(buildSmcZoneLines(smc({}))).toEqual([]);
+    });
+
+    it('builds 5 lines when all three zones present (premium/discount 2 each + equilibrium 1)', () => {
+        const out = buildSmcZoneLines(
+            smc({
+                premiumZone: { high: 110, low: 105, type: 'premium' },
+                discountZone: { high: 95, low: 90, type: 'discount' },
+                equilibriumZone: { high: 101, low: 99, type: 'equilibrium' },
+            })
+        );
+        expect(out).toEqual([
+            { price: 110, color: CHART_COLORS.smcPremium, title: 'Premium' },
+            { price: 105, color: CHART_COLORS.smcPremium, title: '' },
+            { price: 95, color: CHART_COLORS.smcDiscount, title: 'Discount' },
+            { price: 90, color: CHART_COLORS.smcDiscount, title: '' },
+            {
+                price: 100,
+                color: CHART_COLORS.smcEquilibrium,
+                title: 'Equilibrium',
+            },
+        ]);
+    });
+
+    it('equilibrium line uses the (high+low)/2 midpoint', () => {
+        const out = buildSmcZoneLines(
+            smc({
+                equilibriumZone: { high: 102, low: 98, type: 'equilibrium' },
+            })
+        );
+        expect(out).toEqual([
+            {
+                price: 100,
+                color: CHART_COLORS.smcEquilibrium,
+                title: 'Equilibrium',
+            },
+        ]);
+    });
+
+    it('skips null zones independently (premium only)', () => {
+        const out = buildSmcZoneLines(
+            smc({ premiumZone: { high: 110, low: 105, type: 'premium' } })
+        );
+        expect(out).toEqual([
+            { price: 110, color: CHART_COLORS.smcPremium, title: 'Premium' },
+            { price: 105, color: CHART_COLORS.smcPremium, title: '' },
+        ]);
+    });
+});

--- a/src/widgets/chart/hooks/useSmcZones.ts
+++ b/src/widgets/chart/hooks/useSmcZones.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { useEffect, useRef } from 'react';
+import type {
+    IPriceLine,
+    ISeriesApi,
+    LineWidth,
+    UTCTimestamp,
+} from 'lightweight-charts';
+import { LineStyle } from 'lightweight-charts';
+import type { SMCResult } from '@y0ngha/siglens-core';
+import { DEFAULT_LINE_WIDTH } from '../constants';
+import { buildSmcZoneLines } from '../utils/smcZoneUtils';
+
+interface UseSmcZonesParams {
+    seriesRef: RefObject<ISeriesApi<'Candlestick', UTCTimestamp> | null>;
+    smc: SMCResult | undefined;
+    isVisible: boolean;
+    lineWidth?: LineWidth;
+}
+
+export function useSmcZones({
+    seriesRef,
+    smc,
+    isVisible,
+    lineWidth = DEFAULT_LINE_WIDTH,
+}: UseSmcZonesParams): void {
+    const priceLinesRef = useRef<IPriceLine[]>([]);
+
+    useEffect(() => {
+        const series = seriesRef.current;
+
+        priceLinesRef.current.forEach(pl => series?.removePriceLine(pl));
+        priceLinesRef.current = [];
+
+        if (!series || !isVisible) return;
+
+        const lines = buildSmcZoneLines(smc);
+        if (lines.length === 0) return;
+
+        priceLinesRef.current = lines.map(line =>
+            series.createPriceLine({
+                price: line.price,
+                color: line.color,
+                lineWidth,
+                lineStyle: LineStyle.Dashed,
+                // 대표선(title 있음)만 축 라벨 표시 — 밴드 하단선 라벨 중복으로 축 혼잡해지는 것 방지.
+                axisLabelVisible: line.title !== '',
+                title: line.title,
+            })
+        );
+    }, [smc, isVisible, lineWidth, seriesRef]);
+}

--- a/src/widgets/chart/model/indicatorRegistry.ts
+++ b/src/widgets/chart/model/indicatorRegistry.ts
@@ -15,7 +15,7 @@ export type IndicatorCategory =
     | 'statistical'
     | 'smc';
 
-export type IndicatorKind = 'overlay' | 'pane' | 'candle-paint';
+export type IndicatorKind = 'overlay' | 'pane' | 'candle-paint' | 'zone';
 
 export type IndicatorKey =
     | 'ma'
@@ -50,7 +50,8 @@ export type IndicatorKey =
     | 'elderRay'
     | 'squeezeMomentum'
     | 'regression'
-    | 'elderImpulse';
+    | 'elderImpulse'
+    | 'smc';
 
 export interface IndicatorMeta {
     key: IndicatorKey;
@@ -221,6 +222,7 @@ export const INDICATOR_REGISTRY: readonly IndicatorMeta[] = [
         category: 'momentum',
         kind: 'candle-paint',
     },
+    { key: 'smc', label: 'SMC Zones', category: 'smc', kind: 'zone' },
 ];
 
 /**

--- a/src/widgets/chart/utils/smcZoneUtils.ts
+++ b/src/widgets/chart/utils/smcZoneUtils.ts
@@ -14,38 +14,46 @@ export interface SmcZoneLine {
  */
 export function buildSmcZoneLines(smc: SMCResult | undefined): SmcZoneLine[] {
     if (!smc) return [];
-    const lines: SmcZoneLine[] = [];
     const { premiumZone, discountZone, equilibriumZone } = smc;
-    if (premiumZone) {
-        lines.push({
-            price: premiumZone.high,
-            color: CHART_COLORS.smcPremium,
-            title: 'Premium',
-        });
-        lines.push({
-            price: premiumZone.low,
-            color: CHART_COLORS.smcPremium,
-            title: '',
-        });
-    }
-    if (discountZone) {
-        lines.push({
-            price: discountZone.high,
-            color: CHART_COLORS.smcDiscount,
-            title: 'Discount',
-        });
-        lines.push({
-            price: discountZone.low,
-            color: CHART_COLORS.smcDiscount,
-            title: '',
-        });
-    }
-    if (equilibriumZone) {
-        lines.push({
-            price: (equilibriumZone.high + equilibriumZone.low) / 2,
-            color: CHART_COLORS.smcEquilibrium,
-            title: 'Equilibrium',
-        });
-    }
-    return lines;
+    return [
+        // premium·discount는 high/low 밴드(2선, 대표 high선에만 title)
+        ...(premiumZone
+            ? [
+                  {
+                      price: premiumZone.high,
+                      color: CHART_COLORS.smcPremium,
+                      title: 'Premium',
+                  },
+                  {
+                      price: premiumZone.low,
+                      color: CHART_COLORS.smcPremium,
+                      title: '',
+                  },
+              ]
+            : []),
+        ...(discountZone
+            ? [
+                  {
+                      price: discountZone.high,
+                      color: CHART_COLORS.smcDiscount,
+                      title: 'Discount',
+                  },
+                  {
+                      price: discountZone.low,
+                      color: CHART_COLORS.smcDiscount,
+                      title: '',
+                  },
+              ]
+            : []),
+        // equilibrium은 50% 공정가 1선
+        ...(equilibriumZone
+            ? [
+                  {
+                      price: (equilibriumZone.high + equilibriumZone.low) / 2,
+                      color: CHART_COLORS.smcEquilibrium,
+                      title: 'Equilibrium',
+                  },
+              ]
+            : []),
+    ];
 }

--- a/src/widgets/chart/utils/smcZoneUtils.ts
+++ b/src/widgets/chart/utils/smcZoneUtils.ts
@@ -1,0 +1,51 @@
+import type { SMCResult } from '@y0ngha/siglens-core';
+import { CHART_COLORS } from '@/shared/lib/chartColors';
+
+export interface SmcZoneLine {
+    price: number;
+    color: string;
+    title: string;
+}
+
+/**
+ * SMC premium/discount/equilibrium 존을 가격선 스펙으로 변환한다.
+ * premium·discount는 high/low 밴드(2선, 대표 high선에만 title), equilibrium은 50% 공정가 1선.
+ * null 존은 스킵 — 최대 5선.
+ */
+export function buildSmcZoneLines(smc: SMCResult | undefined): SmcZoneLine[] {
+    if (!smc) return [];
+    const lines: SmcZoneLine[] = [];
+    const { premiumZone, discountZone, equilibriumZone } = smc;
+    if (premiumZone) {
+        lines.push({
+            price: premiumZone.high,
+            color: CHART_COLORS.smcPremium,
+            title: 'Premium',
+        });
+        lines.push({
+            price: premiumZone.low,
+            color: CHART_COLORS.smcPremium,
+            title: '',
+        });
+    }
+    if (discountZone) {
+        lines.push({
+            price: discountZone.high,
+            color: CHART_COLORS.smcDiscount,
+            title: 'Discount',
+        });
+        lines.push({
+            price: discountZone.low,
+            color: CHART_COLORS.smcDiscount,
+            title: '',
+        });
+    }
+    if (equilibriumZone) {
+        lines.push({
+            price: (equilibriumZone.high + equilibriumZone.low) / 2,
+            color: CHART_COLORS.smcEquilibrium,
+            title: 'Equilibrium',
+        });
+    }
+    return lines;
+}


### PR DESCRIPTION
## 요약
미사용 보조지표 렌더링 마지막 차수(그룹 D-2). SMC **premium/discount/equilibrium** 가격 밴드를 메인 캔들 시리즈의 가격선(createPriceLine)으로 표시한다. 신규 레지스트리 kind `zone`. premium/discount는 high·low 밴드(각 2선, 대표선 라벨), equilibrium은 50% 공정가 1선. 기존 `useActionRecommendationOverlay` 가격선 패턴을 그대로 따른다. 계산은 `@y0ngha/siglens-core`에 있어 코어 변경 없음. SMC 나머지(swing/orderBlock/FVG/structureBreak)는 스코프 밖.

이 PR로 **미사용 보조지표 렌더링 전체가 완료**된다.

## 변경 사항
- `utils/smcZoneUtils.ts`: `buildSmcZoneLines`(존→가격선 스펙, null 스킵, equilibrium midpoint) — 선언형 spread
- `hooks/useSmcZones.ts`: createPriceLine 밴드 훅(seriesRef·priceLinesRef·isVisible 게이팅·변경 시 전체 제거 후 재생성)
- `model/indicatorRegistry.ts`: 신규 kind `zone` + smc 등록(33→34). smc 카테고리가 이미 있어 모달에 **'SMC' 그룹 첫 노출**
- `shared/lib/chartColors.ts` + `globals.css`: smcPremium/Discount/Equilibrium + @theme
- `StockChart.tsx`: useSmcZones 호출 + binding 1개(34)
- `e2e/specs/chart-indicators.spec.ts`: 모달 토글 + SMC 그룹 노출 E2E

## 검증
- vitest 전체 커버리지 게이트 통과(branches 91.67%, lines 95.84%)
- lint / prettier --check / production build 전부 통과
- 내부 review-agent(Opus): round 1 recommended 1건(push→선언형 spread) 반영 → round 2 APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)