### PR TITLE
feat(sitemap): /[symbol]/congress popular sitemap 추가 (PR #597 stack)

### DIFF
--- a/src/entities/sitemap-entry/__tests__/buildPopularEntries.test.ts
+++ b/src/entities/sitemap-entry/__tests__/buildPopularEntries.test.ts
@@ -30,6 +30,10 @@ describe('buildPopularEntries', () => {
                 `${base}/congress`,
             ])
         );
+
+        const congressEntry = entries.find(e => e.url === `${base}/congress`);
+        expect(congressEntry?.changeFrequency).toBe('weekly');
+        expect(congressEntry?.priority).toBe(0.75);
     });
 
     it('옵션 URL은 generated static options list와 정확히 일치한다', () => {

--- a/src/entities/sitemap-entry/__tests__/buildPopularEntries.test.ts
+++ b/src/entities/sitemap-entry/__tests__/buildPopularEntries.test.ts
@@ -9,11 +9,11 @@ import { buildPopularEntries } from '../lib/buildPopularEntries';
 const NOW = new Date('2026-05-23T21:00:00.000Z');
 
 describe('buildPopularEntries', () => {
-    it('모든 POPULAR_TICKERS에 대해 6축 기본 라우트를 생성하고 options는 generated list에 맞춘다', () => {
+    it('모든 POPULAR_TICKERS에 대해 7축 기본 라우트를 생성하고 options는 generated list에 맞춘다', () => {
         const entries = buildPopularEntries(NOW);
 
         expect(entries).toHaveLength(
-            POPULAR_TICKERS.length * 6 + POPULAR_OPTIONS_TICKERS.length
+            POPULAR_TICKERS.length * 7 + POPULAR_OPTIONS_TICKERS.length
         );
 
         const first = POPULAR_TICKERS[0];
@@ -27,6 +27,7 @@ describe('buildPopularEntries', () => {
                 `${base}/financials`,
                 `${base}/overall`,
                 `${base}/fear-greed`,
+                `${base}/congress`,
             ])
         );
     });

--- a/src/entities/sitemap-entry/lib/buildPopularEntries.ts
+++ b/src/entities/sitemap-entry/lib/buildPopularEntries.ts
@@ -31,7 +31,7 @@ function computeTodayAtMarketClose(now: Date): Date {
 }
 
 /**
- * POPULAR_TICKERS의 모든 sub-route(차트/뉴스/펀더멘털/옵션/종합/공포탐욕)에
+ * POPULAR_TICKERS의 모든 sub-route(차트/뉴스/펀더멘털/옵션/종합/공포탐욕/의회거래)에
  * 대한 sitemap 엔트리를 반환한다. 옵션 페이지는 generated static list에
  * 포함된 ticker만 포함 — 옵션 없는 종목 페이지는 noindex라 sitemap에 두면
  * 품질 신호가 약해진다.
@@ -90,6 +90,12 @@ export function buildPopularEntries(now: Date): SitemapEntry[] {
             lastModified: todayClose,
             changeFrequency: 'daily',
             priority: 0.78,
+        },
+        {
+            url: `${SITE_URL}/${ticker}/congress`,
+            lastModified: todayClose,
+            changeFrequency: 'weekly',
+            priority: 0.75,
         },
     ]);
 }


### PR DESCRIPTION
## Summary

PR #597 stack 후속. `/[symbol]/congress` 라우트는 PR #597에서 종목 탭바·CrossLinkCards에 등록됐지만 `buildPopularEntries.ts`에는 누락되어 있어 검색 엔진이 sitemap 기반으로 발견하지 못했다. 다른 모든 sibling sub-route (`news`/`fundamental`/`financials`/`options`/`overall`/`fear-greed`)는 popular sitemap에 포함되어 있었다.

본 PR은 popular sitemap에만 congress를 추가한다. longtail sitemap은 메모리 `isr_cost_seo_r2` (PR #591/#593)대로 narrowed 상태(chart-only) 유지.

## 변경 범위
- `src/entities/sitemap-entry/lib/buildPopularEntries.ts` — 종목당 congress 항목 emit (changefreq weekly, priority 0.75, fundamental sibling과 동일)
- `src/entities/sitemap-entry/__tests__/buildPopularEntries.test.ts` — 단언 갱신 (× 6 → × 7)

## Test plan
- [x] yarn test src/entities/sitemap-entry src/app/api/sitemap → 11 files / 56 tests 통과
- [x] yarn tsc --noEmit → clean
- [x] yarn lint → 0 error/warn
- [x] popular sitemap 출력에 모든 POPULAR_TICKERS의 /<ticker>/congress URL 존재 확인

## Stacked PR 노트
- base: feat/symbol-congress-trades (PR #597)
- PR #597 머지 후 base가 master로 자동 rebase
- siglens-core 0.24.0 publish는 PR #597과 동일하게 대기 중 (CI는 publish 전까지 실패 예상 — overlay 환경에서 모든 검증 완료)
- push 시 pre-push hook은 사용자 승인 하에 --no-verify로 우회 (PR #597 baseline과 동일 조건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)