### PR TITLE
fix(cache): dedupe market-summary/sector-signals config fingerprint

### DIFF
--- a/src/entities/market-summary/__tests__/marketSummaryStaticCache.test.ts
+++ b/src/entities/market-summary/__tests__/marketSummaryStaticCache.test.ts
@@ -18,6 +18,7 @@ vi.mock('next/cache', () => ({
 
 vi.mock('../api/marketSummaryCache', () => ({
     getCachedMarketSummary: vi.fn(),
+    MARKET_SUMMARY_CONFIG_FINGERPRINT: 'abcdef012345',
 }));
 
 vi.mock('@/shared/api/market/getMarketDataProvider', () => ({

--- a/src/entities/market-summary/api/marketSummaryCache.ts
+++ b/src/entities/market-summary/api/marketSummaryCache.ts
@@ -12,7 +12,16 @@ import { MARKET_INDICES, SECTOR_ETFS } from '@/shared/config/dashboard-tickers';
 import { createCacheConfigFingerprint } from '@/shared/cache/configFingerprint';
 import { allQuotesPresent } from '../lib/marketSummaryCompleteness';
 
-const MARKET_SUMMARY_CONFIG_FINGERPRINT = createCacheConfigFingerprint(
+/**
+ * config(지수+섹터 ETF 목록) fingerprint — cache 키에 박아 config 변경 시 캐시를
+ * 자동 무효화한다. static cache(marketSummaryStaticCache)도 **이 상수를 import해**
+ * 동일 fingerprint를 공유하므로, 직렬화 포맷이 한쪽에서만 바뀌어 키가 어긋나는 일이 없다.
+ *
+ * Redis 키 누적: config가 바뀌면 새 fingerprint 키가 생기고 옛 키는 그대로 남지만,
+ * 모든 엔트리에 TTL(`computeBarsEffectiveTtl`, 최대 24h)이 있어 자연 만료된다 —
+ * 별도 정리 메커니즘 불필요. (config 변경은 배포 단위로 드물어 누적량도 미미.)
+ */
+export const MARKET_SUMMARY_CONFIG_FINGERPRINT = createCacheConfigFingerprint(
     JSON.stringify({ marketIndices: MARKET_INDICES, sectorEtfs: SECTOR_ETFS })
 );
 const MARKET_SUMMARY_CACHE_KEY = `market:summary:${MARKET_SUMMARY_CONFIG_FINGERPRINT}`;

--- a/src/entities/market-summary/api/marketSummaryStaticCache.ts
+++ b/src/entities/market-summary/api/marketSummaryStaticCache.ts
@@ -1,15 +1,12 @@
 import 'server-only';
 import { unstable_cache } from 'next/cache';
 import type { MarketSummaryData } from '@y0ngha/siglens-core';
-import { getCachedMarketSummary } from './marketSummaryCache';
+import {
+    getCachedMarketSummary,
+    MARKET_SUMMARY_CONFIG_FINGERPRINT,
+} from './marketSummaryCache';
 import { getMarketDataProvider } from '@/shared/api/market/getMarketDataProvider';
 import { SECONDS_PER_HOUR } from '@/shared/config/time';
-import { MARKET_INDICES, SECTOR_ETFS } from '@/shared/config/dashboard-tickers';
-import { createCacheConfigFingerprint } from '@/shared/cache/configFingerprint';
-
-const MARKET_SUMMARY_STATIC_CONFIG_FINGERPRINT = createCacheConfigFingerprint(
-    JSON.stringify({ marketIndices: MARKET_INDICES, sectorEtfs: SECTOR_ETFS })
-);
 
 /**
  * ISR static-safe market summary. getCachedMarketSummary(redis getOrSetCache)를 Next
@@ -23,7 +20,7 @@ const MARKET_SUMMARY_STATIC_CONFIG_FINGERPRINT = createCacheConfigFingerprint(
 export function getMarketSummaryStatic(): Promise<MarketSummaryData> {
     return unstable_cache(
         () => getCachedMarketSummary(getMarketDataProvider()),
-        ['market-summary-static', MARKET_SUMMARY_STATIC_CONFIG_FINGERPRINT],
+        ['market-summary-static', MARKET_SUMMARY_CONFIG_FINGERPRINT],
         { revalidate: SECONDS_PER_HOUR, tags: ['market:summary'] }
     )();
 }

--- a/src/entities/sector-signal/__tests__/sectorSignalsStaticCache.test.ts
+++ b/src/entities/sector-signal/__tests__/sectorSignalsStaticCache.test.ts
@@ -18,6 +18,7 @@ vi.mock('next/cache', () => ({
 
 vi.mock('../api/sectorSignalsCache', () => ({
     getCachedSectorSignals: vi.fn(),
+    SECTOR_STOCKS_CONFIG_FINGERPRINT: 'abcdef012345',
 }));
 
 vi.mock('@/shared/api/market/getMarketDataProvider', () => ({

--- a/src/entities/sector-signal/api/sectorSignalsCache.ts
+++ b/src/entities/sector-signal/api/sectorSignalsCache.ts
@@ -14,7 +14,13 @@ import { createCacheConfigFingerprint } from '@/shared/cache/configFingerprint';
 
 /** sector signals도 bars 일봉 TTL 정책을 재사용 — timeframe과 무관한 placeholder. */
 const SIGNALS_TTL_TIMEFRAME = '1Day' as const satisfies Timeframe;
-const SECTOR_STOCKS_CONFIG_FINGERPRINT = createCacheConfigFingerprint(
+
+/**
+ * 종목 목록 fingerprint — cache 키에 박아 config 변경 시 자동 무효화. static
+ * cache(sectorSignalsStaticCache)도 **이 상수를 import해** 동일 fingerprint를 공유한다.
+ * 옛 fingerprint 키는 TTL(`computeBarsEffectiveTtl`, 최대 24h)로 자연 만료 — 별도 정리 불필요.
+ */
+export const SECTOR_STOCKS_CONFIG_FINGERPRINT = createCacheConfigFingerprint(
     JSON.stringify(SECTOR_STOCKS)
 );
 

--- a/src/entities/sector-signal/api/sectorSignalsStaticCache.ts
+++ b/src/entities/sector-signal/api/sectorSignalsStaticCache.ts
@@ -4,15 +4,12 @@ import type {
     DashboardTimeframe,
     SectorSignalsResult,
 } from '@y0ngha/siglens-core';
-import { getCachedSectorSignals } from './sectorSignalsCache';
+import {
+    getCachedSectorSignals,
+    SECTOR_STOCKS_CONFIG_FINGERPRINT,
+} from './sectorSignalsCache';
 import { getMarketDataProvider } from '@/shared/api/market/getMarketDataProvider';
 import { SECONDS_PER_HOUR } from '@/shared/config/time';
-import { SECTOR_STOCKS } from '@/shared/config/dashboard-tickers';
-import { createCacheConfigFingerprint } from '@/shared/cache/configFingerprint';
-
-const SECTOR_SIGNALS_STATIC_CONFIG_FINGERPRINT = createCacheConfigFingerprint(
-    JSON.stringify(SECTOR_STOCKS)
-);
 
 /**
  * ISR static-safe sector signals. timeframe별 캐시. revalidate=1h, `sector:signals` tag.
@@ -23,11 +20,7 @@ export function getSectorSignalsStatic(
 ): Promise<SectorSignalsResult> {
     return unstable_cache(
         () => getCachedSectorSignals(getMarketDataProvider(), timeframe),
-        [
-            'sector-signals-static',
-            timeframe,
-            SECTOR_SIGNALS_STATIC_CONFIG_FINGERPRINT,
-        ],
+        ['sector-signals-static', timeframe, SECTOR_STOCKS_CONFIG_FINGERPRINT],
         { revalidate: SECONDS_PER_HOUR, tags: ['sector:signals'] }
     )();
 }

--- a/src/shared/cache/__tests__/configFingerprint.test.ts
+++ b/src/shared/cache/__tests__/configFingerprint.test.ts
@@ -4,8 +4,9 @@ import { createCacheConfigFingerprint } from '@/shared/cache/configFingerprint';
 
 describe('createCacheConfigFingerprint', () => {
     it('알려진 입력에 대해 SHA-256 앞 12자리 hex를 반환한다', () => {
-        // 결정론적 핀(동일 함수 비교는 SHA-256 특성상 항상 통과해 무의미 — §13).
-        // 값 변경 시 알고리즘/길이 회귀를 잡는다.
+        // 결정론적 핀(같은 입력으로 같은 함수를 두 번 호출해 비교하면 어떤
+        // 결정론적 함수든 항상 통과하므로 무의미 — §13). 고정값으로 박아
+        // 해시 알고리즘/slice 길이 회귀를 잡는다.
         expect(
             createCacheConfigFingerprint(JSON.stringify(['AAPL', 'MSFT']))
         ).toBe('a1c55462c19f');

--- a/src/shared/cache/__tests__/configFingerprint.test.ts
+++ b/src/shared/cache/__tests__/configFingerprint.test.ts
@@ -3,12 +3,12 @@ vi.mock('server-only', () => ({}));
 import { createCacheConfigFingerprint } from '@/shared/cache/configFingerprint';
 
 describe('createCacheConfigFingerprint', () => {
-    it('동일한 설정에는 동일한 fingerprint를 반환한다', () => {
-        const serializedConfig = JSON.stringify(['AAPL', 'MSFT']);
-
-        expect(createCacheConfigFingerprint(serializedConfig)).toBe(
-            createCacheConfigFingerprint(serializedConfig)
-        );
+    it('알려진 입력에 대해 SHA-256 앞 12자리 hex를 반환한다', () => {
+        // 결정론적 핀(동일 함수 비교는 SHA-256 특성상 항상 통과해 무의미 — §13).
+        // 값 변경 시 알고리즘/길이 회귀를 잡는다.
+        expect(
+            createCacheConfigFingerprint(JSON.stringify(['AAPL', 'MSFT']))
+        ).toBe('a1c55462c19f');
     });
 
     it('설정 순서나 값이 달라지면 fingerprint도 달라진다', () => {


### PR DESCRIPTION
## 요약
PR #594 리뷰의 B4/B5/S2/Q1(캐시 fingerprint)을 별도로 처리합니다. 대상 코드(우주산업 fingerprint 캐시)가 master에 올라간 뒤, master 기반 클린 브랜치로 작업했습니다.

## 변경
- **B4**: `MARKET_SUMMARY_CONFIG_FINGERPRINT`를 `marketSummaryCache`에서 export → `marketSummaryStaticCache`가 import(중복 계산 제거). 직렬화 포맷이 한쪽만 바뀌어 키가 어긋나는 것 방지(single source of truth).
- **B5**: `SECTOR_STOCKS_CONFIG_FINGERPRINT` 동일 처리(sectorSignals 쌍).
- **Q1**: 옛 fingerprint 키는 TTL(`computeBarsEffectiveTtl`, ≤24h)로 자연 만료 — 별도 정리 불필요(주석 명시). config 변경은 배포 단위로 드물어 누적 미미.
- **S2**: `configFingerprint.test` 동어반복(같은 함수 자기 비교) → 실제 SHA-256 앞 12자리 핀. static-cache 테스트 mock에 공유 상수 export 추가.

## 검증
- 관련 테스트 64 통과, tsc 0, eslint 0
- pre-push 훅(full build + e2e) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)