### PR TITLE
feat(seo): GoogleOther 비검색 크롤러 robots Disallow

### DIFF
--- a/src/app/__tests__/robots.test.ts
+++ b/src/app/__tests__/robots.test.ts
@@ -35,33 +35,43 @@ describe('robots', () => {
 
     it('disallows GoogleOther non-search crawlers (search indexing unaffected)', () => {
         const result = robots();
+        // 정확히 3개로 결정적이므로 exact 배열 비교 — 실수로 Googlebot 등이 끼면 즉시 실패한다.
         expect(result.rules).toContainEqual(
             expect.objectContaining({
-                userAgent: expect.arrayContaining([
+                userAgent: [
                     'GoogleOther',
                     'GoogleOther-Image',
                     'GoogleOther-Video',
-                ]),
+                ],
                 disallow: '/',
             })
         );
     });
 
-    it('never disallows the real Googlebot search crawler', () => {
+    it('never disallows search-critical Google crawlers', () => {
         const result = robots();
         const rules = Array.isArray(result.rules)
             ? result.rules
             : [result.rules];
-        for (const rule of rules) {
-            const agents = Array.isArray(rule.userAgent)
-                ? rule.userAgent
-                : [rule.userAgent];
-            if (
-                agents.includes('Googlebot') ||
-                agents.includes('Googlebot-Image')
-            ) {
-                expect(rule.disallow).toBeUndefined();
-            }
+        // 검색 색인·SC 디버깅에 필수 — GoogleOther 계열과 이름이 비슷해 오타 차단 위험이 크다.
+        const criticalGoogleBots = [
+            'Googlebot',
+            'Googlebot-Image',
+            'Googlebot-News',
+            'Googlebot-Video',
+            'Google-InspectionTool',
+        ];
+        // disallow:'/' (전면 차단) 규칙에 묶인 user-agent를 모두 모은다.
+        const fullyDisallowedAgents = rules
+            .filter(rule => rule.disallow === '/')
+            .flatMap(rule =>
+                Array.isArray(rule.userAgent)
+                    ? rule.userAgent
+                    : [rule.userAgent]
+            );
+        // 조건부 if 없이 매 봇을 직접 단언 — vacuous pass(0 assertion 통과)를 방지한다.
+        for (const bot of criticalGoogleBots) {
+            expect(fullyDisallowedAgents).not.toContain(bot);
         }
     });
 

--- a/src/app/__tests__/robots.test.ts
+++ b/src/app/__tests__/robots.test.ts
@@ -33,6 +33,38 @@ describe('robots', () => {
         );
     });
 
+    it('disallows GoogleOther non-search crawlers (search indexing unaffected)', () => {
+        const result = robots();
+        expect(result.rules).toContainEqual(
+            expect.objectContaining({
+                userAgent: expect.arrayContaining([
+                    'GoogleOther',
+                    'GoogleOther-Image',
+                    'GoogleOther-Video',
+                ]),
+                disallow: '/',
+            })
+        );
+    });
+
+    it('never disallows the real Googlebot search crawler', () => {
+        const result = robots();
+        const rules = Array.isArray(result.rules)
+            ? result.rules
+            : [result.rules];
+        for (const rule of rules) {
+            const agents = Array.isArray(rule.userAgent)
+                ? rule.userAgent
+                : [rule.userAgent];
+            if (
+                agents.includes('Googlebot') ||
+                agents.includes('Googlebot-Image')
+            ) {
+                expect(rule.disallow).toBeUndefined();
+            }
+        }
+    });
+
     it('limits Anthropic automated crawlers to one crawl every 60 seconds', () => {
         const result = robots();
         expect(result.rules).toContainEqual({

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -17,6 +17,18 @@ const PARASITE_BOT_USER_AGENTS = [
     'DataForSeoBot',
 ];
 
+// Google의 비검색 generic 크롤러. 검색 색인(Googlebot)과 IP 대역은 공유하지만 기능적으로
+// 완전히 분리돼 있다 — Google 공식 문서가 "GoogleOther 대상 크롤링 설정은 어떤 특정 제품에도
+// 영향을 주지 않는다"고 명시한다(내부 R&D / one-off 크롤 용도). 따라서 전면 Disallow해도
+// 검색 랭킹·색인·rich result에 페널티가 없으며, origin fetch(낮은 캐시율 환경의 비용 요인)만
+// 줄인다. Image/Video 변형 토큰도 함께 막는다. ⚠️ Googlebot/Googlebot-Image는 절대 포함 금지
+// (검색 색인이 날아간다). AI 학습 opt-out은 별도 토큰 Google-Extended 소관이라 여기 대상 아님.
+const GOOGLE_NON_SEARCH_USER_AGENTS = [
+    'GoogleOther',
+    'GoogleOther-Image',
+    'GoogleOther-Video',
+];
+
 export default function robots(): MetadataRoute.Robots {
     return {
         rules: [
@@ -42,6 +54,10 @@ export default function robots(): MetadataRoute.Robots {
             },
             {
                 userAgent: PARASITE_BOT_USER_AGENTS,
+                disallow: '/',
+            },
+            {
+                userAgent: GOOGLE_NON_SEARCH_USER_AGENTS,
                 disallow: '/',
             },
         ],


### PR DESCRIPTION
## 구현 내용

GoogleOther, GoogleOther-Image, GoogleOther-Video 크롤러를 robots.txt에서 전면 Disallow하여 불필요한 origin fetch 비용을 줄인다.

이 세 크롤러는 검색 색인용 Googlebot과 분리된 generic 크롤러이므로, 검색 랭킹이나 색인에는 영향이 없다. Googlebot과 Googlebot-Image는 절대 차단하지 않으며, 가드 테스트를 추가하여 실수로 이들이 포함되지 않도록 보장한다.

## 변경 파일 목록

[수정]
- `src/app/robots.ts`: GoogleOther 크롤러 Disallow 추가
- `src/app/__tests__/robots.test.ts`: Googlebot 보호 테스트 추가

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build

🤖 Generated with [Claude Code](https://claude.com/claude-code)