### PR TITLE
fix(congress): senate efdsearch 우회 + PTR ID 노출 (PR #597 stack)

### DIFF
--- a/src/widgets/congress/CongressTradesTable.tsx
+++ b/src/widgets/congress/CongressTradesTable.tsx
@@ -10,11 +10,36 @@ import {
     AmountRangeTooltip,
     ChamberColumnTooltip,
     DisclosureLagTooltip,
+    SenateDisclosureTooltip,
 } from './congressTooltips';
 import { CongressTradesEmpty } from './CongressTradesEmpty';
 
 /** Max rows rendered in a single SSR pass (newest-first). */
 const MAX_ROWS = 50;
+
+const SENATE_EFD_SEARCH_URL = 'https://efdsearch.senate.gov/search/';
+
+/**
+ * Senate efdsearch deep links return 403/404 outside the disclaimer-accepted
+ * session. Route to the search landing page (where the disclaimer flow happens)
+ * and surface the PTR ID separately so users can search after accepting terms.
+ *
+ * House PDF links (disclosures-clerk.house.gov) are static and stay direct.
+ */
+function getDisclosureHref(chamber: Chamber, link: string): string {
+    return chamber === 'senate' ? SENATE_EFD_SEARCH_URL : link;
+}
+
+/**
+ * Extract the PTR UUID from a Senate efdsearch URL like
+ * `https://efdsearch.senate.gov/search/view/ptr/<UUID>/`.
+ * Returns null if the URL doesn't match the expected shape (defensive fallback —
+ * FMP may shape change).
+ */
+function extractSenatePtrId(link: string): string | null {
+    const match = link.match(/\/view\/ptr\/([0-9a-f-]+)\/?$/i);
+    return match ? match[1] : null;
+}
 
 const CHAMBER_LABEL: Record<Chamber, string> = {
     senate: '상원',
@@ -135,6 +160,44 @@ function AssetTypeBadge({ assetType }: AssetTypeBadgeProps) {
         <span className="bg-secondary-700 text-secondary-300 rounded px-1.5 py-0.5 text-xs">
             {label}
         </span>
+    );
+}
+
+interface DisclosureCellProps {
+    chamber: Chamber;
+    link: string;
+    office: string;
+    transactionDate: string;
+}
+
+function DisclosureCell({
+    chamber,
+    link,
+    office,
+    transactionDate,
+}: DisclosureCellProps) {
+    const isSenate = chamber === 'senate';
+    const href = getDisclosureHref(chamber, link);
+    const ptrId = isSenate ? extractSenatePtrId(link) : null;
+
+    return (
+        <div>
+            <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`${CHAMBER_LABEL[chamber]} ${office} ${transactionDate} 공시 ${isSenate ? '검색' : '문서'}`}
+                className="text-primary-400 hover:text-primary-300 text-xs underline transition-colors"
+            >
+                {isSenate ? '공시 검색' : '공시'}
+            </a>
+            {isSenate && <InfoTooltip>{SenateDisclosureTooltip}</InfoTooltip>}
+            {isSenate && ptrId && (
+                <span className="text-secondary-500 block font-mono text-[10px] whitespace-nowrap">
+                    PTR {ptrId.slice(0, 8)}…
+                </span>
+            )}
+        </div>
     );
 }
 
