### PR TITLE
feat(economy): SP-A — 경제 캘린더 DB-backed 이력 데이터 레이어

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,10 @@ next-env.d.ts
 !/scripts/validate-skills.ts
 !/scripts/__tests__/
 !/scripts/__tests__/**
+# SP-A: one-time backfill script + pure helpers (tracked so users can run them).
+!/scripts/backfillEconomicCalendar.ts
+!/scripts/lib/
+!/scripts/lib/**
 
 # Local Lighthouse audit outputs (psi_*.json, desktop.json, mobile.json, headers.txt)
 /lighthouse/

--- a/docs/superpowers/plans/2026-06-20-economy-calendar-SP-A-history-data-layer.md
+++ b/docs/superpowers/plans/2026-06-20-economy-calendar-SP-A-history-data-layer.md
@@ -1,0 +1,1919 @@
+# Economy Calendar SP-A — History Data Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `/economy` calendar's Redis-snapshot data source with a DB-backed history layer so the page can show past events (with `actual` values) plus the future window, fed by a one-time backfill + an on-access `ensure` refresh.
+
+**Architecture:** A new `economic_calendar` Drizzle table stores normalized FMP economic-calendar events keyed by a deterministic `country+dateEt+event` hash (idempotent upsert; `actual` excluded from the key so post-release updates land on the same row). A standalone `tsx` backfill script seeds ~2 years in chunks and dumps the distinct normalized indicator-name set for SP-B. A `'use server'` `ensureEconomicCalendarAction` (mirroring `ensureMarketNewsCardsAnalyzedAction`) fetches a ±1-month window on access, upserts, and `revalidateTag`s the calendar cache. An ISR-cold-gen-safe `getCalendarFromDb` reader (wrapped in `unstable_cache` per the 4-axis rule) supplies the grid. The economy page switches only the calendar axis to DB; indicators/treasury stay on the Redis snapshot. A client widget hook fires the ensure action once on mount.
+
+**Tech Stack:** TypeScript, Drizzle ORM (Neon serverless), `drizzle-kit` migrations, Next.js 16 (RSC + `unstable_cache` + `revalidateTag`), vitest, `@y0ngha/siglens-core` (`normalizeEconomicCalendar`, `EconomicCalendarEvent`, `CalendarImpact`).
+
+---
+
+## Cross-repo scope check
+
+SP-A is **entirely siglens** per the spec table (FMP ingestion I/O, DB schema/storage, display). The only core consumption is the pure normalizer `normalizeEconomicCalendar` and the `EconomicCalendarEvent` / `CalendarImpact` types, which already exist in the published core package (verified in `node_modules/@y0ngha/siglens-core/dist/domain/economy/`). **No core change is required for SP-A.** AI columns (sentiment/summaryKo/interpretationKo/analyzedAt) are explicitly out of scope — they arrive in SP-D via a separate migration.
+
+---
+
+## File Structure
+
+| File | Create/Modify | Responsibility |
+|---|---|---|
+| `src/shared/db/schema.ts` | Modify | Add `economicCalendar` `pgTable` (id PK, country, dateEt, event, impact, estimate, previous, actual, unit, fetchedAt; 3 indexes). |
+| `drizzle/0018_*.sql` + `drizzle/meta/*` | Create (generated) | Migration creating `economic_calendar` table + indexes (output of `yarn db:generate`). |
+| `src/entities/economy/lib/economicCalendarId.ts` | Create | Pure deterministic id hash `economicCalendarId(country, dateEt, event)`. |
+| `src/entities/economy/lib/__tests__/economicCalendarId.test.ts` | Create | Tests for id stability + collision sensitivity. |
+| `src/entities/economy/lib/calendarWindow.ts` | Create | Pure ET-date window helpers (`etToday`, `addEtDays`, `pastWindowStart`, `futureWindowEnd`) reused by reader/action/script. |
+| `src/entities/economy/lib/__tests__/calendarWindow.test.ts` | Create | Tests for ET date arithmetic + window bounds. |
+| `src/entities/economy/api/economicCalendarRepository.ts` | Create | `DrizzleEconomicCalendarRepository`: `upsertEvent` (idempotent, returns changed) + `listInRange(fromEt, toEt)`. |
+| `src/entities/economy/api/__tests__/economicCalendarRepository.test.ts` | Create | Repository upsert/list query-shape tests against a mocked db. |
+| `src/entities/economy/api/getCalendarFromDb.ts` | Create | ISR-safe reader: `unstable_cache`-wrapped past-2-weeks + future-window DB read → `EconomicCalendarEvent[]`. |
+| `src/entities/economy/api/__tests__/getCalendarFromDb.test.ts` | Create | Tests for range computation, sort, mapping, ISR safety (no dynamic API). |
+| `src/entities/economy/lib/economyCalendarConstants.ts` | Create | Window/TTL/tag/refresh-flag constants shared across reader/action. |
+| `src/entities/economy/actions/ensureEconomicCalendarAction.ts` | Create | `'use server'` ±1-month FMP fetch → upsert → `revalidateTag`; fire-and-forget error logging. |
+| `src/entities/economy/actions/__tests__/ensureEconomicCalendarAction.test.ts` | Create | Tests for fetch→upsert→revalidate path + graceful FMP failure. |
+| `src/entities/economy/actions.ts` | Create | Server Action barrel re-exporting `ensureEconomicCalendarAction` (no `'use server'`). |
+| `scripts/backfillEconomicCalendar.ts` | Create | One-time `tsx` backfill: chunked ~2yr fetch → upsert + dump distinct normalized indicator names. |
+| `scripts/lib/normalizeIndicatorBaseName.ts` | Create | Pure base-name normalizer (strip trailing `(May)`/`(Q1)`/`(Jun/20)`) used by the backfill dump. |
+| `scripts/lib/__tests__/normalizeIndicatorBaseName.test.ts` | Create | Tests for suffix stripping. |
+| `package.json` | Modify | Add `db:backfill:calendar` script. |
+| `src/widgets/economy/hooks/useEconomicCalendarTrigger.ts` | Create | `'use client'` hook firing `ensureEconomicCalendarAction()` once on mount. |
+| `src/widgets/economy/hooks/__tests__/useEconomicCalendarTrigger.test.tsx` | Create | Test the once-on-mount fire-and-forget behavior. |
+| `src/widgets/economy/sections/EconomicCalendarGrid.tsx` | Modify | Accept `today` prop (ET-derived KST date key) + fire the trigger; default-select today else nearest upcoming. |
+| `src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx` | Modify | Add default-selection-from-`today` tests. |
+| `src/widgets/economy/index.ts` | Modify (no-op check) | Confirm `EconomicCalendar` export still valid after prop change. |
+| `src/app/economy/page.tsx` | Modify | Switch calendar source to `getCalendarFromDb`; compute ET-today once; pass `events` + `today` to grid. |
+
+**FSD compliance:** pure logic + id hash live in `entities/economy/lib/`; DB repository + reader live in `entities/economy/api/` (server-only, barrel-excluded); the server action lives in `entities/economy/actions/`; the client trigger hook lives in `widgets/economy/hooks/`; the page composes them. The script lives under top-level `scripts/` (not an FSD layer) and imports the repository/normalizer directly via `tsx`.
+
+---
+
+## Conventions to honor (gates)
+
+- **Tests colocated** in `__tests__/` next to the unit. Run a single file with `npx vitest run <path>`.
+- **`tsc`, ESLint, Prettier must pass.** No `eslint-disable`. Run `yarn lint` and `yarn format` before each commit if unsure.
+- **ISR 4-axis safety** (`src/app/CLAUDE.md`): no `cookies()`/`headers()`/`connection()`/`Date.now()` inside the cold-gen render path. The reader wraps the DB read in `unstable_cache`; the page computes "today" with the existing ET formatter (a deterministic `Intl` call, not a forbidden dynamic API — same pattern `economySnapshotCache.isoDate` already uses).
+- **Route segment config stays literal** — `export const revalidate = 86400` already exists in `page.tsx`; do not touch it.
+- **`'use server'` files** export only async functions; constants/classes live in separate files (`entities/CLAUDE.md`).
+- **Barrel exclusion:** `api/` server-only modules and `actions/*` stay out of `entities/economy/index.ts`; consumers deep-import (matching the existing economy barrel comment).
+- **Commit per task** with the conventional-commit messages given. Do not push (git-agent's job) — these `git commit` steps are local checkpoints for the executing worker.
+
+---
+
+## Task 1: `economic_calendar` Drizzle table
+
+**Files:**
+- Modify: `src/shared/db/schema.ts` (append after `earningsReports`, before `termsKindEnum`)
+- Create (generated): `drizzle/0018_*.sql`, `drizzle/meta/0018_snapshot.json`, updated `drizzle/meta/_journal.json`
+
+- [ ] **Step 1: Add the table to the schema**
+
+In `src/shared/db/schema.ts`, add this block immediately after the `earningsReports` `pgTable` definition (line ~323, before `export const termsKindEnum`). It mirrors `marketNews`/`earningsReports` column style and uses the existing imports (`pgTable`, `text`, `doublePrecision`, `index`, `timestamp`). Add `doublePrecision` to the existing `drizzle-orm/pg-core` import list at the top of the file.
+
+```typescript
+/**
+ * 정규화된 FMP economic-calendar 이벤트 이력 (현재 US만 저장).
+ *
+ * `id`는 country+dateEt+event의 결정론적 해시(`economicCalendarId`)다. `actual`을
+ * 포함하지 않으므로 발표 후 actual이 채워져도 같은 행으로 upsert돼 갱신된다
+ * (#610 그리드의 React key `${date}:${event}:${actual}`와는 의도가 다른 안정 키).
+ *
+ * SP-D에서 별도 마이그레이션으로 sentiment/summaryKo/interpretationKo/analyzedAt가
+ * 추가된다 — SP-A 테이블에는 미포함.
+ */
+export const economicCalendar = pgTable(
+    'economic_calendar',
+    {
+        id: text('id').primaryKey(),
+        country: text('country').notNull(),
+        // FMP 원본 'YYYY-MM-DD HH:mm:ss' (ET 벽시계). KST 변환은 표시 계층(etDateTimeToKst).
+        dateEt: text('date_et').notNull(),
+        event: text('event').notNull(),
+        // 'High' | 'Medium' | 'Low' — text 저장, 읽기 경계에서 검증.
+        impact: text('impact').notNull(),
+        estimate: doublePrecision('estimate'),
+        previous: doublePrecision('previous'),
+        // 발표 전 null; ingestion 재fetch 시 채워짐.
+        actual: doublePrecision('actual'),
+        unit: text('unit').notNull(),
+        fetchedAt: timestamp('fetched_at', { withTimezone: true })
+            .notNull()
+            .defaultNow(),
+    },
+    table => [
+        index('economic_calendar_date_et_idx').on(table.dateEt),
+        index('economic_calendar_country_date_et_idx').on(
+            table.country,
+            table.dateEt
+        ),
+        index('economic_calendar_impact_idx').on(table.impact),
+    ]
+);
+```
+
+Add `doublePrecision,` to the `drizzle-orm/pg-core` import (alphabetically near `date`):
+
+```typescript
+import {
+    boolean,
+    date,
+    doublePrecision,
+    index,
+    integer,
+    jsonb,
+    numeric,
+    pgEnum,
+    pgTable,
+    primaryKey,
+    text,
+    timestamp,
+    uniqueIndex,
+    uuid,
+    varchar,
+} from 'drizzle-orm/pg-core';
+```
+
+- [ ] **Step 2: Generate the migration**
+
+Run: `yarn db:generate`
+Expected: drizzle-kit reports a new migration `0018_*` creating `economic_calendar` with 3 indexes; new files appear under `drizzle/` and `drizzle/meta/`. (No DB connection needed for `generate` — it only diffs the schema; `db:generate` runs through `dotenv -e .env.local`.)
+
+- [ ] **Step 3: Verify the generated SQL**
+
+Run: `cat drizzle/0018_*.sql`
+Expected: a `CREATE TABLE "economic_calendar"` with `"id" text PRIMARY KEY NOT NULL`, `"date_et" text NOT NULL`, `"impact" text NOT NULL`, `"estimate"`/`"previous"`/`"actual"` as `double precision`, `"fetched_at" timestamp with time zone DEFAULT now() NOT NULL`, and three `CREATE INDEX` statements (`economic_calendar_date_et_idx`, `economic_calendar_country_date_et_idx`, `economic_calendar_impact_idx`). If the columns/indexes don't match, fix the schema and re-run `yarn db:generate`.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS (no type errors from the new table).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/db/schema.ts drizzle/0018_*.sql drizzle/meta
+git commit -m "feat(economy): add economic_calendar table for calendar history (SP-A)"
+```
+
+> Note: applying the migration to a live DB (`yarn db:migrate`) is an operational step the user runs against their environment — not part of this code plan.
+
+---
+
+## Task 2: Deterministic calendar id hash
+
+**Files:**
+- Create: `src/entities/economy/lib/economicCalendarId.ts`
+- Test: `src/entities/economy/lib/__tests__/economicCalendarId.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { economicCalendarId } from '@/entities/economy/lib/economicCalendarId';
+
+describe('economicCalendarId', () => {
+    it('is deterministic for the same inputs', () => {
+        const a = economicCalendarId(
+            'US',
+            '2026-05-13 08:30:00',
+            'Core CPI MoM (Apr)'
+        );
+        const b = economicCalendarId(
+            'US',
+            '2026-05-13 08:30:00',
+            'Core CPI MoM (Apr)'
+        );
+        expect(a).toBe(b);
+    });
+
+    it('produces a fixed-length lowercase hex string', () => {
+        const id = economicCalendarId(
+            'US',
+            '2026-05-13 08:30:00',
+            'Core CPI MoM (Apr)'
+        );
+        expect(id).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('excludes actual — different actual is irrelevant because actual is not an input', () => {
+        // Same country+dateEt+event must always collide so post-release upserts
+        // land on the same row.
+        const before = economicCalendarId('US', '2026-05-13 08:30:00', 'Core CPI MoM (Apr)');
+        const after = economicCalendarId('US', '2026-05-13 08:30:00', 'Core CPI MoM (Apr)');
+        expect(before).toBe(after);
+    });
+
+    it('differs when any component differs', () => {
+        const base = economicCalendarId('US', '2026-05-13 08:30:00', 'Core CPI MoM (Apr)');
+        expect(economicCalendarId('EU', '2026-05-13 08:30:00', 'Core CPI MoM (Apr)')).not.toBe(base);
+        expect(economicCalendarId('US', '2026-05-14 08:30:00', 'Core CPI MoM (Apr)')).not.toBe(base);
+        expect(economicCalendarId('US', '2026-05-13 08:30:00', 'CPI MoM (Apr)')).not.toBe(base);
+    });
+
+    it('is not fooled by component-boundary ambiguity', () => {
+        // 'a' + 'bc' vs 'ab' + 'c' must not collide — a delimiter separates parts.
+        expect(
+            economicCalendarId('US', 'x', 'yz')
+        ).not.toBe(economicCalendarId('US', 'xy', 'z'));
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/entities/economy/lib/__tests__/economicCalendarId.test.ts`
+Expected: FAIL — `Cannot find module '@/entities/economy/lib/economicCalendarId'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+import { createHash } from 'node:crypto';
+
+/**
+ * 결정론적 PK 해시 — country + dateEt + event의 SHA-256 hex.
+ *
+ * `actual`을 의도적으로 제외한다: 발표 후 actual이 채워져도 같은 이벤트로 upsert해
+ * 갱신하기 위함(`economic_calendar` 테이블 주석 참조). 구성 요소 사이에 ` `
+ * 구분자를 넣어 'a'+'bc'와 'ab'+'c' 같은 경계 충돌을 방지한다.
+ */
+export function economicCalendarId(
+    country: string,
+    dateEt: string,
+    event: string
+): string {
+    return createHash('sha256')
+        .update(`${country} ${dateEt} ${event}`)
+        .digest('hex');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/entities/economy/lib/__tests__/economicCalendarId.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entities/economy/lib/economicCalendarId.ts src/entities/economy/lib/__tests__/economicCalendarId.test.ts
+git commit -m "feat(economy): add deterministic economic_calendar id hash (SP-A)"
+```
+
+---
+
+## Task 3: ET date-window helpers
+
+**Files:**
+- Create: `src/entities/economy/lib/calendarWindow.ts`
+- Test: `src/entities/economy/lib/__tests__/calendarWindow.test.ts`
+
+These pure helpers produce ET-zoned `YYYY-MM-DD` strings and arithmetic, reused by the reader, the action, and the script. They mirror the `economySnapshotCache.isoDate` ET-formatter approach (deterministic `Intl.DateTimeFormat`, no dynamic API).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import {
+    etDateOf,
+    addEtDays,
+    pastWindowStart,
+    futureWindowEnd,
+    PAST_WINDOW_DAYS,
+    FUTURE_WINDOW_DAYS,
+} from '@/entities/economy/lib/calendarWindow';
+
+describe('etDateOf', () => {
+    it('formats a UTC instant to its ET YYYY-MM-DD', () => {
+        // 2026-01-15T02:00:00Z is still 2026-01-14 21:00 in ET (UTC-5).
+        expect(etDateOf(new Date('2026-01-15T02:00:00Z'))).toBe('2026-01-14');
+    });
+
+    it('handles afternoon UTC staying same ET day', () => {
+        expect(etDateOf(new Date('2026-01-15T18:00:00Z'))).toBe('2026-01-15');
+    });
+});
+
+describe('addEtDays', () => {
+    it('adds days to a YYYY-MM-DD string', () => {
+        expect(addEtDays('2026-01-31', 1)).toBe('2026-02-01');
+    });
+    it('subtracts days with a negative delta', () => {
+        expect(addEtDays('2026-03-01', -1)).toBe('2026-02-28');
+    });
+    it('crosses a year boundary', () => {
+        expect(addEtDays('2025-12-31', 1)).toBe('2026-01-01');
+    });
+});
+
+describe('window bounds', () => {
+    it('pastWindowStart is PAST_WINDOW_DAYS before the anchor', () => {
+        expect(pastWindowStart('2026-06-20')).toBe(
+            addEtDays('2026-06-20', -PAST_WINDOW_DAYS)
+        );
+    });
+    it('futureWindowEnd is FUTURE_WINDOW_DAYS after the anchor', () => {
+        expect(futureWindowEnd('2026-06-20')).toBe(
+            addEtDays('2026-06-20', FUTURE_WINDOW_DAYS)
+        );
+    });
+    it('past window is at least two weeks', () => {
+        expect(PAST_WINDOW_DAYS).toBeGreaterThanOrEqual(14);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/entities/economy/lib/__tests__/calendarWindow.test.ts`
+Expected: FAIL — `Cannot find module '@/entities/economy/lib/calendarWindow'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+/**
+ * 캘린더 윈도 일수 상수 + ET-zoned 날짜 헬퍼.
+ *
+ * `economySnapshotCache.isoDate`와 같은 ET formatter 패턴을 쓴다 — 서버가 UTC+0의
+ * 00:00~04:59에 "오늘"을 계산할 때 ET 기준 전날로 밀리는 오차를 막는다. 모든 함수는
+ * 결정론적(`Intl.DateTimeFormat` + 순수 산술)이라 ISR cold-gen에서 안전하다
+ * (`Date.now()`/dynamic API 미사용 — 호출자가 `new Date()` 앵커를 주입).
+ */
+
+/** 과거 윈도 일수 — 최소 2주(spec). */
+export const PAST_WINDOW_DAYS = 14;
+
+/** 미래 윈도 일수 — #610 그리드의 다가오는 ~2주와 정렬. */
+export const FUTURE_WINDOW_DAYS = 14;
+
+const ET_DATE_FORMAT = new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    timeZone: 'America/New_York',
+});
+
+/** UTC instant → ET-zoned 'YYYY-MM-DD'. */
+export function etDateOf(instant: Date): string {
+    const parts = Object.fromEntries(
+        ET_DATE_FORMAT.formatToParts(instant)
+            .filter(p => p.type !== 'literal')
+            .map(p => [p.type, p.value])
+    ) as Record<'year' | 'month' | 'day', string>;
+    return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+/** 'YYYY-MM-DD'에 일수를 더한 'YYYY-MM-DD' (UTC 산술 — TZ 비의존). */
+export function addEtDays(dateEt: string, delta: number): string {
+    const [y, m, d] = dateEt.split('-').map(Number);
+    const shifted = new Date(Date.UTC(y, m - 1, d + delta));
+    const yy = shifted.getUTCFullYear();
+    const mm = String(shifted.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(shifted.getUTCDate()).padStart(2, '0');
+    return `${yy}-${mm}-${dd}`;
+}
+
+/** 앵커일(포함) 기준 과거 윈도 시작일. */
+export function pastWindowStart(anchorEt: string): string {
+    return addEtDays(anchorEt, -PAST_WINDOW_DAYS);
+}
+
+/** 앵커일(포함) 기준 미래 윈도 종료일. */
+export function futureWindowEnd(anchorEt: string): string {
+    return addEtDays(anchorEt, FUTURE_WINDOW_DAYS);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/entities/economy/lib/__tests__/calendarWindow.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entities/economy/lib/calendarWindow.ts src/entities/economy/lib/__tests__/calendarWindow.test.ts
+git commit -m "feat(economy): add ET calendar window helpers (SP-A)"
+```
+
+---
+
+## Task 4: Calendar constants module
+
+**Files:**
+- Create: `src/entities/economy/lib/economyCalendarConstants.ts`
+
+Small constants-only module so the action (`'use server'`, no non-function exports) and the reader can share the cache tag / TTL / refresh-flag window / ingestion window. No test (trivial literals; covered transitively by Tasks 5–7).
+
+- [ ] **Step 1: Write the module**
+
+```typescript
+import { SECONDS_PER_DAY, SECONDS_PER_MINUTE } from '@/shared/config/time';
+
+/** revalidateTag 대상 — 캘린더 ISR 캐시만 무효화한다(스냅샷 캐시와 분리). */
+export const ECONOMY_CALENDAR_CACHE_TAG = 'economy:calendar';
+
+/**
+ * 캘린더 reader의 `unstable_cache` revalidate — 24h, /economy revalidate(86400)와
+ * 단일 TTL 공유. 신선도는 `ensureEconomicCalendarAction`의 revalidateTag가 책임진다.
+ */
+export const ECONOMY_CALENDAR_REVALIDATE_SECONDS = SECONDS_PER_DAY;
+
+/** ensure가 매 접속마다 ±1개월을 fetch하는 ingestion 윈도(일수). */
+export const CALENDAR_INGESTION_WINDOW_DAYS = 30;
+
+/** 'US' — 현재 US 이벤트만 저장/표시. */
+export const CALENDAR_COUNTRY = 'US';
+
+const CALENDAR_REFRESH_FLAG_TTL_MINUTES = 60;
+
+/**
+ * ensure refresh-flag TTL — 이 윈도 안에 재접속(봇 재크롤 포함)하면 FMP fetch를
+ * 건너뛴다. market-news `MARKET_NEWS_REFRESH_FLAG_TTL_SECONDS` 패턴을 미러.
+ */
+export const CALENDAR_REFRESH_FLAG_TTL_SECONDS =
+    CALENDAR_REFRESH_FLAG_TTL_MINUTES * SECONDS_PER_MINUTE;
+
+/** Redis refresh-flag 키 — 단일 글로벌 캘린더(심볼/카테고리 분기 없음). */
+export const CALENDAR_REFRESH_FLAG_KEY = 'economy:calendar:refresh';
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/entities/economy/lib/economyCalendarConstants.ts
+git commit -m "feat(economy): add economy calendar constants (SP-A)"
+```
+
+---
+
+## Task 5: Calendar DB repository
+
+**Files:**
+- Create: `src/entities/economy/api/economicCalendarRepository.ts`
+- Test: `src/entities/economy/api/__tests__/economicCalendarRepository.test.ts`
+
+`DrizzleEconomicCalendarRepository.upsertEvent` mirrors `DrizzleMarketNewsRepository.upsertMarketNewsItem`: insert on the deterministic id, `onConflictDoUpdate` with `setWhere IS DISTINCT FROM` so `actual`/`estimate`/`previous`/`impact`/`unit` update only on genuine change; `.returning({ id })` lets the caller skip `revalidateTag` when nothing changed. `listInRange` reads rows in a `dateEt` lexicographic range (FMP `dateEt` is `YYYY-MM-DD HH:mm:ss`, so string comparison is chronological).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+vi.mock('server-only', () => ({}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
+import { DrizzleEconomicCalendarRepository } from '@/entities/economy/api/economicCalendarRepository';
+
+const EVENT: EconomicCalendarEvent = {
+    date: '2026-06-13 08:30:00',
+    event: 'Core CPI MoM (May)',
+    impact: 'High',
+    actual: null,
+    estimate: 0.3,
+    previous: 0.2,
+    unit: '%',
+};
+
+/** Minimal chainable insert/onConflict/returning + select/from/where/orderBy stub. */
+function makeDb(returningRows: { id: string }[], selectRows: unknown[]) {
+    const returning = vi.fn(async () => returningRows);
+    const onConflictDoUpdate = vi.fn(() => ({ returning }));
+    const values = vi.fn(() => ({ onConflictDoUpdate }));
+    const insert = vi.fn(() => ({ values }));
+
+    const orderBy = vi.fn(async () => selectRows);
+    const where = vi.fn(() => ({ orderBy }));
+    const from = vi.fn(() => ({ where }));
+    const select = vi.fn(() => ({ from }));
+
+    return {
+        db: { insert, select } as never,
+        spies: { insert, values, onConflictDoUpdate, returning, select, from, where, orderBy },
+    };
+}
+
+describe('DrizzleEconomicCalendarRepository.upsertEvent', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('returns true when a row was inserted or changed', async () => {
+        const { db, spies } = makeDb([{ id: 'abc' }], []);
+        const repo = new DrizzleEconomicCalendarRepository(db);
+        const changed = await repo.upsertEvent('US', EVENT);
+        expect(changed).toBe(true);
+        expect(spies.insert).toHaveBeenCalledOnce();
+        expect(spies.onConflictDoUpdate).toHaveBeenCalledOnce();
+    });
+
+    it('returns false when the upsert touched no rows', async () => {
+        const { db } = makeDb([], []);
+        const repo = new DrizzleEconomicCalendarRepository(db);
+        const changed = await repo.upsertEvent('US', EVENT);
+        expect(changed).toBe(false);
+    });
+
+    it('inserts with the deterministic id, country, and dateEt = FMP date', async () => {
+        const { db, spies } = makeDb([{ id: 'abc' }], []);
+        const repo = new DrizzleEconomicCalendarRepository(db);
+        await repo.upsertEvent('US', EVENT);
+        const inserted = spies.values.mock.calls[0][0] as Record<string, unknown>;
+        expect(inserted.country).toBe('US');
+        expect(inserted.dateEt).toBe('2026-06-13 08:30:00');
+        expect(inserted.event).toBe('Core CPI MoM (May)');
+        expect(inserted.impact).toBe('High');
+        expect(typeof inserted.id).toBe('string');
+        expect(inserted.id).toMatch(/^[0-9a-f]{64}$/);
+    });
+});
+
+describe('DrizzleEconomicCalendarRepository.listInRange', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('maps DB rows to EconomicCalendarEvent and coerces unknown impact to Low', async () => {
+        const { db } = makeDb(
+            [],
+            [
+                {
+                    dateEt: '2026-06-13 08:30:00',
+                    event: 'Core CPI MoM (May)',
+                    impact: 'High',
+                    actual: 0.4,
+                    estimate: 0.3,
+                    previous: 0.2,
+                    unit: '%',
+                },
+                {
+                    dateEt: '2026-06-14 10:00:00',
+                    event: 'Mystery',
+                    impact: 'bogus',
+                    actual: null,
+                    estimate: null,
+                    previous: null,
+                    unit: '',
+                },
+            ]
+        );
+        const repo = new DrizzleEconomicCalendarRepository(db);
+        const events = await repo.listInRange('2026-06-01', '2026-06-30');
+        expect(events).toHaveLength(2);
+        expect(events[0]).toEqual({
+            date: '2026-06-13 08:30:00',
+            event: 'Core CPI MoM (May)',
+            impact: 'High',
+            actual: 0.4,
+            estimate: 0.3,
+            previous: 0.2,
+            unit: '%',
+        });
+        expect(events[1].impact).toBe('Low');
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/entities/economy/api/__tests__/economicCalendarRepository.test.ts`
+Expected: FAIL — `Cannot find module '@/entities/economy/api/economicCalendarRepository'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+import 'server-only';
+import { and, asc, gte, lte, sql } from 'drizzle-orm';
+import type {
+    CalendarImpact,
+    EconomicCalendarEvent,
+} from '@y0ngha/siglens-core';
+import { NEON_TRANSIENT_RETRY } from '@/shared/db/isNeonTransientError';
+import { economicCalendar } from '@/shared/db/schema';
+import type { SiglensDatabase } from '@/shared/db/types';
+import { withRetry } from '@/shared/lib/withRetry';
+import { economicCalendarId } from '../lib/economicCalendarId';
+
+/** 읽기 경계에서 검증하는 impact 정규값 — 미지값은 'Low'로 강등(graceful). */
+const IMPACT_RECORD: Record<CalendarImpact, true> = {
+    High: true,
+    Medium: true,
+    Low: true,
+};
+function toImpact(value: string): CalendarImpact {
+    return value in IMPACT_RECORD ? (value as CalendarImpact) : 'Low';
+}
+
+interface CalendarDbRow {
+    dateEt: string;
+    event: string;
+    impact: string;
+    actual: number | null;
+    estimate: number | null;
+    previous: number | null;
+    unit: string;
+}
+
+function toEvent(row: CalendarDbRow): EconomicCalendarEvent {
+    return {
+        date: row.dateEt,
+        event: row.event,
+        impact: toImpact(row.impact),
+        actual: row.actual,
+        estimate: row.estimate,
+        previous: row.previous,
+        unit: row.unit,
+    };
+}
+
+export class DrizzleEconomicCalendarRepository {
+    constructor(private readonly db: SiglensDatabase) {}
+
+    /**
+     * 이벤트를 upsert하고 행이 실제로 삽입/변경됐는지 반환한다. 재fetch가 동일
+     * 내용을 만들면 `setWhere IS DISTINCT FROM`이 UPDATE를 막아 false를 반환하므로
+     * 호출자가 `revalidateTag`를 건너뛸 수 있다(`market_news` upsert와 동일).
+     *
+     * `id`는 country+dateEt+event 해시라 발표 후 actual/estimate/previous가 바뀌면
+     * 같은 행에 UPDATE된다. `country`/`dateEt`/`event`는 키 구성요소라 `set`에서 제외.
+     */
+    async upsertEvent(
+        country: string,
+        event: EconomicCalendarEvent
+    ): Promise<boolean> {
+        const id = economicCalendarId(country, event.date, event.event);
+        const changed = await withRetry(
+            () =>
+                this.db
+                    .insert(economicCalendar)
+                    .values({
+                        id,
+                        country,
+                        dateEt: event.date,
+                        event: event.event,
+                        impact: event.impact,
+                        estimate: event.estimate,
+                        previous: event.previous,
+                        actual: event.actual,
+                        unit: event.unit,
+                    })
+                    .onConflictDoUpdate({
+                        target: economicCalendar.id,
+                        set: {
+                            impact: sql`excluded.impact`,
+                            estimate: sql`excluded.estimate`,
+                            previous: sql`excluded.previous`,
+                            actual: sql`excluded.actual`,
+                            unit: sql`excluded.unit`,
+                            fetchedAt: sql`now()`,
+                        },
+                        setWhere: sql`
+                            ${economicCalendar.impact} IS DISTINCT FROM excluded.impact OR
+                            ${economicCalendar.estimate} IS DISTINCT FROM excluded.estimate OR
+                            ${economicCalendar.previous} IS DISTINCT FROM excluded.previous OR
+                            ${economicCalendar.actual} IS DISTINCT FROM excluded.actual OR
+                            ${economicCalendar.unit} IS DISTINCT FROM excluded.unit
+                        `,
+                    })
+                    .returning({ id: economicCalendar.id }),
+            NEON_TRANSIENT_RETRY
+        );
+        return changed.length > 0;
+    }
+
+    /**
+     * `[fromEt, toEt]` 범위(경계 포함)의 이벤트를 dateEt 오름차순으로 읽는다.
+     * dateEt는 'YYYY-MM-DD HH:mm:ss'라 문자열 비교가 시간순과 일치한다. 경계는
+     * 'YYYY-MM-DD' 날짜키 — `from`은 그대로(<= 그날 00:00:00 포함), `to`는 그날
+     * 23:59:59까지 포함하도록 ' 23:59:59'를 덧붙인다.
+     */
+    async listInRange(
+        fromEt: string,
+        toEt: string
+    ): Promise<EconomicCalendarEvent[]> {
+        const rows = await withRetry(
+            () =>
+                this.db
+                    .select({
+                        dateEt: economicCalendar.dateEt,
+                        event: economicCalendar.event,
+                        impact: economicCalendar.impact,
+                        actual: economicCalendar.actual,
+                        estimate: economicCalendar.estimate,
+                        previous: economicCalendar.previous,
+                        unit: economicCalendar.unit,
+                    })
+                    .from(economicCalendar)
+                    .where(
+                        and(
+                            gte(economicCalendar.dateEt, fromEt),
+                            lte(economicCalendar.dateEt, `${toEt} 23:59:59`)
+                        )
+                    )
+                    .orderBy(asc(economicCalendar.dateEt)),
+            NEON_TRANSIENT_RETRY
+        );
+        return rows.map(toEvent);
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/entities/economy/api/__tests__/economicCalendarRepository.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entities/economy/api/economicCalendarRepository.ts src/entities/economy/api/__tests__/economicCalendarRepository.test.ts
+git commit -m "feat(economy): add economic_calendar DB repository (SP-A)"
+```
+
+---
+
+## Task 6: ISR-safe calendar reader
+
+**Files:**
+- Create: `src/entities/economy/api/getCalendarFromDb.ts`
+- Test: `src/entities/economy/api/__tests__/getCalendarFromDb.test.ts`
+
+`getCalendarFromDb(anchorEt)` computes `[pastWindowStart, futureWindowEnd]`, reads via the repository, and wraps the read in `unstable_cache` (revalidate 24h + `economy:calendar` tag) so ISR cold-gen can statically materialize it (`@neondatabase/serverless` HTTP is no-store; the wrapper makes the page cacheable per axis-1 of the 4-axis rule). The `anchorEt` is injected by the caller (page), keeping this function free of `Date.now()` — but it still derives the today anchor itself from an injected `Date` for callers that pass an instant. We expose an `anchorEt`-string entry point so the page computes ET-today once and passes it.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+vi.mock('server-only', () => ({}));
+vi.mock('next/cache', () => ({
+    unstable_cache:
+        (fn: (...a: unknown[]) => unknown) =>
+        (...a: unknown[]) =>
+            fn(...a),
+}));
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: () => ({ db: {} }),
+}));
+
+const listInRange = vi.fn();
+vi.mock('@/entities/economy/api/economicCalendarRepository', () => ({
+    DrizzleEconomicCalendarRepository: class {
+        listInRange = listInRange;
+    },
+}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { getCalendarFromDb } from '@/entities/economy/api/getCalendarFromDb';
+import {
+    pastWindowStart,
+    futureWindowEnd,
+} from '@/entities/economy/lib/calendarWindow';
+
+describe('getCalendarFromDb', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        listInRange.mockResolvedValue([]);
+    });
+
+    it('reads the past-window..future-window range around the anchor', async () => {
+        await getCalendarFromDb('2026-06-20');
+        expect(listInRange).toHaveBeenCalledWith(
+            pastWindowStart('2026-06-20'),
+            futureWindowEnd('2026-06-20')
+        );
+    });
+
+    it('returns the rows the repository produced', async () => {
+        const event = {
+            date: '2026-06-19 08:30:00',
+            event: 'X',
+            impact: 'High' as const,
+            actual: 1,
+            estimate: 1,
+            previous: 1,
+            unit: '%',
+        };
+        listInRange.mockResolvedValue([event]);
+        const events = await getCalendarFromDb('2026-06-20');
+        expect(events).toEqual([event]);
+    });
+
+    it('degrades to [] on DB failure (graceful, not throw)', async () => {
+        listInRange.mockRejectedValue(new Error('neon down'));
+        const events = await getCalendarFromDb('2026-06-20');
+        expect(events).toEqual([]);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/entities/economy/api/__tests__/getCalendarFromDb.test.ts`
+Expected: FAIL — `Cannot find module '@/entities/economy/api/getCalendarFromDb'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+import 'server-only';
+import { cache } from 'react';
+import { unstable_cache } from 'next/cache';
+import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
+
+import { getDatabaseClient } from '@/shared/db/client';
+
+import { DrizzleEconomicCalendarRepository } from './economicCalendarRepository';
+import {
+    pastWindowStart,
+    futureWindowEnd,
+} from '../lib/calendarWindow';
+import {
+    ECONOMY_CALENDAR_CACHE_TAG,
+    ECONOMY_CALENDAR_REVALIDATE_SECONDS,
+} from '../lib/economyCalendarConstants';
+
+/**
+ * 과거 2주 + 미래 윈도의 캘린더 이벤트를 DB에서 읽는다.
+ *
+ * ISR cold-gen 안전: `@neondatabase/serverless` HTTP는 no-store라 static generate가
+ * `DYNAMIC_SERVER_USAGE`를 throw한다 — `unstable_cache`로 감싸 HTML에 박고 정적화한다
+ * (src/app/CLAUDE.md 4축 규약 축1). revalidate=24h + `economy:calendar` 태그로
+ * `ensureEconomicCalendarAction`이 on-demand 무효화 가능. cookies/headers/connection
+ * 미사용, `anchorEt`는 호출자(페이지 RSC)가 ET-오늘을 1회 계산해 주입 → `Date.now()` 없음.
+ *
+ * DB 실패 시 빈 배열로 graceful — 캘린더 섹션만 비고 페이지는 렌더.
+ *
+ * `anchorEt`를 캐시 키 파트에 넣어 날짜가 바뀌면 자연히 새 윈도로 리프레시한다.
+ * React.cache로 요청 내 dedup(metadata/본문 중복 호출 대비).
+ */
+export const getCalendarFromDb = cache(
+    (anchorEt: string): Promise<EconomicCalendarEvent[]> =>
+        unstable_cache(
+            async () => {
+                try {
+                    const { db } = getDatabaseClient();
+                    const repo = new DrizzleEconomicCalendarRepository(db);
+                    return await repo.listInRange(
+                        pastWindowStart(anchorEt),
+                        futureWindowEnd(anchorEt)
+                    );
+                } catch (error) {
+                    console.error(
+                        '[getCalendarFromDb] DB read failed:',
+                        error
+                    );
+                    return [];
+                }
+            },
+            ['economy-calendar-db', anchorEt],
+            {
+                revalidate: ECONOMY_CALENDAR_REVALIDATE_SECONDS,
+                tags: [ECONOMY_CALENDAR_CACHE_TAG],
+            }
+        )()
+);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/entities/economy/api/__tests__/getCalendarFromDb.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entities/economy/api/getCalendarFromDb.ts src/entities/economy/api/__tests__/getCalendarFromDb.test.ts
+git commit -m "feat(economy): add ISR-safe getCalendarFromDb reader (SP-A)"
+```
+
+---
+
+## Task 7: `ensureEconomicCalendarAction` + barrel
+
+**Files:**
+- Create: `src/entities/economy/actions/ensureEconomicCalendarAction.ts`
+- Create: `src/entities/economy/actions.ts`
+- Test: `src/entities/economy/actions/__tests__/ensureEconomicCalendarAction.test.ts`
+
+Mirrors `ensureMarketNewsCardsAnalyzedAction`: a refresh-flag guard (Redis), ±1-month FMP fetch via `FmpEconomyProvider.getCalendar` (graceful on failure), `Promise.allSettled` upserts with a majority-failure guard, and a single `revalidateTag(ECONOMY_CALENDAR_CACHE_TAG, 'max')` when ≥1 row changed. No AI/LLM steps (those are SP-D). The refresh-flag helpers live inline in this action's slice (single global key, no sentinel) — to keep the `'use server'` file function-only, they go in a tiny non-action helper file.
+
+- [ ] **Step 1: Create the refresh-flag helper (non-action)**
+
+Create `src/entities/economy/api/calendarRefreshFlag.ts`:
+
+```typescript
+import 'server-only';
+import { getRedisClient } from '@/shared/cache/redisClient';
+import {
+    CALENDAR_REFRESH_FLAG_KEY,
+    CALENDAR_REFRESH_FLAG_TTL_SECONDS,
+} from '../lib/economyCalendarConstants';
+
+/** 최근 TTL 내 fetch 여부 — Redis 실패 시 false(항상 fetch). market-news 미러. */
+export async function isCalendarRecentlyFetched(): Promise<boolean> {
+    const redis = getRedisClient();
+    if (redis === null) return false;
+    try {
+        return (await redis.get(CALENDAR_REFRESH_FLAG_KEY)) !== null;
+    } catch (error) {
+        console.error('[calendarRefreshFlag] get failed', error);
+        return false;
+    }
+}
+
+/** "최근 fetch함" 마킹 — Redis 실패 시 noop. */
+export async function markCalendarFetched(): Promise<void> {
+    const redis = getRedisClient();
+    if (redis === null) return;
+    try {
+        await redis.set(CALENDAR_REFRESH_FLAG_KEY, '1', {
+            ex: CALENDAR_REFRESH_FLAG_TTL_SECONDS,
+        });
+    } catch (error) {
+        console.error('[calendarRefreshFlag] set failed', error);
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+vi.mock('server-only', () => ({}));
+
+const revalidateTag = vi.fn();
+vi.mock('next/cache', () => ({ revalidateTag }));
+
+const isCalendarRecentlyFetched = vi.fn();
+const markCalendarFetched = vi.fn();
+vi.mock('@/entities/economy/api/calendarRefreshFlag', () => ({
+    isCalendarRecentlyFetched,
+    markCalendarFetched,
+}));
+
+const getCalendar = vi.fn();
+vi.mock('@/shared/api/fmp/FmpEconomyProvider', () => ({
+    FmpEconomyProvider: class {
+        getCalendar = getCalendar;
+    },
+}));
+
+const upsertEvent = vi.fn();
+vi.mock('@/entities/economy/api/economicCalendarRepository', () => ({
+    DrizzleEconomicCalendarRepository: class {
+        upsertEvent = upsertEvent;
+    },
+}));
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: () => ({ db: {} }),
+}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
+import { ensureEconomicCalendarAction } from '@/entities/economy/actions/ensureEconomicCalendarAction';
+import { ECONOMY_CALENDAR_CACHE_TAG } from '@/entities/economy/lib/economyCalendarConstants';
+
+const EVENT: EconomicCalendarEvent = {
+    date: '2026-06-13 08:30:00',
+    event: 'Core CPI MoM (May)',
+    impact: 'High',
+    actual: 0.4,
+    estimate: 0.3,
+    previous: 0.2,
+    unit: '%',
+};
+
+describe('ensureEconomicCalendarAction', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        isCalendarRecentlyFetched.mockResolvedValue(false);
+        markCalendarFetched.mockResolvedValue(undefined);
+        getCalendar.mockResolvedValue([EVENT]);
+        upsertEvent.mockResolvedValue(true);
+    });
+
+    it('skips fetch when recently fetched', async () => {
+        isCalendarRecentlyFetched.mockResolvedValue(true);
+        await ensureEconomicCalendarAction();
+        expect(getCalendar).not.toHaveBeenCalled();
+        expect(upsertEvent).not.toHaveBeenCalled();
+    });
+
+    it('fetches, upserts, and revalidates the calendar tag on change', async () => {
+        await ensureEconomicCalendarAction();
+        expect(markCalendarFetched).toHaveBeenCalledOnce();
+        expect(getCalendar).toHaveBeenCalledOnce();
+        expect(upsertEvent).toHaveBeenCalledWith('US', EVENT);
+        expect(revalidateTag).toHaveBeenCalledWith(
+            ECONOMY_CALENDAR_CACHE_TAG,
+            'max'
+        );
+    });
+
+    it('does not revalidate when no row changed', async () => {
+        upsertEvent.mockResolvedValue(false);
+        await ensureEconomicCalendarAction();
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it('swallows FMP failure without throwing or revalidating', async () => {
+        getCalendar.mockRejectedValue(new Error('fmp down'));
+        await expect(ensureEconomicCalendarAction()).resolves.toBeUndefined();
+        expect(upsertEvent).not.toHaveBeenCalled();
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run src/entities/economy/actions/__tests__/ensureEconomicCalendarAction.test.ts`
+Expected: FAIL — `Cannot find module '@/entities/economy/actions/ensureEconomicCalendarAction'`.
+
+- [ ] **Step 4: Write the action**
+
+```typescript
+'use server';
+
+import { revalidateTag } from 'next/cache';
+
+import { getDatabaseClient } from '@/shared/db/client';
+import { FmpEconomyProvider } from '@/shared/api/fmp/FmpEconomyProvider';
+
+import { DrizzleEconomicCalendarRepository } from '../api/economicCalendarRepository';
+import {
+    isCalendarRecentlyFetched,
+    markCalendarFetched,
+} from '../api/calendarRefreshFlag';
+import {
+    addEtDays,
+    etDateOf,
+} from '../lib/calendarWindow';
+import {
+    CALENDAR_COUNTRY,
+    CALENDAR_INGESTION_WINDOW_DAYS,
+    ECONOMY_CALENDAR_CACHE_TAG,
+} from '../lib/economyCalendarConstants';
+
+/** upsert 과반 실패 시 abort 임계 분모. */
+const MAJORITY_DIVISOR = 2;
+
+/**
+ * Server Action: ±1개월 윈도의 FMP economic-calendar를 fetch해 `economic_calendar`에
+ * upsert하고, ≥1행이 실제로 변경되면 `economy:calendar` 태그를 무효화한다.
+ *
+ * `ensureMarketNewsCardsAnalyzedAction` 미러: refresh-flag 가드(봇 재크롤 시 fetch 생략),
+ * graceful FMP 실패(빈 결과 X, DB 기존 데이터 유지), 과반 upsert 실패 시 abort.
+ * AI 분석 없음(SP-D 별도). `waitUntil` 안에서 돌도록 설계 — 응답 스트림 비차단.
+ */
+export async function ensureEconomicCalendarAction(): Promise<void> {
+    try {
+        if (await isCalendarRecentlyFetched()) {
+            return;
+        }
+        // async fetch 전에 마킹 — 동시 호출이 이 지점 이후 플래그를 읽으면 FMP 왕복 생략.
+        await markCalendarFetched();
+
+        const today = etDateOf(new Date());
+        const from = addEtDays(today, -CALENDAR_INGESTION_WINDOW_DAYS);
+        const to = addEtDays(today, CALENDAR_INGESTION_WINDOW_DAYS);
+
+        const provider = new FmpEconomyProvider();
+        const fresh = await provider.getCalendar(from, to).catch(
+            (err: unknown) => {
+                console.error(
+                    '[ensureEconomicCalendarAction] FMP fetch failed:',
+                    err
+                );
+                return null;
+            }
+        );
+        if (fresh === null || fresh.length === 0) return;
+
+        const { db } = getDatabaseClient();
+        const repo = new DrizzleEconomicCalendarRepository(db);
+
+        const settled = await Promise.allSettled(
+            fresh.map(event => repo.upsertEvent(CALENDAR_COUNTRY, event))
+        );
+        const failures = settled.filter(r => r.status === 'rejected');
+        if (failures.length > 0) {
+            console.error(
+                `[ensureEconomicCalendarAction] ${failures.length}/${fresh.length} upserts failed`,
+                failures.map(f => (f.status === 'rejected' ? f.reason : null))
+            );
+        }
+        if (failures.length > fresh.length / MAJORITY_DIVISOR) {
+            console.error(
+                `[ensureEconomicCalendarAction] majority upsert failure (${failures.length}/${fresh.length}) — aborting`
+            );
+            return;
+        }
+
+        const changedCount = settled.filter(
+            r => r.status === 'fulfilled' && r.value === true
+        ).length;
+        if (changedCount > 0) {
+            // 'economy:calendar' 태그만 무효화 — 스냅샷(지표/treasury) ISR 캐시는 무관.
+            // Next 16 revalidateTag(tag, profile) — 'max'는 즉시 무효화.
+            revalidateTag(ECONOMY_CALENDAR_CACHE_TAG, 'max');
+        }
+    } catch (error) {
+        console.error('[ensureEconomicCalendarAction]', error);
+    }
+}
+```
+
+- [ ] **Step 5: Create the action barrel**
+
+Create `src/entities/economy/actions.ts` (no `'use server'` — re-export only, per `entities/CLAUDE.md`):
+
+```typescript
+export { submitMacroBriefingAction } from './actions/submitMacroBriefingAction';
+export { pollMacroBriefingAction } from './actions/pollMacroBriefingAction';
+export { ensureEconomicCalendarAction } from './actions/ensureEconomicCalendarAction';
+```
+
+> Verify the first two re-exports match the existing action file exports before saving — if a barrel already exists, just add the `ensureEconomicCalendarAction` line instead of overwriting. (Run `ls src/entities/economy/actions.ts` first; the economy slice currently has no barrel, so the two macro actions are imported deep — keep them deep and make this barrel export only `ensureEconomicCalendarAction` if adding the macro lines would break their existing deep importers. Safest: barrel exports only `ensureEconomicCalendarAction`.)
+
+Final safe barrel content:
+
+```typescript
+export { ensureEconomicCalendarAction } from './actions/ensureEconomicCalendarAction';
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `npx vitest run src/entities/economy/actions/__tests__/ensureEconomicCalendarAction.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 7: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/entities/economy/actions/ensureEconomicCalendarAction.ts src/entities/economy/actions/__tests__/ensureEconomicCalendarAction.test.ts src/entities/economy/api/calendarRefreshFlag.ts src/entities/economy/actions.ts
+git commit -m "feat(economy): add ensureEconomicCalendarAction on-access ingestion (SP-A)"
+```
+
+---
+
+## Task 8: Indicator base-name normalizer (for backfill dump)
+
+**Files:**
+- Create: `scripts/lib/normalizeIndicatorBaseName.ts`
+- Test: `scripts/lib/__tests__/normalizeIndicatorBaseName.test.ts`
+
+The backfill dumps the distinct **base** indicator names (suffix-stripped) for SP-B dictionary seeding. SP-B will own the full normalizer; SP-A only needs the base-name extraction for the enumeration dump. Keep it as a tiny pure function the script and its test import.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { normalizeIndicatorBaseName } from '../normalizeIndicatorBaseName';
+
+describe('normalizeIndicatorBaseName', () => {
+    it('strips a trailing month suffix', () => {
+        expect(normalizeIndicatorBaseName('Core PCE Price Index YoY (May)')).toBe(
+            'Core PCE Price Index YoY'
+        );
+    });
+    it('strips a trailing quarter suffix', () => {
+        expect(normalizeIndicatorBaseName('GDP Growth Rate QoQ (Q1)')).toBe(
+            'GDP Growth Rate QoQ'
+        );
+    });
+    it('strips a trailing date-token suffix', () => {
+        expect(normalizeIndicatorBaseName('Fed Interest Rate Decision (Jun/20)')).toBe(
+            'Fed Interest Rate Decision'
+        );
+    });
+    it('leaves names without a trailing suffix unchanged', () => {
+        expect(normalizeIndicatorBaseName('Initial Jobless Claims')).toBe(
+            'Initial Jobless Claims'
+        );
+    });
+    it('trims surrounding whitespace', () => {
+        expect(normalizeIndicatorBaseName('  CPI YoY (Apr)  ')).toBe('CPI YoY');
+    });
+    it('only strips the final parenthetical, not interior ones', () => {
+        expect(normalizeIndicatorBaseName('Index (ex Food) MoM (Apr)')).toBe(
+            'Index (ex Food) MoM'
+        );
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run scripts/lib/__tests__/normalizeIndicatorBaseName.test.ts`
+Expected: FAIL — `Cannot find module '../normalizeIndicatorBaseName'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+/**
+ * FMP 이벤트명에서 마지막 괄호 접미사를 제거해 base 지표명을 반환한다.
+ * 예: 'Core PCE Price Index YoY (May)' → 'Core PCE Price Index YoY'.
+ *
+ * 마지막 괄호 그룹만 제거한다 — 'Index (ex Food) MoM (Apr)'의 '(ex Food)'는 보존.
+ * SP-B가 전체 정규화(기간 토큰 한국어화 등)를 소유하며, SP-A는 enumeration 덤프용
+ * base명 추출만 필요하다.
+ */
+export function normalizeIndicatorBaseName(raw: string): string {
+    return raw.replace(/\s*\([^()]*\)\s*$/, '').trim();
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run scripts/lib/__tests__/normalizeIndicatorBaseName.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/normalizeIndicatorBaseName.ts scripts/lib/__tests__/normalizeIndicatorBaseName.test.ts
+git commit -m "feat(economy): add indicator base-name normalizer for backfill dump (SP-A)"
+```
+
+---
+
+## Task 9: One-time backfill script
+
+**Files:**
+- Create: `scripts/backfillEconomicCalendar.ts`
+- Modify: `package.json` (add `db:backfill:calendar` script)
+
+The script fetches ~2 years (`now - 1yr` … `now + 1yr`) in 3-month chunks (FMP supports 1yr per request, but 3-month chunks bound per-request payload size and let a partial failure retry a small slice), normalizes each chunk via `normalizeEconomicCalendar` (FMP returns all countries; the normalizer filters to US), upserts idempotently, and writes the distinct base indicator names to `scripts/output/economic-calendar-indicator-names.json` for SP-B seeding. It uses `postgres` + Drizzle directly (like `seed-korean-tickers.ts`) rather than the Neon HTTP client, so it can run as a standalone `tsx` process against `DIRECT_DATABASE_URL`. It calls the FMP endpoint via a direct `fetch` (the app's `fmpGet` is server-only and pulls in `server-only`/Next data-cache; a script-local fetch keeps the script free of Next runtime coupling).
+
+There is no automated test for the script's `run()` (it is network + DB I/O glue, run manually by the user). Its logic-bearing pieces — id hashing (Task 2), normalization (core), base-name extraction (Task 8), window arithmetic (Task 3) — are each unit-tested. We add one importable pure helper `chunkDateRange` with a test to cover the chunking boundary logic.
+
+- [ ] **Step 1: Write the failing test for the chunker**
+
+Create `scripts/lib/__tests__/chunkDateRange.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { chunkDateRange } from '../chunkDateRange';
+
+describe('chunkDateRange', () => {
+    it('splits a range into [from,to] chunks of at most chunkDays', () => {
+        const chunks = chunkDateRange('2026-01-01', '2026-04-01', 30);
+        expect(chunks[0]).toEqual({ from: '2026-01-01', to: '2026-01-31' });
+        // last chunk is clamped to the overall end
+        expect(chunks.at(-1)?.to).toBe('2026-04-01');
+    });
+
+    it('never lets a chunk end after the overall end', () => {
+        const chunks = chunkDateRange('2026-01-01', '2026-01-10', 30);
+        expect(chunks).toEqual([{ from: '2026-01-01', to: '2026-01-10' }]);
+    });
+
+    it('produces contiguous, non-overlapping chunks', () => {
+        const chunks = chunkDateRange('2026-01-01', '2026-03-15', 30);
+        for (let i = 1; i < chunks.length; i++) {
+            // next chunk starts the day after the previous chunk ends
+            const prevEnd = chunks[i - 1].to;
+            const [y, m, d] = prevEnd.split('-').map(Number);
+            const next = new Date(Date.UTC(y, m - 1, d + 1));
+            const expected = `${next.getUTCFullYear()}-${String(next.getUTCMonth() + 1).padStart(2, '0')}-${String(next.getUTCDate()).padStart(2, '0')}`;
+            expect(chunks[i].from).toBe(expected);
+        }
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run scripts/lib/__tests__/chunkDateRange.test.ts`
+Expected: FAIL — `Cannot find module '../chunkDateRange'`.
+
+- [ ] **Step 3: Write the chunker**
+
+Create `scripts/lib/chunkDateRange.ts`:
+
+```typescript
+/** [from,to] 날짜 청크 — 둘 다 'YYYY-MM-DD', 경계 포함. */
+export interface DateChunk {
+    from: string;
+    to: string;
+}
+
+function addDays(dateEt: string, delta: number): string {
+    const [y, m, d] = dateEt.split('-').map(Number);
+    const shifted = new Date(Date.UTC(y, m - 1, d + delta));
+    return `${shifted.getUTCFullYear()}-${String(shifted.getUTCMonth() + 1).padStart(2, '0')}-${String(shifted.getUTCDate()).padStart(2, '0')}`;
+}
+
+/**
+ * `[start, end]`(경계 포함)을 최대 `chunkDays`일 길이의 연속·비중첩 청크로 분할한다.
+ * 마지막 청크의 `to`는 전체 `end`로 클램프된다. 백필이 FMP를 작은 슬라이스로 호출해
+ * per-request 페이로드를 제한하고 부분 실패 시 작은 범위만 재시도하기 위함.
+ */
+export function chunkDateRange(
+    start: string,
+    end: string,
+    chunkDays: number
+): DateChunk[] {
+    const chunks: DateChunk[] = [];
+    let cursor = start;
+    while (cursor <= end) {
+        const candidateEnd = addDays(cursor, chunkDays - 1);
+        const to = candidateEnd > end ? end : candidateEnd;
+        chunks.push({ from: cursor, to });
+        cursor = addDays(to, 1);
+    }
+    return chunks;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run scripts/lib/__tests__/chunkDateRange.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Write the backfill script**
+
+Create `scripts/backfillEconomicCalendar.ts`:
+
+```typescript
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { sql } from 'drizzle-orm';
+import {
+    normalizeEconomicCalendar,
+    type EconomicCalendarEvent,
+} from '@y0ngha/siglens-core';
+
+import { economicCalendar } from '../src/shared/db/schema';
+import { economicCalendarId } from '../src/entities/economy/lib/economicCalendarId';
+import { chunkDateRange } from './lib/chunkDateRange';
+import { normalizeIndicatorBaseName } from './lib/normalizeIndicatorBaseName';
+
+const FMP_API_KEY = process.env.FMP_API_KEY;
+const databaseUrl =
+    process.env.DIRECT_DATABASE_URL || process.env.DATABASE_URL;
+
+if (!FMP_API_KEY) {
+    throw new Error('FMP_API_KEY env var required');
+}
+if (!databaseUrl) {
+    throw new Error('DATABASE_URL env var required');
+}
+
+const CALENDAR_COUNTRY = 'US';
+const CHUNK_DAYS = 90; // 3-month chunks
+const BACKFILL_DAYS_EACH_SIDE = 365; // now ± 1yr
+const FMP_BASE = 'https://financialmodelingprep.com/stable';
+const OUTPUT_DIR = path.join(process.cwd(), 'scripts', 'output');
+const OUTPUT_FILE = path.join(
+    OUTPUT_DIR,
+    'economic-calendar-indicator-names.json'
+);
+
+function isoDate(d: Date): string {
+    return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
+}
+
+async function fetchCalendarChunk(
+    from: string,
+    to: string
+): Promise<EconomicCalendarEvent[]> {
+    const params = new URLSearchParams({ from, to, apikey: FMP_API_KEY! });
+    const res = await fetch(`${FMP_BASE}/economic-calendar?${params.toString()}`);
+    if (!res.ok) {
+        throw new Error(`FMP economic-calendar ${from}..${to} → HTTP ${res.status}`);
+    }
+    const raw = (await res.json()) as unknown;
+    return normalizeEconomicCalendar(raw);
+}
+
+async function run(): Promise<void> {
+    const client = postgres(databaseUrl!, { max: 1 });
+    const db = drizzle(client);
+
+    const now = new Date();
+    const start = isoDate(
+        new Date(now.getTime() - BACKFILL_DAYS_EACH_SIDE * 86_400_000)
+    );
+    const end = isoDate(
+        new Date(now.getTime() + BACKFILL_DAYS_EACH_SIDE * 86_400_000)
+    );
+    const chunks = chunkDateRange(start, end, CHUNK_DAYS);
+    console.log(
+        `Backfilling ${CALENDAR_COUNTRY} calendar ${start}..${end} in ${chunks.length} chunk(s)`
+    );
+
+    const baseNames = new Set<string>();
+    let upserted = 0;
+
+    for (const { from, to } of chunks) {
+        const events = await fetchCalendarChunk(from, to);
+        console.log(`  ${from}..${to}: ${events.length} US events`);
+        for (const event of events) {
+            baseNames.add(normalizeIndicatorBaseName(event.event));
+        }
+        if (events.length === 0) continue;
+
+        // Idempotent upsert — onConflictDoUpdate on the deterministic id.
+        await db
+            .insert(economicCalendar)
+            .values(
+                events.map(event => ({
+                    id: economicCalendarId(
+                        CALENDAR_COUNTRY,
+                        event.date,
+                        event.event
+                    ),
+                    country: CALENDAR_COUNTRY,
+                    dateEt: event.date,
+                    event: event.event,
+                    impact: event.impact,
+                    estimate: event.estimate,
+                    previous: event.previous,
+                    actual: event.actual,
+                    unit: event.unit,
+                }))
+            )
+            .onConflictDoUpdate({
+                target: economicCalendar.id,
+                set: {
+                    impact: sql`excluded.impact`,
+                    estimate: sql`excluded.estimate`,
+                    previous: sql`excluded.previous`,
+                    actual: sql`excluded.actual`,
+                    unit: sql`excluded.unit`,
+                    fetchedAt: sql`now()`,
+                },
+            });
+        upserted += events.length;
+    }
+
+    const sortedNames = [...baseNames].toSorted((a, b) => a.localeCompare(b));
+    await mkdir(OUTPUT_DIR, { recursive: true });
+    await writeFile(OUTPUT_FILE, `${JSON.stringify(sortedNames, null, 2)}\n`);
+
+    console.log(
+        `Done — upserted ${upserted} event rows; dumped ${sortedNames.length} distinct base indicator names to ${OUTPUT_FILE}`
+    );
+    await client.end();
+}
+
+run().catch(error => {
+    console.error('[backfillEconomicCalendar] failed:', error);
+    process.exitCode = 1;
+});
+```
+
+- [ ] **Step 6: Add the package.json script**
+
+In `package.json`, add this line to the `scripts` block, next to the other `db:*` entries (after `db:migrate:tickers`):
+
+```json
+"db:backfill:calendar": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/backfillEconomicCalendar.ts",
+```
+
+- [ ] **Step 7: Typecheck the script**
+
+Run: `npx tsc --noEmit`
+Expected: PASS. (The script imports `postgres-js` drizzle adapter and `postgres`, both already in `node_modules` — confirmed by `seed-korean-tickers.ts` using `postgres`.)
+
+- [ ] **Step 8: Lint the script and helpers**
+
+Run: `yarn lint`
+Expected: PASS (no errors). If `scripts/` is outside the lint glob, that is acceptable — but the `scripts/lib/*.ts` pure helpers and tests must lint clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add scripts/backfillEconomicCalendar.ts scripts/lib/chunkDateRange.ts scripts/lib/__tests__/chunkDateRange.test.ts package.json
+git commit -m "feat(economy): add one-time economic calendar backfill script (SP-A)"
+```
+
+> Note: actually running `yarn db:backfill:calendar` against the live DB is an operational step the user performs once (it requires `FMP_API_KEY` + `DIRECT_DATABASE_URL`). The dumped `economic-calendar-indicator-names.json` feeds SP-B.
+
+---
+
+## Task 10: Client on-access trigger hook
+
+**Files:**
+- Create: `src/widgets/economy/hooks/useEconomicCalendarTrigger.ts`
+- Test: `src/widgets/economy/hooks/__tests__/useEconomicCalendarTrigger.test.tsx`
+
+Mirrors `useMarketNewsAnalysisTrigger`: fire `ensureEconomicCalendarAction()` once on mount (fire-and-forget, errors logged). No category param — the calendar is a single global feed.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+const ensureEconomicCalendarAction = vi.fn();
+vi.mock('@/entities/economy/actions', () => ({ ensureEconomicCalendarAction }));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { useEconomicCalendarTrigger } from '../useEconomicCalendarTrigger';
+
+function Probe() {
+    useEconomicCalendarTrigger();
+    return null;
+}
+
+describe('useEconomicCalendarTrigger', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        ensureEconomicCalendarAction.mockResolvedValue(undefined);
+    });
+
+    it('fires the ensure action once on mount', () => {
+        render(<Probe />);
+        expect(ensureEconomicCalendarAction).toHaveBeenCalledOnce();
+    });
+
+    it('does not re-fire on re-render', () => {
+        const { rerender } = render(<Probe />);
+        rerender(<Probe />);
+        expect(ensureEconomicCalendarAction).toHaveBeenCalledOnce();
+    });
+
+    it('swallows a rejected action without throwing', () => {
+        ensureEconomicCalendarAction.mockRejectedValue(new Error('boom'));
+        expect(() => render(<Probe />)).not.toThrow();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/widgets/economy/hooks/__tests__/useEconomicCalendarTrigger.test.tsx`
+Expected: FAIL — `Cannot find module '../useEconomicCalendarTrigger'`.
+
+- [ ] **Step 3: Write the hook**
+
+```typescript
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { ensureEconomicCalendarAction } from '@/entities/economy/actions';
+
+/**
+ * Fire-and-forget: `ensureEconomicCalendarAction()`를 마운트 시 1회 호출한다(봇 포함).
+ * 에러는 로깅만 — 실패해도 소비자는 반응할 필요가 없다(다음 접속 또는 다음 refresh-flag
+ * 만료 시 재시도). market-news `useMarketNewsAnalysisTrigger` 패턴 미러.
+ */
+export function useEconomicCalendarTrigger(): void {
+    const triggeredRef = useRef(false);
+
+    useEffect(() => {
+        if (triggeredRef.current) return;
+        triggeredRef.current = true;
+        void ensureEconomicCalendarAction().catch((e: unknown) => {
+            console.error(
+                '[useEconomicCalendarTrigger] ensureEconomicCalendarAction failed:',
+                e
+            );
+        });
+    }, []);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/widgets/economy/hooks/__tests__/useEconomicCalendarTrigger.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets/economy/hooks/useEconomicCalendarTrigger.ts src/widgets/economy/hooks/__tests__/useEconomicCalendarTrigger.test.tsx
+git commit -m "feat(economy): add useEconomicCalendarTrigger on-access hook (SP-A)"
+```
+
+---
+
+## Task 11: Grid accepts `today` + default-selects it (and fires the trigger)
+
+**Files:**
+- Modify: `src/widgets/economy/sections/EconomicCalendarGrid.tsx`
+- Modify: `src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx`
+
+The grid currently default-selects the **earliest** group (`groups[0].dateKey`). SP-A adds a `today` prop (a KST `YYYY-MM-DD` date key, computed server-side from the ET-today instant) and changes the default selection to: today if a group for today exists, else the nearest upcoming group (first group with `dateKey >= today`), else the earliest group. It also calls `useEconomicCalendarTrigger()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx`. First add this mock at the top of the file (next to existing mocks) so the trigger's server action import doesn't blow up under jsdom:
+
+```typescript
+vi.mock('@/entities/economy/actions', () => ({
+    ensureEconomicCalendarAction: vi.fn().mockResolvedValue(undefined),
+}));
+```
+
+Then add this describe block:
+
+```typescript
+describe('EconomicCalendarGrid default selection from today', () => {
+    const ev = (date: string): EconomicCalendarEvent => ({
+        date: `${date} 08:30:00`,
+        event: `E ${date}`,
+        impact: 'High',
+        actual: null,
+        estimate: 1,
+        previous: 1,
+        unit: '%',
+    });
+
+    it("selects today's panel when an event exists for today (KST)", () => {
+        // 2026-06-20 08:30 ET → KST 2026-06-20 21:30 → KST date key 2026-06-20.
+        render(
+            <EconomicCalendarGrid
+                events={[ev('2026-06-18'), ev('2026-06-20'), ev('2026-06-25')]}
+                today="2026-06-20"
+            />
+        );
+        // The today day-button is pressed.
+        const todayBtn = screen.getByRole('button', {
+            name: /6월 20일/,
+        });
+        expect(todayBtn).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('selects the nearest upcoming day when today has no events', () => {
+        render(
+            <EconomicCalendarGrid
+                events={[ev('2026-06-18'), ev('2026-06-25')]}
+                today="2026-06-20"
+            />
+        );
+        const upcomingBtn = screen.getByRole('button', {
+            name: /6월 25일/,
+        });
+        expect(upcomingBtn).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('falls back to the earliest day when all events are in the past', () => {
+        render(
+            <EconomicCalendarGrid
+                events={[ev('2026-06-10'), ev('2026-06-12')]}
+                today="2026-06-20"
+            />
+        );
+        const earliestBtn = screen.getByRole('button', {
+            name: /6월 10일/,
+        });
+        expect(earliestBtn).toHaveAttribute('aria-pressed', 'true');
+    });
+});
+```
+
+> Note: existing tests in this file call `<EconomicCalendarGrid events={...} />` without `today`. Make `today` an **optional** prop defaulting to `''` so those tests keep their existing earliest-group behavior (when `today === ''`, no group key is `>= ''`-meaningful, so the fallback to `groups[0]` applies). Confirm existing tests still pass in Step 4.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx`
+Expected: FAIL — the new tests fail because `today` is not yet a prop and selection still defaults to `groups[0]`.
+
+- [ ] **Step 3: Implement the prop + selection logic**
+
+In `src/widgets/economy/sections/EconomicCalendarGrid.tsx`:
+
+(a) Add the trigger import near the top (after the existing `cn`/`formatNum`/`etDateTimeToKst` imports):
+
+```typescript
+import { useEconomicCalendarTrigger } from '../hooks/useEconomicCalendarTrigger';
+```
+
+(b) Add a pure default-selection helper above the component (next to `spannedMonths`):
+
+```typescript
+/**
+ * 기본 선택 날짜 키를 결정한다 — 결정론적(렌더 중 `Date.now()` 금지).
+ * `today`(KST 'YYYY-MM-DD', 서버 RSC가 ET-오늘에서 1회 계산해 주입)에 그룹이 있으면
+ * 그날, 없으면 `today` 이상인 가장 가까운 미래 그룹, 그것도 없으면 가장 이른 그룹.
+ * groups는 dateKey 오름차순 정렬돼 있다(`groupEventsByKstDay`).
+ */
+function pickDefaultDateKey(groups: DayGroup[], today: string): string {
+    if (groups.length === 0) return '';
+    const exact = groups.find(g => g.dateKey === today);
+    if (exact !== undefined) return exact.dateKey;
+    const upcoming = groups.find(g => g.dateKey >= today);
+    if (upcoming !== undefined) return upcoming.dateKey;
+    return groups[0].dateKey;
+}
+```
+
+(c) Extend the props interface:
+
+```typescript
+interface EconomicCalendarGridProps {
+    events: readonly EconomicCalendarEvent[];
+    /**
+     * 기본 선택 기준일 — KST 'YYYY-MM-DD'. 서버 RSC가 ET-오늘 instant를
+     * KST 날짜키로 1회 변환해 주입한다(ISR 안전: 클라에서 `Date.now()` 미사용).
+     * 생략 시 가장 이른 그룹을 기본 선택(기존 동작 유지).
+     */
+    today?: string;
+}
+```
+
+(d) Update the component signature, the trigger call, and the default-selection effect:
+
+```typescript
+export function EconomicCalendarGrid({
+    events,
+    today = '',
+}: EconomicCalendarGridProps) {
+    useEconomicCalendarTrigger();
+
+    const [selectedDateKey, setSelectedDateKey] = useState('');
+    const groups = useMemo(() => groupEventsByKstDay(events), [events]);
+    const groupMap = useMemo(
+        () => new Map<string, DayGroup>(groups.map(g => [g.dateKey, g])),
+        [groups]
+    );
+    const months = useMemo(() => spannedMonths(groups), [groups]);
+
+    /**
+     * events/today가 바뀔 때 기본 선택 날짜를 재동기화한다(오늘 → 가장 가까운 미래 →
+     * 가장 이른 그룹). useEffectEvent로 감싸 안정 참조를 만들고 startTransition으로
+     * react-hooks/set-state-in-effect를 만족시킨다(기존 패턴 유지).
+     */
+    const syncDefault = useEffectEvent((): void => {
+        startTransition(() => {
+            setSelectedDateKey(pickDefaultDateKey(groups, today));
+        });
+    });
+    useEffect(() => {
+        syncDefault();
+    }, [groups, today]);
+```
+
+The rest of the component body (the empty-state early return and the JSX) is unchanged.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx`
+Expected: PASS — new default-selection tests pass and pre-existing tests still pass (earliest-group fallback when `today` omitted).
+
+- [ ] **Step 5: Typecheck + lint**
+
+Run: `npx tsc --noEmit && yarn lint`
+Expected: PASS. (`useEffect` dep array now includes `today`; `syncDefault` is a stable `useEffectEvent` reference so exhaustive-deps is satisfied — same as the existing pattern.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/widgets/economy/sections/EconomicCalendarGrid.tsx src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
+git commit -m "feat(economy): grid default-selects today + fires calendar trigger (SP-A)"
+```
+
+---
+
+## Task 12: Wire the page to the DB calendar source
+
+**Files:**
+- Modify: `src/app/economy/page.tsx`
+
+Switch the calendar axis from the Redis snapshot (`snapshot.calendar`) to `getCalendarFromDb`. Compute ET-today once in the RSC, convert it to a KST date key, and pass both `events` and `today` to `<EconomicCalendar>`. Indicators/treasury stay on `getEconomySnapshotStatic`. The page already exports `revalidate = 86400` (literal) — leave it.
+
+The today instant must become a KST date key for the grid (which groups by KST). The grid's existing `etDateTimeToKst` works on a full `'YYYY-MM-DD HH:mm:ss'` ET string. We compute ET-today as a date string via `etDateOf(new Date())`, then derive the KST date key by feeding a noon-ET timestamp through `etDateTimeToKst` (noon ET → same KST calendar day after the +13/+14h shift, avoiding midnight roll ambiguity).
+
+- [ ] **Step 1: Add imports**
+
+In `src/app/economy/page.tsx`, add after the existing economy api deep-imports (after the `peekMacroBriefingStatic` import):
+
+```typescript
+import { getCalendarFromDb } from '@/entities/economy/api/getCalendarFromDb';
+import { etDateOf } from '@/entities/economy/lib/calendarWindow';
+import { etDateTimeToKst } from '@/shared/lib/etTimeUtils';
+```
+
+- [ ] **Step 2: Replace the calendar data wiring in `EconomyContent`**
+
+In the `EconomyContent` async function, after the `peekSeed` block and before the `return`, compute the calendar events + today key:
+
+```typescript
+    // 캘린더는 Redis 스냅샷이 아니라 DB-backed 이력 레이어에서 읽는다(SP-A). 지표/treasury는
+    // 스냅샷 그대로. ET-오늘을 1회 계산해 reader 앵커 + 그리드 기본 선택일로 공유한다
+    // (ISR 안전: 결정론적 Intl 변환, dynamic API 미사용).
+    const todayEt = etDateOf(new Date());
+    // 정오 ET → KST 날짜키 — 자정 경계 롤오버 모호성 없이 ET-오늘과 같은 KST 달력일을 얻는다.
+    const todayKstKey = etDateTimeToKst(`${todayEt} 12:00:00`).kstDateKey;
+    const calendarEvents = await getCalendarFromDb(todayEt).catch(e => {
+        console.error('[EconomyContent] getCalendarFromDb failed:', e);
+        return [];
+    });
+```
+
+Then change the JSX line:
+
+```typescript
+            <EconomicCalendar events={snapshot.calendar} />
+```
+
+to:
+
+```typescript
+            <EconomicCalendar events={calendarEvents} today={todayKstKey} />
+```
+
+- [ ] **Step 3: Confirm `etDateTimeToKst` exposes `kstDateKey`**
+
+Run: `grep -n "kstDateKey" src/shared/lib/etTimeUtils.ts`
+Expected: at least one match (the `EtToKstResult` return shape includes `kstDateKey`, as consumed by `EconomicCalendarGrid.groupEventsByKstDay`). If the property name differs, use the actual name from `EtToKstResult`.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS. (`getCalendarFromDb` returns `Promise<EconomicCalendarEvent[]>`; `EconomicCalendar` (= `EconomicCalendarGrid`) accepts `events` + optional `today`.)
+
+- [ ] **Step 5: Run the economy widget + page-adjacent test suites**
+
+Run: `npx vitest run src/widgets/economy src/entities/economy`
+Expected: PASS (all economy widget/entity tests green, including the grid default-selection tests).
+
+- [ ] **Step 6: Build to verify ISR/cold-gen safety**
+
+Run: `yarn build > /tmp/economy-build.log 2>&1; echo "EXIT=$?"`
+Expected: `EXIT=0`, and `/economy` builds without a `DYNAMIC_SERVER_USAGE` error. Inspect the log: `grep -iE "economy|DYNAMIC_SERVER_USAGE|error" /tmp/economy-build.log`. There must be **no** `DYNAMIC_SERVER_USAGE` attributed to `/economy` (the `unstable_cache` wrapper in `getCalendarFromDb` is what makes the DB read static-safe). If the build flags `/economy` as dynamic, re-check that `getCalendarFromDb` is `unstable_cache`-wrapped and that no `cookies()`/`headers()`/`connection()` leaked into the page path.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/economy/page.tsx
+git commit -m "feat(economy): switch calendar data source to DB history layer (SP-A)"
+```
+
+---
+
+## Task 13: Full-suite green + final gates
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `yarn test`
+Expected: PASS (no regressions across the repo).
+
+- [ ] **Step 2: Lint + format gates**
+
+Run: `yarn lint && yarn format`
+Expected: lint PASS, format applies no pending changes (or only the files this plan touched, already clean). If `yarn format` rewrites files, re-run `yarn lint` and amend the relevant commit.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 4: Commit any formatting fixups (if produced)**
+
+```bash
+git add -A
+git commit -m "chore(economy): formatting + lint fixups (SP-A)"
+```
+
+(Skip if nothing changed.)
+
+---
+
+## Self-Review
+
+**Spec coverage (SP-A section + shared data model):**
+
+| Spec requirement | Task |
+|---|---|
+| `economic_calendar` table: id deterministic hash(country+dateEt+event), country, dateEt, event, impact, estimate/previous/actual nullable, unit, fetchedAt; indexes on dateEt, (country,dateEt), impact; **no** AI columns | Task 1 (table) + Task 2 (id hash) |
+| id excludes `actual` (post-release upsert lands on same row) | Task 2 (hash inputs) + Task 5 (`set` excludes key parts, updates actual) |
+| `scripts/backfillEconomicCalendar.ts`: ~2yr (now±1yr) in chunks, normalize via core, idempotent `onConflictDoUpdate(id)`, dump distinct normalized indicator names | Task 8 (base-name normalizer) + Task 9 (chunker + script + name dump file) |
+| `ensureEconomicCalendarAction`: 'use server', ±1mo FMP fetch, upsert (insert new + UPDATE actual/estimate/previous), revalidateTag, fire-and-forget error logging | Task 7 |
+| `getCalendarFromDb`: past-2-weeks + future-window DB read, ISR-cold-gen-safe (`unstable_cache`, no cookies/headers/connection), returns `EconomicCalendarEvent[]` | Task 6 (reader) + Task 3 (window helpers) + Task 4 (TTL/tag constants) |
+| economy page: calendar source → `getCalendarFromDb`; indicators/treasury stay on snapshot; pass server-computed ET-today default-selected-day prop | Task 12 |
+| Grid: accept past+future events + `today` prop; default-select today (KST) else nearest upcoming | Task 11 |
+| Client on-access trigger hook firing ensure once on mount (bots included) | Task 10 (hook) + Task 11 (grid wires it) |
+| Error handling: FMP failure → DB graceful (not empty array); upsert conflict absorbed by id PK | Task 7 (FMP catch → keep DB data) + Task 6 (DB failure → []) + Task 5 (onConflictDoUpdate) |
+| Tests: backfill (chunking, idempotent upsert via repo, name extraction), ensure (insert/actual-update branch), getCalendarFromDb (range/sort), ISR safety | Tasks 2, 3, 5, 6, 7, 8, 9, 10, 11 |
+| `economic_indicator_translations` (SP-B), AI columns (SP-D) | **Out of SP-A scope** — explicitly excluded, not implemented here |
+
+**Placeholder scan:** No TBD/TODO/"add error handling"/"similar to Task N". Every code step contains complete code; every command is exact with expected output. Error handling is concrete (try/catch with `console.error` + graceful fallback) in Tasks 5, 6, 7, 10.
+
+**Type consistency check:**
+- `economicCalendarId(country, dateEt, event)` — same 3-arg signature in Tasks 2, 5, 9. ✓
+- `DrizzleEconomicCalendarRepository` exposes `upsertEvent(country, event)` and `listInRange(fromEt, toEt)` — used identically in Tasks 5 (def), 6 (`listInRange`), 7 (`upsertEvent`), and mocked the same way in 6/7 tests. ✓
+- `getCalendarFromDb(anchorEt: string)` — string-anchor entry point in Task 6 def, Task 6 tests, and Task 12 page call. ✓
+- `ensureEconomicCalendarAction()` — zero-arg in Task 7 def/barrel, Task 10 hook, Task 11 grid mock. ✓
+- `EconomicCalendarGridProps` adds optional `today?: string` — Task 11 def matches Task 12 usage (`today={todayKstKey}`). ✓
+- Window helpers `pastWindowStart`/`futureWindowEnd`/`addEtDays`/`etDateOf` + `PAST_WINDOW_DAYS`/`FUTURE_WINDOW_DAYS` — defined Task 3, consumed in Tasks 6 (reader/test) and 7 (action). ✓
+- Constants `ECONOMY_CALENDAR_CACHE_TAG`/`ECONOMY_CALENDAR_REVALIDATE_SECONDS`/`CALENDAR_INGESTION_WINDOW_DAYS`/`CALENDAR_COUNTRY`/refresh-flag — defined Task 4, consumed Tasks 6/7. ✓
+- `normalizeEconomicCalendar(raw): EconomicCalendarEvent[]` and `EconomicCalendarEvent` shape (`date`/`event`/`impact`/`actual`/`estimate`/`previous`/`unit`) — real core exports (verified in `node_modules/@y0ngha/siglens-core/dist/domain/economy/`), used in Tasks 5, 7, 9. ✓
+
+**One open verification deferred to execution** (flagged inline, not a placeholder): Task 12 Step 3 confirms the exact `EtToKstResult` property name (`kstDateKey`) before wiring — it is the name `EconomicCalendarGrid` already destructures from `etDateTimeToKst`, so it is expected to match; the step exists only to guard against a rename.
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-20-economy-calendar-SP-A-history-data-layer.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-06-20-economy-calendar-SP-B-name-translation.md
+++ b/docs/superpowers/plans/2026-06-20-economy-calendar-SP-B-name-translation.md
@@ -1,0 +1,1788 @@
+# Economy Calendar SP-B — Indicator-Name Korean Translation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render English FMP economic-indicator names (e.g. `"Core PCE Price Index YoY (May)"`) in Korean across the `/economy` calendar grid, backed by a code const dictionary (source-of-truth, `dict`) with a DB cache (`ai`) populated on-miss by a core AI translator. Mapped names render Korean immediately; unmapped names render English and trigger a background AI translation that is cached for the next render (mirroring the news "translate-then-cache" flow).
+
+**Architecture:** A pure i18n module `entities/economy/lib/indicatorNameKo.ts` owns `INDICATOR_NAME_KO` (a `Record<string, string>` base-name → Korean map), a `normalizeIndicatorName(raw)` splitter (strips the trailing `(May)`/`(Q1)`/`(Jun/20)` period parenthetical, returning `{ base, period }`), and a period-token Korean-izer (`YoY`→`전년比`, `MoM`→`전월比`, `QoQ`→`전분기比`, month/quarter names). A new `economic_indicator_translations` Drizzle table (mirroring `assetTranslations`) caches AI translations keyed by `normalizedName`. A server-only `DrizzleIndicatorTranslationRepository` reads/upserts that table. A `'use server'` `ensureIndicatorTranslatedAction` calls **core** `translateIndicatorName(normalizedName)` and upserts the result with `source: 'ai'`. The display path splits into two parts: a **pure synchronous** `indicatorLabelKoFromMaps(raw, dbMap)` used inside the client grid (dict + already-loaded DB map → Korean, else English), and a **server-side** `resolveIndicatorLabels(events)` reader that, per request, looks up the DB cache for every distinct normalized base name, returns the resolved label map to the grid, and fire-and-forget triggers `ensureIndicatorTranslatedAction` for the misses. The grid applies the resolved labels at the cell-preview and detail-panel display sites; English is the deterministic fallback.
+
+**Tech Stack:** TypeScript, Drizzle ORM (Neon serverless), `drizzle-kit` migrations, Next.js 16 (RSC + `unstable_cache` + `revalidateTag`), vitest, `@y0ngha/siglens-core` (`translateIndicatorName` — **new core export, see CROSS-REPO note**).
+
+---
+
+## ⚠️ CROSS-REPO DEPENDENCY (separate repo, user publishes)
+
+The AI translation of unmapped indicator names is **analysis-domain logic** and therefore belongs in `@y0ngha/siglens-core` per the spec table ("미매핑 지표명 **AI 번역** → siglens-core") and the CLAUDE.md cross-repo scope guard. **Do NOT implement the core translator in this repo.** The siglens side consumes a new core export whose exact contract is:
+
+```typescript
+// @y0ngha/siglens-core  (NEW export — implemented & published by the user in the core repo)
+//
+// Translates a single normalized (suffix-stripped) economic-indicator base name
+// to Korean. Pure prompt + normalization + validation live in core; siglens only
+// calls it and caches the result. Returns the Korean string, or throws on failure
+// (the siglens caller catches and leaves the row uncached so a later render retries).
+export function translateIndicatorName(normalizedName: string): Promise<string>;
+```
+
+**Until the core export exists, every siglens task in this plan mocks `translateIndicatorName`** via `vi.mock('@y0ngha/siglens-core', ...)`. The single real import site is the server action (Task 7); a `// CORE DEPENDENCY` comment marks it. Sequencing for the human operator: (1) implement + `npm version` + `git push --tags` the core change in the core repo; (2) bump the `@y0ngha/siglens-core` pin in siglens `package.json` and `yarn install`; (3) the import in Task 7 resolves against the real export. The siglens code, tests, and gates in this plan are fully implementable and green **before** core lands, because the action's only real dependency is mocked in its test.
+
+---
+
+## File Structure
+
+| File | Create/Modify | Responsibility |
+|---|---|---|
+| `src/entities/economy/lib/indicatorNameKo.ts` | Create | `INDICATOR_NAME_KO` const map (seed of confirmed entries), `normalizeIndicatorName(raw): NormalizedIndicatorName`, `koreanizePeriodToken(token): string`, `indicatorLabelKoFromMaps(raw, dbMap): string` pure display helper. |
+| `src/entities/economy/lib/__tests__/indicatorNameKo.test.ts` | Create | Tests: normalize splitting, period Korean-ization, dict hit, DB-map hit, English fallback. |
+| `src/shared/db/schema.ts` | Modify | Add `economicIndicatorTranslations` `pgTable` (normalizedName PK, koreanName, source, updatedAt). |
+| `src/shared/db/types.ts` | Modify | Add `IndicatorTranslationRecord` + `IndicatorTranslationRepository` interfaces. |
+| `src/shared/db/__tests__/schema.test.ts` | Modify | Add a presence assertion for the new table (matches existing schema-test style). |
+| `drizzle/0019_*.sql` + `drizzle/meta/*` | Create (generated) | Migration creating `economic_indicator_translations` (output of `yarn db:generate`). |
+| `src/entities/economy/api/indicatorTranslationRepository.ts` | Create | `DrizzleIndicatorTranslationRepository`: `findByNames(names)` (batch) + `upsert(record)`. |
+| `src/entities/economy/api/__tests__/indicatorTranslationRepository.test.ts` | Create | Repository query-shape tests against a mocked db. |
+| `src/entities/economy/lib/indicatorTranslationConstants.ts` | Create | Cache-tag + refresh-flag-key + TTL constants shared by reader/action. |
+| `src/entities/economy/api/indicatorTranslationFlag.ts` | Create | Per-name Redis refresh-flag (`isIndicatorTranslationPending` / `markIndicatorTranslationPending`) to dedupe concurrent AI submissions. |
+| `src/entities/economy/api/__tests__/indicatorTranslationFlag.test.ts` | Create | Redis-null + get/set TTL tests. |
+| `src/entities/economy/actions/ensureIndicatorTranslatedAction.ts` | Create | `'use server'` — call core `translateIndicatorName`, upsert `source:'ai'`, `revalidateTag`. **Only real core import site.** |
+| `src/entities/economy/actions/__tests__/ensureIndicatorTranslatedAction.test.ts` | Create | Tests: skip when cached/pending, translate→upsert→revalidate, graceful core failure (no upsert). |
+| `src/entities/economy/actions.ts` | Modify (or create) | Barrel re-export of `ensureIndicatorTranslatedAction` (no `'use server'`). |
+| `src/entities/economy/api/resolveIndicatorLabels.ts` | Create | Server reader: distinct base names → DB-cache lookup → label map; fire-and-forget triggers AI for misses; `unstable_cache`-wrapped DB read (ISR-safe). |
+| `src/entities/economy/api/__tests__/resolveIndicatorLabels.test.ts` | Create | Tests: dict short-circuit (no DB call), DB hit, miss triggers ensure, label-map shape, ISR safety. |
+| `src/widgets/economy/sections/EconomicCalendarGrid.tsx` | Modify | Accept `labels?: Record<string, string>` (raw event name → display label); apply at cell preview + detail panel. |
+| `src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx` | Modify | Add Korean-label-applied + English-fallback display tests. |
+| `src/app/economy/page.tsx` | Modify | Compute `labels = await resolveIndicatorLabels(calendarEvents)`; pass `labels` to `<EconomicCalendar>`. |
+| `docs/superpowers/seeding/indicator-name-ko-seeding.md` | Create | Documented one-time dictionary-seeding procedure (SP-A name-dump → core AI draft → curate → fill `INDICATOR_NAME_KO`). |
+
+**FSD compliance:** pure i18n + display helper live in `entities/economy/lib/` (no React, no server-only); DB repository + reader + refresh-flag live in `entities/economy/api/` (server-only, barrel-excluded); the server action lives in `entities/economy/actions/`; the grid (client) consumes only the pre-resolved `labels` map (no server import); the page composes the reader. The grid's `indicatorLabelKoFromMaps` import is a pure `lib/` function (client-safe). `economic_indicator_translations` schema lives in `shared/db` alongside `assetTranslations`.
+
+---
+
+## Conventions to honor (gates)
+
+- **Tests colocated** in `__tests__/` next to the unit. Run a single file with `npx vitest run <path>`.
+- **`tsc`, ESLint, Prettier must pass.** No `eslint-disable` (MISTAKES.md #13). Run `yarn lint` and `yarn format` before each commit if unsure.
+- **Hook order** (MISTAKES.md "Predictability"): no derived const between hooks in the grid; the new `labels` prop is read in render/`useMemo`, not via a conditional hook.
+- **Named return types** on every exported function (MISTAKES.md "TypeScript") — e.g. `normalizeIndicatorName(raw): NormalizedIndicatorName`, not an inferred inline object.
+- **No WHAT comments** (MISTAKES.md "Documentation") — comments explain WHY (caching strategy, cross-repo seam), not what the next line does.
+- **Exact assertions** (MISTAKES.md "Tests") — `toBe`/`toEqual` with concrete values, not `toBeTruthy`/`expect.anything()`.
+- **ISR 4-axis safety** (`src/app/CLAUDE.md`): the reader wraps its DB read in `unstable_cache`; no `cookies()`/`headers()`/`connection()`/`Date.now()` in the cold-gen render path. The page's `resolveIndicatorLabels` call is awaited in the RSC the same way `getCalendarFromDb` already is (SP-A).
+- **`'use server'` files** export only async functions; constants/classes/types live in separate files (`entities/CLAUDE.md`).
+- **Barrel exclusion:** `api/` server-only modules and `actions/*` stay out of `entities/economy/index.ts`; consumers deep-import. The pure `lib/indicatorNameKo.ts` MAY be barrel-exported, but the grid deep-imports it from `@/entities/economy/lib/indicatorNameKo` to avoid pulling server-only siblings (matching the existing economy barrel comment).
+- **Commit per task** with the conventional-commit messages given. Do not push (git-agent's job).
+
+---
+
+## Task 1: Pure i18n module — normalize + period Korean-ization + dictionary seed
+
+**Files:**
+- Create: `src/entities/economy/lib/indicatorNameKo.ts`
+- Test: `src/entities/economy/lib/__tests__/indicatorNameKo.test.ts`
+
+This module is the heart of SP-B and is **pure** (no React, no server-only, no DB). It owns the source-of-truth dictionary seed, the splitter, the period Korean-izer, and a synchronous display helper that takes an already-loaded DB-cache map.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import {
+    normalizeIndicatorName,
+    koreanizePeriodToken,
+    indicatorLabelKoFromMaps,
+    INDICATOR_NAME_KO,
+} from '@/entities/economy/lib/indicatorNameKo';
+
+describe('normalizeIndicatorName', () => {
+    it('splits a trailing month parenthetical into base + period', () => {
+        expect(
+            normalizeIndicatorName('Core PCE Price Index YoY (May)')
+        ).toEqual({ base: 'Core PCE Price Index YoY', period: 'May' });
+    });
+
+    it('splits a trailing quarter parenthetical', () => {
+        expect(normalizeIndicatorName('GDP Growth Rate QoQ (Q1)')).toEqual({
+            base: 'GDP Growth Rate QoQ',
+            period: 'Q1',
+        });
+    });
+
+    it('splits a slash date-token parenthetical', () => {
+        expect(
+            normalizeIndicatorName('Fed Interest Rate Decision (Jun/20)')
+        ).toEqual({ base: 'Fed Interest Rate Decision', period: 'Jun/20' });
+    });
+
+    it('returns an empty period when there is no parenthetical', () => {
+        expect(normalizeIndicatorName('Initial Jobless Claims')).toEqual({
+            base: 'Initial Jobless Claims',
+            period: '',
+        });
+    });
+
+    it('strips only the final parenthetical, preserving interior ones', () => {
+        expect(normalizeIndicatorName('Index (ex Food) MoM (Apr)')).toEqual({
+            base: 'Index (ex Food) MoM',
+            period: 'Apr',
+        });
+    });
+
+    it('trims surrounding whitespace from base', () => {
+        expect(normalizeIndicatorName('  CPI YoY (Apr)  ')).toEqual({
+            base: 'CPI YoY',
+            period: 'Apr',
+        });
+    });
+});
+
+describe('koreanizePeriodToken', () => {
+    it('translates change-direction tokens', () => {
+        expect(koreanizePeriodToken('YoY')).toBe('전년比');
+        expect(koreanizePeriodToken('MoM')).toBe('전월比');
+        expect(koreanizePeriodToken('QoQ')).toBe('전분기比');
+    });
+
+    it('translates month abbreviations', () => {
+        expect(koreanizePeriodToken('May')).toBe('5월');
+        expect(koreanizePeriodToken('Jan')).toBe('1월');
+        expect(koreanizePeriodToken('Dec')).toBe('12월');
+    });
+
+    it('translates quarter tokens', () => {
+        expect(koreanizePeriodToken('Q1')).toBe('1분기');
+        expect(koreanizePeriodToken('Q4')).toBe('4분기');
+    });
+
+    it('returns an unknown token unchanged', () => {
+        expect(koreanizePeriodToken('Jun/20')).toBe('Jun/20');
+        expect(koreanizePeriodToken('')).toBe('');
+    });
+});
+
+describe('indicatorLabelKoFromMaps', () => {
+    it('renders dict base + Korean period when the base is mapped', () => {
+        expect(
+            indicatorLabelKoFromMaps('Core PCE Price Index YoY (May)', {})
+        ).toBe('근원 PCE 물가지수(전년比) (5월)');
+    });
+
+    it('renders a mapped base with no period parenthetical', () => {
+        expect(indicatorLabelKoFromMaps('Nonfarm Payrolls', {})).toBe(
+            '비농업 고용'
+        );
+    });
+
+    it('falls back to the DB-cache map when dict misses', () => {
+        expect(
+            indicatorLabelKoFromMaps('Some Obscure Index YoY (May)', {
+                'Some Obscure Index YoY': '어떤 모호한 지수(전년比)',
+            })
+        ).toBe('어떤 모호한 지수(전년比) (5월)');
+    });
+
+    it('falls back to the raw English name when both maps miss', () => {
+        expect(
+            indicatorLabelKoFromMaps('Totally Unknown Thing (Apr)', {})
+        ).toBe('Totally Unknown Thing (Apr)');
+    });
+
+    it('seeds the dictionary with confirmed common indicators', () => {
+        expect(INDICATOR_NAME_KO['Nonfarm Payrolls']).toBe('비농업 고용');
+        expect(INDICATOR_NAME_KO['ADP Employment Change']).toBe(
+            'ADP 고용 변화'
+        );
+        expect(INDICATOR_NAME_KO['10-Year Note Auction']).toBe(
+            '10년물 국채 입찰'
+        );
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/entities/economy/lib/__tests__/indicatorNameKo.test.ts`
+Expected: FAIL — `Cannot find module '@/entities/economy/lib/indicatorNameKo'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+/**
+ * 경제 지표명 한국어화 — 코드 const 사전(source-of-truth, `dict`)이 1차, DB 캐시(`ai`)가
+ * 2차다. 이 모듈은 순수(React/server-only/DB 비의존)하므로 클라 그리드와 서버 reader가
+ * 함께 import할 수 있다. DB 캐시 룩업과 AI 트리거는 서버 계층(api/, actions/)이 담당하고,
+ * 여기서는 이미 로드된 DB 맵을 받아 동기 합성만 한다.
+ *
+ * 초기 사전은 FMP 샘플에서 가장 흔한 지표 일부만 확정해 시드한다. 전체 ~277개 큐레이션은
+ * SP-A 백필 name-dump를 소비하는 별도 데이터 작업이다(docs/superpowers/seeding 참조).
+ */
+
+/** `INDICATOR_NAME_KO`/DB 캐시의 키 = 정규화된 base 지표명, 값 = 한국어. */
+export const INDICATOR_NAME_KO: Record<string, string> = {
+    // 물가
+    'Core PCE Price Index YoY': '근원 PCE 물가지수(전년比)',
+    'Core PCE Price Index MoM': '근원 PCE 물가지수(전월比)',
+    'PCE Price Index YoY': 'PCE 물가지수(전년比)',
+    'Inflation Rate YoY': '소비자물가 상승률(전년比)',
+    'Core Inflation Rate YoY': '근원 소비자물가 상승률(전년比)',
+    CPI: '소비자물가지수',
+    'CPI YoY': '소비자물가지수(전년比)',
+    'CPI MoM': '소비자물가지수(전월比)',
+    'Core CPI YoY': '근원 소비자물가지수(전년比)',
+    'Core CPI MoM': '근원 소비자물가지수(전월比)',
+    'PPI MoM': '생산자물가지수(전월比)',
+    'Core PPI MoM': '근원 생산자물가지수(전월比)',
+    // 고용
+    'Nonfarm Payrolls': '비농업 고용',
+    'ADP Employment Change': 'ADP 고용 변화',
+    'Initial Jobless Claims': '신규 실업수당 청구',
+    'Continuing Jobless Claims': '연속 실업수당 청구',
+    'Unemployment Rate': '실업률',
+    'Average Hourly Earnings MoM': '시간당 평균 임금(전월比)',
+    'JOLTs Job Openings': '구인 건수(JOLTs)',
+    // 성장·심리
+    'GDP Growth Rate QoQ': 'GDP 성장률(전분기比)',
+    'Retail Sales MoM': '소매판매(전월比)',
+    'ISM Manufacturing PMI': 'ISM 제조업 PMI',
+    'ISM Services PMI': 'ISM 서비스업 PMI',
+    'Michigan Consumer Sentiment': '미시간대 소비자심리지수',
+    // 정책·국채
+    'Fed Interest Rate Decision': '연준 기준금리 결정',
+    '10-Year Note Auction': '10년물 국채 입찰',
+    '30-Year Bond Auction': '30년물 국채 입찰',
+    '2-Year Note Auction': '2년물 국채 입찰',
+    '3-Month Bill Auction': '3개월물 국채 입찰',
+};
+
+/** 변화-방향 접미 토큰의 한국어 매핑. */
+const PERIOD_DIRECTION_KO: Record<string, string> = {
+    YoY: '전년比',
+    MoM: '전월比',
+    QoQ: '전분기比',
+};
+
+/** 영어 월 약어 → 1-indexed 월. */
+const MONTH_INDEX: Record<string, number> = {
+    Jan: 1,
+    Feb: 2,
+    Mar: 3,
+    Apr: 4,
+    May: 5,
+    Jun: 6,
+    Jul: 7,
+    Aug: 8,
+    Sep: 9,
+    Oct: 10,
+    Nov: 11,
+    Dec: 12,
+};
+
+/** `normalizeIndicatorName` 반환 형태. */
+export interface NormalizedIndicatorName {
+    /** 접미 괄호를 제거한 base 지표명. */
+    base: string;
+    /** 마지막 괄호 안의 기간 토큰(없으면 ''). 예 'May' | 'Q1' | 'Jun/20'. */
+    period: string;
+}
+
+/**
+ * 마지막 괄호 그룹을 base와 period로 분리한다. 중간 괄호('Index (ex Food) MoM')는
+ * 보존하고 끝 괄호만 떼어낸다. 접미 괄호가 없으면 period는 ''.
+ */
+export function normalizeIndicatorName(raw: string): NormalizedIndicatorName {
+    const match = raw.trim().match(/^(.*?)\s*\(([^()]*)\)\s*$/);
+    if (match === null) {
+        return { base: raw.trim(), period: '' };
+    }
+    return { base: match[1].trim(), period: match[2].trim() };
+}
+
+/**
+ * 기간 토큰을 한국어로 변환한다 — 변화-방향(YoY/MoM/QoQ), 월 약어(May→5월),
+ * 분기(Q1→1분기). 미지 토큰은 원문 유지(예 'Jun/20').
+ */
+export function koreanizePeriodToken(token: string): string {
+    if (token in PERIOD_DIRECTION_KO) {
+        return PERIOD_DIRECTION_KO[token];
+    }
+    if (token in MONTH_INDEX) {
+        return `${MONTH_INDEX[token]}월`;
+    }
+    const quarter = token.match(/^Q([1-4])$/);
+    if (quarter !== null) {
+        return `${quarter[1]}분기`;
+    }
+    return token;
+}
+
+/**
+ * 동기 표시 헬퍼 — dict(코드 사전) → dbMap(이미 로드된 DB 캐시) 순으로 base를 룩업한다.
+ * 둘 다 miss면 raw 영어 원문을 그대로 반환(결정론적 fallback). hit이면 한국어 base에
+ * period 토큰을 한국어로 붙인다(' (5월)'). period가 dict base 안에 이미 녹아 있으면
+ * (예 'Core PCE Price Index YoY' base는 '(전년比)' 포함) period 괄호만 추가된다.
+ *
+ * AI 트리거/캐시 쓰기는 서버 계층(resolveIndicatorLabels)이 담당 — 이 함수는 순수.
+ */
+export function indicatorLabelKoFromMaps(
+    raw: string,
+    dbMap: Record<string, string>
+): string {
+    const { base, period } = normalizeIndicatorName(raw);
+    const ko = INDICATOR_NAME_KO[base] ?? dbMap[base];
+    if (ko === undefined) {
+        return raw;
+    }
+    if (period === '') {
+        return ko;
+    }
+    return `${ko} (${koreanizePeriodToken(period)})`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/entities/economy/lib/__tests__/indicatorNameKo.test.ts`
+Expected: PASS (all describe blocks green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entities/economy/lib/indicatorNameKo.ts src/entities/economy/lib/__tests__/indicatorNameKo.test.ts
+git commit -m "feat(economy): add indicator name Korean i18n module + dict seed (SP-B)"
+```
+
+---
+
+## Task 2: `economic_indicator_translations` Drizzle table + types
+
+**Files:**
+- Modify: `src/shared/db/schema.ts` (append after `economicCalendar` from SP-A, before `termsKindEnum`)
+- Modify: `src/shared/db/types.ts` (add record + repository interfaces)
+- Modify: `src/shared/db/__tests__/schema.test.ts` (presence assertion)
+- Create (generated): `drizzle/0019_*.sql`, `drizzle/meta/0019_snapshot.json`, updated `drizzle/meta/_journal.json`
+
+> Prereq: SP-A's `economicCalendar` table + migration `0018_*` exist. If SP-A has not yet landed, this becomes migration `0018_*` instead — confirm the next free number with `ls drizzle/*.sql | tail -1` before `db:generate` and adjust the commit `git add` glob accordingly.
+
+- [ ] **Step 1: Add the table to the schema**
+
+In `src/shared/db/schema.ts`, add this block immediately after the `economicCalendar` `pgTable` definition (SP-A), before `export const termsKindEnum`. It mirrors `assetTranslations` column style and reuses existing imports (`pgTable`, `text`, `timestamp`).
+
+```typescript
+/**
+ * 경제 지표명 한국어 번역 캐시 — `assetTranslations` 미러. 코드 const 사전
+ * (`INDICATOR_NAME_KO`)이 source-of-truth이고, 이 테이블은 미매핑 지표명의 core AI
+ * 번역 결과를 `source:'ai'`로 캐시한다(추후 코드 사전으로 승격). `normalizedName`은
+ * 접미 괄호를 제거한 base 지표명(`normalizeIndicatorName`의 base).
+ */
+export const economicIndicatorTranslations = pgTable(
+    'economic_indicator_translations',
+    {
+        normalizedName: text('normalized_name').primaryKey(),
+        koreanName: text('korean_name').notNull(),
+        // 'dict' | 'ai' — 출처. text 저장, 읽기 경계에서 검증.
+        source: text('source').notNull(),
+        updatedAt: timestamp('updated_at', { withTimezone: true })
+            .notNull()
+            .defaultNow()
+            .$onUpdateFn(nowFn),
+    }
+);
+```
+
+- [ ] **Step 2: Add the record + repository types**
+
+In `src/shared/db/types.ts`, add after the `ProfileDescriptionTranslationRepository` interface (the translation-types cluster):
+
+```typescript
+/** 'dict' | 'ai' — indicator 번역 출처. */
+export type IndicatorTranslationSource = 'dict' | 'ai';
+
+/** 경제 지표명 한국어 번역 캐시 행. */
+export interface IndicatorTranslationRecord {
+    /** 정규화된 base 지표명(접미 괄호 제거). 예 'Core PCE Price Index YoY'. */
+    normalizedName: string;
+    /** 한국어 번역. */
+    koreanName: string;
+    /** 'dict'(코드 승격) | 'ai'(core 번역 캐시). */
+    source: IndicatorTranslationSource;
+}
+
+/** {@link IndicatorTranslationRecord}를 백킹하는 영속화 연산. */
+export interface IndicatorTranslationRepository {
+    findByNames(
+        normalizedNames: readonly string[]
+    ): Promise<IndicatorTranslationRecord[]>;
+    upsert(record: IndicatorTranslationRecord): Promise<void>;
+}
+```
+
+- [ ] **Step 3: Add the schema presence test**
+
+In `src/shared/db/__tests__/schema.test.ts`, add an assertion next to the existing table-presence checks (match the file's existing style — verify the import name first with `grep -n "economicIndicatorTranslations\|assetTranslations" src/shared/db/__tests__/schema.test.ts`). Append:
+
+```typescript
+import { economicIndicatorTranslations } from '@/shared/db/schema';
+
+describe('economicIndicatorTranslations table', () => {
+    it('exposes the expected columns', () => {
+        const cols = Object.keys(economicIndicatorTranslations);
+        expect(cols).toContain('normalizedName');
+        expect(cols).toContain('koreanName');
+        expect(cols).toContain('source');
+        expect(cols).toContain('updatedAt');
+    });
+});
+```
+
+> If `schema.test.ts` already imports from `@/shared/db/schema` with a single import statement, add `economicIndicatorTranslations` to that existing import list instead of adding a second `import`, to keep lint clean (no duplicate-import).
+
+- [ ] **Step 4: Generate the migration**
+
+Run: `yarn db:generate`
+Expected: drizzle-kit reports a new migration `0019_*` creating `economic_indicator_translations`; new files appear under `drizzle/` and `drizzle/meta/`. (No DB connection needed for `generate`.)
+
+- [ ] **Step 5: Verify the generated SQL**
+
+Run: `cat drizzle/0019_*.sql`
+Expected: `CREATE TABLE "economic_indicator_translations"` with `"normalized_name" text PRIMARY KEY NOT NULL`, `"korean_name" text NOT NULL`, `"source" text NOT NULL`, `"updated_at" timestamp with time zone DEFAULT now() NOT NULL`. If columns don't match, fix the schema and re-run `yarn db:generate`.
+
+- [ ] **Step 6: Typecheck + run the schema test**
+
+Run: `npx tsc --noEmit && npx vitest run src/shared/db/__tests__/schema.test.ts`
+Expected: PASS (no type errors; schema presence test green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/shared/db/schema.ts src/shared/db/types.ts src/shared/db/__tests__/schema.test.ts drizzle/0019_*.sql drizzle/meta
+git commit -m "feat(economy): add economic_indicator_translations table + types (SP-B)"
+```
+
+> Note: applying the migration (`yarn db:migrate`) is an operational step the user runs against their environment — not part of this code plan.
+
+---
+
+## Task 3: Indicator-translation DB repository
+
+**Files:**
+- Create: `src/entities/economy/api/indicatorTranslationRepository.ts`
+- Test: `src/entities/economy/api/__tests__/indicatorTranslationRepository.test.ts`
+
+`DrizzleIndicatorTranslationRepository.findByNames` reads cached rows for a batch of normalized base names (`inArray`); `upsert` writes one AI translation with `onConflictDoUpdate` + `sql\`now()\`` (mirroring `DrizzleAssetTranslationRepository`, since Drizzle's `onConflictDoUpdate` does not fire the `$onUpdateFn` hook — MISTAKES.md DB note).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+vi.mock('server-only', () => ({}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { IndicatorTranslationRecord } from '@/shared/db/types';
+import { DrizzleIndicatorTranslationRepository } from '@/entities/economy/api/indicatorTranslationRepository';
+
+/** Chainable select/from/where + insert/values/onConflictDoUpdate stub. */
+function makeDb(selectRows: unknown[]) {
+    const where = vi.fn(async () => selectRows);
+    const from = vi.fn(() => ({ where }));
+    const select = vi.fn(() => ({ from }));
+
+    const onConflictDoUpdate = vi.fn(async () => undefined);
+    const values = vi.fn(() => ({ onConflictDoUpdate }));
+    const insert = vi.fn(() => ({ values }));
+
+    return {
+        db: { select, insert } as never,
+        spies: { select, from, where, insert, values, onConflictDoUpdate },
+    };
+}
+
+const RECORD: IndicatorTranslationRecord = {
+    normalizedName: 'Some Obscure Index YoY',
+    koreanName: '어떤 모호한 지수(전년比)',
+    source: 'ai',
+};
+
+describe('DrizzleIndicatorTranslationRepository.findByNames', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('returns [] without querying when names is empty', async () => {
+        const { db, spies } = makeDb([]);
+        const repo = new DrizzleIndicatorTranslationRepository(db);
+        const rows = await repo.findByNames([]);
+        expect(rows).toEqual([]);
+        expect(spies.select).not.toHaveBeenCalled();
+    });
+
+    it('maps DB rows to IndicatorTranslationRecord', async () => {
+        const { db } = makeDb([
+            {
+                normalizedName: 'Nonfarm Payrolls',
+                koreanName: '비농업 고용',
+                source: 'ai',
+            },
+        ]);
+        const repo = new DrizzleIndicatorTranslationRepository(db);
+        const rows = await repo.findByNames(['Nonfarm Payrolls']);
+        expect(rows).toEqual([
+            {
+                normalizedName: 'Nonfarm Payrolls',
+                koreanName: '비농업 고용',
+                source: 'ai',
+            },
+        ]);
+    });
+});
+
+describe('DrizzleIndicatorTranslationRepository.upsert', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('inserts with the normalized name, korean name, and source', async () => {
+        const { db, spies } = makeDb([]);
+        const repo = new DrizzleIndicatorTranslationRepository(db);
+        await repo.upsert(RECORD);
+        expect(spies.insert).toHaveBeenCalledOnce();
+        const inserted = spies.values.mock.calls[0][0] as Record<
+            string,
+            unknown
+        >;
+        expect(inserted.normalizedName).toBe('Some Obscure Index YoY');
+        expect(inserted.koreanName).toBe('어떤 모호한 지수(전년比)');
+        expect(inserted.source).toBe('ai');
+        expect(spies.onConflictDoUpdate).toHaveBeenCalledOnce();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/entities/economy/api/__tests__/indicatorTranslationRepository.test.ts`
+Expected: FAIL — `Cannot find module '@/entities/economy/api/indicatorTranslationRepository'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+import 'server-only';
+import { inArray, sql } from 'drizzle-orm';
+import { NEON_TRANSIENT_RETRY } from '@/shared/db/isNeonTransientError';
+import { economicIndicatorTranslations } from '@/shared/db/schema';
+import type { SiglensDatabase } from '@/shared/db/types';
+import type {
+    IndicatorTranslationRecord,
+    IndicatorTranslationRepository,
+    IndicatorTranslationSource,
+} from '@/shared/db/types';
+import { withRetry } from '@/shared/lib/withRetry';
+
+const indicatorTranslationColumns = {
+    normalizedName: economicIndicatorTranslations.normalizedName,
+    koreanName: economicIndicatorTranslations.koreanName,
+    source: economicIndicatorTranslations.source,
+};
+
+interface IndicatorTranslationRow {
+    normalizedName: string;
+    koreanName: string;
+    source: string;
+}
+
+/** 읽기 경계에서 source를 검증 — 미지값은 'ai'로 흡수(캐시 행이므로 합리적 기본). */
+function toSource(value: string): IndicatorTranslationSource {
+    return value === 'dict' ? 'dict' : 'ai';
+}
+
+function toRecord(row: IndicatorTranslationRow): IndicatorTranslationRecord {
+    return {
+        normalizedName: row.normalizedName,
+        koreanName: row.koreanName,
+        source: toSource(row.source),
+    };
+}
+
+/**
+ * `economic_indicator_translations`를 읽고 쓰는 Drizzle repository.
+ * `DrizzleAssetTranslationRepository` 미러 — onConflictDoUpdate는 schema의
+ * `$onUpdateFn`을 트리거하지 않으므로 `updatedAt`을 `sql\`now()\``로 명시한다.
+ */
+export class DrizzleIndicatorTranslationRepository
+    implements IndicatorTranslationRepository
+{
+    constructor(private readonly db: SiglensDatabase) {}
+
+    async findByNames(
+        normalizedNames: readonly string[]
+    ): Promise<IndicatorTranslationRecord[]> {
+        if (normalizedNames.length === 0) return [];
+        const rows = await withRetry(
+            () =>
+                this.db
+                    .select(indicatorTranslationColumns)
+                    .from(economicIndicatorTranslations)
+                    .where(
+                        inArray(
+                            economicIndicatorTranslations.normalizedName,
+                            [...normalizedNames]
+                        )
+                    ),
+            NEON_TRANSIENT_RETRY
+        );
+        return rows.map(toRecord);
+    }
+
+    async upsert(record: IndicatorTranslationRecord): Promise<void> {
+        await withRetry(
+            () =>
+                this.db
+                    .insert(economicIndicatorTranslations)
+                    .values(record)
+                    .onConflictDoUpdate({
+                        target: economicIndicatorTranslations.normalizedName,
+                        set: {
+                            koreanName: sql`excluded.korean_name`,
+                            source: sql`excluded.source`,
+                            updatedAt: sql`now()`,
+                        },
+                    }),
+            NEON_TRANSIENT_RETRY
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/entities/economy/api/__tests__/indicatorTranslationRepository.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entities/economy/api/indicatorTranslationRepository.ts src/entities/economy/api/__tests__/indicatorTranslationRepository.test.ts
+git commit -m "feat(economy): add indicator translation DB repository (SP-B)"
+```
+
+---
+
+## Task 4: Translation constants module
+
+**Files:**
+- Create: `src/entities/economy/lib/indicatorTranslationConstants.ts`
+
+Constants-only module so the `'use server'` action (no non-function exports) and the reader can share the cache tag, refresh-flag key prefix, and TTL. No test (trivial literals; covered transitively by Tasks 5–7).
+
+- [ ] **Step 1: Write the module**
+
+```typescript
+import { SECONDS_PER_MINUTE } from '@/shared/config/time';
+
+/**
+ * revalidateTag 대상 — indicator 번역 캐시만 무효화한다(캘린더 데이터 캐시와 분리).
+ * AI 번역이 새로 캐시되면 다음 렌더에서 reader가 한국어를 집어 오도록 이 태그를 bust.
+ */
+export const INDICATOR_TRANSLATION_CACHE_TAG = 'economy:indicator-translation';
+
+/** Redis pending-flag 키 prefix — 동일 지표명의 동시 AI 제출을 dedupe. */
+export const INDICATOR_TRANSLATION_FLAG_PREFIX = 'economy:indicator-xlate';
+
+const INDICATOR_TRANSLATION_FLAG_TTL_MINUTES = 10;
+
+/**
+ * pending-flag TTL — 이 윈도 안에 같은 지표명이 다시 miss로 들어와도 AI 재제출을
+ * 건너뛴다(in-flight 또는 직전 실패 쿨다운). market-news refresh-flag 패턴 미러.
+ */
+export const INDICATOR_TRANSLATION_FLAG_TTL_SECONDS =
+    INDICATOR_TRANSLATION_FLAG_TTL_MINUTES * SECONDS_PER_MINUTE;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/entities/economy/lib/indicatorTranslationConstants.ts
+git commit -m "feat(economy): add indicator translation constants (SP-B)"
+```
+
+---
+
+## Task 5: Per-name Redis pending-flag
+
+**Files:**
+- Create: `src/entities/economy/api/indicatorTranslationFlag.ts`
+- Test: `src/entities/economy/api/__tests__/indicatorTranslationFlag.test.ts`
+
+Mirrors `market-news` `isRecentlyFetched`/`markFetched`, but keyed per normalized name so concurrent renders of the same unmapped indicator submit at most one AI translation per TTL window.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+vi.mock('server-only', () => ({}));
+
+const { mockGet, mockSet, mockRedis } = vi.hoisted(() => {
+    const mockGet = vi.fn();
+    const mockSet = vi.fn();
+    const mockRedis: Pick<import('@upstash/redis').Redis, 'get' | 'set'> = {
+        get: mockGet,
+        set: mockSet,
+    };
+    return { mockGet, mockSet, mockRedis };
+});
+
+vi.mock('@/shared/cache/redisClient', () => ({
+    getRedisClient: vi.fn(() => mockRedis),
+}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { getRedisClient } from '@/shared/cache/redisClient';
+import {
+    isIndicatorTranslationPending,
+    markIndicatorTranslationPending,
+} from '@/entities/economy/api/indicatorTranslationFlag';
+import { INDICATOR_TRANSLATION_FLAG_TTL_SECONDS } from '@/entities/economy/lib/indicatorTranslationConstants';
+
+describe('indicatorTranslationFlag', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(getRedisClient).mockReturnValue(
+            mockRedis as unknown as import('@upstash/redis').Redis
+        );
+    });
+
+    it('returns false and does not call get when Redis is null', async () => {
+        vi.mocked(getRedisClient).mockReturnValue(null);
+        expect(await isIndicatorTranslationPending('CPI YoY')).toBe(false);
+        expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it('returns true when the flag is set', async () => {
+        mockGet.mockResolvedValue('1');
+        expect(await isIndicatorTranslationPending('CPI YoY')).toBe(true);
+    });
+
+    it('returns false when the flag is absent', async () => {
+        mockGet.mockResolvedValue(null);
+        expect(await isIndicatorTranslationPending('CPI YoY')).toBe(false);
+    });
+
+    it('sets the pending flag with the TTL', async () => {
+        await markIndicatorTranslationPending('CPI YoY');
+        expect(mockSet).toHaveBeenCalledWith(
+            expect.stringContaining('CPI YoY'),
+            '1',
+            { ex: INDICATOR_TRANSLATION_FLAG_TTL_SECONDS }
+        );
+    });
+
+    it('is a no-op when Redis is null on mark', async () => {
+        vi.mocked(getRedisClient).mockReturnValue(null);
+        await markIndicatorTranslationPending('CPI YoY');
+        expect(mockSet).not.toHaveBeenCalled();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/entities/economy/api/__tests__/indicatorTranslationFlag.test.ts`
+Expected: FAIL — `Cannot find module '@/entities/economy/api/indicatorTranslationFlag'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+import 'server-only';
+import { getRedisClient } from '@/shared/cache/redisClient';
+import {
+    INDICATOR_TRANSLATION_FLAG_PREFIX,
+    INDICATOR_TRANSLATION_FLAG_TTL_SECONDS,
+} from '../lib/indicatorTranslationConstants';
+
+function flagKey(normalizedName: string): string {
+    return `${INDICATOR_TRANSLATION_FLAG_PREFIX}:${normalizedName}`;
+}
+
+/**
+ * 해당 지표명의 AI 번역이 최근 TTL 내에 제출됐는지 — Redis 실패/미구성 시 false
+ * (항상 제출 시도). market-news `isRecentlyFetched` 미러.
+ */
+export async function isIndicatorTranslationPending(
+    normalizedName: string
+): Promise<boolean> {
+    const redis = getRedisClient();
+    if (redis === null) return false;
+    try {
+        return (await redis.get(flagKey(normalizedName))) !== null;
+    } catch (error) {
+        console.error('[indicatorTranslationFlag] get failed', error);
+        return false;
+    }
+}
+
+/** "이 지표명 번역 제출함" 마킹 — Redis 실패 시 noop. */
+export async function markIndicatorTranslationPending(
+    normalizedName: string
+): Promise<void> {
+    const redis = getRedisClient();
+    if (redis === null) return;
+    try {
+        await redis.set(flagKey(normalizedName), '1', {
+            ex: INDICATOR_TRANSLATION_FLAG_TTL_SECONDS,
+        });
+    } catch (error) {
+        console.error('[indicatorTranslationFlag] set failed', error);
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/entities/economy/api/__tests__/indicatorTranslationFlag.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entities/economy/api/indicatorTranslationFlag.ts src/entities/economy/api/__tests__/indicatorTranslationFlag.test.ts
+git commit -m "feat(economy): add per-name indicator translation pending-flag (SP-B)"
+```
+
+---
+
+## Task 6: `ensureIndicatorTranslatedAction` (core seam) + barrel
+
+**Files:**
+- Create: `src/entities/economy/actions/ensureIndicatorTranslatedAction.ts`
+- Modify (or create): `src/entities/economy/actions.ts`
+- Test: `src/entities/economy/actions/__tests__/ensureIndicatorTranslatedAction.test.ts`
+
+> **This is the only real core import site.** The test mocks `@y0ngha/siglens-core`'s `translateIndicatorName`; the action imports it for real (resolves once the user publishes core — see CROSS-REPO note). A `// CORE DEPENDENCY` comment marks the import.
+
+The action takes a normalized base name, short-circuits if it's already in the code dict (`INDICATOR_NAME_KO`) or pending (Redis flag), marks pending, calls core `translateIndicatorName`, upserts `source:'ai'`, and `revalidateTag`s the translation cache. Graceful on core failure (no upsert, no revalidate — a later render retries after the pending flag's TTL).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+vi.mock('server-only', () => ({}));
+
+const revalidateTag = vi.fn();
+vi.mock('next/cache', () => ({ revalidateTag }));
+
+const translateIndicatorName = vi.fn();
+vi.mock('@y0ngha/siglens-core', () => ({ translateIndicatorName }));
+
+const isPending = vi.fn();
+const markPending = vi.fn();
+vi.mock('@/entities/economy/api/indicatorTranslationFlag', () => ({
+    isIndicatorTranslationPending: isPending,
+    markIndicatorTranslationPending: markPending,
+}));
+
+const upsert = vi.fn();
+vi.mock('@/entities/economy/api/indicatorTranslationRepository', () => ({
+    DrizzleIndicatorTranslationRepository: class {
+        upsert = upsert;
+    },
+}));
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: () => ({ db: {} }),
+}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ensureIndicatorTranslatedAction } from '@/entities/economy/actions/ensureIndicatorTranslatedAction';
+import { INDICATOR_TRANSLATION_CACHE_TAG } from '@/entities/economy/lib/indicatorTranslationConstants';
+
+describe('ensureIndicatorTranslatedAction', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        isPending.mockResolvedValue(false);
+        markPending.mockResolvedValue(undefined);
+        translateIndicatorName.mockResolvedValue('어떤 모호한 지수(전년比)');
+        upsert.mockResolvedValue(undefined);
+    });
+
+    it('skips when the name is already in the code dictionary', async () => {
+        await ensureIndicatorTranslatedAction('Nonfarm Payrolls');
+        expect(translateIndicatorName).not.toHaveBeenCalled();
+        expect(upsert).not.toHaveBeenCalled();
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it('skips when a translation is already pending', async () => {
+        isPending.mockResolvedValue(true);
+        await ensureIndicatorTranslatedAction('Some Obscure Index YoY');
+        expect(translateIndicatorName).not.toHaveBeenCalled();
+        expect(upsert).not.toHaveBeenCalled();
+    });
+
+    it('translates, upserts source=ai, and revalidates the cache tag', async () => {
+        await ensureIndicatorTranslatedAction('Some Obscure Index YoY');
+        expect(markPending).toHaveBeenCalledOnce();
+        expect(translateIndicatorName).toHaveBeenCalledWith(
+            'Some Obscure Index YoY'
+        );
+        expect(upsert).toHaveBeenCalledWith({
+            normalizedName: 'Some Obscure Index YoY',
+            koreanName: '어떤 모호한 지수(전년比)',
+            source: 'ai',
+        });
+        expect(revalidateTag).toHaveBeenCalledWith(
+            INDICATOR_TRANSLATION_CACHE_TAG,
+            'max'
+        );
+    });
+
+    it('swallows a core failure without upserting or revalidating', async () => {
+        translateIndicatorName.mockRejectedValue(new Error('llm down'));
+        await expect(
+            ensureIndicatorTranslatedAction('Some Obscure Index YoY')
+        ).resolves.toBeUndefined();
+        expect(upsert).not.toHaveBeenCalled();
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it('does not upsert an empty translation', async () => {
+        translateIndicatorName.mockResolvedValue('   ');
+        await ensureIndicatorTranslatedAction('Some Obscure Index YoY');
+        expect(upsert).not.toHaveBeenCalled();
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/entities/economy/actions/__tests__/ensureIndicatorTranslatedAction.test.ts`
+Expected: FAIL — `Cannot find module '@/entities/economy/actions/ensureIndicatorTranslatedAction'`.
+
+- [ ] **Step 3: Write the action**
+
+```typescript
+'use server';
+
+import { revalidateTag } from 'next/cache';
+// CORE DEPENDENCY (separate repo, user publishes): analysis-domain AI translation
+// of an unmapped indicator name. See SP-B plan CROSS-REPO note. Until core ships
+// this export, only the unit test (which mocks it) exercises this file.
+import { translateIndicatorName } from '@y0ngha/siglens-core';
+
+import { getDatabaseClient } from '@/shared/db/client';
+
+import { DrizzleIndicatorTranslationRepository } from '../api/indicatorTranslationRepository';
+import {
+    isIndicatorTranslationPending,
+    markIndicatorTranslationPending,
+} from '../api/indicatorTranslationFlag';
+import { INDICATOR_NAME_KO } from '../lib/indicatorNameKo';
+import { INDICATOR_TRANSLATION_CACHE_TAG } from '../lib/indicatorTranslationConstants';
+
+/**
+ * Server Action: 미매핑 지표명 1건을 core AI로 번역해 `economic_indicator_translations`에
+ * `source:'ai'`로 캐시하고 번역 캐시 태그를 무효화한다(다음 렌더에서 한국어 반영).
+ *
+ * 코드 사전(`INDICATOR_NAME_KO`)에 이미 있으면 즉시 반환 — dict가 source-of-truth라
+ * AI를 호출할 이유가 없다. pending-flag로 동시/연속 제출을 dedupe한다. core 실패 시
+ * graceful(캐시 미기록) — pending-flag TTL 만료 후 다음 렌더가 재시도한다.
+ * `waitUntil` 안에서 fire-and-forget으로 도는 설계 — 응답 스트림 비차단.
+ */
+export async function ensureIndicatorTranslatedAction(
+    normalizedName: string
+): Promise<void> {
+    try {
+        if (normalizedName in INDICATOR_NAME_KO) {
+            return;
+        }
+        if (await isIndicatorTranslationPending(normalizedName)) {
+            return;
+        }
+        // core 왕복 전에 마킹 — 동시 호출이 이 지점 이후 플래그를 읽으면 제출을 생략.
+        await markIndicatorTranslationPending(normalizedName);
+
+        const koreanName = await translateIndicatorName(normalizedName);
+        if (koreanName.trim() === '') {
+            console.error(
+                `[ensureIndicatorTranslatedAction] empty translation for "${normalizedName}"`
+            );
+            return;
+        }
+
+        const { db } = getDatabaseClient();
+        const repo = new DrizzleIndicatorTranslationRepository(db);
+        await repo.upsert({
+            normalizedName,
+            koreanName: koreanName.trim(),
+            source: 'ai',
+        });
+
+        // 번역 캐시 태그만 무효화 — 캘린더 데이터 ISR 캐시는 무관.
+        // Next 16 revalidateTag(tag, profile) — 'max'는 즉시 무효화.
+        revalidateTag(INDICATOR_TRANSLATION_CACHE_TAG, 'max');
+    } catch (error) {
+        console.error('[ensureIndicatorTranslatedAction]', error);
+    }
+}
+```
+
+- [ ] **Step 4: Create/extend the action barrel**
+
+Run `ls src/entities/economy/actions.ts` first.
+- If SP-A already created it (re-exporting `ensureEconomicCalendarAction`), **add** this line to it:
+
+```typescript
+export { ensureIndicatorTranslatedAction } from './actions/ensureIndicatorTranslatedAction';
+```
+
+- If it does not exist, create `src/entities/economy/actions.ts` (no `'use server'` — re-export only, per `entities/CLAUDE.md`):
+
+```typescript
+export { ensureIndicatorTranslatedAction } from './actions/ensureIndicatorTranslatedAction';
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/entities/economy/actions/__tests__/ensureIndicatorTranslatedAction.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS. (If core has NOT yet published `translateIndicatorName`, `tsc` will error `'translateIndicatorName' is not exported`. That is the expected cross-repo gate — see CROSS-REPO note. The vitest suite still passes because the test mocks the module. Mark this task done on green vitest; resolve `tsc` once the core pin is bumped. Until then, the executing worker should note the `tsc` failure is attributable ONLY to the missing core export and to no other code in this task.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/entities/economy/actions/ensureIndicatorTranslatedAction.ts src/entities/economy/actions/__tests__/ensureIndicatorTranslatedAction.test.ts src/entities/economy/actions.ts
+git commit -m "feat(economy): add ensureIndicatorTranslatedAction core translation seam (SP-B)"
+```
+
+---
+
+## Task 7: ISR-safe label resolver (reader + on-miss AI trigger)
+
+**Files:**
+- Create: `src/entities/economy/api/resolveIndicatorLabels.ts`
+- Test: `src/entities/economy/api/__tests__/resolveIndicatorLabels.test.ts`
+
+`resolveIndicatorLabels(events)` is the server bridge between the DB cache and the client grid:
+
+1. Collect the **distinct** normalized base names from the events; partition into dict-hits (already known) and unknowns.
+2. For unknowns, read the DB cache (`unstable_cache`-wrapped, revalidate 24h + `economy:indicator-translation` tag → ISR cold-gen safe; `@neondatabase/serverless` HTTP is no-store).
+3. Build the per-raw-event-name `labels` map by running the pure `indicatorLabelKoFromMaps(raw, dbMap)` for each distinct raw event name.
+4. Fire-and-forget `ensureIndicatorTranslatedAction(name)` for names that are still unresolved (not in dict, not in DB) — this seeds the cache for the next render. Bots included (matches SP-A on-access policy).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+vi.mock('server-only', () => ({}));
+vi.mock('next/cache', () => ({
+    unstable_cache:
+        (fn: (...a: unknown[]) => unknown) =>
+        (...a: unknown[]) =>
+            fn(...a),
+}));
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: () => ({ db: {} }),
+}));
+
+const findByNames = vi.fn();
+vi.mock('@/entities/economy/api/indicatorTranslationRepository', () => ({
+    DrizzleIndicatorTranslationRepository: class {
+        findByNames = findByNames;
+    },
+}));
+
+const ensureIndicatorTranslatedAction = vi.fn();
+vi.mock('@/entities/economy/actions/ensureIndicatorTranslatedAction', () => ({
+    ensureIndicatorTranslatedAction,
+}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
+import { resolveIndicatorLabels } from '@/entities/economy/api/resolveIndicatorLabels';
+
+const ev = (event: string): EconomicCalendarEvent => ({
+    date: '2026-06-13 08:30:00',
+    event,
+    impact: 'High',
+    actual: null,
+    estimate: 1,
+    previous: 1,
+    unit: '%',
+});
+
+describe('resolveIndicatorLabels', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        findByNames.mockResolvedValue([]);
+        ensureIndicatorTranslatedAction.mockResolvedValue(undefined);
+    });
+
+    it('maps dict-known names to Korean without a DB lookup', async () => {
+        const labels = await resolveIndicatorLabels([
+            ev('Nonfarm Payrolls'),
+        ]);
+        expect(labels['Nonfarm Payrolls']).toBe('비농업 고용');
+        // All distinct bases were dict-known → no unknowns → no DB query.
+        expect(findByNames).not.toHaveBeenCalled();
+        expect(ensureIndicatorTranslatedAction).not.toHaveBeenCalled();
+    });
+
+    it('applies a DB-cached translation for an unmapped name', async () => {
+        findByNames.mockResolvedValue([
+            {
+                normalizedName: 'Some Obscure Index YoY',
+                koreanName: '어떤 모호한 지수(전년比)',
+                source: 'ai',
+            },
+        ]);
+        const labels = await resolveIndicatorLabels([
+            ev('Some Obscure Index YoY (May)'),
+        ]);
+        expect(labels['Some Obscure Index YoY (May)']).toBe(
+            '어떤 모호한 지수(전년比) (5월)'
+        );
+        expect(ensureIndicatorTranslatedAction).not.toHaveBeenCalled();
+    });
+
+    it('falls back to English and triggers AI for a name missing everywhere', async () => {
+        const labels = await resolveIndicatorLabels([
+            ev('Totally Unknown Thing (Apr)'),
+        ]);
+        expect(labels['Totally Unknown Thing (Apr)']).toBe(
+            'Totally Unknown Thing (Apr)'
+        );
+        expect(ensureIndicatorTranslatedAction).toHaveBeenCalledWith(
+            'Totally Unknown Thing'
+        );
+    });
+
+    it('queries and triggers each distinct base only once', async () => {
+        await resolveIndicatorLabels([
+            ev('Totally Unknown Thing (Apr)'),
+            ev('Totally Unknown Thing (May)'),
+        ]);
+        expect(findByNames).toHaveBeenCalledTimes(1);
+        expect(findByNames).toHaveBeenCalledWith(['Totally Unknown Thing']);
+        expect(ensureIndicatorTranslatedAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('degrades to English-only labels on DB failure (graceful)', async () => {
+        findByNames.mockRejectedValue(new Error('neon down'));
+        const labels = await resolveIndicatorLabels([
+            ev('Totally Unknown Thing (Apr)'),
+        ]);
+        expect(labels['Totally Unknown Thing (Apr)']).toBe(
+            'Totally Unknown Thing (Apr)'
+        );
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/entities/economy/api/__tests__/resolveIndicatorLabels.test.ts`
+Expected: FAIL — `Cannot find module '@/entities/economy/api/resolveIndicatorLabels'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+import 'server-only';
+import { unstable_cache } from 'next/cache';
+import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
+
+import { getDatabaseClient } from '@/shared/db/client';
+
+import { DrizzleIndicatorTranslationRepository } from './indicatorTranslationRepository';
+import { ensureIndicatorTranslatedAction } from '../actions/ensureIndicatorTranslatedAction';
+import {
+    INDICATOR_NAME_KO,
+    indicatorLabelKoFromMaps,
+    normalizeIndicatorName,
+} from '../lib/indicatorNameKo';
+import {
+    INDICATOR_TRANSLATION_CACHE_TAG,
+    INDICATOR_TRANSLATION_REVALIDATE_SECONDS,
+} from '../lib/indicatorTranslationConstants';
+
+/**
+ * 미매핑 base 이름들의 DB 캐시 행을 읽는다. ISR cold-gen 안전: `@neondatabase/serverless`
+ * HTTP는 no-store라 static generate가 `DYNAMIC_SERVER_USAGE`를 throw하므로 `unstable_cache`로
+ * 감싼다(src/app/CLAUDE.md 4축 축1). revalidate=24h + `economy:indicator-translation` 태그로
+ * `ensureIndicatorTranslatedAction`이 on-demand 무효화 가능. DB 실패 시 빈 맵으로 graceful.
+ *
+ * 캐시 키에 정렬된 이름 목록을 박아 입력이 바뀌면 자연히 리프레시된다.
+ */
+async function readDbMap(
+    unknownNames: string[]
+): Promise<Record<string, string>> {
+    if (unknownNames.length === 0) return {};
+    const sorted = [...unknownNames].toSorted((a, b) => a.localeCompare(b));
+    return unstable_cache(
+        async () => {
+            try {
+                const { db } = getDatabaseClient();
+                const repo = new DrizzleIndicatorTranslationRepository(db);
+                const rows = await repo.findByNames(sorted);
+                return Object.fromEntries(
+                    rows.map(r => [r.normalizedName, r.koreanName])
+                );
+            } catch (error) {
+                console.error('[resolveIndicatorLabels] DB read failed:', error);
+                return {};
+            }
+        },
+        ['economy-indicator-translation', sorted.join('|')],
+        {
+            revalidate: INDICATOR_TRANSLATION_REVALIDATE_SECONDS,
+            tags: [INDICATOR_TRANSLATION_CACHE_TAG],
+        }
+    )();
+}
+
+/**
+ * 이벤트들의 raw 지표명을 표시 레이블(한국어 우선, 영어 fallback)로 매핑한 레코드를
+ * 반환한다(키 = raw event명). dict-known은 즉시, 미매핑은 DB 캐시 룩업, 둘 다 miss면
+ * 영어 fallback + fire-and-forget AI 트리거(다음 렌더 캐시 시드, 봇 포함).
+ *
+ * 그리드(client)는 이 순수 레이블 맵만 받아 표시한다 — server-only 의존성 누출 없음.
+ */
+export async function resolveIndicatorLabels(
+    events: readonly EconomicCalendarEvent[]
+): Promise<Record<string, string>> {
+    const distinctRaw = [...new Set(events.map(e => e.event))];
+    const baseByRaw = new Map(
+        distinctRaw.map(raw => [raw, normalizeIndicatorName(raw).base])
+    );
+
+    const distinctBases = [...new Set(baseByRaw.values())];
+    const unknownBases = distinctBases.filter(
+        base => !(base in INDICATOR_NAME_KO)
+    );
+
+    const dbMap = await readDbMap(unknownBases);
+
+    // 여전히 미해결인(dict X, DB X) base에 대해서만 AI 번역을 트리거 — 각 1회.
+    for (const base of unknownBases) {
+        if (!(base in dbMap)) {
+            void ensureIndicatorTranslatedAction(base).catch(
+                (e: unknown) => {
+                    console.error(
+                        '[resolveIndicatorLabels] ensureIndicatorTranslatedAction failed:',
+                        e
+                    );
+                }
+            );
+        }
+    }
+
+    return Object.fromEntries(
+        distinctRaw.map(raw => [raw, indicatorLabelKoFromMaps(raw, dbMap)])
+    );
+}
+```
+
+- [ ] **Step 4: Add the missing reader-TTL constant**
+
+`readDbMap` references `INDICATOR_TRANSLATION_REVALIDATE_SECONDS`, which Task 4 did not define. Add it to `src/entities/economy/lib/indicatorTranslationConstants.ts`:
+
+```typescript
+import { SECONDS_PER_DAY } from '@/shared/config/time';
+```
+
+(merge into the existing `@/shared/config/time` import line so there is a single import — `import { SECONDS_PER_DAY, SECONDS_PER_MINUTE } from '@/shared/config/time';`), and append:
+
+```typescript
+/**
+ * 번역 reader의 `unstable_cache` revalidate — 24h, /economy revalidate(86400)와 단일
+ * TTL 공유. 신선도는 `ensureIndicatorTranslatedAction`의 revalidateTag가 책임진다.
+ */
+export const INDICATOR_TRANSLATION_REVALIDATE_SECONDS = SECONDS_PER_DAY;
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/entities/economy/api/__tests__/resolveIndicatorLabels.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS (modulo the same cross-repo `translateIndicatorName` export gate noted in Task 6 Step 6, since this file transitively imports the action). On green vitest + a `tsc` failure attributable ONLY to the missing core export, proceed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/entities/economy/api/resolveIndicatorLabels.ts src/entities/economy/api/__tests__/resolveIndicatorLabels.test.ts src/entities/economy/lib/indicatorTranslationConstants.ts
+git commit -m "feat(economy): add ISR-safe indicator label resolver + on-miss AI trigger (SP-B)"
+```
+
+---
+
+## Task 8: Apply labels in `EconomicCalendarGrid` display
+
+**Files:**
+- Modify: `src/widgets/economy/sections/EconomicCalendarGrid.tsx`
+- Modify: `src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx`
+
+The grid receives a pre-resolved `labels?: Record<string, string>` (raw event name → display label) and applies it at the two display sites: the inline cell preview (`DayCell`) and the detail panel (`DayDetailPanel`). When `labels` is omitted or a name is absent, it falls back to the raw `ev.original.event` (current behavior preserved). The label map threads down through props (no new hooks → hook order untouched).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx` a new describe block. (If SP-A already added the `@/entities/economy/actions` mock for the trigger hook, reuse it; otherwise add `vi.mock('@/entities/economy/actions', () => ({ ensureEconomicCalendarAction: vi.fn().mockResolvedValue(undefined) }));` at the top with the other mocks.)
+
+```typescript
+describe('EconomicCalendarGrid Korean indicator labels', () => {
+    const ev = (date: string, event: string): EconomicCalendarEvent => ({
+        date: `${date} 08:30:00`,
+        event,
+        impact: 'High',
+        actual: null,
+        estimate: 1,
+        previous: 1,
+        unit: '%',
+    });
+
+    it('renders the Korean label in the detail panel when provided', () => {
+        render(
+            <EconomicCalendarGrid
+                events={[ev('2026-06-20', 'Nonfarm Payrolls')]}
+                today="2026-06-20"
+                labels={{ 'Nonfarm Payrolls': '비농업 고용' }}
+            />
+        );
+        // The selected (today) panel shows the Korean label, not the English name.
+        expect(screen.getAllByText('비농업 고용').length).toBeGreaterThan(0);
+        expect(screen.queryByText('Nonfarm Payrolls')).toBeNull();
+    });
+
+    it('falls back to the English event name when no label is provided', () => {
+        render(
+            <EconomicCalendarGrid
+                events={[ev('2026-06-20', 'Mystery Index')]}
+                today="2026-06-20"
+            />
+        );
+        expect(screen.getAllByText('Mystery Index').length).toBeGreaterThan(0);
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx`
+Expected: FAIL — `labels` is not yet a prop, and the panel renders the English name (so the Korean-label assertion and the `queryByText('Nonfarm Payrolls')` null assertion fail).
+
+- [ ] **Step 3: Implement the `labels` prop threading**
+
+In `src/widgets/economy/sections/EconomicCalendarGrid.tsx`:
+
+(a) Add a label-lookup helper above `DayDetailPanel` (next to `kstDayOfWeekLabel`):
+
+```typescript
+/**
+ * raw 이벤트명을 표시 레이블로 매핑한다 — `labels`(서버가 resolveIndicatorLabels로 미리
+ * 해결한 한국어 우선 맵)에 있으면 그 값을, 없으면 raw 영어 원문을 반환(결정론적 fallback).
+ */
+function displayEventLabel(
+    rawEvent: string,
+    labels: Record<string, string>
+): string {
+    return labels[rawEvent] ?? rawEvent;
+}
+```
+
+(b) Thread `labels` through the prop interfaces. Extend `DayDetailPanelProps` and `DayCellProps`:
+
+```typescript
+interface DayDetailPanelProps {
+    group: DayGroup;
+    isSelected: boolean;
+    labels: Record<string, string>;
+}
+```
+
+```typescript
+interface DayCellProps {
+    group: DayGroup;
+    isSelected: boolean;
+    onSelect: (dateKey: string) => void;
+    labels: Record<string, string>;
+}
+```
+
+and `MonthCalendarProps`:
+
+```typescript
+interface MonthCalendarProps {
+    year: number;
+    /** 0-indexed */
+    month: number;
+    groupMap: Map<string, DayGroup>;
+    selectedDateKey: string;
+    onSelect: (dateKey: string) => void;
+    labels: Record<string, string>;
+}
+```
+
+(c) In `DayDetailPanel`, change the event-name line:
+
+```typescript
+                                <p className="text-secondary-100 text-sm font-medium">
+                                    {ev.original.event}
+                                </p>
+```
+
+to:
+
+```typescript
+                                <p className="text-secondary-100 text-sm font-medium">
+                                    {displayEventLabel(
+                                        ev.original.event,
+                                        labels
+                                    )}
+                                </p>
+```
+
+and add `labels` to the destructured props: `function DayDetailPanel({ group, isSelected, labels }: DayDetailPanelProps) {`.
+
+(d) In `DayCell`, change the inline-preview event-name span:
+
+```typescript
+                            {ev.kstTimeLabel.replace(/^(오전|오후)\s*/, '')}{' '}
+                            {ev.original.event}
+```
+
+to:
+
+```typescript
+                            {ev.kstTimeLabel.replace(/^(오전|오후)\s*/, '')}{' '}
+                            {displayEventLabel(ev.original.event, labels)}
+```
+
+and add `labels` to its destructured props: `function DayCell({ group, isSelected, onSelect, labels }: DayCellProps) {`.
+
+(e) In `MonthCalendar`, accept `labels` and forward it to each `DayCell`:
+
+```typescript
+function MonthCalendar({
+    year,
+    month,
+    groupMap,
+    selectedDateKey,
+    onSelect,
+    labels,
+}: MonthCalendarProps) {
+```
+
+and in the `DayCell` render, add `labels={labels}`:
+
+```typescript
+                                    <DayCell
+                                        key={cell.dateKey}
+                                        group={cell}
+                                        isSelected={
+                                            selectedDateKey === cell.dateKey
+                                        }
+                                        onSelect={onSelect}
+                                        labels={labels}
+                                    />
+```
+
+(f) Extend `EconomicCalendarGridProps` with the optional prop and default it in the component, then forward it to `MonthCalendar` and `DayDetailPanel`:
+
+```typescript
+interface EconomicCalendarGridProps {
+    events: readonly EconomicCalendarEvent[];
+    today?: string;
+    /**
+     * raw 이벤트명 → 표시 레이블(한국어 우선) 맵. 서버 RSC가 `resolveIndicatorLabels`로
+     * 미리 해결해 주입한다. 생략 시 모든 이벤트가 영어 원문으로 표시된다(결정론적 fallback).
+     */
+    labels?: Record<string, string>;
+}
+```
+
+In the component signature add `labels = {}`:
+
+```typescript
+export function EconomicCalendarGrid({
+    events,
+    today = '',
+    labels = {},
+}: EconomicCalendarGridProps) {
+```
+
+In the months map, pass `labels={labels}`:
+
+```typescript
+                    <MonthCalendar
+                        key={`${year}-${month}`}
+                        year={year}
+                        month={month}
+                        groupMap={groupMap}
+                        selectedDateKey={selectedDateKey}
+                        onSelect={setSelectedDateKey}
+                        labels={labels}
+                    />
+```
+
+In the detail-panels map, pass `labels={labels}`:
+
+```typescript
+                    <DayDetailPanel
+                        key={group.dateKey}
+                        group={group}
+                        isSelected={group.dateKey === selectedDateKey}
+                        labels={labels}
+                    />
+```
+
+> Note: `today` is shown as optional here assuming SP-A landed it. If SP-A has NOT landed, drop the `today` prop references from this task (keep only `events` + `labels`) and re-add `today` when SP-A merges. The `labels` change is independent of `today`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx`
+Expected: PASS — Korean-label + English-fallback tests pass and all pre-existing grid tests still pass (omitted `labels` → English).
+
+- [ ] **Step 5: Typecheck + lint**
+
+Run: `npx tsc --noEmit && yarn lint`
+Expected: PASS (modulo the cross-repo core-export `tsc` gate if Task 6/7 are in the same tree; the grid file itself introduces no core import). No new hooks added → exhaustive-deps and hook-order untouched.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/widgets/economy/sections/EconomicCalendarGrid.tsx src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
+git commit -m "feat(economy): render Korean indicator labels in calendar grid (SP-B)"
+```
+
+---
+
+## Task 9: Wire the page to resolve + pass labels
+
+**Files:**
+- Modify: `src/app/economy/page.tsx`
+
+Compute `labels = await resolveIndicatorLabels(calendarEvents)` in the RSC (right after the SP-A `calendarEvents` line) and pass it to `<EconomicCalendar>`. The page already awaits `getCalendarFromDb` (SP-A); this adds one more awaited reader on the same data.
+
+> Prereq: SP-A's page wiring (`calendarEvents` + `<EconomicCalendar events={calendarEvents} today={todayKstKey} />`) is in place. If SP-A has not landed, adapt to whatever the calendar events source is currently named (e.g. `snapshot.calendar`).
+
+- [ ] **Step 1: Add the import**
+
+In `src/app/economy/page.tsx`, after the SP-A `getCalendarFromDb` import:
+
+```typescript
+import { resolveIndicatorLabels } from '@/entities/economy/api/resolveIndicatorLabels';
+```
+
+- [ ] **Step 2: Resolve labels after the calendar events**
+
+In `EconomyContent`, after the `calendarEvents` assignment (SP-A), add:
+
+```typescript
+    // 지표명 한국어 레이블을 서버에서 미리 해결한다(dict → DB 캐시 → 영어 fallback +
+    // 미매핑 AI 트리거). 그리드는 순수 레이블 맵만 받아 표시한다(SP-B).
+    const indicatorLabels = await resolveIndicatorLabels(calendarEvents).catch(
+        e => {
+            console.error('[EconomyContent] resolveIndicatorLabels failed:', e);
+            return {} as Record<string, string>;
+        }
+    );
+```
+
+- [ ] **Step 3: Pass `labels` to the grid**
+
+Change:
+
+```typescript
+            <EconomicCalendar events={calendarEvents} today={todayKstKey} />
+```
+
+to:
+
+```typescript
+            <EconomicCalendar
+                events={calendarEvents}
+                today={todayKstKey}
+                labels={indicatorLabels}
+            />
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS (modulo the cross-repo core-export gate). `resolveIndicatorLabels(events): Promise<Record<string,string>>`; `EconomicCalendar` (= `EconomicCalendarGrid`) accepts the optional `labels`.
+
+- [ ] **Step 5: Run economy suites**
+
+Run: `npx vitest run src/widgets/economy src/entities/economy`
+Expected: PASS (all economy widget/entity tests green).
+
+- [ ] **Step 6: Build to verify ISR/cold-gen safety (after core pin is bumped)**
+
+Run: `yarn build > /tmp/economy-spb-build.log 2>&1; echo "EXIT=$?"`
+Expected: `EXIT=0` and `/economy` builds without `DYNAMIC_SERVER_USAGE`. Inspect: `grep -iE "economy|DYNAMIC_SERVER_USAGE|translateIndicatorName|error" /tmp/economy-spb-build.log`. There must be **no** `DYNAMIC_SERVER_USAGE` attributed to `/economy` (the `unstable_cache` wrapper in `readDbMap` makes the DB read static-safe). If the build fails with `translateIndicatorName is not exported`, the core pin has not been bumped yet — this build step is **deferred until the user publishes core and bumps the pin** (see CROSS-REPO note). Record the deferral; do not work around it by stubbing core in app code.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/economy/page.tsx
+git commit -m "feat(economy): resolve + pass Korean indicator labels on economy page (SP-B)"
+```
+
+---
+
+## Task 10: Dictionary-seeding procedure doc
+
+**Files:**
+- Create: `docs/superpowers/seeding/indicator-name-ko-seeding.md`
+
+A documented one-time data task (not code): consume SP-A's name-dump, draft via core AI, curate, and fill `INDICATOR_NAME_KO`. The seed in Task 1 covers the most common ~28 indicators; the full ~277 curation is this follow-up.
+
+- [ ] **Step 1: Write the procedure doc**
+
+```markdown
+# Indicator Name Korean Dictionary — One-Time Seeding Procedure
+
+`INDICATOR_NAME_KO` (`src/entities/economy/lib/indicatorNameKo.ts`) is the
+source-of-truth (`dict`) for economic-indicator Korean names. SP-B Task 1 seeds
+the ~28 most common indicators from the FMP sample. This procedure curates the
+full ~277 distinct normalized base names into the dictionary as a follow-up data
+task. Anything not in the dictionary is AI-translated on-miss and cached
+(`source:'ai'`) in `economic_indicator_translations` — so this seeding is an
+optimization (instant Korean, no AI round-trip) and a quality-control gate
+(human-curated vs. machine draft), not a correctness requirement.
+
+## Inputs
+
+- **`scripts/output/economic-calendar-indicator-names.json`** — the distinct
+  normalized base-name set produced by SP-A's backfill
+  (`yarn db:backfill:calendar`). ~277 entries, sorted.
+
+## Steps
+
+1. **Run the SP-A backfill** (user, one-time) to regenerate the name dump:
+   `yarn db:backfill:calendar`. Confirm the JSON file exists and its length is
+   ~277.
+
+2. **Draft translations via core AI.** For each name not already in
+   `INDICATOR_NAME_KO`, obtain a Korean draft. Two equivalent options:
+   - Let the running app self-heal: deploy SP-B, let `/economy` traffic trigger
+     `ensureIndicatorTranslatedAction` for misses, then `SELECT normalized_name,
+     korean_name FROM economic_indicator_translations WHERE source = 'ai'` to
+     read the machine drafts back.
+   - Or call core `translateIndicatorName(name)` directly in a throwaway script
+     over the dump (core must be published first).
+
+3. **Curate.** Review each draft for: domain accuracy (지표 의미), consistent
+   terminology (e.g. always `근원` for "Core", `전년比`/`전월比`/`전분기比` for
+   YoY/MoM/QoQ — these come from `koreanizePeriodToken`, so the **base** must NOT
+   embed the period token; keep base period-free except where the FMP base name
+   itself carries a direction, like `... YoY`, which the seed already folds into
+   the Korean), and house style (no trailing punctuation). Fix anything wrong.
+
+4. **Fill `INDICATOR_NAME_KO`.** Add the curated `'<base>': '<korean>'` entries
+   to the const map, keeping the existing grouping comments (물가 / 고용 /
+   성장·심리 / 정책·국채 / …). Keys MUST be the **normalized base** form
+   (`normalizeIndicatorName(raw).base`) — no trailing `(May)`/`(Q1)`.
+
+5. **Promote, optionally.** Rows curated into the dict can have their DB cache
+   row updated to `source:'dict'` (or left as-is — the dict short-circuits the
+   DB read either way, since `INDICATOR_NAME_KO` is checked first).
+
+6. **Verify.** Extend `indicatorNameKo.test.ts` with spot-check assertions for a
+   handful of newly-added high-traffic indicators, then `yarn test`.
+
+## Guardrails
+
+- Do NOT machine-bulk-paste drafts without review — a wrong indicator
+  translation is user-visible and misleading.
+- Keep base keys period-free; the period parenthetical is Korean-ized separately
+  by `koreanizePeriodToken` at display time.
+- The dictionary is plain data — no logic. Reviewers should treat large dict
+  additions as a data PR (spot-check, not line-by-line lint).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/seeding/indicator-name-ko-seeding.md
+git commit -m "docs(economy): add indicator-name Korean dictionary seeding procedure (SP-B)"
+```
+
+---
+
+## Task 11: Full-suite green + final gates
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `yarn test`
+Expected: PASS (no regressions across the repo). SP-B's only un-mocked external dependency is core `translateIndicatorName`, which every test mocks — so the unit suite is green independent of the core publish.
+
+- [ ] **Step 2: Lint + format gates**
+
+Run: `yarn lint && yarn format`
+Expected: lint PASS, format applies no pending changes (or only files this plan touched, already clean). If `yarn format` rewrites files, re-run `yarn lint` and amend the relevant commit.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS **once the core `translateIndicatorName` export is published and the pin is bumped**. If core has not landed, the ONLY acceptable `tsc` error is `'translateIndicatorName' is not exported from '@y0ngha/siglens-core'` in `ensureIndicatorTranslatedAction.ts`. Any other type error is a real defect to fix.
+
+- [ ] **Step 4: Commit any formatting fixups (if produced)**
+
+```bash
+git add -A
+git commit -m "chore(economy): formatting + lint fixups (SP-B)"
+```
+
+(Skip if nothing changed.)
+
+---
+
+## Self-Review
+
+**Spec coverage (SP-B section + `economic_indicator_translations` shared data model):**
+
+| Spec requirement | Task |
+|---|---|
+| `indicatorNameKo.ts`: `INDICATOR_NAME_KO: Record<string,string>` code const (source-of-truth) | Task 1 (seed of confirmed common indicators) + Task 10 (full ~277 curation procedure) |
+| `normalizeIndicatorName(raw)`: strip trailing `(May)`/`(Q1)`/`(Jun/20)`, return base + period token | Task 1 (`normalizeIndicatorName` → `{ base, period }`, final-parenthetical only, interior preserved) |
+| Period-token Korean-ization (YoY→전년比, MoM→전월比, QoQ→전분기比, month/quarter names) | Task 1 (`koreanizePeriodToken`) |
+| `indicatorLabelKo(raw)` display helper: normalize → dict → DB-cache → miss returns English + background AI trigger | Split per FSD: pure sync `indicatorLabelKoFromMaps` (Task 1) for client; server `resolveIndicatorLabels` (Task 7) does DB-cache lookup + on-miss `ensureIndicatorTranslatedAction` trigger |
+| `economic_indicator_translations` table mirroring `assetTranslations` (normalizedName PK, koreanName, source 'dict'\|'ai', updatedAt) + migration | Task 2 (schema + `$onUpdateFn` updatedAt + types + `db:generate` migration) |
+| siglens adapter calling CORE `translateIndicatorName(normalizedName): Promise<string>`, upsert result `source:'ai'` | Task 6 (`ensureIndicatorTranslatedAction`, only real core import, marked `// CORE DEPENDENCY`) + Task 3 (repository upsert) |
+| CORE CONTRACT defined, core NOT implemented, marked cross-repo, mocked in tests | CROSS-REPO note (exact signature) + Tasks 6/7 mock `@y0ngha/siglens-core` |
+| Apply `indicatorLabelKo` in `EconomicCalendarGrid` (cell preview + detail panel), Korean when mapped, English fallback | Task 8 (`displayEventLabel` at `DayCell` inline preview + `DayDetailPanel`) + Task 9 (page resolves + passes `labels`) |
+| Dictionary seeding (one-time): SP-A name-dump → core AI draft → curate → fill, with a confirmed seed | Task 1 (seed incl. 'Core PCE Price Index YoY'→'근원 PCE 물가지수(전년比)', 'Nonfarm Payrolls'→'비농업 고용', 'ADP Employment Change'→'ADP 고용 변화', 'CPI', 'Initial Jobless Claims', 'Fed Interest Rate Decision', '10-Year Note Auction'→'10년물 국채 입찰') + Task 10 (procedure) |
+| Tests: normalize (suffix split + period token), dict lookup, DB-cache fallback, unmapped English-kept | Task 1 (normalize/period/dict/DB-map/English-fallback) + Task 3 (repo) + Task 7 (resolver: dict short-circuit, DB hit, miss→trigger, graceful) + Task 8 (grid display) |
+
+**Gate compliance:**
+- **No `eslint-disable`** anywhere; no `react-hooks` suppression — Task 8 adds no hooks (label map threads via props).
+- **Named return types** on every export: `normalizeIndicatorName(raw): NormalizedIndicatorName`, `koreanizePeriodToken(token): string`, `indicatorLabelKoFromMaps(...): string`, `resolveIndicatorLabels(...): Promise<Record<string,string>>`, repository methods, action `: Promise<void>`.
+- **Exact assertions** in every test (`toBe`/`toEqual` with concrete Korean strings + call args), no `toBeTruthy`.
+- **WHY comments only** — caching strategy, cross-repo seam, ISR safety, dedupe rationale; no line-narration.
+- **`'use server'` purity** — Task 6 action exports only the async function; constants (Task 4), repository (Task 3), flag (Task 5), and the i18n module (Task 1) are separate files.
+- **FSD layers/barrels** — pure `lib/` (client-safe) consumed by both grid and reader; server-only `api/` + `actions/` barrel-excluded; grid imports only the pure `lib/` helper and the pre-resolved `labels` prop (no server import).
+- **ISR 4-axis** — `resolveIndicatorLabels` wraps its DB read in `unstable_cache` (revalidate 24h + tag); no `cookies()`/`headers()`/`connection()`/`Date.now()` on the cold-gen path; Task 9 Step 6 build-asserts no `DYNAMIC_SERVER_USAGE` for `/economy`.
+
+**Cross-repo handling:** core `translateIndicatorName` is defined as a contract (exact signature in the CROSS-REPO note), NOT implemented in siglens, mocked in every siglens test, imported for real at exactly one site (Task 6, marked). The two cross-repo gates the executing worker may legitimately hit before the core publish are flagged inline (Task 6 Step 6, Task 7 Step 6, Task 9 Step 6, Task 11 Step 3) with the exact, attributable `tsc`/build error and the deferral rule (do NOT stub core in app code as a workaround).
+
+**Placeholder scan:** No TBD/TODO/"similar to". Every code step is complete TypeScript; every command is exact with expected output. Error handling is concrete (try/catch + `console.error` + graceful fallback to English-only labels) in Tasks 3, 5, 6, 7, 9.
+
+**Type-consistency check:**
+- `normalizeIndicatorName(raw): { base, period }` — same shape in Tasks 1 (def/test), 7 (`.base` consumed). ✓
+- `indicatorLabelKoFromMaps(raw, dbMap): string` — Task 1 def, Task 7 consumes per raw name. ✓
+- `DrizzleIndicatorTranslationRepository` exposes `findByNames(names)` + `upsert(record)` — defined Task 3, mocked identically in Tasks 6 (`upsert`) and 7 (`findByNames`). ✓
+- `ensureIndicatorTranslatedAction(normalizedName): Promise<void>` — Task 6 def/barrel, Task 7 trigger, mocked Task 7 test. ✓
+- `resolveIndicatorLabels(events): Promise<Record<string,string>>` — Task 7 def/test, Task 9 page call. ✓
+- `EconomicCalendarGridProps.labels?: Record<string,string>` — Task 8 def matches Task 9 usage (`labels={indicatorLabels}`). ✓
+- Constants `INDICATOR_TRANSLATION_CACHE_TAG`/`INDICATOR_TRANSLATION_FLAG_*`/`INDICATOR_TRANSLATION_REVALIDATE_SECONDS` — defined Tasks 4/7-Step4, consumed Tasks 5/6/7. ✓
+- CORE `translateIndicatorName(normalizedName: string): Promise<string>` — contract in CROSS-REPO note, mocked Task 6 test, imported Task 6 action. ✓
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-20-economy-calendar-SP-B-name-translation.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-06-20-economy-calendar-SP-C-impact-filter.md
+++ b/docs/superpowers/plans/2026-06-20-economy-calendar-SP-C-impact-filter.md
@@ -1,0 +1,903 @@
+# SP-C — 경제 캘린더 중요도 필터 UI 구현 계획 (2026-06-20)
+
+## Goal
+
+`EconomicCalendarGrid`(#610) 상단에 **영향도(High/Medium/Low) 필터 칩**을 추가한다.
+사용자가 칩을 토글하면 캘린더 셀의 **임팩트 점·건수·인라인 미리보기**와 **선택일 상세 패널**이
+선택된 impact만 보이도록 **시각적으로** 한정된다. 단, 전체 이벤트는 **항상 DOM에 유지**되어
+SSR 크롤러가 색인할 수 있다(조건부 렌더/unmount 금지, `hidden` 속성 토글만 사용).
+기본값은 **High + Medium ON, Low OFF**(연간 Low 2,919건 노이즈 정리).
+
+## Architecture
+
+- **레이어**: `widgets/economy` (FSD widgets). 상위 레이어 import 없음, 클라 컴포넌트(`'use client'`).
+- **신규 컴포넌트**: `ImpactFilter` — segmented toggle 칩 그룹. `widgets/financials/PeriodToggle`의
+  `role="group"` + `aria-pressed` 패턴을 미러링하되, **다중 선택**(독립 토글)이라는 점이 다르다
+  (PeriodToggle은 단일 택일). 따라서 `value: ReadonlySet<CalendarImpact>` + `onToggle(impact)` 시그니처.
+- **상태 소유**: `EconomicCalendarGrid`가 `activeImpacts: Set<CalendarImpact>` 클라 상태(useState)를 소유하고
+  `ImpactFilter`에 내려준다. 필터는 prop drilling으로 `MonthCalendar → DayCell`, 그리고
+  `DayDetailPanel`까지 전달된다.
+- **필터 적용 방식 (핵심 결정)**:
+  - **DayCell(점/건수/인라인)**: 비활성 impact의 이벤트를 **미리 제외한 파생 값**으로 렌더한다.
+    셀 내용은 SEO에 핵심이 아니다(상세 패널이 전체 이벤트 텍스트를 이미 DOM에 보유). 점/건수/미리보기는
+    파생(useMemo 없이 props 기반 계산 — DayCell은 cell당 가벼움)으로 활성 impact만 반영.
+    단, **건수가 0이 되어도 날짜 버튼 자체는 유지**(빈 상태 점 없음 + "0건").
+  - **DayDetailPanel(상세 목록)**: 모든 `<li>`를 **항상 렌더**하되, impact가 비활성인 항목에
+    `hidden` 속성을 부여한다. → DOM에는 남아 크롤러가 색인, 시각·a11y 트리에서는 제거.
+    이는 패널 자체가 비선택 시 `hidden`되는 기존 SSR 패턴과 **중첩**된다(패널 hidden ∨ 항목 hidden).
+- **결정론/ISR**: `Date.now()`/`new Date()` 무인수 호출 없음(기존 그리드 제약 그대로). 기본 활성 집합은
+  module-level 상수에서 파생한 결정론적 초기값.
+
+## Tech Stack
+
+- React 19 (`useState`, `useMemo`, `useEffectEvent` — 기존 그리드와 동일), TypeScript strict.
+- `@y0ngha/siglens-core`의 `CalendarImpact`(`'High' | 'Medium' | 'Low'`) 타입.
+- Tailwind v4 semantic tokens(`ui-danger-text`, `ui-warning-text`, `secondary-*`, `primary-*`).
+- vitest + @testing-library/react (jsdom project — `.test.tsx`는 자동으로 `dom` 프로젝트에서 실행되므로
+  `@vitest-environment` 헤더 불필요).
+
+---
+
+## REQUIRED SUB-SKILL: subagent-driven-development
+
+이 계획은 `subagent-driven-development`로 실행한다. 각 TDD 태스크를 독립 sub-agent에 디스패치하고,
+태스크 사이에 게이트(tsc/eslint/prettier/vitest)를 통과시킨다.
+
+> 체크박스 표기: 모든 `- [ ]` 항목은 **완료 시 `- [x]`로 표시**한다. 한 태스크의 모든 스텝이
+> 끝나고 게이트가 통과해야 다음 태스크로 진행한다. 실패 시 멈추고 보고.
+
+---
+
+## File Structure
+
+| 파일 | 상태 | 책임 |
+|---|---|---|
+| `src/widgets/economy/sections/ImpactFilter.tsx` | **신규** | 영향도 필터 칩 그룹(`role="group"`, 토글 버튼 `aria-pressed`). 다중 선택, `value`/`onToggle` 제어 컴포넌트. |
+| `src/widgets/economy/__tests__/ImpactFilter.test.tsx` | **신규** | ImpactFilter 단위 테스트(렌더·aria-pressed·onToggle·group label). |
+| `src/widgets/economy/sections/EconomicCalendarGrid.tsx` | **수정** | `activeImpacts` 상태 추가, `ImpactFilter` 마운트, 필터를 `MonthCalendar`/`DayCell`/`DayDetailPanel`로 전달. DayCell 점/건수/미리보기를 활성 impact로 한정, DayDetailPanel 항목에 `hidden` 부여. |
+| `src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx` | **수정** | 기존 스타일 확장 — 기본 필터 상태, 토글 시 표시 변화, 전체 이벤트 DOM 유지(크롤). |
+| `src/widgets/economy/index.ts` | **수정(선택)** | `ImpactFilter`는 그리드 내부 전용이라 barrel export 불필요. **export 추가하지 않음**(내부 컴포넌트). |
+
+> `ImpactFilter`는 `EconomicCalendarGrid` 외부에서 쓰이지 않으므로 barrel(`index.ts`)에
+> 노출하지 않는다. 기존 `EconomicCalendarGrid as EconomicCalendar` 단일 진입점을 유지한다.
+
+공유 상수 결정:
+- `IMPACT_LABELS`(높음/보통/낮음), `IMPACT_ORDER`(High→Medium→Low)는 현재 `EconomicCalendarGrid.tsx`
+  module-level에 있다. `ImpactFilter`도 이 둘이 필요하다. **순환 import를 피하기 위해**,
+  두 컴포넌트가 같은 파일 트리에 있으므로 `ImpactFilter.tsx`는 자체 `FILTER_IMPACTS`/`FILTER_LABEL`를
+  로컬로 정의한다(작은 중복 < 모듈 분리 오버엔지니어링). 라벨 텍스트는 `IMPACT_LABELS`와 동일하게 맞춘다.
+  (만약 리뷰에서 중복 지적 시, `src/widgets/economy/sections/impactMeta.ts` 추출은 후속 정리로 둔다 —
+  본 SP-C 범위에서는 동작·테스트가 우선.)
+
+---
+
+## TDD 태스크
+
+각 태스크는 **실패 테스트 작성 → 실패 확인 → 최소 구현 → 통과 확인 → 커밋** 순서다.
+명령은 정확한 경로/메시지를 그대로 사용한다.
+
+---
+
+### Task 1 — `ImpactFilter` 컴포넌트 (칩 그룹, 다중 선택)
+
+**Files**
+- 신규: `src/widgets/economy/sections/ImpactFilter.tsx`
+- 신규: `src/widgets/economy/__tests__/ImpactFilter.test.tsx`
+
+- [ ] **실패 테스트 작성** — `src/widgets/economy/__tests__/ImpactFilter.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { CalendarImpact } from '@y0ngha/siglens-core';
+
+import { ImpactFilter } from '@/widgets/economy/sections/ImpactFilter';
+
+const ALL_ON = new Set<CalendarImpact>(['High', 'Medium', 'Low']);
+const DEFAULT = new Set<CalendarImpact>(['High', 'Medium']);
+
+describe('ImpactFilter', () => {
+    it('High/Medium/Low 칩 3개를 버튼으로 렌더한다', () => {
+        render(<ImpactFilter value={ALL_ON} onToggle={vi.fn()} />);
+        expect(
+            screen.getByRole('button', { name: '높음' })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: '보통' })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: '낮음' })
+        ).toBeInTheDocument();
+    });
+
+    it('"중요도 필터" 레이블의 group role로 감싼다', () => {
+        render(<ImpactFilter value={ALL_ON} onToggle={vi.fn()} />);
+        expect(
+            screen.getByRole('group', { name: '중요도 필터' })
+        ).toBeInTheDocument();
+    });
+
+    it('활성 impact 칩만 aria-pressed=true 다', () => {
+        render(<ImpactFilter value={DEFAULT} onToggle={vi.fn()} />);
+        expect(
+            screen.getByRole('button', { name: '높음' })
+        ).toHaveAttribute('aria-pressed', 'true');
+        expect(
+            screen.getByRole('button', { name: '보통' })
+        ).toHaveAttribute('aria-pressed', 'true');
+        expect(
+            screen.getByRole('button', { name: '낮음' })
+        ).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('칩 클릭 시 해당 impact로 onToggle을 호출한다', () => {
+        const onToggle = vi.fn();
+        render(<ImpactFilter value={DEFAULT} onToggle={onToggle} />);
+        fireEvent.click(screen.getByRole('button', { name: '낮음' }));
+        expect(onToggle).toHaveBeenCalledWith('Low');
+    });
+
+    it('각 칩 버튼은 type=button 이다 (form submit 방지)', () => {
+        render(<ImpactFilter value={ALL_ON} onToggle={vi.fn()} />);
+        for (const name of ['높음', '보통', '낮음']) {
+            expect(
+                screen.getByRole('button', { name })
+            ).toHaveAttribute('type', 'button');
+        }
+    });
+});
+```
+
+- [ ] **실패 확인 (run-to-fail)**:
+
+```bash
+npx vitest run src/widgets/economy/__tests__/ImpactFilter.test.tsx
+```
+
+기대: `Failed to resolve import "@/widgets/economy/sections/ImpactFilter"` (모듈 없음) →
+5개 테스트 전부 실패.
+
+- [ ] **최소 구현** — `src/widgets/economy/sections/ImpactFilter.tsx`:
+
+```tsx
+'use client';
+
+import type { CalendarImpact } from '@y0ngha/siglens-core';
+
+import { cn } from '@/shared/lib/cn';
+
+/** 필터 칩 렌더 순서 — High → Medium → Low (그리드 IMPACT_ORDER와 동일) */
+const FILTER_IMPACTS: readonly CalendarImpact[] = ['High', 'Medium', 'Low'];
+
+/** 칩 한국어 레이블 — 그리드 IMPACT_LABELS와 동일하게 유지 */
+const FILTER_LABEL: Record<CalendarImpact, string> = {
+    High: '높음',
+    Medium: '보통',
+    Low: '낮음',
+};
+
+/** 활성 시 칩 색상 — 그리드 IMPACT_BADGE 색 계열과 일치(임팩트 식별성 유지) */
+const FILTER_ACTIVE: Record<CalendarImpact, string> = {
+    High: 'border-ui-danger/50 bg-ui-danger/15 text-ui-danger-text',
+    Medium: 'border-ui-warning/50 bg-ui-warning/15 text-ui-warning-text',
+    Low: 'border-secondary-500 bg-secondary-700 text-secondary-200',
+};
+
+interface ImpactFilterProps {
+    value: ReadonlySet<CalendarImpact>;
+    onToggle: (impact: CalendarImpact) => void;
+}
+
+/**
+ * 경제 캘린더 중요도(영향도) 필터 — 다중 선택 토글 칩 그룹.
+ *
+ * `PeriodToggle`의 `role="group"` + `aria-pressed` 패턴을 미러링하되,
+ * 단일 택일이 아니라 각 칩을 독립 토글하는 다중 선택이다(`value`는 활성 집합).
+ *
+ * 시각 필터 전용: 이 컴포넌트는 어떤 이벤트도 DOM에서 제거하지 않는다.
+ * 상위 그리드가 `value`를 받아 셀/상세를 시각적으로 한정한다.
+ */
+export function ImpactFilter({ value, onToggle }: ImpactFilterProps) {
+    return (
+        <div
+            role="group"
+            aria-label="중요도 필터"
+            className="mb-3 flex items-center gap-2"
+        >
+            {FILTER_IMPACTS.map(impact => {
+                const active = value.has(impact);
+                return (
+                    <button
+                        key={impact}
+                        type="button"
+                        aria-pressed={active}
+                        onClick={() => onToggle(impact)}
+                        className={cn(
+                            'focus-visible:ring-primary-500 inline-flex min-h-11 touch-manipulation items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none motion-reduce:transition-none',
+                            active
+                                ? FILTER_ACTIVE[impact]
+                                : 'border-secondary-700 text-secondary-500 hover:text-secondary-300'
+                        )}
+                    >
+                        <span
+                            aria-hidden="true"
+                            className={cn(
+                                'inline-block h-1.5 w-1.5 rounded-full',
+                                active
+                                    ? 'bg-current'
+                                    : 'bg-secondary-600'
+                            )}
+                        />
+                        {FILTER_LABEL[impact]}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}
+```
+
+- [ ] **통과 확인 (run-to-pass)**:
+
+```bash
+npx vitest run src/widgets/economy/__tests__/ImpactFilter.test.tsx
+```
+
+기대: 5 passed.
+
+- [ ] **게이트**:
+
+```bash
+npx tsc --noEmit && npx eslint src/widgets/economy/sections/ImpactFilter.tsx src/widgets/economy/__tests__/ImpactFilter.test.tsx && npx prettier --check src/widgets/economy/sections/ImpactFilter.tsx src/widgets/economy/__tests__/ImpactFilter.test.tsx
+```
+
+기대: 에러 없음. 포맷 불일치 시 `npx prettier --write <paths>` 후 재확인.
+
+- [ ] **커밋**:
+
+```bash
+git add src/widgets/economy/sections/ImpactFilter.tsx src/widgets/economy/__tests__/ImpactFilter.test.tsx
+git commit -m "feat(economy): add ImpactFilter chip group for calendar (SP-C)"
+```
+
+---
+
+### Task 2 — 그리드에 필터 상태 + `ImpactFilter` 마운트 (DayCell 점/건수 한정)
+
+**Files**
+- 수정: `src/widgets/economy/sections/EconomicCalendarGrid.tsx`
+- 수정: `src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx`
+
+이 태스크는 (a) 필터 상태/칩을 그리드에 붙이고, (b) **DayCell의 점·건수·인라인 미리보기**가
+활성 impact만 반영하도록 한다. DayDetailPanel 항목 필터는 Task 3에서 다룬다.
+
+- [ ] **실패 테스트 작성** — 기존 `EconomicCalendarGrid.test.tsx` 끝에 describe 블록 추가:
+
+```tsx
+describe('EconomicCalendarGrid — 중요도 필터 (기본 상태 · 셀 건수)', () => {
+    it('"중요도 필터" group이 렌더된다', () => {
+        render(<EconomicCalendarGrid events={[EVENT_A, EVENT_C]} />);
+        expect(
+            screen.getByRole('group', { name: '중요도 필터' })
+        ).toBeInTheDocument();
+    });
+
+    it('기본값은 High+Medium ON, Low OFF (칩 aria-pressed)', () => {
+        render(<EconomicCalendarGrid events={[EVENT_A, EVENT_B, EVENT_C]} />);
+        const group = screen.getByRole('group', { name: '중요도 필터' });
+        expect(
+            within(group).getByRole('button', { name: '높음' })
+        ).toHaveAttribute('aria-pressed', 'true');
+        expect(
+            within(group).getByRole('button', { name: '보통' })
+        ).toHaveAttribute('aria-pressed', 'true');
+        expect(
+            within(group).getByRole('button', { name: '낮음' })
+        ).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('기본 상태에서 날짜 셀 건수는 활성 impact만 센다 (Low 제외)', () => {
+        // EVENT_A(High)+EVENT_B(Medium) → KST 6/20, EVENT_C(Low) → KST 6/21.
+        // 기본 필터: Low OFF → 6/21 셀은 0건, 6/20 셀은 2건.
+        render(<EconomicCalendarGrid events={[EVENT_A, EVENT_B, EVENT_C]} />);
+        expect(
+            screen.getByRole('button', { name: /6월 20일.*이벤트 2건/ })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /6월 21일.*이벤트 0건/ })
+        ).toBeInTheDocument();
+    });
+
+    it('Low 칩을 켜면 Low 날짜 셀 건수가 다시 카운트된다', () => {
+        render(<EconomicCalendarGrid events={[EVENT_A, EVENT_B, EVENT_C]} />);
+        const group = screen.getByRole('group', { name: '중요도 필터' });
+        fireEvent.click(within(group).getByRole('button', { name: '낮음' }));
+        expect(
+            screen.getByRole('button', { name: /6월 21일.*이벤트 1건/ })
+        ).toBeInTheDocument();
+    });
+
+    it('High 칩을 끄면 High 셀 건수가 줄어든다', () => {
+        render(<EconomicCalendarGrid events={[EVENT_A, EVENT_B, EVENT_C]} />);
+        const group = screen.getByRole('group', { name: '중요도 필터' });
+        // 기본: 6/20 = High(A)+Medium(B) = 2건. High 끄면 Medium만 → 1건.
+        fireEvent.click(within(group).getByRole('button', { name: '높음' }));
+        expect(
+            screen.getByRole('button', { name: /6월 20일.*이벤트 1건/ })
+        ).toBeInTheDocument();
+    });
+});
+```
+
+> 위 테스트는 `within`을 사용한다. 파일 상단 import를 확장한다(실패 테스트 작성 시 함께 수정):
+> `import { render, screen, fireEvent, within } from '@testing-library/react';`
+> (기존 import 라인을 이 라인으로 교체.)
+
+> 주의 — **기존 KST 그룹핑 테스트 회귀 방지**: 기존
+> `it('ET 날짜가 다르더라도 같은 KST 날이면 한 그룹으로 묶인다')`는 `[EVENT_A, EVENT_B]`(High+Medium)로
+> `이벤트 2건`을 단언한다. 둘 다 기본 활성이므로 셀 건수는 여전히 2건 → **회귀 없음**. 단,
+> `it('KST 날이 다른 이벤트는 별도 날짜 버튼으로 렌더된다')`와 기본-선택/SSR 테스트는 `EVENT_C`(Low)를
+> 사용한다. 이들은 `aria-label`의 **날짜 부분**(`/6월 21일/`)만 매치하므로 건수 변화(`0건`)에 영향받지
+> 않는다 — 정규식이 건수를 포함하지 않으면 통과 유지. 회귀 확인을 위해 Task 2 게이트에서
+> **전체 파일**을 돌린다.
+
+- [ ] **실패 확인 (run-to-fail)**:
+
+```bash
+npx vitest run src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
+```
+
+기대: 신규 describe의 5개 테스트 실패(`role="group" name="중요도 필터"` 없음, 셀 건수가 필터 무시).
+기존 테스트는 통과 유지(import에 `within` 추가만으로는 깨지지 않음).
+
+- [ ] **최소 구현** — `EconomicCalendarGrid.tsx` 수정:
+
+**(2-1) ImpactFilter import 추가** (파일 상단 import 블록, `etTimeUtils` import 다음 줄):
+
+```tsx
+import { ImpactFilter } from '@/widgets/economy/sections/ImpactFilter';
+```
+
+**(2-2) 기본 활성 집합 상수** (module-level, `INLINE_EVENT_MAX` 상수 아래에 추가):
+
+```tsx
+/**
+ * 중요도 필터 기본값 — High+Medium ON, Low OFF.
+ * 연간 Low 이벤트가 2,919건으로 대다수라 기본 노출 시 노이즈가 크다(스펙 SP-C).
+ * 결정론적 초기값 — 렌더 중 시각/난수 의존 없음(ISR 안전).
+ */
+const DEFAULT_ACTIVE_IMPACTS: readonly CalendarImpact[] = ['High', 'Medium'];
+```
+
+**(2-3) DayCell: 활성 impact prop 수용 + 점/건수/미리보기 한정**.
+`DayCellProps`와 `DayCell` 본문을 아래로 교체:
+
+```tsx
+interface DayCellProps {
+    group: DayGroup;
+    isSelected: boolean;
+    activeImpacts: ReadonlySet<CalendarImpact>;
+    onSelect: (dateKey: string) => void;
+}
+
+function DayCell({ group, isSelected, activeImpacts, onSelect }: DayCellProps) {
+    const { day, month, dateKey } = group;
+
+    /**
+     * 활성 impact만 남긴 이벤트 — 셀의 점·건수·인라인 미리보기에 사용.
+     * 시각 필터(셀은 SEO 비핵심, 전체 텍스트는 상세 패널이 DOM에 보유).
+     */
+    const visibleEvents = group.events.filter(e =>
+        activeImpacts.has(e.original.impact)
+    );
+    const count = visibleEvents.length;
+
+    /**
+     * 임팩트 종류 집합 — 점 렌더 순서(High → Medium → Low)를 위해 순서 유지.
+     * 동일 날짜에 High가 여러 건이어도 점은 1개만 표시한다(시각적 노이즈 감소).
+     */
+    const impactSet = new Set(visibleEvents.map(e => e.original.impact));
+    const dots = IMPACT_ORDER.filter(i => impactSet.has(i));
+
+    return (
+        <td className="p-0.5 align-top">
+            <button
+                id={`day-btn-${dateKey}`}
+                type="button"
+                aria-label={`${month + 1}월 ${day}일, 이벤트 ${count}건`}
+                aria-pressed={isSelected}
+                aria-controls={`panel-${dateKey}`}
+                onClick={() => onSelect(dateKey)}
+                className={cn(
+                    'relative min-h-[4rem] w-full rounded-lg p-1 text-left text-xs transition-colors',
+                    'focus-visible:ring-primary-500 focus-visible:ring-2 focus-visible:outline-none',
+                    'motion-reduce:transition-none',
+                    isSelected
+                        ? 'bg-primary-900/30 ring-primary-500 ring-2'
+                        : 'hover:bg-secondary-700/40'
+                )}
+            >
+                <span
+                    className={cn(
+                        'block text-right text-[11px] leading-none tabular-nums',
+                        isSelected
+                            ? 'text-primary-400 font-semibold'
+                            : 'text-secondary-200 font-medium'
+                    )}
+                >
+                    {day}
+                </span>
+
+                <span
+                    aria-hidden="true"
+                    className="mt-1 flex flex-wrap gap-0.5"
+                >
+                    {dots.map(impact => (
+                        <span
+                            key={impact}
+                            className={cn(
+                                'inline-block h-1.5 w-1.5 rounded-full',
+                                IMPACT_DOT[impact]
+                            )}
+                        />
+                    ))}
+                </span>
+
+                <span className="text-secondary-300 mt-0.5 block text-[10px] tabular-nums">
+                    {count}건
+                </span>
+
+                <span className="mt-1 hidden space-y-0.5 sm:block">
+                    {visibleEvents.slice(0, INLINE_EVENT_MAX).map(ev => (
+                        <span
+                            key={`${ev.iso}:${ev.original.event}`}
+                            className="text-secondary-400 block min-w-0 truncate text-[10px] leading-tight"
+                        >
+                            {ev.kstTimeLabel.replace(/^(오전|오후)\s*/, '')}{' '}
+                            {ev.original.event}
+                        </span>
+                    ))}
+                    {count > INLINE_EVENT_MAX && (
+                        <span className="text-secondary-500 block text-[10px]">
+                            +{count - INLINE_EVENT_MAX}
+                        </span>
+                    )}
+                </span>
+            </button>
+        </td>
+    );
+}
+```
+
+**(2-4) MonthCalendar: activeImpacts 통과**.
+`MonthCalendarProps`에 `activeImpacts` 추가하고, 구조분해·`DayCell` 호출에 전달:
+
+```tsx
+interface MonthCalendarProps {
+    year: number;
+    /** 0-indexed */
+    month: number;
+    groupMap: Map<string, DayGroup>;
+    selectedDateKey: string;
+    activeImpacts: ReadonlySet<CalendarImpact>;
+    onSelect: (dateKey: string) => void;
+}
+
+function MonthCalendar({
+    year,
+    month,
+    groupMap,
+    selectedDateKey,
+    activeImpacts,
+    onSelect,
+}: MonthCalendarProps) {
+```
+
+그리고 `MonthCalendar` 본문의 `<DayCell ... />` 호출에 `activeImpacts={activeImpacts}` 추가:
+
+```tsx
+                                    <DayCell
+                                        key={cell.dateKey}
+                                        group={cell}
+                                        isSelected={
+                                            selectedDateKey === cell.dateKey
+                                        }
+                                        activeImpacts={activeImpacts}
+                                        onSelect={onSelect}
+                                    />
+```
+
+**(2-5) `EconomicCalendarGrid`: 필터 상태 + 칩 마운트 + MonthCalendar에 전달**.
+컴포넌트 본문 hook 영역(§17 순서 준수: useState → useMemo → useEffectEvent → useEffect 순)에
+`activeImpacts` 상태와 `toggleImpact` 핸들러를 추가한다.
+
+기존:
+
+```tsx
+export function EconomicCalendarGrid({ events }: EconomicCalendarGridProps) {
+    const [selectedDateKey, setSelectedDateKey] = useState('');
+    const groups = useMemo(() => groupEventsByKstDay(events), [events]);
+```
+
+로 시작하는 부분을 아래로 교체(상태 1개 추가):
+
+```tsx
+export function EconomicCalendarGrid({ events }: EconomicCalendarGridProps) {
+    const [selectedDateKey, setSelectedDateKey] = useState('');
+    const [activeImpacts, setActiveImpacts] = useState<
+        ReadonlySet<CalendarImpact>
+    >(() => new Set(DEFAULT_ACTIVE_IMPACTS));
+    const groups = useMemo(() => groupEventsByKstDay(events), [events]);
+```
+
+핸들러는 hook 순서상 useEffect **이전**(derived/handlers 구간)에 둔다. 기존 `useEffect(...)` **위**에
+`toggleImpact`를 추가한다(setState만 호출하므로 useCallback 불필요 — 안정 참조가 필요한 의존성 없음):
+
+```tsx
+    const months = useMemo(() => spannedMonths(groups), [groups]);
+
+    function toggleImpact(impact: CalendarImpact): void {
+        setActiveImpacts(prev => {
+            const next = new Set(prev);
+            if (next.has(impact)) {
+                next.delete(impact);
+            } else {
+                next.add(impact);
+            }
+            return next;
+        });
+    }
+
+    const syncDefault = useEffectEvent((): void => {
+```
+
+> §17 순서: `useState ×2 → useMemo ×3 → const toggleImpact(handler) → useEffectEvent → useEffect`.
+> `toggleImpact`는 파생/핸들러 구간(useMemo 뒤, useEffect 앞)이므로 순서 위반 아님.
+> `toggleImpact`는 effect 의존성에 들어가지 않으므로 `useEffectEvent`/`useCallback` 불필요.
+
+**JSX 변경 1 — `ImpactFilter` 마운트**: `<h2>` 닫는 태그 다음, 캘린더 `<div className="border-...">`
+**앞**에 칩을 둔다:
+
+```tsx
+            <ImpactFilter value={activeImpacts} onToggle={toggleImpact} />
+
+            <div className="border-secondary-700 space-y-6 rounded-xl border p-3 sm:p-4">
+```
+
+**JSX 변경 2 — `MonthCalendar`에 activeImpacts 전달**:
+
+```tsx
+                    <MonthCalendar
+                        key={`${year}-${month}`}
+                        year={year}
+                        month={month}
+                        groupMap={groupMap}
+                        selectedDateKey={selectedDateKey}
+                        activeImpacts={activeImpacts}
+                        onSelect={setSelectedDateKey}
+                    />
+```
+
+> **빈 상태 분기 주의**: `if (events.length === 0)` early-return은 그대로 둔다. 필터 칩은
+> 이벤트가 0건이면 의미 없으므로 빈 상태에는 렌더하지 않는다(기존 빈 상태 블록 미변경).
+
+- [ ] **통과 확인 (run-to-pass)**:
+
+```bash
+npx vitest run src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
+```
+
+기대: 신규 5 + 기존 전부 passed(회귀 0). `0건` 단언이 통과하는지 확인.
+
+- [ ] **게이트**:
+
+```bash
+npx tsc --noEmit && npx eslint src/widgets/economy/sections/EconomicCalendarGrid.tsx src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx && npx prettier --check src/widgets/economy/sections/EconomicCalendarGrid.tsx src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
+```
+
+기대: 에러 없음.
+
+- [ ] **커밋**:
+
+```bash
+git add src/widgets/economy/sections/EconomicCalendarGrid.tsx src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
+git commit -m "feat(economy): wire impact filter state to calendar cells (SP-C)"
+```
+
+---
+
+### Task 3 — `DayDetailPanel` 항목 시각 필터 (`hidden`, DOM 유지)
+
+**Files**
+- 수정: `src/widgets/economy/sections/EconomicCalendarGrid.tsx`
+- 수정: `src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx`
+
+상세 패널의 각 이벤트 `<li>`를 항상 렌더하되, impact가 비활성이면 `hidden` 속성을 부여한다.
+→ 크롤러는 전체 텍스트 색인(DOM 유지), 사용자/스크린리더는 활성 impact만 본다.
+
+- [ ] **실패 테스트 작성** — `EconomicCalendarGrid.test.tsx`에 describe 추가:
+
+```tsx
+describe('EconomicCalendarGrid — 중요도 필터 (상세 패널 · DOM 유지)', () => {
+    it('비활성 impact 이벤트도 상세 패널 DOM에 남는다 (크롤러 색인)', () => {
+        // EVENT_C(Low) → KST 6/21. 기본 필터 Low OFF.
+        // 6/21을 선택해 패널을 열어도, Low 항목은 hidden이지만 DOM엔 존재해야 한다.
+        const { container } = render(
+            <EconomicCalendarGrid events={[EVENT_A, EVENT_B, EVENT_C]} />
+        );
+        const group = screen.getByRole('group', { name: '중요도 필터' });
+        // 패널을 열기 위해 6/21 날짜 버튼 클릭(Low 칩은 여전히 OFF)
+        fireEvent.click(screen.getByRole('button', { name: /6월 21일/ }));
+        // Low 칩 OFF 상태이므로 화면(getByText)에는 안 보이지만 DOM엔 있다.
+        expect(container.textContent).toContain('Unemployment Claims');
+        // 해당 li가 hidden 인지 확인
+        const li = screen
+            .getByText('Unemployment Claims')
+            .closest('li');
+        expect(li).toHaveAttribute('hidden');
+        // group 변수는 아래 토글 테스트와 대칭을 위해 참조(미사용 경고 방지)
+        expect(group).toBeInTheDocument();
+    });
+
+    it('활성 impact 이벤트의 상세 li는 hidden이 아니다', () => {
+        // EVENT_A(High) → KST 6/20, 기본 선택 + High 활성.
+        render(<EconomicCalendarGrid events={[EVENT_A, EVENT_B, EVENT_C]} />);
+        const li = screen.getByText('Fed Rate Decision').closest('li');
+        expect(li).not.toHaveAttribute('hidden');
+    });
+
+    it('Low 칩을 켜면 상세 패널의 Low li에서 hidden이 사라진다', () => {
+        render(<EconomicCalendarGrid events={[EVENT_A, EVENT_B, EVENT_C]} />);
+        const group = screen.getByRole('group', { name: '중요도 필터' });
+        fireEvent.click(screen.getByRole('button', { name: /6월 21일/ }));
+        // 켜기 전: hidden
+        expect(
+            screen.getByText('Unemployment Claims').closest('li')
+        ).toHaveAttribute('hidden');
+        // Low 켜기
+        fireEvent.click(within(group).getByRole('button', { name: '낮음' }));
+        expect(
+            screen.getByText('Unemployment Claims').closest('li')
+        ).not.toHaveAttribute('hidden');
+    });
+
+    it('Medium 칩을 끄면 상세 패널의 Medium li가 hidden 된다', () => {
+        // EVENT_B(Medium) → KST 6/20, 기본 선택일.
+        render(<EconomicCalendarGrid events={[EVENT_A, EVENT_B, EVENT_C]} />);
+        const group = screen.getByRole('group', { name: '중요도 필터' });
+        // 기본: Medium ON → CPI Release li는 hidden 아님
+        expect(
+            screen.getByText('CPI Release').closest('li')
+        ).not.toHaveAttribute('hidden');
+        fireEvent.click(within(group).getByRole('button', { name: '보통' }));
+        expect(
+            screen.getByText('CPI Release').closest('li')
+        ).toHaveAttribute('hidden');
+    });
+});
+```
+
+> 주의: `screen.getByText`는 `hidden` 요소도 매치한다(기본 `ignore: 'style'`만, `hidden` 속성은
+> jsdom에서 텍스트 조회 자체를 막지 않는다 — `getByRole`만 hidden을 제외). 따라서 hidden li의
+> 텍스트도 `getByText`로 잡힌다. 위 테스트는 이를 전제로 한다(검증 완료 패턴: 기존 SSR 테스트는
+> hidden 패널 텍스트를 `container.textContent`로 확인하지만, `getByText`도 hidden li 텍스트를 찾는다).
+
+- [ ] **실패 확인 (run-to-fail)**:
+
+```bash
+npx vitest run src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
+```
+
+기대: 신규 4개 실패(`<li>`에 `hidden` 속성 없음 — 현재 패널은 모든 항목을 무조건 표시).
+
+- [ ] **최소 구현** — `EconomicCalendarGrid.tsx`의 `DayDetailPanel` 수정.
+
+**(3-1) `DayDetailPanelProps`에 `activeImpacts` 추가**:
+
+```tsx
+interface DayDetailPanelProps {
+    group: DayGroup;
+    isSelected: boolean;
+    activeImpacts: ReadonlySet<CalendarImpact>;
+}
+
+function DayDetailPanel({
+    group,
+    isSelected,
+    activeImpacts,
+}: DayDetailPanelProps) {
+```
+
+**(3-2) `<li>`에 `hidden` 속성 부여** — `group.events.map(ev => (` 의 `<li>` 여는 태그를 교체.
+기존:
+
+```tsx
+                {group.events.map(ev => (
+                    <li
+                        key={`${ev.iso}:${ev.original.event}:${ev.original.actual ?? ''}`}
+                        className="border-secondary-700 bg-secondary-800/50 rounded-lg border p-3"
+                    >
+```
+
+교체 후:
+
+```tsx
+                {group.events.map(ev => (
+                    <li
+                        key={`${ev.iso}:${ev.original.event}:${ev.original.actual ?? ''}`}
+                        hidden={!activeImpacts.has(ev.original.impact)}
+                        className="border-secondary-700 bg-secondary-800/50 rounded-lg border p-3"
+                    >
+```
+
+> **시각 필터 / DOM 유지 원칙**: 조건부 렌더(`{cond && <li>}`)나 배열 `.filter()`로 항목을
+> 제거하지 **않는다**. `hidden` 속성만 토글 → 크롤러는 전체 이벤트 텍스트를 색인하고,
+> 사용자·스크린리더(a11y 트리)는 활성 impact만 본다. 이는 비선택 패널을 `hidden`으로 유지하는
+> 기존 SSR 패턴과 동일한 철학이며, 패널-레벨 `hidden`과 항목-레벨 `hidden`이 OR로 중첩된다.
+
+**(3-3) `EconomicCalendarGrid` 본문의 `<DayDetailPanel ... />` 호출에 `activeImpacts` 전달**:
+
+```tsx
+                {groups.map(group => (
+                    <DayDetailPanel
+                        key={group.dateKey}
+                        group={group}
+                        isSelected={group.dateKey === selectedDateKey}
+                        activeImpacts={activeImpacts}
+                    />
+                ))}
+```
+
+- [ ] **통과 확인 (run-to-pass)**:
+
+```bash
+npx vitest run src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
+```
+
+기대: 신규 4 + Task 2 신규 5 + 기존 전부 passed.
+
+> **기존 SSR 테스트 회귀 확인**: 기존
+> `it('비선택 패널은 hidden 속성을 가진다')` 등은 **패널 div**(`#panel-...`)의 hidden을 확인하지,
+> li의 hidden과 무관 → 영향 없음. 기존 `it('임팩트 뱃지 한국어 레이블 표시 (High → 높음)')`는
+> `[EVENT_A]`(High 단건)로 `getAllByText('높음')` 길이 1을 단언한다. **주의**: 이제 화면에
+> `ImpactFilter` 칩 "높음"이 추가로 렌더된다 → `getAllByText('높음')`이 **2개**(칩 + 뱃지)로 잡혀
+> **회귀**한다. → 아래 (3-4)에서 이 기존 테스트를 수정한다.
+
+**(3-4) 기존 테스트 회귀 수정** — `EconomicCalendarGrid.test.tsx`의
+`it('임팩트 뱃지 한국어 레이블 표시 (High → 높음)')`를 칩과 뱃지를 구분하도록 교체. 기존:
+
+```tsx
+    it('임팩트 뱃지 한국어 레이블 표시 (High → 높음)', () => {
+        render(<EconomicCalendarGrid events={[EVENT_A]} />);
+        // EVENT_A 1건(High) → 상세 패널에 뱃지 1개만 렌더됨
+        expect(screen.getAllByText('높음')).toHaveLength(1);
+    });
+```
+
+교체 후 (필터 칩의 "높음" 버튼을 제외하고 패널 뱃지 span만 검증):
+
+```tsx
+    it('임팩트 뱃지 한국어 레이블 표시 (High → 높음)', () => {
+        render(<EconomicCalendarGrid events={[EVENT_A]} />);
+        // 화면에는 필터 칩 "높음"(button)과 상세 뱃지 "높음"(span)이 함께 존재.
+        // 뱃지만 검증하기 위해 button role을 제외한 매치를 센다.
+        const highLabels = screen.getAllByText('높음');
+        const badges = highLabels.filter(
+            el => el.closest('button') === null
+        );
+        expect(badges).toHaveLength(1);
+    });
+```
+
+> 이 회귀는 Task 2에서 칩이 마운트되는 시점부터 발생할 수 있다. 만약 Task 2 게이트의 전체-파일
+> 실행에서 이 단언이 먼저 깨지면, (3-4) 수정을 **Task 2로 앞당겨** 적용한다. 계획상 분리해 두었으나
+> 실행 시 깨지는 시점에 맞춰 고친다(둘 다 같은 수정).
+
+- [ ] **게이트**:
+
+```bash
+npx tsc --noEmit && npx eslint src/widgets/economy/sections/EconomicCalendarGrid.tsx src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx && npx prettier --check src/widgets/economy/sections/EconomicCalendarGrid.tsx src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
+```
+
+기대: 에러 없음.
+
+- [ ] **전체 economy 위젯 스위트 회귀 확인**:
+
+```bash
+npx vitest run src/widgets/economy
+```
+
+기대: 모든 economy 테스트 passed(필터 회귀 0).
+
+- [ ] **커밋**:
+
+```bash
+git add src/widgets/economy/sections/EconomicCalendarGrid.tsx src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
+git commit -m "feat(economy): visually filter detail panel items by impact, keep in DOM (SP-C)"
+```
+
+---
+
+### Task 4 — 최종 게이트 (tsc/eslint/prettier 전역) + 빌드 sanity
+
+**Files**: 없음(검증 전용).
+
+- [ ] **타입 + 린트 + 포맷 전역**:
+
+```bash
+npx tsc --noEmit && yarn lint && npx prettier --check "src/widgets/economy/**/*.{ts,tsx}"
+```
+
+기대: 에러 없음. (eslint-disable 금지 §13 — 어떤 suppression도 추가하지 않았는지 확인.)
+
+- [ ] **전체 단위 테스트(dom project) 회귀**:
+
+```bash
+npx vitest run
+```
+
+기대: 전 스위트 passed.
+
+> `yarn build`는 SP-C가 클라 컴포넌트 prop/상태만 바꾸므로 RSC/ISR 경계에 영향 없음. 다만 안전을 위해
+> 시간 여유가 있으면 `yarn build`로 prerender 회귀가 없는지 1회 확인(선택). 이 단계에서 빌드 실패 시
+> exit code를 파이프 없이 직접 캡처(`> /tmp/b.log 2>&1; echo $?`).
+
+- [ ] **커밋 없음** — Task 4는 검증만. 게이트 실패 시 멈추고 보고.
+
+---
+
+## 375px 친화 / 디자인 노트
+
+- 칩 3개(`높음/보통/낮음`) + `gap-2` + `rounded-full px-3` 는 375px 폭에서 한 줄에 충분히 들어간다
+  (각 칩 ≈ 60–72px). 넘칠 우려 시 칩 컨테이너에 `flex-wrap`은 추가하지 않는다(현재 3개 고정 폭이라
+  불필요). 만약 SP-B(긴 라벨)와 결합돼도 칩 라벨은 고정 2글자라 영향 없음.
+- 터치 타깃: 칩 `min-h-11`(44px) — WCAG 터치 타깃 충족(PeriodToggle과 동일).
+- `focus-visible:ring-2` + `motion-reduce:transition-none` — 기존 그리드/토글 컨벤션과 일치.
+- semantic token만 사용(`ui-danger-text`/`ui-warning-text`/`secondary-*`/`primary-*`), 하드코딩 색 없음.
+
+---
+
+## MISTAKES.md 준수 체크
+
+- **§17 hook 순서**: `EconomicCalendarGrid`는 `useState ×2 → useMemo ×3 → const toggleImpact(handler)
+  → useEffectEvent → useEffect`. 파생/핸들러가 useMemo 뒤·useEffect 앞 — 위반 없음.
+- **§13 eslint-disable 금지**: 어떤 suppression도 없음.
+- **named return type**: `toggleImpact(impact): void`, `syncDefault(): void`(기존), `DayCell`/`ImpactFilter`
+  props 인터페이스 명시.
+- **WHAT 주석 금지**: 추가 주석은 전부 WHY(필터 철학·DOM 유지 이유·기본값 근거). WHAT 나열 없음.
+- **useMemo for derived**: DayCell의 `visibleEvents`/`dots`는 **셀당 가벼운 파생**이라 const 유지(기존
+  `dots`도 const였음 — 일관). 그리드-레벨 무거운 파생(`groups`/`groupMap`/`months`)은 기존 useMemo 유지.
+  필터는 이들 입력(events)을 바꾸지 않으므로 재계산 안 일어남(셀 렌더 시점 필터링만).
+- **set-state-in-effect**: `toggleImpact`는 effect가 아닌 onClick 핸들러 → 규칙 무관. 기존 `syncDefault`
+  (useEffectEvent) 패턴 미변경.
+- **exact test assertions**: 모든 단언은 정확값(`이벤트 0건`, `aria-pressed`, `hidden` 유무, `closest('li')`).
+- **role correctness**: 칩 그룹 `role="group" aria-label="중요도 필터"`, 칩 토글 `aria-pressed`(다중 선택엔
+  radio/tab 부적절 — 독립 toggle은 `aria-pressed` 버튼이 정석). 고아 ARIA 없음.
+
+---
+
+## Self-Review — 스펙(SP-C) 커버리지 확인
+
+| 스펙 요구 | 충족 위치 |
+|---|---|
+| 상단 영향도 필터 칩(High/Medium/Low 토글) | `ImpactFilter` (Task 1), 그리드 `<h2>` 아래 마운트 (Task 2) |
+| 클라 상태(useState) | `EconomicCalendarGrid`의 `activeImpacts` useState (Task 2) |
+| 기본값 High+Medium ON, Low OFF | `DEFAULT_ACTIVE_IMPACTS = ['High','Medium']` + 테스트로 aria-pressed 검증 (Task 2) |
+| 셀 점/건수를 선택 impact로 한정 | DayCell `visibleEvents` 필터 → 점·`count`·인라인 미리보기 (Task 2) |
+| 상세 목록을 선택 impact로 한정 | DayDetailPanel `<li hidden>` (Task 3) |
+| 전체 이벤트 DOM 유지(SSR 크롤) — 시각 필터, `hidden`-toggle | li 제거 대신 `hidden` 속성만, `container.textContent` 색인 테스트 (Task 3) |
+| 기존 SSR 패턴과 reconcile(패널 hidden + 항목 hidden 중첩) | DayDetailPanel 패널-div hidden(기존) ∨ li hidden(신규) — 양립 (Task 3 주석) |
+| a11y: 칩 `aria-pressed`, group `role="group" aria-label="중요도 필터"` | `ImpactFilter` (Task 1) |
+| motion-reduce / focus-visible:ring-2 / semantic token | `ImpactFilter` className (Task 1) |
+| 테스트: 기본 필터 상태·토글 시 변화·전체 DOM 유지 | Task 1·2·3 테스트 일체 |
+| MISTAKES.md(§17 등) 준수 | 위 "MISTAKES.md 준수 체크" 전 항목 |
+| 375px 친화 | "375px 친화" 노트 — `min-h-11`, 3 고정칩 1줄 |
+| SP-A 무의존 독립 ship | 그리드 props 무변경(`events`만), DB/페이지 변경 없음 — #610만으로 동작 |
+
+**누락/리스크**:
+- `getAllByText('높음')` 회귀(칩+뱃지) — Task 3 (3-4)에서 명시적으로 고침(실행 시 Task 2에서 먼저
+  깨지면 앞당김).
+- `ImpactFilter` 라벨/순서 상수가 그리드 `IMPACT_LABELS`/`IMPACT_ORDER`와 중복 — 의도적 결정(소규모
+  중복 < 모듈 추출 오버엔지니어링). 리뷰에서 강하게 요구되면 `impactMeta.ts` 추출은 후속.
+- 모든 칩 OFF 시 캘린더가 전부 "0건"이 되는 빈 그리드 — 의도된 동작(사용자 선택), 별도 빈-상태 안내는
+  스펙 범위 밖이라 추가하지 않음(필요 시 후속 UX).

--- a/docs/superpowers/plans/2026-06-20-economy-calendar-SP-D-event-ai-analysis.md
+++ b/docs/superpowers/plans/2026-06-20-economy-calendar-SP-D-event-ai-analysis.md
@@ -1,0 +1,1520 @@
+# Economy Calendar SP-D — Event AI Analysis (Medium+) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add AI sentiment/summary/interpretation to announced Medium+ economic-calendar events. A new migration adds four AI columns (`sentiment`, `summaryKo`, `interpretationKo`, `analyzedAt`) deferred from SP-A; an `ensureEconomicEventsAnalyzedAction` (mirroring `ensureMarketNewsCardsAnalyzedAction`) finds rows where `impact IN ('High','Medium') AND actual IS NOT NULL AND analyzedAt IS NULL`, calls core `analyzeEconomicEvent`, writes the result, and `revalidateTag`s the calendar cache; the `DayDetailPanel` renders a sentiment badge + summary + interpretation for analyzed events.
+
+**Architecture:** SP-D extends the SP-A `economic_calendar` table (DO NOT re-create it — reuse the SP-A `DrizzleEconomicCalendarRepository` and add methods to it). Analysis is **synchronous** (not a submit/poll worker job): the spec defines `analyzeEconomicEvent(input): EconomicEventAnalysis` as a direct call returning a single small JSON, the Medium+ announced volume is low (~140/month, and per-access only the not-yet-analyzed announced subset), and each call is one short structured output — so the macro-briefing submit/poll job queue is overkill here (justification §"Sync vs async" below). The ensure action mirrors market-news's refresh-flag guard + bounded-parallel `Promise.allSettled` + majority-failure guard + single `revalidateTag` on change, but replaces the `submit→poll→attachAnalysis` loop with a direct `analyzeEconomicEvent → attachEventAnalysis` per event. Two trigger modes share the same ensure: SEED (a one-time `tsx` script over all current Medium+ announced rows) and ON-ACCESS (the existing SP-A `useEconomicCalendarTrigger` fires it on `/economy` mount, bots included). The `DayDetailPanel` reads the AI columns off each `EconomicCalendarEvent` (extended with optional analysis fields) and renders a badge + two paragraphs when present.
+
+**Tech Stack:** TypeScript, Drizzle ORM (Neon serverless + `postgres-js` for the seed script), `drizzle-kit` migrations, Next.js 16 (`'use server'` actions + `revalidateTag`), vitest + `@testing-library/react`, `@y0ngha/siglens-core` (`analyzeEconomicEvent`, `EconomicEventAnalysis`, `EconomicEventAnalysisInput`, `EconomicCalendarEvent`, `CalendarImpact`, `NewsSentiment` re-use for the badge tri-state).
+
+---
+
+## ⛔ CROSS-REPO NOTE — core release gates this plan
+
+`analyzeEconomicEvent` is **analysis-domain logic** and lives in **`@y0ngha/siglens-core`** (a separate repo the user publishes, per CLAUDE.md cross-repo guard and the spec table row "이벤트 AI 분석 로직/프롬프트 → siglens-core"). **DO NOT implement the core function in this repo.**
+
+The required ordering is:
+
+1. **User** implements `analyzeEconomicEvent` in siglens-core (prompt, normalization, validation, `PROMPT_TEMPLATE_VERSION` bump), then **publishes** it (`npm version` + `git push --tags` → GitHub Packages; the user does the release, not Claude — see MEMORY `siglens-core release method` + `user handles core publish`).
+2. **This siglens plan** is gated on that release: after the user bumps the published version, siglens updates the `@y0ngha/siglens-core` pin in `package.json` and `yarn install`s, then implements the tasks below.
+3. **Until the core release lands, every siglens task here mocks `analyzeEconomicEvent`** via `vi.mock('@y0ngha/siglens-core', ...)`. The contract below is the exact mock surface — siglens code is written against it, and the only real-core dependency is at runtime after the version pin is updated.
+
+### Exact core contract (defined here, implemented + released by the user in core)
+
+```typescript
+// Published by @y0ngha/siglens-core — siglens imports these types + the function.
+
+/** Input to the per-event analyzer. All numeric fields may be null (pre-/partial release). */
+export interface EconomicEventAnalysisInput {
+    /** FMP event name, e.g. 'Core CPI MoM (May)'. */
+    event: string;
+    /** 'High' | 'Medium' | 'Low' — SP-D only ever calls for High/Medium. */
+    impact: CalendarImpact;
+    /** Announced value. SP-D only calls when actual !== null. */
+    actual: number;
+    estimate: number | null;
+    previous: number | null;
+    unit: string;
+    /**
+     * Optional recent trend (oldest→newest prior actuals) the analyzer may use
+     * for context. SP-D passes it when cheaply available; core must handle [].
+     */
+    recentTrend?: number[];
+}
+
+/** LLM output — small structured JSON, validated + normalized inside core. */
+export interface EconomicEventAnalysis {
+    /** Directional read for risk assets. Re-uses the bullish/neutral/bearish tri-state. */
+    sentiment: 'bullish' | 'neutral' | 'bearish';
+    /** 1–2 sentence Korean summary of what was announced. */
+    summaryKo: string;
+    /** Korean interpretation — why it matters / likely market read. */
+    interpretationKo: string;
+}
+
+/** Synchronous-ish: resolves the analysis directly (no jobId/poll). */
+export function analyzeEconomicEvent(
+    input: EconomicEventAnalysisInput
+): Promise<EconomicEventAnalysis>;
+```
+
+`PROMPT_TEMPLATE_VERSION` is core's concern (it owns the analysis-cache key — see MEMORY `prompt template cache version`). siglens does **not** hash or version the prompt; siglens idempotency is the DB `analyzedAt` column + the refresh-flag (below).
+
+### Sync vs async (submit/poll) — decision
+
+market-news per-card analysis uses a **worker submit/poll** (`submitNewsCardAnalysis`/`pollNewsCardAnalysis`) because card enrichment is a multi-field translation over up to ~50 items per category. macro-briefing uses submit/poll because the briefing is a large multi-section document. **SP-D uses a synchronous `analyzeEconomicEvent`** because: (1) the spec explicitly defines a direct `(input) → EconomicEventAnalysis` return (no jobId); (2) the per-access workload is tiny — only Medium+ **announced** events **not yet analyzed** (steady state is a handful per access; ~140 Medium+/month total, seeded once); (3) each output is one short 3-field JSON. The ensure still bounds concurrency (`LLM_PARALLEL_LIMIT`) and runs fire-and-forget inside the on-access trigger, so a slow core call never blocks the response. If core later proves expensive enough to need a queue, the swap is contained to `analyzeAndPersistEvent` (submit/poll instead of a direct call) — the action/repo/display contracts are unchanged.
+
+---
+
+## File Structure
+
+| File | Create/Modify | Responsibility |
+|---|---|---|
+| `package.json` | Modify | Bump `@y0ngha/siglens-core` to the version that ships `analyzeEconomicEvent` (after the user's release); add `db:seed:calendar-analysis` script. |
+| `src/shared/db/schema.ts` | Modify | Add `sentiment`, `summaryKo`, `interpretationKo`, `analyzedAt` columns to `economicCalendar` (the SP-A table) + `(impact, analyzedAt)` partial-friendly index. |
+| `drizzle/0019_*.sql` + `drizzle/meta/*` | Create (generated) | Migration adding the four AI columns + index (output of `yarn db:generate`). |
+| `src/entities/economy/lib/economyCalendarConstants.ts` | Modify | Add `LLM_PARALLEL_LIMIT` + the analyzed-events cache tag reuse (tag already exists from SP-A). |
+| `src/entities/economy/model.ts` | Create | `EconomicCalendarEventWithAnalysis` view type + sentiment validation record (read-boundary coercion). |
+| `src/entities/economy/lib/__tests__/economicEventAnalysisGuard.test.ts` | Create | Tests for the sentiment read-boundary guard. |
+| `src/entities/economy/lib/economicEventAnalysisGuard.ts` | Create | Pure `toEventSentiment(value): NewsSentiment \| null` coercion (mirrors `isNewsSentiment`). |
+| `src/entities/economy/api/economicCalendarRepository.ts` | Modify (SP-A file) | Add `attachEventAnalysis(id, analysis)` (write-once via `analyzedAt IS NULL` guard) + `listUnanalyzedAnnounced(impacts)` + extend `listInRange` select to return AI columns. |
+| `src/entities/economy/api/__tests__/economicCalendarRepository.analysis.test.ts` | Create | Tests for the three new/changed repo paths (separate file from the SP-A repo test). |
+| `src/entities/economy/actions/ensureEconomicEventsAnalyzedAction.ts` | Create | `'use server'` — refresh-flag guard → select unanalyzed announced Medium+ → bounded-parallel `analyzeEconomicEvent` + `attachEventAnalysis` → `revalidateTag` on change. |
+| `src/entities/economy/actions/__tests__/ensureEconomicEventsAnalyzedAction.test.ts` | Create | Tests for condition filtering, analyze→persist, graceful core failure, no-revalidate-when-none. |
+| `src/entities/economy/api/calendarAnalysisRefreshFlag.ts` | Create | Redis refresh-flag for the analysis pass (separate key from SP-A's ingestion flag). |
+| `src/entities/economy/actions.ts` | Modify (SP-A barrel) | Add `ensureEconomicEventsAnalyzedAction` re-export. |
+| `scripts/seedEconomicEventAnalysis.ts` | Create | One-time `tsx` SEED: analyze all current Medium+ announced unanalyzed rows. |
+| `src/widgets/economy/sections/EconomicCalendarGrid.tsx` | Modify (SP-A file) | `DayDetailPanel` renders sentiment badge + summaryKo + interpretationKo for analyzed events; fire `ensureEconomicEventsAnalyzedAction` alongside the SP-A ingest trigger. |
+| `src/widgets/economy/sections/__tests__/EconomicCalendarGrid.analysis.test.tsx` | Create | Tests for analyzed-event display + untouched not-analyzed/Low/unannounced. |
+| `src/widgets/economy/hooks/useEconomicCalendarTrigger.ts` | Modify (SP-A hook) | Also fire `ensureEconomicEventsAnalyzedAction` once on mount (sequenced after ingest). |
+| `src/widgets/economy/hooks/__tests__/useEconomicCalendarTrigger.test.tsx` | Modify (SP-A test) | Assert both ensure actions fire once. |
+
+**FSD compliance:** AI columns live on the SP-A `economic_calendar` table (`shared/db`); the pure sentiment guard + view type live in `entities/economy/lib`/`model.ts`; the repo extension stays in `entities/economy/api` (server-only, barrel-excluded); the action lives in `entities/economy/actions/` and is re-exported through the SP-A `actions.ts` barrel (no `'use server'` on the barrel — `entities/CLAUDE.md`); the client trigger stays in `widgets/economy/hooks`; the display change stays in the existing grid section. The seed script lives under top-level `scripts/` (not an FSD layer) and deep-imports the repo + core via `tsx`.
+
+---
+
+## Conventions to honor (gates)
+
+- **Reuse SP-A — never duplicate.** The `economic_calendar` table, `DrizzleEconomicCalendarRepository`, `economicCalendarId`, window helpers, and `ensureEconomicCalendarAction` are SP-A's. SP-D **adds columns + repo methods + a second ensure action**; it does not re-declare any SP-A artifact.
+- **Migration is additive + nullable.** All four columns are `NULL`-able (announced-but-unanalyzed and unannounced rows stay `NULL`) — no `NOT NULL`/`DEFAULT` backfill needed. SP-A reserved `0018`; SP-D is `0019`.
+- **Tests colocated** in `__tests__/`. Run a single file with `npx vitest run <path>`.
+- **`tsc`, ESLint, Prettier must pass.** No `eslint-disable`. Multi-line JSDoc is allowed (CLAUDE.md Documentation Policy override).
+- **`'use server'` files export only async functions** — constants/guards/types live in separate files (`entities/CLAUDE.md`).
+- **Barrel exclusion:** `api/` server-only modules + `actions/*` stay out of `entities/economy/index.ts`; consumers deep-import. The model view-type is client-safe and may be barrel-exported if needed, but the grid imports `EconomicCalendarEvent` from core directly (it already does).
+- **ISR safety:** SP-D adds no new page render path. The action reads AI columns through `listInRange` (already `unstable_cache`-wrapped by SP-A's `getCalendarFromDb`); the grid stays a client component. No `cookies()`/`headers()`/`connection()`/`Date.now()` introduced into the cold-gen path. `revalidateTag(ECONOMY_CALENDAR_CACHE_TAG, 'max')` reuses SP-A's tag so an analysis pass refreshes the same cached calendar read.
+- **Sentiment is validated at the read boundary** (raw `text` column, no CHECK) — coerce unknown → `null` so display degrades gracefully (mirrors `market_news` `NEWS_SENTIMENT_RECORD`).
+- **Commit per task** with the conventional-commit messages given. Do not push (git-agent's job).
+
+---
+
+## Task 0: Gate on the core release (no code)
+
+**Files:** `package.json` (version pin only)
+
+- [ ] **Step 1: Confirm the core release shipped**
+
+Run: `npm view @y0ngha/siglens-core@latest version --registry=https://npm.pkg.github.com` (or check the user's release note). Confirm the published version exports `analyzeEconomicEvent` + `EconomicEventAnalysis` + `EconomicEventAnalysisInput`.
+
+Expected: a version newer than the SP-A pin. **If the core release has NOT landed, STOP and report to the user** — every task below depends on it (tasks are written against the mock, but Task 12's typecheck/build needs the real types). Do not invent the core function locally.
+
+- [ ] **Step 2: Bump the pin + install**
+
+In `package.json`, set `"@y0ngha/siglens-core": "<released version>"`. Run: `yarn install`.
+Expected: lockfile updates; `node_modules/@y0ngha/siglens-core/dist/domain/economy/` exposes `analyzeEconomicEvent` (verify: `grep -rl "analyzeEconomicEvent" node_modules/@y0ngha/siglens-core/dist`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json yarn.lock
+git commit -m "chore(economy): bump siglens-core for analyzeEconomicEvent (SP-D)"
+```
+
+> If the worktree has a stale `node_modules` core version (MEMORY `worktree core version mismatch`), `rm -rf node_modules && yarn install` rather than `--no-verify` past failing tests.
+
+---
+
+## Task 1: Add AI columns to `economic_calendar`
+
+**Files:**
+- Modify: `src/shared/db/schema.ts` (the SP-A `economicCalendar` `pgTable`)
+- Create (generated): `drizzle/0019_*.sql`, `drizzle/meta/0019_snapshot.json`, updated `drizzle/meta/_journal.json`
+
+- [ ] **Step 1: Add the four columns + index to the SP-A table**
+
+In `src/shared/db/schema.ts`, inside the existing `economicCalendar` `pgTable` (added by SP-A), add the AI columns after `fetchedAt` and add a fourth index. The columns mirror `marketNews`'s analysis columns (`text` + nullable + `analyzed_at` timestamptz).
+
+Replace the SP-A column-block tail (`fetchedAt: timestamp(...).notNull().defaultNow(),` immediately followed by the closing `},`) with:
+
+```typescript
+        fetchedAt: timestamp('fetched_at', { withTimezone: true })
+            .notNull()
+            .defaultNow(),
+        // --- SP-D AI 분석 컬럼 (Medium+ 발표 이벤트만 채워짐) ---
+        /** core analyzeEconomicEvent 결과: 'bullish' | 'neutral' | 'bearish'. 미분석=null. */
+        sentiment: text('sentiment'),
+        /** 발표 내용 1~2문장 한국어 요약. 미분석=null. */
+        summaryKo: text('summary_ko'),
+        /** 발표의 시장 해석(왜 중요한지). 미분석=null. */
+        interpretationKo: text('interpretation_ko'),
+        /** 분석 완료 시각 — 멱등성 가드(IS NULL이면 미분석). */
+        analyzedAt: timestamp('analyzed_at', { withTimezone: true }),
+```
+
+And add a fourth index in the table's index array (after `economic_calendar_impact_idx`):
+
+```typescript
+        // 미분석 발표분 스캔용 — ensureEconomicEventsAnalyzedAction이 impact+analyzedAt로 필터.
+        index('economic_calendar_impact_analyzed_at_idx').on(
+            table.impact,
+            table.analyzedAt
+        ),
+```
+
+- [ ] **Step 2: Generate the migration**
+
+Run: `yarn db:generate`
+Expected: drizzle-kit reports `0019_*` ALTERing `economic_calendar` to add four columns + one index. (No DB connection needed for `generate`.)
+
+- [ ] **Step 3: Verify the generated SQL**
+
+Run: `cat drizzle/0019_*.sql`
+Expected: `ALTER TABLE "economic_calendar" ADD COLUMN "sentiment" text;`, `"summary_ko" text`, `"interpretation_ko" text`, `"analyzed_at" timestamp with time zone`, and `CREATE INDEX "economic_calendar_impact_analyzed_at_idx"`. All columns nullable, no `NOT NULL`/`DEFAULT` (additive, safe on a populated table). If it differs, fix the schema and re-run `yarn db:generate`.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/db/schema.ts drizzle/0019_*.sql drizzle/meta
+git commit -m "feat(economy): add AI analysis columns to economic_calendar (SP-D)"
+```
+
+> Applying the migration (`yarn db:migrate`) is an operational step the user runs against their environment — not part of this code plan.
+
+---
+
+## Task 2: Sentiment read-boundary guard + view type
+
+**Files:**
+- Create: `src/entities/economy/lib/economicEventAnalysisGuard.ts`
+- Create: `src/entities/economy/model.ts`
+- Test: `src/entities/economy/lib/__tests__/economicEventAnalysisGuard.test.ts`
+
+The DB stores `sentiment` as raw `text` (no CHECK), so we validate it at the read boundary and coerce unknown values to `null` — display falls back to "no badge" gracefully. We re-use core's `NewsSentiment` (`'bullish'|'neutral'|'bearish'`) since `EconomicEventAnalysis.sentiment` is the same tri-state (DESIGN tokens already exist for it).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { toEventSentiment } from '@/entities/economy/lib/economicEventAnalysisGuard';
+
+describe('toEventSentiment', () => {
+    it('passes through the three valid sentiments', () => {
+        expect(toEventSentiment('bullish')).toBe('bullish');
+        expect(toEventSentiment('neutral')).toBe('neutral');
+        expect(toEventSentiment('bearish')).toBe('bearish');
+    });
+
+    it('coerces unknown strings to null', () => {
+        expect(toEventSentiment('positive')).toBeNull();
+        expect(toEventSentiment('')).toBeNull();
+    });
+
+    it('coerces null/undefined to null', () => {
+        expect(toEventSentiment(null)).toBeNull();
+        expect(toEventSentiment(undefined)).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/entities/economy/lib/__tests__/economicEventAnalysisGuard.test.ts`
+Expected: FAIL — `Cannot find module '@/entities/economy/lib/economicEventAnalysisGuard'`.
+
+- [ ] **Step 3: Write the guard**
+
+```typescript
+import type { NewsSentiment } from '@y0ngha/siglens-core';
+
+/**
+ * `economic_calendar.sentiment`(raw text, CHECK 없음)를 읽기 경계에서 검증한다.
+ * 유효하지 않은 값(스키마 드리프트·수동 SQL·구버전 데이터)은 null로 강등해 표시
+ * 계층이 배지 없이 graceful 폴백한다(`market_news`의 NEWS_SENTIMENT_RECORD 미러).
+ *
+ * `EconomicEventAnalysis.sentiment`는 core의 `NewsSentiment`와 동일한
+ * 'bullish'|'neutral'|'bearish' tri-state라 같은 DESIGN 토큰을 재사용한다.
+ */
+const EVENT_SENTIMENT_RECORD: Record<NewsSentiment, true> = {
+    bullish: true,
+    neutral: true,
+    bearish: true,
+};
+
+export function toEventSentiment(value: unknown): NewsSentiment | null {
+    return typeof value === 'string' && value in EVENT_SENTIMENT_RECORD
+        ? (value as NewsSentiment)
+        : null;
+}
+```
+
+- [ ] **Step 4: Write the view type (`model.ts`)**
+
+```typescript
+import type {
+    EconomicCalendarEvent,
+    NewsSentiment,
+} from '@y0ngha/siglens-core';
+
+/**
+ * 표시 계층용 캘린더 이벤트 + (선택) AI 분석. SP-A `EconomicCalendarEvent`에
+ * SP-D 분석 필드를 합성한 view 타입이다. `sentiment`는 읽기 경계에서 검증된
+ * `NewsSentiment | null`(`toEventSentiment`), 요약/해석은 미분석이면 null.
+ *
+ * 미발표/Low/미분석 이벤트는 세 필드가 모두 null이라 기존 표시와 동일하게 렌더된다.
+ */
+export interface EconomicCalendarEventWithAnalysis extends EconomicCalendarEvent {
+    sentiment: NewsSentiment | null;
+    summaryKo: string | null;
+    interpretationKo: string | null;
+    analyzedAt: Date | null;
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/entities/economy/lib/__tests__/economicEventAnalysisGuard.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/entities/economy/lib/economicEventAnalysisGuard.ts src/entities/economy/lib/__tests__/economicEventAnalysisGuard.test.ts src/entities/economy/model.ts
+git commit -m "feat(economy): add event-sentiment guard + analysis view type (SP-D)"
+```
+
+---
+
+## Task 3: Constants — parallel limit + analysis refresh flag key
+
+**Files:**
+- Modify: `src/entities/economy/lib/economyCalendarConstants.ts` (the SP-A constants file)
+
+Add the bounded-parallel limit and a **separate** Redis refresh-flag key for the analysis pass (so the analysis pass and SP-A's ±1mo ingestion pass throttle independently — analysis can re-scan even when ingestion was recently skipped). The cache tag (`ECONOMY_CALENDAR_CACHE_TAG`) is reused from SP-A.
+
+- [ ] **Step 1: Append to the SP-A constants file**
+
+```typescript
+/**
+ * 분석 ensure가 동시에 호출하는 core analyzeEconomicEvent 최대 병렬 수.
+ * market-news LLM_PARALLEL_LIMIT 패턴 — worker 큐 stampede 방지. 발표 Medium+ 미분석분이
+ * 매 접속 소수라 작게 잡는다.
+ */
+export const CALENDAR_ANALYSIS_PARALLEL_LIMIT = 4;
+
+/** core가 표준 Record 키로 받는 Medium+ 임팩트 집합 — 분석 대상 필터. */
+export const CALENDAR_ANALYZED_IMPACTS = ['High', 'Medium'] as const;
+
+const CALENDAR_ANALYSIS_REFRESH_FLAG_TTL_MINUTES = 30;
+
+/**
+ * 분석 pass refresh-flag TTL — 이 윈도 안 재접속(봇 재크롤 포함)이면 분석 스캔을 건너뛴다.
+ * SP-A 인제스션 플래그와 별도 키라 두 pass가 독립적으로 쓰로틀된다.
+ */
+export const CALENDAR_ANALYSIS_REFRESH_FLAG_TTL_SECONDS =
+    CALENDAR_ANALYSIS_REFRESH_FLAG_TTL_MINUTES * SECONDS_PER_MINUTE;
+
+/** Redis 분석 refresh-flag 키 — 단일 글로벌 캘린더(SP-A 인제스션 키와 분리). */
+export const CALENDAR_ANALYSIS_REFRESH_FLAG_KEY = 'economy:calendar:analysis:refresh';
+```
+
+> `SECONDS_PER_MINUTE` is already imported in the SP-A constants file. If not, add it to the existing `@/shared/config/time` import.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/entities/economy/lib/economyCalendarConstants.ts
+git commit -m "feat(economy): add calendar-analysis constants (SP-D)"
+```
+
+---
+
+## Task 4: Repository — analysis read/write methods
+
+**Files:**
+- Modify: `src/entities/economy/api/economicCalendarRepository.ts` (the SP-A repo)
+- Test: `src/entities/economy/api/__tests__/economicCalendarRepository.analysis.test.ts`
+
+Add three things to the SP-A `DrizzleEconomicCalendarRepository`:
+1. `attachEventAnalysis(id, analysis)` — write-once `UPDATE ... WHERE id = ? AND analyzed_at IS NULL` (mirrors `attachAnalysis`); sets `analyzedAt = now()`.
+2. `listUnanalyzedAnnounced(impacts)` — `SELECT id + analyzer inputs WHERE impact IN (...) AND actual IS NOT NULL AND analyzed_at IS NULL`.
+3. Extend `listInRange`'s select to also return `sentiment`/`summaryKo`/`interpretationKo`/`analyzedAt`, and map them onto the returned events (coerced via `toEventSentiment`) so the display layer gets them through SP-A's reader unchanged.
+
+- [ ] **Step 1: Write the failing test (new file)**
+
+```typescript
+vi.mock('server-only', () => ({}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { DrizzleEconomicCalendarRepository } from '@/entities/economy/api/economicCalendarRepository';
+
+/** Chainable update/select stub returning the rows we hand it. */
+function makeDb(selectRows: unknown[]) {
+    const where = vi.fn(async () => undefined);
+    const set = vi.fn(() => ({ where }));
+    const update = vi.fn(() => ({ set }));
+
+    const selectWhere = vi.fn(async () => selectRows);
+    const from = vi.fn(() => ({ where: selectWhere }));
+    const select = vi.fn(() => ({ from }));
+
+    return {
+        db: { update, select } as never,
+        spies: { update, set, where, select, from, selectWhere },
+    };
+}
+
+describe('DrizzleEconomicCalendarRepository.attachEventAnalysis', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('updates the analysis columns guarded by analyzed_at IS NULL', async () => {
+        const { db, spies } = makeDb([]);
+        const repo = new DrizzleEconomicCalendarRepository(db);
+        await repo.attachEventAnalysis('abc', {
+            sentiment: 'bullish',
+            summaryKo: '요약',
+            interpretationKo: '해석',
+        });
+        expect(spies.update).toHaveBeenCalledOnce();
+        const setArg = spies.set.mock.calls[0][0] as Record<string, unknown>;
+        expect(setArg.sentiment).toBe('bullish');
+        expect(setArg.summaryKo).toBe('요약');
+        expect(setArg.interpretationKo).toBe('해석');
+        expect(setArg.analyzedAt).toBeInstanceOf(Date);
+        expect(spies.where).toHaveBeenCalledOnce();
+    });
+});
+
+describe('DrizzleEconomicCalendarRepository.listUnanalyzedAnnounced', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('maps rows to analyzer inputs (id + event fields)', async () => {
+        const { db } = makeDb([
+            {
+                id: 'id1',
+                dateEt: '2026-06-13 08:30:00',
+                event: 'Core CPI MoM (May)',
+                impact: 'High',
+                actual: 0.4,
+                estimate: 0.3,
+                previous: 0.2,
+                unit: '%',
+            },
+        ]);
+        const repo = new DrizzleEconomicCalendarRepository(db);
+        const rows = await repo.listUnanalyzedAnnounced(['High', 'Medium']);
+        expect(rows).toEqual([
+            {
+                id: 'id1',
+                event: 'Core CPI MoM (May)',
+                impact: 'High',
+                actual: 0.4,
+                estimate: 0.3,
+                previous: 0.2,
+                unit: '%',
+            },
+        ]);
+    });
+});
+
+describe('DrizzleEconomicCalendarRepository.listInRange (analysis columns)', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('maps AI columns onto events and coerces unknown sentiment to null', async () => {
+        const { db } = makeDb([
+            {
+                dateEt: '2026-06-13 08:30:00',
+                event: 'Core CPI MoM (May)',
+                impact: 'High',
+                actual: 0.4,
+                estimate: 0.3,
+                previous: 0.2,
+                unit: '%',
+                sentiment: 'bearish',
+                summaryKo: '요약',
+                interpretationKo: '해석',
+                analyzedAt: new Date('2026-06-13T13:00:00Z'),
+            },
+            {
+                dateEt: '2026-06-14 10:00:00',
+                event: 'Mystery',
+                impact: 'Low',
+                actual: null,
+                estimate: null,
+                previous: null,
+                unit: '',
+                sentiment: 'bogus',
+                summaryKo: null,
+                interpretationKo: null,
+                analyzedAt: null,
+            },
+        ]);
+        const repo = new DrizzleEconomicCalendarRepository(db);
+        const events = await repo.listInRange('2026-06-01', '2026-06-30');
+        expect(events[0].sentiment).toBe('bearish');
+        expect(events[0].summaryKo).toBe('요약');
+        expect(events[0].interpretationKo).toBe('해석');
+        expect(events[1].sentiment).toBeNull(); // 'bogus' coerced
+        expect(events[1].summaryKo).toBeNull();
+    });
+});
+```
+
+> The chainable stub here covers a single `.where()` terminal (no `.orderBy()`); the SP-A repo test already covers the `.orderBy()` chain. Since SP-D extends `listInRange`, this test asserts only the AI-column mapping — keep the SP-A repo test (with `orderBy`) green too (it does not assert AI columns, so its row-shape additions are backward-compatible). If the SP-A test's `makeDb` stub omits the new select keys, the extended `select()` still resolves them as `undefined`, mapping to `null` — verify the SP-A repo test still passes in Step 4.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/entities/economy/api/__tests__/economicCalendarRepository.analysis.test.ts`
+Expected: FAIL — `attachEventAnalysis`/`listUnanalyzedAnnounced` are not functions (or `listInRange` does not map AI columns).
+
+- [ ] **Step 3: Extend the SP-A repository**
+
+Add these imports to the existing import block (top of `economicCalendarRepository.ts`):
+
+```typescript
+import { eq, inArray, isNotNull, isNull } from 'drizzle-orm';
+import type { EconomicEventAnalysis } from '@y0ngha/siglens-core';
+import { toEventSentiment } from '../lib/economicEventAnalysisGuard';
+import type { EconomicCalendarEventWithAnalysis } from '../model';
+```
+
+> SP-A's repo already imports `and, asc, gte, lte, sql`. Merge `eq, inArray, isNotNull, isNull` into that one `drizzle-orm` import line rather than adding a second import.
+
+Add an analyzer-input shape near the existing `CalendarDbRow` interface:
+
+```typescript
+/** ensure가 core analyzeEconomicEvent에 넘기는 입력 + 행 식별 id. */
+export interface UnanalyzedAnnouncedEvent {
+    id: string;
+    event: string;
+    impact: CalendarImpact;
+    /** actual IS NOT NULL로 필터되므로 number 보장. */
+    actual: number;
+    estimate: number | null;
+    previous: number | null;
+    unit: string;
+}
+```
+
+Change the SP-A `listInRange` select + mapper to include the AI columns. Replace the SP-A `toEvent` mapper and the `listInRange` `.select({...})` block:
+
+(a) extend the select projection inside `listInRange` to add the four AI columns:
+
+```typescript
+                    .select({
+                        dateEt: economicCalendar.dateEt,
+                        event: economicCalendar.event,
+                        impact: economicCalendar.impact,
+                        actual: economicCalendar.actual,
+                        estimate: economicCalendar.estimate,
+                        previous: economicCalendar.previous,
+                        unit: economicCalendar.unit,
+                        sentiment: economicCalendar.sentiment,
+                        summaryKo: economicCalendar.summaryKo,
+                        interpretationKo: economicCalendar.interpretationKo,
+                        analyzedAt: economicCalendar.analyzedAt,
+                    })
+```
+
+(b) widen `CalendarDbRow` and `toEvent` to carry the AI columns:
+
+```typescript
+interface CalendarDbRow {
+    dateEt: string;
+    event: string;
+    impact: string;
+    actual: number | null;
+    estimate: number | null;
+    previous: number | null;
+    unit: string;
+    sentiment: string | null;
+    summaryKo: string | null;
+    interpretationKo: string | null;
+    analyzedAt: Date | null;
+}
+
+function toEvent(row: CalendarDbRow): EconomicCalendarEventWithAnalysis {
+    return {
+        date: row.dateEt,
+        event: row.event,
+        impact: toImpact(row.impact),
+        actual: row.actual,
+        estimate: row.estimate,
+        previous: row.previous,
+        unit: row.unit,
+        sentiment: toEventSentiment(row.sentiment),
+        summaryKo: row.summaryKo,
+        interpretationKo: row.interpretationKo,
+        analyzedAt: row.analyzedAt,
+    };
+}
+```
+
+> Change `listInRange`'s return type from `Promise<EconomicCalendarEvent[]>` to `Promise<EconomicCalendarEventWithAnalysis[]>`. Since `EconomicCalendarEventWithAnalysis extends EconomicCalendarEvent`, all SP-A consumers (`getCalendarFromDb`, the grid via `events` prop) remain type-compatible — the extra fields are additive. Update SP-A's `getCalendarFromDb` return type to `Promise<EconomicCalendarEventWithAnalysis[]>` (Task 8 wires the display; the type already flows through because the grid prop is widened in Task 7).
+
+Add the two new methods to the class (after `listInRange`):
+
+```typescript
+    /**
+     * 분석 결과를 write-once로 기록한다 — `analyzed_at IS NULL` 가드로 재분석/덮어쓰기를
+     * 막는다(market-news `attachAnalysis` 미러). 동시 분석 경합에서 한 호출만 승리한다.
+     */
+    async attachEventAnalysis(
+        id: string,
+        analysis: EconomicEventAnalysis,
+        analyzedAt: Date = new Date()
+    ): Promise<void> {
+        await withRetry(
+            () =>
+                this.db
+                    .update(economicCalendar)
+                    .set({
+                        sentiment: analysis.sentiment,
+                        summaryKo: analysis.summaryKo,
+                        interpretationKo: analysis.interpretationKo,
+                        analyzedAt,
+                    })
+                    .where(
+                        and(
+                            eq(economicCalendar.id, id),
+                            isNull(economicCalendar.analyzedAt)
+                        )
+                    ),
+            NEON_TRANSIENT_RETRY
+        );
+    }
+
+    /**
+     * 분석 대상 행을 읽는다: impact ∈ impacts AND actual IS NOT NULL AND analyzed_at IS NULL.
+     * 발표된(actual 채워진) Medium+ 미분석 이벤트만 반환해 ensure가 core에 넘긴다.
+     */
+    async listUnanalyzedAnnounced(
+        impacts: readonly CalendarImpact[]
+    ): Promise<UnanalyzedAnnouncedEvent[]> {
+        const rows = await withRetry(
+            () =>
+                this.db
+                    .select({
+                        id: economicCalendar.id,
+                        event: economicCalendar.event,
+                        impact: economicCalendar.impact,
+                        actual: economicCalendar.actual,
+                        estimate: economicCalendar.estimate,
+                        previous: economicCalendar.previous,
+                        unit: economicCalendar.unit,
+                    })
+                    .from(economicCalendar)
+                    .where(
+                        and(
+                            inArray(economicCalendar.impact, [...impacts]),
+                            isNotNull(economicCalendar.actual),
+                            isNull(economicCalendar.analyzedAt)
+                        )
+                    ),
+            NEON_TRANSIENT_RETRY
+        );
+        return rows
+            .filter((r): r is typeof r & { actual: number } => r.actual !== null)
+            .map(r => ({
+                id: r.id,
+                event: r.event,
+                impact: toImpact(r.impact),
+                actual: r.actual,
+                estimate: r.estimate,
+                previous: r.previous,
+                unit: r.unit,
+            }));
+    }
+```
+
+> The `.filter(...actual !== null)` is redundant with the SQL guard but narrows `number | null → number` for the typed return (no `!` assertion — MISTAKES.md type-safety).
+
+- [ ] **Step 4: Run test to verify it passes (both repo tests)**
+
+Run: `npx vitest run src/entities/economy/api/__tests__/economicCalendarRepository.analysis.test.ts src/entities/economy/api/__tests__/economicCalendarRepository.test.ts`
+Expected: PASS — new analysis tests green AND the SP-A repo test still green (AI-column additions are backward-compatible).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/entities/economy/api/economicCalendarRepository.ts src/entities/economy/api/__tests__/economicCalendarRepository.analysis.test.ts
+git commit -m "feat(economy): repo analysis read/write + AI-column mapping (SP-D)"
+```
+
+---
+
+## Task 5: Analysis refresh-flag helper
+
+**Files:**
+- Create: `src/entities/economy/api/calendarAnalysisRefreshFlag.ts`
+
+Mirrors SP-A's `calendarRefreshFlag` but with the analysis key/TTL — kept as a non-action helper so the `'use server'` action file stays function-only.
+
+- [ ] **Step 1: Write the helper**
+
+```typescript
+import 'server-only';
+import { getRedisClient } from '@/shared/cache/redisClient';
+import {
+    CALENDAR_ANALYSIS_REFRESH_FLAG_KEY,
+    CALENDAR_ANALYSIS_REFRESH_FLAG_TTL_SECONDS,
+} from '../lib/economyCalendarConstants';
+
+/** 최근 TTL 내 분석 pass 수행 여부 — Redis 실패 시 false(항상 스캔). SP-A 플래그 미러. */
+export async function isAnalysisRecentlyRun(): Promise<boolean> {
+    const redis = getRedisClient();
+    if (redis === null) return false;
+    try {
+        return (await redis.get(CALENDAR_ANALYSIS_REFRESH_FLAG_KEY)) !== null;
+    } catch (error) {
+        console.error('[calendarAnalysisRefreshFlag] get failed', error);
+        return false;
+    }
+}
+
+/** "최근 분석함" 마킹 — Redis 실패 시 noop. */
+export async function markAnalysisRun(): Promise<void> {
+    const redis = getRedisClient();
+    if (redis === null) return;
+    try {
+        await redis.set(CALENDAR_ANALYSIS_REFRESH_FLAG_KEY, '1', {
+            ex: CALENDAR_ANALYSIS_REFRESH_FLAG_TTL_SECONDS,
+        });
+    } catch (error) {
+        console.error('[calendarAnalysisRefreshFlag] set failed', error);
+    }
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/entities/economy/api/calendarAnalysisRefreshFlag.ts
+git commit -m "feat(economy): add calendar-analysis refresh flag (SP-D)"
+```
+
+---
+
+## Task 6: `ensureEconomicEventsAnalyzedAction` + barrel
+
+**Files:**
+- Create: `src/entities/economy/actions/ensureEconomicEventsAnalyzedAction.ts`
+- Modify: `src/entities/economy/actions.ts` (SP-A barrel)
+- Test: `src/entities/economy/actions/__tests__/ensureEconomicEventsAnalyzedAction.test.ts`
+
+Mirrors `ensureMarketNewsCardsAnalyzedAction`: refresh-flag guard (mark before async work so concurrent callers skip), select unanalyzed announced Medium+ via the repo, bounded-parallel `analyzeEconomicEvent → attachEventAnalysis` (the synchronous replacement for submit/poll), majority-failure logging, single `revalidateTag(ECONOMY_CALENDAR_CACHE_TAG, 'max')` when ≥1 row was persisted. Fire-and-forget, errors logged. E2E short-circuit (`isE2E()`) like market-news so prod-build prerender / E2E never hits the LLM.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+vi.mock('server-only', () => ({}));
+
+const revalidateTag = vi.fn();
+vi.mock('next/cache', () => ({ revalidateTag }));
+
+const isAnalysisRecentlyRun = vi.fn();
+const markAnalysisRun = vi.fn();
+vi.mock('@/entities/economy/api/calendarAnalysisRefreshFlag', () => ({
+    isAnalysisRecentlyRun,
+    markAnalysisRun,
+}));
+
+const analyzeEconomicEvent = vi.fn();
+vi.mock('@y0ngha/siglens-core', () => ({ analyzeEconomicEvent }));
+
+const listUnanalyzedAnnounced = vi.fn();
+const attachEventAnalysis = vi.fn();
+vi.mock('@/entities/economy/api/economicCalendarRepository', () => ({
+    DrizzleEconomicCalendarRepository: class {
+        listUnanalyzedAnnounced = listUnanalyzedAnnounced;
+        attachEventAnalysis = attachEventAnalysis;
+    },
+}));
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: () => ({ db: {} }),
+}));
+
+const isE2E = vi.fn(() => false);
+vi.mock('@/shared/api/e2eEnv', () => ({ isE2E: () => isE2E() }));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ensureEconomicEventsAnalyzedAction } from '@/entities/economy/actions/ensureEconomicEventsAnalyzedAction';
+import { ECONOMY_CALENDAR_CACHE_TAG } from '@/entities/economy/lib/economyCalendarConstants';
+
+const ROW = {
+    id: 'id1',
+    event: 'Core CPI MoM (May)',
+    impact: 'High' as const,
+    actual: 0.4,
+    estimate: 0.3,
+    previous: 0.2,
+    unit: '%',
+};
+const ANALYSIS = {
+    sentiment: 'bullish' as const,
+    summaryKo: '요약',
+    interpretationKo: '해석',
+};
+
+describe('ensureEconomicEventsAnalyzedAction', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        isE2E.mockReturnValue(false);
+        isAnalysisRecentlyRun.mockResolvedValue(false);
+        markAnalysisRun.mockResolvedValue(undefined);
+        listUnanalyzedAnnounced.mockResolvedValue([ROW]);
+        analyzeEconomicEvent.mockResolvedValue(ANALYSIS);
+        attachEventAnalysis.mockResolvedValue(undefined);
+    });
+
+    it('skips when recently run', async () => {
+        isAnalysisRecentlyRun.mockResolvedValue(true);
+        await ensureEconomicEventsAnalyzedAction();
+        expect(listUnanalyzedAnnounced).not.toHaveBeenCalled();
+        expect(analyzeEconomicEvent).not.toHaveBeenCalled();
+    });
+
+    it('short-circuits under E2E (no LLM calls)', async () => {
+        isE2E.mockReturnValue(true);
+        await ensureEconomicEventsAnalyzedAction();
+        expect(analyzeEconomicEvent).not.toHaveBeenCalled();
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it('analyzes Medium+ announced unanalyzed events and revalidates on change', async () => {
+        await ensureEconomicEventsAnalyzedAction();
+        expect(markAnalysisRun).toHaveBeenCalledOnce();
+        expect(listUnanalyzedAnnounced).toHaveBeenCalledWith(['High', 'Medium']);
+        expect(analyzeEconomicEvent).toHaveBeenCalledWith({
+            event: 'Core CPI MoM (May)',
+            impact: 'High',
+            actual: 0.4,
+            estimate: 0.3,
+            previous: 0.2,
+            unit: '%',
+        });
+        expect(attachEventAnalysis).toHaveBeenCalledWith('id1', ANALYSIS);
+        expect(revalidateTag).toHaveBeenCalledWith(
+            ECONOMY_CALENDAR_CACHE_TAG,
+            'max'
+        );
+    });
+
+    it('does not revalidate when there is nothing to analyze', async () => {
+        listUnanalyzedAnnounced.mockResolvedValue([]);
+        await ensureEconomicEventsAnalyzedAction();
+        expect(analyzeEconomicEvent).not.toHaveBeenCalled();
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it('swallows a core failure without throwing and skips persist for that event', async () => {
+        analyzeEconomicEvent.mockRejectedValue(new Error('llm down'));
+        await expect(
+            ensureEconomicEventsAnalyzedAction()
+        ).resolves.toBeUndefined();
+        expect(attachEventAnalysis).not.toHaveBeenCalled();
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/entities/economy/actions/__tests__/ensureEconomicEventsAnalyzedAction.test.ts`
+Expected: FAIL — `Cannot find module '@/entities/economy/actions/ensureEconomicEventsAnalyzedAction'`.
+
+- [ ] **Step 3: Write the action**
+
+```typescript
+'use server';
+
+import { revalidateTag } from 'next/cache';
+import { analyzeEconomicEvent } from '@y0ngha/siglens-core';
+
+import { isE2E } from '@/shared/api/e2eEnv';
+import { getDatabaseClient } from '@/shared/db/client';
+
+import {
+    DrizzleEconomicCalendarRepository,
+    type UnanalyzedAnnouncedEvent,
+} from '../api/economicCalendarRepository';
+import {
+    isAnalysisRecentlyRun,
+    markAnalysisRun,
+} from '../api/calendarAnalysisRefreshFlag';
+import {
+    CALENDAR_ANALYSIS_PARALLEL_LIMIT,
+    CALENDAR_ANALYZED_IMPACTS,
+    ECONOMY_CALENDAR_CACHE_TAG,
+} from '../lib/economyCalendarConstants';
+
+/** upsert/analyze 과반 실패 시 abort 임계 분모. */
+const MAJORITY_DIVISOR = 2;
+
+/**
+ * `items`를 최대 `limit`개씩 동시 실행한다(입력 순서 보존). market-news
+ * `withConcurrencyLimit` 미러 — p-limit 의존성 없이 O(수십) 규모에 충분.
+ */
+async function withConcurrencyLimit<T, R>(
+    items: T[],
+    limit: number,
+    fn: (item: T) => Promise<R>
+): Promise<PromiseSettledResult<R>[]> {
+    const results: PromiseSettledResult<R>[] = [];
+    for (let i = 0; i < items.length; i += limit) {
+        const chunk = items.slice(i, i + limit);
+        results.push(...(await Promise.allSettled(chunk.map(fn))));
+    }
+    return results;
+}
+
+/**
+ * 한 이벤트를 core로 분석하고 DB에 write-once 기록한다. 실패는 호출자(allSettled)가
+ * reject로 수거 — 한 건이 실패해도 나머지는 정상 진행한다. 호출자가 actual !== null
+ * AND analyzed_at IS NULL을 보장한다(`listUnanalyzedAnnounced`).
+ */
+async function analyzeAndPersistEvent(
+    row: UnanalyzedAnnouncedEvent,
+    repo: DrizzleEconomicCalendarRepository
+): Promise<void> {
+    const analysis = await analyzeEconomicEvent({
+        event: row.event,
+        impact: row.impact,
+        actual: row.actual,
+        estimate: row.estimate,
+        previous: row.previous,
+        unit: row.unit,
+    });
+    await repo.attachEventAnalysis(row.id, analysis);
+}
+
+/**
+ * Server Action: 발표된(actual≠null) Medium+ 미분석 이벤트를 core analyzeEconomicEvent로
+ * 분석해 `economic_calendar`에 채우고, ≥1행이 분석되면 `economy:calendar` 태그를 무효화한다.
+ *
+ * 두 트리거가 공유한다: (a) SEED — 백필 후 전량 1회(seed 스크립트), (b) ON-ACCESS —
+ * /economy 마운트 시(SP-A 트리거 hook이 인제스션 직후 호출, 봇 포함). market-news
+ * `ensureMarketNewsCardsAnalyzedAction` 미러 — refresh-flag 가드, 멱등성(analyzed_at IS NULL),
+ * 동시성 제한, 과반 실패 로깅, fire-and-forget(throw 없음). 동기 core 호출이라 submit/poll 없음.
+ *
+ * E2E/prerender에서는 즉시 반환(LLM 비용 0) — market-news와 동일.
+ * `waitUntil` 안에서 돌도록 설계 — 응답 스트림 비차단.
+ */
+export async function ensureEconomicEventsAnalyzedAction(): Promise<void> {
+    try {
+        if (isE2E()) return;
+        if (await isAnalysisRecentlyRun()) return;
+        // async 작업 전에 마킹 — 동시 호출이 이 지점 이후 플래그를 읽으면 스캔 생략.
+        await markAnalysisRun();
+
+        const { db } = getDatabaseClient();
+        const repo = new DrizzleEconomicCalendarRepository(db);
+
+        const pending = await repo.listUnanalyzedAnnounced(
+            CALENDAR_ANALYZED_IMPACTS
+        );
+        if (pending.length === 0) return;
+
+        const settled = await withConcurrencyLimit(
+            pending,
+            CALENDAR_ANALYSIS_PARALLEL_LIMIT,
+            row => analyzeAndPersistEvent(row, repo)
+        );
+        const failures = settled.filter(r => r.status === 'rejected');
+        if (failures.length > 0) {
+            console.error(
+                `[ensureEconomicEventsAnalyzedAction] ${failures.length}/${pending.length} analyze failed`,
+                failures.map(f => (f.status === 'rejected' ? f.reason : null))
+            );
+        }
+        if (failures.length > pending.length / MAJORITY_DIVISOR) {
+            console.error(
+                `[ensureEconomicEventsAnalyzedAction] majority analyze failure (${failures.length}/${pending.length})`
+            );
+        }
+
+        const persisted = settled.filter(r => r.status === 'fulfilled').length;
+        if (persisted > 0) {
+            // SP-A와 같은 'economy:calendar' 태그만 무효화 — 다음 렌더가 분석 채워진 행을 읽는다.
+            revalidateTag(ECONOMY_CALENDAR_CACHE_TAG, 'max');
+        }
+    } catch (error) {
+        console.error('[ensureEconomicEventsAnalyzedAction]', error);
+    }
+}
+```
+
+- [ ] **Step 4: Add to the SP-A action barrel**
+
+In `src/entities/economy/actions.ts` (created by SP-A — re-export only, no `'use server'`), add:
+
+```typescript
+export { ensureEconomicEventsAnalyzedAction } from './actions/ensureEconomicEventsAnalyzedAction';
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/entities/economy/actions/__tests__/ensureEconomicEventsAnalyzedAction.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/entities/economy/actions/ensureEconomicEventsAnalyzedAction.ts src/entities/economy/actions/__tests__/ensureEconomicEventsAnalyzedAction.test.ts src/entities/economy/actions.ts
+git commit -m "feat(economy): add ensureEconomicEventsAnalyzedAction (SP-D)"
+```
+
+---
+
+## Task 7: Grid display — sentiment badge + summary + interpretation
+
+**Files:**
+- Modify: `src/widgets/economy/sections/EconomicCalendarGrid.tsx` (SP-A file)
+- Test: `src/widgets/economy/sections/__tests__/EconomicCalendarGrid.analysis.test.tsx`
+
+`DayDetailPanel` renders, for events that carry analysis, a sentiment badge (using the AA tri-state tokens) + the Korean summary + the interpretation, below the existing estimate/previous/actual line. Events without analysis (unannounced, Low, or not-yet-analyzed) render exactly as before. The grid's `events` prop type widens to `EconomicCalendarEventWithAnalysis` (which extends `EconomicCalendarEvent`, so SP-A behavior is unchanged).
+
+- [ ] **Step 1: Write the failing test (new file)**
+
+```typescript
+vi.mock('@/entities/economy/actions', () => ({
+    ensureEconomicCalendarAction: vi.fn().mockResolvedValue(undefined),
+    ensureEconomicEventsAnalyzedAction: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { vi, describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { EconomicCalendarEventWithAnalysis } from '@/entities/economy/model';
+import { EconomicCalendarGrid } from '@/widgets/economy/sections/EconomicCalendarGrid';
+
+function ev(
+    over: Partial<EconomicCalendarEventWithAnalysis> = {}
+): EconomicCalendarEventWithAnalysis {
+    return {
+        date: '2026-06-20 08:30:00',
+        event: 'Core CPI MoM (May)',
+        impact: 'High',
+        actual: 0.4,
+        estimate: 0.3,
+        previous: 0.2,
+        unit: '%',
+        sentiment: null,
+        summaryKo: null,
+        interpretationKo: null,
+        analyzedAt: null,
+        ...over,
+    };
+}
+
+describe('EconomicCalendarGrid analysis display', () => {
+    it('renders sentiment badge + summary + interpretation for an analyzed event', () => {
+        render(
+            <EconomicCalendarGrid
+                events={[
+                    ev({
+                        sentiment: 'bullish',
+                        summaryKo: 'CPI가 예상을 상회했어요.',
+                        interpretationKo: '인플레 우려로 금리 인하 기대가 후퇴할 수 있어요.',
+                        analyzedAt: new Date('2026-06-20T13:00:00Z'),
+                    }),
+                ]}
+                today="2026-06-20"
+            />
+        );
+        expect(screen.getByText('긍정')).toBeInTheDocument();
+        expect(
+            screen.getByText('CPI가 예상을 상회했어요.')
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                '인플레 우려로 금리 인하 기대가 후퇴할 수 있어요.'
+            )
+        ).toBeInTheDocument();
+    });
+
+    it('renders no sentiment badge for a not-yet-analyzed announced event', () => {
+        render(
+            <EconomicCalendarGrid
+                events={[ev({ sentiment: null, summaryKo: null })]}
+                today="2026-06-20"
+            />
+        );
+        expect(screen.queryByText('긍정')).not.toBeInTheDocument();
+        expect(screen.queryByText('중립')).not.toBeInTheDocument();
+        expect(screen.queryByText('부정')).not.toBeInTheDocument();
+    });
+
+    it('renders no analysis block for an unannounced event (actual null)', () => {
+        render(
+            <EconomicCalendarGrid
+                events={[
+                    ev({ actual: null, sentiment: null, summaryKo: null }),
+                ]}
+                today="2026-06-20"
+            />
+        );
+        expect(screen.queryByText('부정')).not.toBeInTheDocument();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/widgets/economy/sections/__tests__/EconomicCalendarGrid.analysis.test.tsx`
+Expected: FAIL — the badge/summary/interpretation are not rendered yet (and possibly a type error on `events` until Step 3).
+
+- [ ] **Step 3: Implement the display**
+
+In `src/widgets/economy/sections/EconomicCalendarGrid.tsx`:
+
+(a) Add imports near the existing core-type import:
+
+```typescript
+import type { EconomicCalendarEventWithAnalysis } from '@/entities/economy/model';
+import {
+    SENTIMENT_LABEL,
+    SENTIMENT_CLASS,
+} from '@/widgets/market-news/utils/sentimentConstants';
+```
+
+> `SENTIMENT_LABEL`/`SENTIMENT_CLASS` are `Record<NewsSentiment, …>` and already encode the AA tri-state tokens (`text-ui-success-text`/`text-ui-danger-text`/secondary neutral). Reusing them keeps the badge consistent with market-news and satisfies the spec's "AA 토큰" requirement without duplicating a color map. This is a `widgets → widgets` cross-import (allowed per `widgets/CLAUDE.md`); both are leaf util modules (no server-only deps).
+
+(b) Widen `KstEvent.original` and the props to the analysis view type. Change the `KstEvent` interface field and `groupEventsByKstDay` signature + `EconomicCalendarGridProps.events` from `EconomicCalendarEvent` to `EconomicCalendarEventWithAnalysis`:
+
+```typescript
+interface KstEvent {
+    iso: string;
+    kstTimeLabel: string;
+    original: EconomicCalendarEventWithAnalysis;
+}
+```
+
+```typescript
+function groupEventsByKstDay(
+    events: readonly EconomicCalendarEventWithAnalysis[]
+): DayGroup[] {
+```
+
+```typescript
+interface EconomicCalendarGridProps {
+    events: readonly EconomicCalendarEventWithAnalysis[];
+    /** SP-A: 기본 선택 기준일 KST 'YYYY-MM-DD'. */
+    today?: string;
+}
+```
+
+> `EconomicCalendarEvent` is still imported for `CalendarImpact`/label maps; keep that import. `EconomicCalendarEventWithAnalysis extends EconomicCalendarEvent`, so all existing field reads (`ev.original.event`, `.estimate`, `.impact`, …) still typecheck.
+
+(c) Add an analysis block at the end of each event `<li>` in `DayDetailPanel`, after the closing `</div>` of the flex row (still inside the `<li>`). Insert before the `</li>`:
+
+```tsx
+                        {ev.original.sentiment !== null &&
+                            ev.original.summaryKo !== null && (
+                                <div className="border-secondary-700/60 mt-2 space-y-1 border-t pt-2">
+                                    <span
+                                        className={cn(
+                                            'inline-block rounded px-2 py-0.5 text-xs font-medium',
+                                            SENTIMENT_CLASS[ev.original.sentiment]
+                                        )}
+                                    >
+                                        {SENTIMENT_LABEL[ev.original.sentiment]}
+                                    </span>
+                                    <p className="text-secondary-200 text-sm">
+                                        {ev.original.summaryKo}
+                                    </p>
+                                    {ev.original.interpretationKo !== null && (
+                                        <p className="text-secondary-400 text-xs leading-relaxed">
+                                            {ev.original.interpretationKo}
+                                        </p>
+                                    )}
+                                </div>
+                            )}
+```
+
+> Guard on both `sentiment !== null` AND `summaryKo !== null` so a partially-written row (should not happen — `attachEventAnalysis` writes all three atomically) never renders a lone badge. `interpretationKo` is guarded independently for defense in depth.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/widgets/economy/sections/__tests__/EconomicCalendarGrid.analysis.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run the full grid suite (no SP-A regression)**
+
+Run: `npx vitest run src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx src/widgets/economy/sections/__tests__/EconomicCalendarGrid.analysis.test.tsx`
+Expected: PASS — SP-A grid tests (default selection, empty state, SSR panels) stay green; the prop-type widening is source-compatible (SP-A tests pass plain `EconomicCalendarEvent` literals, which now need the four analysis fields → **update the SP-A test's event factory** to include `sentiment: null, summaryKo: null, interpretationKo: null, analyzedAt: null`, OR make those four fields optional on the props type). Choose the optional-field approach to avoid editing SP-A tests: see Step 6.
+
+- [ ] **Step 6: Make analysis fields optional on the prop boundary (avoid SP-A test churn)**
+
+To keep SP-A's `<EconomicCalendarGrid events={[plainEvent]} />` tests compiling without edits, accept the SP-A event shape at the prop boundary by making the four analysis fields optional there. Change `EconomicCalendarEventWithAnalysis` consumption in the grid to a prop-local type:
+
+```typescript
+/**
+ * 그리드 입력 — SP-A `EconomicCalendarEvent` + (선택) SP-D 분석 필드. 분석 필드를
+ * optional로 둬 SP-A 호출부(분석 없는 이벤트 리터럴)도 그대로 컴파일된다. DB reader
+ * (`getCalendarFromDb`)는 항상 네 필드를 채워 넘기므로 런타임엔 항상 존재(또는 null).
+ */
+type CalendarGridEvent = EconomicCalendarEvent &
+    Partial<
+        Pick<
+            EconomicCalendarEventWithAnalysis,
+            'sentiment' | 'summaryKo' | 'interpretationKo' | 'analyzedAt'
+        >
+    >;
+```
+
+Use `CalendarGridEvent` in `KstEvent.original`, `groupEventsByKstDay`, and `EconomicCalendarGridProps.events`. The display guard `ev.original.sentiment !== null && ev.original.summaryKo !== null` already handles `undefined` correctly (`undefined !== null` is `true`, but then `SENTIMENT_CLASS[undefined]` would be unsafe — so tighten the guard to truthy):
+
+Change the guard to:
+
+```tsx
+                        {ev.original.sentiment != null &&
+                            ev.original.summaryKo != null && (
+```
+
+(`!= null` excludes both `null` and `undefined`, narrowing `sentiment` to `NewsSentiment` for the `SENTIMENT_CLASS` index.)
+
+Re-run Step 4 + Step 5 commands — both green, SP-A tests untouched.
+
+- [ ] **Step 7: Typecheck + lint**
+
+Run: `npx tsc --noEmit && yarn lint`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/widgets/economy/sections/EconomicCalendarGrid.tsx src/widgets/economy/sections/__tests__/EconomicCalendarGrid.analysis.test.tsx
+git commit -m "feat(economy): display event AI sentiment/summary/interpretation (SP-D)"
+```
+
+---
+
+## Task 8: Wire the on-access analysis trigger into the SP-A hook
+
+**Files:**
+- Modify: `src/widgets/economy/hooks/useEconomicCalendarTrigger.ts` (SP-A hook)
+- Modify: `src/widgets/economy/hooks/__tests__/useEconomicCalendarTrigger.test.tsx` (SP-A test)
+
+The SP-A hook already fires `ensureEconomicCalendarAction()` once on mount. SP-D adds a second fire of `ensureEconomicEventsAnalyzedAction()` on the same mount (sequenced after ingest so freshly-upserted announced rows are analyzed in the same visit; if ingest is slow the analysis still runs against whatever announced rows exist — eventual via the next mount). Bots included (spec: "봇 포함").
+
+- [ ] **Step 1: Update the SP-A hook test**
+
+In `src/widgets/economy/hooks/__tests__/useEconomicCalendarTrigger.test.tsx`, change the mock to include both actions and add an assertion:
+
+```typescript
+const ensureEconomicCalendarAction = vi.fn();
+const ensureEconomicEventsAnalyzedAction = vi.fn();
+vi.mock('@/entities/economy/actions', () => ({
+    ensureEconomicCalendarAction,
+    ensureEconomicEventsAnalyzedAction,
+}));
+```
+
+In the existing `beforeEach`, also reset the new mock:
+
+```typescript
+        ensureEconomicEventsAnalyzedAction.mockResolvedValue(undefined);
+```
+
+Add a test:
+
+```typescript
+    it('also fires the analysis ensure once on mount', () => {
+        render(<Probe />);
+        expect(ensureEconomicEventsAnalyzedAction).toHaveBeenCalledOnce();
+    });
+```
+
+> The SP-A "fires once on mount" + "does not re-fire on re-render" + "swallows rejection" tests stay; the ingest assertions are unchanged.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/widgets/economy/hooks/__tests__/useEconomicCalendarTrigger.test.tsx`
+Expected: FAIL — `ensureEconomicEventsAnalyzedAction` is never called by the current hook.
+
+- [ ] **Step 3: Update the hook**
+
+In `src/widgets/economy/hooks/useEconomicCalendarTrigger.ts`, import both actions and fire both inside the existing once-guard effect:
+
+```typescript
+'use client';
+
+import { useEffect, useRef } from 'react';
+import {
+    ensureEconomicCalendarAction,
+    ensureEconomicEventsAnalyzedAction,
+} from '@/entities/economy/actions';
+
+/**
+ * Fire-and-forget on mount (봇 포함, 1회):
+ * 1. `ensureEconomicCalendarAction` — ±1mo FMP 인제스션(SP-A).
+ * 2. `ensureEconomicEventsAnalyzedAction` — 발표된 Medium+ 미분석 이벤트 AI 분석(SP-D).
+ *
+ * 인제스션 직후 분석을 트리거해 같은 방문에서 새로 채워진 actual을 분석한다. 둘 다 자체
+ * refresh-flag로 쓰로틀되고 에러는 로깅만 — 실패해도 다음 접속/플래그 만료 시 재시도된다.
+ */
+export function useEconomicCalendarTrigger(): void {
+    const triggeredRef = useRef(false);
+
+    useEffect(() => {
+        if (triggeredRef.current) return;
+        triggeredRef.current = true;
+        void ensureEconomicCalendarAction().catch((e: unknown) => {
+            console.error(
+                '[useEconomicCalendarTrigger] ensureEconomicCalendarAction failed:',
+                e
+            );
+        });
+        void ensureEconomicEventsAnalyzedAction().catch((e: unknown) => {
+            console.error(
+                '[useEconomicCalendarTrigger] ensureEconomicEventsAnalyzedAction failed:',
+                e
+            );
+        });
+    }, []);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/widgets/economy/hooks/__tests__/useEconomicCalendarTrigger.test.tsx`
+Expected: PASS (SP-A tests + the new analysis-fire test).
+
+- [ ] **Step 5: Typecheck + lint**
+
+Run: `npx tsc --noEmit && yarn lint`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/widgets/economy/hooks/useEconomicCalendarTrigger.ts src/widgets/economy/hooks/__tests__/useEconomicCalendarTrigger.test.tsx
+git commit -m "feat(economy): fire analysis ensure on calendar mount (SP-D)"
+```
+
+---
+
+## Task 9: One-time SEED script
+
+**Files:**
+- Create: `scripts/seedEconomicEventAnalysis.ts`
+- Modify: `package.json` (add `db:seed:calendar-analysis`)
+
+A one-time `tsx` SEED the user runs after the SP-A backfill: it analyzes **all** current Medium+ announced unanalyzed rows once (the spec's trigger mode (a)). It uses `postgres-js` + Drizzle directly (like SP-A's backfill script and `seed-korean-tickers.ts`) so it runs standalone against `DIRECT_DATABASE_URL`, calls the real core `analyzeEconomicEvent`, and writes via the same write-once update. Bounded sequential-chunk parallelism keeps the LLM load sane.
+
+There is no automated test for `run()` (network + DB + LLM glue). Its logic-bearing pieces (repo write-once, the analyzer-input mapping) are unit-tested in Tasks 4/6. The script reuses the repo's `attachEventAnalysis`/`listUnanalyzedAnnounced` rather than re-implementing SQL.
+
+- [ ] **Step 1: Write the script**
+
+```typescript
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { analyzeEconomicEvent } from '@y0ngha/siglens-core';
+
+import { DrizzleEconomicCalendarRepository } from '../src/entities/economy/api/economicCalendarRepository';
+import { CALENDAR_ANALYZED_IMPACTS } from '../src/entities/economy/lib/economyCalendarConstants';
+
+const databaseUrl =
+    process.env.DIRECT_DATABASE_URL || process.env.DATABASE_URL;
+if (!databaseUrl) {
+    throw new Error('DATABASE_URL env var required');
+}
+
+/** 동시 분석 상한 — seed는 일괄이라 작게 잡아 LLM 큐 압박을 피한다. */
+const SEED_PARALLEL_LIMIT = 4;
+
+async function run(): Promise<void> {
+    const client = postgres(databaseUrl!, { max: 1 });
+    const db = drizzle(client);
+    const repo = new DrizzleEconomicCalendarRepository(
+        db as unknown as Parameters<
+            typeof DrizzleEconomicCalendarRepository.prototype.constructor
+        >[0] extends never
+            ? never
+            : never
+    );
+    // NOTE: DrizzleEconomicCalendarRepository takes a SiglensDatabase; the
+    // postgres-js drizzle instance is structurally compatible for the queries
+    // used here (insert/select/update). Cast through the constructor param type.
+
+    const pending = await repo.listUnanalyzedAnnounced(CALENDAR_ANALYZED_IMPACTS);
+    console.log(`Seeding analysis for ${pending.length} Medium+ announced event(s)`);
+
+    let analyzed = 0;
+    let failed = 0;
+    for (let i = 0; i < pending.length; i += SEED_PARALLEL_LIMIT) {
+        const chunk = pending.slice(i, i + SEED_PARALLEL_LIMIT);
+        const results = await Promise.allSettled(
+            chunk.map(async row => {
+                const analysis = await analyzeEconomicEvent({
+                    event: row.event,
+                    impact: row.impact,
+                    actual: row.actual,
+                    estimate: row.estimate,
+                    previous: row.previous,
+                    unit: row.unit,
+                });
+                await repo.attachEventAnalysis(row.id, analysis);
+            })
+        );
+        for (const r of results) {
+            if (r.status === 'fulfilled') analyzed += 1;
+            else {
+                failed += 1;
+                console.error('  analyze failed:', r.reason);
+            }
+        }
+        console.log(`  ${Math.min(i + SEED_PARALLEL_LIMIT, pending.length)}/${pending.length}`);
+    }
+
+    console.log(`Done — analyzed ${analyzed}, failed ${failed}`);
+    await client.end();
+}
+
+run().catch(error => {
+    console.error('[seedEconomicEventAnalysis] failed:', error);
+    process.exitCode = 1;
+});
+```
+
+> **Simplify the repo-construction cast before finalizing:** the awkward conditional type above is a placeholder to flag that `drizzle(postgres(...))` is a `PostgresJsDatabase`, not the app's Neon `SiglensDatabase`. SP-A's `backfillEconomicCalendar.ts` does NOT reuse the repo — it inlines the upsert against the `postgres-js` db. **Mirror that here:** do the same and inline the write-once update + select using the `postgres-js` `db`, OR (cleaner) construct the repo with `new DrizzleEconomicCalendarRepository(db as unknown as SiglensDatabase)` importing `type { SiglensDatabase } from '../src/shared/db/types'`. Use the simple `as unknown as SiglensDatabase` cast (the repo only uses `insert/select/update`, present on both adapters) and delete the conditional-type block. Final repo line:
+>
+> ```typescript
+> import type { SiglensDatabase } from '../src/shared/db/types';
+> // ...
+> const repo = new DrizzleEconomicCalendarRepository(
+>     db as unknown as SiglensDatabase
+> );
+> ```
+
+- [ ] **Step 2: Add the package.json script**
+
+In `package.json` `scripts`, next to SP-A's `db:backfill:calendar`:
+
+```json
+"db:seed:calendar-analysis": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seedEconomicEventAnalysis.ts",
+```
+
+- [ ] **Step 3: Typecheck + lint**
+
+Run: `npx tsc --noEmit && yarn lint`
+Expected: PASS. (The `as unknown as SiglensDatabase` cast is the single intentional structural bridge between the script's `postgres-js` db and the app's Neon db type — documented inline.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/seedEconomicEventAnalysis.ts package.json
+git commit -m "feat(economy): add one-time event-analysis seed script (SP-D)"
+```
+
+> Note: running `yarn db:seed:calendar-analysis` against the live DB (requires `DIRECT_DATABASE_URL` + the core LLM env) is an operational step the user performs once after the SP-A backfill. The on-access trigger keeps subsequent newly-announced events analyzed.
+
+---
+
+## Task 10: Full-suite green + final gates
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the economy + market-news suites**
+
+Run: `npx vitest run src/entities/economy src/widgets/economy src/entities/market-news`
+Expected: PASS (SP-A + SP-D economy tests, no market-news regression from the shared sentiment-constants reuse).
+
+- [ ] **Step 2: Full unit suite**
+
+Run: `yarn test`
+Expected: PASS (no repo-wide regressions).
+
+- [ ] **Step 3: Lint + format + typecheck gates**
+
+Run: `npx tsc --noEmit && yarn lint && yarn format`
+Expected: tsc PASS, lint PASS, format applies no pending changes (or only this plan's files, already clean).
+
+- [ ] **Step 4: Build — ISR/cold-gen safety unchanged**
+
+Run: `yarn build > /tmp/economy-spd-build.log 2>&1; echo "EXIT=$?"`
+Expected: `EXIT=0`. SP-D adds no new page render path; `/economy` must still build without `DYNAMIC_SERVER_USAGE` (the AI columns flow through SP-A's `unstable_cache`-wrapped `getCalendarFromDb`; the action is client-triggered, not in the cold-gen path). Inspect: `grep -iE "economy|DYNAMIC_SERVER_USAGE|error" /tmp/economy-spd-build.log` — no `DYNAMIC_SERVER_USAGE` attributed to `/economy`.
+
+- [ ] **Step 5: Commit any formatting fixups (if produced)**
+
+```bash
+git add -A
+git commit -m "chore(economy): formatting + lint fixups (SP-D)"
+```
+
+(Skip if nothing changed.)
+
+---
+
+## Self-Review
+
+**Spec coverage (SP-D section + shared data model AI columns note):**
+
+| Spec requirement | Task |
+|---|---|
+| **CORE** `analyzeEconomicEvent(input): EconomicEventAnalysis`, input {event, impact, actual, estimate, previous, unit} (+ optional recent trend), output {sentiment, summaryKo, interpretationKo}; PROMPT_TEMPLATE_VERSION in core; user-released; siglens mocks it | Cross-repo note (exact contract) + Task 0 (gate/version bump) + every siglens task mocks `@y0ngha/siglens-core` |
+| Migration adding `sentiment`/`summaryKo`/`interpretationKo`/`analyzedAt` to `economic_calendar` (deferred from SP-A) | Task 1 (additive nullable `0019` migration) |
+| `ensureEconomicEventsAnalyzedAction` — `impact IN ('High','Medium') AND actual IS NOT NULL AND analyzedAt IS NULL` → core → write sentiment/summaryKo/interpretationKo/analyzedAt | Task 4 (`listUnanalyzedAnnounced` + `attachEventAnalysis`) + Task 6 (action) |
+| Trigger mode (a) SEED — batch over all current Medium+ announced once | Task 9 (seed script) |
+| Trigger mode (b) ON-ACCESS — fired on /economy mount (mirror market-news; bots included) for not-yet-analyzed announced | Task 8 (SP-A hook fires analysis ensure on mount, bots included) |
+| Cooldown / idempotency | Task 5 (analysis refresh-flag, separate key) + Task 4 (`analyzed_at IS NULL` write-once guard) + Task 6 (mark-before-async dedup) |
+| Display in DayDetailPanel — sentiment badge (ui-*-text AA tokens), summary, interpretation; unchanged for unannounced/Low/not-yet-analyzed | Task 7 (badge via reused AA `SENTIMENT_CLASS` + summary + interpretation, null-guarded) |
+| Expensive/async → submit/poll, else market-news-style ensure; justify | Cross-repo note §"Sync vs async" (synchronous `analyzeEconomicEvent`, justified by spec contract + low volume + small output) + Task 6 (ensure with direct call, swap-contained) |
+| Reuse SP-A `economic_calendar` repo (don't duplicate) | Task 4 extends the SP-A `DrizzleEconomicCalendarRepository`; Tasks 6/9 consume it; no SP-A artifact re-declared |
+| Same on-access condition as News | Task 6 mirrors `ensureMarketNewsCardsAnalyzedAction` (refresh-flag, allSettled, majority guard, single revalidateTag, `isE2E` short-circuit) |
+
+**Cross-repo ordering (explicit):** SP-D depends on **(1) SP-A merged** (table, repo, `getCalendarFromDb`, `ensureEconomicCalendarAction`, the trigger hook, the `actions.ts` barrel, the constants file — all extended here) **and (2) the core release** of `analyzeEconomicEvent` (Task 0). Within SP-D: Task 0 (core gate) → Task 1 (migration) → Task 2 (guard/type) → Task 3 (constants) → Task 4 (repo) → Task 5 (flag) → Task 6 (action) → Task 7 (display) → Task 8 (trigger wiring) → Task 9 (seed) → Task 10 (gates). Tasks 1–5 are independent of each other after Task 0; Task 6 needs 3+4+5; Task 7 needs 2; Task 8 needs 6; Task 9 needs 4.
+
+**Placeholder scan:** No TBD/TODO/"similar to Task N" left as code. The only inline "decide-at-execution" note is Task 9 Step 1's repo-construction cast — it gives the **exact final code** (`as unknown as SiglensDatabase` + the import) and instructs deleting the placeholder conditional-type; not a gap. Every other code step is complete; every command is exact with expected output.
+
+**Type-consistency check:**
+- `EconomicEventAnalysisInput` / `EconomicEventAnalysis` / `analyzeEconomicEvent` — contract defined once (Cross-repo note); mocked identically in Tasks 6/7 tests; consumed in Task 6 action + Task 9 seed with the same 6-field input object (`event/impact/actual/estimate/previous/unit`). ✓
+- `DrizzleEconomicCalendarRepository` gains `attachEventAnalysis(id, analysis)` + `listUnanalyzedAnnounced(impacts)` and widens `listInRange` → `EconomicCalendarEventWithAnalysis[]` — defined Task 4, consumed Tasks 6/9, mocked identically in Task 6 test. ✓
+- `UnanalyzedAnnouncedEvent` (id + 6 analyzer fields) — exported Task 4, imported Task 6. ✓
+- `EconomicCalendarEventWithAnalysis extends EconomicCalendarEvent` — defined Task 2 (`model.ts`), consumed Task 4 (repo return) + Task 7 (grid prop, via optional `CalendarGridEvent` bridge). Backward-compatible with SP-A consumers. ✓
+- `toEventSentiment` (Task 2) — read-boundary coercion used in Task 4 mapper + Task 7 display tri-state. ✓
+- Constants `CALENDAR_ANALYSIS_PARALLEL_LIMIT`/`CALENDAR_ANALYZED_IMPACTS`/analysis-flag key+TTL — defined Task 3, consumed Tasks 5/6/9. ✓
+- `ECONOMY_CALENDAR_CACHE_TAG` — SP-A constant reused by Task 6 `revalidateTag` (same tag → SP-A reader refresh). ✓
+- `SENTIMENT_LABEL`/`SENTIMENT_CLASS` (`Record<NewsSentiment, …>`) — real existing exports (`src/widgets/market-news/utils/sentimentConstants.ts`, verified), reused in Task 7. ✓
+- `isE2E` (`@/shared/api/e2eEnv`) — real existing export used by `ensureMarketNewsCardsAnalyzedAction`, reused in Task 6. ✓
+
+**Gates honored:** additive nullable migration (no backfill); `'use server'` file function-only (guards/constants/flag in separate files); barrel-excluded `api/` modules deep-imported; SP-A `actions.ts` barrel gets the new re-export (no `'use server'` on barrel); ISR cold-gen path untouched (Task 10 build check); reused-not-duplicated SP-A repo/table/hook/constants; no `eslint-disable`; multi-line JSDoc allowed per Documentation Policy; sentiment validated at read boundary; commit-per-task, no push.

--- a/docs/superpowers/specs/2026-06-20-economy-calendar-iteration-design.md
+++ b/docs/superpowers/specs/2026-06-20-economy-calendar-iteration-design.md
@@ -1,0 +1,160 @@
+# 경제 캘린더 후속 이터레이션 설계 (2026-06-20)
+
+PR #610(월 그리드 캘린더 + KST, `EconomicCalendarGrid`)이 머지된 상태에서 이어가는 후속
+이터레이션. 4개 sub-project로 분해하며, 공유 데이터 모델 위에서 독립적으로 구현 가능하다.
+
+## 목표 (사용자 pain → 해결)
+
+1. **과거 이벤트 표시** — 현재 미래 window만 보여 어제 발표된 지표를 선택할 수 없다. 최소
+   지난 2주 + 발표치(actual)까지 표시.
+2. **지표명 한국어화** — FMP 이벤트명이 영어("Core PCE Price Index YoY (May)")라 가독성이 낮다.
+3. **중요도 필터** — High/Medium/Low 필터로 노이즈(연간 Low 2,919건) 정리.
+4. **이벤트 AI 분석(Medium+)** — bullish/bearish·해석·요약.
+
+## 실측 데이터 (FMP `/stable/economic-calendar`, `from`/`to` 지원)
+
+- 1년 단일 요청 OK: 전체 29,225건 / **US 4,601건** / 355일 (범위 캡 없음).
+- 정규화(끝 괄호 `(May)`/`(Q1)` 제거) **distinct 지표명 = ~277개** (raw 3,123은 기간 변형 포함).
+- impact 분포(연간): **High 324 · Medium 1,350 · Low 2,919** → Medium+ = 1,674/년(~140/월).
+
+## Cross-repo 경계 (CLAUDE.md guard)
+
+| 작업 | 레포 |
+|---|---|
+| FMP 백필/ingestion I/O, DB 스키마/저장, 필터 UI, 지표명 코드 사전, 표시, AI 잡/캐시/어댑터 | **siglens** |
+| 이벤트 **AI 분석 로직/프롬프트**(sentiment·해석·요약), 미매핑 지표명 **AI 번역** | **siglens-core** |
+
+core 변경은 사용자가 publish(`npm version` + `git push --tags`). siglens는 core 릴리스 후 버전 갱신·import.
+
+---
+
+## 공유 데이터 모델 (siglens, `src/shared/db/schema.ts`)
+
+기존 `marketNews`(발표 후 채워지는 필드 + AI 필드 + analyzedAt)와 `earningsReports`(actual 후채움),
+`assetTranslations`(번역 테이블) 패턴을 미러링한다.
+
+### `economic_calendar`
+
+```
+id            text PK         -- 결정론적 해시(country + dateEt + event), upsert 키
+country       text NOT NULL   -- 'US' (현재 US만 저장)
+dateEt        text NOT NULL   -- FMP 원본 'YYYY-MM-DD HH:mm:ss' (ET 벽시계). KST 변환은 표시 계층(etDateTimeToKst)
+event         text NOT NULL   -- FMP 원본 이벤트명(영어)
+impact        text NOT NULL   -- 'High' | 'Medium' | 'Low'
+estimate      double NULL
+previous      double NULL
+actual        double NULL     -- 발표 전 null, ingestion 재fetch 시 채워짐
+unit          text NOT NULL
+fetchedAt     timestamptz NOT NULL DEFAULT now()
+-- SP-D에서 별도 마이그레이션으로 추가(SP-A 테이블에는 미포함):
+--   sentiment text NULL ('bullish'|'neutral'|'bearish'), summaryKo text NULL,
+--   interpretationKo text NULL, analyzedAt timestamptz NULL
+index: (dateEt), (country, dateEt), (impact)
+```
+
+`id` 해시는 `actual`을 포함하지 않는다 — actual이 발표 후 바뀌어도 같은 이벤트로 upsert해 갱신한다.
+(이는 #610 그리드의 React key `${date}:${event}:${actual}`와 의도가 다름에 주의: DB는 안정 키.)
+
+### `economic_indicator_translations` (SP-B)
+
+`assetTranslations` 미러.
+
+```
+normalizedName text PK   -- 정규화된 지표 base명(접미사 제거), 예 'Core PCE Price Index YoY'
+koreanName     text NOT NULL
+source         text NOT NULL  -- 'dict' | 'ai'
+updatedAt      timestamptz NOT NULL DEFAULT now() $onUpdate
+```
+
+코드 const 맵이 source-of-truth(`dict`), 미매핑은 core AI 번역 결과를 여기에 `ai`로 캐시한다.
+
+---
+
+## SP-A — 이력 데이터 레이어 (기반, siglens)
+
+다른 SP 전부의 전제. 캘린더 데이터를 Redis 스냅샷에서 분리해 DB-backed로 전환한다.
+
+### 컴포넌트
+- **`scripts/backfillEconomicCalendar.ts`** — 사용자가 **1회 수동 실행**. now±1년(~2년)을 청크(예 월별/3개월별)로 FMP fetch → `economic_calendar` upsert. 재실행 안전(idempotent upsert). 동시에 SP-B 사전 시드용으로 distinct 정규화 이름 집합을 추출/덤프.
+- **`entities/economy/actions/ensureEconomicCalendarAction.ts`** — `ensureMarketNewsCardsAnalyzedAction` 미러. **±1개월 윈도우** FMP fetch → upsert(신규 insert + 기존 `actual`/estimate/previous update). fire-and-forget, 에러는 로깅만.
+- **`entities/economy/api/`** — `getCalendarFromDb(fromEt, toEt)`: DB에서 과거2주+미래window 읽기. ISR cold-gen 안전(`staticSymbolCache`/unstable_cache 래핑, 4축 규약 준수).
+- **economy 페이지**: 캘린더 데이터 소스를 `economySnapshotCache`(Redis)에서 **`getCalendarFromDb`**로 교체. 지표/treasury 스냅샷은 그대로. `EconomicCalendarGrid`에 과거+미래 이벤트를 함께 전달. **기본 선택일 = 오늘(KST)**, 오늘 이벤트가
+없으면 가장 가까운 미래일 — 결정론적(렌더 중 `Date.now()` 금지 위배 주의: 페이지 RSC에서 ET 기준
+오늘을 1회 계산해 prop으로 전달, 그리드는 그 값을 받아 사용).
+- **on-access 트리거**: 클라 위젯이 마운트 시 `ensureEconomicCalendarAction` 1회 호출(news `useMarketNewsAnalysisTrigger` 패턴). 봇 포함(봇 접속 시도 갱신).
+
+### 데이터 흐름
+페이지 ISR 렌더 → DB read(과거2주+미래) → 그리드. 클라 마운트 → ensure(±1mo fetch+upsert) → revalidateTag로 다음 렌더 신선화(news `revalidateTag('news:..','max')` 미러).
+
+### 에러 처리
+FMP 실패 시 DB의 기존 데이터로 graceful(빈 배열 아님). upsert 충돌은 id PK로 흡수.
+
+### 테스트
+backfill 스크립트(청크 분할·idempotent upsert·이름 추출), ensure 액션(insert/actual-update 분기), getCalendarFromDb(범위·정렬), ISR 안전(connection 금지). vitest + 기존 economy 테스트 스타일.
+
+---
+
+## SP-B — 지표명 한국어화 (siglens i18n + core AI 번역)
+
+### 컴포넌트
+- **`entities/economy/lib/indicatorNameKo.ts`** — `INDICATOR_NAME_KO: Record<string, string>` 코드 const(~277, source-of-truth). + **정규화 함수** `normalizeIndicatorName(raw)`: 끝 괄호(`(May)`/`(Q1)`/`(Jun/20)`) 분리, base명 + 기간 토큰 반환. + 기간 토큰 한국어화(YoY→전년比, MoM→전월比, QoQ→전분기比, 월/분기명).
+- **표시 헬퍼** `indicatorLabelKo(raw)`: 정규화 → 코드 사전 룩업 → DB 캐시 룩업 → 미매핑이면 원문(영어) + (백그라운드) AI 번역 트리거. "매핑되면 즉시, 안 되면 AI 1회 후 캐시"(news 번역 결).
+- **`economic_indicator_translations` DB 캐시** — core AI 번역 결과 저장(`source:'ai'`), 추후 코드 사전 승격.
+- **core**: `translateIndicatorName(normalizedName): Promise<string>` (또는 배치) — 분석 계열이므로 core. siglens 어댑터가 호출 + 캐시.
+- **초기 277 사전 구축**: SP-A 백필 enumeration → 정규화 distinct 추출 → core AI로 초벌 번역 → 사용자/내가 큐레이션 → `indicatorNameKo.ts` 고정(1회 데이터 작업).
+
+### 데이터 흐름
+표시 시 raw명 → normalize → dict(코드) hit이면 즉시 / miss이면 DB(`ai`) hit이면 즉시 / 둘 다 miss이면 영어 표시 + ensure식 백그라운드 AI 번역 → DB 캐시 → 다음 렌더 한국어.
+
+### 테스트
+normalize(접미사 분리·기간 토큰), dict 룩업, DB 캐시 fallback, 미매핑 영어 유지. core 번역은 core 테스트.
+
+---
+
+## SP-C — 중요도 필터 UI (siglens, 작고 독립)
+
+### 컴포넌트
+- **`EconomicCalendarGrid`** 상단에 영향도 필터 칩(High/Medium/Low 토글). 클라 상태(useState). **기본값: High+Medium 켜고 Low 끔**(연간 Low 2,919 노이즈 정리). 전체 이벤트는 DOM 유지(SSR 크롤), 필터는 시각적(셀 점/건수·상세 목록을 선택 impact로 한정).
+- 접근성: 토글 버튼 `aria-pressed`, 그룹 `role="group" aria-label="중요도 필터"`. SSR 크롤러는 필터 무관 전체 텍스트 봄(hidden 아님, 시각 필터).
+
+### 의존
+#610 캘린더만 필요. SP-A 없이도 미래 window에 적용 가능(단 과거 데이터는 SP-A 후 풍부).
+
+### 테스트
+기본 필터 상태, 토글 시 표시 변화, 전체 이벤트 DOM 유지(크롤). vitest.
+
+---
+
+## SP-D — 이벤트 AI 분석 (Medium+) (core 분석 + siglens 잡)
+
+### core (siglens-core)
+- **`analyzeEconomicEvent(input): EconomicEventAnalysis`** — 입력: event명·impact·actual/estimate/previous·unit(+필요시 직전 추세). 출력 구조: `{ sentiment: 'bullish'|'neutral'|'bearish', summaryKo, interpretationKo }`. 프롬프트·정규화·검증 = core. PROMPT_TEMPLATE_VERSION 관리.
+
+### siglens
+- **DB**: `economic_calendar`의 sentiment/summaryKo/interpretationKo/analyzedAt 채움.
+- **`ensureEconomicEventsAnalyzedAction`** — Medium+ & `actual !== null` & `analyzedAt === null`인 이벤트만 core 분석 호출 → DB 저장. **seed**: 백필 후 Medium+ 전량 1회 배치. **on-access**: /economy 마운트 시 미분석 발표분만(news 조건과 동일). 봇 포함.
+- 비동기 비용 큰 경우 macroBriefing식 submit/poll(잡 큐) 미러. 쿨다운·재분석은 news/macro 패턴 따름.
+- 표시: 상세 패널에 sentiment 배지(AA 토큰)·요약·해석. 미분석(미발표/Low)은 기존대로.
+
+### 의존
+SP-A(이벤트+actual DB) 필요. cross-repo: core 먼저 릴리스 → siglens 어댑터.
+
+### 테스트
+ensure 분기(Medium+/actual/analyzedAt 조건), DB 저장, 표시. core analyze는 core 테스트.
+
+---
+
+## 구현 순서
+
+1. **SP-A**(기반: DB·백필·ensure·페이지 DB 전환) — 나머지 전제.
+2. **SP-C**(필터: 작고 독립, 빠른 UX) — A와 병렬 가능.
+3. **SP-B**(번역: A 백필로 사전 시드) — core 번역 + 코드 사전.
+4. **SP-D**(AI 분석: A 필요, 최대·cross-repo) — core 릴리스 후.
+
+각 SP는 자체 plan→구현. SP-D의 core 부분은 별도 core 작업(사용자 publish).
+
+## 비용/성능 고려
+
+- 매 접속 1년 fetch 금지(전송 비용) → 1회 백필 + ±1개월 ingestion.
+- ISR(86400) 유지, 신선도는 ensure + revalidateTag(news 미러).
+- AI 분석은 Medium+(~140/월)로 한정, seed 1회 + 미분석분만.

--- a/drizzle/0018_spotty_solo.sql
+++ b/drizzle/0018_spotty_solo.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "economic_calendar" (
+	"id" text PRIMARY KEY NOT NULL,
+	"country" text NOT NULL,
+	"date_et" text NOT NULL,
+	"event" text NOT NULL,
+	"impact" text NOT NULL,
+	"estimate" double precision,
+	"previous" double precision,
+	"actual" double precision,
+	"unit" text NOT NULL,
+	"fetched_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "economic_calendar_date_et_idx" ON "economic_calendar" USING btree ("date_et");--> statement-breakpoint
+CREATE INDEX "economic_calendar_country_date_et_idx" ON "economic_calendar" USING btree ("country","date_et");--> statement-breakpoint
+CREATE INDEX "economic_calendar_impact_idx" ON "economic_calendar" USING btree ("impact");

--- a/drizzle/meta/0018_snapshot.json
+++ b/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,1540 @@
+{
+    "id": "b9bdd92d-5e2d-4de9-bfe9-5b453a5febbb",
+    "prevId": "1068f0e3-113b-4d46-a799-b21eac47348a",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.agreements": {
+            "name": "agreements",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "terms_id": {
+                    "name": "terms_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "agreed": {
+                    "name": "agreed",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "agreed_at": {
+                    "name": "agreed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "agreements_user_terms_uidx": {
+                    "name": "agreements_user_terms_uidx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "terms_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "agreements_user_id_idx": {
+                    "name": "agreements_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "agreements_terms_id_idx": {
+                    "name": "agreements_terms_id_idx",
+                    "columns": [
+                        {
+                            "expression": "terms_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "agreements_user_id_users_id_fk": {
+                    "name": "agreements_user_id_users_id_fk",
+                    "tableFrom": "agreements",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "agreements_terms_id_terms_id_fk": {
+                    "name": "agreements_terms_id_terms_id_fk",
+                    "tableFrom": "agreements",
+                    "tableTo": "terms",
+                    "columnsFrom": ["terms_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "restrict",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.asset_translations": {
+            "name": "asset_translations",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "fmp_symbol": {
+                    "name": "fmp_symbol",
+                    "type": "varchar(64)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.earnings_reports": {
+            "name": "earnings_reports",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "earnings_date": {
+                    "name": "earnings_date",
+                    "type": "date",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "eps_actual": {
+                    "name": "eps_actual",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "eps_estimated": {
+                    "name": "eps_estimated",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "revenue_actual": {
+                    "name": "revenue_actual",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "revenue_estimated": {
+                    "name": "revenue_estimated",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "last_updated": {
+                    "name": "last_updated",
+                    "type": "date",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "raw_payload": {
+                    "name": "raw_payload",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {
+                "earnings_reports_symbol_earnings_date_pk": {
+                    "name": "earnings_reports_symbol_earnings_date_pk",
+                    "columns": ["symbol", "earnings_date"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.economic_calendar": {
+            "name": "economic_calendar",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "country": {
+                    "name": "country",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "date_et": {
+                    "name": "date_et",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "event": {
+                    "name": "event",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "impact": {
+                    "name": "impact",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "estimate": {
+                    "name": "estimate",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "previous": {
+                    "name": "previous",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "actual": {
+                    "name": "actual",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "unit": {
+                    "name": "unit",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "economic_calendar_date_et_idx": {
+                    "name": "economic_calendar_date_et_idx",
+                    "columns": [
+                        {
+                            "expression": "date_et",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "economic_calendar_country_date_et_idx": {
+                    "name": "economic_calendar_country_date_et_idx",
+                    "columns": [
+                        {
+                            "expression": "country",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "date_et",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "economic_calendar_impact_idx": {
+                    "name": "economic_calendar_impact_idx",
+                    "columns": [
+                        {
+                            "expression": "impact",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.inquiries": {
+            "name": "inquiries",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "title": {
+                    "name": "title",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "content": {
+                    "name": "content",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "email": {
+                    "name": "email",
+                    "type": "varchar(320)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "answered": {
+                    "name": "answered",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.korean_tickers": {
+            "name": "korean_tickers",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "exchange": {
+                    "name": "exchange",
+                    "type": "varchar(32)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "exchange_full_name": {
+                    "name": "exchange_full_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.market_news": {
+            "name": "market_news",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "symbol": {
+                    "name": "symbol",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "source": {
+                    "name": "source",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "url": {
+                    "name": "url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "published_at": {
+                    "name": "published_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_ko": {
+                    "name": "title_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_en": {
+                    "name": "body_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_ko": {
+                    "name": "body_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "summary_ko": {
+                    "name": "summary_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "sentiment": {
+                    "name": "sentiment",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "category": {
+                    "name": "category",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "price_impact": {
+                    "name": "price_impact",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "tickers": {
+                    "name": "tickers",
+                    "type": "text[]",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "ARRAY[]::text[]"
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "analyzed_at": {
+                    "name": "analyzed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "market_news_symbol_published_at_idx": {
+                    "name": "market_news_symbol_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "symbol",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "market_news_published_at_idx": {
+                    "name": "market_news_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "market_news_url_unique": {
+                    "name": "market_news_url_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["url"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.news": {
+            "name": "news",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "symbol": {
+                    "name": "symbol",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "source": {
+                    "name": "source",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "url": {
+                    "name": "url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "published_at": {
+                    "name": "published_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_ko": {
+                    "name": "title_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_en": {
+                    "name": "body_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_ko": {
+                    "name": "body_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "summary_ko": {
+                    "name": "summary_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "sentiment": {
+                    "name": "sentiment",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "category": {
+                    "name": "category",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "price_impact": {
+                    "name": "price_impact",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "raw_payload": {
+                    "name": "raw_payload",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "analyzed_at": {
+                    "name": "analyzed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "news_symbol_published_at_idx": {
+                    "name": "news_symbol_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "symbol",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "news_published_at_idx": {
+                    "name": "news_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "news_url_unique": {
+                    "name": "news_url_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["url"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.notices": {
+            "name": "notices",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "title": {
+                    "name": "title",
+                    "type": "varchar(200)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "body": {
+                    "name": "body",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "link_url": {
+                    "name": "link_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "link_label": {
+                    "name": "link_label",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "path_pattern": {
+                    "name": "path_pattern",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "priority": {
+                    "name": "priority",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 0
+                },
+                "is_active": {
+                    "name": "is_active",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": true
+                },
+                "starts_at": {
+                    "name": "starts_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "ends_at": {
+                    "name": "ends_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "notices_active_window_idx": {
+                    "name": "notices_active_window_idx",
+                    "columns": [
+                        {
+                            "expression": "is_active",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "starts_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "ends_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.oauth_accounts": {
+            "name": "oauth_accounts",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider": {
+                    "name": "provider",
+                    "type": "oauth_provider",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider_account_id": {
+                    "name": "provider_account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "access_token": {
+                    "name": "access_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "refresh_token": {
+                    "name": "refresh_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "token_expires_at": {
+                    "name": "token_expires_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "oauth_accounts_user_id_idx": {
+                    "name": "oauth_accounts_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "oauth_accounts_provider_account_uidx": {
+                    "name": "oauth_accounts_provider_account_uidx",
+                    "columns": [
+                        {
+                            "expression": "provider",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "provider_account_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "oauth_accounts_user_id_users_id_fk": {
+                    "name": "oauth_accounts_user_id_users_id_fk",
+                    "tableFrom": "oauth_accounts",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.profile_description_translations": {
+            "name": "profile_description_translations",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "description_ko": {
+                    "name": "description_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.sessions": {
+            "name": "sessions",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "sessions_user_id_idx": {
+                    "name": "sessions_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "sessions_expires_at_idx": {
+                    "name": "sessions_expires_at_idx",
+                    "columns": [
+                        {
+                            "expression": "expires_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "sessions_user_id_users_id_fk": {
+                    "name": "sessions_user_id_users_id_fk",
+                    "tableFrom": "sessions",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.terms": {
+            "name": "terms",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "kind": {
+                    "name": "kind",
+                    "type": "terms_kind",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "version": {
+                    "name": "version",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "effective_date": {
+                    "name": "effective_date",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "body": {
+                    "name": "body",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "terms_kind_version_uidx": {
+                    "name": "terms_kind_version_uidx",
+                    "columns": [
+                        {
+                            "expression": "kind",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "version",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "terms_kind_effective_date_idx": {
+                    "name": "terms_kind_effective_date_idx",
+                    "columns": [
+                        {
+                            "expression": "kind",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "effective_date",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.usage_logs": {
+            "name": "usage_logs",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "ip_hash": {
+                    "name": "ip_hash",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "action_type": {
+                    "name": "action_type",
+                    "type": "usage_action_type",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "model_used": {
+                    "name": "model_used",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "date": {
+                    "name": "date",
+                    "type": "date",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "usage_logs_user_id_idx": {
+                    "name": "usage_logs_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "usage_logs_ip_hash_date_idx": {
+                    "name": "usage_logs_ip_hash_date_idx",
+                    "columns": [
+                        {
+                            "expression": "ip_hash",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "date",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "usage_logs_user_id_users_id_fk": {
+                    "name": "usage_logs_user_id_users_id_fk",
+                    "tableFrom": "usage_logs",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.user_api_keys": {
+            "name": "user_api_keys",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider": {
+                    "name": "provider",
+                    "type": "llm_provider",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "encrypted_api_key": {
+                    "name": "encrypted_api_key",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "user_api_keys_user_id_idx": {
+                    "name": "user_api_keys_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "user_api_keys_user_provider_uidx": {
+                    "name": "user_api_keys_user_provider_uidx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "provider",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "user_api_keys_user_id_users_id_fk": {
+                    "name": "user_api_keys_user_id_users_id_fk",
+                    "tableFrom": "user_api_keys",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.users": {
+            "name": "users",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "email": {
+                    "name": "email",
+                    "type": "varchar(320)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "password_hash": {
+                    "name": "password_hash",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "avatar_url": {
+                    "name": "avatar_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "tier": {
+                    "name": "tier",
+                    "type": "user_tier",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'free'"
+                },
+                "email_verified": {
+                    "name": "email_verified",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "users_email_unique": {
+                    "name": "users_email_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["email"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {
+        "public.llm_provider": {
+            "name": "llm_provider",
+            "schema": "public",
+            "values": ["anthropic", "google", "openai"]
+        },
+        "public.oauth_provider": {
+            "name": "oauth_provider",
+            "schema": "public",
+            "values": ["google", "kakao", "apple"]
+        },
+        "public.terms_kind": {
+            "name": "terms_kind",
+            "schema": "public",
+            "values": ["privacy", "tos"]
+        },
+        "public.usage_action_type": {
+            "name": "usage_action_type",
+            "schema": "public",
+            "values": ["analysis", "chatbot", "premium_model"]
+        },
+        "public.user_tier": {
+            "name": "user_tier",
+            "schema": "public",
+            "values": ["free", "member", "pro"]
+        }
+    },
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
             "when": 1781591483491,
             "tag": "0017_perpetual_sentry",
             "breakpoints": true
+        },
+        {
+            "idx": 18,
+            "version": "7",
+            "when": 1781897708671,
+            "tag": "0018_spotty_solo",
+            "breakpoints": true
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "db:migrate": "dotenv -e .env.local -- node_modules/.bin/tsx db/scripts/migrate.ts",
         "db:seed:terms": "dotenv -e .env.local -- node_modules/.bin/tsx db/scripts/seedTerms.ts",
         "db:migrate:tickers": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seed-korean-tickers.ts",
+        "db:backfill:calendar": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/backfillEconomicCalendar.ts",
         "test": "NODE_OPTIONS=--no-experimental-webstorage vitest run",
         "test:quiet": "NODE_NO_WARNINGS=1 NODE_OPTIONS=--no-experimental-webstorage vitest run --reporter=dot",
         "test:related": "NODE_NO_WARNINGS=1 NODE_OPTIONS=--no-experimental-webstorage vitest related --run --passWithNoTests",

--- a/scripts/backfillEconomicCalendar.ts
+++ b/scripts/backfillEconomicCalendar.ts
@@ -10,6 +10,7 @@ import {
 
 import { economicCalendar } from '../src/shared/db/schema';
 import { economicCalendarId } from '../src/entities/economy/lib/economicCalendarId';
+import { CALENDAR_COUNTRY } from '../src/entities/economy/lib/economyCalendarConstants';
 import { chunkDateRange } from './lib/chunkDateRange';
 import { normalizeIndicatorBaseName } from './lib/normalizeIndicatorBaseName';
 
@@ -22,8 +23,6 @@ if (!FMP_API_KEY) {
 if (!databaseUrl) {
     throw new Error('DATABASE_URL env var required');
 }
-
-const CALENDAR_COUNTRY = 'US';
 const CHUNK_DAYS = 90; // 3-month chunks
 const BACKFILL_DAYS_EACH_SIDE = 365; // now ± 1yr
 const FMP_BASE = 'https://financialmodelingprep.com/stable';
@@ -79,18 +78,23 @@ async function run(): Promise<void> {
         for (const event of events) {
             baseNames.add(normalizeIndicatorBaseName(event.event));
         }
-        if (events.length === 0) continue;
+        // id(country+date+event) 기준 dedup — 단일 배치에 중복 id가 있으면
+        // ON CONFLICT가 "cannot affect row a second time"로 실패한다.
+        const uniqueRows = new Map<string, (typeof events)[number]>();
+        for (const event of events) {
+            uniqueRows.set(
+                economicCalendarId(CALENDAR_COUNTRY, event.date, event.event),
+                event
+            );
+        }
+        if (uniqueRows.size === 0) continue;
 
-        // Idempotent upsert — onConflictDoUpdate on the deterministic id.
+        // 멱등 upsert(fetchedAt 제외) — 데이터 필드 동일 시 행 내용은 그대로, fetchedAt만 갱신.
         await db
             .insert(economicCalendar)
             .values(
-                events.map(event => ({
-                    id: economicCalendarId(
-                        CALENDAR_COUNTRY,
-                        event.date,
-                        event.event
-                    ),
+                [...uniqueRows.entries()].map(([id, event]) => ({
+                    id,
                     country: CALENDAR_COUNTRY,
                     dateEt: event.date,
                     event: event.event,
@@ -112,7 +116,7 @@ async function run(): Promise<void> {
                     fetchedAt: sql`now()`,
                 },
             });
-        upserted += events.length;
+        upserted += uniqueRows.size;
     }
 
     const sortedNames = [...baseNames].toSorted((a, b) => a.localeCompare(b));

--- a/scripts/backfillEconomicCalendar.ts
+++ b/scripts/backfillEconomicCalendar.ts
@@ -1,0 +1,131 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { sql } from 'drizzle-orm';
+import {
+    normalizeEconomicCalendar,
+    type EconomicCalendarEvent,
+} from '@y0ngha/siglens-core';
+
+import { economicCalendar } from '../src/shared/db/schema';
+import { economicCalendarId } from '../src/entities/economy/lib/economicCalendarId';
+import { chunkDateRange } from './lib/chunkDateRange';
+import { normalizeIndicatorBaseName } from './lib/normalizeIndicatorBaseName';
+
+const FMP_API_KEY = process.env.FMP_API_KEY;
+const databaseUrl = process.env.DIRECT_DATABASE_URL || process.env.DATABASE_URL;
+
+if (!FMP_API_KEY) {
+    throw new Error('FMP_API_KEY env var required');
+}
+if (!databaseUrl) {
+    throw new Error('DATABASE_URL env var required');
+}
+
+const CALENDAR_COUNTRY = 'US';
+const CHUNK_DAYS = 90; // 3-month chunks
+const BACKFILL_DAYS_EACH_SIDE = 365; // now ± 1yr
+const FMP_BASE = 'https://financialmodelingprep.com/stable';
+const OUTPUT_DIR = path.join(process.cwd(), 'scripts', 'output');
+const OUTPUT_FILE = path.join(
+    OUTPUT_DIR,
+    'economic-calendar-indicator-names.json'
+);
+
+function isoDate(d: Date): string {
+    return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
+}
+
+async function fetchCalendarChunk(
+    from: string,
+    to: string
+): Promise<EconomicCalendarEvent[]> {
+    const params = new URLSearchParams({ from, to, apikey: FMP_API_KEY! });
+    const res = await fetch(
+        `${FMP_BASE}/economic-calendar?${params.toString()}`
+    );
+    if (!res.ok) {
+        throw new Error(
+            `FMP economic-calendar ${from}..${to} → HTTP ${res.status}`
+        );
+    }
+    const raw = (await res.json()) as unknown;
+    return normalizeEconomicCalendar(raw);
+}
+
+async function run(): Promise<void> {
+    const client = postgres(databaseUrl!, { max: 1 });
+    const db = drizzle(client);
+
+    const now = new Date();
+    const start = isoDate(
+        new Date(now.getTime() - BACKFILL_DAYS_EACH_SIDE * 86_400_000)
+    );
+    const end = isoDate(
+        new Date(now.getTime() + BACKFILL_DAYS_EACH_SIDE * 86_400_000)
+    );
+    const chunks = chunkDateRange(start, end, CHUNK_DAYS);
+    console.log(
+        `Backfilling ${CALENDAR_COUNTRY} calendar ${start}..${end} in ${chunks.length} chunk(s)`
+    );
+
+    const baseNames = new Set<string>();
+    let upserted = 0;
+
+    for (const { from, to } of chunks) {
+        const events = await fetchCalendarChunk(from, to);
+        console.log(`  ${from}..${to}: ${events.length} US events`);
+        for (const event of events) {
+            baseNames.add(normalizeIndicatorBaseName(event.event));
+        }
+        if (events.length === 0) continue;
+
+        // Idempotent upsert — onConflictDoUpdate on the deterministic id.
+        await db
+            .insert(economicCalendar)
+            .values(
+                events.map(event => ({
+                    id: economicCalendarId(
+                        CALENDAR_COUNTRY,
+                        event.date,
+                        event.event
+                    ),
+                    country: CALENDAR_COUNTRY,
+                    dateEt: event.date,
+                    event: event.event,
+                    impact: event.impact,
+                    estimate: event.estimate,
+                    previous: event.previous,
+                    actual: event.actual,
+                    unit: event.unit,
+                }))
+            )
+            .onConflictDoUpdate({
+                target: economicCalendar.id,
+                set: {
+                    impact: sql`excluded.impact`,
+                    estimate: sql`excluded.estimate`,
+                    previous: sql`excluded.previous`,
+                    actual: sql`excluded.actual`,
+                    unit: sql`excluded.unit`,
+                    fetchedAt: sql`now()`,
+                },
+            });
+        upserted += events.length;
+    }
+
+    const sortedNames = [...baseNames].toSorted((a, b) => a.localeCompare(b));
+    await mkdir(OUTPUT_DIR, { recursive: true });
+    await writeFile(OUTPUT_FILE, `${JSON.stringify(sortedNames, null, 2)}\n`);
+
+    console.log(
+        `Done — upserted ${upserted} event rows; dumped ${sortedNames.length} distinct base indicator names to ${OUTPUT_FILE}`
+    );
+    await client.end();
+}
+
+run().catch(error => {
+    console.error('[backfillEconomicCalendar] failed:', error);
+    process.exitCode = 1;
+});

--- a/scripts/lib/__tests__/chunkDateRange.test.ts
+++ b/scripts/lib/__tests__/chunkDateRange.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { chunkDateRange } from '../chunkDateRange';
+
+describe('chunkDateRange', () => {
+    it('splits a range into [from,to] chunks of at most chunkDays', () => {
+        const chunks = chunkDateRange('2026-01-01', '2026-04-01', 30);
+        expect(chunks[0]).toEqual({ from: '2026-01-01', to: '2026-01-31' });
+        // last chunk is clamped to the overall end
+        expect(chunks.at(-1)?.to).toBe('2026-04-01');
+    });
+
+    it('never lets a chunk end after the overall end', () => {
+        const chunks = chunkDateRange('2026-01-01', '2026-01-10', 30);
+        expect(chunks).toEqual([{ from: '2026-01-01', to: '2026-01-10' }]);
+    });
+
+    it('produces contiguous, non-overlapping chunks', () => {
+        const chunks = chunkDateRange('2026-01-01', '2026-03-15', 30);
+        for (let i = 1; i < chunks.length; i++) {
+            // next chunk starts the day after the previous chunk ends
+            const prevEnd = chunks[i - 1].to;
+            const [y, m, d] = prevEnd.split('-').map(Number);
+            const next = new Date(Date.UTC(y, m - 1, d + 1));
+            const expected = `${next.getUTCFullYear()}-${String(next.getUTCMonth() + 1).padStart(2, '0')}-${String(next.getUTCDate()).padStart(2, '0')}`;
+            expect(chunks[i].from).toBe(expected);
+        }
+    });
+});

--- a/scripts/lib/__tests__/chunkDateRange.test.ts
+++ b/scripts/lib/__tests__/chunkDateRange.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { chunkDateRange } from '../chunkDateRange';
 
+describe('chunkDateRange guard', () => {
+    it('throws RangeError when chunkDays < 1', () => {
+        expect(() => chunkDateRange('2026-01-01', '2026-01-10', 0)).toThrow(
+            RangeError
+        );
+    });
+});
+
 describe('chunkDateRange', () => {
     it('splits a range into [from,to] chunks of at most chunkDays', () => {
         const chunks = chunkDateRange('2026-01-01', '2026-04-01', 30);

--- a/scripts/lib/__tests__/normalizeIndicatorBaseName.test.ts
+++ b/scripts/lib/__tests__/normalizeIndicatorBaseName.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeIndicatorBaseName } from '../normalizeIndicatorBaseName';
+
+describe('normalizeIndicatorBaseName', () => {
+    it('strips a trailing month suffix', () => {
+        expect(
+            normalizeIndicatorBaseName('Core PCE Price Index YoY (May)')
+        ).toBe('Core PCE Price Index YoY');
+    });
+    it('strips a trailing quarter suffix', () => {
+        expect(normalizeIndicatorBaseName('GDP Growth Rate QoQ (Q1)')).toBe(
+            'GDP Growth Rate QoQ'
+        );
+    });
+    it('strips a trailing date-token suffix', () => {
+        expect(
+            normalizeIndicatorBaseName('Fed Interest Rate Decision (Jun/20)')
+        ).toBe('Fed Interest Rate Decision');
+    });
+    it('leaves names without a trailing suffix unchanged', () => {
+        expect(normalizeIndicatorBaseName('Initial Jobless Claims')).toBe(
+            'Initial Jobless Claims'
+        );
+    });
+    it('trims surrounding whitespace', () => {
+        expect(normalizeIndicatorBaseName('  CPI YoY (Apr)  ')).toBe('CPI YoY');
+    });
+    it('only strips the final parenthetical, not interior ones', () => {
+        expect(normalizeIndicatorBaseName('Index (ex Food) MoM (Apr)')).toBe(
+            'Index (ex Food) MoM'
+        );
+    });
+});

--- a/scripts/lib/chunkDateRange.ts
+++ b/scripts/lib/chunkDateRange.ts
@@ -20,6 +20,7 @@ export function chunkDateRange(
     end: string,
     chunkDays: number
 ): DateChunk[] {
+    if (chunkDays < 1) throw new RangeError('chunkDays must be >= 1');
     const chunks: DateChunk[] = [];
     let cursor = start;
     while (cursor <= end) {

--- a/scripts/lib/chunkDateRange.ts
+++ b/scripts/lib/chunkDateRange.ts
@@ -1,0 +1,32 @@
+/** [from,to] 날짜 청크 — 둘 다 'YYYY-MM-DD', 경계 포함. */
+export interface DateChunk {
+    from: string;
+    to: string;
+}
+
+function addDays(dateEt: string, delta: number): string {
+    const [y, m, d] = dateEt.split('-').map(Number);
+    const shifted = new Date(Date.UTC(y, m - 1, d + delta));
+    return `${shifted.getUTCFullYear()}-${String(shifted.getUTCMonth() + 1).padStart(2, '0')}-${String(shifted.getUTCDate()).padStart(2, '0')}`;
+}
+
+/**
+ * `[start, end]`(경계 포함)을 최대 `chunkDays`일 길이의 연속·비중첩 청크로 분할한다.
+ * 마지막 청크의 `to`는 전체 `end`로 클램프된다. 백필이 FMP를 작은 슬라이스로 호출해
+ * per-request 페이로드를 제한하고 부분 실패 시 작은 범위만 재시도하기 위함.
+ */
+export function chunkDateRange(
+    start: string,
+    end: string,
+    chunkDays: number
+): DateChunk[] {
+    const chunks: DateChunk[] = [];
+    let cursor = start;
+    while (cursor <= end) {
+        const candidateEnd = addDays(cursor, chunkDays);
+        const to = candidateEnd > end ? end : candidateEnd;
+        chunks.push({ from: cursor, to });
+        cursor = addDays(to, 1);
+    }
+    return chunks;
+}

--- a/scripts/lib/normalizeIndicatorBaseName.ts
+++ b/scripts/lib/normalizeIndicatorBaseName.ts
@@ -1,0 +1,11 @@
+/**
+ * FMP 이벤트명에서 마지막 괄호 접미사를 제거해 base 지표명을 반환한다.
+ * 예: 'Core PCE Price Index YoY (May)' → 'Core PCE Price Index YoY'.
+ *
+ * 마지막 괄호 그룹만 제거한다 — 'Index (ex Food) MoM (Apr)'의 '(ex Food)'는 보존.
+ * SP-B가 전체 정규화(기간 토큰 한국어화 등)를 소유하며, SP-A는 enumeration 덤프용
+ * base명 추출만 필요하다.
+ */
+export function normalizeIndicatorBaseName(raw: string): string {
+    return raw.replace(/\s*\([^()]*\)\s*$/, '').trim();
+}

--- a/src/app/economy/page.tsx
+++ b/src/app/economy/page.tsx
@@ -16,8 +16,7 @@ import {
 import { getEconomySnapshotStatic } from '@/entities/economy/api/economySnapshotStaticCache';
 import { peekMacroBriefingStatic } from '@/entities/economy/api/macroBriefingStaticCache';
 import { getCalendarFromDb } from '@/entities/economy/api/getCalendarFromDb';
-import { etDateOf } from '@/entities/economy/lib/calendarWindow';
-import { etDateTimeToKst } from '@/shared/lib/etTimeUtils';
+import { etDateOf, kstDateOf } from '@/entities/economy/lib/calendarWindow';
 import { isEmptyEconomySnapshot } from '@/entities/economy';
 import {
     buildBreadcrumbJsonLd,
@@ -149,9 +148,12 @@ async function EconomyContent() {
     // 캘린더는 Redis 스냅샷이 아니라 DB-backed 이력 레이어에서 읽는다(SP-A). 지표/treasury는
     // 스냅샷 그대로. ET-오늘을 1회 계산해 reader 앵커 + 그리드 기본 선택일로 공유한다
     // (ISR 안전: 결정론적 Intl 변환, dynamic API 미사용).
-    const todayEt = etDateOf(new Date());
-    // 정오 ET → KST 날짜키 — 자정 경계 롤오버 모호성 없이 ET-오늘과 같은 KST 달력일을 얻는다.
-    const todayKstKey = etDateTimeToKst(`${todayEt} 12:00:00`).kstDateKey;
+    const now = new Date();
+    const todayEt = etDateOf(now);
+    // 그리드 기본 선택일 = 현재 인스턴트의 KST 달력일. 그리드가 이벤트를 ET-인스턴트의
+    // kstDateKey로 그룹화하므로(EconomicCalendarGrid groupEventsByKstDay) 앵커도 같은 KST
+    // keyspace여야 한다. 정오-ET 합성은 KST 다음날로 밀려 오늘 그룹을 건너뛰므로 금지.
+    const todayKstKey = kstDateOf(now);
     const calendarEvents = await getCalendarFromDb(todayEt).catch(
         (e: unknown) => {
             console.error('[EconomyContent] getCalendarFromDb failed:', e);

--- a/src/app/economy/page.tsx
+++ b/src/app/economy/page.tsx
@@ -15,6 +15,9 @@ import {
 // 클라이언트 번들 누출 위험이 없으므로 허용된다.
 import { getEconomySnapshotStatic } from '@/entities/economy/api/economySnapshotStaticCache';
 import { peekMacroBriefingStatic } from '@/entities/economy/api/macroBriefingStaticCache';
+import { getCalendarFromDb } from '@/entities/economy/api/getCalendarFromDb';
+import { etDateOf } from '@/entities/economy/lib/calendarWindow';
+import { etDateTimeToKst } from '@/shared/lib/etTimeUtils';
 import { isEmptyEconomySnapshot } from '@/entities/economy';
 import {
     buildBreadcrumbJsonLd,
@@ -143,6 +146,19 @@ async function EconomyContent() {
         }
     );
 
+    // 캘린더는 Redis 스냅샷이 아니라 DB-backed 이력 레이어에서 읽는다(SP-A). 지표/treasury는
+    // 스냅샷 그대로. ET-오늘을 1회 계산해 reader 앵커 + 그리드 기본 선택일로 공유한다
+    // (ISR 안전: 결정론적 Intl 변환, dynamic API 미사용).
+    const todayEt = etDateOf(new Date());
+    // 정오 ET → KST 날짜키 — 자정 경계 롤오버 모호성 없이 ET-오늘과 같은 KST 달력일을 얻는다.
+    const todayKstKey = etDateTimeToKst(`${todayEt} 12:00:00`).kstDateKey;
+    const calendarEvents = await getCalendarFromDb(todayEt).catch(
+        (e: unknown) => {
+            console.error('[EconomyContent] getCalendarFromDb failed:', e);
+            return [];
+        }
+    );
+
     return (
         <div className="space-y-6">
             {/* SSR 크롤 텍스트 — MacroBriefing은 'use client'라 크롤러에 빈 HTML을
@@ -151,7 +167,7 @@ async function EconomyContent() {
             <EconomyMacroFacts snapshot={snapshot} />
             <MacroBriefing peekSeed={peekSeed} />
             <EconomicIndicatorGrid snapshot={snapshot} />
-            <EconomicCalendar events={snapshot.calendar} />
+            <EconomicCalendar events={calendarEvents} today={todayKstKey} />
         </div>
     );
 }

--- a/src/entities/economy/actions.ts
+++ b/src/entities/economy/actions.ts
@@ -1,0 +1,1 @@
+export { ensureEconomicCalendarAction } from './actions/ensureEconomicCalendarAction';

--- a/src/entities/economy/actions/__tests__/ensureEconomicCalendarAction.test.ts
+++ b/src/entities/economy/actions/__tests__/ensureEconomicCalendarAction.test.ts
@@ -20,7 +20,7 @@ vi.mock('@/shared/db/client', () => ({
     getDatabaseClient: vi.fn(() => ({ db: {} })),
 }));
 
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
 import { revalidateTag } from 'next/cache';
 import {
@@ -30,7 +30,11 @@ import {
 import { FmpEconomyProvider } from '@/shared/api/fmp/FmpEconomyProvider';
 import { DrizzleEconomicCalendarRepository } from '@/entities/economy/api/economicCalendarRepository';
 import { ensureEconomicCalendarAction } from '@/entities/economy/actions/ensureEconomicCalendarAction';
-import { ECONOMY_CALENDAR_CACHE_TAG } from '@/entities/economy/lib/economyCalendarConstants';
+import {
+    ECONOMY_CALENDAR_CACHE_TAG,
+    CALENDAR_INGESTION_WINDOW_DAYS,
+} from '@/entities/economy/lib/economyCalendarConstants';
+import { addEtDays, etDateOf } from '@/entities/economy/lib/calendarWindow';
 
 const EVENT: EconomicCalendarEvent = {
     date: '2026-06-13 08:30:00',
@@ -47,6 +51,9 @@ describe('ensureEconomicCalendarAction', () => {
     let upsertEvent: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-20T12:00:00Z'));
+
         vi.clearAllMocks();
         vi.mocked(isCalendarRecentlyFetched).mockResolvedValue(false);
         vi.mocked(markCalendarFetched).mockResolvedValue(undefined);
@@ -66,6 +73,10 @@ describe('ensureEconomicCalendarAction', () => {
         );
     });
 
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     it('skips fetch when recently fetched', async () => {
         vi.mocked(isCalendarRecentlyFetched).mockResolvedValue(true);
         await ensureEconomicCalendarAction();
@@ -77,6 +88,14 @@ describe('ensureEconomicCalendarAction', () => {
         await ensureEconomicCalendarAction();
         expect(markCalendarFetched).toHaveBeenCalledOnce();
         expect(getCalendar).toHaveBeenCalledOnce();
+
+        // B3: assert FMP was called with the computed window
+        const day = etDateOf(new Date('2026-06-20T12:00:00Z'));
+        expect(getCalendar).toHaveBeenCalledWith(
+            addEtDays(day, -CALENDAR_INGESTION_WINDOW_DAYS),
+            addEtDays(day, CALENDAR_INGESTION_WINDOW_DAYS)
+        );
+
         expect(upsertEvent).toHaveBeenCalledWith('US', EVENT);
         expect(revalidateTag).toHaveBeenCalledWith(
             ECONOMY_CALENDAR_CACHE_TAG,
@@ -95,5 +114,59 @@ describe('ensureEconomicCalendarAction', () => {
         await expect(ensureEconomicCalendarAction()).resolves.toBeUndefined();
         expect(upsertEvent).not.toHaveBeenCalled();
         expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    // B4: majority failure branch — all upserts fail → no revalidate
+    it('aborts and does not revalidate when majority upserts fail', async () => {
+        const singleEvent: EconomicCalendarEvent = {
+            date: '2026-06-20 08:30:00',
+            event: 'Jobs Report',
+            impact: 'High',
+            actual: null,
+            estimate: 200000,
+            previous: 180000,
+            unit: '건',
+        };
+        getCalendar.mockResolvedValue([singleEvent]);
+        upsertEvent.mockRejectedValue(new Error('db'));
+
+        await ensureEconomicCalendarAction();
+
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    // B4: minority failure branch — some upserts fail but majority succeed → revalidate
+    it('continues and revalidates when minority upserts fail', async () => {
+        // Two DISTINCT-id events (different date) so dedup keeps both
+        const eventA: EconomicCalendarEvent = {
+            date: '2026-06-20 08:30:00',
+            event: 'Jobs Report',
+            impact: 'High',
+            actual: null,
+            estimate: 200000,
+            previous: 180000,
+            unit: '건',
+        };
+        const eventB: EconomicCalendarEvent = {
+            date: '2026-06-21 08:30:00',
+            event: 'CPI MoM',
+            impact: 'High',
+            actual: null,
+            estimate: 0.3,
+            previous: 0.2,
+            unit: '%',
+        };
+        getCalendar.mockResolvedValue([eventA, eventB]);
+        // First call rejects, second resolves true
+        upsertEvent
+            .mockRejectedValueOnce(new Error('db'))
+            .mockResolvedValueOnce(true);
+
+        await ensureEconomicCalendarAction();
+
+        expect(revalidateTag).toHaveBeenCalledWith(
+            ECONOMY_CALENDAR_CACHE_TAG,
+            'max'
+        );
     });
 });

--- a/src/entities/economy/actions/__tests__/ensureEconomicCalendarAction.test.ts
+++ b/src/entities/economy/actions/__tests__/ensureEconomicCalendarAction.test.ts
@@ -1,0 +1,99 @@
+// All vi.mock() calls are hoisted before static imports — factory cannot reference
+// outer-scope variables. Access mocked fns via vi.mocked() after import.
+vi.mock('server-only', () => ({}));
+vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }));
+vi.mock('@/entities/economy/api/calendarRefreshFlag', () => ({
+    isCalendarRecentlyFetched: vi.fn(),
+    markCalendarFetched: vi.fn(),
+}));
+vi.mock('@/shared/api/fmp/FmpEconomyProvider', () => ({
+    FmpEconomyProvider: vi.fn(function () {
+        return { getCalendar: vi.fn() };
+    }),
+}));
+vi.mock('@/entities/economy/api/economicCalendarRepository', () => ({
+    DrizzleEconomicCalendarRepository: vi.fn(function () {
+        return { upsertEvent: vi.fn() };
+    }),
+}));
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: vi.fn(() => ({ db: {} })),
+}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
+import { revalidateTag } from 'next/cache';
+import {
+    isCalendarRecentlyFetched,
+    markCalendarFetched,
+} from '@/entities/economy/api/calendarRefreshFlag';
+import { FmpEconomyProvider } from '@/shared/api/fmp/FmpEconomyProvider';
+import { DrizzleEconomicCalendarRepository } from '@/entities/economy/api/economicCalendarRepository';
+import { ensureEconomicCalendarAction } from '@/entities/economy/actions/ensureEconomicCalendarAction';
+import { ECONOMY_CALENDAR_CACHE_TAG } from '@/entities/economy/lib/economyCalendarConstants';
+
+const EVENT: EconomicCalendarEvent = {
+    date: '2026-06-13 08:30:00',
+    event: 'Core CPI MoM (May)',
+    impact: 'High',
+    actual: 0.4,
+    estimate: 0.3,
+    previous: 0.2,
+    unit: '%',
+};
+
+describe('ensureEconomicCalendarAction', () => {
+    let getCalendar: ReturnType<typeof vi.fn>;
+    let upsertEvent: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(isCalendarRecentlyFetched).mockResolvedValue(false);
+        vi.mocked(markCalendarFetched).mockResolvedValue(undefined);
+
+        // Set up fresh mocks on the class instances created by the action
+        getCalendar = vi.fn().mockResolvedValue([EVENT]);
+        upsertEvent = vi.fn().mockResolvedValue(true);
+        vi.mocked(FmpEconomyProvider).mockImplementation(function () {
+            return { getCalendar } as unknown as FmpEconomyProvider;
+        });
+        vi.mocked(DrizzleEconomicCalendarRepository).mockImplementation(
+            function () {
+                return {
+                    upsertEvent,
+                } as unknown as DrizzleEconomicCalendarRepository;
+            }
+        );
+    });
+
+    it('skips fetch when recently fetched', async () => {
+        vi.mocked(isCalendarRecentlyFetched).mockResolvedValue(true);
+        await ensureEconomicCalendarAction();
+        expect(getCalendar).not.toHaveBeenCalled();
+        expect(upsertEvent).not.toHaveBeenCalled();
+    });
+
+    it('fetches, upserts, and revalidates the calendar tag on change', async () => {
+        await ensureEconomicCalendarAction();
+        expect(markCalendarFetched).toHaveBeenCalledOnce();
+        expect(getCalendar).toHaveBeenCalledOnce();
+        expect(upsertEvent).toHaveBeenCalledWith('US', EVENT);
+        expect(revalidateTag).toHaveBeenCalledWith(
+            ECONOMY_CALENDAR_CACHE_TAG,
+            'max'
+        );
+    });
+
+    it('does not revalidate when no row changed', async () => {
+        upsertEvent.mockResolvedValue(false);
+        await ensureEconomicCalendarAction();
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it('swallows FMP failure without throwing or revalidating', async () => {
+        getCalendar.mockRejectedValue(new Error('fmp down'));
+        await expect(ensureEconomicCalendarAction()).resolves.toBeUndefined();
+        expect(upsertEvent).not.toHaveBeenCalled();
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+});

--- a/src/entities/economy/actions/ensureEconomicCalendarAction.ts
+++ b/src/entities/economy/actions/ensureEconomicCalendarAction.ts
@@ -33,7 +33,7 @@ export async function ensureEconomicCalendarAction(): Promise<void> {
         if (await isCalendarRecentlyFetched()) {
             return;
         }
-        // async fetch 전에 마킹 — 동시 호출이 이 지점 이후 플래그를 읽으면 FMP 왕복 생략.
+        // 플래그를 fetch 전에 set: 동시 마운트 dedup(news 패턴). 전량 실패 시 복구는 TTL 만료까지 대기.
         await markCalendarFetched();
 
         const today = etDateOf(new Date());

--- a/src/entities/economy/actions/ensureEconomicCalendarAction.ts
+++ b/src/entities/economy/actions/ensureEconomicCalendarAction.ts
@@ -11,6 +11,7 @@ import {
     markCalendarFetched,
 } from '../api/calendarRefreshFlag';
 import { addEtDays, etDateOf } from '../lib/calendarWindow';
+import { economicCalendarId } from '../lib/economicCalendarId';
 import {
     CALENDAR_COUNTRY,
     CALENDAR_INGESTION_WINDOW_DAYS,
@@ -55,19 +56,29 @@ export async function ensureEconomicCalendarAction(): Promise<void> {
         const { db } = getDatabaseClient();
         const repo = new DrizzleEconomicCalendarRepository(db);
 
+        // 같은 id 이벤트의 병렬 upsert는 동일 행 동시 갱신 → deadlock 위험. 먼저 id 기준 dedup.
+        const uniqueEvents = new Map<string, (typeof fresh)[number]>();
+        for (const event of fresh) {
+            uniqueEvents.set(
+                economicCalendarId(CALENDAR_COUNTRY, event.date, event.event),
+                event
+            );
+        }
+        const deduped = [...uniqueEvents.values()];
+
         const settled = await Promise.allSettled(
-            fresh.map(event => repo.upsertEvent(CALENDAR_COUNTRY, event))
+            deduped.map(event => repo.upsertEvent(CALENDAR_COUNTRY, event))
         );
         const failures = settled.filter(r => r.status === 'rejected');
         if (failures.length > 0) {
             console.error(
-                `[ensureEconomicCalendarAction] ${failures.length}/${fresh.length} upserts failed`,
+                `[ensureEconomicCalendarAction] ${failures.length}/${deduped.length} upserts failed`,
                 failures.map(f => (f.status === 'rejected' ? f.reason : null))
             );
         }
-        if (failures.length > fresh.length / MAJORITY_DIVISOR) {
+        if (failures.length > deduped.length / MAJORITY_DIVISOR) {
             console.error(
-                `[ensureEconomicCalendarAction] majority upsert failure (${failures.length}/${fresh.length}) — aborting`
+                `[ensureEconomicCalendarAction] majority upsert failure (${failures.length}/${deduped.length}) — aborting`
             );
             return;
         }

--- a/src/entities/economy/actions/ensureEconomicCalendarAction.ts
+++ b/src/entities/economy/actions/ensureEconomicCalendarAction.ts
@@ -57,14 +57,21 @@ export async function ensureEconomicCalendarAction(): Promise<void> {
         const repo = new DrizzleEconomicCalendarRepository(db);
 
         // 같은 id 이벤트의 병렬 upsert는 동일 행 동시 갱신 → deadlock 위험. 먼저 id 기준 dedup.
-        const uniqueEvents = new Map<string, (typeof fresh)[number]>();
-        for (const event of fresh) {
-            uniqueEvents.set(
-                economicCalendarId(CALENDAR_COUNTRY, event.date, event.event),
-                event
-            );
-        }
-        const deduped = [...uniqueEvents.values()];
+        const deduped = [
+            ...new Map(
+                fresh.map(
+                    event =>
+                        [
+                            economicCalendarId(
+                                CALENDAR_COUNTRY,
+                                event.date,
+                                event.event
+                            ),
+                            event,
+                        ] as const
+                )
+            ).values(),
+        ];
 
         const settled = await Promise.allSettled(
             deduped.map(event => repo.upsertEvent(CALENDAR_COUNTRY, event))

--- a/src/entities/economy/actions/ensureEconomicCalendarAction.ts
+++ b/src/entities/economy/actions/ensureEconomicCalendarAction.ts
@@ -1,0 +1,86 @@
+'use server';
+
+import { revalidateTag } from 'next/cache';
+
+import { getDatabaseClient } from '@/shared/db/client';
+import { FmpEconomyProvider } from '@/shared/api/fmp/FmpEconomyProvider';
+
+import { DrizzleEconomicCalendarRepository } from '../api/economicCalendarRepository';
+import {
+    isCalendarRecentlyFetched,
+    markCalendarFetched,
+} from '../api/calendarRefreshFlag';
+import { addEtDays, etDateOf } from '../lib/calendarWindow';
+import {
+    CALENDAR_COUNTRY,
+    CALENDAR_INGESTION_WINDOW_DAYS,
+    ECONOMY_CALENDAR_CACHE_TAG,
+} from '../lib/economyCalendarConstants';
+
+/** upsert 과반 실패 시 abort 임계 분모. */
+const MAJORITY_DIVISOR = 2;
+
+/**
+ * Server Action: ±1개월 윈도의 FMP economic-calendar를 fetch해 `economic_calendar`에
+ * upsert하고, ≥1행이 실제로 변경되면 `economy:calendar` 태그를 무효화한다.
+ *
+ * `ensureMarketNewsCardsAnalyzedAction` 미러: refresh-flag 가드(봇 재크롤 시 fetch 생략),
+ * graceful FMP 실패(빈 결과 X, DB 기존 데이터 유지), 과반 upsert 실패 시 abort.
+ * AI 분석 없음(SP-D 별도). `waitUntil` 안에서 돌도록 설계 — 응답 스트림 비차단.
+ */
+export async function ensureEconomicCalendarAction(): Promise<void> {
+    try {
+        if (await isCalendarRecentlyFetched()) {
+            return;
+        }
+        // async fetch 전에 마킹 — 동시 호출이 이 지점 이후 플래그를 읽으면 FMP 왕복 생략.
+        await markCalendarFetched();
+
+        const today = etDateOf(new Date());
+        const from = addEtDays(today, -CALENDAR_INGESTION_WINDOW_DAYS);
+        const to = addEtDays(today, CALENDAR_INGESTION_WINDOW_DAYS);
+
+        const provider = new FmpEconomyProvider();
+        const fresh = await provider
+            .getCalendar(from, to)
+            .catch((err: unknown) => {
+                console.error(
+                    '[ensureEconomicCalendarAction] FMP fetch failed:',
+                    err
+                );
+                return null;
+            });
+        if (fresh === null || fresh.length === 0) return;
+
+        const { db } = getDatabaseClient();
+        const repo = new DrizzleEconomicCalendarRepository(db);
+
+        const settled = await Promise.allSettled(
+            fresh.map(event => repo.upsertEvent(CALENDAR_COUNTRY, event))
+        );
+        const failures = settled.filter(r => r.status === 'rejected');
+        if (failures.length > 0) {
+            console.error(
+                `[ensureEconomicCalendarAction] ${failures.length}/${fresh.length} upserts failed`,
+                failures.map(f => (f.status === 'rejected' ? f.reason : null))
+            );
+        }
+        if (failures.length > fresh.length / MAJORITY_DIVISOR) {
+            console.error(
+                `[ensureEconomicCalendarAction] majority upsert failure (${failures.length}/${fresh.length}) — aborting`
+            );
+            return;
+        }
+
+        const changedCount = settled.filter(
+            r => r.status === 'fulfilled' && r.value === true
+        ).length;
+        if (changedCount > 0) {
+            // 'economy:calendar' 태그만 무효화 — 스냅샷(지표/treasury) ISR 캐시는 무관.
+            // Next 16 revalidateTag(tag, profile) — 'max'는 즉시 무효화.
+            revalidateTag(ECONOMY_CALENDAR_CACHE_TAG, 'max');
+        }
+    } catch (error) {
+        console.error('[ensureEconomicCalendarAction]', error);
+    }
+}

--- a/src/entities/economy/api/__tests__/economicCalendarRepository.test.ts
+++ b/src/entities/economy/api/__tests__/economicCalendarRepository.test.ts
@@ -64,10 +64,8 @@ describe('DrizzleEconomicCalendarRepository.upsertEvent', () => {
         const { db, spies } = makeDb([{ id: 'abc' }], []);
         const repo = new DrizzleEconomicCalendarRepository(db);
         await repo.upsertEvent('US', EVENT);
-        const inserted = spies.values.mock.calls[0][0] as Record<
-            string,
-            unknown
-        >;
+        const firstCall = spies.values.mock.calls[0] as unknown[];
+        const inserted = firstCall[0] as Record<string, unknown>;
         expect(inserted.country).toBe('US');
         expect(inserted.dateEt).toBe('2026-06-13 08:30:00');
         expect(inserted.event).toBe('Core CPI MoM (May)');

--- a/src/entities/economy/api/__tests__/economicCalendarRepository.test.ts
+++ b/src/entities/economy/api/__tests__/economicCalendarRepository.test.ts
@@ -1,5 +1,27 @@
 vi.mock('server-only', () => ({}));
 
+/**
+ * drizzle-orm의 gte/lte를 spy로 래핑해 listInRange 경계 계약을 단언한다.
+ * ESM namespace는 vi.spyOn 불가 — vi.mock 팩토리에서 래핑한다.
+ * and/asc/sql은 실제 구현을 그대로 사용해 쿼리 빌더 체인 동작을 보존한다.
+ */
+const gteSpy = vi.fn();
+const lteSpy = vi.fn();
+vi.mock('drizzle-orm', async importOriginal => {
+    const original = await importOriginal<typeof import('drizzle-orm')>();
+    return {
+        ...original,
+        gte: (...args: Parameters<typeof original.gte>) => {
+            gteSpy(...args);
+            return original.gte(...args);
+        },
+        lte: (...args: Parameters<typeof original.lte>) => {
+            lteSpy(...args);
+            return original.lte(...args);
+        },
+    };
+});
+
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
 import { DrizzleEconomicCalendarRepository } from '@/entities/economy/api/economicCalendarRepository';
@@ -77,6 +99,19 @@ describe('DrizzleEconomicCalendarRepository.upsertEvent', () => {
 
 describe('DrizzleEconomicCalendarRepository.listInRange', () => {
     beforeEach(() => vi.clearAllMocks());
+
+    it('queries with inclusive lower bound and upper bound extended to 23:59:59', async () => {
+        const { db } = makeDb([], []);
+        const repo = new DrizzleEconomicCalendarRepository(db);
+        await repo.listInRange('2026-06-01', '2026-06-30');
+        // gte 두 번째 인수는 fromEt 그대로 (하한 경계 포함)
+        expect(gteSpy).toHaveBeenCalledWith(expect.anything(), '2026-06-01');
+        // lte 두 번째 인수는 toEt + ' 23:59:59' (같은 날 이벤트 누락 방지)
+        expect(lteSpy).toHaveBeenCalledWith(
+            expect.anything(),
+            '2026-06-30 23:59:59'
+        );
+    });
 
     it('maps DB rows to EconomicCalendarEvent and coerces unknown impact to Low', async () => {
         const { db } = makeDb(

--- a/src/entities/economy/api/__tests__/economicCalendarRepository.test.ts
+++ b/src/entities/economy/api/__tests__/economicCalendarRepository.test.ts
@@ -1,0 +1,121 @@
+vi.mock('server-only', () => ({}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
+import { DrizzleEconomicCalendarRepository } from '@/entities/economy/api/economicCalendarRepository';
+
+const EVENT: EconomicCalendarEvent = {
+    date: '2026-06-13 08:30:00',
+    event: 'Core CPI MoM (May)',
+    impact: 'High',
+    actual: null,
+    estimate: 0.3,
+    previous: 0.2,
+    unit: '%',
+};
+
+/** Minimal chainable insert/onConflict/returning + select/from/where/orderBy stub. */
+function makeDb(returningRows: { id: string }[], selectRows: unknown[]) {
+    const returning = vi.fn(async () => returningRows);
+    const onConflictDoUpdate = vi.fn(() => ({ returning }));
+    const values = vi.fn(() => ({ onConflictDoUpdate }));
+    const insert = vi.fn(() => ({ values }));
+
+    const orderBy = vi.fn(async () => selectRows);
+    const where = vi.fn(() => ({ orderBy }));
+    const from = vi.fn(() => ({ where }));
+    const select = vi.fn(() => ({ from }));
+
+    return {
+        db: { insert, select } as never,
+        spies: {
+            insert,
+            values,
+            onConflictDoUpdate,
+            returning,
+            select,
+            from,
+            where,
+            orderBy,
+        },
+    };
+}
+
+describe('DrizzleEconomicCalendarRepository.upsertEvent', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('returns true when a row was inserted or changed', async () => {
+        const { db, spies } = makeDb([{ id: 'abc' }], []);
+        const repo = new DrizzleEconomicCalendarRepository(db);
+        const changed = await repo.upsertEvent('US', EVENT);
+        expect(changed).toBe(true);
+        expect(spies.insert).toHaveBeenCalledOnce();
+        expect(spies.onConflictDoUpdate).toHaveBeenCalledOnce();
+    });
+
+    it('returns false when the upsert touched no rows', async () => {
+        const { db } = makeDb([], []);
+        const repo = new DrizzleEconomicCalendarRepository(db);
+        const changed = await repo.upsertEvent('US', EVENT);
+        expect(changed).toBe(false);
+    });
+
+    it('inserts with the deterministic id, country, and dateEt = FMP date', async () => {
+        const { db, spies } = makeDb([{ id: 'abc' }], []);
+        const repo = new DrizzleEconomicCalendarRepository(db);
+        await repo.upsertEvent('US', EVENT);
+        const inserted = spies.values.mock.calls[0][0] as Record<
+            string,
+            unknown
+        >;
+        expect(inserted.country).toBe('US');
+        expect(inserted.dateEt).toBe('2026-06-13 08:30:00');
+        expect(inserted.event).toBe('Core CPI MoM (May)');
+        expect(inserted.impact).toBe('High');
+        expect(typeof inserted.id).toBe('string');
+        expect(inserted.id).toMatch(/^[0-9a-f]{64}$/);
+    });
+});
+
+describe('DrizzleEconomicCalendarRepository.listInRange', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('maps DB rows to EconomicCalendarEvent and coerces unknown impact to Low', async () => {
+        const { db } = makeDb(
+            [],
+            [
+                {
+                    dateEt: '2026-06-13 08:30:00',
+                    event: 'Core CPI MoM (May)',
+                    impact: 'High',
+                    actual: 0.4,
+                    estimate: 0.3,
+                    previous: 0.2,
+                    unit: '%',
+                },
+                {
+                    dateEt: '2026-06-14 10:00:00',
+                    event: 'Mystery',
+                    impact: 'bogus',
+                    actual: null,
+                    estimate: null,
+                    previous: null,
+                    unit: '',
+                },
+            ]
+        );
+        const repo = new DrizzleEconomicCalendarRepository(db);
+        const events = await repo.listInRange('2026-06-01', '2026-06-30');
+        expect(events).toHaveLength(2);
+        expect(events[0]).toEqual({
+            date: '2026-06-13 08:30:00',
+            event: 'Core CPI MoM (May)',
+            impact: 'High',
+            actual: 0.4,
+            estimate: 0.3,
+            previous: 0.2,
+            unit: '%',
+        });
+        expect(events[1].impact).toBe('Low');
+    });
+});

--- a/src/entities/economy/api/__tests__/getCalendarFromDb.test.ts
+++ b/src/entities/economy/api/__tests__/getCalendarFromDb.test.ts
@@ -1,0 +1,60 @@
+vi.mock('server-only', () => ({}));
+vi.mock('next/cache', () => ({
+    unstable_cache:
+        (fn: (...a: unknown[]) => unknown) =>
+        (...a: unknown[]) =>
+            fn(...a),
+}));
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: () => ({ db: {} }),
+}));
+
+const listInRange = vi.fn();
+vi.mock('@/entities/economy/api/economicCalendarRepository', () => ({
+    DrizzleEconomicCalendarRepository: class {
+        listInRange = listInRange;
+    },
+}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { getCalendarFromDb } from '@/entities/economy/api/getCalendarFromDb';
+import {
+    pastWindowStart,
+    futureWindowEnd,
+} from '@/entities/economy/lib/calendarWindow';
+
+describe('getCalendarFromDb', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        listInRange.mockResolvedValue([]);
+    });
+
+    it('reads the past-window..future-window range around the anchor', async () => {
+        await getCalendarFromDb('2026-06-20');
+        expect(listInRange).toHaveBeenCalledWith(
+            pastWindowStart('2026-06-20'),
+            futureWindowEnd('2026-06-20')
+        );
+    });
+
+    it('returns the rows the repository produced', async () => {
+        const event = {
+            date: '2026-06-19 08:30:00',
+            event: 'X',
+            impact: 'High' as const,
+            actual: 1,
+            estimate: 1,
+            previous: 1,
+            unit: '%',
+        };
+        listInRange.mockResolvedValue([event]);
+        const events = await getCalendarFromDb('2026-06-20');
+        expect(events).toEqual([event]);
+    });
+
+    it('degrades to [] on DB failure (graceful, not throw)', async () => {
+        listInRange.mockRejectedValue(new Error('neon down'));
+        const events = await getCalendarFromDb('2026-06-20');
+        expect(events).toEqual([]);
+    });
+});

--- a/src/entities/economy/api/__tests__/getCalendarFromDb.test.ts
+++ b/src/entities/economy/api/__tests__/getCalendarFromDb.test.ts
@@ -3,6 +3,10 @@ vi.mock('server-only', () => ({}));
 /**
  * unstable_cache mock: call-through이지만 (fn, keyParts, options) 인자를 캡처해
  * 캐시 키·revalidate·tags 계약을 단언할 수 있게 한다.
+ *
+ * 모듈-레벨 unstable_cache(fn, keyParts, options) 구조:
+ * - keyParts: ['economy-calendar-db']
+ * - anchorEt는 반환된 래퍼 함수의 인자로 전달(auto-keyed by Next.js)
  */
 let capturedKeyParts: string[] = [];
 let capturedOptions: Record<string, unknown> = {};
@@ -49,10 +53,9 @@ describe('getCalendarFromDb', () => {
         listInRange.mockResolvedValue([]);
     });
 
-    it('passes the correct cache key parts to unstable_cache', async () => {
+    it('passes the correct key array to unstable_cache', async () => {
         await getCalendarFromDb('2026-06-20');
-        expect(capturedKeyParts).toContain('economy-calendar-db');
-        expect(capturedKeyParts).toContain('2026-06-20');
+        expect(capturedKeyParts).toEqual(['economy-calendar-db']);
     });
 
     it('passes the correct revalidate and tags to unstable_cache', async () => {

--- a/src/entities/economy/api/__tests__/getCalendarFromDb.test.ts
+++ b/src/entities/economy/api/__tests__/getCalendarFromDb.test.ts
@@ -1,9 +1,23 @@
 vi.mock('server-only', () => ({}));
+
+/**
+ * unstable_cache mock: call-through이지만 (fn, keyParts, options) 인자를 캡처해
+ * 캐시 키·revalidate·tags 계약을 단언할 수 있게 한다.
+ */
+let capturedKeyParts: string[] = [];
+let capturedOptions: Record<string, unknown> = {};
 vi.mock('next/cache', () => ({
     unstable_cache:
-        (fn: (...a: unknown[]) => unknown) =>
-        (...a: unknown[]) =>
-            fn(...a),
+        (
+            fn: (...a: unknown[]) => unknown,
+            keyParts: string[],
+            options: Record<string, unknown>
+        ) =>
+        (...a: unknown[]) => {
+            capturedKeyParts = keyParts;
+            capturedOptions = options;
+            return fn(...a);
+        },
 }));
 vi.mock('@/shared/db/client', () => ({
     getDatabaseClient: () => ({ db: {} }),
@@ -22,11 +36,31 @@ import {
     pastWindowStart,
     futureWindowEnd,
 } from '@/entities/economy/lib/calendarWindow';
+import {
+    ECONOMY_CALENDAR_CACHE_TAG,
+    ECONOMY_CALENDAR_REVALIDATE_SECONDS,
+} from '@/entities/economy/lib/economyCalendarConstants';
 
 describe('getCalendarFromDb', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        capturedKeyParts = [];
+        capturedOptions = {};
         listInRange.mockResolvedValue([]);
+    });
+
+    it('passes the correct cache key parts to unstable_cache', async () => {
+        await getCalendarFromDb('2026-06-20');
+        expect(capturedKeyParts).toContain('economy-calendar-db');
+        expect(capturedKeyParts).toContain('2026-06-20');
+    });
+
+    it('passes the correct revalidate and tags to unstable_cache', async () => {
+        await getCalendarFromDb('2026-06-20');
+        expect(capturedOptions).toMatchObject({
+            revalidate: ECONOMY_CALENDAR_REVALIDATE_SECONDS,
+            tags: [ECONOMY_CALENDAR_CACHE_TAG],
+        });
     });
 
     it('reads the past-window..future-window range around the anchor', async () => {

--- a/src/entities/economy/api/calendarRefreshFlag.ts
+++ b/src/entities/economy/api/calendarRefreshFlag.ts
@@ -1,0 +1,31 @@
+import 'server-only';
+import { getRedisClient } from '@/shared/cache/redisClient';
+import {
+    CALENDAR_REFRESH_FLAG_KEY,
+    CALENDAR_REFRESH_FLAG_TTL_SECONDS,
+} from '../lib/economyCalendarConstants';
+
+/** 최근 TTL 내 fetch 여부 — Redis 실패 시 false(항상 fetch). market-news 미러. */
+export async function isCalendarRecentlyFetched(): Promise<boolean> {
+    const redis = getRedisClient();
+    if (redis === null) return false;
+    try {
+        return (await redis.get(CALENDAR_REFRESH_FLAG_KEY)) !== null;
+    } catch (error) {
+        console.error('[calendarRefreshFlag] get failed', error);
+        return false;
+    }
+}
+
+/** "최근 fetch함" 마킹 — Redis 실패 시 noop. */
+export async function markCalendarFetched(): Promise<void> {
+    const redis = getRedisClient();
+    if (redis === null) return;
+    try {
+        await redis.set(CALENDAR_REFRESH_FLAG_KEY, '1', {
+            ex: CALENDAR_REFRESH_FLAG_TTL_SECONDS,
+        });
+    } catch (error) {
+        console.error('[calendarRefreshFlag] set failed', error);
+    }
+}

--- a/src/entities/economy/api/economicCalendarRepository.ts
+++ b/src/entities/economy/api/economicCalendarRepository.ts
@@ -1,0 +1,134 @@
+import 'server-only';
+import { and, asc, gte, lte, sql } from 'drizzle-orm';
+import type {
+    CalendarImpact,
+    EconomicCalendarEvent,
+} from '@y0ngha/siglens-core';
+import { NEON_TRANSIENT_RETRY } from '@/shared/db/isNeonTransientError';
+import { economicCalendar } from '@/shared/db/schema';
+import type { SiglensDatabase } from '@/shared/db/types';
+import { withRetry } from '@/shared/lib/withRetry';
+import { economicCalendarId } from '../lib/economicCalendarId';
+
+/** 읽기 경계에서 검증하는 impact 정규값 — 미지값은 'Low'로 강등(graceful). */
+const IMPACT_RECORD: Record<CalendarImpact, true> = {
+    High: true,
+    Medium: true,
+    Low: true,
+};
+function toImpact(value: string): CalendarImpact {
+    return value in IMPACT_RECORD ? (value as CalendarImpact) : 'Low';
+}
+
+interface CalendarDbRow {
+    dateEt: string;
+    event: string;
+    impact: string;
+    actual: number | null;
+    estimate: number | null;
+    previous: number | null;
+    unit: string;
+}
+
+function toEvent(row: CalendarDbRow): EconomicCalendarEvent {
+    return {
+        date: row.dateEt,
+        event: row.event,
+        impact: toImpact(row.impact),
+        actual: row.actual,
+        estimate: row.estimate,
+        previous: row.previous,
+        unit: row.unit,
+    };
+}
+
+export class DrizzleEconomicCalendarRepository {
+    constructor(private readonly db: SiglensDatabase) {}
+
+    /**
+     * 이벤트를 upsert하고 행이 실제로 삽입/변경됐는지 반환한다. 재fetch가 동일
+     * 내용을 만들면 `setWhere IS DISTINCT FROM`이 UPDATE를 막아 false를 반환하므로
+     * 호출자가 `revalidateTag`를 건너뛸 수 있다(`market_news` upsert와 동일).
+     *
+     * `id`는 country+dateEt+event 해시라 발표 후 actual/estimate/previous가 바뀌면
+     * 같은 행에 UPDATE된다. `country`/`dateEt`/`event`는 키 구성요소라 `set`에서 제외.
+     */
+    async upsertEvent(
+        country: string,
+        event: EconomicCalendarEvent
+    ): Promise<boolean> {
+        const id = economicCalendarId(country, event.date, event.event);
+        const changed = await withRetry(
+            () =>
+                this.db
+                    .insert(economicCalendar)
+                    .values({
+                        id,
+                        country,
+                        dateEt: event.date,
+                        event: event.event,
+                        impact: event.impact,
+                        estimate: event.estimate,
+                        previous: event.previous,
+                        actual: event.actual,
+                        unit: event.unit,
+                    })
+                    .onConflictDoUpdate({
+                        target: economicCalendar.id,
+                        set: {
+                            impact: sql`excluded.impact`,
+                            estimate: sql`excluded.estimate`,
+                            previous: sql`excluded.previous`,
+                            actual: sql`excluded.actual`,
+                            unit: sql`excluded.unit`,
+                            fetchedAt: sql`now()`,
+                        },
+                        setWhere: sql`
+                            ${economicCalendar.impact} IS DISTINCT FROM excluded.impact OR
+                            ${economicCalendar.estimate} IS DISTINCT FROM excluded.estimate OR
+                            ${economicCalendar.previous} IS DISTINCT FROM excluded.previous OR
+                            ${economicCalendar.actual} IS DISTINCT FROM excluded.actual OR
+                            ${economicCalendar.unit} IS DISTINCT FROM excluded.unit
+                        `,
+                    })
+                    .returning({ id: economicCalendar.id }),
+            NEON_TRANSIENT_RETRY
+        );
+        return changed.length > 0;
+    }
+
+    /**
+     * `[fromEt, toEt]` 범위(경계 포함)의 이벤트를 dateEt 오름차순으로 읽는다.
+     * dateEt는 'YYYY-MM-DD HH:mm:ss'라 문자열 비교가 시간순과 일치한다. 경계는
+     * 'YYYY-MM-DD' 날짜키 — `from`은 그대로(<= 그날 00:00:00 포함), `to`는 그날
+     * 23:59:59까지 포함하도록 ' 23:59:59'를 덧붙인다.
+     */
+    async listInRange(
+        fromEt: string,
+        toEt: string
+    ): Promise<EconomicCalendarEvent[]> {
+        const rows = await withRetry(
+            () =>
+                this.db
+                    .select({
+                        dateEt: economicCalendar.dateEt,
+                        event: economicCalendar.event,
+                        impact: economicCalendar.impact,
+                        actual: economicCalendar.actual,
+                        estimate: economicCalendar.estimate,
+                        previous: economicCalendar.previous,
+                        unit: economicCalendar.unit,
+                    })
+                    .from(economicCalendar)
+                    .where(
+                        and(
+                            gte(economicCalendar.dateEt, fromEt),
+                            lte(economicCalendar.dateEt, `${toEt} 23:59:59`)
+                        )
+                    )
+                    .orderBy(asc(economicCalendar.dateEt)),
+            NEON_TRANSIENT_RETRY
+        );
+        return rows.map(toEvent);
+    }
+}

--- a/src/entities/economy/api/economicCalendarRepository.ts
+++ b/src/entities/economy/api/economicCalendarRepository.ts
@@ -17,6 +17,7 @@ const IMPACT_RECORD: Record<CalendarImpact, true> = {
     Low: true,
 };
 function toImpact(value: string): CalendarImpact {
+    // `in` 멤버십 검사가 value가 CalendarImpact임을 보장하므로 타입 단언은 안전하다.
     return value in IMPACT_RECORD ? (value as CalendarImpact) : 'Low';
 }
 

--- a/src/entities/economy/api/getCalendarFromDb.ts
+++ b/src/entities/economy/api/getCalendarFromDb.ts
@@ -13,39 +13,48 @@ import {
 } from '../lib/economyCalendarConstants';
 
 /**
+ * `anchorEt`를 인자로 받아 Next.js ISR 캐시에 올리는 모듈-레벨 래퍼.
+ * `unstable_cache`는 함수 인자를 자동으로 캐시 키에 포함하므로 날짜가
+ * 바뀌면 자연히 새 윈도로 리프레시된다.
+ *
+ * ISR cold-gen 안전: `@neondatabase/serverless` HTTP는 no-store라 static
+ * generate가 `DYNAMIC_SERVER_USAGE`를 throw한다 — `unstable_cache`로 감싸
+ * HTML에 박고 정적화한다 (src/app/CLAUDE.md 4축 규약 축1).
+ * revalidate=24h + `economy:calendar` 태그로 `ensureEconomicCalendarAction`이
+ * on-demand 무효화 가능. cookies/headers/connection 미사용.
+ */
+const fetchCalendar = unstable_cache(
+    async (anchorEt: string): Promise<EconomicCalendarEvent[]> => {
+        const { db } = getDatabaseClient();
+        const repo = new DrizzleEconomicCalendarRepository(db);
+        return repo.listInRange(
+            pastWindowStart(anchorEt),
+            futureWindowEnd(anchorEt)
+        );
+    },
+    ['economy-calendar-db'],
+    {
+        revalidate: ECONOMY_CALENDAR_REVALIDATE_SECONDS,
+        tags: [ECONOMY_CALENDAR_CACHE_TAG],
+    }
+);
+
+/**
  * 과거 2주 + 미래 윈도의 캘린더 이벤트를 DB에서 읽는다.
  *
- * ISR cold-gen 안전: `@neondatabase/serverless` HTTP는 no-store라 static generate가
- * `DYNAMIC_SERVER_USAGE`를 throw한다 — `unstable_cache`로 감싸 HTML에 박고 정적화한다
- * (src/app/CLAUDE.md 4축 규약 축1). revalidate=24h + `economy:calendar` 태그로
- * `ensureEconomicCalendarAction`이 on-demand 무효화 가능. cookies/headers/connection
- * 미사용, `anchorEt`는 호출자(페이지 RSC)가 ET-오늘을 1회 계산해 주입 → `Date.now()` 없음.
+ * `anchorEt`는 호출자(페이지 RSC)가 ET-오늘을 1회 계산해 주입하며, 모듈-레벨
+ * `unstable_cache` 래퍼(`fetchCalendar`)에 인자로 전달 — `Date.now()` 없음.
+ * React.cache로 요청 내 dedup(metadata/본문 중복 호출 대비).
  *
  * DB 실패 시 빈 배열로 graceful — 캘린더 섹션만 비고 페이지는 렌더.
- *
- * `anchorEt`를 캐시 키 파트에 넣어 날짜가 바뀌면 자연히 새 윈도로 리프레시한다.
- * React.cache로 요청 내 dedup(metadata/본문 중복 호출 대비).
  */
 export const getCalendarFromDb = cache(
-    (anchorEt: string): Promise<EconomicCalendarEvent[]> =>
-        unstable_cache(
-            async () => {
-                try {
-                    const { db } = getDatabaseClient();
-                    const repo = new DrizzleEconomicCalendarRepository(db);
-                    return await repo.listInRange(
-                        pastWindowStart(anchorEt),
-                        futureWindowEnd(anchorEt)
-                    );
-                } catch (error) {
-                    console.error('[getCalendarFromDb] DB read failed:', error);
-                    return [];
-                }
-            },
-            ['economy-calendar-db', anchorEt],
-            {
-                revalidate: ECONOMY_CALENDAR_REVALIDATE_SECONDS,
-                tags: [ECONOMY_CALENDAR_CACHE_TAG],
-            }
-        )()
+    async (anchorEt: string): Promise<EconomicCalendarEvent[]> => {
+        try {
+            return await fetchCalendar(anchorEt);
+        } catch (error) {
+            console.error('[getCalendarFromDb] DB read failed:', error);
+            return [];
+        }
+    }
 );

--- a/src/entities/economy/api/getCalendarFromDb.ts
+++ b/src/entities/economy/api/getCalendarFromDb.ts
@@ -1,0 +1,51 @@
+import 'server-only';
+import { cache } from 'react';
+import { unstable_cache } from 'next/cache';
+import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
+
+import { getDatabaseClient } from '@/shared/db/client';
+
+import { DrizzleEconomicCalendarRepository } from './economicCalendarRepository';
+import { pastWindowStart, futureWindowEnd } from '../lib/calendarWindow';
+import {
+    ECONOMY_CALENDAR_CACHE_TAG,
+    ECONOMY_CALENDAR_REVALIDATE_SECONDS,
+} from '../lib/economyCalendarConstants';
+
+/**
+ * 과거 2주 + 미래 윈도의 캘린더 이벤트를 DB에서 읽는다.
+ *
+ * ISR cold-gen 안전: `@neondatabase/serverless` HTTP는 no-store라 static generate가
+ * `DYNAMIC_SERVER_USAGE`를 throw한다 — `unstable_cache`로 감싸 HTML에 박고 정적화한다
+ * (src/app/CLAUDE.md 4축 규약 축1). revalidate=24h + `economy:calendar` 태그로
+ * `ensureEconomicCalendarAction`이 on-demand 무효화 가능. cookies/headers/connection
+ * 미사용, `anchorEt`는 호출자(페이지 RSC)가 ET-오늘을 1회 계산해 주입 → `Date.now()` 없음.
+ *
+ * DB 실패 시 빈 배열로 graceful — 캘린더 섹션만 비고 페이지는 렌더.
+ *
+ * `anchorEt`를 캐시 키 파트에 넣어 날짜가 바뀌면 자연히 새 윈도로 리프레시한다.
+ * React.cache로 요청 내 dedup(metadata/본문 중복 호출 대비).
+ */
+export const getCalendarFromDb = cache(
+    (anchorEt: string): Promise<EconomicCalendarEvent[]> =>
+        unstable_cache(
+            async () => {
+                try {
+                    const { db } = getDatabaseClient();
+                    const repo = new DrizzleEconomicCalendarRepository(db);
+                    return await repo.listInRange(
+                        pastWindowStart(anchorEt),
+                        futureWindowEnd(anchorEt)
+                    );
+                } catch (error) {
+                    console.error('[getCalendarFromDb] DB read failed:', error);
+                    return [];
+                }
+            },
+            ['economy-calendar-db', anchorEt],
+            {
+                revalidate: ECONOMY_CALENDAR_REVALIDATE_SECONDS,
+                tags: [ECONOMY_CALENDAR_CACHE_TAG],
+            }
+        )()
+);

--- a/src/entities/economy/lib/__tests__/calendarWindow.test.ts
+++ b/src/entities/economy/lib/__tests__/calendarWindow.test.ts
@@ -66,7 +66,8 @@ describe('window bounds', () => {
             addEtDays('2026-06-20', FUTURE_WINDOW_DAYS)
         );
     });
-    it('past window is at least two weeks', () => {
-        expect(PAST_WINDOW_DAYS).toBeGreaterThanOrEqual(14);
+    // spec: 과거 윈도는 최소 2주 — 현재 PAST_WINDOW_DAYS = 14
+    it('PAST_WINDOW_DAYS is 14', () => {
+        expect(PAST_WINDOW_DAYS).toBe(14);
     });
 });

--- a/src/entities/economy/lib/__tests__/calendarWindow.test.ts
+++ b/src/entities/economy/lib/__tests__/calendarWindow.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import {
+    etDateOf,
+    addEtDays,
+    pastWindowStart,
+    futureWindowEnd,
+    PAST_WINDOW_DAYS,
+    FUTURE_WINDOW_DAYS,
+} from '@/entities/economy/lib/calendarWindow';
+
+describe('etDateOf', () => {
+    it('formats a UTC instant to its ET YYYY-MM-DD', () => {
+        // 2026-01-15T02:00:00Z is still 2026-01-14 21:00 in ET (UTC-5).
+        expect(etDateOf(new Date('2026-01-15T02:00:00Z'))).toBe('2026-01-14');
+    });
+
+    it('handles afternoon UTC staying same ET day', () => {
+        expect(etDateOf(new Date('2026-01-15T18:00:00Z'))).toBe('2026-01-15');
+    });
+});
+
+describe('addEtDays', () => {
+    it('adds days to a YYYY-MM-DD string', () => {
+        expect(addEtDays('2026-01-31', 1)).toBe('2026-02-01');
+    });
+    it('subtracts days with a negative delta', () => {
+        expect(addEtDays('2026-03-01', -1)).toBe('2026-02-28');
+    });
+    it('crosses a year boundary', () => {
+        expect(addEtDays('2025-12-31', 1)).toBe('2026-01-01');
+    });
+});
+
+describe('window bounds', () => {
+    it('pastWindowStart is PAST_WINDOW_DAYS before the anchor', () => {
+        expect(pastWindowStart('2026-06-20')).toBe(
+            addEtDays('2026-06-20', -PAST_WINDOW_DAYS)
+        );
+    });
+    it('futureWindowEnd is FUTURE_WINDOW_DAYS after the anchor', () => {
+        expect(futureWindowEnd('2026-06-20')).toBe(
+            addEtDays('2026-06-20', FUTURE_WINDOW_DAYS)
+        );
+    });
+    it('past window is at least two weeks', () => {
+        expect(PAST_WINDOW_DAYS).toBeGreaterThanOrEqual(14);
+    });
+});

--- a/src/entities/economy/lib/__tests__/calendarWindow.test.ts
+++ b/src/entities/economy/lib/__tests__/calendarWindow.test.ts
@@ -15,7 +15,7 @@ describe('kstDateOf', () => {
         expect(kstDateOf(new Date('2026-06-20T12:30:00Z'))).toBe('2026-06-20');
     });
 
-    it('crosses KST midnight: noon ET on 2026-06-20 (17:00Z) → 2026-06-21 KST', () => {
+    it('crosses KST midnight: noon ET on 2026-06-20 (16:00Z) → 2026-06-21 KST', () => {
         // 2026-06-20T16:00:00Z = 12:00 ET = 01:00 KST next day (2026-06-21) — exact old-code failure case
         expect(kstDateOf(new Date('2026-06-20T16:00:00Z'))).toBe('2026-06-21');
     });

--- a/src/entities/economy/lib/__tests__/calendarWindow.test.ts
+++ b/src/entities/economy/lib/__tests__/calendarWindow.test.ts
@@ -1,12 +1,36 @@
 import { describe, it, expect } from 'vitest';
 import {
     etDateOf,
+    kstDateOf,
     addEtDays,
     pastWindowStart,
     futureWindowEnd,
     PAST_WINDOW_DAYS,
     FUTURE_WINDOW_DAYS,
 } from '@/entities/economy/lib/calendarWindow';
+
+describe('kstDateOf', () => {
+    it('returns same KST day for morning US release (08:30 ET → 12:30Z → KST same day)', () => {
+        // 2026-06-20T12:30:00Z = 08:30 ET = 21:30 KST → still 2026-06-20 KST
+        expect(kstDateOf(new Date('2026-06-20T12:30:00Z'))).toBe('2026-06-20');
+    });
+
+    it('crosses KST midnight: noon ET on 2026-06-20 (17:00Z) → 2026-06-21 KST', () => {
+        // 2026-06-20T16:00:00Z = 12:00 ET = 01:00 KST next day (2026-06-21) — exact old-code failure case
+        expect(kstDateOf(new Date('2026-06-20T16:00:00Z'))).toBe('2026-06-21');
+    });
+
+    it('crosses KST midnight at year boundary', () => {
+        // 2026-01-01T20:00:00Z = 05:00 KST 2026-01-02
+        expect(kstDateOf(new Date('2026-01-01T20:00:00Z'))).toBe('2026-01-02');
+    });
+
+    it('returns a YYYY-MM-DD formatted string', () => {
+        expect(kstDateOf(new Date('2026-06-20T12:30:00Z'))).toMatch(
+            /^\d{4}-\d{2}-\d{2}$/
+        );
+    });
+});
 
 describe('etDateOf', () => {
     it('formats a UTC instant to its ET YYYY-MM-DD', () => {

--- a/src/entities/economy/lib/__tests__/economicCalendarId.test.ts
+++ b/src/entities/economy/lib/__tests__/economicCalendarId.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { economicCalendarId } from '@/entities/economy/lib/economicCalendarId';
+
+describe('economicCalendarId', () => {
+    it('is deterministic for the same inputs', () => {
+        const a = economicCalendarId(
+            'US',
+            '2026-05-13 08:30:00',
+            'Core CPI MoM (Apr)'
+        );
+        const b = economicCalendarId(
+            'US',
+            '2026-05-13 08:30:00',
+            'Core CPI MoM (Apr)'
+        );
+        expect(a).toBe(b);
+    });
+
+    it('produces a fixed-length lowercase hex string', () => {
+        const id = economicCalendarId(
+            'US',
+            '2026-05-13 08:30:00',
+            'Core CPI MoM (Apr)'
+        );
+        expect(id).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('excludes actual — different actual is irrelevant because actual is not an input', () => {
+        // Same country+dateEt+event must always collide so post-release upserts
+        // land on the same row.
+        const before = economicCalendarId(
+            'US',
+            '2026-05-13 08:30:00',
+            'Core CPI MoM (Apr)'
+        );
+        const after = economicCalendarId(
+            'US',
+            '2026-05-13 08:30:00',
+            'Core CPI MoM (Apr)'
+        );
+        expect(before).toBe(after);
+    });
+
+    it('differs when any component differs', () => {
+        const base = economicCalendarId(
+            'US',
+            '2026-05-13 08:30:00',
+            'Core CPI MoM (Apr)'
+        );
+        expect(
+            economicCalendarId(
+                'EU',
+                '2026-05-13 08:30:00',
+                'Core CPI MoM (Apr)'
+            )
+        ).not.toBe(base);
+        expect(
+            economicCalendarId(
+                'US',
+                '2026-05-14 08:30:00',
+                'Core CPI MoM (Apr)'
+            )
+        ).not.toBe(base);
+        expect(
+            economicCalendarId('US', '2026-05-13 08:30:00', 'CPI MoM (Apr)')
+        ).not.toBe(base);
+    });
+
+    it('is not fooled by component-boundary ambiguity', () => {
+        // 'a' + 'bc' vs 'ab' + 'c' must not collide — a delimiter separates parts.
+        expect(economicCalendarId('US', 'x', 'yz')).not.toBe(
+            economicCalendarId('US', 'xy', 'z')
+        );
+    });
+});

--- a/src/entities/economy/lib/__tests__/economicCalendarId.test.ts
+++ b/src/entities/economy/lib/__tests__/economicCalendarId.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+// economicCalendarId(country, dateEt, event) — actual은 파라미터가 아니므로 해시에서 구조적으로 제외(발표 후 actual 변경 시 같은 id로 upsert).
 import { economicCalendarId } from '@/entities/economy/lib/economicCalendarId';
 
 describe('economicCalendarId', () => {
@@ -23,22 +24,6 @@ describe('economicCalendarId', () => {
             'Core CPI MoM (Apr)'
         );
         expect(id).toMatch(/^[0-9a-f]{64}$/);
-    });
-
-    it('excludes actual — different actual is irrelevant because actual is not an input', () => {
-        // Same country+dateEt+event must always collide so post-release upserts
-        // land on the same row.
-        const before = economicCalendarId(
-            'US',
-            '2026-05-13 08:30:00',
-            'Core CPI MoM (Apr)'
-        );
-        const after = economicCalendarId(
-            'US',
-            '2026-05-13 08:30:00',
-            'Core CPI MoM (Apr)'
-        );
-        expect(before).toBe(after);
     });
 
     it('differs when any component differs', () => {

--- a/src/entities/economy/lib/calendarWindow.ts
+++ b/src/entities/economy/lib/calendarWindow.ts
@@ -33,6 +33,7 @@ export function etDateOf(instant: Date): string {
         ET_DATE_FORMAT.formatToParts(instant)
             .filter(p => p.type !== 'literal')
             .map(p => [p.type, p.value])
+        // Intl.DateTimeFormat configured with year/month/day always emits parts of these exact types.
     ) as Record<'year' | 'month' | 'day', string>;
     return `${parts.year}-${parts.month}-${parts.day}`;
 }
@@ -43,6 +44,7 @@ export function kstDateOf(instant: Date): string {
         KST_DATE_FORMAT.formatToParts(instant)
             .filter(p => p.type !== 'literal')
             .map(p => [p.type, p.value])
+        // Intl.DateTimeFormat configured with year/month/day always emits parts of these exact types.
     ) as Record<'year' | 'month' | 'day', string>;
     return `${parts.year}-${parts.month}-${parts.day}`;
 }

--- a/src/entities/economy/lib/calendarWindow.ts
+++ b/src/entities/economy/lib/calendarWindow.ts
@@ -1,0 +1,51 @@
+/**
+ * 캘린더 윈도 일수 상수 + ET-zoned 날짜 헬퍼.
+ *
+ * `economySnapshotCache.isoDate`와 같은 ET formatter 패턴을 쓴다 — 서버가 UTC+0의
+ * 00:00~04:59에 "오늘"을 계산할 때 ET 기준 전날로 밀리는 오차를 막는다. 모든 함수는
+ * 결정론적(`Intl.DateTimeFormat` + 순수 산술)이라 ISR cold-gen에서 안전하다
+ * (`Date.now()`/dynamic API 미사용 — 호출자가 `new Date()` 앵커를 주입).
+ */
+
+/** 과거 윈도 일수 — 최소 2주(spec). */
+export const PAST_WINDOW_DAYS = 14;
+
+/** 미래 윈도 일수 — #610 그리드의 다가오는 ~2주와 정렬. */
+export const FUTURE_WINDOW_DAYS = 14;
+
+const ET_DATE_FORMAT = new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    timeZone: 'America/New_York',
+});
+
+/** UTC instant → ET-zoned 'YYYY-MM-DD'. */
+export function etDateOf(instant: Date): string {
+    const parts = Object.fromEntries(
+        ET_DATE_FORMAT.formatToParts(instant)
+            .filter(p => p.type !== 'literal')
+            .map(p => [p.type, p.value])
+    ) as Record<'year' | 'month' | 'day', string>;
+    return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+/** 'YYYY-MM-DD'에 일수를 더한 'YYYY-MM-DD' (UTC 산술 — TZ 비의존). */
+export function addEtDays(dateEt: string, delta: number): string {
+    const [y, m, d] = dateEt.split('-').map(Number);
+    const shifted = new Date(Date.UTC(y, m - 1, d + delta));
+    const yy = shifted.getUTCFullYear();
+    const mm = String(shifted.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(shifted.getUTCDate()).padStart(2, '0');
+    return `${yy}-${mm}-${dd}`;
+}
+
+/** 앵커일(포함) 기준 과거 윈도 시작일. */
+export function pastWindowStart(anchorEt: string): string {
+    return addEtDays(anchorEt, -PAST_WINDOW_DAYS);
+}
+
+/** 앵커일(포함) 기준 미래 윈도 종료일. */
+export function futureWindowEnd(anchorEt: string): string {
+    return addEtDays(anchorEt, FUTURE_WINDOW_DAYS);
+}

--- a/src/entities/economy/lib/calendarWindow.ts
+++ b/src/entities/economy/lib/calendarWindow.ts
@@ -20,10 +20,27 @@ const ET_DATE_FORMAT = new Intl.DateTimeFormat('en-US', {
     timeZone: 'America/New_York',
 });
 
+const KST_DATE_FORMAT = new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    timeZone: 'Asia/Seoul',
+});
+
 /** UTC instant → ET-zoned 'YYYY-MM-DD'. */
 export function etDateOf(instant: Date): string {
     const parts = Object.fromEntries(
         ET_DATE_FORMAT.formatToParts(instant)
+            .filter(p => p.type !== 'literal')
+            .map(p => [p.type, p.value])
+    ) as Record<'year' | 'month' | 'day', string>;
+    return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+/** UTC instant → KST-zoned 'YYYY-MM-DD'. */
+export function kstDateOf(instant: Date): string {
+    const parts = Object.fromEntries(
+        KST_DATE_FORMAT.formatToParts(instant)
             .filter(p => p.type !== 'literal')
             .map(p => [p.type, p.value])
     ) as Record<'year' | 'month' | 'day', string>;

--- a/src/entities/economy/lib/economicCalendarId.ts
+++ b/src/entities/economy/lib/economicCalendarId.ts
@@ -1,0 +1,18 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * 결정론적 PK 해시 — country + dateEt + event의 SHA-256 hex.
+ *
+ * `actual`을 의도적으로 제외한다: 발표 후 actual이 채워져도 같은 이벤트로 upsert해
+ * 갱신하기 위함(`economic_calendar` 테이블 주석 참조). 구성 요소 사이에 ` `
+ * 구분자를 넣어 'a'+'bc'와 'ab'+'c' 같은 경계 충돌을 방지한다.
+ */
+export function economicCalendarId(
+    country: string,
+    dateEt: string,
+    event: string
+): string {
+    return createHash('sha256')
+        .update(`${country} ${dateEt} ${event}`)
+        .digest('hex');
+}

--- a/src/entities/economy/lib/economyCalendarConstants.ts
+++ b/src/entities/economy/lib/economyCalendarConstants.ts
@@ -1,0 +1,28 @@
+import { SECONDS_PER_DAY, SECONDS_PER_MINUTE } from '@/shared/config/time';
+
+/** revalidateTag 대상 — 캘린더 ISR 캐시만 무효화한다(스냅샷 캐시와 분리). */
+export const ECONOMY_CALENDAR_CACHE_TAG = 'economy:calendar';
+
+/**
+ * 캘린더 reader의 `unstable_cache` revalidate — 24h, /economy revalidate(86400)와
+ * 단일 TTL 공유. 신선도는 `ensureEconomicCalendarAction`의 revalidateTag가 책임진다.
+ */
+export const ECONOMY_CALENDAR_REVALIDATE_SECONDS = SECONDS_PER_DAY;
+
+/** ensure가 매 접속마다 ±1개월을 fetch하는 ingestion 윈도(일수). */
+export const CALENDAR_INGESTION_WINDOW_DAYS = 30;
+
+/** 'US' — 현재 US 이벤트만 저장/표시. */
+export const CALENDAR_COUNTRY = 'US';
+
+const CALENDAR_REFRESH_FLAG_TTL_MINUTES = 60;
+
+/**
+ * ensure refresh-flag TTL — 이 윈도 안에 재접속(봇 재크롤 포함)하면 FMP fetch를
+ * 건너뛴다. market-news `MARKET_NEWS_REFRESH_FLAG_TTL_SECONDS` 패턴을 미러.
+ */
+export const CALENDAR_REFRESH_FLAG_TTL_SECONDS =
+    CALENDAR_REFRESH_FLAG_TTL_MINUTES * SECONDS_PER_MINUTE;
+
+/** Redis refresh-flag 키 — 단일 글로벌 캘린더(심볼/카테고리 분기 없음). */
+export const CALENDAR_REFRESH_FLAG_KEY = 'economy:calendar:refresh';

--- a/src/shared/db/schema.ts
+++ b/src/shared/db/schema.ts
@@ -2,6 +2,7 @@ import { sql } from 'drizzle-orm';
 import {
     boolean,
     date,
+    doublePrecision,
     index,
     integer,
     jsonb,
@@ -320,6 +321,45 @@ export const earningsReports = pgTable(
             .defaultNow(),
     },
     table => [primaryKey({ columns: [table.symbol, table.earningsDate] })]
+);
+
+/**
+ * 정규화된 FMP economic-calendar 이벤트 이력 (현재 US만 저장).
+ *
+ * `id`는 country+dateEt+event의 결정론적 해시(`economicCalendarId`)다. `actual`을
+ * 포함하지 않으므로 발표 후 actual이 채워져도 같은 행으로 upsert돼 갱신된다
+ * (#610 그리드의 React key `${date}:${event}:${actual}`와는 의도가 다른 안정 키).
+ *
+ * SP-D에서 별도 마이그레이션으로 sentiment/summaryKo/interpretationKo/analyzedAt가
+ * 추가된다 — SP-A 테이블에는 미포함.
+ */
+export const economicCalendar = pgTable(
+    'economic_calendar',
+    {
+        id: text('id').primaryKey(),
+        country: text('country').notNull(),
+        // FMP 원본 'YYYY-MM-DD HH:mm:ss' (ET 벽시계). KST 변환은 표시 계층(etDateTimeToKst).
+        dateEt: text('date_et').notNull(),
+        event: text('event').notNull(),
+        // 'High' | 'Medium' | 'Low' — text 저장, 읽기 경계에서 검증.
+        impact: text('impact').notNull(),
+        estimate: doublePrecision('estimate'),
+        previous: doublePrecision('previous'),
+        // 발표 전 null; ingestion 재fetch 시 채워짐.
+        actual: doublePrecision('actual'),
+        unit: text('unit').notNull(),
+        fetchedAt: timestamp('fetched_at', { withTimezone: true })
+            .notNull()
+            .defaultNow(),
+    },
+    table => [
+        index('economic_calendar_date_et_idx').on(table.dateEt),
+        index('economic_calendar_country_date_et_idx').on(
+            table.country,
+            table.dateEt
+        ),
+        index('economic_calendar_impact_idx').on(table.impact),
+    ]
 );
 
 /** Postgres enum for legal terms document kinds. */

--- a/src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
+++ b/src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
@@ -1,6 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
+
+vi.mock('@/entities/economy/actions', () => ({
+    ensureEconomicCalendarAction: vi.fn().mockResolvedValue(undefined),
+}));
 
 import { EconomicCalendarGrid } from '@/widgets/economy/sections/EconomicCalendarGrid';
 
@@ -232,5 +236,58 @@ describe('EconomicCalendarGrid — 그리드 구조', () => {
         // 가시적 월 레이블(<p>)과 sr-only caption 모두 2026년 6월을 포함하므로
         // 두 요소가 매치된다.
         expect(screen.getAllByText(/2026년 6월/)).toHaveLength(2);
+    });
+});
+
+describe('EconomicCalendarGrid default selection from today', () => {
+    const ev = (date: string): EconomicCalendarEvent => ({
+        date: `${date} 08:30:00`,
+        event: `E ${date}`,
+        impact: 'High',
+        actual: null,
+        estimate: 1,
+        previous: 1,
+        unit: '%',
+    });
+
+    it("selects today's panel when an event exists for today (KST)", () => {
+        // 2026-06-20 08:30 ET → KST 2026-06-20 21:30 → KST date key 2026-06-20.
+        render(
+            <EconomicCalendarGrid
+                events={[ev('2026-06-18'), ev('2026-06-20'), ev('2026-06-25')]}
+                today="2026-06-20"
+            />
+        );
+        // The today day-button is pressed.
+        const todayBtn = screen.getByRole('button', {
+            name: /6월 20일/,
+        });
+        expect(todayBtn).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('selects the nearest upcoming day when today has no events', () => {
+        render(
+            <EconomicCalendarGrid
+                events={[ev('2026-06-18'), ev('2026-06-25')]}
+                today="2026-06-20"
+            />
+        );
+        const upcomingBtn = screen.getByRole('button', {
+            name: /6월 25일/,
+        });
+        expect(upcomingBtn).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('falls back to the earliest day when all events are in the past', () => {
+        render(
+            <EconomicCalendarGrid
+                events={[ev('2026-06-10'), ev('2026-06-12')]}
+                today="2026-06-20"
+            />
+        );
+        const earliestBtn = screen.getByRole('button', {
+            name: /6월 10일/,
+        });
+        expect(earliestBtn).toHaveAttribute('aria-pressed', 'true');
     });
 });

--- a/src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
+++ b/src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
@@ -1,12 +1,11 @@
 import { vi, describe, it, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
+import { EconomicCalendarGrid } from '@/widgets/economy/sections/EconomicCalendarGrid';
 
 vi.mock('@/entities/economy/actions', () => ({
     ensureEconomicCalendarAction: vi.fn().mockResolvedValue(undefined),
 }));
-
-import { EconomicCalendarGrid } from '@/widgets/economy/sections/EconomicCalendarGrid';
 
 /**
  * 기준 이벤트: 2026-06-19 19:30:00 ET(-04:00) → KST 2026-06-20 오전 8:30

--- a/src/widgets/economy/hooks/__tests__/useEconomicCalendarTrigger.test.tsx
+++ b/src/widgets/economy/hooks/__tests__/useEconomicCalendarTrigger.test.tsx
@@ -1,0 +1,38 @@
+vi.mock('@/entities/economy/actions', () => ({
+    ensureEconomicCalendarAction: vi.fn(),
+}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { ensureEconomicCalendarAction } from '@/entities/economy/actions';
+import { useEconomicCalendarTrigger } from '../useEconomicCalendarTrigger';
+
+function Probe() {
+    useEconomicCalendarTrigger();
+    return null;
+}
+
+describe('useEconomicCalendarTrigger', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(ensureEconomicCalendarAction).mockResolvedValue(undefined);
+    });
+
+    it('fires the ensure action once on mount', () => {
+        render(<Probe />);
+        expect(ensureEconomicCalendarAction).toHaveBeenCalledOnce();
+    });
+
+    it('does not re-fire on re-render', () => {
+        const { rerender } = render(<Probe />);
+        rerender(<Probe />);
+        expect(ensureEconomicCalendarAction).toHaveBeenCalledOnce();
+    });
+
+    it('swallows a rejected action without throwing', () => {
+        vi.mocked(ensureEconomicCalendarAction).mockRejectedValue(
+            new Error('boom')
+        );
+        expect(() => render(<Probe />)).not.toThrow();
+    });
+});

--- a/src/widgets/economy/hooks/useEconomicCalendarTrigger.ts
+++ b/src/widgets/economy/hooks/useEconomicCalendarTrigger.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { ensureEconomicCalendarAction } from '@/entities/economy/actions';
+
+/**
+ * Fire-and-forget: `ensureEconomicCalendarAction()`를 마운트 시 1회 호출한다(봇 포함).
+ * 에러는 로깅만 — 실패해도 소비자는 반응할 필요가 없다(다음 접속 또는 다음 refresh-flag
+ * 만료 시 재시도). market-news `useMarketNewsAnalysisTrigger` 패턴 미러.
+ */
+export function useEconomicCalendarTrigger(): void {
+    const triggeredRef = useRef(false);
+
+    useEffect(() => {
+        if (triggeredRef.current) return;
+        triggeredRef.current = true;
+        void ensureEconomicCalendarAction().catch((e: unknown) => {
+            console.error(
+                '[useEconomicCalendarTrigger] ensureEconomicCalendarAction failed:',
+                e
+            );
+        });
+    }, []);
+}

--- a/src/widgets/economy/sections/EconomicCalendarGrid.tsx
+++ b/src/widgets/economy/sections/EconomicCalendarGrid.tsx
@@ -15,6 +15,7 @@ import type {
 import { cn } from '@/shared/lib/cn';
 import { formatNum } from '@/shared/lib/formatNum';
 import { etDateTimeToKst } from '@/shared/lib/etTimeUtils';
+import { useEconomicCalendarTrigger } from '../hooks/useEconomicCalendarTrigger';
 
 const IMPACT_LABELS: Record<CalendarImpact, string> = {
     High: '높음',
@@ -438,8 +439,29 @@ function MonthCalendar({
     );
 }
 
+/**
+ * 기본 선택 날짜 키를 결정한다 — 결정론적(렌더 중 `Date.now()` 금지).
+ * `today`(KST 'YYYY-MM-DD', 서버 RSC가 ET-오늘에서 1회 계산해 주입)에 그룹이 있으면
+ * 그날, 없으면 `today` 이상인 가장 가까운 미래 그룹, 그것도 없으면 가장 이른 그룹.
+ * groups는 dateKey 오름차순 정렬돼 있다(`groupEventsByKstDay`).
+ */
+function pickDefaultDateKey(groups: DayGroup[], today: string): string {
+    if (groups.length === 0) return '';
+    const exact = groups.find(g => g.dateKey === today);
+    if (exact !== undefined) return exact.dateKey;
+    const upcoming = groups.find(g => g.dateKey >= today);
+    if (upcoming !== undefined) return upcoming.dateKey;
+    return groups[0].dateKey;
+}
+
 interface EconomicCalendarGridProps {
     events: readonly EconomicCalendarEvent[];
+    /**
+     * 기본 선택 기준일 — KST 'YYYY-MM-DD'. 서버 RSC가 ET-오늘 instant를
+     * KST 날짜키로 1회 변환해 주입한다(ISR 안전: 클라에서 `Date.now()` 미사용).
+     * 생략 시 가장 이른 그룹을 기본 선택(기존 동작 유지).
+     */
+    today?: string;
 }
 
 /**
@@ -453,9 +475,14 @@ interface EconomicCalendarGridProps {
  *    SSR 크롤러가 전체 이벤트 텍스트를 색인할 수 있도록 보장한다.
  *
  * ISR 안전: `Date.now()` / `new Date()` (무인수) 호출 없음.
- * 기본 선택 날짜 = 이벤트가 있는 가장 이른 KST 날짜(결정론적).
+ * 기본 선택 날짜 = `today`(KST) → 가장 가까운 미래 → 가장 이른 그룹.
  */
-export function EconomicCalendarGrid({ events }: EconomicCalendarGridProps) {
+export function EconomicCalendarGrid({
+    events,
+    today = '',
+}: EconomicCalendarGridProps) {
+    useEconomicCalendarTrigger();
+
     const [selectedDateKey, setSelectedDateKey] = useState('');
     const groups = useMemo(() => groupEventsByKstDay(events), [events]);
     const groupMap = useMemo(
@@ -465,20 +492,18 @@ export function EconomicCalendarGrid({ events }: EconomicCalendarGridProps) {
     const months = useMemo(() => spannedMonths(groups), [groups]);
 
     /**
-     * events가 바뀔 때 기본 선택 날짜를 가장 이른 그룹으로 재동기화한다.
-     * useEffectEvent로 감싸 syncDefault 자체를 안정적인 참조로 만들어
-     * useEffect 의존성 배열에서 제외할 수 있게 한다.
-     * startTransition으로 감싸 react-hooks/set-state-in-effect 규칙을 만족시킨다
-     * (OptionsPageClient.tsx의 captureNow 패턴과 동일).
+     * events/today가 바뀔 때 기본 선택 날짜를 재동기화한다(오늘 → 가장 가까운 미래 →
+     * 가장 이른 그룹). useEffectEvent로 감싸 안정 참조를 만들고 startTransition으로
+     * react-hooks/set-state-in-effect를 만족시킨다(기존 패턴 유지).
      */
     const syncDefault = useEffectEvent((): void => {
         startTransition(() => {
-            setSelectedDateKey(groups.length > 0 ? groups[0].dateKey : '');
+            setSelectedDateKey(pickDefaultDateKey(groups, today));
         });
     });
     useEffect(() => {
         syncDefault();
-    }, [groups]);
+    }, [groups, today]);
 
     if (events.length === 0) {
         return (

--- a/src/widgets/economy/sections/EconomicCalendarGrid.tsx
+++ b/src/widgets/economy/sections/EconomicCalendarGrid.tsx
@@ -362,28 +362,29 @@ function MonthCalendar({
     selectedDateKey,
     onSelect,
 }: MonthCalendarProps) {
-    const totalDays = daysInMonth(year, month);
-    /** 1일의 요일 (0=일 … 6=토) */
-    const firstDow = new Date(Date.UTC(year, month, 1)).getUTCDay();
+    const weeks = useMemo(() => {
+        const totalDays = daysInMonth(year, month);
+        /** 1일의 요일 (0=일 … 6=토) */
+        const firstDow = new Date(Date.UTC(year, month, 1)).getUTCDay();
 
-    const rawCells: (DayGroup | null)[] = [
-        ...Array<null>(firstDow).fill(null),
-        ...Array.from({ length: totalDays }, (_, i) => {
-            const d = i + 1;
-            const key = `${year}-${String(month + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
-            return groupMap.get(key) ?? null;
-        }),
-    ];
-    const padCount = (7 - (rawCells.length % 7)) % 7;
-    const cells =
-        padCount > 0
-            ? [...rawCells, ...Array<null>(padCount).fill(null)]
-            : rawCells;
+        const rawCells: (DayGroup | null)[] = [
+            ...Array<null>(firstDow).fill(null),
+            ...Array.from({ length: totalDays }, (_, i) => {
+                const d = i + 1;
+                const key = `${year}-${String(month + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+                return groupMap.get(key) ?? null;
+            }),
+        ];
+        const padCount = (7 - (rawCells.length % 7)) % 7;
+        const cells =
+            padCount > 0
+                ? [...rawCells, ...Array<null>(padCount).fill(null)]
+                : rawCells;
 
-    const weeks: (DayGroup | null)[][] = Array.from(
-        { length: cells.length / 7 },
-        (_, i) => cells.slice(i * 7, i * 7 + 7)
-    );
+        return Array.from({ length: cells.length / 7 }, (_, i) =>
+            cells.slice(i * 7, i * 7 + 7)
+        ) as (DayGroup | null)[][];
+    }, [year, month, groupMap]);
 
     const captionText = `${year}년 ${MONTH_LABELS[month]} 경제 캘린더`;
 
@@ -481,9 +482,8 @@ export function EconomicCalendarGrid({
     events,
     today = '',
 }: EconomicCalendarGridProps) {
-    useEconomicCalendarTrigger();
-
     const [selectedDateKey, setSelectedDateKey] = useState('');
+    useEconomicCalendarTrigger();
     const groups = useMemo(() => groupEventsByKstDay(events), [events]);
     const groupMap = useMemo(
         () => new Map<string, DayGroup>(groups.map(g => [g.dateKey, g])),


### PR DESCRIPTION
## SP-A: 경제 캘린더 이력 데이터 레이어 (4-SP 이터레이션 #1)

경제 캘린더 데이터 소스를 Redis 스냅샷에서 **DB-backed 이력 레이어**로 전환한다. 후속 SP-B(지표명 한국어화)·SP-C(중요도 필터)·SP-D(이벤트 AI 분석)의 기반.

스펙: `docs/superpowers/specs/2026-06-20-economy-calendar-iteration-design.md`
플랜: `docs/superpowers/plans/2026-06-20-economy-calendar-SP-A-history-data-layer.md`

### 변경 사항
- **`economic_calendar` 테이블** + 마이그레이션(`drizzle/0018`): 결정론적 id 해시(country+dateEt+event, `actual` 제외 → 발표 후 같은 행 upsert), 3개 인덱스(dateEt / country,dateEt / impact).
- **`DrizzleEconomicCalendarRepository`**: idempotent `upsertEvent`(IS DISTINCT FROM setWhere), `listInRange`(범위 경계 23:59:59 포함).
- **`getCalendarFromDb(anchorEt)`**: `unstable_cache` 래핑 리더(과거 14일 + 미래 14일). ISR cold-gen 안전(쿠키/헤더/connection/Date.now() 미사용).
- **`ensureEconomicCalendarAction`**: 클라 마운트 시 ±1개월 FMP fetch → upsert → revalidateTag. fire-and-forget(`ensureMarketNewsCardsAnalyzedAction` 미러). 봇 포함 on-access 갱신.
- **`useEconomicCalendarTrigger`**: 마운트 1회 트리거 훅(news 패턴).
- **백필 스크립트**(`scripts/backfillEconomicCalendar.ts`): 사용자 1회 수동 실행, ~2년 청크 fetch + upsert + SP-B용 distinct 정규화 이름 덤프.
- **economy 페이지**: 캘린더 소스를 DB 리더로 교체. ET-오늘(리더 앵커) + KST-오늘(그리드 기본 선택일) 단일 인스턴트로 계산. 지표/treasury 스냅샷은 그대로.

### 검증
- tsc 0 · lint 0 · format 0 · vitest 6357개 통과(815 파일) · build EXIT=0 · `/economy` static(○)+1d revalidate · DYNAMIC_SERVER_USAGE 0건.
- Opus 4.8 2단계 리뷰(spec 준수 + 코드 품질) + 통합 리뷰 통과. R1(KST today 앵커 off-by-one) 수정.

### ⚠️ 사용자 게이트(인프라)
- `yarn db:migrate`로 마이그레이션 적용
- `yarn db:backfill:calendar`로 1회 백필 실행
둘 다 자동 실행하지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)