### PR TITLE
fix(financials): PR #594 R7 후속 suggestions (React.cache dedup, 테스트·문서 보강)

### DIFF
--- a/src/app/[symbol]/financials/page.tsx
+++ b/src/app/[symbol]/financials/page.tsx
@@ -68,10 +68,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     }
     // profile은 있으나 6종 재무 fetch가 모두 비면(FMP 일시 장애 등) 본문은 degrade를
     // 렌더하므로(아래 default export 참조) 메타도 noindex로 일치시킨다.
-    // 데이터가 있는 경우: staticSymbolCache(unstable_cache) 덕에 generateMetadata와 페이지
-    // 렌더가 동일 캐시 엔트리를 공유한다. 빈 스냅샷(FMP 장애)의 경우: cacheNonEmpty가
-    // Next.js 캐싱을 의도적으로 건너뛰므로 같은 요청 내 두 번 호출되지만, Redis
-    // (CachedFinancialStatementsProvider)가 중복 FMP API 호출을 차단한다(React.cache는 없음).
+    // getFinancialsSnapshot은 React.cache로 감싸 per-request 메모이즈되므로,
+    // generateMetadata와 페이지 렌더가 같은 인자로 호출하면 두 번째는 즉시 반환된다
+    // (빈 스냅샷 경로처럼 cacheNonEmpty가 Next 캐싱을 우회해도 재실행 없음). cross-request
+    // 정적화는 staticSymbolCache(unstable_cache), 빈 경로의 cross-request dedup은 Redis가 담당.
     const snapshot = await getFinancialsSnapshot(upper);
     if (isEmptyFinancialsSnapshot(snapshot)) {
         return NOINDEX_SYMBOL_METADATA;

--- a/src/entities/financials-statements/lib/__tests__/getFinancialsSnapshot.test.ts
+++ b/src/entities/financials-statements/lib/__tests__/getFinancialsSnapshot.test.ts
@@ -227,11 +227,14 @@ describe('getFinancialsSnapshot (entity lib — single source)', () => {
             const result = await getFinancialsSnapshot('AAPL');
 
             // 예기치 못한 에러도 []로 graceful degrade한다(Promise.all 전체 실패 방지).
-            // income은 reject(unexpected), 나머지 섹션은 sentinel(빈 결과) 경로 →
-            // 둘 다 []로 수렴함을 함께 단언해 회귀 진단을 빠르게 한다.
+            // income은 reject(unexpected), 나머지 5개 섹션은 sentinel(빈 결과) 경로 →
+            // 전부 []로 수렴함을 단언해 회귀 진단을 빠르게 한다(주석과 단언 범위 일치).
             expect(result.income).toEqual([]);
             expect(result.balance).toEqual([]);
             expect(result.cashFlow).toEqual([]);
+            expect(result.incomeGrowth).toEqual([]);
+            expect(result.financialGrowth).toEqual([]);
+            expect(result.cashFlowGrowth).toEqual([]);
             expect(errorSpy).toHaveBeenCalledWith(
                 '[cacheNonEmpty] unexpected cache error:',
                 expect.objectContaining({ message: 'FMP 5xx' })

--- a/src/entities/financials-statements/lib/__tests__/getFinancialsSnapshot.test.ts
+++ b/src/entities/financials-statements/lib/__tests__/getFinancialsSnapshot.test.ts
@@ -227,7 +227,11 @@ describe('getFinancialsSnapshot (entity lib — single source)', () => {
             const result = await getFinancialsSnapshot('AAPL');
 
             // 예기치 못한 에러도 []로 graceful degrade한다(Promise.all 전체 실패 방지).
+            // income은 reject(unexpected), 나머지 섹션은 sentinel(빈 결과) 경로 →
+            // 둘 다 []로 수렴함을 함께 단언해 회귀 진단을 빠르게 한다.
             expect(result.income).toEqual([]);
+            expect(result.balance).toEqual([]);
+            expect(result.cashFlow).toEqual([]);
             expect(errorSpy).toHaveBeenCalledWith(
                 '[cacheNonEmpty] unexpected cache error:',
                 expect.objectContaining({ message: 'FMP 5xx' })

--- a/src/entities/financials-statements/lib/getFinancialsSnapshot.ts
+++ b/src/entities/financials-statements/lib/getFinancialsSnapshot.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import { staticSymbolCache } from '@/shared/cache/staticSymbolCache';
 import { getFinancialStatementsProvider } from '@/shared/api/fmp/getFinancialStatementsProvider';
 import { normalizeFinancialsSnapshot } from '@y0ngha/siglens-core';
@@ -99,73 +100,80 @@ export function isEmptyFinancialsSnapshot(
  *
  * 각 fetch는 `cacheNonEmpty`로 Next data cache에 저장된다(ISR revalidate=1h,
  * `symbol:${SYMBOL}` + `financials:${SYMBOL}` 태그). 빈 결과는 캐싱하지 않아 FMP
- * 일시 장애가 캐시를 오염시키지 않는다. CachedFinancialStatementsProvider가 Redis
- * cross-request dedup을 담당하므로 이 파일에서 중복 캐싱 레이어를 추가하지 않는다.
+ * 일시 장애가 캐시를 오염시키지 않는다.
+ *
+ * **React.cache로 감싸 per-request 메모이즈**한다(같은 인자 → 1회 실행). 한 요청에서
+ * `generateMetadata`와 페이지 렌더가 둘 다 호출해도 두 번째는 즉시 반환된다 — 특히
+ * 빈 스냅샷 경로(`cacheNonEmpty`가 Next data cache를 우회)에서도 6개 FMP 엔드포인트
+ * × 2회 재시도가 Redis 1회 조회로 줄어든다(빈 경로의 cross-request dedup은 여전히
+ * CachedFinancialStatementsProvider의 Redis 계층이 담당).
  *
  * provider가 빈 배열을 반환하면(데이터 없는 심볼 / FMP throw swallow) 정규화된
  * snapshot의 각 섹션도 빈 배열이 된다 — 호출 측에서 `isEmptyFinancialsSnapshot`로
  * 실패를 판정한다.
  */
-export async function getFinancialsSnapshot(
-    symbol: string,
-    period: StatementPeriod = 'annual',
-    limit = ANNUAL_LIMIT
-): Promise<FinancialsSnapshot> {
-    const p = getFinancialStatementsProvider();
-    const extraTags = tag(symbol);
+export const getFinancialsSnapshot = cache(
+    async (
+        symbol: string,
+        period: StatementPeriod = 'annual',
+        limit = ANNUAL_LIMIT
+    ): Promise<FinancialsSnapshot> => {
+        const p = getFinancialStatementsProvider();
+        const extraTags = tag(symbol);
 
-    const [
-        income,
-        balance,
-        cashFlow,
-        incomeGrowth,
-        financialGrowth,
-        cashFlowGrowth,
-    ] = await Promise.all([
-        cacheNonEmpty(
-            ['financials:income', symbol, period],
-            symbol,
-            () => p.getIncomeStatements(symbol, period, limit),
-            extraTags
-        ),
-        cacheNonEmpty(
-            ['financials:balance', symbol, period],
-            symbol,
-            () => p.getBalanceSheets(symbol, period, limit),
-            extraTags
-        ),
-        cacheNonEmpty(
-            ['financials:cashflow', symbol, period],
-            symbol,
-            () => p.getCashFlowStatements(symbol, period, limit),
-            extraTags
-        ),
-        cacheNonEmpty(
-            ['financials:income-growth', symbol, period],
-            symbol,
-            () => p.getIncomeStatementGrowths(symbol, period, limit),
-            extraTags
-        ),
-        cacheNonEmpty(
-            ['financials:financial-growth', symbol, period],
-            symbol,
-            () => p.getFinancialGrowths(symbol, period, limit),
-            extraTags
-        ),
-        cacheNonEmpty(
-            ['financials:cashflow-growth', symbol, period],
-            symbol,
-            () => p.getCashFlowGrowths(symbol, period, limit),
-            extraTags
-        ),
-    ]);
+        const [
+            income,
+            balance,
+            cashFlow,
+            incomeGrowth,
+            financialGrowth,
+            cashFlowGrowth,
+        ] = await Promise.all([
+            cacheNonEmpty(
+                ['financials:income', symbol, period],
+                symbol,
+                () => p.getIncomeStatements(symbol, period, limit),
+                extraTags
+            ),
+            cacheNonEmpty(
+                ['financials:balance', symbol, period],
+                symbol,
+                () => p.getBalanceSheets(symbol, period, limit),
+                extraTags
+            ),
+            cacheNonEmpty(
+                ['financials:cashflow', symbol, period],
+                symbol,
+                () => p.getCashFlowStatements(symbol, period, limit),
+                extraTags
+            ),
+            cacheNonEmpty(
+                ['financials:income-growth', symbol, period],
+                symbol,
+                () => p.getIncomeStatementGrowths(symbol, period, limit),
+                extraTags
+            ),
+            cacheNonEmpty(
+                ['financials:financial-growth', symbol, period],
+                symbol,
+                () => p.getFinancialGrowths(symbol, period, limit),
+                extraTags
+            ),
+            cacheNonEmpty(
+                ['financials:cashflow-growth', symbol, period],
+                symbol,
+                () => p.getCashFlowGrowths(symbol, period, limit),
+                extraTags
+            ),
+        ]);
 
-    return normalizeFinancialsSnapshot({
-        income,
-        balance,
-        cashFlow,
-        incomeGrowth,
-        financialGrowth,
-        cashFlowGrowth,
-    });
-}
+        return normalizeFinancialsSnapshot({
+            income,
+            balance,
+            cashFlow,
+            incomeGrowth,
+            financialGrowth,
+            cashFlowGrowth,
+        });
+    }
+);

--- a/src/entities/financials-statements/lib/getFinancialsSnapshot.ts
+++ b/src/entities/financials-statements/lib/getFinancialsSnapshot.ts
@@ -105,8 +105,8 @@ export function isEmptyFinancialsSnapshot(
  * **React.cache로 감싸 per-request 메모이즈**한다(같은 인자 → 1회 실행). 한 요청에서
  * `generateMetadata`와 페이지 렌더가 둘 다 호출해도 두 번째는 즉시 반환된다 — 특히
  * 빈 스냅샷 경로(`cacheNonEmpty`가 Next data cache를 우회)에서도 6개 FMP 엔드포인트
- * × 2회 재시도가 Redis 1회 조회로 줄어든다(빈 경로의 cross-request dedup은 여전히
- * CachedFinancialStatementsProvider의 Redis 계층이 담당).
+ * × 2회 호출(generateMetadata + 페이지 렌더의 정상 흐름)이 Redis 1회 조회로 줄어든다
+ * (빈 경로의 cross-request dedup은 여전히 CachedFinancialStatementsProvider의 Redis 계층이 담당).
  *
  * provider가 빈 배열을 반환하면(데이터 없는 심볼 / FMP throw swallow) 정규화된
  * snapshot의 각 섹션도 빈 배열이 된다 — 호출 측에서 `isEmptyFinancialsSnapshot`로

--- a/src/shared/lib/fmpSymbol.ts
+++ b/src/shared/lib/fmpSymbol.ts
@@ -13,6 +13,12 @@ const FMP_SYMBOL_ALIASES: Readonly<Record<string, string>> = {
  * symbols (e.g. `VOD.L`, `7203.T`) and index symbols (`^SPX`). So, like
  * {@link toYahooSymbol}, this maps only verified aliases and passes everything
  * else through unchanged.
+ *
+ * Extending `FMP_SYMBOL_ALIASES`: add an entry ONLY after confirming the exact
+ * FMP notation against the live FMP API (e.g. a profile/quote call returns data
+ * for the hyphenated form but not the dotted one). Do not infer aliases by
+ * pattern — a blanket dot→hyphen rule is exactly what this map avoids. Each
+ * entry should be a SigLens-ticker → verified-FMP-ticker pair.
  */
 export function toFmpSymbol(symbol: string): string {
     return FMP_SYMBOL_ALIASES[symbol] ?? symbol;


### PR DESCRIPTION
## 관련 이슈

PR #594 merge 후 round-7 APPROVED review의 reference suggestions 반영

## 구현 내용

### S1: getFinancialsSnapshot React.cache 적용 (per-request dedup)
- `getFinancialsSnapshot`을 `React.cache`로 감싸 per-request 메모이제이션 추가
- 같은 인자로 호출되면 두 번째 이후는 즉시 반환 (캐시된 결과)
- 특히 빈 스냅샷 경로에서 FMP 재시도 6개 엔드포인트×2회를 Redis 1회 조회로 단축
- JSDoc 추가: per-request dedup + React.cache 적용 배경 명시

### S2: 테스트 단언 강화 (unexpected-error 섹션)
- `unexpected cache error` 테스트 케이스에서 `balance`, `cashFlow` degrade 단언 추가
- income 외 섹션도 마찬가지로 `[]`로 graceful degrade 검증

### S3: FMP alias 확장 기준 명시 (fmpSymbol.ts JSDoc)
- FMP_SYMBOL_ALIASES 확장 시 live FMP API 검증 필수 (패턴 추론 금지)
- 각 entry는 SigLens-ticker → verified-FMP-ticker 정확히 검증된 쌍만 추가

## 레이어 및 코드 품질 체크

- [x] @docs/conventions/CONVENTIONS.md 준수 확인
- [x] @docs/conventions/FF.md 준수 확인
- [x] @docs/workflows/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] any 타입 없음
- [x] 테스트 구조: describe → describe(context) → it
- [x] 매직 넘버 없음

## 변경 파일 목록

[수정]
- `src/entities/financials-statements/lib/getFinancialsSnapshot.ts` — React.cache 적용 + 상세 JSDoc
- `src/app/[symbol]/financials/page.tsx` — cache 주석 업데이트 (§15.6 정확성)
- `src/entities/financials-statements/lib/__tests__/getFinancialsSnapshot.test.ts` — unexpected-error 테스트 단언 강화
- `src/shared/lib/fmpSymbol.ts` — alias 확장 기준 JSDoc 추가

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build