### PR TITLE
fix(sitemap): longtail 캐시 키 v2 + 배포 전 감사 커버리지 보강 (PR #591 후속)

### DIFF
--- a/docs/superpowers/plans/2026-06-15-isr-cost-seo-r2.md
+++ b/docs/superpowers/plans/2026-06-15-isr-cost-seo-r2.md
@@ -155,7 +155,7 @@ Expected: 매치 없음(빌더·테스트에서 모두 제거됨). 매치가 남
 ```
  *   - /sitemap-longtail-{n}.xml : long-tail 종목당 메인 차트(/TICKER) 1 URL, page당 LONGTAIL_TICKERS_PER_PAGE tickers
 ```
-(코드 로직은 불변 — `LONGTAIL_TICKERS_PER_PAGE`=2000 유지, 1 URL/티커라 파일당 2000 URL로 50k 한도 내.)
+(PR #591 리뷰 반영으로 `LONGTAIL_TICKERS_PER_PAGE` 2000→**10000** 상향 — 1 URL/티커라 파일당 10000 URL로 50k 한도 내이며, sub-sitemap 파일 수가 줄어 dynamic `/sitemap-longtail-{n}.xml` 함수 호출이 감소한다.)
 
 - [ ] **Step 7: 인접 테스트 회귀 확인**
 

--- a/e2e/specs/seo-smoke.spec.ts
+++ b/e2e/specs/seo-smoke.spec.ts
@@ -61,8 +61,8 @@ test.describe('seo smoke', () => {
         const response = await page.request.get('/robots.txt');
         expect(response.status()).toBe(200);
         const body = await response.text();
-        expect(body).toContain('GPTBot'); // AI 학습봇 Disallow 그룹
-        expect(body).toMatch(/Crawl-delay:\s*60/i); // AI 검색/Anthropic crawl-delay
+        expect(body).toContain('GPTBot');
+        expect(body).toMatch(/Crawl-delay:\s*60/i);
         expect(body).toContain('Disallow: /api/');
         expect(body).toMatch(/Sitemap:\s*\S+\/sitemap\.xml/i);
     });

--- a/e2e/specs/seo-smoke.spec.ts
+++ b/e2e/specs/seo-smoke.spec.ts
@@ -52,4 +52,29 @@ test.describe('seo smoke', () => {
             expect(response.headers()['content-type']).toMatch(/image\/png/);
         });
     }
+
+    // robots.txt는 unit 테스트가 객체를 검증하지만, 실제 직렬화된 본문(크롤러가 보는 것)이
+    // AI-bot 정책을 담고 있는지는 unit이 못 잡는다. 본문을 직접 probe해 직렬화 회귀를 막는다.
+    test('/robots.txt body advertises the AI-bot policy + /api/ disallow + sitemap', async ({
+        page,
+    }) => {
+        const response = await page.request.get('/robots.txt');
+        expect(response.status()).toBe(200);
+        const body = await response.text();
+        expect(body).toContain('GPTBot'); // AI 학습봇 Disallow 그룹
+        expect(body).toMatch(/Crawl-delay:\s*60/i); // AI 검색/Anthropic crawl-delay
+        expect(body).toContain('Disallow: /api/');
+        expect(body).toMatch(/Sitemap:\s*\S+\/sitemap\.xml/i);
+    });
+
+    // long-tail sub-sitemap 라우트는 unit-mock만 돼 있어 next.config rewrite
+    // (/sitemap-longtail-{n}.xml → /api/sitemap/longtail/{n})가 e2e로 검증된 적이 없다.
+    // 범위 밖 페이지는 DB 시드와 무관하게 핸들러가 자체 404를 반환하므로, rewrite+핸들러
+    // 결선을 결정적으로 검증한다(MAX_LONGTAIL_SITEMAP_PAGE=10000 초과 → 404).
+    test('/sitemap-longtail-99999.xml (out-of-range) routes to the handler and 404s', async ({
+        page,
+    }) => {
+        const response = await page.request.get('/sitemap-longtail-99999.xml');
+        expect(response.status()).toBe(404);
+    });
 });

