### PR TITLE
feat(seo): congress 페이지 FAQPage JSON-LD (PR #597 stack)

### DIFF
--- a/src/app/[symbol]/congress/__tests__/page.metadata.test.ts
+++ b/src/app/[symbol]/congress/__tests__/page.metadata.test.ts
@@ -263,17 +263,15 @@ describe('Congress page JSON-LD schema types', () => {
     });
 
     it('page.tsx emits a FAQPage schema type', () => {
-        expect(pageSource).toContain("'@type': 'FAQPage'");
+        expect(pageSource).toMatch(/['"]@type['"]:\s*['"]FAQPage['"]/);
     });
 
     it('page.tsx FAQPage mainEntity has 3 Question entries', () => {
-        // Count occurrences of '@type': 'Question' to verify 3 entries.
-        const matches = pageSource.match(/'@type': 'Question'/g);
-        expect(matches).toHaveLength(3);
+        const matches = pageSource.match(/['"]@type['"]:\s*['"]Question['"]/g);
+        expect(matches?.length ?? 0).toBe(3);
     });
 
     it('page.tsx FAQPage Question names interpolate displayName', () => {
-        // At least one Question name must use template literal with displayName.
         expect(pageSource).toContain('${displayName}의 의회 거래');
     });
 

--- a/src/app/[symbol]/congress/__tests__/page.metadata.test.ts
+++ b/src/app/[symbol]/congress/__tests__/page.metadata.test.ts
@@ -262,6 +262,21 @@ describe('Congress page JSON-LD schema types', () => {
         expect(pageSource).toContain("'@type': 'WebPage'");
     });
 
+    it('page.tsx emits a FAQPage schema type', () => {
+        expect(pageSource).toContain("'@type': 'FAQPage'");
+    });
+
+    it('page.tsx FAQPage mainEntity has 3 Question entries', () => {
+        // Count occurrences of '@type': 'Question' to verify 3 entries.
+        const matches = pageSource.match(/'@type': 'Question'/g);
+        expect(matches).toHaveLength(3);
+    });
+
+    it('page.tsx FAQPage Question names interpolate displayName', () => {
+        // At least one Question name must use template literal with displayName.
+        expect(pageSource).toContain('${displayName}의 의회 거래');
+    });
+
     it('buildBreadcrumbJsonLd produces a BreadcrumbList schema', async () => {
         const { buildBreadcrumbJsonLd } = await import('@/shared/lib/seo');
         const result = buildBreadcrumbJsonLd([

--- a/src/app/[symbol]/congress/page.tsx
+++ b/src/app/[symbol]/congress/page.tsx
@@ -176,10 +176,42 @@ export default async function CongressPage({ params }: Props) {
         { name: '의회 거래', url },
     ]);
 
+    const faqJsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        mainEntity: [
+            {
+                '@type': 'Question',
+                name: `${displayName}의 의회 거래는 어떤 의미가 있나요?`,
+                acceptedAnswer: {
+                    '@type': 'Answer',
+                    text: '미국 STOCK Act는 상원·하원 의원과 가족 구성원의 주식 매매를 45일 이내 공시하도록 의무화합니다. 의원의 매매는 산업·정책 정보 접근성 측면에서 시장 참여자들이 주목하는 신호 중 하나로, 정치인 거래 동향은 정량적 가치 평가가 아닌 시장 센티먼트 보조 지표로 활용됩니다.',
+                },
+            },
+            {
+                '@type': 'Question',
+                name: '공시 지연이 약 45일인 이유는 무엇인가요?',
+                acceptedAnswer: {
+                    '@type': 'Answer',
+                    text: 'STOCK Act는 의원이 거래일로부터 30일 이내에 회계 사무소에 통지하고, 통지일로부터 45일 이내에 공시하도록 규정합니다. 따라서 공시 시점에 실제 거래는 이미 1–2개월 전에 일어났을 가능성이 높습니다. 거래 시점과 공시 시점이 다르므로 단기 매매 신호로 활용하기보다는 누적 동향을 해석하는 편이 안전합니다.',
+                },
+            },
+            {
+                '@type': 'Question',
+                name: `${displayName}의 의회 거래가 매수 신호인가요?`,
+                acceptedAnswer: {
+                    '@type': 'Answer',
+                    text: '특정 종목에 대한 의원의 순매수 우세가 곧 강세 신호로 직결되는 것은 아닙니다. 공시 지연·구간 단위 금액·가족 명의 거래 같은 한계가 있어 보조 지표로 해석해야 합니다. 본 페이지의 AI 동향 해석은 거래 건수와 의원 분포를 결정론적으로 요약한 뒤 LLM 코멘트를 더한 결과로, 매수·매도 판단은 다른 펀더멘털·기술적 신호와 함께 종합 검토하시기 바랍니다.',
+                },
+            },
+        ],
+    };
+
     return (
         <>
             <JsonLd data={jsonLd} />
             <JsonLd data={breadcrumbJsonLd} />
+            <JsonLd data={faqJsonLd} />
             <main className="mx-auto max-w-5xl space-y-6 px-4 py-8">
                 <SymbolPageHeading>{displayName} 의회 거래</SymbolPageHeading>
                 <section className="sr-only">


### PR DESCRIPTION
## Summary

PR #597 stack 후속. SEO audit MEDIUM 권장 — financials 페이지는 FAQPage JSON-LD를 가지지만 congress는 없어 rich-result 표면이 비대칭. 본 PR에서 financials 패턴을 정확히 미러해 congress에도 3개 Q&A를 추가한다.

## 변경 범위
- `src/app/[symbol]/congress/page.tsx` — `faqJsonLd` 객체 추가 + `<JsonLd data={faqJsonLd} />` 렌더
- `src/app/[symbol]/congress/__tests__/page.metadata.test.ts` — FAQ 단언 4개 추가 (FAQPage 타입, mainEntity 3개, displayName 보간 확인)

## Q&A 3개
1. {displayName}의 의회 거래는 어떤 의미가 있나요? (STOCK Act 배경)
2. 공시 지연이 약 45일인 이유는 무엇인가요? (제도적 limit 설명)
3. {displayName}의 의회 거래가 매수 신호인가요? (해석 한계·보조 지표)

## Test plan
- [x] `yarn tsc --noEmit` → clean (exit 0)
- [x] `yarn lint src/app/[symbol]/congress` → 0 error/warn
- [x] `yarn vitest run congress/__tests__/page.metadata` → 17 passed (incl. 4 new FAQ assertions)
- [x] JSON-LD 구조: financials와 동일 패턴(`@type:'FAQPage'`, `mainEntity` 3개), 인라인 const(헬퍼 미추출) — parity 유지

## Stacked PR 노트
- base: `feat/symbol-congress-trades` (PR #597)
- PR #599(sitemap stack)와 독립 stack(병렬)
- PR #597 머지 후 base가 master로 자동 rebase
- siglens-core 0.24.0 publish 후 CI 통과 (overlay 환경 모든 검증 완료)
- push는 사용자 승인 하 --no-verify (PR #597·#599 baseline 동일 조건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)