### PR TITLE
fix(a11y+ux): v0.21 신규 페이지 follow-up — 대비·터치타겟·모션·폴링 상한·DeltaBadge

### DIFF
--- a/src/app/economy/page.tsx
+++ b/src/app/economy/page.tsx
@@ -34,7 +34,7 @@ import { EconomyDegraded } from './EconomyDegraded';
 /** 페이지 최상단 h1 — Suspense 위에 렌더되어 ready와 degraded 양 경로에서 항상 표시된다. */
 function EconomyHeroH1() {
     return (
-        <h1 className="text-secondary-100 px-6 pt-10 text-2xl font-bold tracking-tight text-balance sm:text-3xl lg:px-[15vw]">
+        <h1 className="text-secondary-100 text-2xl font-bold tracking-tight text-balance sm:text-3xl">
             {ECONOMY_TITLE}
         </h1>
     );
@@ -143,7 +143,7 @@ async function EconomyContent() {
     );
 
     return (
-        <div className="space-y-8 px-6 py-8 lg:px-[15vw]">
+        <div className="space-y-6">
             {/* SSR 크롤 텍스트 — MacroBriefing은 'use client'라 크롤러에 빈 HTML을
                 반환한다. EconomyMacroFacts가 서버사이드에서 핵심 수치를 텍스트로
                 노출해 검색 엔진이 수치 데이터를 색인할 수 있도록 한다. */}
@@ -246,7 +246,7 @@ export default function EconomyPage() {
             <JsonLd data={breadcrumbJsonLd} />
             <JsonLd data={DATASET_JSON_LD} />
             <JsonLd data={FAQ_JSON_LD} />
-            <main className="flex-1">
+            <main className="mx-auto w-full max-w-5xl space-y-6 px-4 py-8">
                 <EconomyHeroH1 />
                 <Suspense fallback={null}>
                     <EconomyContent />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -106,6 +106,14 @@
     --color-ui-warning: #f59e0b;
     --color-ui-danger: #ef5350;
 
+    /* Financials letter-grade ramp (A best → F worst). 5 distinct hues so
+       adjacent grades are distinguishable by color alone, not opacity. */
+    --color-grade-a: #22c55e; /* green  — A (≥80) */
+    --color-grade-b: #84cc16; /* lime   — B (65–79) */
+    --color-grade-c: #eab308; /* yellow — C (50–64) */
+    --color-grade-d: #f97316; /* orange — D (35–49) */
+    --color-grade-f: #ef5350; /* red    — F (0–34) */
+
     /* Brand — Social login */
     --color-brand-kakao: #fee500;
 

--- a/src/app/news/[category]/__tests__/page.test.tsx
+++ b/src/app/news/[category]/__tests__/page.test.tsx
@@ -58,11 +58,13 @@ describe('/news/[category] generateMetadata는', () => {
         expect(String(meta.title)).toContain('암호화폐');
     });
 
-    it('유효하지 않은 카테고리면 noindex 메타를 반환한다', async () => {
+    it('유효하지 않은 카테고리면 robots 없이 title/description만 반환한다 (noindex는 not-found.tsx가 담당)', async () => {
         const meta = await generateMetadata({
             params: Promise.resolve({ category: 'bogus' }),
         });
-        expect(meta.robots).toMatchObject({ index: false });
+        // robots/alternates는 not-found.tsx가 단독 책임 — 이중 robots 태그 방지.
+        expect(meta.robots).toBeUndefined();
+        expect(String(meta.title)).toBeTruthy();
     });
 
     it('유효 카테고리이지만 스냅샷이 비어 있으면 noindex + canonical null을 반환한다', async () => {

--- a/src/app/news/[category]/page.tsx
+++ b/src/app/news/[category]/page.tsx
@@ -75,12 +75,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const cat = categoryFromSlug(slug);
 
     if (!cat) {
-        // 잘못된 slug — noindex, canonical null(루트 layout canonical 상속 방지).
+        // 잘못된 slug — not-found.tsx가 404와 robots 메타데이터를 담당하므로
+        // 여기서 robots/alternates를 중복 설정하지 않는다(이중 robots 태그 방지).
         return {
             title: '뉴스 카테고리를 찾을 수 없어요',
             description: '요청하신 뉴스 카테고리가 존재하지 않아요.',
-            robots: { index: false, follow: false },
-            alternates: { canonical: null },
         };
     }
 

--- a/src/shared/config/pollingConfig.ts
+++ b/src/shared/config/pollingConfig.ts
@@ -29,3 +29,11 @@ export const NEWS_CARD_EMPTY_SNAPSHOT_MAX_POLLS = 20;
 
 /** Card polling — overall hard ceiling. */
 export const NEWS_CARD_MAX_POLL_DURATION_MS = 5 * MS_PER_MINUTE;
+
+/**
+ * Analysis job polling — overall hard ceiling shared across long-running LLM
+ * jobs (Congress, Financials, etc.).  If the worker stalls in `processing` for
+ * longer than this, the poll loop breaks and surfaces an error so the user can
+ * retry rather than seeing an infinite skeleton.
+ */
+export const ANALYSIS_POLL_MAX_DURATION_MS = 5 * MS_PER_MINUTE;

--- a/src/shared/ui/InfoTooltip.tsx
+++ b/src/shared/ui/InfoTooltip.tsx
@@ -20,7 +20,7 @@ interface InfoTooltipProps {
 }
 
 const DEFAULT_TRIGGER_CLASS =
-    'text-secondary-600 hover:text-secondary-400 focus-visible:ring-primary-400 ml-1 cursor-help rounded text-xs leading-none transition-colors focus:outline-none focus-visible:ring-1';
+    'text-secondary-400 hover:text-secondary-200 focus-visible:ring-primary-400 ml-1 cursor-help rounded text-xs leading-none transition-colors focus:outline-none focus-visible:ring-2';
 
 export function InfoTooltip({ children, className }: InfoTooltipProps) {
     const tooltipId = useId();

--- a/src/widgets/chart/StockChart.tsx
+++ b/src/widgets/chart/StockChart.tsx
@@ -661,7 +661,7 @@ export function StockChart({
     if (bars.length === 0) {
         return (
             <div className="flex h-full w-full items-center justify-center">
-                <p className="text-secondary-500 text-sm">
+                <p className="text-secondary-400 text-sm">
                     차트 데이터가 없습니다
                 </p>
             </div>

--- a/src/widgets/congress/CongressTradesTable.tsx
+++ b/src/widgets/congress/CongressTradesTable.tsx
@@ -107,7 +107,7 @@ function ChamberBadge({ chamber }: ChamberBadgeProps) {
             className={cn(
                 'rounded px-1.5 py-0.5 text-xs font-medium',
                 chamber === 'senate'
-                    ? 'bg-primary-500/10 text-chart-bullish'
+                    ? 'bg-primary-500/10 text-primary-400'
                     : 'bg-secondary-700 text-secondary-300'
             )}
             aria-label={chamber === 'senate' ? '상원 (Senate)' : '하원 (House)'}

--- a/src/widgets/congress/CongressTradesTable.tsx
+++ b/src/widgets/congress/CongressTradesTable.tsx
@@ -202,7 +202,7 @@ function DisclosureCell({
             </a>
             {isSenate && <InfoTooltip>{SenateDisclosureTooltip}</InfoTooltip>}
             {isSenate && ptrId && (
-                <span className="text-secondary-500 block font-mono text-[10px] whitespace-nowrap">
+                <span className="text-secondary-400 block font-mono text-[10px] whitespace-nowrap">
                     PTR {ptrId.slice(0, PTR_ID_PREFIX_LENGTH)}…
                 </span>
             )}
@@ -374,7 +374,7 @@ export function CongressTradesTable({ trades }: CongressTradesTableProps) {
                                             }
                                         />
                                     ) : (
-                                        <span className="text-secondary-500 text-xs">
+                                        <span className="text-secondary-400 text-xs">
                                             —
                                         </span>
                                     )}

--- a/src/widgets/congress/CongressTrendSummaryError.tsx
+++ b/src/widgets/congress/CongressTrendSummaryError.tsx
@@ -30,7 +30,7 @@ export function CongressTrendSummaryError({
             <button
                 type="button"
                 onClick={resetErrorBoundary}
-                className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-800 mt-4 rounded px-3 py-1.5 text-xs text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-800 mt-4 inline-flex min-h-11 items-center rounded px-3 py-2 text-xs text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
             >
                 다시 시도
             </button>

--- a/src/widgets/congress/CongressTrendSummarySkeleton.tsx
+++ b/src/widgets/congress/CongressTrendSummarySkeleton.tsx
@@ -20,7 +20,7 @@ export function CongressTrendSummarySkeleton() {
             <div className="flex items-center gap-3">
                 <div
                     aria-hidden="true"
-                    className="border-primary-500 h-4 w-4 animate-spin rounded-full border-2 border-t-transparent"
+                    className="border-primary-500 h-4 w-4 animate-spin rounded-full border-2 border-t-transparent motion-reduce:animate-none"
                 />
                 <p
                     className="text-secondary-400 text-sm"
@@ -34,7 +34,7 @@ export function CongressTrendSummarySkeleton() {
                 {[...Array(SKELETON_LINE_COUNT)].map((_, i) => (
                     <div
                         key={`skeleton-line-${i}`}
-                        className="bg-secondary-700 h-4 w-(--skeleton-w) animate-pulse rounded"
+                        className="bg-secondary-700 h-4 w-(--skeleton-w) animate-pulse rounded motion-reduce:animate-none"
                         style={
                             {
                                 '--skeleton-w': `${SKELETON_WIDTH_START_PCT - i * SKELETON_WIDTH_STEP_PCT}%`,

--- a/src/widgets/congress/hooks/__tests__/useCongressTrendBranches.test.tsx
+++ b/src/widgets/congress/hooks/__tests__/useCongressTrendBranches.test.tsx
@@ -98,333 +98,340 @@ describe('useCongressTrend — branch coverage', () => {
         queryClients.splice(0).forEach(client => client.clear());
     });
 
-    // ─── pagehide cancel — getPageHideJobs (lines ~137-142) ──────────────────
+    describe('pagehide/unmount cleanup', () => {
+        it('getPageHideJobs: jobId가 있으면 ref를 null로 비우고 엔트리를 반환한다', async () => {
+            mockSubmit.mockResolvedValue({
+                status: 'submitted',
+                jobId: 'job-pagehide-1',
+            });
+            // poll이 완료되기 전에 pagehide를 시뮬레이션한다.
+            // sleep은 즉시 resolve되지만 poll 완료 전에 getPageHideJobs를 호출한다.
+            mockPoll.mockReturnValue(new Promise(() => {})); // 절대 resolve하지 않음
 
-    it('getPageHideJobs: jobId가 있으면 ref를 null로 비우고 엔트리를 반환한다', async () => {
-        mockSubmit.mockResolvedValue({
-            status: 'submitted',
-            jobId: 'job-pagehide-1',
+            // usePageHideCancel mock이 첫 번째 인자(getPageHideJobs)를 캡처한다.
+            let capturedGetJobs:
+                | (() => ReturnType<typeof usePageHideCancel>)
+                | null = null;
+            mockUsePageHideCancel.mockImplementation((fn: () => unknown) => {
+                capturedGetJobs = fn as () => ReturnType<
+                    typeof usePageHideCancel
+                >;
+            });
+
+            const wrapper = makeWrapper();
+            renderHook(
+                () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+                {
+                    wrapper,
+                }
+            );
+
+            // submit이 완료돼 jobId가 ref에 저장될 때까지 대기
+            await waitFor(() => {
+                expect(mockSubmit).toHaveBeenCalledTimes(1);
+            });
+            // sleep이 즉시 resolve되므로 onJobId(submitted.jobId)도 호출됐을 것.
+            // 짧은 대기로 microtask flush
+            await act(async () => {
+                await new Promise(resolve => setTimeout(resolve, 0));
+            });
+
+            expect(capturedGetJobs).not.toBeNull();
+
+            // getPageHideJobs 호출 — jobId가 있는 경우
+            const jobs = capturedGetJobs!();
+            expect(jobs).toEqual([
+                { jobId: 'job-pagehide-1', type: 'congress' },
+            ]);
         });
-        // poll이 완료되기 전에 pagehide를 시뮬레이션한다.
-        // sleep은 즉시 resolve되지만 poll 완료 전에 getPageHideJobs를 호출한다.
-        mockPoll.mockReturnValue(new Promise(() => {})); // 절대 resolve하지 않음
 
-        // usePageHideCancel mock이 첫 번째 인자(getPageHideJobs)를 캡처한다.
-        let capturedGetJobs:
-            | (() => ReturnType<typeof usePageHideCancel>)
-            | null = null;
-        mockUsePageHideCancel.mockImplementation((fn: () => unknown) => {
-            capturedGetJobs = fn as () => ReturnType<typeof usePageHideCancel>;
+        it('getPageHideJobs: jobId가 없으면 null을 반환한다', async () => {
+            // cached → jobId가 설정되지 않음
+            mockSubmit.mockResolvedValue({
+                status: 'cached',
+                result: CONGRESS_RESULT,
+            });
+
+            let capturedGetJobs: (() => unknown) | null = null;
+            mockUsePageHideCancel.mockImplementation((fn: () => unknown) => {
+                capturedGetJobs = fn;
+            });
+
+            const wrapper = makeWrapper();
+            const { result } = renderHook(
+                () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+                { wrapper }
+            );
+
+            await waitFor(() => {
+                expect(result.current.status).toBe('done');
+            });
+
+            expect(capturedGetJobs).not.toBeNull();
+            // cached path → jobId ref == null
+            expect(capturedGetJobs!()).toBeNull();
         });
 
-        const wrapper = makeWrapper();
-        renderHook(() => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'), {
-            wrapper,
+        it('unmount 시 jobId가 없으면 cancel을 호출하지 않는다', async () => {
+            // cached → jobId가 설정되지 않음
+            mockSubmit.mockResolvedValue({
+                status: 'cached',
+                result: CONGRESS_RESULT,
+            });
+
+            const wrapper = makeWrapper();
+            const { result, unmount } = renderHook(
+                () => useCongressTrend('MSFT', 'gemini-2.5-flash-lite'),
+                { wrapper }
+            );
+
+            await waitFor(() => {
+                expect(result.current.status).toBe('done');
+            });
+
+            unmount();
+
+            await new Promise(resolve => setTimeout(resolve, 0));
+            // cached path → jobId ref는 null → cancel 미호출
+            expect(mockCancel).not.toHaveBeenCalled();
         });
 
-        // submit이 완료돼 jobId가 ref에 저장될 때까지 대기
-        await waitFor(() => {
+        it('unmount cancel 실패는 warn만 출력하고 에러를 던지지 않는다 (lines ~161-162)', async () => {
+            const warnSpy = vi
+                .spyOn(console, 'warn')
+                .mockImplementation(() => {});
+
+            mockSubmit.mockResolvedValue({
+                status: 'submitted',
+                jobId: 'job-cancel-fail',
+            });
+            // poll이 never resolve → unmount 시 jobId ref가 null이 아님
+            mockPoll.mockReturnValue(new Promise(() => {}));
+            mockCancel.mockRejectedValue(new Error('cancel network error'));
+
+            const wrapper = makeWrapper();
+            const { unmount } = renderHook(
+                () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+                { wrapper }
+            );
+
+            // submit 완료 + onJobId 호출 대기
+            await waitFor(() => {
+                expect(mockSubmit).toHaveBeenCalledTimes(1);
+            });
+            await act(async () => {
+                await new Promise(resolve => setTimeout(resolve, 0));
+            });
+
+            // unmount → cleanup → cancel 실패 → warn
+            unmount();
+
+            await waitFor(() => {
+                expect(mockCancel).toHaveBeenCalledWith('job-cancel-fail');
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 20));
+            // uncaught rejection이 없어야 한다 — warn만 호출됨
+            expect(warnSpy).toHaveBeenCalledWith(
+                '[useCongressTrend] cancel failed',
+                expect.any(Error)
+            );
+
+            warnSpy.mockRestore();
+        });
+    });
+
+    describe('poll ceiling', () => {
+        it('폴링이 5분 초과하면 error 상태로 전환된다', async () => {
+            mockSubmit.mockResolvedValue({
+                status: 'submitted',
+                jobId: 'job-ceiling-1',
+            });
+            // sleep이 즉시 resolve되고 ceiling 체크가 첫 반복에서 발동한다.
+            mockPoll.mockResolvedValue({ status: 'processing' } as never);
+
+            const now = 1_700_000_000_000;
+            const dateSpy = vi
+                .spyOn(Date, 'now')
+                .mockReturnValueOnce(now) // pollStartTime 기록 시
+                .mockReturnValue(now + 5 * 60 * 1000 + 1); // 첫 번째 ceiling 체크 시
+
+            const wrapper = makeWrapper();
+            const { result } = renderHook(
+                () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+                { wrapper }
+            );
+
+            await waitFor(() => {
+                expect(result.current.status).toBe('error');
+            });
+
+            dateSpy.mockRestore();
+
+            if (result.current.status !== 'error') {
+                throw new Error('expected error state');
+            }
+            expect(result.current.error.message).toContain('응답하지 않습니다');
+        });
+
+        it('poll ceiling error 후 retry하면 캐시 히트로 복구된다', async () => {
+            mockSubmit.mockResolvedValueOnce({
+                status: 'submitted',
+                jobId: 'job-ceiling-retry',
+            });
+            mockPoll.mockResolvedValue({ status: 'processing' } as never);
+
+            const now = 1_700_000_000_000;
+            const dateSpy = vi
+                .spyOn(Date, 'now')
+                .mockReturnValueOnce(now)
+                .mockReturnValue(now + 5 * 60 * 1000 + 1);
+
+            const wrapper = makeWrapper();
+            const { result } = renderHook(
+                () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+                { wrapper }
+            );
+
+            await waitFor(() => {
+                expect(result.current.status).toBe('error');
+            });
+
+            dateSpy.mockRestore();
+
+            mockSubmit.mockResolvedValueOnce({
+                status: 'cached',
+                result: CONGRESS_RESULT,
+            });
+
+            if (result.current.status !== 'error') {
+                throw new Error('expected error state');
+            }
+
+            const state = result.current;
+            act(() => {
+                state.retry();
+            });
+
+            await waitFor(() => {
+                expect(result.current.status).toBe('done');
+            });
+            expect(mockSubmit).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('에러 처리', () => {
+        it('non-Error query error는 Error로 래핑된다', async () => {
+            mockSubmit.mockRejectedValue('string_error');
+
+            const wrapper = makeWrapper();
+            const { result } = renderHook(
+                () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+                { wrapper }
+            );
+
+            await waitFor(() => {
+                expect(result.current.status).toBe('error');
+            });
+
+            if (result.current.status !== 'error') {
+                throw new Error('expected error state');
+            }
+            expect(result.current.error).toBeInstanceOf(Error);
+            expect(result.current.error.message).toContain(
+                '오류가 발생했습니다'
+            );
+        });
+
+        it('poll이 error 상태를 반환하면 error 메시지로 throw된다', async () => {
+            mockSubmit.mockResolvedValue({
+                status: 'submitted',
+                jobId: 'job-poll-error-1',
+            });
+            mockPoll.mockResolvedValueOnce({
+                status: 'error',
+                error: '분석 워커 오류',
+            });
+
+            const wrapper = makeWrapper();
+            const { result } = renderHook(
+                () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+                { wrapper }
+            );
+
+            await waitFor(() => {
+                expect(result.current.status).toBe('error');
+            });
+
+            if (result.current.status !== 'error') {
+                throw new Error('expected error state');
+            }
+            expect(result.current.error.message).toBe('분석 워커 오류');
+        });
+
+        it('poll error에 메시지가 없으면 기본 메시지가 사용된다', async () => {
+            mockSubmit.mockResolvedValue({
+                status: 'submitted',
+                jobId: 'job-poll-error-2',
+            });
+            mockPoll.mockResolvedValueOnce({
+                status: 'error',
+            } as { status: 'error'; error: string });
+
+            const wrapper = makeWrapper();
+            const { result } = renderHook(
+                () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+                { wrapper }
+            );
+
+            await waitFor(() => {
+                expect(result.current.status).toBe('error');
+            });
+
+            if (result.current.status !== 'error') {
+                throw new Error('expected error state');
+            }
+            expect(result.current.error.message).toContain(
+                '오류가 발생했습니다'
+            );
+        });
+    });
+
+    describe('hydration gate', () => {
+        it('SSR 하이드레이션 게이트가 닫혀 있으면 fetch를 실행하지 않는다', async () => {
+            mockUseHydrated.mockReturnValue(false);
+
+            const wrapper = makeWrapper();
+            const { result } = renderHook(
+                () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+                { wrapper }
+            );
+
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(mockSubmit).not.toHaveBeenCalled();
+            expect(result.current.status).toBe('loading');
+        });
+
+        it('쿼리 데이터가 이미 존재하면 refetch를 건너뛴다', async () => {
+            mockSubmit.mockResolvedValue({
+                status: 'cached',
+                result: CONGRESS_RESULT,
+            });
+
+            const wrapper = makeWrapper();
+            const { result, rerender } = renderHook(
+                () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+                { wrapper }
+            );
+
+            await waitFor(() => {
+                expect(result.current.status).toBe('done');
+            });
+
+            rerender();
+
             expect(mockSubmit).toHaveBeenCalledTimes(1);
         });
-        // sleep이 즉시 resolve되므로 onJobId(submitted.jobId)도 호출됐을 것.
-        // 짧은 대기로 microtask flush
-        await act(async () => {
-            await new Promise(resolve => setTimeout(resolve, 0));
-        });
-
-        expect(capturedGetJobs).not.toBeNull();
-
-        // getPageHideJobs 호출 — jobId가 있는 경우
-        const jobs = capturedGetJobs!();
-        expect(jobs).toEqual([{ jobId: 'job-pagehide-1', type: 'congress' }]);
-    });
-
-    it('getPageHideJobs: jobId가 없으면 null을 반환한다', async () => {
-        // cached → jobId가 설정되지 않음
-        mockSubmit.mockResolvedValue({
-            status: 'cached',
-            result: CONGRESS_RESULT,
-        });
-
-        let capturedGetJobs: (() => unknown) | null = null;
-        mockUsePageHideCancel.mockImplementation((fn: () => unknown) => {
-            capturedGetJobs = fn;
-        });
-
-        const wrapper = makeWrapper();
-        const { result } = renderHook(
-            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
-            { wrapper }
-        );
-
-        await waitFor(() => {
-            expect(result.current.status).toBe('done');
-        });
-
-        expect(capturedGetJobs).not.toBeNull();
-        // cached path → jobId ref == null
-        expect(capturedGetJobs!()).toBeNull();
-    });
-
-    // ─── unmount cancel (lines ~157-166) ──────────────────────────────────────
-
-    it('unmount 시 jobId가 없으면 cancel을 호출하지 않는다', async () => {
-        // cached → jobId가 설정되지 않음
-        mockSubmit.mockResolvedValue({
-            status: 'cached',
-            result: CONGRESS_RESULT,
-        });
-
-        const wrapper = makeWrapper();
-        const { result, unmount } = renderHook(
-            () => useCongressTrend('MSFT', 'gemini-2.5-flash-lite'),
-            { wrapper }
-        );
-
-        await waitFor(() => {
-            expect(result.current.status).toBe('done');
-        });
-
-        unmount();
-
-        await new Promise(resolve => setTimeout(resolve, 0));
-        // cached path → jobId ref는 null → cancel 미호출
-        expect(mockCancel).not.toHaveBeenCalled();
-    });
-
-    it('unmount cancel 실패는 warn만 출력하고 에러를 던지지 않는다 (lines ~161-162)', async () => {
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-        mockSubmit.mockResolvedValue({
-            status: 'submitted',
-            jobId: 'job-cancel-fail',
-        });
-        // poll이 never resolve → unmount 시 jobId ref가 null이 아님
-        mockPoll.mockReturnValue(new Promise(() => {}));
-        mockCancel.mockRejectedValue(new Error('cancel network error'));
-
-        const wrapper = makeWrapper();
-        const { unmount } = renderHook(
-            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
-            { wrapper }
-        );
-
-        // submit 완료 + onJobId 호출 대기
-        await waitFor(() => {
-            expect(mockSubmit).toHaveBeenCalledTimes(1);
-        });
-        await act(async () => {
-            await new Promise(resolve => setTimeout(resolve, 0));
-        });
-
-        // unmount → cleanup → cancel 실패 → warn
-        unmount();
-
-        await waitFor(() => {
-            expect(mockCancel).toHaveBeenCalledWith('job-cancel-fail');
-        });
-
-        await new Promise(resolve => setTimeout(resolve, 20));
-        // uncaught rejection이 없어야 한다 — warn만 호출됨
-        expect(warnSpy).toHaveBeenCalledWith(
-            '[useCongressTrend] cancel failed',
-            expect.any(Error)
-        );
-
-        warnSpy.mockRestore();
-    });
-
-    // ─── poll ceiling → error (M5) ────────────────────────────────────────────
-
-    it('폴링이 5분 초과하면 error 상태로 전환된다', async () => {
-        mockSubmit.mockResolvedValue({
-            status: 'submitted',
-            jobId: 'job-ceiling-1',
-        });
-        // sleep이 즉시 resolve되고 ceiling 체크가 첫 반복에서 발동한다.
-        mockPoll.mockResolvedValue({ status: 'processing' } as never);
-
-        const now = 1_700_000_000_000;
-        const dateSpy = vi
-            .spyOn(Date, 'now')
-            .mockReturnValueOnce(now) // pollStartTime 기록 시
-            .mockReturnValue(now + 5 * 60 * 1000 + 1); // 첫 번째 ceiling 체크 시
-
-        const wrapper = makeWrapper();
-        const { result } = renderHook(
-            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
-            { wrapper }
-        );
-
-        await waitFor(() => {
-            expect(result.current.status).toBe('error');
-        });
-
-        dateSpy.mockRestore();
-
-        if (result.current.status !== 'error') {
-            throw new Error('expected error state');
-        }
-        expect(result.current.error.message).toContain('응답하지 않습니다');
-    });
-
-    it('poll ceiling error 후 retry하면 캐시 히트로 복구된다', async () => {
-        mockSubmit.mockResolvedValueOnce({
-            status: 'submitted',
-            jobId: 'job-ceiling-retry',
-        });
-        mockPoll.mockResolvedValue({ status: 'processing' } as never);
-
-        const now = 1_700_000_000_000;
-        const dateSpy = vi
-            .spyOn(Date, 'now')
-            .mockReturnValueOnce(now)
-            .mockReturnValue(now + 5 * 60 * 1000 + 1);
-
-        const wrapper = makeWrapper();
-        const { result } = renderHook(
-            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
-            { wrapper }
-        );
-
-        await waitFor(() => {
-            expect(result.current.status).toBe('error');
-        });
-
-        dateSpy.mockRestore();
-
-        mockSubmit.mockResolvedValueOnce({
-            status: 'cached',
-            result: CONGRESS_RESULT,
-        });
-
-        if (result.current.status !== 'error') {
-            throw new Error('expected error state');
-        }
-
-        const state = result.current;
-        act(() => {
-            state.retry();
-        });
-
-        await waitFor(() => {
-            expect(result.current.status).toBe('done');
-        });
-        expect(mockSubmit).toHaveBeenCalledTimes(2);
-    });
-
-    // ─── non-Error query error wrapping ───────────────────────────────────────
-
-    it('non-Error query error는 Error로 래핑된다', async () => {
-        mockSubmit.mockRejectedValue('string_error');
-
-        const wrapper = makeWrapper();
-        const { result } = renderHook(
-            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
-            { wrapper }
-        );
-
-        await waitFor(() => {
-            expect(result.current.status).toBe('error');
-        });
-
-        if (result.current.status !== 'error') {
-            throw new Error('expected error state');
-        }
-        expect(result.current.error).toBeInstanceOf(Error);
-        expect(result.current.error.message).toContain('오류가 발생했습니다');
-    });
-
-    // ─── hydration gate closed ────────────────────────────────────────────────
-
-    it('SSR 하이드레이션 게이트가 닫혀 있으면 fetch를 실행하지 않는다', async () => {
-        mockUseHydrated.mockReturnValue(false);
-
-        const wrapper = makeWrapper();
-        const { result } = renderHook(
-            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
-            { wrapper }
-        );
-
-        await new Promise(resolve => setTimeout(resolve, 0));
-
-        expect(mockSubmit).not.toHaveBeenCalled();
-        expect(result.current.status).toBe('loading');
-    });
-
-    // ─── query data already cached (skip refetch) ─────────────────────────────
-
-    it('쿼리 데이터가 이미 존재하면 refetch를 건너뛴다', async () => {
-        mockSubmit.mockResolvedValue({
-            status: 'cached',
-            result: CONGRESS_RESULT,
-        });
-
-        const wrapper = makeWrapper();
-        const { result, rerender } = renderHook(
-            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
-            { wrapper }
-        );
-
-        await waitFor(() => {
-            expect(result.current.status).toBe('done');
-        });
-
-        rerender();
-
-        expect(mockSubmit).toHaveBeenCalledTimes(1);
-    });
-
-    // ─── poll returns error status (lines ~84-88) ─────────────────────────────
-
-    it('poll이 error 상태를 반환하면 error 메시지로 throw된다', async () => {
-        mockSubmit.mockResolvedValue({
-            status: 'submitted',
-            jobId: 'job-poll-error-1',
-        });
-        mockPoll.mockResolvedValueOnce({
-            status: 'error',
-            error: '분석 워커 오류',
-        });
-
-        const wrapper = makeWrapper();
-        const { result } = renderHook(
-            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
-            { wrapper }
-        );
-
-        await waitFor(() => {
-            expect(result.current.status).toBe('error');
-        });
-
-        if (result.current.status !== 'error') {
-            throw new Error('expected error state');
-        }
-        expect(result.current.error.message).toBe('분석 워커 오류');
-    });
-
-    it('poll error에 메시지가 없으면 기본 메시지가 사용된다', async () => {
-        mockSubmit.mockResolvedValue({
-            status: 'submitted',
-            jobId: 'job-poll-error-2',
-        });
-        mockPoll.mockResolvedValueOnce({
-            status: 'error',
-        } as { status: 'error'; error: string });
-
-        const wrapper = makeWrapper();
-        const { result } = renderHook(
-            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
-            { wrapper }
-        );
-
-        await waitFor(() => {
-            expect(result.current.status).toBe('error');
-        });
-
-        if (result.current.status !== 'error') {
-            throw new Error('expected error state');
-        }
-        expect(result.current.error.message).toContain('오류가 발생했습니다');
     });
 });

--- a/src/widgets/congress/hooks/__tests__/useCongressTrendBranches.test.tsx
+++ b/src/widgets/congress/hooks/__tests__/useCongressTrendBranches.test.tsx
@@ -1,0 +1,430 @@
+/**
+ * Branch coverage tests for useCongressTrend — targets previously-uncovered
+ * branches: pagehide cancel (getPageHideJobs), unmount cancel (jobId != null
+ * path, cancel-failed warn), poll ceiling → error, non-Error query error
+ * wrapping, hydration gate, and the skip-refetch path.
+ *
+ * Mirror of useFinancialsAnalysisBranches.test.tsx style.
+ */
+
+import type { MockedFunction, Mock } from 'vitest';
+import { useCongressTrend } from '@/widgets/congress/hooks/useCongressTrend';
+import { useHydrated } from '@/shared/hooks/useHydrated';
+import { usePageHideCancel } from '@/shared/hooks/usePageHideCancel';
+import {
+    cancelCongressTrendJobAction,
+    pollCongressTrendAction,
+    submitCongressTrendAction,
+} from '@/entities/analysis/actions';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { CongressTrendResponse } from '@y0ngha/siglens-core';
+import type { ReactNode } from 'react';
+
+vi.mock('@/entities/analysis/actions', () => ({
+    submitCongressTrendAction: vi.fn(),
+    pollCongressTrendAction: vi.fn(),
+    cancelCongressTrendJobAction: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/shared/lib/sleep', () => ({
+    sleep: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/shared/hooks/usePageHideCancel', () => ({
+    usePageHideCancel: vi.fn(),
+}));
+
+vi.mock('@/widgets/symbol-page', () => ({
+    BotBlockedError: class BotBlockedError extends Error {
+        constructor() {
+            super('bot_blocked');
+            this.name = 'BotBlockedError';
+        }
+    },
+}));
+
+// SSR hydration gate — default hydrated so tests auto-trigger on mount.
+vi.mock('@/shared/hooks/useHydrated', () => ({
+    useHydrated: vi.fn(() => true),
+}));
+
+const mockSubmit = submitCongressTrendAction as MockedFunction<
+    typeof submitCongressTrendAction
+>;
+const mockPoll = pollCongressTrendAction as MockedFunction<
+    typeof pollCongressTrendAction
+>;
+const mockCancel = cancelCongressTrendJobAction as MockedFunction<
+    typeof cancelCongressTrendJobAction
+>;
+const mockUseHydrated = vi.mocked(useHydrated);
+const mockUsePageHideCancel = usePageHideCancel as unknown as Mock;
+
+const CONGRESS_RESULT: CongressTrendResponse = {
+    summaryKo: '의회 매수세 우위',
+    notableMembersKo: ['Nancy Pelosi'],
+    riskNoteKo: '공시 지연 위험',
+    overallSentiment: 'bullish',
+};
+
+const queryClients: QueryClient[] = [];
+
+function makeWrapper() {
+    const client = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    queryClients.push(client);
+    return function Wrapper({ children }: { children: ReactNode }) {
+        return (
+            <QueryClientProvider client={client}>
+                {children}
+            </QueryClientProvider>
+        );
+    };
+}
+
+describe('useCongressTrend — branch coverage', () => {
+    beforeEach(() => {
+        mockSubmit.mockReset();
+        mockPoll.mockReset();
+        mockCancel.mockReset();
+        mockCancel.mockResolvedValue(undefined);
+        mockUseHydrated.mockReturnValue(true);
+        mockUsePageHideCancel.mockReset();
+    });
+
+    afterEach(() => {
+        queryClients.splice(0).forEach(client => client.clear());
+    });
+
+    // ─── pagehide cancel — getPageHideJobs (lines ~137-142) ──────────────────
+
+    it('getPageHideJobs: jobId가 있으면 ref를 null로 비우고 엔트리를 반환한다', async () => {
+        mockSubmit.mockResolvedValue({
+            status: 'submitted',
+            jobId: 'job-pagehide-1',
+        });
+        // poll이 완료되기 전에 pagehide를 시뮬레이션한다.
+        // sleep은 즉시 resolve되지만 poll 완료 전에 getPageHideJobs를 호출한다.
+        mockPoll.mockReturnValue(new Promise(() => {})); // 절대 resolve하지 않음
+
+        // usePageHideCancel mock이 첫 번째 인자(getPageHideJobs)를 캡처한다.
+        let capturedGetJobs:
+            | (() => ReturnType<typeof usePageHideCancel>)
+            | null = null;
+        mockUsePageHideCancel.mockImplementation((fn: () => unknown) => {
+            capturedGetJobs = fn as () => ReturnType<typeof usePageHideCancel>;
+        });
+
+        const wrapper = makeWrapper();
+        renderHook(() => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'), {
+            wrapper,
+        });
+
+        // submit이 완료돼 jobId가 ref에 저장될 때까지 대기
+        await waitFor(() => {
+            expect(mockSubmit).toHaveBeenCalledTimes(1);
+        });
+        // sleep이 즉시 resolve되므로 onJobId(submitted.jobId)도 호출됐을 것.
+        // 짧은 대기로 microtask flush
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 0));
+        });
+
+        expect(capturedGetJobs).not.toBeNull();
+
+        // getPageHideJobs 호출 — jobId가 있는 경우
+        const jobs = capturedGetJobs!();
+        expect(jobs).toEqual([{ jobId: 'job-pagehide-1', type: 'congress' }]);
+    });
+
+    it('getPageHideJobs: jobId가 없으면 null을 반환한다', async () => {
+        // cached → jobId가 설정되지 않음
+        mockSubmit.mockResolvedValue({
+            status: 'cached',
+            result: CONGRESS_RESULT,
+        });
+
+        let capturedGetJobs: (() => unknown) | null = null;
+        mockUsePageHideCancel.mockImplementation((fn: () => unknown) => {
+            capturedGetJobs = fn;
+        });
+
+        const wrapper = makeWrapper();
+        const { result } = renderHook(
+            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+            { wrapper }
+        );
+
+        await waitFor(() => {
+            expect(result.current.status).toBe('done');
+        });
+
+        expect(capturedGetJobs).not.toBeNull();
+        // cached path → jobId ref == null
+        expect(capturedGetJobs!()).toBeNull();
+    });
+
+    // ─── unmount cancel (lines ~157-166) ──────────────────────────────────────
+
+    it('unmount 시 jobId가 없으면 cancel을 호출하지 않는다', async () => {
+        // cached → jobId가 설정되지 않음
+        mockSubmit.mockResolvedValue({
+            status: 'cached',
+            result: CONGRESS_RESULT,
+        });
+
+        const wrapper = makeWrapper();
+        const { result, unmount } = renderHook(
+            () => useCongressTrend('MSFT', 'gemini-2.5-flash-lite'),
+            { wrapper }
+        );
+
+        await waitFor(() => {
+            expect(result.current.status).toBe('done');
+        });
+
+        unmount();
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        // cached path → jobId ref는 null → cancel 미호출
+        expect(mockCancel).not.toHaveBeenCalled();
+    });
+
+    it('unmount cancel 실패는 warn만 출력하고 에러를 던지지 않는다 (lines ~161-162)', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        mockSubmit.mockResolvedValue({
+            status: 'submitted',
+            jobId: 'job-cancel-fail',
+        });
+        // poll이 never resolve → unmount 시 jobId ref가 null이 아님
+        mockPoll.mockReturnValue(new Promise(() => {}));
+        mockCancel.mockRejectedValue(new Error('cancel network error'));
+
+        const wrapper = makeWrapper();
+        const { unmount } = renderHook(
+            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+            { wrapper }
+        );
+
+        // submit 완료 + onJobId 호출 대기
+        await waitFor(() => {
+            expect(mockSubmit).toHaveBeenCalledTimes(1);
+        });
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 0));
+        });
+
+        // unmount → cleanup → cancel 실패 → warn
+        unmount();
+
+        await waitFor(() => {
+            expect(mockCancel).toHaveBeenCalledWith('job-cancel-fail');
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 20));
+        // uncaught rejection이 없어야 한다 — warn만 호출됨
+        expect(warnSpy).toHaveBeenCalledWith(
+            '[useCongressTrend] cancel failed',
+            expect.any(Error)
+        );
+
+        warnSpy.mockRestore();
+    });
+
+    // ─── poll ceiling → error (M5) ────────────────────────────────────────────
+
+    it('폴링이 5분 초과하면 error 상태로 전환된다', async () => {
+        mockSubmit.mockResolvedValue({
+            status: 'submitted',
+            jobId: 'job-ceiling-1',
+        });
+        // sleep이 즉시 resolve되고 ceiling 체크가 첫 반복에서 발동한다.
+        mockPoll.mockResolvedValue({ status: 'processing' } as never);
+
+        const now = 1_700_000_000_000;
+        const dateSpy = vi
+            .spyOn(Date, 'now')
+            .mockReturnValueOnce(now) // pollStartTime 기록 시
+            .mockReturnValue(now + 5 * 60 * 1000 + 1); // 첫 번째 ceiling 체크 시
+
+        const wrapper = makeWrapper();
+        const { result } = renderHook(
+            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+            { wrapper }
+        );
+
+        await waitFor(() => {
+            expect(result.current.status).toBe('error');
+        });
+
+        dateSpy.mockRestore();
+
+        if (result.current.status !== 'error') {
+            throw new Error('expected error state');
+        }
+        expect(result.current.error.message).toContain('응답하지 않습니다');
+    });
+
+    it('poll ceiling error 후 retry하면 캐시 히트로 복구된다', async () => {
+        mockSubmit.mockResolvedValueOnce({
+            status: 'submitted',
+            jobId: 'job-ceiling-retry',
+        });
+        mockPoll.mockResolvedValue({ status: 'processing' } as never);
+
+        const now = 1_700_000_000_000;
+        const dateSpy = vi
+            .spyOn(Date, 'now')
+            .mockReturnValueOnce(now)
+            .mockReturnValue(now + 5 * 60 * 1000 + 1);
+
+        const wrapper = makeWrapper();
+        const { result } = renderHook(
+            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+            { wrapper }
+        );
+
+        await waitFor(() => {
+            expect(result.current.status).toBe('error');
+        });
+
+        dateSpy.mockRestore();
+
+        mockSubmit.mockResolvedValueOnce({
+            status: 'cached',
+            result: CONGRESS_RESULT,
+        });
+
+        if (result.current.status !== 'error') {
+            throw new Error('expected error state');
+        }
+
+        const state = result.current;
+        act(() => {
+            state.retry();
+        });
+
+        await waitFor(() => {
+            expect(result.current.status).toBe('done');
+        });
+        expect(mockSubmit).toHaveBeenCalledTimes(2);
+    });
+
+    // ─── non-Error query error wrapping ───────────────────────────────────────
+
+    it('non-Error query error는 Error로 래핑된다', async () => {
+        mockSubmit.mockRejectedValue('string_error');
+
+        const wrapper = makeWrapper();
+        const { result } = renderHook(
+            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+            { wrapper }
+        );
+
+        await waitFor(() => {
+            expect(result.current.status).toBe('error');
+        });
+
+        if (result.current.status !== 'error') {
+            throw new Error('expected error state');
+        }
+        expect(result.current.error).toBeInstanceOf(Error);
+        expect(result.current.error.message).toContain('오류가 발생했습니다');
+    });
+
+    // ─── hydration gate closed ────────────────────────────────────────────────
+
+    it('SSR 하이드레이션 게이트가 닫혀 있으면 fetch를 실행하지 않는다', async () => {
+        mockUseHydrated.mockReturnValue(false);
+
+        const wrapper = makeWrapper();
+        const { result } = renderHook(
+            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+            { wrapper }
+        );
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(mockSubmit).not.toHaveBeenCalled();
+        expect(result.current.status).toBe('loading');
+    });
+
+    // ─── query data already cached (skip refetch) ─────────────────────────────
+
+    it('쿼리 데이터가 이미 존재하면 refetch를 건너뛴다', async () => {
+        mockSubmit.mockResolvedValue({
+            status: 'cached',
+            result: CONGRESS_RESULT,
+        });
+
+        const wrapper = makeWrapper();
+        const { result, rerender } = renderHook(
+            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+            { wrapper }
+        );
+
+        await waitFor(() => {
+            expect(result.current.status).toBe('done');
+        });
+
+        rerender();
+
+        expect(mockSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    // ─── poll returns error status (lines ~84-88) ─────────────────────────────
+
+    it('poll이 error 상태를 반환하면 error 메시지로 throw된다', async () => {
+        mockSubmit.mockResolvedValue({
+            status: 'submitted',
+            jobId: 'job-poll-error-1',
+        });
+        mockPoll.mockResolvedValueOnce({
+            status: 'error',
+            error: '분석 워커 오류',
+        });
+
+        const wrapper = makeWrapper();
+        const { result } = renderHook(
+            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+            { wrapper }
+        );
+
+        await waitFor(() => {
+            expect(result.current.status).toBe('error');
+        });
+
+        if (result.current.status !== 'error') {
+            throw new Error('expected error state');
+        }
+        expect(result.current.error.message).toBe('분석 워커 오류');
+    });
+
+    it('poll error에 메시지가 없으면 기본 메시지가 사용된다', async () => {
+        mockSubmit.mockResolvedValue({
+            status: 'submitted',
+            jobId: 'job-poll-error-2',
+        });
+        mockPoll.mockResolvedValueOnce({
+            status: 'error',
+        } as { status: 'error'; error: string });
+
+        const wrapper = makeWrapper();
+        const { result } = renderHook(
+            () => useCongressTrend('AAPL', 'gemini-2.5-flash-lite'),
+            { wrapper }
+        );
+
+        await waitFor(() => {
+            expect(result.current.status).toBe('error');
+        });
+
+        if (result.current.status !== 'error') {
+            throw new Error('expected error state');
+        }
+        expect(result.current.error.message).toContain('오류가 발생했습니다');
+    });
+});

--- a/src/widgets/congress/hooks/__tests__/useCongressTrendBranches.test.tsx
+++ b/src/widgets/congress/hooks/__tests__/useCongressTrendBranches.test.tsx
@@ -11,6 +11,7 @@ import type { MockedFunction, Mock } from 'vitest';
 import { useCongressTrend } from '@/widgets/congress/hooks/useCongressTrend';
 import { useHydrated } from '@/shared/hooks/useHydrated';
 import { usePageHideCancel } from '@/shared/hooks/usePageHideCancel';
+import { ANALYSIS_POLL_MAX_DURATION_MS } from '@/shared/config/pollingConfig';
 import {
     cancelCongressTrendJobAction,
     pollCongressTrendAction,
@@ -254,7 +255,7 @@ describe('useCongressTrend — branch coverage', () => {
             const dateSpy = vi
                 .spyOn(Date, 'now')
                 .mockReturnValueOnce(now) // pollStartTime 기록 시
-                .mockReturnValue(now + 5 * 60 * 1000 + 1); // 첫 번째 ceiling 체크 시
+                .mockReturnValue(now + ANALYSIS_POLL_MAX_DURATION_MS + 1); // 첫 번째 ceiling 체크 시
 
             const wrapper = makeWrapper();
             const { result } = renderHook(
@@ -285,7 +286,7 @@ describe('useCongressTrend — branch coverage', () => {
             const dateSpy = vi
                 .spyOn(Date, 'now')
                 .mockReturnValueOnce(now)
-                .mockReturnValue(now + 5 * 60 * 1000 + 1);
+                .mockReturnValue(now + ANALYSIS_POLL_MAX_DURATION_MS + 1);
 
             const wrapper = makeWrapper();
             const { result } = renderHook(

--- a/src/widgets/congress/hooks/useCongressTrend.ts
+++ b/src/widgets/congress/hooks/useCongressTrend.ts
@@ -10,7 +10,10 @@ import {
 } from '@/entities/analysis/actions';
 import { sleep } from '@/shared/lib/sleep';
 import { QUERY_KEYS } from '@/shared/config/queryConfig';
-import { ANALYSIS_POLL_INTERVAL_MS } from '@/shared/config/pollingConfig';
+import {
+    ANALYSIS_POLL_INTERVAL_MS,
+    ANALYSIS_POLL_MAX_DURATION_MS,
+} from '@/shared/config/pollingConfig';
 import { usePageHideCancel } from '@/shared/hooks/usePageHideCancel';
 import { useHydrated } from '@/shared/hooks/useHydrated';
 import { BotBlockedError } from '@/widgets/symbol-page';
@@ -65,11 +68,17 @@ async function fetchCongressTrend(
     }
 
     onJobId(submitted.jobId);
+    const pollStartTime = Date.now();
     try {
         const { jobId } = submitted;
         while (!signal.aborted) {
             await sleep(ANALYSIS_POLL_INTERVAL_MS);
             if (signal.aborted) break;
+            if (Date.now() - pollStartTime > ANALYSIS_POLL_MAX_DURATION_MS) {
+                throw new Error(
+                    '동향 해석이 응답하지 않습니다. 잠시 후 다시 시도해 주세요.'
+                );
+            }
             const polled = await pollCongressTrendAction(jobId);
             if (polled.status === 'done') return polled.result;
             if (polled.status === 'error') {

--- a/src/widgets/congress/hooks/useCongressTrend.ts
+++ b/src/widgets/congress/hooks/useCongressTrend.ts
@@ -72,13 +72,13 @@ async function fetchCongressTrend(
     try {
         const { jobId } = submitted;
         while (!signal.aborted) {
-            await sleep(ANALYSIS_POLL_INTERVAL_MS);
-            if (signal.aborted) break;
-            if (Date.now() - pollStartTime > ANALYSIS_POLL_MAX_DURATION_MS) {
+            if (Date.now() - pollStartTime >= ANALYSIS_POLL_MAX_DURATION_MS) {
                 throw new Error(
                     '동향 해석이 응답하지 않습니다. 잠시 후 다시 시도해 주세요.'
                 );
             }
+            await sleep(ANALYSIS_POLL_INTERVAL_MS);
+            if (signal.aborted) break;
             const polled = await pollCongressTrendAction(jobId);
             if (polled.status === 'done') return polled.result;
             if (polled.status === 'error') {

--- a/src/widgets/economy/__tests__/EconomicIndicatorGrid.test.tsx
+++ b/src/widgets/economy/__tests__/EconomicIndicatorGrid.test.tsx
@@ -51,10 +51,16 @@ describe('EconomicIndicatorGrid', () => {
         expect(screen.queryByText('GDP')).not.toBeInTheDocument();
     });
 
-    it('전기 대비 변화 — 양수는 + 부호', () => {
+    it('전기 대비 변화 — 양수는 + 부호 + 중립 색상(ui-success/danger 없음)', () => {
         render(<EconomicIndicatorGrid snapshot={snap()} />);
         // 3.63 - 3.58 = 0.05
-        expect(screen.getByText(/\+0\.05/)).toBeInTheDocument();
+        const badge = screen.getByText(/\+0\.05/);
+        expect(badge).toBeInTheDocument();
+        // DeltaBadge는 지표 유형과 무관하게 중립 색상을 사용한다
+        // (상승이 CPI·실업률 등에서는 부정적 의미여서 green/red 표시가 오해를 유발).
+        expect(badge).not.toHaveClass('text-ui-success');
+        expect(badge).not.toHaveClass('text-ui-danger');
+        expect(badge).toHaveClass('text-secondary-300');
     });
 
     it('금리 섹션은 treasury 카드 3종(2Y·10Y·2s10s) 렌더', () => {

--- a/src/widgets/economy/__tests__/MacroBriefing.test.tsx
+++ b/src/widgets/economy/__tests__/MacroBriefing.test.tsx
@@ -2,7 +2,7 @@ vi.mock('@/widgets/economy/hooks/useMacroBriefing');
 vi.mock('@/widgets/economy/hooks/useMacroBriefingPoll');
 
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import type { MacroBriefingResponse } from '@y0ngha/siglens-core';
 
 import { MacroBriefing } from '@/widgets/economy/sections/MacroBriefing';
@@ -18,13 +18,15 @@ const BRIEFING: MacroBriefingResponse = {
     regime: 'recovery',
 };
 
+const noop = vi.fn();
+
 describe('MacroBriefing', () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
 
     it('input=undefined → 로딩 스켈레톤(aria-busy)', () => {
-        mockUseBriefing.mockReturnValue({ input: undefined });
+        mockUseBriefing.mockReturnValue({ input: undefined, refetch: noop });
         render(<MacroBriefing peekSeed={null} />);
         expect(
             screen.getByLabelText('거시 경제 브리핑 로딩 중')
@@ -32,7 +34,7 @@ describe('MacroBriefing', () => {
     });
 
     it('input=null → 봇 차단 안내', () => {
-        mockUseBriefing.mockReturnValue({ input: null });
+        mockUseBriefing.mockReturnValue({ input: null, refetch: noop });
         render(<MacroBriefing peekSeed={null} />);
         expect(
             screen.getByText('크롤러 접근으로 분석을 생성하지 않았어요.')
@@ -40,11 +42,19 @@ describe('MacroBriefing', () => {
     });
 
     it("input='error' → 오류 inline notice (role=alert)", () => {
-        mockUseBriefing.mockReturnValue({ input: 'error' });
+        mockUseBriefing.mockReturnValue({ input: 'error', refetch: noop });
         render(<MacroBriefing peekSeed={null} />);
         expect(screen.getByRole('alert')).toHaveTextContent(
             '지금은 거시 브리핑을 만들지 못했어요.'
         );
+    });
+
+    it("input='error' → '다시 시도' 버튼 클릭 시 refetch 호출", () => {
+        const refetch = vi.fn();
+        mockUseBriefing.mockReturnValue({ input: 'error', refetch });
+        render(<MacroBriefing peekSeed={null} />);
+        fireEvent.click(screen.getByRole('button', { name: '다시 시도' }));
+        expect(refetch).toHaveBeenCalledTimes(1);
     });
 
     it('input=cached → 브리핑 본문 + regime 배지', () => {
@@ -54,6 +64,7 @@ describe('MacroBriefing', () => {
                 briefing: BRIEFING,
                 generatedAt: '2026-06-17T00:00:00.000Z',
             },
+            refetch: noop,
         });
         render(<MacroBriefing peekSeed={null} />);
         expect(screen.getByText('금리 동결 국면이에요.')).toBeInTheDocument();
@@ -67,8 +78,9 @@ describe('MacroBriefing', () => {
     it('input=submitted → 폴링 위임: processing이면 스켈레톤', () => {
         mockUseBriefing.mockReturnValue({
             input: { status: 'submitted', jobId: 'job-1' },
+            refetch: noop,
         });
-        mockUsePoll.mockReturnValue({ status: 'processing' });
+        mockUsePoll.mockReturnValue({ status: 'processing', refetch: noop });
         render(<MacroBriefing peekSeed={null} />);
         expect(
             screen.getByLabelText('거시 경제 브리핑 로딩 중')
@@ -79,11 +91,13 @@ describe('MacroBriefing', () => {
     it('input=submitted → 폴링 done이면 브리핑 본문 렌더', () => {
         mockUseBriefing.mockReturnValue({
             input: { status: 'submitted', jobId: 'job-1' },
+            refetch: noop,
         });
         mockUsePoll.mockReturnValue({
             status: 'done',
             briefing: BRIEFING,
             generatedAt: '2026-06-17T00:00:00.000Z',
+            refetch: noop,
         });
         render(<MacroBriefing peekSeed={null} />);
         expect(screen.getByText('금리 동결 국면이에요.')).toBeInTheDocument();
@@ -92,14 +106,32 @@ describe('MacroBriefing', () => {
     it('input=submitted → 폴링 error면 오류 inline notice', () => {
         mockUseBriefing.mockReturnValue({
             input: { status: 'submitted', jobId: 'job-1' },
+            refetch: noop,
         });
         mockUsePoll.mockReturnValue({
             status: 'error',
             error: 'worker boom',
+            refetch: noop,
         });
         render(<MacroBriefing peekSeed={null} />);
         expect(screen.getByRole('alert')).toHaveTextContent(
             '지금은 거시 브리핑을 만들지 못했어요.'
         );
+    });
+
+    it('input=submitted → 폴링 error 시 "다시 시도" 버튼 클릭하면 poll refetch 호출', () => {
+        const pollRefetch = vi.fn();
+        mockUseBriefing.mockReturnValue({
+            input: { status: 'submitted', jobId: 'job-1' },
+            refetch: noop,
+        });
+        mockUsePoll.mockReturnValue({
+            status: 'error',
+            error: 'worker boom',
+            refetch: pollRefetch,
+        });
+        render(<MacroBriefing peekSeed={null} />);
+        fireEvent.click(screen.getByRole('button', { name: '다시 시도' }));
+        expect(pollRefetch).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/widgets/economy/hooks/__tests__/useMacroBriefingPoll.test.tsx
+++ b/src/widgets/economy/hooks/__tests__/useMacroBriefingPoll.test.tsx
@@ -177,6 +177,48 @@ describe('useMacroBriefingPoll', () => {
         }
     });
 
+    it('쿼리 disabled 상태(useHydrated=false)에서는 ceiling 타이머가 발동되지 않는다', async () => {
+        // gemini edge-case: when the query is disabled, isSettled stays false
+        // but the ceiling timer must NOT arm — otherwise a spurious poll_timeout
+        // fires before polling even starts.
+        vi.useFakeTimers();
+        mockUseHydrated.mockReturnValue(false);
+
+        const { result } = renderHook(
+            () => useMacroBriefingPoll('j-disabled'),
+            {
+                wrapper: makeWrapper(),
+            }
+        );
+
+        // Advance well past the (mocked 50ms) ceiling.
+        await vi.advanceTimersByTimeAsync(200);
+
+        // Must stay 'processing' — no poll_timeout emitted.
+        expect(result.current.status).toBe('processing');
+        expect(mockPoll).not.toHaveBeenCalled();
+
+        vi.useRealTimers();
+    });
+
+    it('jobId가 빈 문자열이면 ceiling 타이머가 발동되지 않는다(disabled query)', async () => {
+        // Same disabled-query guard: jobId='' disables the query and must not arm the timer.
+        vi.useFakeTimers();
+        mockUseHydrated.mockReturnValue(true);
+
+        const { result } = renderHook(() => useMacroBriefingPoll(''), {
+            wrapper: makeWrapper(),
+        });
+
+        await vi.advanceTimersByTimeAsync(200);
+
+        // Must stay 'processing' — no poll_timeout emitted.
+        expect(result.current.status).toBe('processing');
+        expect(mockPoll).not.toHaveBeenCalled();
+
+        vi.useRealTimers();
+    });
+
     it('unmount 시 polling이 중단된다', async () => {
         // processing 상태를 유지해 refetchInterval이 계속 발생할 수 있는 환경을 만든다.
         mockPoll.mockResolvedValue({ status: 'processing' });

--- a/src/widgets/economy/hooks/__tests__/useMacroBriefingPoll.test.tsx
+++ b/src/widgets/economy/hooks/__tests__/useMacroBriefingPoll.test.tsx
@@ -1,5 +1,8 @@
 vi.mock('@/entities/economy/actions/pollMacroBriefingAction');
 vi.mock('@/shared/hooks/useHydrated');
+vi.mock('@/shared/config/pollingConfig', () => ({
+    ANALYSIS_POLL_MAX_DURATION_MS: 50, // 50ms in tests to avoid waiting 5 min
+}));
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
@@ -40,7 +43,7 @@ describe('useMacroBriefingPoll', () => {
         const { result } = renderHook(() => useMacroBriefingPoll('j'), {
             wrapper: makeWrapper(),
         });
-        expect(result.current).toEqual({ status: 'processing' });
+        expect(result.current.status).toBe('processing');
         expect(mockPoll).not.toHaveBeenCalled();
     });
 
@@ -50,7 +53,7 @@ describe('useMacroBriefingPoll', () => {
             wrapper: makeWrapper(),
         });
         // 쿼리 disabled → data 없음 → processing 반환
-        expect(result.current).toEqual({ status: 'processing' });
+        expect(result.current.status).toBe('processing');
         expect(mockPoll).not.toHaveBeenCalled();
     });
 
@@ -59,9 +62,7 @@ describe('useMacroBriefingPoll', () => {
         const { result } = renderHook(() => useMacroBriefingPoll('j'), {
             wrapper: makeWrapper(),
         });
-        await waitFor(() =>
-            expect(result.current).toEqual({ status: 'processing' })
-        );
+        await waitFor(() => expect(result.current.status).toBe('processing'));
     });
 
     it('action done → done variant 전달', async () => {
@@ -96,6 +97,84 @@ describe('useMacroBriefingPoll', () => {
                 expect(result.current.error).toBe('worker boom');
             }
         });
+    });
+
+    it('반환값에 항상 refetch 콜백이 포함된다', async () => {
+        mockPoll.mockResolvedValue({ status: 'processing' });
+        const { result } = renderHook(() => useMacroBriefingPoll('j'), {
+            wrapper: makeWrapper(),
+        });
+        await waitFor(() => expect(result.current.status).toBe('processing'));
+        expect(typeof result.current.refetch).toBe('function');
+    });
+
+    it('polling이 ANALYSIS_POLL_MAX_DURATION_MS를 초과하면 error 상태로 전환', async () => {
+        // ANALYSIS_POLL_MAX_DURATION_MS는 이 파일의 vi.mock에서 50ms로 오버라이드됨.
+        // processing을 계속 반환해 타임아웃이 발생할 조건을 만든다.
+        mockPoll.mockResolvedValue({ status: 'processing' });
+
+        const { result } = renderHook(() => useMacroBriefingPoll('j-timeout'), {
+            wrapper: makeWrapper(),
+        });
+
+        // ceiling 타이머(50ms)가 발동될 때까지 대기.
+        await waitFor(
+            () => {
+                expect(result.current.status).toBe('error');
+            },
+            { timeout: 500 }
+        );
+
+        // error 상태일 때도 refetch 콜백이 있어야 한다(재시도 버튼이 의존).
+        if (result.current.status === 'error') {
+            expect(typeof result.current.refetch).toBe('function');
+        }
+    });
+
+    it('retry 후 ceiling이 재무장되어 stall이 지속되면 다시 error로 전환된다', async () => {
+        // ANALYSIS_POLL_MAX_DURATION_MS는 vi.mock에서 50ms로 오버라이드됨.
+        // processing을 계속 반환해 첫 번째 ceiling을 발동시킨 뒤, refetch()를 호출한다.
+        // 버그 코드에서는 isSettled가 false로 유지돼 effect가 재실행되지 않으므로
+        // 두 번째 ceiling이 발동되지 않고 status가 'processing'에 머문다.
+        // 수정 후에는 pollWindow 카운터 증가로 effect가 재실행되어 다시 'error'로 전환된다.
+        mockPoll.mockResolvedValue({ status: 'processing' });
+
+        const { result } = renderHook(
+            () => useMacroBriefingPoll('j-retry-rearm'),
+            { wrapper: makeWrapper() }
+        );
+
+        // 첫 번째 ceiling(50ms) 발동 대기.
+        await waitFor(
+            () => {
+                expect(result.current.status).toBe('error');
+            },
+            { timeout: 500 }
+        );
+
+        // 재시도 — timedOut 초기화 + pollWindow++ + queryRefetch.
+        // 잡은 여전히 processing을 반환하므로 두 번째 ceiling이 발동돼야 한다.
+        result.current.refetch();
+
+        // refetch() 직후 status가 'processing'으로 돌아왔는지 확인.
+        await waitFor(
+            () => {
+                expect(result.current.status).toBe('processing');
+            },
+            { timeout: 200 }
+        );
+
+        // 두 번째 ceiling(50ms) 발동 대기 — 버그 코드에서는 여기서 timeout.
+        await waitFor(
+            () => {
+                expect(result.current.status).toBe('error');
+            },
+            { timeout: 500 }
+        );
+
+        if (result.current.status === 'error') {
+            expect(result.current.error).toBe('poll_timeout');
+        }
     });
 
     it('unmount 시 polling이 중단된다', async () => {

--- a/src/widgets/economy/hooks/useMacroBriefing.ts
+++ b/src/widgets/economy/hooks/useMacroBriefing.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type {
     MacroBriefingResponse,
@@ -44,6 +44,8 @@ export type MacroBriefingInput =
 
 export interface UseMacroBriefingReturn {
     input: MacroBriefingInput;
+    /** Re-triggers the submit action. Call when `input === 'error'` to retry. */
+    refetch: () => void;
 }
 
 /**
@@ -56,12 +58,19 @@ export function useMacroBriefing(
     peekSeed?: MacroBriefingResponse | null
 ): UseMacroBriefingReturn {
     const isHydrated = useHydrated();
-    const { data } = useQuery({
+
+    // §17 exception: `refetch` is destructured immediately after useQuery
+    // because it feeds the useCallback below.
+    const { data, refetch: queryRefetch } = useQuery({
         queryKey: QUERY_KEYS.macroBriefing(),
         queryFn: submitMacroBriefingAction,
         enabled: isHydrated,
         staleTime: Infinity,
     });
+
+    const refetch = useCallback(() => {
+        void queryRefetch();
+    }, [queryRefetch]);
 
     const seedInput = useMemo<SeedMacroBriefingCached | undefined>(
         () =>
@@ -71,8 +80,8 @@ export function useMacroBriefing(
         [peekSeed]
     );
 
-    if (!data) return { input: seedInput };
-    if ('ok' in data) return { input: 'error' };
-    if (data.botBlocked) return { input: null };
-    return { input: data.briefing };
+    if (!data) return { input: seedInput, refetch };
+    if ('ok' in data) return { input: 'error', refetch };
+    if (data.botBlocked) return { input: null, refetch };
+    return { input: data.briefing, refetch };
 }

--- a/src/widgets/economy/hooks/useMacroBriefingPoll.ts
+++ b/src/widgets/economy/hooks/useMacroBriefingPoll.ts
@@ -1,13 +1,27 @@
 'use client';
 
+import { useState, useEffect, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import type { PollMacroBriefingResult } from '@y0ngha/siglens-core';
+import type {
+    PollMacroBriefingDone,
+    PollMacroBriefingError,
+} from '@y0ngha/siglens-core';
 
 import { pollMacroBriefingAction } from '@/entities/economy/actions/pollMacroBriefingAction';
 import { QUERY_KEYS } from '@/shared/config/queryConfig';
+import { ANALYSIS_POLL_MAX_DURATION_MS } from '@/shared/config/pollingConfig';
 import { useHydrated } from '@/shared/hooks/useHydrated';
 
 const POLL_INTERVAL_MS = 5_000;
+
+/**
+ * 폴링 결과 union — core의 PollMacroBriefingResult에 `refetch` 콜백이 추가된 형태.
+ * error variant는 재시도 버튼이, processing variant는 아직 로딩 중임을 표시한다.
+ */
+export type UseMacroBriefingPollResult =
+    | ({ status: 'processing' } & { refetch: () => void })
+    | (PollMacroBriefingError & { refetch: () => void })
+    | (PollMacroBriefingDone & { refetch: () => void });
 
 /**
  * jobId가 끝날 때까지 5초 간격으로 poll. done/error 도달 시 polling 종료.
@@ -15,10 +29,35 @@ const POLL_INTERVAL_MS = 5_000;
  * core의 `PollMacroBriefingResult`(processing | error | done)를 그대로 반환한다 —
  * error variant를 throw로 raise하지 않고 결과 union으로 surface해 위젯이 inline notice를
  * 렌더한다(route 단위 error boundary로 빠지면 grid·calendar까지 함께 unmount되므로 회피).
+ *
+ * 폴링 경과 시간이 `ANALYSIS_POLL_MAX_DURATION_MS`(5분)를 초과하면 error 상태로
+ * 전환한다 — 잡이 stall됐을 때 무한 스켈레톤 대신 재시도 가능한 오류 화면을 보여준다.
  */
-export function useMacroBriefingPoll(jobId: string): PollMacroBriefingResult {
+export function useMacroBriefingPoll(
+    jobId: string
+): UseMacroBriefingPollResult {
     const isHydrated = useHydrated();
-    const { data } = useQuery({
+
+    /**
+     * `timedOut` becomes true when the ceiling timer fires while polling is
+     * still in `processing`. A separate boolean state (rather than deriving
+     * from Date.now() during render) ensures the component re-renders as soon
+     * as the ceiling is reached, showing MacroBriefingError immediately.
+     */
+    const [timedOut, setTimedOut] = useState(false);
+
+    /**
+     * Monotonically-increasing counter that identifies the current poll window.
+     * Incrementing it on retry causes the ceiling `useEffect` to re-run even
+     * though `isSettled` is still `false`, which arms a fresh ceiling timer for
+     * the new window and prevents the infinite-skeleton bug.
+     */
+    const [pollWindow, setPollWindow] = useState(0);
+
+    // §17 exception: `refetch` is destructured immediately after useQuery
+    // because it feeds the useCallback below. The `refetch` reference is
+    // stable across renders (React Query guarantees this).
+    const { data, refetch: queryRefetch } = useQuery({
         queryKey: QUERY_KEYS.macroBriefingPoll(jobId),
         queryFn: () => pollMacroBriefingAction(jobId),
         enabled: isHydrated && jobId !== '',
@@ -32,13 +71,54 @@ export function useMacroBriefingPoll(jobId: string): PollMacroBriefingResult {
         refetchIntervalInBackground: true,
     });
 
-    if (!data || data.status === 'processing') return { status: 'processing' };
+    const isSettled = data?.status === 'done' || data?.status === 'error';
+
+    /**
+     * Hard-ceiling timer: if the job is still `processing` after
+     * `ANALYSIS_POLL_MAX_DURATION_MS`, flip `timedOut` to force an error render
+     * so the user sees a retryable error instead of an infinite skeleton.
+     *
+     * The effect re-runs whenever `isSettled` or `pollWindow` changes:
+     * - `isSettled` transition → clears the timer once the job finishes.
+     * - `pollWindow` increment (triggered by `refetch`) → arms a fresh ceiling
+     *   timer for the new attempt even though `isSettled` is still `false`.
+     *   Without this second dependency, a retry on a still-stalled job would
+     *   never re-arm the timer and the ceiling would never fire again.
+     */
+    useEffect(() => {
+        if (isSettled) return;
+
+        const id = setTimeout(() => {
+            setTimedOut(true);
+        }, ANALYSIS_POLL_MAX_DURATION_MS);
+
+        return () => {
+            clearTimeout(id);
+        };
+    }, [isSettled, pollWindow]);
+
+    const refetch = useCallback(() => {
+        // Reset the timeout flag and advance the poll-window counter so the
+        // ceiling useEffect re-runs and arms a fresh timer for this attempt.
+        setTimedOut(false);
+        setPollWindow(w => w + 1);
+        void queryRefetch();
+    }, [queryRefetch]);
+
+    if (timedOut && !isSettled) {
+        return { status: 'error', error: 'poll_timeout', refetch };
+    }
+
+    if (!data || data.status === 'processing') {
+        return { status: 'processing', refetch };
+    }
     if (data.status === 'error') {
-        return { status: 'error', error: data.error };
+        return { status: 'error', error: data.error, refetch };
     }
     return {
         status: 'done',
         briefing: data.briefing,
         generatedAt: data.generatedAt,
+        refetch,
     };
 }

--- a/src/widgets/economy/hooks/useMacroBriefingPoll.ts
+++ b/src/widgets/economy/hooks/useMacroBriefingPoll.ts
@@ -3,8 +3,9 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type {
-    PollMacroBriefingDone,
+    PollMacroBriefingProcessing,
     PollMacroBriefingError,
+    PollMacroBriefingDone,
 } from '@y0ngha/siglens-core';
 
 import { pollMacroBriefingAction } from '@/entities/economy/actions/pollMacroBriefingAction';
@@ -19,7 +20,7 @@ const POLL_INTERVAL_MS = 5_000;
  * error variant는 재시도 버튼이, processing variant는 아직 로딩 중임을 표시한다.
  */
 type MacroBriefingPollVariant =
-    | { status: 'processing' }
+    | PollMacroBriefingProcessing
     | PollMacroBriefingError
     | PollMacroBriefingDone;
 

--- a/src/widgets/economy/hooks/useMacroBriefingPoll.ts
+++ b/src/widgets/economy/hooks/useMacroBriefingPoll.ts
@@ -18,10 +18,14 @@ const POLL_INTERVAL_MS = 5_000;
  * 폴링 결과 union — core의 PollMacroBriefingResult에 `refetch` 콜백이 추가된 형태.
  * error variant는 재시도 버튼이, processing variant는 아직 로딩 중임을 표시한다.
  */
-export type UseMacroBriefingPollResult =
-    | ({ status: 'processing' } & { refetch: () => void })
-    | (PollMacroBriefingError & { refetch: () => void })
-    | (PollMacroBriefingDone & { refetch: () => void });
+type MacroBriefingPollVariant =
+    | { status: 'processing' }
+    | PollMacroBriefingError
+    | PollMacroBriefingDone;
+
+export type UseMacroBriefingPollResult = MacroBriefingPollVariant & {
+    refetch: () => void;
+};
 
 /**
  * jobId가 끝날 때까지 5초 간격으로 poll. done/error 도달 시 polling 종료.
@@ -36,8 +40,6 @@ export type UseMacroBriefingPollResult =
 export function useMacroBriefingPoll(
     jobId: string
 ): UseMacroBriefingPollResult {
-    const isHydrated = useHydrated();
-
     /**
      * `timedOut` becomes true when the ceiling timer fires while polling is
      * still in `processing`. A separate boolean state (rather than deriving
@@ -53,6 +55,9 @@ export function useMacroBriefingPoll(
      * the new window and prevents the infinite-skeleton bug.
      */
     const [pollWindow, setPollWindow] = useState(0);
+
+    // B1: useHydrated after useState declarations (§17 hook order).
+    const isHydrated = useHydrated();
 
     // §17 exception: `refetch` is destructured immediately after useQuery
     // because it feeds the useCallback below. The `refetch` reference is
@@ -71,6 +76,15 @@ export function useMacroBriefingPoll(
         refetchIntervalInBackground: true,
     });
 
+    // B2: useCallback before derived const and useEffect (§17 hook order).
+    const refetch = useCallback(() => {
+        // Reset the timeout flag and advance the poll-window counter so the
+        // ceiling useEffect re-runs and arms a fresh timer for this attempt.
+        setTimedOut(false);
+        setPollWindow(w => w + 1);
+        void queryRefetch();
+    }, [queryRefetch]);
+
     const isSettled = data?.status === 'done' || data?.status === 'error';
 
     /**
@@ -84,9 +98,13 @@ export function useMacroBriefingPoll(
      *   timer for the new attempt even though `isSettled` is still `false`.
      *   Without this second dependency, a retry on a still-stalled job would
      *   never re-arm the timer and the ceiling would never fire again.
+     *
+     * Guard: only arm when the query is enabled (!isHydrated or jobId==='' means
+     * polling never starts, yet isSettled is false — without this guard the timer
+     * would fire and emit a spurious poll_timeout before polling even begins).
      */
     useEffect(() => {
-        if (isSettled) return;
+        if (isSettled || !isHydrated || jobId === '') return;
 
         const id = setTimeout(() => {
             setTimedOut(true);
@@ -95,15 +113,7 @@ export function useMacroBriefingPoll(
         return () => {
             clearTimeout(id);
         };
-    }, [isSettled, pollWindow]);
-
-    const refetch = useCallback(() => {
-        // Reset the timeout flag and advance the poll-window counter so the
-        // ceiling useEffect re-runs and arms a fresh timer for this attempt.
-        setTimedOut(false);
-        setPollWindow(w => w + 1);
-        void queryRefetch();
-    }, [queryRefetch]);
+    }, [isSettled, pollWindow, isHydrated, jobId]);
 
     if (timedOut && !isSettled) {
         return { status: 'error', error: 'poll_timeout', refetch };

--- a/src/widgets/economy/sections/EconomicIndicatorGrid.tsx
+++ b/src/widgets/economy/sections/EconomicIndicatorGrid.tsx
@@ -193,7 +193,7 @@ function IndicatorCard({ meta, series }: IndicatorCardProps) {
                     unit={meta.unit}
                 />
             )}
-            <p className="text-secondary-500 mt-1 text-xs">{latest.date}</p>
+            <p className="text-secondary-400 mt-1 text-xs">{latest.date}</p>
         </article>
     );
 }
@@ -212,7 +212,7 @@ function TreasuryYieldCard({ snapshot, maturity }: TreasuryYieldCardProps) {
                 {value.toFixed(TREASURY_YIELD_PRECISION)}
                 <span className="text-secondary-400 ml-1 text-sm">{unit}</span>
             </div>
-            <p className="text-secondary-500 mt-1 text-xs">{snapshot.date}</p>
+            <p className="text-secondary-400 mt-1 text-xs">{snapshot.date}</p>
         </article>
     );
 }
@@ -240,7 +240,7 @@ function YieldSpreadCard({ snapshot }: YieldSpreadCardProps) {
                 {spread.toFixed(TREASURY_YIELD_PRECISION)}
                 <span className="text-secondary-400 ml-1 text-sm">%p</span>
             </div>
-            <p className="text-secondary-500 mt-1 text-xs">{snapshot.date}</p>
+            <p className="text-secondary-400 mt-1 text-xs">{snapshot.date}</p>
         </article>
     );
 }
@@ -258,13 +258,23 @@ function DeltaBadge({ delta, precision, unit }: DeltaBadgeProps) {
     }
     const positive = delta > 0;
     const sign = positive ? '+' : '';
+    // Direction chevrons convey movement without implying good/bad valence —
+    // green/red would be semantically wrong for indicators like CPI or
+    // unemployment where rising values are not positive outcomes.
     return (
-        <span
-            className={cn(
-                'mt-1 inline-block text-xs',
-                positive ? 'text-ui-success' : 'text-ui-danger'
-            )}
-        >
+        <span className="text-secondary-300 mt-1 inline-flex items-center gap-1 text-xs">
+            <svg
+                aria-hidden="true"
+                viewBox="0 0 10 10"
+                className="h-2.5 w-2.5 fill-none stroke-current"
+                strokeWidth={1.5}
+            >
+                {positive ? (
+                    <path d="M2 6.5 5 3.5 8 6.5" />
+                ) : (
+                    <path d="M2 3.5 5 6.5 8 3.5" />
+                )}
+            </svg>
             전기 대비 {sign}
             {formatted}
             {unit}

--- a/src/widgets/economy/sections/MacroBriefing.tsx
+++ b/src/widgets/economy/sections/MacroBriefing.tsx
@@ -37,6 +37,10 @@ interface MacroBriefingViewProps {
     generatedAt: string | null;
 }
 
+interface MacroBriefingErrorProps {
+    onRetry: () => void;
+}
+
 /**
  * /economy 상단 거시 AI 브리핑 위젯.
  *
@@ -49,11 +53,11 @@ interface MacroBriefingViewProps {
  * 빠지면 indicator grid·calendar까지 unmount되므로 회피.
  */
 export function MacroBriefing({ peekSeed }: MacroBriefingProps) {
-    const { input } = useMacroBriefing(peekSeed);
+    const { input, refetch } = useMacroBriefing(peekSeed);
 
     if (input === undefined) return <MacroBriefingSkeleton />;
     if (input === null) return <MacroBriefingBotBlocked />;
-    if (input === 'error') return <MacroBriefingError />;
+    if (input === 'error') return <MacroBriefingError onRetry={refetch} />;
     if (input.status === 'cached') {
         return (
             <MacroBriefingView
@@ -68,7 +72,8 @@ export function MacroBriefing({ peekSeed }: MacroBriefingProps) {
 function MacroBriefingPollingView({ jobId }: MacroBriefingPollingViewProps) {
     const poll = useMacroBriefingPoll(jobId);
     if (poll.status === 'processing') return <MacroBriefingSkeleton />;
-    if (poll.status === 'error') return <MacroBriefingError />;
+    if (poll.status === 'error')
+        return <MacroBriefingError onRetry={poll.refetch} />;
     return (
         <MacroBriefingView
             briefing={poll.briefing}
@@ -118,7 +123,7 @@ function MacroBriefingView({ briefing, generatedAt }: MacroBriefingViewProps) {
                 </ul>
             )}
             {generatedAt !== null && (
-                <p className="text-secondary-500 mt-3 text-xs">
+                <p className="text-secondary-400 mt-3 text-xs">
                     생성 시각: {new Date(generatedAt).toLocaleString('ko-KR')}
                 </p>
             )}
@@ -129,7 +134,7 @@ function MacroBriefingView({ briefing, generatedAt }: MacroBriefingViewProps) {
 function MacroBriefingSkeleton() {
     return (
         <section
-            className="border-secondary-700 bg-secondary-800 animate-pulse rounded-xl border p-6"
+            className="border-secondary-700 bg-secondary-800 animate-pulse rounded-xl border p-6 motion-reduce:animate-none"
             aria-busy="true"
             aria-label="거시 경제 브리핑 로딩 중"
         >
@@ -151,14 +156,24 @@ function MacroBriefingBotBlocked() {
     );
 }
 
-function MacroBriefingError() {
+function MacroBriefingError({ onRetry }: MacroBriefingErrorProps) {
     return (
         <section
-            className="border-secondary-700 bg-secondary-800 text-secondary-300 rounded-xl border p-6 text-sm"
+            className="border-secondary-700 bg-secondary-800 rounded-xl border p-6"
             role="alert"
             aria-label="거시 경제 브리핑 안내"
         >
-            지금은 거시 브리핑을 만들지 못했어요. 잠시 후 다시 시도해 주세요.
+            <p className="text-secondary-300 text-sm">
+                지금은 거시 브리핑을 만들지 못했어요. 잠시 후 다시 시도해
+                주세요.
+            </p>
+            <button
+                type="button"
+                onClick={onRetry}
+                className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-800 mt-4 inline-flex min-h-11 items-center rounded px-3 py-2 text-xs text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            >
+                다시 시도
+            </button>
         </section>
     );
 }

--- a/src/widgets/financials/AxisScoreCard.tsx
+++ b/src/widgets/financials/AxisScoreCard.tsx
@@ -20,13 +20,13 @@ interface AxisScoreCardProps {
     axis: AxisScore;
 }
 
-/** Grade badge background + text colors (semantic tokens only). */
+/** Grade badge background + text colors (grade-ramp tokens). */
 const GRADE_BADGE_CLASS: Record<FinancialsGrade, string> = {
-    A: 'bg-ui-success/10 text-ui-success',
-    B: 'bg-chart-bullish/10 text-chart-bullish',
-    C: 'bg-ui-warning/10 text-ui-warning',
-    D: 'bg-ui-danger/10 text-ui-danger',
-    F: 'bg-chart-bearish/10 text-chart-bearish',
+    A: 'bg-grade-a/10 text-grade-a',
+    B: 'bg-grade-b/10 text-grade-b',
+    C: 'bg-grade-c/10 text-grade-c',
+    D: 'bg-grade-d/10 text-grade-d',
+    F: 'bg-grade-f/10 text-grade-f',
 };
 
 /** Signal chip colors keyed by direction. */
@@ -63,13 +63,13 @@ function formatMetricValue(
     }
 }
 
-/** Progress bar for the axis score (0–100), colored by grade. */
+/** Progress bar for the axis score (0–100), colored by grade (grade-ramp tokens). */
 const PROGRESS_GRADE_COLOR: Record<FinancialsGrade, string> = {
-    A: 'bg-ui-success',
-    B: 'bg-chart-bullish',
-    C: 'bg-ui-warning',
-    D: 'bg-ui-danger',
-    F: 'bg-chart-bearish',
+    A: 'bg-grade-a',
+    B: 'bg-grade-b',
+    C: 'bg-grade-c',
+    D: 'bg-grade-d',
+    F: 'bg-grade-f',
 };
 
 interface SignalChipProps {

--- a/src/widgets/financials/CompositeGradeGauge.tsx
+++ b/src/widgets/financials/CompositeGradeGauge.tsx
@@ -22,28 +22,29 @@ interface SegmentDef {
 }
 
 /**
- * 5-segment palette using design-system semantic tokens:
- *   0–34   → text-ui-danger       (F/D — danger)
- *   35–49  → text-ui-warning      (D/C — caution)
- *   50–64  → text-secondary-400   (C — neutral)
- *   65–79  → text-ui-success/60   (B — lighter success)
- *   80–100 → text-ui-success      (A — strongest success)
+ * 5-segment palette using the grade-ramp design tokens.
+ * Each band maps exactly to the grade cutoffs from financialsScorecard (core):
+ *   0–34   → text-grade-f  (F — red)
+ *   35–49  → text-grade-d  (D — orange)
+ *   50–64  → text-grade-c  (C — yellow)
+ *   65–79  → text-grade-b  (B — lime)
+ *   80–100 → text-grade-a  (A — green)
  */
 const SEGMENTS: ReadonlyArray<SegmentDef> = [
-    { from: 0, to: 35, strokeClass: 'text-ui-danger' },
-    { from: 35, to: 50, strokeClass: 'text-ui-warning' },
-    { from: 50, to: 65, strokeClass: 'text-secondary-400' },
-    { from: 65, to: 80, strokeClass: 'text-ui-success/60' },
-    { from: 80, to: 100, strokeClass: 'text-ui-success' },
+    { from: 0, to: 35, strokeClass: 'text-grade-f' },
+    { from: 35, to: 50, strokeClass: 'text-grade-d' },
+    { from: 50, to: 65, strokeClass: 'text-grade-c' },
+    { from: 65, to: 80, strokeClass: 'text-grade-b' },
+    { from: 80, to: 100, strokeClass: 'text-grade-a' },
 ];
 
-/** Grade → large letter text color (semantic tokens only). */
+/** Grade → large letter text color (grade-ramp tokens). */
 const GRADE_TEXT_COLOR: Record<FinancialsGrade, string> = {
-    A: 'text-ui-success',
-    B: 'text-chart-bullish',
-    C: 'text-ui-warning',
-    D: 'text-ui-danger',
-    F: 'text-chart-bearish',
+    A: 'text-grade-a',
+    B: 'text-grade-b',
+    C: 'text-grade-c',
+    D: 'text-grade-d',
+    F: 'text-grade-f',
 };
 
 const GAUGE_CX = 100;

--- a/src/widgets/financials/FinancialsAiSummaryError.tsx
+++ b/src/widgets/financials/FinancialsAiSummaryError.tsx
@@ -30,7 +30,7 @@ export function FinancialsAiSummaryError({
             <button
                 type="button"
                 onClick={resetErrorBoundary}
-                className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-800 mt-4 rounded px-3 py-1.5 text-xs text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-800 mt-4 inline-flex min-h-11 items-center rounded px-3 py-2 text-xs text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
             >
                 다시 시도
             </button>

--- a/src/widgets/financials/FinancialsAiSummarySkeleton.tsx
+++ b/src/widgets/financials/FinancialsAiSummarySkeleton.tsx
@@ -20,7 +20,7 @@ export function FinancialsAiSummarySkeleton() {
             <div className="flex items-center gap-3">
                 <div
                     aria-hidden="true"
-                    className="border-primary-500 h-4 w-4 animate-spin rounded-full border-2 border-t-transparent"
+                    className="border-primary-500 h-4 w-4 animate-spin rounded-full border-2 border-t-transparent motion-reduce:animate-none"
                 />
                 <p
                     className="text-secondary-400 text-sm"
@@ -34,7 +34,7 @@ export function FinancialsAiSummarySkeleton() {
                 {[...Array(SKELETON_LINE_COUNT)].map((_, i) => (
                     <div
                         key={`skeleton-line-${i}`}
-                        className="bg-secondary-700 h-4 w-(--skeleton-w) animate-pulse rounded"
+                        className="bg-secondary-700 h-4 w-(--skeleton-w) animate-pulse rounded motion-reduce:animate-none"
                         style={
                             {
                                 '--skeleton-w': `${SKELETON_WIDTH_START_PCT - i * SKELETON_WIDTH_STEP_PCT}%`,

--- a/src/widgets/financials/FinancialsStatements.tsx
+++ b/src/widgets/financials/FinancialsStatements.tsx
@@ -43,7 +43,7 @@ export function FinancialsStatements({
                         role="status"
                         aria-live="polite"
                     >
-                        <span className="border-primary-500 h-3 w-3 animate-spin rounded-full border-2 border-t-transparent" />
+                        <span className="border-primary-500 h-3 w-3 animate-spin rounded-full border-2 border-t-transparent motion-reduce:animate-none" />
                         불러오는 중...
                     </span>
                 )}

--- a/src/widgets/financials/FinancialsStatements.tsx
+++ b/src/widgets/financials/FinancialsStatements.tsx
@@ -43,8 +43,11 @@ export function FinancialsStatements({
                         role="status"
                         aria-live="polite"
                     >
-                        <span className="border-primary-500 h-3 w-3 animate-spin rounded-full border-2 border-t-transparent motion-reduce:animate-none" />
-                        불러오는 중...
+                        <span
+                            aria-hidden="true"
+                            className="border-primary-500 h-3 w-3 animate-spin rounded-full border-2 border-t-transparent motion-reduce:animate-none"
+                        />
+                        불러오는 중…
                     </span>
                 )}
             </div>

--- a/src/widgets/financials/PeriodToggle.tsx
+++ b/src/widgets/financials/PeriodToggle.tsx
@@ -39,7 +39,7 @@ export function PeriodToggle({ value, onChange }: PeriodToggleProps) {
                     aria-pressed={period === value}
                     onClick={() => onChange(period)}
                     className={cn(
-                        'focus-visible:ring-primary-500 touch-manipulation rounded border px-3 py-1 text-sm font-medium transition-colors focus-visible:ring-1 focus-visible:outline-none',
+                        'focus-visible:ring-primary-500 inline-flex min-h-11 touch-manipulation items-center justify-center rounded border px-4 py-2 text-sm font-medium transition-colors focus-visible:ring-1 focus-visible:outline-none',
                         period === value
                             ? 'border-primary-400 text-primary-400'
                             : 'text-secondary-400 hover:text-secondary-200 border-transparent'

--- a/src/widgets/financials/PeriodToggle.tsx
+++ b/src/widgets/financials/PeriodToggle.tsx
@@ -39,7 +39,7 @@ export function PeriodToggle({ value, onChange }: PeriodToggleProps) {
                     aria-pressed={period === value}
                     onClick={() => onChange(period)}
                     className={cn(
-                        'focus-visible:ring-primary-500 inline-flex min-h-11 touch-manipulation items-center justify-center rounded border px-4 py-2 text-sm font-medium transition-colors focus-visible:ring-1 focus-visible:outline-none',
+                        'focus-visible:ring-primary-500 inline-flex min-h-11 touch-manipulation items-center justify-center rounded border px-4 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none',
                         period === value
                             ? 'border-primary-400 text-primary-400'
                             : 'text-secondary-400 hover:text-secondary-200 border-transparent'

--- a/src/widgets/financials/__tests__/hooks/useFinancialsAnalysisBranches.test.tsx
+++ b/src/widgets/financials/__tests__/hooks/useFinancialsAnalysisBranches.test.tsx
@@ -1,7 +1,8 @@
 /**
  * Branch coverage tests for useFinancialsAnalysis — targets uncovered branches in
  * fetchFinancialsAnalysis: miss_no_trigger, gate blocked, fetch_failed, key_error,
- * poll error with/without message, non-Error query error wrapping, query data.
+ * poll error with/without message, non-Error query error wrapping, query data,
+ * and the poll-ceiling path (ANALYSIS_POLL_MAX_DURATION_MS exceeded).
  */
 
 import type { MockedFunction, Mock } from 'vitest';
@@ -12,6 +13,7 @@ import {
     submitFinancialsAnalysisAction,
 } from '@/entities/analysis/actions';
 import { isGateBlockedResult } from '@/entities/analysis';
+import { ANALYSIS_POLL_MAX_DURATION_MS } from '@/shared/config/pollingConfig';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import type { FinancialsAnalysisResponse } from '@y0ngha/siglens-core';
@@ -340,5 +342,48 @@ describe('useFinancialsAnalysis — branch coverage', () => {
         rerender();
 
         expect(mockSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it('poll ceiling → error state when job stalls beyond ANALYSIS_POLL_MAX_DURATION_MS', async () => {
+        // Arrange: job is submitted but poll always returns 'processing'.
+        // Freeze Date.now() past the ceiling on the first check so the loop
+        // breaks immediately without iterating (avoids needing many poll calls).
+        mockSubmit.mockResolvedValue({
+            status: 'submitted',
+            jobId: 'job-stalled',
+        } as never);
+        // poll resolves with 'processing' status (not 'done' / 'error')
+        mockPoll.mockResolvedValue({ status: 'processing' } as never);
+
+        const realNow = Date.now;
+        const frozenStart = realNow();
+        let callCount = 0;
+        vi.spyOn(Date, 'now').mockImplementation(() => {
+            // First call (pollStart = Date.now()) returns current time.
+            // Second call (ceiling check inside while loop) returns time past ceiling.
+            callCount += 1;
+            return callCount === 1
+                ? frozenStart
+                : frozenStart + ANALYSIS_POLL_MAX_DURATION_MS + 1;
+        });
+
+        try {
+            const { result } = renderHook(
+                () => useFinancialsAnalysis('AAPL', 'gemini-2.5-flash-lite'),
+                { wrapper: makeWrapper() }
+            );
+
+            await waitFor(() => {
+                expect(result.current.status).toBe('error');
+            });
+
+            if (result.current.status !== 'error')
+                throw new Error('expected error state');
+            expect(result.current.error.message).toContain(
+                '너무 오래 걸립니다'
+            );
+        } finally {
+            vi.spyOn(Date, 'now').mockRestore();
+        }
     });
 });

--- a/src/widgets/financials/__tests__/hooks/useFinancialsAnalysisBranches.test.tsx
+++ b/src/widgets/financials/__tests__/hooks/useFinancialsAnalysisBranches.test.tsx
@@ -358,7 +358,7 @@ describe('useFinancialsAnalysis — branch coverage', () => {
         const realNow = Date.now;
         const frozenStart = realNow();
         let callCount = 0;
-        vi.spyOn(Date, 'now').mockImplementation(() => {
+        const dateSpy = vi.spyOn(Date, 'now').mockImplementation(() => {
             // First call (pollStart = Date.now()) returns current time.
             // Second call (ceiling check inside while loop) returns time past ceiling.
             callCount += 1;
@@ -383,7 +383,7 @@ describe('useFinancialsAnalysis — branch coverage', () => {
                 '너무 오래 걸립니다'
             );
         } finally {
-            vi.spyOn(Date, 'now').mockRestore();
+            dateSpy.mockRestore();
         }
     });
 });

--- a/src/widgets/financials/hooks/useFinancialsAnalysis.ts
+++ b/src/widgets/financials/hooks/useFinancialsAnalysis.ts
@@ -11,7 +11,10 @@ import {
 import { isGateBlockedResult } from '@/entities/analysis';
 import { sleep } from '@/shared/lib/sleep';
 import { QUERY_KEYS } from '@/shared/config/queryConfig';
-import { ANALYSIS_POLL_INTERVAL_MS } from '@/shared/config/pollingConfig';
+import {
+    ANALYSIS_POLL_INTERVAL_MS,
+    ANALYSIS_POLL_MAX_DURATION_MS,
+} from '@/shared/config/pollingConfig';
 import { usePageHideCancel } from '@/shared/hooks/usePageHideCancel';
 import { useHydrated } from '@/shared/hooks/useHydrated';
 import { BotBlockedError } from '@/widgets/symbol-page';
@@ -53,9 +56,15 @@ async function fetchFinancialsAnalysis(
     }
 
     onJobId(submitted.jobId);
+    const pollStart = Date.now();
     try {
         const { jobId } = submitted;
         while (!signal.aborted) {
+            if (Date.now() - pollStart >= ANALYSIS_POLL_MAX_DURATION_MS) {
+                throw new Error(
+                    '분석이 너무 오래 걸립니다. 잠시 후 다시 시도해 주세요.'
+                );
+            }
             await sleep(ANALYSIS_POLL_INTERVAL_MS);
             if (signal.aborted) break;
             const polled = await pollFinancialsAnalysisAction(jobId);

--- a/src/widgets/financials/sections/FinancialTrendChart.tsx
+++ b/src/widgets/financials/sections/FinancialTrendChart.tsx
@@ -253,7 +253,7 @@ export function FinancialTrendChart({
 
             <div className="mt-1 flex justify-between">
                 {periods.map(p => (
-                    <span key={p} className="text-secondary-500 text-xs">
+                    <span key={p} className="text-secondary-400 text-xs">
                         {p}
                     </span>
                 ))}

--- a/src/widgets/financials/sections/StatementTable.tsx
+++ b/src/widgets/financials/sections/StatementTable.tsx
@@ -60,10 +60,13 @@ export function StatementTable({
                 )}
                 <thead>
                     <tr className="text-secondary-400 border-secondary-700 border-b text-xs tracking-widest uppercase">
-                        <th className="pb-2 text-left font-medium">지표</th>
+                        <th scope="col" className="pb-2 text-left font-medium">
+                            지표
+                        </th>
                         {columns.map(col => (
                             <th
                                 key={col}
+                                scope="col"
                                 className="pb-2 text-right font-medium"
                             >
                                 {col}
@@ -77,12 +80,15 @@ export function StatementTable({
                             key={row.labelKo}
                             className="hover:bg-secondary-800/40 border-secondary-700/50 border-b transition-colors last:border-b-0"
                         >
-                            <td className="text-secondary-300 py-2.5 pr-4 text-xs font-medium whitespace-nowrap">
+                            <th
+                                scope="row"
+                                className="text-secondary-300 py-2.5 pr-4 text-left text-xs font-normal whitespace-nowrap"
+                            >
                                 {row.labelKo}
                                 {row.tooltip && (
                                     <span className="ml-1">{row.tooltip}</span>
                                 )}
-                            </td>
+                            </th>
                             {row.values.map((v, j) => {
                                 const formatted = formatValue(v, row.format);
                                 const isNegative = v !== null && v < 0;
@@ -94,7 +100,7 @@ export function StatementTable({
                                         className={cn(
                                             'py-2.5 text-right font-mono text-xs tabular-nums',
                                             formatted === '—'
-                                                ? 'text-secondary-500'
+                                                ? 'text-secondary-400'
                                                 : isNegative
                                                   ? 'text-chart-bearish'
                                                   : isPositive

--- a/src/widgets/financials/sections/__tests__/StatementTable.test.tsx
+++ b/src/widgets/financials/sections/__tests__/StatementTable.test.tsx
@@ -100,8 +100,9 @@ describe('StatementTable', () => {
         const { container } = render(<StatementTable {...BASE_PROPS} />);
         const rows = container.querySelectorAll('tbody tr');
         rows.forEach(row => {
-            // label + 3 value columns
-            expect(row.querySelectorAll('td').length).toBe(4);
+            // 1 th[scope=row] label + 3 value td cells
+            expect(row.querySelectorAll('th[scope="row"]').length).toBe(1);
+            expect(row.querySelectorAll('td').length).toBe(3);
         });
     });
 

--- a/src/widgets/layout/ContactDialog.tsx
+++ b/src/widgets/layout/ContactDialog.tsx
@@ -5,7 +5,7 @@ import { useDialog } from '@/shared/hooks/useDialog';
 import { cn } from '@/shared/lib/cn';
 
 const TRIGGER_BASE_CLASS =
-    'rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-500';
+    'rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500';
 
 interface ContactDialogProps {
     triggerLabel?: string;
@@ -58,7 +58,7 @@ export function ContactDialog({
                                 type="button"
                                 onClick={close}
                                 aria-label="닫기"
-                                className="text-secondary-400 hover:text-secondary-300 focus-visible:ring-primary-500 -mt-1 -mr-1 rounded p-1 transition-colors focus-visible:ring-1 focus-visible:outline-none"
+                                className="text-secondary-400 hover:text-secondary-300 focus-visible:ring-primary-500 -mt-1 -mr-1 rounded p-1 transition-colors focus-visible:ring-2 focus-visible:outline-none"
                             >
                                 <svg
                                     width="16"

--- a/src/widgets/layout/ContactDialog.tsx
+++ b/src/widgets/layout/ContactDialog.tsx
@@ -58,7 +58,7 @@ export function ContactDialog({
                                 type="button"
                                 onClick={close}
                                 aria-label="닫기"
-                                className="text-secondary-500 hover:text-secondary-300 focus-visible:ring-primary-500 -mt-1 -mr-1 rounded p-1 transition-colors focus-visible:ring-1 focus-visible:outline-none"
+                                className="text-secondary-400 hover:text-secondary-300 focus-visible:ring-primary-500 -mt-1 -mr-1 rounded p-1 transition-colors focus-visible:ring-1 focus-visible:outline-none"
                             >
                                 <svg
                                     width="16"

--- a/src/widgets/layout/HeaderNav.tsx
+++ b/src/widgets/layout/HeaderNav.tsx
@@ -20,8 +20,9 @@ export function HeaderNav({ items }: HeaderNavProps) {
         <nav aria-label="주요 네비게이션" className="flex gap-1 sm:gap-4">
             {items.map(item => {
                 const isActive =
-                    pathname === item.href ||
-                    pathname.startsWith(`${item.href}/`);
+                    pathname !== null &&
+                    (pathname === item.href ||
+                        pathname.startsWith(`${item.href}/`));
                 return (
                     <Link
                         key={item.href}

--- a/src/widgets/layout/HeaderUserMenu.tsx
+++ b/src/widgets/layout/HeaderUserMenu.tsx
@@ -50,7 +50,7 @@ export function HeaderUserMenu({ currentUser, loading }: HeaderUserMenuProps) {
             <div
                 role="status"
                 aria-label="로딩 중"
-                className="bg-secondary-800 size-10 animate-pulse rounded-full"
+                className="bg-secondary-800 size-10 animate-pulse rounded-full motion-reduce:animate-none"
             />
         );
     }

--- a/src/widgets/market-news/MarketNewsCard.tsx
+++ b/src/widgets/market-news/MarketNewsCard.tsx
@@ -118,7 +118,7 @@ function TickerChips({ category, tickers }: TickerChipsProps) {
                         href={`/${ticker}`}
                         aria-label={`${ticker} 종목 페이지로 이동`}
                         data-testid="ticker-chip"
-                        className="text-primary-400 hover:text-primary-300 focus-visible:ring-primary-500 rounded px-1.5 py-0.5 text-xs font-medium transition-colors focus-visible:ring-1 focus-visible:outline-none"
+                        className="text-primary-400 hover:text-primary-300 focus-visible:ring-primary-500 rounded px-1.5 py-0.5 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none"
                     >
                         {ticker}
                     </Link>
@@ -234,7 +234,7 @@ export function MarketNewsCard({ category, item }: MarketNewsCardProps) {
                         href={item.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-primary-400 focus-visible:ring-primary-500 mt-2 inline-block text-xs transition-opacity hover:opacity-70 focus-visible:ring-1 focus-visible:outline-none"
+                        className="text-primary-400 focus-visible:ring-primary-500 mt-2 inline-block text-xs transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:outline-none"
                     >
                         원문 보기 <span aria-hidden="true">→</span>
                     </a>

--- a/src/widgets/market-news/MarketNewsCard.tsx
+++ b/src/widgets/market-news/MarketNewsCard.tsx
@@ -76,7 +76,7 @@ function AnalysisSkeleton() {
         >
             <div className="bg-secondary-700 h-5 w-10 animate-pulse rounded motion-reduce:animate-none" />
             <div className="bg-secondary-700 h-5 w-20 animate-pulse rounded motion-reduce:animate-none" />
-            <span className="text-secondary-500 text-xs">AI 분석 중…</span>
+            <span className="text-secondary-400 text-xs">AI 분석 중…</span>
         </div>
     );
 }

--- a/src/widgets/market-news/MarketNewsDigest.tsx
+++ b/src/widgets/market-news/MarketNewsDigest.tsx
@@ -159,7 +159,7 @@ function DigestErrorView({ error, onRetry }: DigestErrorViewProps) {
             <button
                 type="button"
                 onClick={onRetry}
-                className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-800 mt-4 rounded px-3 py-1.5 text-xs text-white transition-colors focus-visible:ring-1 focus-visible:ring-offset-2 focus-visible:outline-none"
+                className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-800 mt-4 inline-flex min-h-11 items-center rounded px-3 py-2 text-xs text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
             >
                 다시 시도
             </button>

--- a/src/widgets/market-news/MarketNewsList.tsx
+++ b/src/widgets/market-news/MarketNewsList.tsx
@@ -152,7 +152,7 @@ export function MarketNewsList({
                 <button
                     type="button"
                     onClick={() => setVisibleCount(c => c + PAGE_SIZE)}
-                    className="border-secondary-700 text-secondary-400 hover:text-secondary-100 focus-visible:ring-primary-500 w-full rounded-lg border py-2 text-sm transition-colors focus-visible:ring-1 focus-visible:outline-none"
+                    className="border-secondary-700 text-secondary-400 hover:text-secondary-100 focus-visible:ring-primary-500 inline-flex min-h-11 w-full items-center justify-center rounded-lg border py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none"
                 >
                     더보기 ({items.length - visibleCount}개 남음)
                 </button>

--- a/src/widgets/market-news/hooks/useMarketNewsDigest.ts
+++ b/src/widgets/market-news/hooks/useMarketNewsDigest.ts
@@ -100,9 +100,15 @@ export function useMarketNewsDigest(
 
     useMarketNewsAnalysisTrigger(category);
 
+    // §17 exception: `refetch` is destructured immediately after useQuery
+    // because it feeds the useCallback below. The `refetch` reference is
+    // stable across renders (React Query guarantee), so this satisfies
+    // exhaustive-deps without introducing unstable derived values.
+    const { refetch } = query;
+
     const retry = useCallback(() => {
-        void query.refetch();
-    }, [query.refetch]);
+        void refetch();
+    }, [refetch]);
 
     // Cancel in-flight digest job on unmount or category change.
     useEffect(() => {

--- a/src/widgets/news-hub/CategoryCard.tsx
+++ b/src/widgets/news-hub/CategoryCard.tsx
@@ -70,7 +70,7 @@ export function CategoryCard({
 
             <Link
                 href={`/news/${slug}`}
-                className="text-primary-400 hover:text-primary-300 focus-visible:ring-primary-500 mt-auto text-sm transition-colors focus-visible:ring-1 focus-visible:outline-none"
+                className="text-primary-400 hover:text-primary-300 focus-visible:ring-primary-500 mt-auto text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none"
                 aria-label={`${koLabel} 뉴스 더보기`}
             >
                 더보기 <span aria-hidden="true">→</span>

--- a/src/widgets/news-hub/CategoryCard.tsx
+++ b/src/widgets/news-hub/CategoryCard.tsx
@@ -42,7 +42,7 @@ export function CategoryCard({
             <h2 className="mb-1 text-base font-semibold tracking-tight text-balance">
                 {koLabel}
             </h2>
-            <p className="text-secondary-500 mb-3 text-xs leading-relaxed">
+            <p className="text-secondary-400 mb-3 text-xs leading-relaxed">
                 {koDescription}
             </p>
 
@@ -63,7 +63,7 @@ export function CategoryCard({
                     ))}
                 </ul>
             ) : (
-                <p className="text-secondary-500 mb-4 text-sm">
+                <p className="text-secondary-400 mb-4 text-sm">
                     최신 뉴스를 불러오고 있어요.
                 </p>
             )}

--- a/src/widgets/symbol-page/FearGreedCard.tsx
+++ b/src/widgets/symbol-page/FearGreedCard.tsx
@@ -18,7 +18,7 @@ export function FearGreedCard({ snapshot }: FearGreedCardProps) {
     if (!snapshot) {
         return (
             <section className="bg-secondary-800/40 rounded p-3">
-                <div className="text-secondary-500 text-sm">
+                <div className="text-secondary-400 text-sm">
                     공포 탐욕 지수 데이터 부족
                 </div>
             </section>
@@ -68,7 +68,7 @@ export function FearGreedCard({ snapshot }: FearGreedCardProps) {
                                 </span>
                                 <span className="font-mono">
                                     {formatFactorRaw(f.key, f.rawValue)}
-                                    <span className="text-secondary-500 ml-1">
+                                    <span className="text-secondary-400 ml-1">
                                         ({Math.round(f.percentile)}th)
                                     </span>
                                 </span>
@@ -78,7 +78,7 @@ export function FearGreedCard({ snapshot }: FearGreedCardProps) {
                 </div>
             ))}
 
-            <footer className="text-secondary-500 text-[10px]">
+            <footer className="text-secondary-400 text-[10px]">
                 {formatConfidenceFooter(
                     snapshot.sampleSize,
                     snapshot.confidence

--- a/src/widgets/symbol-page/SymbolLayoutHeader.tsx
+++ b/src/widgets/symbol-page/SymbolLayoutHeader.tsx
@@ -45,7 +45,7 @@ export function SymbolLayoutHeader({ symbol }: SymbolLayoutHeaderProps) {
                 <div className="flex min-w-0 items-center gap-2 sm:flex-1">
                     <Link
                         href="/"
-                        className="text-secondary-500 hover:text-secondary-300 font-mono text-xs tracking-[0.2em] uppercase transition-colors"
+                        className="text-secondary-400 hover:text-secondary-300 font-mono text-xs tracking-[0.2em] uppercase transition-colors"
                     >
                         SIGLENS
                     </Link>
@@ -91,7 +91,7 @@ export function SymbolLayoutHeader({ symbol }: SymbolLayoutHeaderProps) {
                 </div>
 
                 <div className="flex items-center gap-2 sm:order-3 sm:shrink-0">
-                    <span className="text-secondary-500 text-xs whitespace-nowrap">
+                    <span className="text-secondary-400 text-xs whitespace-nowrap">
                         AI 분석 모델
                     </span>
                     <ModelSelector

--- a/src/widgets/symbol-page/SymbolTabs.tsx
+++ b/src/widgets/symbol-page/SymbolTabs.tsx
@@ -29,9 +29,9 @@ export function SymbolTabs({ symbol }: SymbolTabsProps) {
                         href={href}
                         aria-current={active ? 'page' : undefined}
                         className={cn(
-                            'focus-visible:ring-primary-500 px-4 py-2 text-sm whitespace-nowrap focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+                            'focus-visible:ring-primary-500 -mb-px flex min-h-11 touch-manipulation items-center border-b-2 border-transparent px-4 py-2 text-sm whitespace-nowrap focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
                             active
-                                ? 'border-primary-500 text-secondary-100 border-b-2 font-medium'
+                                ? 'border-primary-500 text-secondary-100 font-medium'
                                 : 'text-secondary-400 hover:text-secondary-100'
                         )}
                     >

--- a/src/widgets/symbol-page/TechnicalFactsSummary.tsx
+++ b/src/widgets/symbol-page/TechnicalFactsSummary.tsx
@@ -80,7 +80,7 @@ export function TechnicalFactsSummary({
                     </dd>
                 </div>
             </dl>
-            <p className="text-secondary-500 text-xs">
+            <p className="text-secondary-400 text-xs">
                 위 지표는 실시간 시세 기반 자동 계산값입니다.
             </p>
         </section>


### PR DESCRIPTION
## 배경
PR #604(머지 완료) 후 신규 페이지(/news, /economy, /[symbol]/congress, /[symbol]/financials) 종합 검수에서 도출된 a11y/UX/correctness 폴리시를 일괄 처리합니다. (seo-audit·frontend-design·web-design-guidelines 스킬 + 종합 Opus 감사)

## 변경
### a11y
- **WCAG 대비**: `text-secondary-500`(작은 글자 ~3.0-3.7:1 미달) → `text-secondary-400`(5.7-7.0 PASS). 신규 위젯 + 기존 symbol/chart 잔여 포함.
- **터치타겟 44px**: SymbolTabs, PeriodToggle, MarketNewsList "더보기", 4개 AI 에러 "다시 시도" 버튼.
- **motion-reduce**: 스켈레톤/스피너 5곳.
- **StatementTable** `th scope` (col/row).

### correctness
- `HeaderNav` null-pathname guard (잠재 크래시).
- **AI 폴링 5분 상한** (financials/congress/economy) → stall 시 무한 로딩 대신 재시도 가능 error. macro는 재시도 타이머 재무장까지.
- **DeltaBadge 중립화** — 일반 지표 초록/빨강 valence 제거(실업률↑=초록 오해 방지). 2s10s 스프레드 색은 도메인 의미라 보존.

### 테스트
- `useCongressTrend` 커버리지 67.5%→88%, 폴링 상한·재시도·cleanup 분기 테스트 추가.

## 검증
- vitest **6287** 통과, tsc/lint(0 warnings)/prettier 클린, prod 빌드 + curl(SEO 불변) + Chrome 시각 확인(DeltaBadge 중립+chevron, 대비 향상)
- Opus review-agent: R1에서 macro 폴링 재시도 버그 1건 적발 → 수정 → R2 **APPROVED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)