### PR TITLE
feat(chart): 보조지표 선택 localStorage 영속 + 모달 2열 그리드 레이아웃

### DIFF
--- a/docs/superpowers/specs/2026-06-12-indicator-modal-grid-persist-design.md
+++ b/docs/superpowers/specs/2026-06-12-indicator-modal-grid-persist-design.md
@@ -1,0 +1,63 @@
+# 보조지표 모달 — 그리드 레이아웃 + 선택 영속 설계
+
+- **작성일**: 2026-06-12
+- **상태**: 설계(사용자 직접 지시 기반), 구현 진행
+- **브랜치**: `feat/indicator-modal-grid-persist` (base: `master` = 보조지표 렌더링 9-PR 머지본, core 0.21.1)
+
+## 1. 배경 / 문제
+
+보조지표 렌더링 스택 머지 후 실증 중 사용자가 발견한 두 UX 문제:
+1. **모달이 너무 김** — 34개 지표가 카테고리별 **단일 세로열**(`flex flex-col`)로 쌓여, 특히 모바일에서 모달이 화면을 넘겨 가려진다.
+2. **영속 없음** — `useIndicatorVisibility`·overlay 훅·MA/EMA period 모두 `useState`만 사용 → **새로고침하면 선택이 전부 초기화**된다. 사용자는 선택/해제가 새로고침 후에도 유지되길 기대.
+
+## 2. 요구사항 (사용자 지시)
+
+- 모달 체크리스트를 **그리드(가로·세로 2D)** 배치 — 길이를 줄여 모달이 가려지지 않게. **모바일** 포함.
+- 선택 **자동 영속**(즉시 적용 + localStorage, 별도 저장 버튼 없음). 새로고침·재접속 후 복원.
+- **검증 매트릭스**: ① 체크 → 차트/별도 pane 렌더 ② 체크 해제 → pane/차트에서 제거 ③ 새로고침 → 선택 복원 ④ 해제 상태도 복원 ⑤ 모바일에서 모달 안 가려짐.
+
+## 3. 아키텍처
+
+### 3.1 신규 공통 훅 `usePersistentState<T>(key, default)` (`shared/hooks`)
+SSR-safe localStorage 영속:
+- `useState(default)` (서버·초기 렌더는 default — hydration mismatch 방지).
+- 마운트 `useEffect`: localStorage[key] 읽어 있으면 set(파싱 실패/없음은 default 유지).
+- 값 변경 `useEffect`: localStorage[key]에 JSON 저장. `typeof window` 가드.
+- 반환 `[value, setValue]` (useState와 동일 시그니처 → 드롭인 교체).
+
+### 3.2 영속 대상(드롭인 교체 — API 무변경)
+- `useIndicatorVisibility`: `useState(initialVisibility)` → `usePersistentState('siglens.chart.visible', initialVisibility())`. 키 누락/레지스트리 증가 대비, 복원 시 `{ ...initialVisibility(), ...stored }`로 머지(신규 키 default 보강).
+- overlay 훅 8개(bollinger/keltner/donchian/supertrend/parabolicSar/chandelier/ichimoku/volumeProfile): `useState(false)` → `usePersistentState('siglens.chart.overlay.<key>', false)`.
+- `useMovingAverageOverlay`(MA/EMA 공용): `useState<number[]>(defaultPeriods)` → `usePersistentState(storageKey, defaultPeriods)`. **storageKey를 파라미터로 추가**해 useMAOverlay='siglens.chart.ma.periods', useEMAOverlay='siglens.chart.ema.periods'로 구분.
+
+토글/해제는 기존 경로 그대로(즉시 적용·removeSeries) + 상태가 영속되므로 새로고침 후 복원.
+
+### 3.3 모달 그리드 (`ui/IndicatorSettingsModal.tsx`)
+- 각 카테고리 `<section>`의 항목 컨테이너 `flex flex-col gap-0.5` → **`grid grid-cols-2 gap-x-4 gap-y-0.5`**(데스크톱), 모바일도 2열 유지(좁으면 `grid-cols-2`가 충분히 짧음). period 행(MA/EMA)은 칩이 넓으므로 `col-span-2`(전체폭) 유지.
+- 모달 폭 `max-w-md` → 그리드 수용 위해 `max-w-lg`로 약간 확대. `max-h-[calc(100vh-2rem)] overflow-y-auto`는 유지(세로 넘치면 내부 스크롤).
+- 모바일: 2열 그리드로 높이 대폭 감소 → 뷰포트 내 수용. `p-4` 컨테이너 패딩 유지.
+
+## 4. 테스트
+
+- **`usePersistentState`** 단위: 초기 default, localStorage 복원, 변경 시 저장, 파싱 실패 graceful, SSR(window 없음) 안전.
+- **useIndicatorVisibility** 테스트: 영속 키 read/write, 신규 키 머지 복원, 기존 toggle/paneIndices 회귀.
+- overlay/MA 훅 테스트: 영속 키로 초기화·저장 확인(기존 토글 동작 회귀 유지).
+- 모달 테스트: 그리드 클래스 적용·항목 렌더·period 행 col-span 회귀.
+- **실증(Chrome)**: 검증 매트릭스 ①~⑤ — 토글 렌더, 해제 제거, 새로고침 복원, 모바일 그리드 수용.
+
+## 5. FSD / 범위
+- `usePersistentState`는 `shared/hooks`(범용). 차트 훅·모달은 `widgets/chart`. localStorage는 클라 전용(브라우저 영속) — core 무관, 도메인 로직 아님. 레이어 정상.
+
+## 6. 비범위
+- 저장 버튼/스테이징(사용자가 자동 영속 선택). period 외 지표 파라미터 커스터마이즈. 서버 동기화(클라 localStorage만).
+
+## 7. 실증 결과 (2026-06-12, Chrome)
+
+prod-like 빌드(`E2E_TEST=1` + `.env.e2e`, docker Postgres/Redis/SRH, `http://localhost:4300`), 시드 AAPL. 검증 매트릭스 ①~⑤ **전부 PASS**:
+
+- **① 토글 ON → 렌더**: BB(overlay)→좌상단 "BB Upper/Middle/Lower" 범례+밴드, RSI(pane)→별도 pane "RSI(14)" 라벨, Elder Impulse(candle-paint)→메인 캔들 teal 재색칠. 동시에 localStorage에 `siglens.chart.visible`(rsi/elderImpulse=true), `siglens.chart.overlay.bollinger="true"` 기록.
+- **② 토글 OFF → 제거**: 3종 해제 시 범례·pane·재색칠 모두 사라지고 기본 캔들 복귀, localStorage 값 false 갱신.
+- **③ 새로고침 → 복원**: 재토글 없이 BB 범례·RSI pane·Elder Impulse 색칠 복원.
+- **④ 해제 상태 영속**: 해제 후 새로고침해도 OFF 유지(깨끗한 기본 차트).
+- **⑤ 모바일 모달**: 390px 폭에서 2열 그리드 정상 reflow, 가로 오버플로우 0(dialog scrollWidth=clientWidth=356), 세로는 viewport 내 수용+내부 스크롤, 라벨 클리핑 없음.
+- 전 과정 **콘솔 에러 0**. 단위 661 pass, tsc/lint/prettier 클린.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -57,7 +57,14 @@ const eslintConfig = defineConfig([
         // latest state/props in a mount-only effect without adding reactive deps.
         // The URL-restore-on-mount pattern here is a legitimate external-system sync
         // (URLSearchParams → React state), not a cascading-render anti-pattern.
-        files: ['src/widgets/dashboard/hooks/useSectorSignalState.ts'],
+        //
+        // usePersistentState: mount-only effect reads localStorage (external system)
+        // and restores state once. This is the canonical SSR-safe hydration pattern —
+        // server renders initial value, client mount syncs from the external store.
+        files: [
+            'src/widgets/dashboard/hooks/useSectorSignalState.ts',
+            'src/shared/hooks/usePersistentState.ts',
+        ],
         rules: {
             'react-hooks/set-state-in-effect': 'off',
         },

--- a/src/shared/hooks/__tests__/usePersistentState.test.ts
+++ b/src/shared/hooks/__tests__/usePersistentState.test.ts
@@ -50,7 +50,6 @@ describe('usePersistentState', () => {
     it('does not persist the initial value until it changes (writes only user changes)', () => {
         // 마운트 직후 첫 write effect는 건너뛰므로 initial은 저장되지 않는다 — 저장값을 잠깐
         // initial로 덮어쓰는 transient를 막고 localStorage엔 사용자 변경만 남긴다.
-        localStorage.clear();
         const { result } = renderHook(() =>
             usePersistentState('test.nowrite', 99)
         );

--- a/src/shared/hooks/__tests__/usePersistentState.test.ts
+++ b/src/shared/hooks/__tests__/usePersistentState.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePersistentState } from '../usePersistentState';
+
+describe('usePersistentState', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('returns initial value when nothing is stored', () => {
+        const { result } = renderHook(() => usePersistentState('test.key', 42));
+        expect(result.current[0]).toBe(42);
+    });
+
+    it('restores stored value after mount (useEffect fires in jsdom)', async () => {
+        localStorage.setItem('test.restore', JSON.stringify({ count: 7 }));
+        const { result } = renderHook(() =>
+            usePersistentState('test.restore', { count: 0 })
+        );
+        // After effects run, the stored value should be restored
+        expect(result.current[0]).toEqual({ count: 7 });
+    });
+
+    it('persists new value to localStorage on setValue change', () => {
+        const { result } = renderHook(() =>
+            usePersistentState('test.persist', 'initial')
+        );
+
+        act(() => {
+            result.current[1]('updated');
+        });
+
+        expect(result.current[0]).toBe('updated');
+        // After value changes (hydrated.current=true after mount effect), it should write
+        expect(localStorage.getItem('test.persist')).toBe(
+            JSON.stringify('updated')
+        );
+    });
+
+    it('keeps initial value and does not throw on malformed JSON in localStorage', () => {
+        localStorage.setItem('test.bad', 'NOT_VALID_JSON{{{');
+        const { result } = renderHook(() =>
+            usePersistentState('test.bad', 'fallback')
+        );
+        // Parsing fails silently — should retain initial
+        expect(result.current[0]).toBe('fallback');
+    });
+
+    it('writes the initial value to localStorage once hydration completes', () => {
+        // The write effect is gated on hydrated.current, which only flips true after the
+        // mount effect runs — so during SSR (no effects) nothing is written, avoiding a
+        // hydration mismatch. renderHook runs effects synchronously, so here we assert the
+        // post-hydration outcome: the initial value lands in storage.
+        localStorage.clear();
+        renderHook(() => usePersistentState('test.nowrite', 99));
+        expect(JSON.parse(localStorage.getItem('test.nowrite') ?? 'null')).toBe(
+            99
+        );
+    });
+
+    it('returns a stable setState function reference across rerenders', () => {
+        const { result, rerender } = renderHook(() =>
+            usePersistentState('test.stable', 0)
+        );
+        const firstSetter = result.current[1];
+        rerender();
+        expect(result.current[1]).toBe(firstSetter);
+    });
+
+    it('works with arrays as initial value', () => {
+        localStorage.setItem('test.arr', JSON.stringify([1, 2, 3]));
+        const { result } = renderHook(() =>
+            usePersistentState<number[]>('test.arr', [])
+        );
+        expect(result.current[0]).toEqual([1, 2, 3]);
+    });
+
+    it('works with boolean initial value false', () => {
+        const { result } = renderHook(() =>
+            usePersistentState('test.bool', false)
+        );
+        expect(result.current[0]).toBe(false);
+
+        act(() => {
+            result.current[1](true);
+        });
+        expect(result.current[0]).toBe(true);
+        expect(localStorage.getItem('test.bool')).toBe('true');
+    });
+});

--- a/src/shared/hooks/__tests__/usePersistentState.test.ts
+++ b/src/shared/hooks/__tests__/usePersistentState.test.ts
@@ -34,7 +34,6 @@ describe('usePersistentState', () => {
         });
 
         expect(result.current[0]).toBe('updated');
-        // After value changes (hydrated.current=true after mount effect), it should write
         expect(localStorage.getItem('test.persist')).toBe(
             JSON.stringify('updated')
         );

--- a/src/shared/hooks/__tests__/usePersistentState.test.ts
+++ b/src/shared/hooks/__tests__/usePersistentState.test.ts
@@ -13,7 +13,7 @@ describe('usePersistentState', () => {
         expect(result.current[0]).toBe(42);
     });
 
-    it('restores stored value after mount (useEffect fires in jsdom)', async () => {
+    it('restores stored value after mount (useEffect fires in jsdom)', () => {
         localStorage.setItem('test.restore', JSON.stringify({ count: 7 }));
         const { result } = renderHook(() =>
             usePersistentState('test.restore', { count: 0 })

--- a/src/shared/hooks/__tests__/usePersistentState.test.ts
+++ b/src/shared/hooks/__tests__/usePersistentState.test.ts
@@ -19,6 +19,9 @@ describe('usePersistentState', () => {
             usePersistentState('test.restore', { count: 0 })
         );
         expect(result.current[0]).toEqual({ count: 7 });
+        expect(
+            JSON.parse(localStorage.getItem('test.restore') ?? 'null')
+        ).toEqual({ count: 7 });
     });
 
     it('persists new value to localStorage on setValue change', () => {
@@ -45,15 +48,20 @@ describe('usePersistentState', () => {
         expect(result.current[0]).toBe('fallback');
     });
 
-    it('writes the initial value to localStorage once hydration completes', () => {
-        // The write effect is gated on hydrated.current, which only flips true after the
-        // mount effect runs — so during SSR (no effects) nothing is written, avoiding a
-        // hydration mismatch. renderHook runs effects synchronously, so here we assert the
-        // post-hydration outcome: the initial value lands in storage.
+    it('does not persist the initial value until it changes (writes only user changes)', () => {
+        // 마운트 직후 첫 write effect는 건너뛰므로 initial은 저장되지 않는다 — 저장값을 잠깐
+        // initial로 덮어쓰는 transient를 막고 localStorage엔 사용자 변경만 남긴다.
         localStorage.clear();
-        renderHook(() => usePersistentState('test.nowrite', 99));
+        const { result } = renderHook(() =>
+            usePersistentState('test.nowrite', 99)
+        );
+        expect(localStorage.getItem('test.nowrite')).toBeNull();
+
+        act(() => {
+            result.current[1](100);
+        });
         expect(JSON.parse(localStorage.getItem('test.nowrite') ?? 'null')).toBe(
-            99
+            100
         );
     });
 

--- a/src/shared/hooks/__tests__/usePersistentState.test.ts
+++ b/src/shared/hooks/__tests__/usePersistentState.test.ts
@@ -18,7 +18,6 @@ describe('usePersistentState', () => {
         const { result } = renderHook(() =>
             usePersistentState('test.restore', { count: 0 })
         );
-        // After effects run, the stored value should be restored
         expect(result.current[0]).toEqual({ count: 7 });
     });
 
@@ -43,7 +42,6 @@ describe('usePersistentState', () => {
         const { result } = renderHook(() =>
             usePersistentState('test.bad', 'fallback')
         );
-        // Parsing fails silently — should retain initial
         expect(result.current[0]).toBe('fallback');
     });
 

--- a/src/shared/hooks/usePersistentState.ts
+++ b/src/shared/hooks/usePersistentState.ts
@@ -5,17 +5,21 @@ import { useEffect, useEffectEvent, useRef, useState } from 'react';
 /**
  * useState와 동일 시그니처의 localStorage 영속 상태. SSR-safe:
  * 서버/초기 렌더는 initial을 사용해 hydration mismatch를 피하고, 마운트 후 저장값으로 복원하며,
- * 이후 값 변경 시 저장한다. 복원 setValue는 useEffectEvent로 감싸 effect 의존성에서 제외한다
- * (React 19 canonical 패턴, MISTAKES §10). 다만 eslint-plugin-react-hooks@7.1.1은
- * useEffectEvent를 통과해 setState를 추적하므로 set-state-in-effect가 여전히 false-positive로
- * 발생한다 — 이 파일은 eslint.config.mjs에서 해당 규칙을 예외 처리한다(useSectorSignalState.ts 선례 동일).
+ * 이후 **사용자 변경분만** 저장한다(initial은 저장하지 않는다 — 마운트 직후 저장값을 잠깐
+ * initial로 덮어쓰는 transient를 막고 localStorage엔 실제 선택만 남긴다).
+ *
+ * 복원 setValue는 useEffectEvent로 감싸 effect 의존성에서 제외한다(React 19 canonical 패턴,
+ * MISTAKES §10). 다만 eslint-plugin-react-hooks@7.1.1은 useEffectEvent를 통과해 setState를
+ * 추적하므로 set-state-in-effect가 여전히 false-positive로 발생한다 — 이 파일은
+ * eslint.config.mjs에서 해당 규칙을 예외 처리한다(useSectorSignalState.ts 선례 동일).
  */
 export function usePersistentState<T>(
     key: string,
     initial: T
 ): [T, React.Dispatch<React.SetStateAction<T>>] {
     const [value, setValue] = useState<T>(initial);
-    const hydrated = useRef(false);
+    // 저장 effect의 마운트 첫 실행(아직 initial 값) 1회를 건너뛰기 위한 플래그.
+    const writeArmed = useRef(false);
 
     const restoreFromStorage = useEffectEvent(() => {
         if (typeof window === 'undefined') return;
@@ -27,7 +31,6 @@ export function usePersistentState<T>(
         } catch {
             // 파싱 실패/접근 불가 시 initial 유지 (의도된 graceful fallback — 빈 catch 아님)
         }
-        hydrated.current = true;
     });
 
     useEffect(() => {
@@ -35,7 +38,12 @@ export function usePersistentState<T>(
     }, []);
 
     useEffect(() => {
-        if (typeof window === 'undefined' || !hydrated.current) return;
+        // 마운트 직후 첫 실행은 복원 전 initial 값이므로 저장하지 않고 건너뛴다.
+        if (!writeArmed.current) {
+            writeArmed.current = true;
+            return;
+        }
+        if (typeof window === 'undefined') return;
         try {
             window.localStorage.setItem(key, JSON.stringify(value));
         } catch {

--- a/src/shared/hooks/usePersistentState.ts
+++ b/src/shared/hooks/usePersistentState.ts
@@ -13,6 +13,9 @@ import type { Dispatch, SetStateAction } from 'react';
  * MISTAKES §10). 다만 eslint-plugin-react-hooks@7.1.1은 useEffectEvent를 통과해 setState를
  * 추적하므로 set-state-in-effect가 여전히 false-positive로 발생한다 — 이 파일은
  * eslint.config.mjs에서 해당 규칙을 예외 처리한다(useSectorSignalState.ts 선례 동일).
+ *
+ * `key`는 렌더 간 안정적인 상수여야 한다. 복원은 마운트 1회([]) 실행이라 key가 동적으로
+ * 바뀌면 새 key의 저장값이 복원되지 않는다 — 동적 key는 지원 범위 밖이다(현 사용처는 전부 상수).
  */
 export function usePersistentState<T>(
     key: string,
@@ -36,6 +39,11 @@ export function usePersistentState<T>(
 
     useEffect(() => {
         restoreFromStorage();
+        // StrictMode(dev) 시뮬레이션 unmount→remount 시 writeArmed가 true로 남아 재마운트의
+        // 첫 write가 initial을 저장하는 것을 막는다 — 재마운트마다 첫 write 건너뛰기를 복구.
+        return () => {
+            writeArmed.current = false;
+        };
     }, []);
 
     useEffect(() => {

--- a/src/shared/hooks/usePersistentState.ts
+++ b/src/shared/hooks/usePersistentState.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useEffectEvent, useRef, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 
 /**
  * useState와 동일 시그니처의 localStorage 영속 상태. SSR-safe:
@@ -16,7 +17,7 @@ import { useEffect, useEffectEvent, useRef, useState } from 'react';
 export function usePersistentState<T>(
     key: string,
     initial: T
-): [T, React.Dispatch<React.SetStateAction<T>>] {
+): [T, Dispatch<SetStateAction<T>>] {
     const [value, setValue] = useState<T>(initial);
     // 저장 effect의 마운트 첫 실행(아직 initial 값) 1회를 건너뛰기 위한 플래그.
     const writeArmed = useRef(false);

--- a/src/shared/hooks/usePersistentState.ts
+++ b/src/shared/hooks/usePersistentState.ts
@@ -5,8 +5,10 @@ import { useEffect, useEffectEvent, useRef, useState } from 'react';
 /**
  * useState와 동일 시그니처의 localStorage 영속 상태. SSR-safe:
  * 서버/초기 렌더는 initial을 사용해 hydration mismatch를 피하고, 마운트 후 저장값으로 복원하며,
- * 이후 값 변경 시 저장한다. 복원 로직은 useEffectEvent로 감싸 effect 의존성에서 빠지므로
- * set-state-in-effect 린트를 suppress 없이 만족한다 (MISTAKES §10 — React 19 canonical fix).
+ * 이후 값 변경 시 저장한다. 복원 setValue는 useEffectEvent로 감싸 effect 의존성에서 제외한다
+ * (React 19 canonical 패턴, MISTAKES §10). 다만 eslint-plugin-react-hooks@7.1.1은
+ * useEffectEvent를 통과해 setState를 추적하므로 set-state-in-effect가 여전히 false-positive로
+ * 발생한다 — 이 파일은 eslint.config.mjs에서 해당 규칙을 예외 처리한다(useSectorSignalState.ts 선례 동일).
  */
 export function usePersistentState<T>(
     key: string,

--- a/src/shared/hooks/usePersistentState.ts
+++ b/src/shared/hooks/usePersistentState.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * useState와 동일 시그니처의 localStorage 영속 상태. SSR-safe:
+ * 서버/초기 렌더는 initial(hydration mismatch 방지), 마운트 후 저장값으로 복원, 변경 시 저장.
+ */
+export function usePersistentState<T>(
+    key: string,
+    initial: T
+): [T, React.Dispatch<React.SetStateAction<T>>] {
+    const [value, setValue] = useState<T>(initial);
+    const hydrated = useRef(false);
+
+    // 마운트 시 1회 복원 (있으면). 파싱 실패/없음은 initial 유지.
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        try {
+            const raw = window.localStorage.getItem(key);
+            if (raw !== null) setValue(JSON.parse(raw) as T);
+        } catch {
+            // 파싱 실패 — initial 유지
+        }
+        hydrated.current = true;
+    }, [key]);
+
+    // 값 변경 시 저장 (마운트 복원 이후부터).
+    useEffect(() => {
+        if (typeof window === 'undefined' || !hydrated.current) return;
+        try {
+            window.localStorage.setItem(key, JSON.stringify(value));
+        } catch {
+            // quota/직렬화 실패 — 무시
+        }
+    }, [key, value]);
+
+    return [value, setValue];
+}

--- a/src/shared/hooks/usePersistentState.ts
+++ b/src/shared/hooks/usePersistentState.ts
@@ -1,10 +1,12 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useEffectEvent, useRef, useState } from 'react';
 
 /**
  * useState와 동일 시그니처의 localStorage 영속 상태. SSR-safe:
- * 서버/초기 렌더는 initial(hydration mismatch 방지), 마운트 후 저장값으로 복원, 변경 시 저장.
+ * 서버/초기 렌더는 initial을 사용해 hydration mismatch를 피하고, 마운트 후 저장값으로 복원하며,
+ * 이후 값 변경 시 저장한다. 복원 로직은 useEffectEvent로 감싸 effect 의존성에서 빠지므로
+ * set-state-in-effect 린트를 suppress 없이 만족한다 (MISTAKES §10 — React 19 canonical fix).
  */
 export function usePersistentState<T>(
     key: string,
@@ -13,25 +15,29 @@ export function usePersistentState<T>(
     const [value, setValue] = useState<T>(initial);
     const hydrated = useRef(false);
 
-    // 마운트 시 1회 복원 (있으면). 파싱 실패/없음은 initial 유지.
-    useEffect(() => {
+    const restoreFromStorage = useEffectEvent(() => {
         if (typeof window === 'undefined') return;
         try {
             const raw = window.localStorage.getItem(key);
+            // JSON.parse는 any를 반환한다. 이 훅이 같은 key의 쓰기(JSON.stringify(value: T))를 단독
+            // 소유하므로 역직렬화 결과는 항상 T와 일치한다 — 런타임 보장이 있는 안전한 캐스트.
             if (raw !== null) setValue(JSON.parse(raw) as T);
         } catch {
-            // 파싱 실패 — initial 유지
+            // 파싱 실패/접근 불가 시 initial 유지 (의도된 graceful fallback — 빈 catch 아님)
         }
         hydrated.current = true;
-    }, [key]);
+    });
 
-    // 값 변경 시 저장 (마운트 복원 이후부터).
+    useEffect(() => {
+        restoreFromStorage();
+    }, []);
+
     useEffect(() => {
         if (typeof window === 'undefined' || !hydrated.current) return;
         try {
             window.localStorage.setItem(key, JSON.stringify(value));
         } catch {
-            // quota/직렬화 실패 — 무시
+            // quota 초과/직렬화 실패는 무시 (영속 실패가 앱 동작을 막지 않도록)
         }
     }, [key, value]);
 

--- a/src/widgets/chart/__tests__/hooks/useBollingerOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useBollingerOverlay.test.ts
@@ -45,6 +45,7 @@ const FAKE_BARS: Bar[] = [
 describe('useBollingerOverlay', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        localStorage.clear();
     });
 
     it('returns isVisible false initially', () => {

--- a/src/widgets/chart/__tests__/hooks/useBollingerOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useBollingerOverlay.test.ts
@@ -2,6 +2,7 @@
 import { act, renderHook } from '@testing-library/react';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
 import { useBollingerOverlay } from '../../hooks/useBollingerOverlay';
+import { STORAGE_KEYS } from '../../constants';
 
 const mockSetData = vi.fn();
 const mockApplyOptions = vi.fn();
@@ -127,6 +128,18 @@ describe('useBollingerOverlay', () => {
         });
 
         expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+
+    it('restores isVisible true from localStorage on mount', () => {
+        localStorage.setItem(STORAGE_KEYS.overlay('bollinger'), 'true');
+        const { result } = renderHook(() =>
+            useBollingerOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        expect(result.current.isVisible).toBe(true);
     });
 
     it('provides stable toggle function reference', () => {

--- a/src/widgets/chart/__tests__/hooks/useBollingerOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useBollingerOverlay.test.ts
@@ -130,6 +130,22 @@ describe('useBollingerOverlay', () => {
         expect(mockRemoveSeries).toHaveBeenCalled();
     });
 
+    it('persists isVisible to localStorage on toggle', () => {
+        const { result } = renderHook(() =>
+            useBollingerOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => {
+            result.current.toggle();
+        });
+        expect(localStorage.getItem(STORAGE_KEYS.overlay('bollinger'))).toBe(
+            'true'
+        );
+    });
+
     it('restores isVisible true from localStorage on mount', () => {
         localStorage.setItem(STORAGE_KEYS.overlay('bollinger'), 'true');
         const { result } = renderHook(() =>

--- a/src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts
@@ -250,6 +250,22 @@ describe('useChandelierOverlay', () => {
         expect(mockSetData).not.toHaveBeenCalled();
     });
 
+    it('persists isVisible to localStorage on toggle', () => {
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => {
+            result.current.toggle();
+        });
+        expect(localStorage.getItem(STORAGE_KEYS.overlay('chandelier'))).toBe(
+            'true'
+        );
+    });
+
     it('restores isVisible true from localStorage on mount', () => {
         localStorage.setItem(STORAGE_KEYS.overlay('chandelier'), 'true');
         const { result } = renderHook(() =>

--- a/src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 import type { LineWidth } from 'lightweight-charts';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
 import { useChandelierOverlay } from '../../hooks/useChandelierOverlay';
+import { STORAGE_KEYS } from '../../constants';
 import { buildTrendSplitData } from '../../utils/seriesDataUtils';
 
 const mockSetData = vi.fn();
@@ -247,6 +248,18 @@ describe('useChandelierOverlay', () => {
         );
         act(() => result.current.toggle());
         expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('restores isVisible true from localStorage on mount', () => {
+        localStorage.setItem(STORAGE_KEYS.overlay('chandelier'), 'true');
+        const { result } = renderHook(() =>
+            useChandelierOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        expect(result.current.isVisible).toBe(true);
     });
 
     it('provides stable toggle function reference', () => {

--- a/src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useChandelierOverlay.test.ts
@@ -47,6 +47,7 @@ const FAKE_BARS: Bar[] = [
 describe('useChandelierOverlay', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        localStorage.clear();
     });
 
     it('returns isVisible false initially', () => {

--- a/src/widgets/chart/__tests__/hooks/useDonchianOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useDonchianOverlay.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
 import { LineStyle, LineType } from 'lightweight-charts';
 import { useDonchianOverlay } from '../../hooks/useDonchianOverlay';
+import { STORAGE_KEYS } from '../../constants';
 
 const mockSetData = vi.fn();
 const mockApplyOptions = vi.fn();
@@ -219,6 +220,18 @@ describe('useDonchianOverlay', () => {
                 lineStyle: LineStyle.Dashed,
             })
         );
+    });
+
+    it('restores isVisible true from localStorage on mount', () => {
+        localStorage.setItem(STORAGE_KEYS.overlay('donchian'), 'true');
+        const { result } = renderHook(() =>
+            useDonchianOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        expect(result.current.isVisible).toBe(true);
     });
 
     it('provides stable toggle function reference', () => {

--- a/src/widgets/chart/__tests__/hooks/useDonchianOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useDonchianOverlay.test.ts
@@ -58,6 +58,7 @@ const FAKE_BARS: Bar[] = [
 describe('useDonchianOverlay', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        localStorage.clear();
     });
 
     it('returns isVisible false initially', () => {

--- a/src/widgets/chart/__tests__/hooks/useDonchianOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useDonchianOverlay.test.ts
@@ -222,6 +222,22 @@ describe('useDonchianOverlay', () => {
         );
     });
 
+    it('persists isVisible to localStorage on toggle', () => {
+        const { result } = renderHook(() =>
+            useDonchianOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => {
+            result.current.toggle();
+        });
+        expect(localStorage.getItem(STORAGE_KEYS.overlay('donchian'))).toBe(
+            'true'
+        );
+    });
+
     it('restores isVisible true from localStorage on mount', () => {
         localStorage.setItem(STORAGE_KEYS.overlay('donchian'), 'true');
         const { result } = renderHook(() =>

--- a/src/widgets/chart/__tests__/hooks/useEMAOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useEMAOverlay.test.ts
@@ -41,6 +41,7 @@ const FAKE_BARS: Bar[] = [
 describe('useEMAOverlay', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        localStorage.clear();
     });
 
     it('returns empty visiblePeriods by default', () => {

--- a/src/widgets/chart/__tests__/hooks/useEMAOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useEMAOverlay.test.ts
@@ -2,6 +2,7 @@
 import { act, renderHook } from '@testing-library/react';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
 import { useEMAOverlay } from '../../hooks/useEMAOverlay';
+import { STORAGE_KEYS } from '../../constants';
 
 const mockSetData = vi.fn();
 const mockApplyOptions = vi.fn();
@@ -124,5 +125,17 @@ describe('useEMAOverlay', () => {
         });
 
         expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+
+    it('restores visiblePeriods from localStorage (STORAGE_KEYS.emaPeriods)', () => {
+        localStorage.setItem(STORAGE_KEYS.emaPeriods, JSON.stringify([20]));
+        const { result } = renderHook(() =>
+            useEMAOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: INDICATORS,
+            })
+        );
+        expect(result.current.visiblePeriods).toEqual([20]);
     });
 });

--- a/src/widgets/chart/__tests__/hooks/useIchimokuOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useIchimokuOverlay.test.ts
@@ -153,6 +153,22 @@ describe('useIchimokuOverlay', () => {
         expect(mockRemoveSeries).toHaveBeenCalled();
     });
 
+    it('persists isVisible to localStorage on toggle', () => {
+        const { result } = renderHook(() =>
+            useIchimokuOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => {
+            result.current.toggle();
+        });
+        expect(localStorage.getItem(STORAGE_KEYS.overlay('ichimoku'))).toBe(
+            'true'
+        );
+    });
+
     it('restores isVisible true from localStorage on mount', () => {
         localStorage.setItem(STORAGE_KEYS.overlay('ichimoku'), 'true');
         const { result } = renderHook(() =>

--- a/src/widgets/chart/__tests__/hooks/useIchimokuOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useIchimokuOverlay.test.ts
@@ -2,6 +2,7 @@
 import { act, renderHook } from '@testing-library/react';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
 import { useIchimokuOverlay } from '../../hooks/useIchimokuOverlay';
+import { STORAGE_KEYS } from '../../constants';
 
 const mockSetData = vi.fn();
 const mockApplyOptions = vi.fn();
@@ -150,6 +151,18 @@ describe('useIchimokuOverlay', () => {
         });
 
         expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+
+    it('restores isVisible true from localStorage on mount', () => {
+        localStorage.setItem(STORAGE_KEYS.overlay('ichimoku'), 'true');
+        const { result } = renderHook(() =>
+            useIchimokuOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        expect(result.current.isVisible).toBe(true);
     });
 
     it('provides stable toggle reference', () => {

--- a/src/widgets/chart/__tests__/hooks/useIchimokuOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useIchimokuOverlay.test.ts
@@ -68,6 +68,7 @@ const FAKE_BARS: Bar[] = [
 describe('useIchimokuOverlay', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        localStorage.clear();
     });
 
     it('returns isVisible false initially', () => {

--- a/src/widgets/chart/__tests__/hooks/useIndicatorVisibility.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useIndicatorVisibility.test.ts
@@ -5,7 +5,9 @@ import { useIndicatorVisibility } from '../../hooks/useIndicatorVisibility';
 import {
     FIRST_INDICATOR_PANE_INDEX,
     INACTIVE_PANE_INDEX,
+    STORAGE_KEYS,
 } from '../../constants';
+import { INDICATOR_REGISTRY } from '../../model/indicatorRegistry';
 
 describe('useIndicatorVisibility', () => {
     beforeEach(() => {
@@ -70,5 +72,51 @@ describe('useIndicatorVisibility', () => {
         for (const k of paneKeys) {
             expect(result.current.paneIndices[k]).toBe(INACTIVE_PANE_INDEX);
         }
+    });
+
+    it('restores persisted visibility from localStorage on mount', () => {
+        localStorage.setItem(
+            STORAGE_KEYS.visible,
+            JSON.stringify({ rsi: true })
+        );
+        const { result } = renderHook(() => useIndicatorVisibility());
+        expect(result.current.visible.rsi).toBe(true);
+        expect(result.current.paneIndices.rsi).toBe(FIRST_INDICATOR_PANE_INDEX);
+    });
+
+    it('fills missing registry keys with false when restoring a partial state', () => {
+        // 레지스트리 성장 전 저장된 데이터처럼 일부 키만 있는 상황 — 신규 키가 누락되어도
+        // 모든 등록 키가 boolean으로 채워져야 paneIndices 계산이 안전하다.
+        localStorage.setItem(
+            STORAGE_KEYS.visible,
+            JSON.stringify({ rsi: true })
+        );
+        const { result } = renderHook(() => useIndicatorVisibility());
+        for (const indicator of INDICATOR_REGISTRY) {
+            expect(typeof result.current.visible[indicator.key]).toBe(
+                'boolean'
+            );
+        }
+        expect(result.current.visible.macd).toBe(false);
+    });
+
+    it('toggle works correctly after restoring from localStorage', () => {
+        localStorage.setItem(
+            STORAGE_KEYS.visible,
+            JSON.stringify({ rsi: true })
+        );
+        const { result } = renderHook(() => useIndicatorVisibility());
+        act(() => result.current.toggle('rsi'));
+        expect(result.current.visible.rsi).toBe(false);
+        expect(result.current.paneIndices.rsi).toBe(INACTIVE_PANE_INDEX);
+    });
+
+    it('persists visibility changes to localStorage', () => {
+        const { result } = renderHook(() => useIndicatorVisibility());
+        act(() => result.current.toggle('rsi'));
+        const stored = JSON.parse(
+            localStorage.getItem(STORAGE_KEYS.visible) ?? '{}'
+        );
+        expect(stored.rsi).toBe(true);
     });
 });

--- a/src/widgets/chart/__tests__/hooks/useIndicatorVisibility.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useIndicatorVisibility.test.ts
@@ -92,12 +92,11 @@ describe('useIndicatorVisibility', () => {
             JSON.stringify({ rsi: true })
         );
         const { result } = renderHook(() => useIndicatorVisibility());
+        // 저장값에 없던 키는 전부 false로 채워져야 한다(rsi=true는 위 별도 테스트가 검증).
         for (const indicator of INDICATOR_REGISTRY) {
-            expect(typeof result.current.visible[indicator.key]).toBe(
-                'boolean'
-            );
+            if (indicator.key === 'rsi') continue;
+            expect(result.current.visible[indicator.key]).toBe(false);
         }
-        expect(result.current.visible.macd).toBe(false);
     });
 
     it('toggle works correctly after restoring from localStorage', () => {

--- a/src/widgets/chart/__tests__/hooks/useIndicatorVisibility.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useIndicatorVisibility.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useIndicatorVisibility } from '../../hooks/useIndicatorVisibility';
 import {
@@ -8,6 +8,10 @@ import {
 } from '../../constants';
 
 describe('useIndicatorVisibility', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
     it('starts with all pane indicators hidden (INACTIVE)', () => {
         const { result } = renderHook(() => useIndicatorVisibility());
         expect(result.current.visible.rsi).toBe(false);

--- a/src/widgets/chart/__tests__/hooks/useKeltnerOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useKeltnerOverlay.test.ts
@@ -45,6 +45,7 @@ const FAKE_BARS: Bar[] = [
 describe('useKeltnerOverlay', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        localStorage.clear();
     });
 
     it('returns isVisible false initially', () => {

--- a/src/widgets/chart/__tests__/hooks/useKeltnerOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useKeltnerOverlay.test.ts
@@ -2,6 +2,7 @@
 import { act, renderHook } from '@testing-library/react';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
 import { useKeltnerOverlay } from '../../hooks/useKeltnerOverlay';
+import { STORAGE_KEYS } from '../../constants';
 
 const mockSetData = vi.fn();
 const mockApplyOptions = vi.fn();
@@ -161,6 +162,18 @@ describe('useKeltnerOverlay', () => {
         });
 
         expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('restores isVisible true from localStorage on mount', () => {
+        localStorage.setItem(STORAGE_KEYS.overlay('keltner'), 'true');
+        const { result } = renderHook(() =>
+            useKeltnerOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        expect(result.current.isVisible).toBe(true);
     });
 
     it('provides stable toggle function reference', () => {

--- a/src/widgets/chart/__tests__/hooks/useKeltnerOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useKeltnerOverlay.test.ts
@@ -164,6 +164,22 @@ describe('useKeltnerOverlay', () => {
         expect(mockSetData).not.toHaveBeenCalled();
     });
 
+    it('persists isVisible to localStorage on toggle', () => {
+        const { result } = renderHook(() =>
+            useKeltnerOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => {
+            result.current.toggle();
+        });
+        expect(localStorage.getItem(STORAGE_KEYS.overlay('keltner'))).toBe(
+            'true'
+        );
+    });
+
     it('restores isVisible true from localStorage on mount', () => {
         localStorage.setItem(STORAGE_KEYS.overlay('keltner'), 'true');
         const { result } = renderHook(() =>

--- a/src/widgets/chart/__tests__/hooks/useMAOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useMAOverlay.test.ts
@@ -2,6 +2,7 @@
 import { act, renderHook } from '@testing-library/react';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
 import { useMAOverlay } from '../../hooks/useMAOverlay';
+import { STORAGE_KEYS } from '../../constants';
 
 const mockSetData = vi.fn();
 const mockApplyOptions = vi.fn();
@@ -125,6 +126,34 @@ describe('useMAOverlay', () => {
         });
 
         expect(mockRemoveSeries).toHaveBeenCalled();
+    });
+
+    it('restores visiblePeriods from localStorage (STORAGE_KEYS.maPeriods)', () => {
+        localStorage.setItem(STORAGE_KEYS.maPeriods, JSON.stringify([20]));
+        const { result } = renderHook(() =>
+            useMAOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: INDICATORS,
+            })
+        );
+        expect(result.current.visiblePeriods).toEqual([20]);
+    });
+
+    it('persists visiblePeriods to localStorage on toggle', () => {
+        const { result } = renderHook(() =>
+            useMAOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: INDICATORS,
+            })
+        );
+        act(() => {
+            result.current.togglePeriod(20);
+        });
+        expect(
+            JSON.parse(localStorage.getItem(STORAGE_KEYS.maPeriods) ?? '[]')
+        ).toContain(20);
     });
 
     it('provides stable togglePeriod reference', () => {

--- a/src/widgets/chart/__tests__/hooks/useMAOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useMAOverlay.test.ts
@@ -39,6 +39,7 @@ const FAKE_BARS: Bar[] = [
 describe('useMAOverlay', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        localStorage.clear();
     });
 
     it('returns empty visiblePeriods by default', () => {

--- a/src/widgets/chart/__tests__/hooks/useMAOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useMAOverlay.test.ts
@@ -153,7 +153,7 @@ describe('useMAOverlay', () => {
         });
         expect(
             JSON.parse(localStorage.getItem(STORAGE_KEYS.maPeriods) ?? '[]')
-        ).toContain(20);
+        ).toEqual([20]);
     });
 
     it('provides stable togglePeriod reference', () => {

--- a/src/widgets/chart/__tests__/hooks/useMovingAverageOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useMovingAverageOverlay.test.ts
@@ -48,6 +48,7 @@ const FAKE_BARS: Bar[] = [
 describe('useMovingAverageOverlay', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        localStorage.clear();
     });
 
     it('returns empty visiblePeriods by default', () => {
@@ -56,6 +57,7 @@ describe('useMovingAverageOverlay', () => {
                 chartRef: makeChartRef(),
                 bars: [],
                 indicators: INDICATORS,
+                storageKey: 'test.ma.default',
                 lineStyle: 0,
                 getIndicatorData: mockAccessor,
             })
@@ -70,6 +72,7 @@ describe('useMovingAverageOverlay', () => {
                 chartRef: makeChartRef(),
                 bars: [],
                 indicators: INDICATORS,
+                storageKey: 'test.ma.defaults',
                 defaultPeriods: [10, 20],
                 lineStyle: 0,
                 getIndicatorData: mockAccessor,
@@ -85,6 +88,7 @@ describe('useMovingAverageOverlay', () => {
                 chartRef: makeChartRef(),
                 bars: [],
                 indicators: INDICATORS,
+                storageKey: 'test.ma.toggle',
                 lineStyle: 0,
                 getIndicatorData: mockAccessor,
             })
@@ -113,6 +117,7 @@ describe('useMovingAverageOverlay', () => {
                 chartRef: makeChartRef(chart),
                 bars: FAKE_BARS,
                 indicators: INDICATORS,
+                storageKey: 'test.ma.creates',
                 defaultPeriods: [10, 20],
                 lineStyle: 0,
                 getIndicatorData: mockAccessor,
@@ -128,6 +133,7 @@ describe('useMovingAverageOverlay', () => {
                 chartRef: makeChartRef(null),
                 bars: FAKE_BARS,
                 indicators: INDICATORS,
+                storageKey: 'test.ma.nonull',
                 defaultPeriods: [10],
                 lineStyle: 0,
                 getIndicatorData: mockAccessor,
@@ -144,6 +150,7 @@ describe('useMovingAverageOverlay', () => {
                 chartRef: makeChartRef(chart),
                 bars: FAKE_BARS,
                 indicators: INDICATORS,
+                storageKey: 'test.ma.removes',
                 defaultPeriods: [10],
                 lineStyle: 0,
                 getIndicatorData: mockAccessor,
@@ -163,6 +170,7 @@ describe('useMovingAverageOverlay', () => {
                 chartRef: makeChartRef(),
                 bars: [],
                 indicators: INDICATORS,
+                storageKey: 'test.ma.stable',
                 lineStyle: 0,
                 getIndicatorData: mockAccessor,
             })

--- a/src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts
@@ -2,6 +2,7 @@
 import { act, renderHook } from '@testing-library/react';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
 import { useParabolicSarOverlay } from '../../hooks/useParabolicSarOverlay';
+import { STORAGE_KEYS } from '../../constants';
 import { buildTrendSplitData } from '../../utils/seriesDataUtils';
 
 const mockSetData = vi.fn();
@@ -208,6 +209,18 @@ describe('useParabolicSarOverlay', () => {
         );
         act(() => result.current.toggle());
         expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('restores isVisible true from localStorage on mount', () => {
+        localStorage.setItem(STORAGE_KEYS.overlay('parabolicSar'), 'true');
+        const { result } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        expect(result.current.isVisible).toBe(true);
     });
 
     it('provides stable toggle function reference', () => {

--- a/src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts
@@ -45,6 +45,7 @@ const FAKE_BARS: Bar[] = [
 describe('useParabolicSarOverlay', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        localStorage.clear();
     });
 
     it('returns isVisible false initially', () => {

--- a/src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useParabolicSarOverlay.test.ts
@@ -211,6 +211,22 @@ describe('useParabolicSarOverlay', () => {
         expect(mockSetData).not.toHaveBeenCalled();
     });
 
+    it('persists isVisible to localStorage on toggle', () => {
+        const { result } = renderHook(() =>
+            useParabolicSarOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => {
+            result.current.toggle();
+        });
+        expect(localStorage.getItem(STORAGE_KEYS.overlay('parabolicSar'))).toBe(
+            'true'
+        );
+    });
+
     it('restores isVisible true from localStorage on mount', () => {
         localStorage.setItem(STORAGE_KEYS.overlay('parabolicSar'), 'true');
         const { result } = renderHook(() =>

--- a/src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts
@@ -198,6 +198,22 @@ describe('useSupertrendOverlay', () => {
         expect(mockSetData).not.toHaveBeenCalled();
     });
 
+    it('persists isVisible to localStorage on toggle', () => {
+        const { result } = renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        act(() => {
+            result.current.toggle();
+        });
+        expect(localStorage.getItem(STORAGE_KEYS.overlay('supertrend'))).toBe(
+            'true'
+        );
+    });
+
     it('restores isVisible true from localStorage on mount', () => {
         localStorage.setItem(STORAGE_KEYS.overlay('supertrend'), 'true');
         const { result } = renderHook(() =>

--- a/src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts
@@ -45,6 +45,7 @@ const FAKE_BARS: Bar[] = [
 describe('useSupertrendOverlay', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        localStorage.clear();
     });
 
     it('returns isVisible false initially', () => {

--- a/src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useSupertrendOverlay.test.ts
@@ -2,6 +2,7 @@
 import { act, renderHook } from '@testing-library/react';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
 import { useSupertrendOverlay } from '../../hooks/useSupertrendOverlay';
+import { STORAGE_KEYS } from '../../constants';
 import { buildTrendSplitData } from '../../utils/seriesDataUtils';
 
 const mockSetData = vi.fn();
@@ -195,6 +196,18 @@ describe('useSupertrendOverlay', () => {
         );
         act(() => result.current.toggle());
         expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    it('restores isVisible true from localStorage on mount', () => {
+        localStorage.setItem(STORAGE_KEYS.overlay('supertrend'), 'true');
+        const { result } = renderHook(() =>
+            useSupertrendOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: EMPTY_INDICATORS,
+            })
+        );
+        expect(result.current.isVisible).toBe(true);
     });
 
     it('provides stable toggle function reference', () => {

--- a/src/widgets/chart/__tests__/hooks/useVolumeProfileOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useVolumeProfileOverlay.test.ts
@@ -143,6 +143,22 @@ describe('useVolumeProfileOverlay', () => {
         expect(mockSetData).toHaveBeenCalledWith([]);
     });
 
+    it('persists isVisible to localStorage on toggle', () => {
+        const { result } = renderHook(() =>
+            useVolumeProfileOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: NO_VP_INDICATORS,
+            })
+        );
+        act(() => {
+            result.current.toggle();
+        });
+        expect(
+            localStorage.getItem(STORAGE_KEYS.overlay('volumeProfile'))
+        ).toBe('true');
+    });
+
     it('restores isVisible true from localStorage on mount', () => {
         localStorage.setItem(STORAGE_KEYS.overlay('volumeProfile'), 'true');
         const { result } = renderHook(() =>

--- a/src/widgets/chart/__tests__/hooks/useVolumeProfileOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useVolumeProfileOverlay.test.ts
@@ -41,6 +41,7 @@ const FAKE_BARS: Bar[] = [
 describe('useVolumeProfileOverlay', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        localStorage.clear();
     });
 
     it('returns isVisible false initially', () => {

--- a/src/widgets/chart/__tests__/hooks/useVolumeProfileOverlay.test.ts
+++ b/src/widgets/chart/__tests__/hooks/useVolumeProfileOverlay.test.ts
@@ -2,6 +2,7 @@
 import { act, renderHook } from '@testing-library/react';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
 import { useVolumeProfileOverlay } from '../../hooks/useVolumeProfileOverlay';
+import { STORAGE_KEYS } from '../../constants';
 
 const mockSetData = vi.fn();
 const mockApplyOptions = vi.fn();
@@ -140,6 +141,18 @@ describe('useVolumeProfileOverlay', () => {
         });
 
         expect(mockSetData).toHaveBeenCalledWith([]);
+    });
+
+    it('restores isVisible true from localStorage on mount', () => {
+        localStorage.setItem(STORAGE_KEYS.overlay('volumeProfile'), 'true');
+        const { result } = renderHook(() =>
+            useVolumeProfileOverlay({
+                chartRef: makeChartRef(),
+                bars: [],
+                indicators: NO_VP_INDICATORS,
+            })
+        );
+        expect(result.current.isVisible).toBe(true);
     });
 
     it('provides stable toggle reference', () => {

--- a/src/widgets/chart/__tests__/ui/IndicatorSettingsModal.test.tsx
+++ b/src/widgets/chart/__tests__/ui/IndicatorSettingsModal.test.tsx
@@ -198,4 +198,22 @@ describe('IndicatorSettingsModal', () => {
             screen.queryByRole('button', { name: /20/ })
         ).not.toBeInTheDocument();
     });
+
+    it('renders indicator items in a 2-column grid container (layout regression)', () => {
+        openDialog();
+        render(
+            <IndicatorSettingsModal bindings={[rsiBinding(), maBinding()]} />
+        );
+        // 카테고리별 항목 컨테이너가 2열 그리드여야 모달 길이가 짧아져 모바일에서 안 가려진다.
+        expect(
+            document.querySelectorAll('.grid.grid-cols-2').length
+        ).toBeGreaterThan(0);
+    });
+
+    it('wraps period rows with col-span-2 so chips span the full width', () => {
+        openDialog();
+        render(<IndicatorSettingsModal bindings={[maBinding()]} />);
+        // period 행(MA/EMA)은 칩이 넓어 2열 그리드에서 전체폭(col-span-2)을 차지해야 한다.
+        expect(document.querySelector('.col-span-2')).toBeInTheDocument();
+    });
 });

--- a/src/widgets/chart/__tests__/ui/IndicatorSettingsModal.test.tsx
+++ b/src/widgets/chart/__tests__/ui/IndicatorSettingsModal.test.tsx
@@ -205,9 +205,8 @@ describe('IndicatorSettingsModal', () => {
             <IndicatorSettingsModal bindings={[rsiBinding(), maBinding()]} />
         );
         // 카테고리별 항목 컨테이너가 2열 그리드여야 모달 길이가 짧아져 모바일에서 안 가려진다.
-        expect(
-            document.querySelectorAll('.grid.grid-cols-2').length
-        ).toBeGreaterThan(0);
+        // rsi(momentum)+ma(trend) = 정확히 2개 카테고리 → 그리드 컨테이너 2개(결정적).
+        expect(document.querySelectorAll('.grid.grid-cols-2').length).toBe(2);
     });
 
     it('wraps period rows with col-span-2 so chips span the full width', () => {

--- a/src/widgets/chart/__tests__/ui/IndicatorSettingsModal.test.tsx
+++ b/src/widgets/chart/__tests__/ui/IndicatorSettingsModal.test.tsx
@@ -213,6 +213,7 @@ describe('IndicatorSettingsModal', () => {
         openDialog();
         render(<IndicatorSettingsModal bindings={[maBinding()]} />);
         // period 행(MA/EMA)은 칩이 넓어 2열 그리드에서 전체폭(col-span-2)을 차지해야 한다.
-        expect(document.querySelector('.col-span-2')).toBeInTheDocument();
+        // ma 바인딩 1개 → col-span-2 래퍼 정확히 1개(결정적).
+        expect(document.querySelectorAll('.col-span-2').length).toBe(1);
     });
 });

--- a/src/widgets/chart/constants.ts
+++ b/src/widgets/chart/constants.ts
@@ -24,6 +24,5 @@ export const STORAGE_KEYS = {
     visible: `${STORAGE_PREFIX}.visible`,
     maPeriods: `${STORAGE_PREFIX}.ma.periods`,
     emaPeriods: `${STORAGE_PREFIX}.ema.periods`,
-    // overlay 토글 8종(bollinger·keltner·donchian·supertrend·parabolicSar·chandelier·ichimoku·volumeProfile)
-    overlay: (key: string) => `${STORAGE_PREFIX}.overlay.${key}`,
+    overlay: (key: string): string => `${STORAGE_PREFIX}.overlay.${key}`,
 } as const;

--- a/src/widgets/chart/constants.ts
+++ b/src/widgets/chart/constants.ts
@@ -20,9 +20,23 @@ export const BASE_PATTERN_SERIES_OPTIONS = {
 // 'siglens.chart.*' 단일 네임스페이스로 모아 오타·충돌을 막고 영속 대상을 한눈에 보이게 한다.
 // 영속 자체는 usePersistentState가 담당하고, 여기서는 키 목록만 단일 소스로 관리한다.
 const STORAGE_PREFIX = 'siglens.chart';
+
+// overlay 토글 영속 키를 가진 훅들. 유니온으로 제약해 오타('bolingger' 등)를 컴파일 타임에 잡고,
+// 향후 overlay 추가/삭제 시 누락된 호출을 타입 에러로 드러낸다.
+export type OverlayStorageKey =
+    | 'bollinger'
+    | 'keltner'
+    | 'donchian'
+    | 'supertrend'
+    | 'parabolicSar'
+    | 'chandelier'
+    | 'ichimoku'
+    | 'volumeProfile';
+
 export const STORAGE_KEYS = {
     visible: `${STORAGE_PREFIX}.visible`,
     maPeriods: `${STORAGE_PREFIX}.ma.periods`,
     emaPeriods: `${STORAGE_PREFIX}.ema.periods`,
-    overlay: (key: string): string => `${STORAGE_PREFIX}.overlay.${key}`,
+    overlay: (key: OverlayStorageKey): string =>
+        `${STORAGE_PREFIX}.overlay.${key}`,
 } as const;

--- a/src/widgets/chart/constants.ts
+++ b/src/widgets/chart/constants.ts
@@ -15,3 +15,15 @@ export const BASE_PATTERN_SERIES_OPTIONS = {
     priceLineVisible: false,
     lastValueVisible: false,
 } as const;
+
+// 차트 보조지표 선택을 새로고침 후에도 복원하기 위한 localStorage 키.
+// 'siglens.chart.*' 단일 네임스페이스로 모아 오타·충돌을 막고 영속 대상을 한눈에 보이게 한다.
+// 영속 자체는 usePersistentState가 담당하고, 여기서는 키 목록만 단일 소스로 관리한다.
+const STORAGE_PREFIX = 'siglens.chart';
+export const STORAGE_KEYS = {
+    visible: `${STORAGE_PREFIX}.visible`,
+    maPeriods: `${STORAGE_PREFIX}.ma.periods`,
+    emaPeriods: `${STORAGE_PREFIX}.ema.periods`,
+    // overlay 토글 8종(bollinger·keltner·donchian·supertrend·parabolicSar·chandelier·ichimoku·volumeProfile)
+    overlay: (key: string) => `${STORAGE_PREFIX}.overlay.${key}`,
+} as const;

--- a/src/widgets/chart/hooks/useBollingerOverlay.ts
+++ b/src/widgets/chart/hooks/useBollingerOverlay.ts
@@ -1,18 +1,13 @@
 'use client';
 
 import type { RefObject } from 'react';
-import {
-    useCallback,
-    useEffect,
-    useEffectEvent,
-    useRef,
-    useState,
-} from 'react';
+import { useCallback, useEffect, useEffectEvent, useRef } from 'react';
+import { usePersistentState } from '@/shared/hooks/usePersistentState';
 import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
 import { AreaSeries, LineSeries } from 'lightweight-charts';
 import { CHART_COLORS } from '@/shared/lib/chartColors';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
-import { DEFAULT_LINE_WIDTH } from '../constants';
+import { DEFAULT_LINE_WIDTH, STORAGE_KEYS } from '../constants';
 import { buildSeriesData } from '../utils/seriesDataUtils';
 
 interface UseBollingerOverlayParams {
@@ -33,7 +28,10 @@ export function useBollingerOverlay({
     indicators,
     lineWidth = DEFAULT_LINE_WIDTH,
 }: UseBollingerOverlayParams): UseBollingerOverlayReturn {
-    const [isVisible, setIsVisible] = useState(false);
+    const [isVisible, setIsVisible] = usePersistentState(
+        STORAGE_KEYS.overlay('bollinger'),
+        false
+    );
     const prevChartRef = useRef<IChartApi | null>(null);
     const upperSeriesRef = useRef<ISeriesApi<'Area'> | null>(null);
     const middleSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
@@ -41,7 +39,7 @@ export function useBollingerOverlay({
 
     const toggle = useCallback(() => {
         setIsVisible(prev => !prev);
-    }, []);
+    }, [setIsVisible]);
 
     // chart 인스턴스 교체 시 ref만 초기화 (removeSeries 불필요 — 이전 chart는 부모가 소멸)
     const clearSeriesRefs = useEffectEvent(() => {

--- a/src/widgets/chart/hooks/useBollingerOverlay.ts
+++ b/src/widgets/chart/hooks/useBollingerOverlay.ts
@@ -28,14 +28,14 @@ export function useBollingerOverlay({
     indicators,
     lineWidth = DEFAULT_LINE_WIDTH,
 }: UseBollingerOverlayParams): UseBollingerOverlayReturn {
-    const [isVisible, setIsVisible] = usePersistentState(
-        STORAGE_KEYS.overlay('bollinger'),
-        false
-    );
     const prevChartRef = useRef<IChartApi | null>(null);
     const upperSeriesRef = useRef<ISeriesApi<'Area'> | null>(null);
     const middleSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
     const lowerSeriesRef = useRef<ISeriesApi<'Area'> | null>(null);
+    const [isVisible, setIsVisible] = usePersistentState(
+        STORAGE_KEYS.overlay('bollinger'),
+        false
+    );
 
     const toggle = useCallback(() => {
         setIsVisible(prev => !prev);

--- a/src/widgets/chart/hooks/useChandelierOverlay.ts
+++ b/src/widgets/chart/hooks/useChandelierOverlay.ts
@@ -1,18 +1,13 @@
 'use client';
 
 import type { RefObject } from 'react';
-import {
-    useCallback,
-    useEffect,
-    useEffectEvent,
-    useRef,
-    useState,
-} from 'react';
+import { useCallback, useEffect, useEffectEvent, useRef } from 'react';
+import { usePersistentState } from '@/shared/hooks/usePersistentState';
 import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
 import { LineSeries, LineStyle } from 'lightweight-charts';
 import { CHART_COLORS } from '@/shared/lib/chartColors';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
-import { DEFAULT_LINE_WIDTH } from '../constants';
+import { DEFAULT_LINE_WIDTH, STORAGE_KEYS } from '../constants';
 import { buildTrendSplitData } from '../utils/seriesDataUtils';
 
 interface UseChandelierOverlayParams {
@@ -33,14 +28,17 @@ export function useChandelierOverlay({
     indicators,
     lineWidth = DEFAULT_LINE_WIDTH,
 }: UseChandelierOverlayParams): UseChandelierOverlayReturn {
-    const [isVisible, setIsVisible] = useState(false);
+    const [isVisible, setIsVisible] = usePersistentState(
+        STORAGE_KEYS.overlay('chandelier'),
+        false
+    );
     const prevChartRef = useRef<IChartApi | null>(null);
     const longSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
     const shortSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
 
     const toggle = useCallback(() => {
         setIsVisible(prev => !prev);
-    }, []);
+    }, [setIsVisible]);
 
     const clearSeriesRefs = useEffectEvent(() => {
         longSeriesRef.current = null;

--- a/src/widgets/chart/hooks/useChandelierOverlay.ts
+++ b/src/widgets/chart/hooks/useChandelierOverlay.ts
@@ -28,13 +28,13 @@ export function useChandelierOverlay({
     indicators,
     lineWidth = DEFAULT_LINE_WIDTH,
 }: UseChandelierOverlayParams): UseChandelierOverlayReturn {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const longSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+    const shortSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
     const [isVisible, setIsVisible] = usePersistentState(
         STORAGE_KEYS.overlay('chandelier'),
         false
     );
-    const prevChartRef = useRef<IChartApi | null>(null);
-    const longSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
-    const shortSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
 
     const toggle = useCallback(() => {
         setIsVisible(prev => !prev);

--- a/src/widgets/chart/hooks/useDonchianOverlay.ts
+++ b/src/widgets/chart/hooks/useDonchianOverlay.ts
@@ -1,13 +1,8 @@
 'use client';
 
 import type { RefObject } from 'react';
-import {
-    useCallback,
-    useEffect,
-    useEffectEvent,
-    useRef,
-    useState,
-} from 'react';
+import { useCallback, useEffect, useEffectEvent, useRef } from 'react';
+import { usePersistentState } from '@/shared/hooks/usePersistentState';
 import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
 import {
     AreaSeries,
@@ -17,7 +12,7 @@ import {
 } from 'lightweight-charts';
 import { CHART_COLORS } from '@/shared/lib/chartColors';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
-import { DEFAULT_LINE_WIDTH } from '../constants';
+import { DEFAULT_LINE_WIDTH, STORAGE_KEYS } from '../constants';
 import { buildSeriesData } from '../utils/seriesDataUtils';
 
 interface UseDonchianOverlayParams {
@@ -38,7 +33,10 @@ export function useDonchianOverlay({
     indicators,
     lineWidth = DEFAULT_LINE_WIDTH,
 }: UseDonchianOverlayParams): UseDonchianOverlayReturn {
-    const [isVisible, setIsVisible] = useState(false);
+    const [isVisible, setIsVisible] = usePersistentState(
+        STORAGE_KEYS.overlay('donchian'),
+        false
+    );
     const prevChartRef = useRef<IChartApi | null>(null);
     const upperSeriesRef = useRef<ISeriesApi<'Area'> | null>(null);
     const middleSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
@@ -46,7 +44,7 @@ export function useDonchianOverlay({
 
     const toggle = useCallback(() => {
         setIsVisible(prev => !prev);
-    }, []);
+    }, [setIsVisible]);
 
     // chart 인스턴스 교체 시 ref만 초기화 (removeSeries 불필요 — 이전 chart는 부모가 소멸)
     const clearSeriesRefs = useEffectEvent(() => {

--- a/src/widgets/chart/hooks/useDonchianOverlay.ts
+++ b/src/widgets/chart/hooks/useDonchianOverlay.ts
@@ -33,14 +33,14 @@ export function useDonchianOverlay({
     indicators,
     lineWidth = DEFAULT_LINE_WIDTH,
 }: UseDonchianOverlayParams): UseDonchianOverlayReturn {
-    const [isVisible, setIsVisible] = usePersistentState(
-        STORAGE_KEYS.overlay('donchian'),
-        false
-    );
     const prevChartRef = useRef<IChartApi | null>(null);
     const upperSeriesRef = useRef<ISeriesApi<'Area'> | null>(null);
     const middleSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
     const lowerSeriesRef = useRef<ISeriesApi<'Area'> | null>(null);
+    const [isVisible, setIsVisible] = usePersistentState(
+        STORAGE_KEYS.overlay('donchian'),
+        false
+    );
 
     const toggle = useCallback(() => {
         setIsVisible(prev => !prev);

--- a/src/widgets/chart/hooks/useEMAOverlay.ts
+++ b/src/widgets/chart/hooks/useEMAOverlay.ts
@@ -4,6 +4,7 @@ import type { RefObject } from 'react';
 import type { IChartApi, LineWidth } from 'lightweight-charts';
 import { LineStyle } from 'lightweight-charts';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { STORAGE_KEYS } from '../constants';
 import {
     type IndicatorDataAccessor,
     useMovingAverageOverlay,
@@ -16,6 +17,7 @@ interface UseEMAOverlayParams {
     chartRef: RefObject<IChartApi | null>;
     bars: Bar[];
     indicators: IndicatorResult;
+    storageKey?: string;
     defaultPeriods?: number[];
     lineWidth?: LineWidth;
 }
@@ -29,6 +31,7 @@ export function useEMAOverlay({
     chartRef,
     bars,
     indicators,
+    storageKey = STORAGE_KEYS.emaPeriods,
     defaultPeriods,
     lineWidth,
 }: UseEMAOverlayParams): UseEMAOverlayReturn {
@@ -36,6 +39,7 @@ export function useEMAOverlay({
         chartRef,
         bars,
         indicators,
+        storageKey,
         defaultPeriods,
         lineWidth,
         lineStyle: LineStyle.Dotted,

--- a/src/widgets/chart/hooks/useIchimokuOverlay.ts
+++ b/src/widgets/chart/hooks/useIchimokuOverlay.ts
@@ -34,10 +34,6 @@ export function useIchimokuOverlay({
     indicators,
     lineWidth = DEFAULT_LINE_WIDTH,
 }: UseIchimokuOverlayParams): UseIchimokuOverlayReturn {
-    const [isVisible, setIsVisible] = usePersistentState(
-        STORAGE_KEYS.overlay('ichimoku'),
-        false
-    );
     const prevChartRef = useRef<IChartApi | null>(null);
     const tenkanRef = useRef<ISeriesApi<'Line'> | null>(null);
     const kijunRef = useRef<ISeriesApi<'Line'> | null>(null);
@@ -46,6 +42,10 @@ export function useIchimokuOverlay({
     const senkouBRef = useRef<ISeriesApi<'Line'> | null>(null);
     const cloudBullishRef = useRef<ISeriesApi<'Area'> | null>(null);
     const cloudBearishRef = useRef<ISeriesApi<'Area'> | null>(null);
+    const [isVisible, setIsVisible] = usePersistentState(
+        STORAGE_KEYS.overlay('ichimoku'),
+        false
+    );
 
     const toggle = useCallback(() => {
         setIsVisible(prev => !prev);

--- a/src/widgets/chart/hooks/useIchimokuOverlay.ts
+++ b/src/widgets/chart/hooks/useIchimokuOverlay.ts
@@ -1,13 +1,8 @@
 'use client';
 
 import type { RefObject } from 'react';
-import {
-    useCallback,
-    useEffect,
-    useEffectEvent,
-    useRef,
-    useState,
-} from 'react';
+import { useCallback, useEffect, useEffectEvent, useRef } from 'react';
+import { usePersistentState } from '@/shared/hooks/usePersistentState';
 import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
 import { AreaSeries, LineSeries, LineStyle } from 'lightweight-charts';
 import { CHART_COLORS } from '@/shared/lib/chartColors';
@@ -16,7 +11,7 @@ import {
     type IndicatorResult,
     calculateIchimokuFutureCloud,
 } from '@y0ngha/siglens-core';
-import { DEFAULT_LINE_WIDTH } from '../constants';
+import { DEFAULT_LINE_WIDTH, STORAGE_KEYS } from '../constants';
 import { buildSeriesData } from '../utils/seriesDataUtils';
 import type { FutureCloudBase } from '../utils/ichimokuUtils';
 import { buildCloudData, extendWithFutureCloud } from '../utils/ichimokuUtils';
@@ -39,7 +34,10 @@ export function useIchimokuOverlay({
     indicators,
     lineWidth = DEFAULT_LINE_WIDTH,
 }: UseIchimokuOverlayParams): UseIchimokuOverlayReturn {
-    const [isVisible, setIsVisible] = useState(false);
+    const [isVisible, setIsVisible] = usePersistentState(
+        STORAGE_KEYS.overlay('ichimoku'),
+        false
+    );
     const prevChartRef = useRef<IChartApi | null>(null);
     const tenkanRef = useRef<ISeriesApi<'Line'> | null>(null);
     const kijunRef = useRef<ISeriesApi<'Line'> | null>(null);
@@ -51,7 +49,7 @@ export function useIchimokuOverlay({
 
     const toggle = useCallback(() => {
         setIsVisible(prev => !prev);
-    }, []);
+    }, [setIsVisible]);
 
     const clearSeriesRefs = useEffectEvent(() => {
         tenkanRef.current = null;

--- a/src/widgets/chart/hooks/useIndicatorVisibility.ts
+++ b/src/widgets/chart/hooks/useIndicatorVisibility.ts
@@ -25,23 +25,26 @@ interface UseIndicatorVisibilityReturn {
 }
 
 function initialVisibility(): VisibilityState {
-    // INDICATOR_REGISTRY 전체 키(18개)를 채우므로 Record<IndicatorKey, boolean>가
+    // INDICATOR_REGISTRY 전체 키를 채우므로 Record<IndicatorKey, boolean>가
     // 런타임에 완전히 충족된다 — 안전한 캐스트.
     return Object.fromEntries(
         INDICATOR_REGISTRY.map(m => [m.key, false])
     ) as VisibilityState;
 }
 
+// INDICATOR_REGISTRY(정적)에서만 파생되는 순수 값 — 매 렌더 재호출 대신 모듈 레벨 상수로 1회 고정.
+const INITIAL_VISIBILITY: VisibilityState = initialVisibility();
+
 export function useIndicatorVisibility(): UseIndicatorVisibilityReturn {
     const [persistedPartial, setVisible] = usePersistentState<VisibilityState>(
         STORAGE_KEYS.visible,
-        initialVisibility()
+        INITIAL_VISIBILITY
     );
 
-    // 레지스트리 성장 대비: 저장된 값에 없는 새 키는 initialVisibility()의 기본값(false)으로 채운다.
+    // 레지스트리 성장 대비: 저장된 값에 없는 새 키는 기본값(false)으로 채운다.
     // paneIndices 계산이 모든 등록 키를 필요로 하므로 완전한 Record를 항상 보장한다.
     const visible = useMemo<VisibilityState>(
-        () => ({ ...initialVisibility(), ...persistedPartial }),
+        () => ({ ...INITIAL_VISIBILITY, ...persistedPartial }),
         [persistedPartial]
     );
 

--- a/src/widgets/chart/hooks/useIndicatorVisibility.ts
+++ b/src/widgets/chart/hooks/useIndicatorVisibility.ts
@@ -1,7 +1,12 @@
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
-import { FIRST_INDICATOR_PANE_INDEX, INACTIVE_PANE_INDEX } from '../constants';
+import { useCallback, useMemo } from 'react';
+import { usePersistentState } from '@/shared/hooks/usePersistentState';
+import {
+    FIRST_INDICATOR_PANE_INDEX,
+    INACTIVE_PANE_INDEX,
+    STORAGE_KEYS,
+} from '../constants';
 import {
     INDICATOR_REGISTRY,
     type IndicatorKey,
@@ -28,11 +33,24 @@ function initialVisibility(): VisibilityState {
 }
 
 export function useIndicatorVisibility(): UseIndicatorVisibilityReturn {
-    const [visible, setVisible] = useState<VisibilityState>(initialVisibility);
+    const [persistedPartial, setVisible] = usePersistentState<VisibilityState>(
+        STORAGE_KEYS.visible,
+        initialVisibility()
+    );
 
-    const toggle = useCallback((key: IndicatorKey) => {
-        setVisible(prev => ({ ...prev, [key]: !prev[key] }));
-    }, []);
+    // 레지스트리 성장 대비: 저장된 값에 없는 새 키는 initialVisibility()의 기본값(false)으로 채운다.
+    // paneIndices 계산이 모든 등록 키를 필요로 하므로 완전한 Record를 항상 보장한다.
+    const visible = useMemo<VisibilityState>(
+        () => ({ ...initialVisibility(), ...persistedPartial }),
+        [persistedPartial]
+    );
+
+    const toggle = useCallback(
+        (key: IndicatorKey) => {
+            setVisible(prev => ({ ...prev, [key]: !prev[key] }));
+        },
+        [setVisible]
+    );
 
     const paneIndices: PaneIndices = useMemo(() => {
         // 가변 카운터 없이 순수하게 계산 — 활성 pane을 등록 순서로 추려 Map으로 위치를 부여.

--- a/src/widgets/chart/hooks/useIndicatorVisibility.ts
+++ b/src/widgets/chart/hooks/useIndicatorVisibility.ts
@@ -49,13 +49,6 @@ export function useIndicatorVisibility(): UseIndicatorVisibilityReturn {
         [persistedPartial]
     );
 
-    const toggle = useCallback(
-        (key: IndicatorKey) => {
-            setVisible(prev => ({ ...prev, [key]: !prev[key] }));
-        },
-        [setVisible]
-    );
-
     const paneIndices: PaneIndices = useMemo(() => {
         // 가변 카운터 없이 순수하게 계산 — 활성 pane을 등록 순서로 추려 Map으로 위치를 부여.
         const activePaneKeys = INDICATOR_REGISTRY.filter(
@@ -67,7 +60,7 @@ export function useIndicatorVisibility(): UseIndicatorVisibilityReturn {
                 FIRST_INDICATOR_PANE_INDEX + i,
             ])
         );
-        // INDICATOR_REGISTRY 전체 키(18개)를 채우므로 Record<IndicatorKey,number>가 런타임에 완전히 충족 — 안전한 캐스트.
+        // INDICATOR_REGISTRY 전체 키를 채우므로 Record<IndicatorKey,number>가 런타임에 완전히 충족 — 안전한 캐스트.
         return Object.fromEntries(
             INDICATOR_REGISTRY.map(m => [
                 m.key,
@@ -75,6 +68,13 @@ export function useIndicatorVisibility(): UseIndicatorVisibilityReturn {
             ])
         ) as PaneIndices;
     }, [visible]);
+
+    const toggle = useCallback(
+        (key: IndicatorKey) => {
+            setVisible(prev => ({ ...prev, [key]: !prev[key] }));
+        },
+        [setVisible]
+    );
 
     return { visible, toggle, paneIndices };
 }

--- a/src/widgets/chart/hooks/useIndicatorVisibility.ts
+++ b/src/widgets/chart/hooks/useIndicatorVisibility.ts
@@ -36,10 +36,11 @@ function initialVisibility(): VisibilityState {
 const INITIAL_VISIBILITY: VisibilityState = initialVisibility();
 
 export function useIndicatorVisibility(): UseIndicatorVisibilityReturn {
-    const [persistedPartial, setVisible] = usePersistentState<VisibilityState>(
-        STORAGE_KEYS.visible,
-        INITIAL_VISIBILITY
-    );
+    // 복원값은 구 버전 저장 데이터처럼 일부 키만 있을 수 있으므로 Partial로 받는다(타입-런타임 일치).
+    // INITIAL_VISIBILITY(완전한 Record)는 Partial의 상위 타입이므로 초기값으로 그대로 허용된다.
+    const [persistedPartial, setVisible] = usePersistentState<
+        Partial<Record<IndicatorKey, boolean>>
+    >(STORAGE_KEYS.visible, INITIAL_VISIBILITY);
 
     // 레지스트리 성장 대비: 저장된 값에 없는 새 키는 기본값(false)으로 채운다.
     // paneIndices 계산이 모든 등록 키를 필요로 하므로 완전한 Record를 항상 보장한다.

--- a/src/widgets/chart/hooks/useIndicatorVisibility.ts
+++ b/src/widgets/chart/hooks/useIndicatorVisibility.ts
@@ -13,7 +13,7 @@ import {
 } from '../model/indicatorRegistry';
 import type { PaneIndices } from '../types';
 
-// visible은 INDICATOR_REGISTRY 전체(18키)를 담는다 — Record<IndicatorKey,boolean> 캐스트를
+// visible은 INDICATOR_REGISTRY 전체 키를 담는다 — Record<IndicatorKey,boolean> 캐스트를
 // 런타임에 완전히 충족시키기 위함이다. overlay 키(ma·bollinger 등)는 별도 훅
 // (useMAOverlay·useBollingerOverlay 등)이 관리하므로 여기선 항상 false이며 pane 토글에만 쓰인다.
 type VisibilityState = Record<IndicatorKey, boolean>;

--- a/src/widgets/chart/hooks/useKeltnerOverlay.ts
+++ b/src/widgets/chart/hooks/useKeltnerOverlay.ts
@@ -28,14 +28,14 @@ export function useKeltnerOverlay({
     indicators,
     lineWidth = DEFAULT_LINE_WIDTH,
 }: UseKeltnerOverlayParams): UseKeltnerOverlayReturn {
-    const [isVisible, setIsVisible] = usePersistentState(
-        STORAGE_KEYS.overlay('keltner'),
-        false
-    );
     const prevChartRef = useRef<IChartApi | null>(null);
     const upperSeriesRef = useRef<ISeriesApi<'Area'> | null>(null);
     const middleSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
     const lowerSeriesRef = useRef<ISeriesApi<'Area'> | null>(null);
+    const [isVisible, setIsVisible] = usePersistentState(
+        STORAGE_KEYS.overlay('keltner'),
+        false
+    );
 
     const toggle = useCallback(() => {
         setIsVisible(prev => !prev);

--- a/src/widgets/chart/hooks/useKeltnerOverlay.ts
+++ b/src/widgets/chart/hooks/useKeltnerOverlay.ts
@@ -1,18 +1,13 @@
 'use client';
 
 import type { RefObject } from 'react';
-import {
-    useCallback,
-    useEffect,
-    useEffectEvent,
-    useRef,
-    useState,
-} from 'react';
+import { useCallback, useEffect, useEffectEvent, useRef } from 'react';
+import { usePersistentState } from '@/shared/hooks/usePersistentState';
 import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
 import { AreaSeries, LineSeries } from 'lightweight-charts';
 import { CHART_COLORS } from '@/shared/lib/chartColors';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
-import { DEFAULT_LINE_WIDTH } from '../constants';
+import { DEFAULT_LINE_WIDTH, STORAGE_KEYS } from '../constants';
 import { buildSeriesData } from '../utils/seriesDataUtils';
 
 interface UseKeltnerOverlayParams {
@@ -33,7 +28,10 @@ export function useKeltnerOverlay({
     indicators,
     lineWidth = DEFAULT_LINE_WIDTH,
 }: UseKeltnerOverlayParams): UseKeltnerOverlayReturn {
-    const [isVisible, setIsVisible] = useState(false);
+    const [isVisible, setIsVisible] = usePersistentState(
+        STORAGE_KEYS.overlay('keltner'),
+        false
+    );
     const prevChartRef = useRef<IChartApi | null>(null);
     const upperSeriesRef = useRef<ISeriesApi<'Area'> | null>(null);
     const middleSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
@@ -41,7 +39,7 @@ export function useKeltnerOverlay({
 
     const toggle = useCallback(() => {
         setIsVisible(prev => !prev);
-    }, []);
+    }, [setIsVisible]);
 
     // chart 인스턴스 교체 시 ref만 초기화 (removeSeries 불필요 — 이전 chart는 부모가 소멸)
     const clearSeriesRefs = useEffectEvent(() => {

--- a/src/widgets/chart/hooks/useMAOverlay.ts
+++ b/src/widgets/chart/hooks/useMAOverlay.ts
@@ -4,6 +4,7 @@ import type { RefObject } from 'react';
 import type { IChartApi, LineWidth } from 'lightweight-charts';
 import { LineStyle } from 'lightweight-charts';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
+import { STORAGE_KEYS } from '../constants';
 import {
     type IndicatorDataAccessor,
     useMovingAverageOverlay,
@@ -16,6 +17,7 @@ interface UseMAOverlayParams {
     chartRef: RefObject<IChartApi | null>;
     bars: Bar[];
     indicators: IndicatorResult;
+    storageKey?: string;
     defaultPeriods?: number[];
     lineWidth?: LineWidth;
 }
@@ -29,6 +31,7 @@ export function useMAOverlay({
     chartRef,
     bars,
     indicators,
+    storageKey = STORAGE_KEYS.maPeriods,
     defaultPeriods,
     lineWidth,
 }: UseMAOverlayParams): UseMAOverlayReturn {
@@ -36,6 +39,7 @@ export function useMAOverlay({
         chartRef,
         bars,
         indicators,
+        storageKey,
         defaultPeriods,
         lineWidth,
         lineStyle: LineStyle.Solid,

--- a/src/widgets/chart/hooks/useMovingAverageOverlay.ts
+++ b/src/widgets/chart/hooks/useMovingAverageOverlay.ts
@@ -1,13 +1,8 @@
 'use client';
 
 import type { RefObject } from 'react';
-import {
-    useCallback,
-    useEffect,
-    useEffectEvent,
-    useRef,
-    useState,
-} from 'react';
+import { useCallback, useEffect, useEffectEvent, useRef } from 'react';
+import { usePersistentState } from '@/shared/hooks/usePersistentState';
 import type {
     IChartApi,
     ISeriesApi,
@@ -29,6 +24,7 @@ interface UseMovingAverageOverlayParams {
     chartRef: RefObject<IChartApi | null>;
     bars: Bar[];
     indicators: IndicatorResult;
+    storageKey: string;
     defaultPeriods?: number[];
     lineWidth?: LineWidth;
     lineStyle: LineStyle;
@@ -44,23 +40,29 @@ export function useMovingAverageOverlay({
     chartRef,
     bars,
     indicators,
+    storageKey,
     defaultPeriods = [],
     lineWidth = DEFAULT_LINE_WIDTH,
     lineStyle,
     getIndicatorData,
 }: UseMovingAverageOverlayParams): UseMovingAverageOverlayReturn {
-    const [visiblePeriods, setVisiblePeriods] =
-        useState<number[]>(defaultPeriods);
+    const [visiblePeriods, setVisiblePeriods] = usePersistentState<number[]>(
+        storageKey,
+        defaultPeriods
+    );
     const prevChartRef = useRef<IChartApi | null>(null);
     const seriesRef = useRef<Record<number, ISeriesApi<'Line'>>>({});
 
-    const togglePeriod = useCallback((period: number) => {
-        setVisiblePeriods(prev =>
-            prev.includes(period)
-                ? prev.filter(p => p !== period)
-                : [...prev, period]
-        );
-    }, []);
+    const togglePeriod = useCallback(
+        (period: number) => {
+            setVisiblePeriods(prev =>
+                prev.includes(period)
+                    ? prev.filter(p => p !== period)
+                    : [...prev, period]
+            );
+        },
+        [setVisiblePeriods]
+    );
 
     // chart 인스턴스 교체 시 ref만 초기화 (removeSeries 불필요 — 이전 chart는 부모가 소멸)
     const clearSeriesRefs = useEffectEvent(() => {

--- a/src/widgets/chart/hooks/useMovingAverageOverlay.ts
+++ b/src/widgets/chart/hooks/useMovingAverageOverlay.ts
@@ -46,12 +46,12 @@ export function useMovingAverageOverlay({
     lineStyle,
     getIndicatorData,
 }: UseMovingAverageOverlayParams): UseMovingAverageOverlayReturn {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const seriesRef = useRef<Record<number, ISeriesApi<'Line'>>>({});
     const [visiblePeriods, setVisiblePeriods] = usePersistentState<number[]>(
         storageKey,
         defaultPeriods
     );
-    const prevChartRef = useRef<IChartApi | null>(null);
-    const seriesRef = useRef<Record<number, ISeriesApi<'Line'>>>({});
 
     const togglePeriod = useCallback(
         (period: number) => {

--- a/src/widgets/chart/hooks/useParabolicSarOverlay.ts
+++ b/src/widgets/chart/hooks/useParabolicSarOverlay.ts
@@ -1,18 +1,13 @@
 'use client';
 
 import type { RefObject } from 'react';
-import {
-    useCallback,
-    useEffect,
-    useEffectEvent,
-    useRef,
-    useState,
-} from 'react';
+import { useCallback, useEffect, useEffectEvent, useRef } from 'react';
+import { usePersistentState } from '@/shared/hooks/usePersistentState';
 import type { IChartApi, ISeriesApi } from 'lightweight-charts';
 import { LineSeries } from 'lightweight-charts';
 import { CHART_COLORS } from '@/shared/lib/chartColors';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
-import { DEFAULT_POINT_MARKERS_RADIUS } from '../constants';
+import { DEFAULT_POINT_MARKERS_RADIUS, STORAGE_KEYS } from '../constants';
 import { buildTrendSplitData } from '../utils/seriesDataUtils';
 
 interface UseParabolicSarOverlayParams {
@@ -31,14 +26,17 @@ export function useParabolicSarOverlay({
     bars,
     indicators,
 }: UseParabolicSarOverlayParams): UseParabolicSarOverlayReturn {
-    const [isVisible, setIsVisible] = useState(false);
+    const [isVisible, setIsVisible] = usePersistentState(
+        STORAGE_KEYS.overlay('parabolicSar'),
+        false
+    );
     const prevChartRef = useRef<IChartApi | null>(null);
     const upSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
     const downSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
 
     const toggle = useCallback(() => {
         setIsVisible(prev => !prev);
-    }, []);
+    }, [setIsVisible]);
 
     const clearSeriesRefs = useEffectEvent(() => {
         upSeriesRef.current = null;

--- a/src/widgets/chart/hooks/useParabolicSarOverlay.ts
+++ b/src/widgets/chart/hooks/useParabolicSarOverlay.ts
@@ -26,13 +26,13 @@ export function useParabolicSarOverlay({
     bars,
     indicators,
 }: UseParabolicSarOverlayParams): UseParabolicSarOverlayReturn {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const upSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+    const downSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
     const [isVisible, setIsVisible] = usePersistentState(
         STORAGE_KEYS.overlay('parabolicSar'),
         false
     );
-    const prevChartRef = useRef<IChartApi | null>(null);
-    const upSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
-    const downSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
 
     const toggle = useCallback(() => {
         setIsVisible(prev => !prev);

--- a/src/widgets/chart/hooks/useSupertrendOverlay.ts
+++ b/src/widgets/chart/hooks/useSupertrendOverlay.ts
@@ -1,18 +1,13 @@
 'use client';
 
 import type { RefObject } from 'react';
-import {
-    useCallback,
-    useEffect,
-    useEffectEvent,
-    useRef,
-    useState,
-} from 'react';
+import { useCallback, useEffect, useEffectEvent, useRef } from 'react';
+import { usePersistentState } from '@/shared/hooks/usePersistentState';
 import type { IChartApi, ISeriesApi, LineWidth } from 'lightweight-charts';
 import { LineSeries } from 'lightweight-charts';
 import { CHART_COLORS } from '@/shared/lib/chartColors';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
-import { DEFAULT_LINE_WIDTH } from '../constants';
+import { DEFAULT_LINE_WIDTH, STORAGE_KEYS } from '../constants';
 import { buildTrendSplitData } from '../utils/seriesDataUtils';
 
 interface UseSupertrendOverlayParams {
@@ -33,14 +28,17 @@ export function useSupertrendOverlay({
     indicators,
     lineWidth = DEFAULT_LINE_WIDTH,
 }: UseSupertrendOverlayParams): UseSupertrendOverlayReturn {
-    const [isVisible, setIsVisible] = useState(false);
+    const [isVisible, setIsVisible] = usePersistentState(
+        STORAGE_KEYS.overlay('supertrend'),
+        false
+    );
     const prevChartRef = useRef<IChartApi | null>(null);
     const upSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
     const downSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
 
     const toggle = useCallback(() => {
         setIsVisible(prev => !prev);
-    }, []);
+    }, [setIsVisible]);
 
     const clearSeriesRefs = useEffectEvent(() => {
         upSeriesRef.current = null;

--- a/src/widgets/chart/hooks/useSupertrendOverlay.ts
+++ b/src/widgets/chart/hooks/useSupertrendOverlay.ts
@@ -28,13 +28,13 @@ export function useSupertrendOverlay({
     indicators,
     lineWidth = DEFAULT_LINE_WIDTH,
 }: UseSupertrendOverlayParams): UseSupertrendOverlayReturn {
+    const prevChartRef = useRef<IChartApi | null>(null);
+    const upSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+    const downSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
     const [isVisible, setIsVisible] = usePersistentState(
         STORAGE_KEYS.overlay('supertrend'),
         false
     );
-    const prevChartRef = useRef<IChartApi | null>(null);
-    const upSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
-    const downSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
 
     const toggle = useCallback(() => {
         setIsVisible(prev => !prev);

--- a/src/widgets/chart/hooks/useVolumeProfileOverlay.ts
+++ b/src/widgets/chart/hooks/useVolumeProfileOverlay.ts
@@ -1,13 +1,8 @@
 'use client';
 
 import type { RefObject } from 'react';
-import {
-    useCallback,
-    useEffect,
-    useEffectEvent,
-    useRef,
-    useState,
-} from 'react';
+import { useCallback, useEffect, useEffectEvent, useRef } from 'react';
+import { usePersistentState } from '@/shared/hooks/usePersistentState';
 import type {
     IChartApi,
     ISeriesApi,
@@ -17,7 +12,7 @@ import type {
 import { LineSeries } from 'lightweight-charts';
 import type { Bar, IndicatorResult } from '@y0ngha/siglens-core';
 import { CHART_COLORS } from '@/shared/lib/chartColors';
-import { DEFAULT_LINE_WIDTH } from '../constants';
+import { DEFAULT_LINE_WIDTH, STORAGE_KEYS } from '../constants';
 
 interface UseVolumeProfileOverlayParams {
     chartRef: RefObject<IChartApi | null>;
@@ -37,7 +32,10 @@ export function useVolumeProfileOverlay({
     indicators,
     lineWidth = DEFAULT_LINE_WIDTH,
 }: UseVolumeProfileOverlayParams): UseVolumeProfileOverlayReturn {
-    const [isVisible, setIsVisible] = useState(false);
+    const [isVisible, setIsVisible] = usePersistentState(
+        STORAGE_KEYS.overlay('volumeProfile'),
+        false
+    );
     const prevChartRef = useRef<IChartApi | null>(null);
     const pocSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
     const vahSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
@@ -45,7 +43,7 @@ export function useVolumeProfileOverlay({
 
     const toggle = useCallback(() => {
         setIsVisible(prev => !prev);
-    }, []);
+    }, [setIsVisible]);
 
     // chart 인스턴스 교체 시 ref만 초기화 (removeSeries 불필요 — 이전 chart는 부모가 소멸)
     const clearSeriesRefs = useEffectEvent(() => {

--- a/src/widgets/chart/hooks/useVolumeProfileOverlay.ts
+++ b/src/widgets/chart/hooks/useVolumeProfileOverlay.ts
@@ -32,14 +32,14 @@ export function useVolumeProfileOverlay({
     indicators,
     lineWidth = DEFAULT_LINE_WIDTH,
 }: UseVolumeProfileOverlayParams): UseVolumeProfileOverlayReturn {
-    const [isVisible, setIsVisible] = usePersistentState(
-        STORAGE_KEYS.overlay('volumeProfile'),
-        false
-    );
     const prevChartRef = useRef<IChartApi | null>(null);
     const pocSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
     const vahSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
     const valSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+    const [isVisible, setIsVisible] = usePersistentState(
+        STORAGE_KEYS.overlay('volumeProfile'),
+        false
+    );
 
     const toggle = useCallback(() => {
         setIsVisible(prev => !prev);

--- a/src/widgets/chart/ui/IndicatorSettingsModal.tsx
+++ b/src/widgets/chart/ui/IndicatorSettingsModal.tsx
@@ -147,7 +147,7 @@ export function IndicatorSettingsModal({
                             aria-modal="true"
                             aria-labelledby={titleId}
                             tabIndex={-1}
-                            className="border-secondary-700 bg-secondary-800 max-h-[calc(100vh-2rem)] w-full max-w-md overflow-y-auto rounded-xl border text-left shadow-2xl outline-none"
+                            className="border-secondary-700 bg-secondary-800 max-h-[calc(100vh-2rem)] w-full max-w-lg overflow-y-auto rounded-xl border text-left shadow-2xl outline-none"
                         >
                             <div className="border-secondary-700 flex items-start justify-between border-b px-5 py-4">
                                 <h2
@@ -185,13 +185,17 @@ export function IndicatorSettingsModal({
                                         <h3 className="text-secondary-500 mb-1 text-xs font-semibold tracking-wide uppercase">
                                             {group.label}
                                         </h3>
-                                        <div className="flex flex-col gap-0.5">
+                                        <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
                                             {group.items.map(binding =>
                                                 binding.meta.hasPeriods ? (
-                                                    <PeriodRow
+                                                    <div
                                                         key={binding.meta.key}
-                                                        binding={binding}
-                                                    />
+                                                        className="col-span-2"
+                                                    >
+                                                        <PeriodRow
+                                                            binding={binding}
+                                                        />
+                                                    </div>
                                                 ) : (
                                                     <ToggleRow
                                                         key={binding.meta.key}


### PR DESCRIPTION
## 관련 이슈

기술 설계 사용자 지시 구현 (모달 UI/UX + 상태 영속)

## 구현 내용

보조지표 렌더링 스택 머지 후 발견된 2가지 UX 문제 해결:

### 1. 선택 상태 localStorage 영속

- **신규 `usePersistentState<T>(key, default)`** (`shared/hooks`)
  - SSR-safe: 초기 렌더는 default, 마운트 후 localStorage 복원
  - `typeof window` 가드로 서버 렌더링 안전
  - 기존 `useState`와 동일 시그니처 → 드롭인 교체

- **영속 대상** (API 무변경, 드롭인 교체)
  - `useIndicatorVisibility`: `siglens.chart.visible` 키로 보조지표 on/off 상태 복원
  - overlay 8종(Bollinger/Keltner/Donchian/Supertrend/Parabolic SAR/Chandelier/Ichimoku/Volume Profile): 각각 `siglens.chart.overlay.<key>` 키로 영속
  - `useMovingAverageOverlay`/`useEMAOverlay`: 각각 `siglens.chart.ma.periods`, `siglens.chart.ema.periods` 키로 period 배열 영속
  - STORAGE_KEYS 네임스페이스로 중앙화

### 2. 모달 2열 그리드 레이아웃

- **IndicatorSettingsModal.tsx**: `flex flex-col` → `grid grid-cols-2` (데스크톱·모바일 동일, 34개 지표가 2D로 reflow)
- period 행(MA/EMA)은 `col-span-2`로 전체폭 유지
- 모달 폭 `max-w-md` → `max-w-lg` (그리드 수용)
- 모바일 390px에서 오버플로우 0, 뷰포트 내 수용

## 검증 결과 (Chrome, prod-like 빌드)

| # | 항목 | 결과 |
|---|---|---|
| ① | 토글 ON → 렌더 | PASS — localStorage에 on 상태 기록 |
| ② | 토글 OFF → 제거 | PASS — localStorage에 off 상태 갱신 |
| ③ | 새로고침 → 복원 | PASS — 재토글 없이 선택 복원 |
| ④ | 해제 상태 영속 | PASS — off 상태도 새로고침 후 유지 |
| ⑤ | 모바일 모달 | PASS — 2열 그리드 정상 reflow, 오버플로우/클리핑 0 |

- 콘솔 에러 0
- 단위 테스트 661 pass
- tsc/lint/prettier 클린

## 레이어 및 코드 품질 체크

- [x] @docs/conventions/CONVENTIONS.md 준수 확인
- [x] @docs/conventions/FF.md 준수 확인
- [x] @docs/workflows/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it

## 변경 파일 목록

[생성]
- `src/shared/hooks/usePersistentState.ts` (SSR-safe localStorage 훅)
- `src/shared/hooks/__tests__/usePersistentState.test.ts` (단위 테스트)
- `docs/superpowers/specs/2026-06-12-indicator-modal-grid-persist-design.md` (설계·검증)

[수정]
- `src/widgets/chart/constants.ts` (STORAGE_KEYS 네임스페이스)
- `src/widgets/chart/hooks/useIndicatorVisibility.ts` (영속 + 머지)
- `src/widgets/chart/hooks/useMovingAverageOverlay.ts` (storageKey 파라미터)
- `src/widgets/chart/hooks/useMAOverlay.ts` (영속)
- `src/widgets/chart/hooks/useEMAOverlay.ts` (영속)
- `src/widgets/chart/hooks/{useBollinger,useKeltner,useDonchian,useParabolicSar,useChandelier,useIchimoku,useVolumeProfile}Overlay.ts` (영속, 7개)
- `src/widgets/chart/__tests__/hooks/{*}.test.ts` (beforeEach localStorage.clear, 14개)
- `src/widgets/chart/ui/IndicatorSettingsModal.tsx` (그리드 레이아웃)
- `eslint.config.mjs` (usePersistentState 추가)

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build

Generated with [Claude Code](https://claude.com/claude-code)