--- a/src/entities/sitemap-entry/__tests__/buildLongTailEntries.test.ts
+++ b/src/entities/sitemap-entry/__tests__/buildLongTailEntries.test.ts
@@ -11,6 +11,12 @@ import { LONGTAIL_ENTRIES_PER_TICKER } from '../model';
 const BUILD_DATE = new Date('2026-01-15T00:00:00.000Z');
 
 describe('buildLongTailEntries', () => {
+    it('LONGTAIL_ENTRIES_PER_TICKER는 1로 고정된다 — 서브 라우트 미광고(비용 절감) 결정 핀', () => {
+        // 다른 테스트는 상수를 symbolic하게 쓰므로, 값이 5로 되돌아가도 조용히 따라간다.
+        // 이 핀이 그 회귀를 즉시 실패시킨다.
+        expect(LONGTAIL_ENTRIES_PER_TICKER).toBe(1);
+    });
+
     it('티커 1개 → 메인 차트 1개 엔트리만 반환한다(서브 라우트 미광고)', () => {
         const entries = buildLongTailEntries(['AAPL'], BUILD_DATE);
         expect(entries).toHaveLength(LONGTAIL_ENTRIES_PER_TICKER);

--- a/src/entities/sitemap-entry/__tests__/loadLongTailTickerPage.test.ts
+++ b/src/entities/sitemap-entry/__tests__/loadLongTailTickerPage.test.ts
@@ -59,7 +59,7 @@ describe('loadLongTailTickerPage', () => {
 
         expect(unstable_cache).toHaveBeenLastCalledWith(
             expect.any(Function),
-            ['sitemap:longtail:page:v1:3'],
+            ['sitemap:longtail:page:v2:3'],
             { revalidate: SECONDS_PER_DAY }
         );
     });
@@ -87,13 +87,13 @@ describe('loadLongTailTickerPage', () => {
         expect(unstable_cache).toHaveBeenNthCalledWith(
             1,
             expect.any(Function),
-            ['sitemap:longtail:page:v1:1'],
+            ['sitemap:longtail:page:v2:1'],
             { revalidate: SECONDS_PER_DAY }
         );
         expect(unstable_cache).toHaveBeenNthCalledWith(
             2,
             expect.any(Function),
-            ['sitemap:longtail:page:v1:2'],
+            ['sitemap:longtail:page:v2:2'],
             { revalidate: SECONDS_PER_DAY }
         );
     });

--- a/src/entities/sitemap-entry/__tests__/loadLongTailTickerPage.test.ts
+++ b/src/entities/sitemap-entry/__tests__/loadLongTailTickerPage.test.ts
@@ -59,7 +59,7 @@ describe('loadLongTailTickerPage', () => {
 
         expect(unstable_cache).toHaveBeenLastCalledWith(
             expect.any(Function),
-            ['sitemap:longtail:page:v2:3'],
+            [`sitemap:longtail:page:${LONGTAIL_TICKERS_PER_PAGE}:3`],
             { revalidate: SECONDS_PER_DAY }
         );
     });
@@ -87,13 +87,13 @@ describe('loadLongTailTickerPage', () => {
         expect(unstable_cache).toHaveBeenNthCalledWith(
             1,
             expect.any(Function),
-            ['sitemap:longtail:page:v2:1'],
+            [`sitemap:longtail:page:${LONGTAIL_TICKERS_PER_PAGE}:1`],
             { revalidate: SECONDS_PER_DAY }
         );
         expect(unstable_cache).toHaveBeenNthCalledWith(
             2,
             expect.any(Function),
-            ['sitemap:longtail:page:v2:2'],
+            [`sitemap:longtail:page:${LONGTAIL_TICKERS_PER_PAGE}:2`],
             { revalidate: SECONDS_PER_DAY }
         );
     });

--- a/src/entities/sitemap-entry/lib/loadLongTailTickerPage.ts
+++ b/src/entities/sitemap-entry/lib/loadLongTailTickerPage.ts
@@ -15,10 +15,11 @@ export function loadLongTailTickerPage(
             const source = new DrizzleLongTailTickerSource(client.db);
             return source.loadPage(pageNumber, LONGTAIL_TICKERS_PER_PAGE);
         },
-        // 캐시 키 버전. pageSize(LONGTAIL_TICKERS_PER_PAGE)가 SQL offset/limit에 박히므로
-        // 그 값을 바꾸면 키를 bump해 이전 page size로 캐시된 청크가 서빙되지 않게 한다
-        // (v1=2000 → v2=10000). 안 그러면 1일 TTL 동안 옛 2000행 청크가 남아 롱테일 일부가 누락될 수 있다.
-        [`sitemap:longtail:page:v2:${pageNumber}`],
+        // 캐시 키에 pageSize(LONGTAIL_TICKERS_PER_PAGE)를 직접 포함한다. pageSize가 SQL
+        // offset/limit에 박히므로, 값이 바뀌면 키가 자동으로 달라져 옛 page size로 캐시된 청크가
+        // 서빙되지 않는다 — 수동 버전 bump가 불필요하고, 변경 누락으로 stale 청크가 1일 TTL 동안
+        // 남는 위험이 사라진다.
+        [`sitemap:longtail:page:${LONGTAIL_TICKERS_PER_PAGE}:${pageNumber}`],
         { revalidate: SECONDS_PER_DAY }
     )();
 }

--- a/src/entities/sitemap-entry/lib/loadLongTailTickerPage.ts
+++ b/src/entities/sitemap-entry/lib/loadLongTailTickerPage.ts
@@ -15,7 +15,10 @@ export function loadLongTailTickerPage(
             const source = new DrizzleLongTailTickerSource(client.db);
             return source.loadPage(pageNumber, LONGTAIL_TICKERS_PER_PAGE);
         },
-        [`sitemap:longtail:page:v1:${pageNumber}`],
+        // 캐시 키 버전. pageSize(LONGTAIL_TICKERS_PER_PAGE)가 SQL offset/limit에 박히므로
+        // 그 값을 바꾸면 키를 bump해 이전 page size로 캐시된 청크가 서빙되지 않게 한다
+        // (v1=2000 → v2=10000). 안 그러면 1일 TTL 동안 옛 2000행 청크가 남아 롱테일 일부가 누락될 수 있다.
+        [`sitemap:longtail:page:v2:${pageNumber}`],
         { revalidate: SECONDS_PER_DAY }
     )();
 }


### PR DESCRIPTION
PR #591(ISR 비용·SEO 최적화)의 **배포 전 안정성 감사** 후속. 감사 시트: `docs/qa/2026-06-15-isr-cost-seo-r2-audit.md`.

## 변경 (A+B+C)
- **A (correctness)**: `loadLongTailTickerPage` 캐시 키 `v1→v2`. pageSize(2000→10000)가 SQL offset/limit에 박히나 캐시 키엔 없어, 1일 TTL 잔존 캐시가 옛 청크를 서빙하면 롱테일 일부 누락 가능 → 키 bump으로 제로 리스크화. 테스트 단언도 v2 동기화.
- **B (coverage)**: `LONGTAIL_ENTRIES_PER_TICKER===1` 핀 테스트 + seo-smoke e2e 2종(robots.txt 본문 정책 마커, out-of-range `/sitemap-longtail-99999.xml`→404 = next.config rewrite+핸들러 결선 검증, DB 시드 무관).
- **C (docs)**: plan 문서 stale "2000 유지" → 10000 정정.

저위험 correctness + 테스트/문서 변경. 유닛 통과·lint·typecheck 0, pre-push full build/e2e 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)