@@ -293,15 +356,14 @@ export function CongressTradesTable({ trades }: CongressTradesTableProps) {
 
                                 <td className="px-4 py-3 whitespace-nowrap">
                                     {trade.link ? (
-                                        <a
-                                            href={trade.link}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            aria-label={`${CHAMBER_LABEL[trade.chamber]} ${trade.office} ${trade.transactionDate} 공시 문서`}
-                                            className="text-primary-400 hover:text-primary-300 text-xs underline transition-colors"
-                                        >
-                                            공시
-                                        </a>
+                                        <DisclosureCell
+                                            chamber={trade.chamber}
+                                            link={trade.link}
+                                            office={trade.office}
+                                            transactionDate={
+                                                trade.transactionDate
+                                            }
+                                        />
                                     ) : (
                                         <span className="text-secondary-500 text-xs">
                                             —

--- a/src/widgets/congress/CongressTradesTable.tsx
+++ b/src/widgets/congress/CongressTradesTable.tsx
@@ -23,8 +23,6 @@ export const SENATE_EFD_SEARCH_URL = 'https://efdsearch.senate.gov/search/';
 export const PTR_ID_PREFIX_LENGTH = 8;
 
 /**
- * Routes a disclosure href based on chamber.
- *
  * Senate efdsearch deep links return 403/404 outside the disclaimer-accepted
  * session, so senate links always point to the search landing page instead of
  * the original deep link. House PDF links (disclosures-clerk.house.gov) are
@@ -35,10 +33,8 @@ function getDisclosureHref(chamber: Chamber, link: string): string {
 }
 
 /**
- * Extract the PTR UUID from a Senate efdsearch URL like
- * `https://efdsearch.senate.gov/search/view/ptr/<UUID>/`.
  * Returns null if the URL doesn't match the expected shape (defensive fallback —
- * FMP may shape change).
+ * FMP may change the URL structure).
  *
  * The trailing `$` anchor is intentionally omitted so the regex stays robust
  * to future query strings or fragments appended to the URL.
@@ -178,8 +174,6 @@ interface DisclosureCellProps {
 }
 
 /**
- * Renders the disclosure link cell for a trade row.
- *
  * For senate rows, the href routes to the efdsearch landing page (see
  * `getDisclosureHref`) and the PTR UUID prefix is displayed separately so
  * users can copy-paste it into the search form after accepting the disclaimer.

--- a/src/widgets/congress/CongressTradesTable.tsx
+++ b/src/widgets/congress/CongressTradesTable.tsx
@@ -17,14 +17,18 @@ import { CongressTradesEmpty } from './CongressTradesEmpty';
 /** Max rows rendered in a single SSR pass (newest-first). */
 const MAX_ROWS = 50;
 
-const SENATE_EFD_SEARCH_URL = 'https://efdsearch.senate.gov/search/';
+export const SENATE_EFD_SEARCH_URL = 'https://efdsearch.senate.gov/search/';
+
+/** Number of PTR UUID characters shown as a prefix hint in the disclosure cell. */
+export const PTR_ID_PREFIX_LENGTH = 8;
 
 /**
- * Senate efdsearch deep links return 403/404 outside the disclaimer-accepted
- * session. Route to the search landing page (where the disclaimer flow happens)
- * and surface the PTR ID separately so users can search after accepting terms.
+ * Routes a disclosure href based on chamber.
  *
- * House PDF links (disclosures-clerk.house.gov) are static and stay direct.
+ * Senate efdsearch deep links return 403/404 outside the disclaimer-accepted
+ * session, so senate links always point to the search landing page instead of
+ * the original deep link. House PDF links (disclosures-clerk.house.gov) are
+ * static and stay direct.
  */
 function getDisclosureHref(chamber: Chamber, link: string): string {
     return chamber === 'senate' ? SENATE_EFD_SEARCH_URL : link;
@@ -35,9 +39,12 @@ function getDisclosureHref(chamber: Chamber, link: string): string {
  * `https://efdsearch.senate.gov/search/view/ptr/<UUID>/`.
  * Returns null if the URL doesn't match the expected shape (defensive fallback —
  * FMP may shape change).
+ *
+ * The trailing `$` anchor is intentionally omitted so the regex stays robust
+ * to future query strings or fragments appended to the URL.
  */
 function extractSenatePtrId(link: string): string | null {
-    const match = link.match(/\/view\/ptr\/([0-9a-f-]+)\/?$/i);
+    const match = link.match(/\/view\/ptr\/([0-9a-f-]+)/i);
     return match ? match[1] : null;
 }
 
@@ -170,6 +177,14 @@ interface DisclosureCellProps {
     transactionDate: string;
 }
 
+/**
+ * Renders the disclosure link cell for a trade row.
+ *
+ * For senate rows, the href routes to the efdsearch landing page (see
+ * `getDisclosureHref`) and the PTR UUID prefix is displayed separately so
+ * users can copy-paste it into the search form after accepting the disclaimer.
+ * House rows link directly to the PDF document — no PTR hint needed.
+ */
 function DisclosureCell({
     chamber,
     link,
@@ -194,7 +209,7 @@ function DisclosureCell({
             {isSenate && <InfoTooltip>{SenateDisclosureTooltip}</InfoTooltip>}
             {isSenate && ptrId && (
                 <span className="text-secondary-500 block font-mono text-[10px] whitespace-nowrap">
-                    PTR {ptrId.slice(0, 8)}…
+                    PTR {ptrId.slice(0, PTR_ID_PREFIX_LENGTH)}…
                 </span>
             )}
         </div>

--- a/src/widgets/congress/__tests__/CongressTradesTable.test.tsx
+++ b/src/widgets/congress/__tests__/CongressTradesTable.test.tsx
@@ -12,6 +12,11 @@ vi.mock('@/shared/ui/InfoTooltip', () => ({
     ),
 }));
 
+const SENATE_PTR_LINK =
+    'https://efdsearch.senate.gov/search/view/ptr/029f67f3-1234-5678-abcd-ef0123456789/';
+const SENATE_EFD_SEARCH_URL = 'https://efdsearch.senate.gov/search/';
+const HOUSE_PDF_LINK = 'https://disclosures-clerk.house.gov/ptr/example.pdf';
+
 const BASE_TRADE: CongressTrade = {
     chamber: 'senate',
     firstName: 'Jane',
@@ -30,7 +35,7 @@ const BASE_TRADE: CongressTrade = {
     assetDescription: 'Apple Inc. Common Stock',
     transactionDate: '2024-01-15',
     disclosureDate: '2024-02-28',
-    link: 'https://efts.house.gov/example',
+    link: SENATE_PTR_LINK,
     capitalGainsOver200USD: false,
 };
 
@@ -49,7 +54,7 @@ const SELL_PARTIAL_TRADE: CongressTrade = {
     assetDescription: 'Tesla Inc. Options',
     transactionDate: '2024-02-10',
     disclosureDate: '2024-03-20',
-    link: 'https://efts.house.gov/example2',
+    link: HOUSE_PDF_LINK,
 };
 
 const SELL_FULL_TRADE: CongressTrade = {
@@ -162,6 +167,24 @@ describe('CongressTradesTable', () => {
             expect(rel).toContain('noreferrer');
         });
 
+        it('senate row: href routes to efdsearch search page (not the deep link)', () => {
+            render(<CongressTradesTable trades={[BASE_TRADE]} />);
+            const link = screen.getByRole('link', { name: /공시/ });
+            expect(link.getAttribute('href')).toBe(SENATE_EFD_SEARCH_URL);
+        });
+
+        it('senate row: PTR ID prefix (first 8 chars) is shown', () => {
+            render(<CongressTradesTable trades={[BASE_TRADE]} />);
+            expect(screen.getByText(/PTR 029f67f3/)).toBeDefined();
+        });
+
+        it('senate row: link text is "공시 검색"', () => {
+            render(<CongressTradesTable trades={[BASE_TRADE]} />);
+            expect(
+                screen.getByRole('link', { name: /공시 검색/ })
+            ).toBeDefined();
+        });
+
         it('renders district as sub-label under office', () => {
             render(<CongressTradesTable trades={[BASE_TRADE]} />);
             expect(screen.getByText('CA')).toBeDefined();
@@ -265,6 +288,41 @@ describe('CongressTradesTable', () => {
             };
             render(<CongressTradesTable trades={[childTrade]} />);
             expect(screen.getByText('자녀')).toBeDefined();
+        });
+    });
+
+    describe('disclosure link — chamber-aware routing', () => {
+        it('house row: href is the original PDF URL (not redirected)', () => {
+            render(<CongressTradesTable trades={[SELL_PARTIAL_TRADE]} />);
+            const link = screen.getByRole('link', { name: /공시/ });
+            expect(link.getAttribute('href')).toBe(HOUSE_PDF_LINK);
+        });
+
+        it('house row: link text is "공시" (not "공시 검색")', () => {
+            render(<CongressTradesTable trades={[SELL_PARTIAL_TRADE]} />);
+            expect(
+                screen.getByRole('link', {
+                    name: '하원 Bob Jones 2024-02-10 공시 문서',
+                })
+            ).toBeDefined();
+        });
+
+        it('house row: no PTR ID prefix span shown', () => {
+            render(<CongressTradesTable trades={[SELL_PARTIAL_TRADE]} />);
+            expect(screen.queryByText(/^PTR [0-9a-f]/)).toBeNull();
+        });
+
+        it('senate row with unparseable link: routes to efdsearch, no PTR ID prefix span', () => {
+            const unparseableSenate: CongressTrade = {
+                ...BASE_TRADE,
+                link: 'https://efdsearch.senate.gov/oddshape/',
+            };
+            render(<CongressTradesTable trades={[unparseableSenate]} />);
+            const link = screen.getByRole('link', { name: /공시/ });
+            expect(link.getAttribute('href')).toBe(SENATE_EFD_SEARCH_URL);
+            // Tooltip mentions "PTR ID" but the 8-char prefix span (e.g. "PTR 029f67f3…")
+            // must not appear when the URL is unparseable.
+            expect(screen.queryByText(/^PTR [0-9a-f]/)).toBeNull();
         });
     });
 

--- a/src/widgets/congress/__tests__/CongressTradesTable.test.tsx
+++ b/src/widgets/congress/__tests__/CongressTradesTable.test.tsx
@@ -2,7 +2,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import type { CongressTrade } from '@y0ngha/siglens-core';
-import { CongressTradesTable } from '../CongressTradesTable';
+import {
+    CongressTradesTable,
+    SENATE_EFD_SEARCH_URL,
+    PTR_ID_PREFIX_LENGTH,
+} from '../CongressTradesTable';
 
 // InfoTooltip uses createPortal + DOM refs. Stub it to a plain <button> so
 // RTL renders without a real DOM and without react-dom/server warnings.
@@ -14,7 +18,6 @@ vi.mock('@/shared/ui/InfoTooltip', () => ({
 
 const SENATE_PTR_LINK =
     'https://efdsearch.senate.gov/search/view/ptr/029f67f3-1234-5678-abcd-ef0123456789/';
-const SENATE_EFD_SEARCH_URL = 'https://efdsearch.senate.gov/search/';
 const HOUSE_PDF_LINK = 'https://disclosures-clerk.house.gov/ptr/example.pdf';
 
 const BASE_TRADE: CongressTrade = {
@@ -145,17 +148,17 @@ describe('CongressTradesTable', () => {
     describe('sample trade row', () => {
         it('renders office text', () => {
             render(<CongressTradesTable trades={[BASE_TRADE]} />);
-            expect(screen.getByText('Jane Smith')).toBeDefined();
+            expect(screen.getByText('Jane Smith')).toBeInTheDocument();
         });
 
         it('renders amount.label', () => {
             render(<CongressTradesTable trades={[BASE_TRADE]} />);
-            expect(screen.getByText('$1,001 - $15,000')).toBeDefined();
+            expect(screen.getByText('$1,001 - $15,000')).toBeInTheDocument();
         });
 
         it('renders transactionDate', () => {
             render(<CongressTradesTable trades={[BASE_TRADE]} />);
-            expect(screen.getByText('2024-01-15')).toBeDefined();
+            expect(screen.getByText('2024-01-15')).toBeInTheDocument();
         });
 
         it('renders a disclosure link with target=_blank and rel including noopener noreferrer', () => {
@@ -173,38 +176,45 @@ describe('CongressTradesTable', () => {
             expect(link.getAttribute('href')).toBe(SENATE_EFD_SEARCH_URL);
         });
 
-        it('senate row: PTR ID prefix (first 8 chars) is shown', () => {
+        it('senate row: PTR ID prefix is shown, length tied to PTR_ID_PREFIX_LENGTH', () => {
             render(<CongressTradesTable trades={[BASE_TRADE]} />);
-            expect(screen.getByText(/PTR 029f67f3/)).toBeDefined();
+            const expectedPtrPrefix = SENATE_PTR_LINK.match(
+                /\/ptr\/([^/]+)/
+            )?.[1]?.slice(0, PTR_ID_PREFIX_LENGTH);
+            expect(
+                screen.getByText(new RegExp(`PTR ${expectedPtrPrefix}`))
+            ).toBeInTheDocument();
         });
 
         it('senate row: link text is "공시 검색"', () => {
             render(<CongressTradesTable trades={[BASE_TRADE]} />);
             expect(
                 screen.getByRole('link', { name: /공시 검색/ })
-            ).toBeDefined();
+            ).toBeInTheDocument();
         });
 
         it('renders district as sub-label under office', () => {
             render(<CongressTradesTable trades={[BASE_TRADE]} />);
-            expect(screen.getByText('CA')).toBeDefined();
+            expect(screen.getByText('CA')).toBeInTheDocument();
         });
 
         it('renders asset description text', () => {
             render(<CongressTradesTable trades={[BASE_TRADE]} />);
-            expect(screen.getByText('Apple Inc. Common Stock')).toBeDefined();
+            expect(
+                screen.getByText('Apple Inc. Common Stock')
+            ).toBeInTheDocument();
         });
     });
 
     describe('asset type badge', () => {
         it('renders "주식" badge for assetType="Stock"', () => {
             render(<CongressTradesTable trades={[BASE_TRADE]} />);
-            expect(screen.getByText('주식')).toBeDefined();
+            expect(screen.getByText('주식')).toBeInTheDocument();
         });
 
         it('renders "옵션" badge for assetType="Stock Option"', () => {
             render(<CongressTradesTable trades={[SELL_PARTIAL_TRADE]} />);
-            expect(screen.getByText('옵션')).toBeDefined();
+            expect(screen.getByText('옵션')).toBeInTheDocument();
         });
 
         it('renders "기타" badge for an unknown assetType (e.g. "Cryptocurrency")', () => {
@@ -213,7 +223,7 @@ describe('CongressTradesTable', () => {
                 assetType: 'Cryptocurrency',
             };
             render(<CongressTradesTable trades={[cryptoTrade]} />);
-            expect(screen.getByText('기타')).toBeDefined();
+            expect(screen.getByText('기타')).toBeInTheDocument();
             // Raw assetType string must not appear as a badge
             expect(screen.queryByText('Cryptocurrency')).toBeNull();
         });
@@ -242,7 +252,7 @@ describe('CongressTradesTable', () => {
     describe('empty state', () => {
         it('renders "거래 내역 없음" text when trades is empty', () => {
             render(<CongressTradesTable trades={[]} />);
-            expect(screen.getByText('거래 내역 없음')).toBeDefined();
+            expect(screen.getByText('거래 내역 없음')).toBeInTheDocument();
         });
 
         it('does NOT render a table element when trades is empty', () => {
@@ -254,12 +264,12 @@ describe('CongressTradesTable', () => {
     describe('owner badge', () => {
         it('renders "본인" badge for owner="self"', () => {
             render(<CongressTradesTable trades={[BASE_TRADE]} />);
-            expect(screen.getByText('본인')).toBeDefined();
+            expect(screen.getByText('본인')).toBeInTheDocument();
         });
 
         it('renders "배우자" badge for owner="spouse"', () => {
             render(<CongressTradesTable trades={[SELL_PARTIAL_TRADE]} />);
-            expect(screen.getByText('배우자')).toBeDefined();
+            expect(screen.getByText('배우자')).toBeInTheDocument();
         });
 
         it('does NOT render a badge for owner="unknown"', () => {
@@ -278,7 +288,7 @@ describe('CongressTradesTable', () => {
                 owner: 'joint',
             };
             render(<CongressTradesTable trades={[jointTrade]} />);
-            expect(screen.getByText('공동')).toBeDefined();
+            expect(screen.getByText('공동')).toBeInTheDocument();
         });
 
         it('renders "자녀" for owner="child"', () => {
@@ -287,7 +297,7 @@ describe('CongressTradesTable', () => {
                 owner: 'child',
             };
             render(<CongressTradesTable trades={[childTrade]} />);
-            expect(screen.getByText('자녀')).toBeDefined();
+            expect(screen.getByText('자녀')).toBeInTheDocument();
         });
     });
 
@@ -304,7 +314,7 @@ describe('CongressTradesTable', () => {
                 screen.getByRole('link', {
                     name: '하원 Bob Jones 2024-02-10 공시 문서',
                 })
-            ).toBeDefined();
+            ).toBeInTheDocument();
         });
 
         it('house row: no PTR ID prefix span shown', () => {
@@ -323,6 +333,22 @@ describe('CongressTradesTable', () => {
             // Tooltip mentions "PTR ID" but the 8-char prefix span (e.g. "PTR 029f67f3…")
             // must not appear when the URL is unparseable.
             expect(screen.queryByText(/^PTR [0-9a-f]/)).toBeNull();
+        });
+
+        it('extracts PTR ID even when URL has query parameters (regex robustness guard)', () => {
+            const linkWithQuery: CongressTrade = {
+                ...BASE_TRADE,
+                link: 'https://efdsearch.senate.gov/search/view/ptr/029f67f3-1234-5678-abcd-ef0123456789/?utm_source=fmp',
+            };
+            render(<CongressTradesTable trades={[linkWithQuery]} />);
+            const expectedPtrPrefix =
+                '029f67f3-1234-5678-abcd-ef0123456789'.slice(
+                    0,
+                    PTR_ID_PREFIX_LENGTH
+                );
+            expect(
+                screen.getByText(new RegExp(`PTR ${expectedPtrPrefix}`))
+            ).toBeInTheDocument();
         });
     });
 

--- a/src/widgets/congress/__tests__/CongressTradesTable.test.tsx
+++ b/src/widgets/congress/__tests__/CongressTradesTable.test.tsx
@@ -178,9 +178,10 @@ describe('CongressTradesTable', () => {
 
         it('senate row: PTR ID prefix is shown, length tied to PTR_ID_PREFIX_LENGTH', () => {
             render(<CongressTradesTable trades={[BASE_TRADE]} />);
-            const expectedPtrPrefix = SENATE_PTR_LINK.match(
-                /\/ptr\/([^/]+)/
-            )?.[1]?.slice(0, PTR_ID_PREFIX_LENGTH);
+            // UUID in SENATE_PTR_LINK: '029f67f3-1234-5678-abcd-ef0123456789'
+            // First PTR_ID_PREFIX_LENGTH (8) chars = '029f67f3'.
+            // If PTR_ID_PREFIX_LENGTH changes, update this literal to match.
+            const expectedPtrPrefix = '029f67f3';
             expect(
                 screen.getByText(new RegExp(`PTR ${expectedPtrPrefix}`))
             ).toBeInTheDocument();

--- a/src/widgets/congress/congressTooltips.tsx
+++ b/src/widgets/congress/congressTooltips.tsx
@@ -84,3 +84,18 @@ export const ChamberColumnTooltip = (
         <p>임기가 긴 상원의원의 거래는 장기 투자 관점을 반영할 수 있어요.</p>
     </>
 );
+
+/**
+ * 상원 공시 링크 tooltip — efdsearch 동의 페이지 흐름을 안내한다.
+ *
+ * 상원(Senate) 공시는 efdsearch.senate.gov의 disclaimer 동의 세션이 있어야
+ * 열 수 있어요. 세션 없이 deep link를 직접 열면 403 오류가 발생해요.
+ * 검색 페이지에서 PTR ID로 다시 찾을 수 있어요.
+ */
+export const SenateDisclosureTooltip = (
+    <p className="max-w-xs leading-relaxed">
+        상원 공시(efdsearch)는 동의 페이지를 통과해야 열 수 있어요. 검색
+        페이지에서 PTR ID로 다시 찾아주세요. 하원 공시는 PDF 직링크라 바로
+        열려요.
+    </p>
+);


### PR DESCRIPTION
## Summary

PR #597 stack 후속 — UX 버그 수정.

FMP `senate-trades` 응답의 `link` 필드는 `https://efdsearch.senate.gov/search/view/ptr/<UUID>/` 형식인데, efdsearch.senate.gov는 deep link 접근 시 **403** (브라우저는 404처럼 보임)을 반환한다. 미국 상원 공시 사이트가 disclaimer 동의 후에만 view 경로 접근을 허용하는 구조이기 때문이다.

실측:
- senate deep link → HTTP 403
- house PDF 직링크 → HTTP 200 (정상)

## 변경 범위
- `src/widgets/congress/CongressTradesTable.tsx`:
  - 모듈 레벨 헬퍼 2개 추가: `getDisclosureHref(chamber, link)` + `extractSenatePtrId(link)`
  - `DisclosureCell` 서브 컴포넌트 추출 (MISTAKES §9: IIFE 금지)
  - senate 행은 `efdsearch.senate.gov/search/`로 우회 + PTR ID 8자 prefix 노출
  - house 행은 기존 PDF 직링크 그대로
  - 파싱 실패 시 PTR ID 미표기(graceful fallback)
- `src/widgets/congress/congressTooltips.tsx`: `SenateDisclosureTooltip` 추가
- `src/widgets/congress/__tests__/CongressTradesTable.test.tsx`: senate/house href 양방향 + 파싱 실패 케이스 단언 (50 tests, all pass)

## Test plan
- [x] senate href = efdsearch 검색 페이지, PTR ID prefix 노출
- [x] house href = 원본 PDF URL 유지
- [x] 파싱 실패 senate link도 검색 페이지로(403 회피), PTR ID 없음
- [x] tsc/lint/test 통과 (50 tests)

## Stacked PR 노트
- base: `feat/symbol-congress-trades` (PR #597)
- PR #599(sitemap), PR #601(FAQ)와 병렬 stack
- PR #597 머지 후 base가 master로 자동 rebase
- siglens-core 0.24.0 publish 후 CI 통과 예정
- push는 사용자 승인 하 --no-verify (PR #597·#599·#601 baseline 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)