### PR TITLE
feat(economy): SP-B — 경제 캘린더 지표명 한국어화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ next-env.d.ts
 /docs/superpowers/*
 !/docs/superpowers/specs/
 !/docs/superpowers/plans/
+!/docs/superpowers/seeding/
 
 # backtest batch job state
 /scripts/backtests/.batch-job.txt

--- a/docs/superpowers/seeding/indicator-name-ko-seeding.md
+++ b/docs/superpowers/seeding/indicator-name-ko-seeding.md
@@ -1,0 +1,59 @@
+# Indicator Name Korean Dictionary — One-Time Seeding Procedure
+
+`INDICATOR_NAME_KO` (`src/entities/economy/lib/indicatorNameKo.ts`) is the
+source-of-truth (`dict`) for economic-indicator Korean names. SP-B Task 1 seeds
+the ~28 most common indicators from the FMP sample. This procedure curates the
+full ~277 distinct normalized base names into the dictionary as a follow-up data
+task. Anything not in the dictionary is AI-translated on-miss and cached
+(`source:'ai'`) in `economic_indicator_translations` — so this seeding is an
+optimization (instant Korean, no AI round-trip) and a quality-control gate
+(human-curated vs. machine draft), not a correctness requirement.
+
+## Inputs
+
+- **`scripts/output/economic-calendar-indicator-names.json`** — the distinct
+  normalized base-name set produced by SP-A's backfill
+  (`yarn db:backfill:calendar`). ~277 entries, sorted.
+
+## Steps
+
+1. **Run the SP-A backfill** (user, one-time) to regenerate the name dump:
+   `yarn db:backfill:calendar`. Confirm the JSON file exists and its length is
+   ~277.
+
+2. **Draft translations via core AI.** For each name not already in
+   `INDICATOR_NAME_KO`, obtain a Korean draft. Two equivalent options:
+   - Let the running app self-heal: deploy SP-B, let `/economy` traffic trigger
+     `ensureIndicatorTranslatedAction` for misses, then `SELECT normalized_name,
+     korean_name FROM economic_indicator_translations WHERE source = 'ai'` to
+     read the machine drafts back.
+   - Or call core `submitIndicatorTranslation(name)` + `pollIndicatorTranslation`
+     directly in a throwaway script over the dump (core must be published first).
+
+3. **Curate.** Review each draft for: domain accuracy (지표 의미), consistent
+   terminology (e.g. always `근원` for "Core", `전년比`/`전월比`/`전분기比` for
+   YoY/MoM/QoQ — these come from `koreanizePeriodToken`, so the **base** must NOT
+   embed the period token; keep base period-free except where the FMP base name
+   itself carries a direction, like `... YoY`, which the seed already folds into
+   the Korean), and house style (no trailing punctuation). Fix anything wrong.
+
+4. **Fill `INDICATOR_NAME_KO`.** Add the curated `'<base>': '<korean>'` entries
+   to the const map, keeping the existing grouping comments (물가 / 고용 /
+   성장·심리 / 정책·국채 / …). Keys MUST be the **normalized base** form
+   (`normalizeIndicatorName(raw).base`) — no trailing `(May)`/`(Q1)`.
+
+5. **Promote, optionally.** Rows curated into the dict can have their DB cache
+   row updated to `source:'dict'` (or left as-is — the dict short-circuits the
+   DB read either way, since `INDICATOR_NAME_KO` is checked first).
+
+6. **Verify.** Extend `indicatorNameKo.test.ts` with spot-check assertions for a
+   handful of newly-added high-traffic indicators, then `yarn test`.
+
+## Guardrails
+
+- Do NOT machine-bulk-paste drafts without review — a wrong indicator
+  translation is user-visible and misleading.
+- Keep base keys period-free; the period parenthetical is Korean-ized separately
+  by `koreanizePeriodToken` at display time.
+- The dictionary is plain data — no logic. Reviewers should treat large dict
+  additions as a data PR (spot-check, not line-by-line lint).

--- a/drizzle/0019_perfect_zodiak.sql
+++ b/drizzle/0019_perfect_zodiak.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "economic_indicator_translations" (
+	"normalized_name" text PRIMARY KEY NOT NULL,
+	"korean_name" text NOT NULL,
+	"source" text NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/drizzle/meta/0019_snapshot.json
+++ b/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,1578 @@
+{
+    "id": "429894c3-0ba6-465d-be63-8c5f286068c4",
+    "prevId": "b9bdd92d-5e2d-4de9-bfe9-5b453a5febbb",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.agreements": {
+            "name": "agreements",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "terms_id": {
+                    "name": "terms_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "agreed": {
+                    "name": "agreed",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "agreed_at": {
+                    "name": "agreed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "agreements_user_terms_uidx": {
+                    "name": "agreements_user_terms_uidx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "terms_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "agreements_user_id_idx": {
+                    "name": "agreements_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "agreements_terms_id_idx": {
+                    "name": "agreements_terms_id_idx",
+                    "columns": [
+                        {
+                            "expression": "terms_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "agreements_user_id_users_id_fk": {
+                    "name": "agreements_user_id_users_id_fk",
+                    "tableFrom": "agreements",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "agreements_terms_id_terms_id_fk": {
+                    "name": "agreements_terms_id_terms_id_fk",
+                    "tableFrom": "agreements",
+                    "tableTo": "terms",
+                    "columnsFrom": ["terms_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "restrict",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.asset_translations": {
+            "name": "asset_translations",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "fmp_symbol": {
+                    "name": "fmp_symbol",
+                    "type": "varchar(64)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.earnings_reports": {
+            "name": "earnings_reports",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "earnings_date": {
+                    "name": "earnings_date",
+                    "type": "date",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "eps_actual": {
+                    "name": "eps_actual",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "eps_estimated": {
+                    "name": "eps_estimated",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "revenue_actual": {
+                    "name": "revenue_actual",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "revenue_estimated": {
+                    "name": "revenue_estimated",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "last_updated": {
+                    "name": "last_updated",
+                    "type": "date",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "raw_payload": {
+                    "name": "raw_payload",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {
+                "earnings_reports_symbol_earnings_date_pk": {
+                    "name": "earnings_reports_symbol_earnings_date_pk",
+                    "columns": ["symbol", "earnings_date"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.economic_calendar": {
+            "name": "economic_calendar",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "country": {
+                    "name": "country",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "date_et": {
+                    "name": "date_et",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "event": {
+                    "name": "event",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "impact": {
+                    "name": "impact",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "estimate": {
+                    "name": "estimate",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "previous": {
+                    "name": "previous",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "actual": {
+                    "name": "actual",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "unit": {
+                    "name": "unit",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "economic_calendar_date_et_idx": {
+                    "name": "economic_calendar_date_et_idx",
+                    "columns": [
+                        {
+                            "expression": "date_et",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "economic_calendar_country_date_et_idx": {
+                    "name": "economic_calendar_country_date_et_idx",
+                    "columns": [
+                        {
+                            "expression": "country",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "date_et",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "economic_calendar_impact_idx": {
+                    "name": "economic_calendar_impact_idx",
+                    "columns": [
+                        {
+                            "expression": "impact",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.economic_indicator_translations": {
+            "name": "economic_indicator_translations",
+            "schema": "",
+            "columns": {
+                "normalized_name": {
+                    "name": "normalized_name",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "source": {
+                    "name": "source",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.inquiries": {
+            "name": "inquiries",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "title": {
+                    "name": "title",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "content": {
+                    "name": "content",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "email": {
+                    "name": "email",
+                    "type": "varchar(320)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "answered": {
+                    "name": "answered",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.korean_tickers": {
+            "name": "korean_tickers",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "exchange": {
+                    "name": "exchange",
+                    "type": "varchar(32)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "exchange_full_name": {
+                    "name": "exchange_full_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.market_news": {
+            "name": "market_news",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "symbol": {
+                    "name": "symbol",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "source": {
+                    "name": "source",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "url": {
+                    "name": "url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "published_at": {
+                    "name": "published_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_ko": {
+                    "name": "title_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_en": {
+                    "name": "body_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_ko": {
+                    "name": "body_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "summary_ko": {
+                    "name": "summary_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "sentiment": {
+                    "name": "sentiment",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "category": {
+                    "name": "category",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "price_impact": {
+                    "name": "price_impact",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "tickers": {
+                    "name": "tickers",
+                    "type": "text[]",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "ARRAY[]::text[]"
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "analyzed_at": {
+                    "name": "analyzed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "market_news_symbol_published_at_idx": {
+                    "name": "market_news_symbol_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "symbol",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "market_news_published_at_idx": {
+                    "name": "market_news_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "market_news_url_unique": {
+                    "name": "market_news_url_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["url"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.news": {
+            "name": "news",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "symbol": {
+                    "name": "symbol",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "source": {
+                    "name": "source",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "url": {
+                    "name": "url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "published_at": {
+                    "name": "published_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_ko": {
+                    "name": "title_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_en": {
+                    "name": "body_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_ko": {
+                    "name": "body_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "summary_ko": {
+                    "name": "summary_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "sentiment": {
+                    "name": "sentiment",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "category": {
+                    "name": "category",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "price_impact": {
+                    "name": "price_impact",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "raw_payload": {
+                    "name": "raw_payload",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "analyzed_at": {
+                    "name": "analyzed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "news_symbol_published_at_idx": {
+                    "name": "news_symbol_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "symbol",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "news_published_at_idx": {
+                    "name": "news_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "news_url_unique": {
+                    "name": "news_url_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["url"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.notices": {
+            "name": "notices",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "title": {
+                    "name": "title",
+                    "type": "varchar(200)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "body": {
+                    "name": "body",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "link_url": {
+                    "name": "link_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "link_label": {
+                    "name": "link_label",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "path_pattern": {
+                    "name": "path_pattern",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "priority": {
+                    "name": "priority",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 0
+                },
+                "is_active": {
+                    "name": "is_active",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": true
+                },
+                "starts_at": {
+                    "name": "starts_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "ends_at": {
+                    "name": "ends_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "notices_active_window_idx": {
+                    "name": "notices_active_window_idx",
+                    "columns": [
+                        {
+                            "expression": "is_active",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "starts_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "ends_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.oauth_accounts": {
+            "name": "oauth_accounts",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider": {
+                    "name": "provider",
+                    "type": "oauth_provider",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider_account_id": {
+                    "name": "provider_account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "access_token": {
+                    "name": "access_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "refresh_token": {
+                    "name": "refresh_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "token_expires_at": {
+                    "name": "token_expires_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "oauth_accounts_user_id_idx": {
+                    "name": "oauth_accounts_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "oauth_accounts_provider_account_uidx": {
+                    "name": "oauth_accounts_provider_account_uidx",
+                    "columns": [
+                        {
+                            "expression": "provider",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "provider_account_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "oauth_accounts_user_id_users_id_fk": {
+                    "name": "oauth_accounts_user_id_users_id_fk",
+                    "tableFrom": "oauth_accounts",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.profile_description_translations": {
+            "name": "profile_description_translations",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "description_ko": {
+                    "name": "description_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.sessions": {
+            "name": "sessions",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "sessions_user_id_idx": {
+                    "name": "sessions_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "sessions_expires_at_idx": {
+                    "name": "sessions_expires_at_idx",
+                    "columns": [
+                        {
+                            "expression": "expires_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "sessions_user_id_users_id_fk": {
+                    "name": "sessions_user_id_users_id_fk",
+                    "tableFrom": "sessions",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.terms": {
+            "name": "terms",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "kind": {
+                    "name": "kind",
+                    "type": "terms_kind",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "version": {
+                    "name": "version",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "effective_date": {
+                    "name": "effective_date",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "body": {
+                    "name": "body",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "terms_kind_version_uidx": {
+                    "name": "terms_kind_version_uidx",
+                    "columns": [
+                        {
+                            "expression": "kind",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "version",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "terms_kind_effective_date_idx": {
+                    "name": "terms_kind_effective_date_idx",
+                    "columns": [
+                        {
+                            "expression": "kind",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "effective_date",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.usage_logs": {
+            "name": "usage_logs",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "ip_hash": {
+                    "name": "ip_hash",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "action_type": {
+                    "name": "action_type",
+                    "type": "usage_action_type",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "model_used": {
+                    "name": "model_used",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "date": {
+                    "name": "date",
+                    "type": "date",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "usage_logs_user_id_idx": {
+                    "name": "usage_logs_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "usage_logs_ip_hash_date_idx": {
+                    "name": "usage_logs_ip_hash_date_idx",
+                    "columns": [
+                        {
+                            "expression": "ip_hash",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "date",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "usage_logs_user_id_users_id_fk": {
+                    "name": "usage_logs_user_id_users_id_fk",
+                    "tableFrom": "usage_logs",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.user_api_keys": {
+            "name": "user_api_keys",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider": {
+                    "name": "provider",
+                    "type": "llm_provider",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "encrypted_api_key": {
+                    "name": "encrypted_api_key",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "user_api_keys_user_id_idx": {
+                    "name": "user_api_keys_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "user_api_keys_user_provider_uidx": {
+                    "name": "user_api_keys_user_provider_uidx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "provider",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "user_api_keys_user_id_users_id_fk": {
+                    "name": "user_api_keys_user_id_users_id_fk",
+                    "tableFrom": "user_api_keys",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.users": {
+            "name": "users",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "email": {
+                    "name": "email",
+                    "type": "varchar(320)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "password_hash": {
+                    "name": "password_hash",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "avatar_url": {
+                    "name": "avatar_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "tier": {
+                    "name": "tier",
+                    "type": "user_tier",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'free'"
+                },
+                "email_verified": {
+                    "name": "email_verified",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "users_email_unique": {
+                    "name": "users_email_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["email"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {
+        "public.llm_provider": {
+            "name": "llm_provider",
+            "schema": "public",
+            "values": ["anthropic", "google", "openai"]
+        },
+        "public.oauth_provider": {
+            "name": "oauth_provider",
+            "schema": "public",
+            "values": ["google", "kakao", "apple"]
+        },
+        "public.terms_kind": {
+            "name": "terms_kind",
+            "schema": "public",
+            "values": ["privacy", "tos"]
+        },
+        "public.usage_action_type": {
+            "name": "usage_action_type",
+            "schema": "public",
+            "values": ["analysis", "chatbot", "premium_model"]
+        },
+        "public.user_tier": {
+            "name": "user_tier",
+            "schema": "public",
+            "values": ["free", "member", "pro"]
+        }
+    },
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
             "when": 1781897708671,
             "tag": "0018_spotty_solo",
             "breakpoints": true
+        },
+        {
+            "idx": 19,
+            "version": "7",
+            "when": 1781933220827,
+            "tag": "0019_perfect_zodiak",
+            "breakpoints": true
         }
     ]
 }

--- a/e2e/setup/seed.ts
+++ b/e2e/setup/seed.ts
@@ -1,8 +1,11 @@
 import { like } from 'drizzle-orm';
 import { bcryptPasswordHasher } from '@/entities/session';
+import { economicCalendarId } from '@/entities/economy/lib/economicCalendarId';
+import { addEtDays, etDateOf } from '@/entities/economy/lib/calendarWindow';
 import { getDatabaseClient } from '@/shared/db/client';
 import {
     assetTranslations,
+    economicCalendar,
     marketNews,
     terms,
     users,
@@ -165,6 +168,68 @@ async function seed(): Promise<void> {
     );
     await db.insert(marketNews).values(newsRows);
 
+    // economic_calendar — Seed 3 calendar events relative to NOW so they always
+    // fall within the app's ±14-day window (pastWindowStart..futureWindowEnd).
+    // SP-A switched the calendar grid source from FakeEconomyProvider.getCalendar()
+    // to getCalendarFromDb (reads `economic_calendar` table). Without this seed,
+    // CI (clean DB) renders an empty calendar → "Fed Rate Decision" absent from
+    // SSR HTML → economy.spec.ts:53 fails (local-pass/CI-fail because dev DB has rows).
+    //
+    // Events mirror FakeEconomyProvider.getCalendar() by name/impact/values, but
+    // dateEt is computed relative to today-ET so the rows never fall out of window.
+    const todayEt = etDateOf(new Date());
+    const todayMinus1 = addEtDays(todayEt, -1);
+    const todayPlus1 = addEtDays(todayEt, 1);
+
+    const calendarRows = [
+        {
+            id: economicCalendarId(
+                'US',
+                `${todayEt} 14:00:00`,
+                'Fed Rate Decision'
+            ),
+            country: 'US',
+            dateEt: `${todayEt} 14:00:00`,
+            event: 'Fed Rate Decision',
+            impact: 'High',
+            estimate: 3.63,
+            previous: 3.63,
+            actual: null,
+            unit: '%',
+        },
+        {
+            id: economicCalendarId('US', `${todayMinus1} 12:30:00`, 'CPI YoY'),
+            country: 'US',
+            dateEt: `${todayMinus1} 12:30:00`,
+            event: 'CPI YoY',
+            impact: 'High',
+            estimate: 2.3,
+            previous: 2.4,
+            actual: null,
+            unit: '%',
+        },
+        {
+            id: economicCalendarId(
+                'US',
+                `${todayPlus1} 12:30:00`,
+                'Initial Jobless Claims'
+            ),
+            country: 'US',
+            dateEt: `${todayPlus1} 12:30:00`,
+            event: 'Initial Jobless Claims',
+            impact: 'Medium',
+            estimate: 230000,
+            previous: 229000,
+            actual: null,
+            unit: '',
+        },
+    ];
+    await db
+        .insert(economicCalendar)
+        .values(calendarRows)
+        .onConflictDoNothing();
+
+    console.log('e2e seed: economic_calendar ok');
     console.log('e2e seed: ok');
 }
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "@upstash/redis": "^1.37.0",
         "@vercel/analytics": "^2.0.1",
         "@vercel/functions": "^3.4.3",
-        "@y0ngha/siglens-core": "0.24.0",
+        "@y0ngha/siglens-core": "0.25.0",
         "bcryptjs": "^3.0.3",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",

--- a/src/app/economy/page.tsx
+++ b/src/app/economy/page.tsx
@@ -166,6 +166,7 @@ async function EconomyContent() {
     const indicatorLabels = await resolveIndicatorLabels(calendarEvents).catch(
         (e: unknown) => {
             console.error('[EconomyContent] resolveIndicatorLabels failed:', e);
+            // empty object is always a valid Record<string, string>
             return {} as Record<string, string>;
         }
     );

--- a/src/app/economy/page.tsx
+++ b/src/app/economy/page.tsx
@@ -162,8 +162,7 @@ async function EconomyContent() {
         }
     );
 
-    // 지표명 한국어 레이블을 서버에서 미리 해결한다(dict → DB 캐시 → 영어 fallback +
-    // 미매핑 AI 트리거). 그리드는 순수 레이블 맵만 받아 표시한다(SP-B).
+    // dict → DB 캐시 → 영어 fallback 체인. 미매핑은 클라 훅이 AI 트리거(SP-B 설계).
     const indicatorLabels = await resolveIndicatorLabels(calendarEvents).catch(
         (e: unknown) => {
             console.error('[EconomyContent] resolveIndicatorLabels failed:', e);

--- a/src/app/economy/page.tsx
+++ b/src/app/economy/page.tsx
@@ -16,6 +16,7 @@ import {
 import { getEconomySnapshotStatic } from '@/entities/economy/api/economySnapshotStaticCache';
 import { peekMacroBriefingStatic } from '@/entities/economy/api/macroBriefingStaticCache';
 import { getCalendarFromDb } from '@/entities/economy/api/getCalendarFromDb';
+import { resolveIndicatorLabels } from '@/entities/economy/api/resolveIndicatorLabels';
 import { etDateOf, kstDateOf } from '@/entities/economy/lib/calendarWindow';
 import { isEmptyEconomySnapshot } from '@/entities/economy';
 import {
@@ -161,6 +162,15 @@ async function EconomyContent() {
         }
     );
 
+    // 지표명 한국어 레이블을 서버에서 미리 해결한다(dict → DB 캐시 → 영어 fallback +
+    // 미매핑 AI 트리거). 그리드는 순수 레이블 맵만 받아 표시한다(SP-B).
+    const indicatorLabels = await resolveIndicatorLabels(calendarEvents).catch(
+        (e: unknown) => {
+            console.error('[EconomyContent] resolveIndicatorLabels failed:', e);
+            return {} as Record<string, string>;
+        }
+    );
+
     return (
         <div className="space-y-6">
             {/* SSR 크롤 텍스트 — MacroBriefing은 'use client'라 크롤러에 빈 HTML을
@@ -169,7 +179,11 @@ async function EconomyContent() {
             <EconomyMacroFacts snapshot={snapshot} />
             <MacroBriefing peekSeed={peekSeed} />
             <EconomicIndicatorGrid snapshot={snapshot} />
-            <EconomicCalendar events={calendarEvents} today={todayKstKey} />
+            <EconomicCalendar
+                events={calendarEvents}
+                today={todayKstKey}
+                labels={indicatorLabels}
+            />
         </div>
     );
 }

--- a/src/entities/economy/actions.ts
+++ b/src/entities/economy/actions.ts
@@ -1,1 +1,2 @@
 export { ensureEconomicCalendarAction } from './actions/ensureEconomicCalendarAction';
+export { ensureIndicatorTranslatedAction } from './actions/ensureIndicatorTranslatedAction';

--- a/src/entities/economy/actions/__tests__/ensureIndicatorTranslatedAction.test.ts
+++ b/src/entities/economy/actions/__tests__/ensureIndicatorTranslatedAction.test.ts
@@ -156,4 +156,17 @@ describe('ensureIndicatorTranslatedAction', () => {
         expect(mockUpsert).not.toHaveBeenCalled();
         expect(revalidateTag).not.toHaveBeenCalled();
     });
+
+    it('logs a warning and does not upsert or revalidate when all polls time out', async () => {
+        vi.mocked(submitIndicatorTranslation).mockResolvedValue({
+            status: 'submitted',
+            jobId: 'job-timeout',
+        });
+        vi.mocked(pollIndicatorTranslation).mockResolvedValue({
+            status: 'processing',
+        });
+        await ensureIndicatorTranslatedAction('Some Obscure Index YoY');
+        expect(mockUpsert).not.toHaveBeenCalled();
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
 });

--- a/src/entities/economy/actions/__tests__/ensureIndicatorTranslatedAction.test.ts
+++ b/src/entities/economy/actions/__tests__/ensureIndicatorTranslatedAction.test.ts
@@ -139,4 +139,20 @@ describe('ensureIndicatorTranslatedAction', () => {
         await ensureIndicatorTranslatedAction('Some Obscure Index YoY');
         expect(revalidateTag).not.toHaveBeenCalled();
     });
+
+    it('does not upsert or revalidate when poll done returns whitespace nameKo', async () => {
+        vi.mocked(submitIndicatorTranslation).mockResolvedValue({
+            status: 'submitted',
+            jobId: 'job-789',
+        });
+        vi.mocked(pollIndicatorTranslation).mockResolvedValue({
+            status: 'done',
+            nameKo: '   ',
+        });
+        await expect(
+            ensureIndicatorTranslatedAction('Some Obscure Index YoY')
+        ).resolves.toBeUndefined();
+        expect(upsert).not.toHaveBeenCalled();
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
 });

--- a/src/entities/economy/actions/__tests__/ensureIndicatorTranslatedAction.test.ts
+++ b/src/entities/economy/actions/__tests__/ensureIndicatorTranslatedAction.test.ts
@@ -1,3 +1,7 @@
+const { mockUpsert } = vi.hoisted(() => ({
+    mockUpsert: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('server-only', () => ({}));
 vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }));
 
@@ -13,7 +17,7 @@ vi.mock('@/entities/economy/api/indicatorTranslationFlag', () => ({
 
 vi.mock('@/entities/economy/api/indicatorTranslationRepository', () => ({
     DrizzleIndicatorTranslationRepository: class {
-        upsert = vi.fn();
+        upsert = mockUpsert;
     },
 }));
 vi.mock('@/shared/db/client', () => ({
@@ -34,15 +38,13 @@ import {
     isIndicatorTranslationPending,
     markIndicatorTranslationPending,
 } from '@/entities/economy/api/indicatorTranslationFlag';
-import { DrizzleIndicatorTranslationRepository } from '@/entities/economy/api/indicatorTranslationRepository';
 import { ensureIndicatorTranslatedAction } from '@/entities/economy/actions/ensureIndicatorTranslatedAction';
 import { INDICATOR_TRANSLATION_CACHE_TAG } from '@/entities/economy/lib/indicatorTranslationConstants';
 
 describe('ensureIndicatorTranslatedAction', () => {
-    let upsert: ReturnType<typeof vi.fn>;
-
     beforeEach(() => {
         vi.clearAllMocks();
+        mockUpsert.mockClear();
         vi.mocked(isIndicatorTranslationPending).mockResolvedValue(false);
         vi.mocked(markIndicatorTranslationPending).mockResolvedValue(undefined);
         // Default: cached result (short-circuit, no poll needed)
@@ -50,13 +52,6 @@ describe('ensureIndicatorTranslatedAction', () => {
             status: 'cached',
             nameKo: '어떤 모호한 지수(전년比)',
         });
-        // Get the upsert mock from the repository instance
-        const RepoClass =
-            DrizzleIndicatorTranslationRepository as unknown as new () => {
-                upsert: ReturnType<typeof vi.fn>;
-            };
-        upsert = new RepoClass().upsert;
-        upsert.mockResolvedValue(undefined);
     });
 
     it('skips when the name is already in the code dictionary', async () => {
@@ -102,6 +97,12 @@ describe('ensureIndicatorTranslatedAction', () => {
 
         await ensureIndicatorTranslatedAction('Some Obscure Index YoY');
         expect(pollIndicatorTranslation).toHaveBeenCalledWith('job-123');
+        expect(mockUpsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                normalizedName: 'Some Obscure Index YoY',
+                source: 'ai',
+            })
+        );
         expect(revalidateTag).toHaveBeenCalledWith(
             INDICATOR_TRANSLATION_CACHE_TAG,
             'max'
@@ -152,7 +153,7 @@ describe('ensureIndicatorTranslatedAction', () => {
         await expect(
             ensureIndicatorTranslatedAction('Some Obscure Index YoY')
         ).resolves.toBeUndefined();
-        expect(upsert).not.toHaveBeenCalled();
+        expect(mockUpsert).not.toHaveBeenCalled();
         expect(revalidateTag).not.toHaveBeenCalled();
     });
 });

--- a/src/entities/economy/actions/__tests__/ensureIndicatorTranslatedAction.test.ts
+++ b/src/entities/economy/actions/__tests__/ensureIndicatorTranslatedAction.test.ts
@@ -1,0 +1,142 @@
+vi.mock('server-only', () => ({}));
+vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }));
+
+vi.mock('@y0ngha/siglens-core', () => ({
+    submitIndicatorTranslation: vi.fn(),
+    pollIndicatorTranslation: vi.fn(),
+}));
+
+vi.mock('@/entities/economy/api/indicatorTranslationFlag', () => ({
+    isIndicatorTranslationPending: vi.fn(),
+    markIndicatorTranslationPending: vi.fn(),
+}));
+
+vi.mock('@/entities/economy/api/indicatorTranslationRepository', () => ({
+    DrizzleIndicatorTranslationRepository: class {
+        upsert = vi.fn();
+    },
+}));
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: () => ({ db: {} }),
+}));
+
+vi.mock('@/shared/lib/sleep', () => ({
+    sleep: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { revalidateTag } from 'next/cache';
+import {
+    submitIndicatorTranslation,
+    pollIndicatorTranslation,
+} from '@y0ngha/siglens-core';
+import {
+    isIndicatorTranslationPending,
+    markIndicatorTranslationPending,
+} from '@/entities/economy/api/indicatorTranslationFlag';
+import { DrizzleIndicatorTranslationRepository } from '@/entities/economy/api/indicatorTranslationRepository';
+import { ensureIndicatorTranslatedAction } from '@/entities/economy/actions/ensureIndicatorTranslatedAction';
+import { INDICATOR_TRANSLATION_CACHE_TAG } from '@/entities/economy/lib/indicatorTranslationConstants';
+
+describe('ensureIndicatorTranslatedAction', () => {
+    let upsert: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(isIndicatorTranslationPending).mockResolvedValue(false);
+        vi.mocked(markIndicatorTranslationPending).mockResolvedValue(undefined);
+        // Default: cached result (short-circuit, no poll needed)
+        vi.mocked(submitIndicatorTranslation).mockResolvedValue({
+            status: 'cached',
+            nameKo: '어떤 모호한 지수(전년比)',
+        });
+        // Get the upsert mock from the repository instance
+        const RepoClass =
+            DrizzleIndicatorTranslationRepository as unknown as new () => {
+                upsert: ReturnType<typeof vi.fn>;
+            };
+        upsert = new RepoClass().upsert;
+        upsert.mockResolvedValue(undefined);
+    });
+
+    it('skips when the name is already in the code dictionary', async () => {
+        await ensureIndicatorTranslatedAction('Nonfarm Payrolls');
+        expect(submitIndicatorTranslation).not.toHaveBeenCalled();
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it('skips when a translation is already pending', async () => {
+        vi.mocked(isIndicatorTranslationPending).mockResolvedValue(true);
+        await ensureIndicatorTranslatedAction('Some Obscure Index YoY');
+        expect(submitIndicatorTranslation).not.toHaveBeenCalled();
+    });
+
+    it('uses cached result directly without polling', async () => {
+        vi.mocked(submitIndicatorTranslation).mockResolvedValue({
+            status: 'cached',
+            nameKo: '어떤 모호한 지수(전년比)',
+        });
+        await ensureIndicatorTranslatedAction('Some Obscure Index YoY');
+        expect(markIndicatorTranslationPending).toHaveBeenCalledOnce();
+        expect(submitIndicatorTranslation).toHaveBeenCalledWith(
+            'Some Obscure Index YoY'
+        );
+        expect(pollIndicatorTranslation).not.toHaveBeenCalled();
+        expect(revalidateTag).toHaveBeenCalledWith(
+            INDICATOR_TRANSLATION_CACHE_TAG,
+            'max'
+        );
+    });
+
+    it('polls until done, upserts, and revalidates the cache tag', async () => {
+        vi.mocked(submitIndicatorTranslation).mockResolvedValue({
+            status: 'submitted',
+            jobId: 'job-123',
+        });
+        vi.mocked(pollIndicatorTranslation)
+            .mockResolvedValueOnce({ status: 'processing' })
+            .mockResolvedValueOnce({
+                status: 'done',
+                nameKo: '어떤 모호한 지수(전년比)',
+            });
+
+        await ensureIndicatorTranslatedAction('Some Obscure Index YoY');
+        expect(pollIndicatorTranslation).toHaveBeenCalledWith('job-123');
+        expect(revalidateTag).toHaveBeenCalledWith(
+            INDICATOR_TRANSLATION_CACHE_TAG,
+            'max'
+        );
+    });
+
+    it('swallows a core submission failure without upserting or revalidating', async () => {
+        vi.mocked(submitIndicatorTranslation).mockRejectedValue(
+            new Error('llm down')
+        );
+        await expect(
+            ensureIndicatorTranslatedAction('Some Obscure Index YoY')
+        ).resolves.toBeUndefined();
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it('does not upsert or revalidate for an empty translation (cached path)', async () => {
+        vi.mocked(submitIndicatorTranslation).mockResolvedValue({
+            status: 'cached',
+            nameKo: '   ',
+        });
+        await ensureIndicatorTranslatedAction('Some Obscure Index YoY');
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it('does not revalidate when poll returns error', async () => {
+        vi.mocked(submitIndicatorTranslation).mockResolvedValue({
+            status: 'submitted',
+            jobId: 'job-456',
+        });
+        vi.mocked(pollIndicatorTranslation).mockResolvedValue({
+            status: 'error',
+            error: 'translation failed',
+        });
+        await ensureIndicatorTranslatedAction('Some Obscure Index YoY');
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+});

--- a/src/entities/economy/actions/ensureIndicatorTranslatedAction.ts
+++ b/src/entities/economy/actions/ensureIndicatorTranslatedAction.ts
@@ -40,7 +40,6 @@ async function submitAndPoll(normalizedName: string): Promise<string | null> {
         return sub.nameKo;
     }
 
-    // status === 'submitted' — poll until done or timeout
     const { jobId } = sub;
     for (
         let attempt = 0;

--- a/src/entities/economy/actions/ensureIndicatorTranslatedAction.ts
+++ b/src/entities/economy/actions/ensureIndicatorTranslatedAction.ts
@@ -1,0 +1,121 @@
+'use server';
+
+import { revalidateTag } from 'next/cache';
+// CORE DEPENDENCY (separate repo, user publishes): analysis-domain AI translation
+// of an unmapped indicator name. See SP-B plan CROSS-REPO note. The actual core
+// export is a submit/poll pair (not a synchronous `translateIndicatorName`);
+// this file implements the bounded poll loop mirroring ensureNewsCardsAnalyzedAction.
+import {
+    submitIndicatorTranslation,
+    pollIndicatorTranslation,
+} from '@y0ngha/siglens-core';
+
+import { getDatabaseClient } from '@/shared/db/client';
+import { sleep } from '@/shared/lib/sleep';
+import { MS_PER_SECOND } from '@/shared/config/time';
+
+import { DrizzleIndicatorTranslationRepository } from '../api/indicatorTranslationRepository';
+import {
+    isIndicatorTranslationPending,
+    markIndicatorTranslationPending,
+} from '../api/indicatorTranslationFlag';
+import { INDICATOR_NAME_KO } from '../lib/indicatorNameKo';
+import {
+    INDICATOR_TRANSLATION_CACHE_TAG,
+    INDICATOR_TRANSLATION_POLL_INTERVAL_MS,
+    INDICATOR_TRANSLATION_POLL_MAX_ATTEMPTS,
+} from '../lib/indicatorTranslationConstants';
+
+/**
+ * submit → poll 루프를 실행해 번역 결과를 얻는다. core 캐시 hit이면 즉시 반환
+ * (poll 없음). submitted면 최대 POLL_MAX_ATTEMPTS 회 polling. done이면 nameKo,
+ * error/timeout이면 null(호출자가 upsert 생략).
+ *
+ * `ensureNewsCardsAnalyzedAction`의 `analyzeAndPersist` 패턴 미러.
+ */
+async function submitAndPoll(normalizedName: string): Promise<string | null> {
+    const sub = await submitIndicatorTranslation(normalizedName);
+
+    if (sub.status === 'cached') {
+        return sub.nameKo;
+    }
+
+    // status === 'submitted' — poll until done or timeout
+    const { jobId } = sub;
+    for (
+        let attempt = 0;
+        attempt < INDICATOR_TRANSLATION_POLL_MAX_ATTEMPTS;
+        attempt++
+    ) {
+        await sleep(INDICATOR_TRANSLATION_POLL_INTERVAL_MS);
+        const polled = await pollIndicatorTranslation(jobId);
+        if (polled.status === 'done') {
+            return polled.nameKo;
+        }
+        if (polled.status === 'error') {
+            console.error(
+                `[ensureIndicatorTranslatedAction] poll error "${normalizedName}": ${polled.error}`
+            );
+            return null;
+        }
+        // status === 'processing' — continue polling
+    }
+
+    const timeoutSecs =
+        (INDICATOR_TRANSLATION_POLL_MAX_ATTEMPTS *
+            INDICATOR_TRANSLATION_POLL_INTERVAL_MS) /
+        MS_PER_SECOND;
+    console.warn(
+        `[ensureIndicatorTranslatedAction] poll timeout after ${timeoutSecs}s — "${normalizedName}"`
+    );
+    return null;
+}
+
+/**
+ * Server Action: 미매핑 지표명 1건을 core AI로 번역해 `economic_indicator_translations`에
+ * `source:'ai'`로 캐시하고 번역 캐시 태그를 무효화한다(다음 렌더에서 한국어 반영).
+ *
+ * 코드 사전(`INDICATOR_NAME_KO`)에 이미 있으면 즉시 반환 — dict가 source-of-truth라
+ * AI를 호출할 이유가 없다. pending-flag로 동시/연속 제출을 dedupe한다. core 실패 시
+ * graceful(캐시 미기록) — pending-flag TTL 만료 후 다음 렌더가 재시도한다.
+ * `waitUntil` 안에서 fire-and-forget으로 도는 설계 — 응답 스트림 비차단.
+ */
+export async function ensureIndicatorTranslatedAction(
+    normalizedName: string
+): Promise<void> {
+    try {
+        if (normalizedName in INDICATOR_NAME_KO) {
+            return;
+        }
+        if (await isIndicatorTranslationPending(normalizedName)) {
+            return;
+        }
+        // core 왕복 전에 마킹 — 동시 호출이 이 지점 이후 플래그를 읽으면 제출을 생략.
+        await markIndicatorTranslationPending(normalizedName);
+
+        const nameKo = await submitAndPoll(normalizedName);
+        if (nameKo === null || nameKo.trim() === '') {
+            // null = poll error/timeout; empty = core의 "번역 불가" 시그널 → 영어 유지
+            if (nameKo !== null) {
+                console.error(
+                    `[ensureIndicatorTranslatedAction] empty translation for "${normalizedName}"`
+                );
+            }
+            return;
+        }
+
+        const { db } = getDatabaseClient();
+        const repo = new DrizzleIndicatorTranslationRepository(db);
+        await repo.upsert({
+            normalizedName,
+            koreanName: nameKo.trim(),
+            source: 'ai',
+        });
+
+        // 번역 캐시 태그만 무효화 — 캘린더 데이터 ISR 캐시는 무관.
+        // Next 16 revalidateTag(tag, profile) — 'max'는 즉시 무효화.
+        revalidateTag(INDICATOR_TRANSLATION_CACHE_TAG, 'max');
+    } catch (error) {
+        console.error('[ensureIndicatorTranslatedAction]', error);
+    }
+}

--- a/src/entities/economy/actions/ensureIndicatorTranslatedAction.ts
+++ b/src/entities/economy/actions/ensureIndicatorTranslatedAction.ts
@@ -58,7 +58,6 @@ async function submitAndPoll(normalizedName: string): Promise<string | null> {
             );
             return null;
         }
-        // status === 'processing' — continue polling
     }
 
     const timeoutSecs =

--- a/src/entities/economy/api/__tests__/indicatorTranslationFlag.test.ts
+++ b/src/entities/economy/api/__tests__/indicatorTranslationFlag.test.ts
@@ -20,7 +20,10 @@ import {
     isIndicatorTranslationPending,
     markIndicatorTranslationPending,
 } from '@/entities/economy/api/indicatorTranslationFlag';
-import { INDICATOR_TRANSLATION_FLAG_TTL_SECONDS } from '@/entities/economy/lib/indicatorTranslationConstants';
+import {
+    INDICATOR_TRANSLATION_FLAG_PREFIX,
+    INDICATOR_TRANSLATION_FLAG_TTL_SECONDS,
+} from '@/entities/economy/lib/indicatorTranslationConstants';
 
 describe('indicatorTranslationFlag', () => {
     beforeEach(() => {
@@ -49,7 +52,7 @@ describe('indicatorTranslationFlag', () => {
     it('sets the pending flag with the TTL', async () => {
         await markIndicatorTranslationPending('CPI YoY');
         expect(mockSet).toHaveBeenCalledWith(
-            expect.stringContaining('CPI YoY'),
+            `${INDICATOR_TRANSLATION_FLAG_PREFIX}:CPI YoY`,
             '1',
             { ex: INDICATOR_TRANSLATION_FLAG_TTL_SECONDS }
         );
@@ -59,5 +62,17 @@ describe('indicatorTranslationFlag', () => {
         vi.mocked(getRedisClient).mockReturnValue(null);
         await markIndicatorTranslationPending('CPI YoY');
         expect(mockSet).not.toHaveBeenCalled();
+    });
+
+    it('returns false when redis.get throws', async () => {
+        mockGet.mockRejectedValue(new Error('redis timeout'));
+        expect(await isIndicatorTranslationPending('CPI YoY')).toBe(false);
+    });
+
+    it('does not throw when redis.set throws on mark', async () => {
+        mockSet.mockRejectedValue(new Error('redis timeout'));
+        await expect(
+            markIndicatorTranslationPending('CPI YoY')
+        ).resolves.toBeUndefined();
     });
 });

--- a/src/entities/economy/api/__tests__/indicatorTranslationFlag.test.ts
+++ b/src/entities/economy/api/__tests__/indicatorTranslationFlag.test.ts
@@ -1,0 +1,63 @@
+vi.mock('server-only', () => ({}));
+
+const { mockGet, mockSet, mockRedis } = vi.hoisted(() => {
+    const mockGet = vi.fn();
+    const mockSet = vi.fn();
+    const mockRedis: Pick<import('@upstash/redis').Redis, 'get' | 'set'> = {
+        get: mockGet,
+        set: mockSet,
+    };
+    return { mockGet, mockSet, mockRedis };
+});
+
+vi.mock('@/shared/cache/redisClient', () => ({
+    getRedisClient: vi.fn(() => mockRedis),
+}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { getRedisClient } from '@/shared/cache/redisClient';
+import {
+    isIndicatorTranslationPending,
+    markIndicatorTranslationPending,
+} from '@/entities/economy/api/indicatorTranslationFlag';
+import { INDICATOR_TRANSLATION_FLAG_TTL_SECONDS } from '@/entities/economy/lib/indicatorTranslationConstants';
+
+describe('indicatorTranslationFlag', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(getRedisClient).mockReturnValue(
+            mockRedis as unknown as import('@upstash/redis').Redis
+        );
+    });
+
+    it('returns false and does not call get when Redis is null', async () => {
+        vi.mocked(getRedisClient).mockReturnValue(null);
+        expect(await isIndicatorTranslationPending('CPI YoY')).toBe(false);
+        expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it('returns true when the flag is set', async () => {
+        mockGet.mockResolvedValue('1');
+        expect(await isIndicatorTranslationPending('CPI YoY')).toBe(true);
+    });
+
+    it('returns false when the flag is absent', async () => {
+        mockGet.mockResolvedValue(null);
+        expect(await isIndicatorTranslationPending('CPI YoY')).toBe(false);
+    });
+
+    it('sets the pending flag with the TTL', async () => {
+        await markIndicatorTranslationPending('CPI YoY');
+        expect(mockSet).toHaveBeenCalledWith(
+            expect.stringContaining('CPI YoY'),
+            '1',
+            { ex: INDICATOR_TRANSLATION_FLAG_TTL_SECONDS }
+        );
+    });
+
+    it('is a no-op when Redis is null on mark', async () => {
+        vi.mocked(getRedisClient).mockReturnValue(null);
+        await markIndicatorTranslationPending('CPI YoY');
+        expect(mockSet).not.toHaveBeenCalled();
+    });
+});

--- a/src/entities/economy/api/__tests__/indicatorTranslationRepository.test.ts
+++ b/src/entities/economy/api/__tests__/indicatorTranslationRepository.test.ts
@@ -55,6 +55,19 @@ describe('DrizzleIndicatorTranslationRepository.findByNames', () => {
             },
         ]);
     });
+
+    it('maps a dict-sourced row correctly', async () => {
+        const { db } = makeDb([
+            {
+                normalizedName: 'CPI YoY',
+                koreanName: '소비자물가지수(전년比)',
+                source: 'dict',
+            },
+        ]);
+        const repo = new DrizzleIndicatorTranslationRepository(db);
+        const rows = await repo.findByNames(['CPI YoY']);
+        expect(rows[0].source).toBe('dict');
+    });
 });
 
 describe('DrizzleIndicatorTranslationRepository.upsert', () => {

--- a/src/entities/economy/api/__tests__/indicatorTranslationRepository.test.ts
+++ b/src/entities/economy/api/__tests__/indicatorTranslationRepository.test.ts
@@ -1,0 +1,77 @@
+vi.mock('server-only', () => ({}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { IndicatorTranslationRecord } from '@/shared/db/types';
+import { DrizzleIndicatorTranslationRepository } from '@/entities/economy/api/indicatorTranslationRepository';
+
+/** Chainable select/from/where + insert/values/onConflictDoUpdate stub. */
+function makeDb(selectRows: unknown[]) {
+    const where = vi.fn(async () => selectRows);
+    const from = vi.fn(() => ({ where }));
+    const select = vi.fn(() => ({ from }));
+
+    const onConflictDoUpdate = vi.fn(async () => undefined);
+    const values = vi.fn(() => ({ onConflictDoUpdate }));
+    const insert = vi.fn(() => ({ values }));
+
+    return {
+        db: { select, insert } as never,
+        spies: { select, from, where, insert, values, onConflictDoUpdate },
+    };
+}
+
+const RECORD: IndicatorTranslationRecord = {
+    normalizedName: 'Some Obscure Index YoY',
+    koreanName: '어떤 모호한 지수(전년比)',
+    source: 'ai',
+};
+
+describe('DrizzleIndicatorTranslationRepository.findByNames', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('returns [] without querying when names is empty', async () => {
+        const { db, spies } = makeDb([]);
+        const repo = new DrizzleIndicatorTranslationRepository(db);
+        const rows = await repo.findByNames([]);
+        expect(rows).toEqual([]);
+        expect(spies.select).not.toHaveBeenCalled();
+    });
+
+    it('maps DB rows to IndicatorTranslationRecord', async () => {
+        const { db } = makeDb([
+            {
+                normalizedName: 'Nonfarm Payrolls',
+                koreanName: '비농업 고용',
+                source: 'ai',
+            },
+        ]);
+        const repo = new DrizzleIndicatorTranslationRepository(db);
+        const rows = await repo.findByNames(['Nonfarm Payrolls']);
+        expect(rows).toEqual([
+            {
+                normalizedName: 'Nonfarm Payrolls',
+                koreanName: '비농업 고용',
+                source: 'ai',
+            },
+        ]);
+    });
+});
+
+describe('DrizzleIndicatorTranslationRepository.upsert', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('inserts with the normalized name, korean name, and source', async () => {
+        const { db, spies } = makeDb([]);
+        const repo = new DrizzleIndicatorTranslationRepository(db);
+        await repo.upsert(RECORD);
+        expect(spies.insert).toHaveBeenCalledOnce();
+        const inserted = spies.values.mock.calls[0][0] as Record<
+            string,
+            unknown
+        >;
+        expect(inserted.normalizedName).toBe('Some Obscure Index YoY');
+        expect(inserted.koreanName).toBe('어떤 모호한 지수(전년比)');
+        expect(inserted.source).toBe('ai');
+        expect(spies.onConflictDoUpdate).toHaveBeenCalledOnce();
+    });
+});

--- a/src/entities/economy/api/__tests__/indicatorTranslationRepository.test.ts
+++ b/src/entities/economy/api/__tests__/indicatorTranslationRepository.test.ts
@@ -65,7 +65,7 @@ describe('DrizzleIndicatorTranslationRepository.upsert', () => {
         const repo = new DrizzleIndicatorTranslationRepository(db);
         await repo.upsert(RECORD);
         expect(spies.insert).toHaveBeenCalledOnce();
-        const inserted = spies.values.mock.calls[0][0] as Record<
+        const inserted = (spies.values.mock.calls[0] as unknown[])[0] as Record<
             string,
             unknown
         >;

--- a/src/entities/economy/api/__tests__/resolveIndicatorLabels.test.ts
+++ b/src/entities/economy/api/__tests__/resolveIndicatorLabels.test.ts
@@ -17,13 +17,8 @@ vi.mock('@/entities/economy/api/indicatorTranslationRepository', () => ({
     },
 }));
 
-vi.mock('@/entities/economy/actions/ensureIndicatorTranslatedAction', () => ({
-    ensureIndicatorTranslatedAction: vi.fn(),
-}));
-
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
-import { ensureIndicatorTranslatedAction } from '@/entities/economy/actions/ensureIndicatorTranslatedAction';
 import { resolveIndicatorLabels } from '@/entities/economy/api/resolveIndicatorLabels';
 
 const ev = (event: string): EconomicCalendarEvent => ({
@@ -40,7 +35,6 @@ describe('resolveIndicatorLabels', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         findByNames.mockResolvedValue([]);
-        vi.mocked(ensureIndicatorTranslatedAction).mockResolvedValue(undefined);
     });
 
     it('maps dict-known names to Korean without a DB lookup', async () => {
@@ -48,7 +42,6 @@ describe('resolveIndicatorLabels', () => {
         expect(labels['Nonfarm Payrolls']).toBe('비농업 고용');
         // All distinct bases were dict-known → no unknowns → no DB query.
         expect(findByNames).not.toHaveBeenCalled();
-        expect(ensureIndicatorTranslatedAction).not.toHaveBeenCalled();
     });
 
     it('applies a DB-cached translation for an unmapped name', async () => {
@@ -65,29 +58,27 @@ describe('resolveIndicatorLabels', () => {
         expect(labels['Some Obscure Index YoY (May)']).toBe(
             '어떤 모호한 지수(전년比) (5월)'
         );
-        expect(ensureIndicatorTranslatedAction).not.toHaveBeenCalled();
     });
 
-    it('falls back to English and triggers AI for a name missing everywhere', async () => {
+    it('falls back to English for a name missing from both dict and DB', async () => {
         const labels = await resolveIndicatorLabels([
             ev('Totally Unknown Thing (Apr)'),
         ]);
         expect(labels['Totally Unknown Thing (Apr)']).toBe(
             'Totally Unknown Thing (Apr)'
         );
-        expect(ensureIndicatorTranslatedAction).toHaveBeenCalledWith(
-            'Totally Unknown Thing'
-        );
+        // No trigger: resolveIndicatorLabels is now a pure reader.
+        // AI translation is triggered client-side by useIndicatorTranslationTrigger.
+        expect(findByNames).toHaveBeenCalledWith(['Totally Unknown Thing']);
     });
 
-    it('queries and triggers each distinct base only once', async () => {
+    it('queries each distinct base only once', async () => {
         await resolveIndicatorLabels([
             ev('Totally Unknown Thing (Apr)'),
             ev('Totally Unknown Thing (May)'),
         ]);
         expect(findByNames).toHaveBeenCalledTimes(1);
         expect(findByNames).toHaveBeenCalledWith(['Totally Unknown Thing']);
-        expect(ensureIndicatorTranslatedAction).toHaveBeenCalledTimes(1);
     });
 
     it('degrades to English-only labels on DB failure (graceful)', async () => {
@@ -98,5 +89,25 @@ describe('resolveIndicatorLabels', () => {
         expect(labels['Totally Unknown Thing (Apr)']).toBe(
             'Totally Unknown Thing (Apr)'
         );
+    });
+
+    it('builds a correct label map shape for mixed dict/DB/unknown names', async () => {
+        findByNames.mockResolvedValue([
+            {
+                normalizedName: 'Some Obscure Index YoY',
+                koreanName: '어떤 모호한 지수(전년比)',
+                source: 'ai',
+            },
+        ]);
+        const labels = await resolveIndicatorLabels([
+            ev('Nonfarm Payrolls'),
+            ev('Some Obscure Index YoY (May)'),
+            ev('Totally Unknown Thing'),
+        ]);
+        expect(labels['Nonfarm Payrolls']).toBe('비농업 고용');
+        expect(labels['Some Obscure Index YoY (May)']).toBe(
+            '어떤 모호한 지수(전년比) (5월)'
+        );
+        expect(labels['Totally Unknown Thing']).toBe('Totally Unknown Thing');
     });
 });

--- a/src/entities/economy/api/__tests__/resolveIndicatorLabels.test.ts
+++ b/src/entities/economy/api/__tests__/resolveIndicatorLabels.test.ts
@@ -37,6 +37,12 @@ describe('resolveIndicatorLabels', () => {
         findByNames.mockResolvedValue([]);
     });
 
+    it('returns an empty map and skips DB for empty events', async () => {
+        const labels = await resolveIndicatorLabels([]);
+        expect(labels).toEqual({});
+        expect(findByNames).not.toHaveBeenCalled();
+    });
+
     it('maps dict-known names to Korean without a DB lookup', async () => {
         const labels = await resolveIndicatorLabels([ev('Nonfarm Payrolls')]);
         expect(labels['Nonfarm Payrolls']).toBe('비농업 고용');

--- a/src/entities/economy/api/__tests__/resolveIndicatorLabels.test.ts
+++ b/src/entities/economy/api/__tests__/resolveIndicatorLabels.test.ts
@@ -1,0 +1,102 @@
+vi.mock('server-only', () => ({}));
+vi.mock('next/cache', () => ({
+    unstable_cache:
+        (fn: (...a: unknown[]) => unknown) =>
+        (...a: unknown[]) =>
+            fn(...a),
+}));
+vi.mock('@/shared/db/client', () => ({
+    getDatabaseClient: () => ({ db: {} }),
+}));
+
+// Shared findByNames spy — all repository instances share this mock.
+const findByNames = vi.fn();
+vi.mock('@/entities/economy/api/indicatorTranslationRepository', () => ({
+    DrizzleIndicatorTranslationRepository: class {
+        findByNames = findByNames;
+    },
+}));
+
+vi.mock('@/entities/economy/actions/ensureIndicatorTranslatedAction', () => ({
+    ensureIndicatorTranslatedAction: vi.fn(),
+}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
+import { ensureIndicatorTranslatedAction } from '@/entities/economy/actions/ensureIndicatorTranslatedAction';
+import { resolveIndicatorLabels } from '@/entities/economy/api/resolveIndicatorLabels';
+
+const ev = (event: string): EconomicCalendarEvent => ({
+    date: '2026-06-13 08:30:00',
+    event,
+    impact: 'High',
+    actual: null,
+    estimate: 1,
+    previous: 1,
+    unit: '%',
+});
+
+describe('resolveIndicatorLabels', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        findByNames.mockResolvedValue([]);
+        vi.mocked(ensureIndicatorTranslatedAction).mockResolvedValue(undefined);
+    });
+
+    it('maps dict-known names to Korean without a DB lookup', async () => {
+        const labels = await resolveIndicatorLabels([ev('Nonfarm Payrolls')]);
+        expect(labels['Nonfarm Payrolls']).toBe('비농업 고용');
+        // All distinct bases were dict-known → no unknowns → no DB query.
+        expect(findByNames).not.toHaveBeenCalled();
+        expect(ensureIndicatorTranslatedAction).not.toHaveBeenCalled();
+    });
+
+    it('applies a DB-cached translation for an unmapped name', async () => {
+        findByNames.mockResolvedValue([
+            {
+                normalizedName: 'Some Obscure Index YoY',
+                koreanName: '어떤 모호한 지수(전년比)',
+                source: 'ai',
+            },
+        ]);
+        const labels = await resolveIndicatorLabels([
+            ev('Some Obscure Index YoY (May)'),
+        ]);
+        expect(labels['Some Obscure Index YoY (May)']).toBe(
+            '어떤 모호한 지수(전년比) (5월)'
+        );
+        expect(ensureIndicatorTranslatedAction).not.toHaveBeenCalled();
+    });
+
+    it('falls back to English and triggers AI for a name missing everywhere', async () => {
+        const labels = await resolveIndicatorLabels([
+            ev('Totally Unknown Thing (Apr)'),
+        ]);
+        expect(labels['Totally Unknown Thing (Apr)']).toBe(
+            'Totally Unknown Thing (Apr)'
+        );
+        expect(ensureIndicatorTranslatedAction).toHaveBeenCalledWith(
+            'Totally Unknown Thing'
+        );
+    });
+
+    it('queries and triggers each distinct base only once', async () => {
+        await resolveIndicatorLabels([
+            ev('Totally Unknown Thing (Apr)'),
+            ev('Totally Unknown Thing (May)'),
+        ]);
+        expect(findByNames).toHaveBeenCalledTimes(1);
+        expect(findByNames).toHaveBeenCalledWith(['Totally Unknown Thing']);
+        expect(ensureIndicatorTranslatedAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('degrades to English-only labels on DB failure (graceful)', async () => {
+        findByNames.mockRejectedValue(new Error('neon down'));
+        const labels = await resolveIndicatorLabels([
+            ev('Totally Unknown Thing (Apr)'),
+        ]);
+        expect(labels['Totally Unknown Thing (Apr)']).toBe(
+            'Totally Unknown Thing (Apr)'
+        );
+    });
+});

--- a/src/entities/economy/api/indicatorTranslationFlag.ts
+++ b/src/entities/economy/api/indicatorTranslationFlag.ts
@@ -1,0 +1,42 @@
+import 'server-only';
+import { getRedisClient } from '@/shared/cache/redisClient';
+import {
+    INDICATOR_TRANSLATION_FLAG_PREFIX,
+    INDICATOR_TRANSLATION_FLAG_TTL_SECONDS,
+} from '../lib/indicatorTranslationConstants';
+
+function flagKey(normalizedName: string): string {
+    return `${INDICATOR_TRANSLATION_FLAG_PREFIX}:${normalizedName}`;
+}
+
+/**
+ * 해당 지표명의 AI 번역이 최근 TTL 내에 제출됐는지 — Redis 실패/미구성 시 false
+ * (항상 제출 시도). market-news `isRecentlyFetched` 미러.
+ */
+export async function isIndicatorTranslationPending(
+    normalizedName: string
+): Promise<boolean> {
+    const redis = getRedisClient();
+    if (redis === null) return false;
+    try {
+        return (await redis.get(flagKey(normalizedName))) !== null;
+    } catch (error) {
+        console.error('[indicatorTranslationFlag] get failed', error);
+        return false;
+    }
+}
+
+/** "이 지표명 번역 제출함" 마킹 — Redis 실패 시 noop. */
+export async function markIndicatorTranslationPending(
+    normalizedName: string
+): Promise<void> {
+    const redis = getRedisClient();
+    if (redis === null) return;
+    try {
+        await redis.set(flagKey(normalizedName), '1', {
+            ex: INDICATOR_TRANSLATION_FLAG_TTL_SECONDS,
+        });
+    } catch (error) {
+        console.error('[indicatorTranslationFlag] set failed', error);
+    }
+}

--- a/src/entities/economy/api/indicatorTranslationRepository.ts
+++ b/src/entities/economy/api/indicatorTranslationRepository.ts
@@ -1,0 +1,82 @@
+import 'server-only';
+import { inArray, sql } from 'drizzle-orm';
+import { NEON_TRANSIENT_RETRY } from '@/shared/db/isNeonTransientError';
+import { economicIndicatorTranslations } from '@/shared/db/schema';
+import type { SiglensDatabase } from '@/shared/db/types';
+import type {
+    IndicatorTranslationRecord,
+    IndicatorTranslationRepository,
+    IndicatorTranslationSource,
+} from '@/shared/db/types';
+import { withRetry } from '@/shared/lib/withRetry';
+
+const indicatorTranslationColumns = {
+    normalizedName: economicIndicatorTranslations.normalizedName,
+    koreanName: economicIndicatorTranslations.koreanName,
+    source: economicIndicatorTranslations.source,
+};
+
+interface IndicatorTranslationRow {
+    normalizedName: string;
+    koreanName: string;
+    source: string;
+}
+
+/** 읽기 경계에서 source를 검증 — 미지값은 'ai'로 흡수(캐시 행이므로 합리적 기본). */
+function toSource(value: string): IndicatorTranslationSource {
+    return value === 'dict' ? 'dict' : 'ai';
+}
+
+function toRecord(row: IndicatorTranslationRow): IndicatorTranslationRecord {
+    return {
+        normalizedName: row.normalizedName,
+        koreanName: row.koreanName,
+        source: toSource(row.source),
+    };
+}
+
+/**
+ * `economic_indicator_translations`를 읽고 쓰는 Drizzle repository.
+ * `DrizzleAssetTranslationRepository` 미러 — onConflictDoUpdate는 schema의
+ * `$onUpdateFn`을 트리거하지 않으므로 `updatedAt`을 `sql\`now()\``로 명시한다.
+ */
+export class DrizzleIndicatorTranslationRepository implements IndicatorTranslationRepository {
+    constructor(private readonly db: SiglensDatabase) {}
+
+    async findByNames(
+        normalizedNames: readonly string[]
+    ): Promise<IndicatorTranslationRecord[]> {
+        if (normalizedNames.length === 0) return [];
+        const rows = await withRetry(
+            () =>
+                this.db
+                    .select(indicatorTranslationColumns)
+                    .from(economicIndicatorTranslations)
+                    .where(
+                        inArray(economicIndicatorTranslations.normalizedName, [
+                            ...normalizedNames,
+                        ])
+                    ),
+            NEON_TRANSIENT_RETRY
+        );
+        return rows.map(toRecord);
+    }
+
+    async upsert(record: IndicatorTranslationRecord): Promise<void> {
+        await withRetry(
+            () =>
+                this.db
+                    .insert(economicIndicatorTranslations)
+                    .values(record)
+                    .onConflictDoUpdate({
+                        target: economicIndicatorTranslations.normalizedName,
+                        set: {
+                            koreanName: sql`excluded.korean_name`,
+                            source: sql`excluded.source`,
+                            updatedAt: sql`now()`,
+                        },
+                    }),
+            NEON_TRANSIENT_RETRY
+        );
+    }
+}

--- a/src/entities/economy/api/resolveIndicatorLabels.ts
+++ b/src/entities/economy/api/resolveIndicatorLabels.ts
@@ -16,41 +16,46 @@ import {
 } from '../lib/indicatorTranslationConstants';
 
 /**
- * 미매핑 base 이름들의 DB 캐시 행을 읽는다. ISR cold-gen 안전: `@neondatabase/serverless`
- * HTTP는 no-store라 static generate가 `DYNAMIC_SERVER_USAGE`를 throw하므로 `unstable_cache`로
+ * Module-level `unstable_cache` — ISR cold-gen 안전: `@neondatabase/serverless` HTTP는
+ * no-store라 static generate가 `DYNAMIC_SERVER_USAGE`를 throw하므로 `unstable_cache`로
  * 감싼다(src/app/CLAUDE.md 4축 축1). revalidate=24h + `economy:indicator-translation` 태그로
  * `ensureIndicatorTranslatedAction`이 on-demand 무효화 가능. DB 실패 시 빈 맵으로 graceful.
  *
- * 캐시 키에 정렬된 이름 목록을 박아 입력이 바뀌면 자연히 리프레시된다.
+ * `sortedNames`를 인자로 받아 Next.js가 자동으로 캐시 키에 포함시킨다
+ * — 입력이 바뀌면 자연히 리프레시된다. per-call 생성 대신 module-level 호이스트로
+ * SP-A `getCalendarFromDb` 패턴을 미러한다.
+ */
+const getCachedIndicatorDbMap = unstable_cache(
+    async (sortedNames: string[]): Promise<Record<string, string>> => {
+        try {
+            const { db } = getDatabaseClient();
+            const repo = new DrizzleIndicatorTranslationRepository(db);
+            const rows = await repo.findByNames(sortedNames);
+            return Object.fromEntries(
+                rows.map(r => [r.normalizedName, r.koreanName])
+            );
+        } catch (error) {
+            console.error('[resolveIndicatorLabels] DB read failed:', error);
+            return {};
+        }
+    },
+    ['economy-indicator-translation'],
+    {
+        revalidate: INDICATOR_TRANSLATION_REVALIDATE_SECONDS,
+        tags: [INDICATOR_TRANSLATION_CACHE_TAG],
+    }
+);
+
+/**
+ * 미매핑 base 이름들의 DB 캐시 행을 읽는다.
+ * 캐시 키에 정렬된 이름 목록이 인자로 자동 포함되므로 입력이 바뀌면 자연히 리프레시된다.
  */
 async function readDbMap(
     unknownNames: string[]
 ): Promise<Record<string, string>> {
     if (unknownNames.length === 0) return {};
     const sorted = [...unknownNames].toSorted((a, b) => a.localeCompare(b));
-    return unstable_cache(
-        async () => {
-            try {
-                const { db } = getDatabaseClient();
-                const repo = new DrizzleIndicatorTranslationRepository(db);
-                const rows = await repo.findByNames(sorted);
-                return Object.fromEntries(
-                    rows.map(r => [r.normalizedName, r.koreanName])
-                );
-            } catch (error) {
-                console.error(
-                    '[resolveIndicatorLabels] DB read failed:',
-                    error
-                );
-                return {};
-            }
-        },
-        ['economy-indicator-translation', sorted.join('|')],
-        {
-            revalidate: INDICATOR_TRANSLATION_REVALIDATE_SECONDS,
-            tags: [INDICATOR_TRANSLATION_CACHE_TAG],
-        }
-    )();
+    return getCachedIndicatorDbMap(sorted);
 }
 
 /**

--- a/src/entities/economy/api/resolveIndicatorLabels.ts
+++ b/src/entities/economy/api/resolveIndicatorLabels.ts
@@ -1,0 +1,94 @@
+import 'server-only';
+import { unstable_cache } from 'next/cache';
+import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
+
+import { getDatabaseClient } from '@/shared/db/client';
+
+import { DrizzleIndicatorTranslationRepository } from './indicatorTranslationRepository';
+import { ensureIndicatorTranslatedAction } from '../actions/ensureIndicatorTranslatedAction';
+import {
+    INDICATOR_NAME_KO,
+    indicatorLabelKoFromMaps,
+    normalizeIndicatorName,
+} from '../lib/indicatorNameKo';
+import {
+    INDICATOR_TRANSLATION_CACHE_TAG,
+    INDICATOR_TRANSLATION_REVALIDATE_SECONDS,
+} from '../lib/indicatorTranslationConstants';
+
+/**
+ * 미매핑 base 이름들의 DB 캐시 행을 읽는다. ISR cold-gen 안전: `@neondatabase/serverless`
+ * HTTP는 no-store라 static generate가 `DYNAMIC_SERVER_USAGE`를 throw하므로 `unstable_cache`로
+ * 감싼다(src/app/CLAUDE.md 4축 축1). revalidate=24h + `economy:indicator-translation` 태그로
+ * `ensureIndicatorTranslatedAction`이 on-demand 무효화 가능. DB 실패 시 빈 맵으로 graceful.
+ *
+ * 캐시 키에 정렬된 이름 목록을 박아 입력이 바뀌면 자연히 리프레시된다.
+ */
+async function readDbMap(
+    unknownNames: string[]
+): Promise<Record<string, string>> {
+    if (unknownNames.length === 0) return {};
+    const sorted = [...unknownNames].toSorted((a, b) => a.localeCompare(b));
+    return unstable_cache(
+        async () => {
+            try {
+                const { db } = getDatabaseClient();
+                const repo = new DrizzleIndicatorTranslationRepository(db);
+                const rows = await repo.findByNames(sorted);
+                return Object.fromEntries(
+                    rows.map(r => [r.normalizedName, r.koreanName])
+                );
+            } catch (error) {
+                console.error(
+                    '[resolveIndicatorLabels] DB read failed:',
+                    error
+                );
+                return {};
+            }
+        },
+        ['economy-indicator-translation', sorted.join('|')],
+        {
+            revalidate: INDICATOR_TRANSLATION_REVALIDATE_SECONDS,
+            tags: [INDICATOR_TRANSLATION_CACHE_TAG],
+        }
+    )();
+}
+
+/**
+ * 이벤트들의 raw 지표명을 표시 레이블(한국어 우선, 영어 fallback)로 매핑한 레코드를
+ * 반환한다(키 = raw event명). dict-known은 즉시, 미매핑은 DB 캐시 룩업, 둘 다 miss면
+ * 영어 fallback + fire-and-forget AI 트리거(다음 렌더 캐시 시드, 봇 포함).
+ *
+ * 그리드(client)는 이 순수 레이블 맵만 받아 표시한다 — server-only 의존성 누출 없음.
+ */
+export async function resolveIndicatorLabels(
+    events: readonly EconomicCalendarEvent[]
+): Promise<Record<string, string>> {
+    const distinctRaw = [...new Set(events.map(e => e.event))];
+    const baseByRaw = new Map(
+        distinctRaw.map(raw => [raw, normalizeIndicatorName(raw).base])
+    );
+
+    const distinctBases = [...new Set(baseByRaw.values())];
+    const unknownBases = distinctBases.filter(
+        base => !(base in INDICATOR_NAME_KO)
+    );
+
+    const dbMap = await readDbMap(unknownBases);
+
+    // 여전히 미해결인(dict X, DB X) base에 대해서만 AI 번역을 트리거 — 각 1회.
+    for (const base of unknownBases) {
+        if (!(base in dbMap)) {
+            void ensureIndicatorTranslatedAction(base).catch((e: unknown) => {
+                console.error(
+                    '[resolveIndicatorLabels] ensureIndicatorTranslatedAction failed:',
+                    e
+                );
+            });
+        }
+    }
+
+    return Object.fromEntries(
+        distinctRaw.map(raw => [raw, indicatorLabelKoFromMaps(raw, dbMap)])
+    );
+}

--- a/src/entities/economy/api/resolveIndicatorLabels.ts
+++ b/src/entities/economy/api/resolveIndicatorLabels.ts
@@ -5,7 +5,6 @@ import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
 import { getDatabaseClient } from '@/shared/db/client';
 
 import { DrizzleIndicatorTranslationRepository } from './indicatorTranslationRepository';
-import { ensureIndicatorTranslatedAction } from '../actions/ensureIndicatorTranslatedAction';
 import {
     INDICATOR_NAME_KO,
     indicatorLabelKoFromMaps,
@@ -57,7 +56,11 @@ async function readDbMap(
 /**
  * 이벤트들의 raw 지표명을 표시 레이블(한국어 우선, 영어 fallback)로 매핑한 레코드를
  * 반환한다(키 = raw event명). dict-known은 즉시, 미매핑은 DB 캐시 룩업, 둘 다 miss면
- * 영어 fallback + fire-and-forget AI 트리거(다음 렌더 캐시 시드, 봇 포함).
+ * 영어 fallback을 반환한다(결정론적, 사이드 이펙트 없음).
+ *
+ * 미해결 이름에 대한 AI 번역 트리거는 클라이언트 훅(`useIndicatorTranslationTrigger`)이
+ * 마운트 시 담당한다 — RSC prerender/ISR cold-gen에서 고아 프로미스·revalidateTag를
+ * 실행하는 렌더 부작용을 제거하기 위해 SP-A 패턴(`useEconomicCalendarTrigger`)을 미러.
  *
  * 그리드(client)는 이 순수 레이블 맵만 받아 표시한다 — server-only 의존성 누출 없음.
  */
@@ -71,22 +74,10 @@ export async function resolveIndicatorLabels(
 
     const distinctBases = [...new Set(baseByRaw.values())];
     const unknownBases = distinctBases.filter(
-        base => !(base in INDICATOR_NAME_KO)
+        base => !Object.hasOwn(INDICATOR_NAME_KO, base)
     );
 
     const dbMap = await readDbMap(unknownBases);
-
-    // 여전히 미해결인(dict X, DB X) base에 대해서만 AI 번역을 트리거 — 각 1회.
-    for (const base of unknownBases) {
-        if (!(base in dbMap)) {
-            void ensureIndicatorTranslatedAction(base).catch((e: unknown) => {
-                console.error(
-                    '[resolveIndicatorLabels] ensureIndicatorTranslatedAction failed:',
-                    e
-                );
-            });
-        }
-    }
 
     return Object.fromEntries(
         distinctRaw.map(raw => [raw, indicatorLabelKoFromMaps(raw, dbMap)])

--- a/src/entities/economy/index.ts
+++ b/src/entities/economy/index.ts
@@ -6,5 +6,13 @@
  * 가진 api/ 모듈(`economySnapshotStaticCache`, `macroBriefingStaticCache`, `economySnapshotCache`)과
  * Server Action(`actions/*`)은 client 번들 누출 방지를 위해 barrel 제외 — 호출부가 deep
  * path로 직접 import한다(entities/CLAUDE.md "barrel 제외 대상" 규칙).
+ *
+ * `indicatorNameKo` 모듈은 순수(React/server-only/DB 비의존)이므로 client 소비자
+ * (`useIndicatorTranslationTrigger`)에서 barrel을 통해 import할 수 있다.
  */
 export { isEmptyEconomySnapshot } from './lib/economyCompleteness';
+export {
+    INDICATOR_NAME_KO,
+    normalizeIndicatorName,
+} from './lib/indicatorNameKo';
+export type { NormalizedIndicatorName } from './lib/indicatorNameKo';

--- a/src/entities/economy/lib/__tests__/indicatorNameKo.test.ts
+++ b/src/entities/economy/lib/__tests__/indicatorNameKo.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+    normalizeIndicatorName,
+    koreanizePeriodToken,
+    indicatorLabelKoFromMaps,
+    INDICATOR_NAME_KO,
+} from '@/entities/economy/lib/indicatorNameKo';
+
+describe('normalizeIndicatorName', () => {
+    it('splits a trailing month parenthetical into base + period', () => {
+        expect(
+            normalizeIndicatorName('Core PCE Price Index YoY (May)')
+        ).toEqual({ base: 'Core PCE Price Index YoY', period: 'May' });
+    });
+
+    it('splits a trailing quarter parenthetical', () => {
+        expect(normalizeIndicatorName('GDP Growth Rate QoQ (Q1)')).toEqual({
+            base: 'GDP Growth Rate QoQ',
+            period: 'Q1',
+        });
+    });
+
+    it('splits a slash date-token parenthetical', () => {
+        expect(
+            normalizeIndicatorName('Fed Interest Rate Decision (Jun/20)')
+        ).toEqual({ base: 'Fed Interest Rate Decision', period: 'Jun/20' });
+    });
+
+    it('returns an empty period when there is no parenthetical', () => {
+        expect(normalizeIndicatorName('Initial Jobless Claims')).toEqual({
+            base: 'Initial Jobless Claims',
+            period: '',
+        });
+    });
+
+    it('strips only the final parenthetical, preserving interior ones', () => {
+        expect(normalizeIndicatorName('Index (ex Food) MoM (Apr)')).toEqual({
+            base: 'Index (ex Food) MoM',
+            period: 'Apr',
+        });
+    });
+
+    it('trims surrounding whitespace from base', () => {
+        expect(normalizeIndicatorName('  CPI YoY (Apr)  ')).toEqual({
+            base: 'CPI YoY',
+            period: 'Apr',
+        });
+    });
+});
+
+describe('koreanizePeriodToken', () => {
+    it('translates change-direction tokens', () => {
+        expect(koreanizePeriodToken('YoY')).toBe('전년比');
+        expect(koreanizePeriodToken('MoM')).toBe('전월比');
+        expect(koreanizePeriodToken('QoQ')).toBe('전분기比');
+    });
+
+    it('translates month abbreviations', () => {
+        expect(koreanizePeriodToken('May')).toBe('5월');
+        expect(koreanizePeriodToken('Jan')).toBe('1월');
+        expect(koreanizePeriodToken('Dec')).toBe('12월');
+    });
+
+    it('translates quarter tokens', () => {
+        expect(koreanizePeriodToken('Q1')).toBe('1분기');
+        expect(koreanizePeriodToken('Q4')).toBe('4분기');
+    });
+
+    it('returns an unknown token unchanged', () => {
+        expect(koreanizePeriodToken('Jun/20')).toBe('Jun/20');
+        expect(koreanizePeriodToken('')).toBe('');
+    });
+});
+
+describe('indicatorLabelKoFromMaps', () => {
+    it('renders dict base + Korean period when the base is mapped', () => {
+        expect(
+            indicatorLabelKoFromMaps('Core PCE Price Index YoY (May)', {})
+        ).toBe('근원 PCE 물가지수(전년比) (5월)');
+    });
+
+    it('renders a mapped base with no period parenthetical', () => {
+        expect(indicatorLabelKoFromMaps('Nonfarm Payrolls', {})).toBe(
+            '비농업 고용'
+        );
+    });
+
+    it('falls back to the DB-cache map when dict misses', () => {
+        expect(
+            indicatorLabelKoFromMaps('Some Obscure Index YoY (May)', {
+                'Some Obscure Index YoY': '어떤 모호한 지수(전년比)',
+            })
+        ).toBe('어떤 모호한 지수(전년比) (5월)');
+    });
+
+    it('falls back to the raw English name when both maps miss', () => {
+        expect(
+            indicatorLabelKoFromMaps('Totally Unknown Thing (Apr)', {})
+        ).toBe('Totally Unknown Thing (Apr)');
+    });
+
+    it('seeds the dictionary with confirmed common indicators', () => {
+        expect(INDICATOR_NAME_KO['Nonfarm Payrolls']).toBe('비농업 고용');
+        expect(INDICATOR_NAME_KO['ADP Employment Change']).toBe(
+            'ADP 고용 변화'
+        );
+        expect(INDICATOR_NAME_KO['10-Year Note Auction']).toBe(
+            '10년물 국채 입찰'
+        );
+    });
+});

--- a/src/entities/economy/lib/indicatorNameKo.ts
+++ b/src/entities/economy/lib/indicatorNameKo.ts
@@ -119,7 +119,12 @@ export function indicatorLabelKoFromMaps(
     dbMap: Record<string, string>
 ): string {
     const { base, period } = normalizeIndicatorName(raw);
-    const ko = INDICATOR_NAME_KO[base] ?? dbMap[base];
+    // `Record<string, string>` 타입은 `noUncheckedIndexedAccess` 없이 항상 string을
+    // 반환하므로 `?? dbMap[base]` fallback이 타입 상 dead code처럼 보인다. `Object.hasOwn`으로
+    // dict miss를 명시적으로 검사해 fallback 체인(dict → dbMap → raw)을 타입 안전하게 만든다.
+    const ko = Object.hasOwn(INDICATOR_NAME_KO, base)
+        ? INDICATOR_NAME_KO[base]
+        : (dbMap[base] ?? undefined);
     if (ko === undefined) {
         return raw;
     }

--- a/src/entities/economy/lib/indicatorNameKo.ts
+++ b/src/entities/economy/lib/indicatorNameKo.ts
@@ -1,0 +1,130 @@
+/**
+ * 경제 지표명 한국어화 — 코드 const 사전(source-of-truth, `dict`)이 1차, DB 캐시(`ai`)가
+ * 2차다. 이 모듈은 순수(React/server-only/DB 비의존)하므로 클라 그리드와 서버 reader가
+ * 함께 import할 수 있다. DB 캐시 룩업과 AI 트리거는 서버 계층(api/, actions/)이 담당하고,
+ * 여기서는 이미 로드된 DB 맵을 받아 동기 합성만 한다.
+ *
+ * 초기 사전은 FMP 샘플에서 가장 흔한 지표 일부만 확정해 시드한다. 전체 ~277개 큐레이션은
+ * SP-A 백필 name-dump를 소비하는 별도 데이터 작업이다(docs/superpowers/seeding 참조).
+ */
+
+/** `INDICATOR_NAME_KO`/DB 캐시의 키 = 정규화된 base 지표명, 값 = 한국어. */
+export const INDICATOR_NAME_KO: Record<string, string> = {
+    // 물가
+    'Core PCE Price Index YoY': '근원 PCE 물가지수(전년比)',
+    'Core PCE Price Index MoM': '근원 PCE 물가지수(전월比)',
+    'PCE Price Index YoY': 'PCE 물가지수(전년比)',
+    'Inflation Rate YoY': '소비자물가 상승률(전년比)',
+    'Core Inflation Rate YoY': '근원 소비자물가 상승률(전년比)',
+    CPI: '소비자물가지수',
+    'CPI YoY': '소비자물가지수(전년比)',
+    'CPI MoM': '소비자물가지수(전월比)',
+    'Core CPI YoY': '근원 소비자물가지수(전년比)',
+    'Core CPI MoM': '근원 소비자물가지수(전월比)',
+    'PPI MoM': '생산자물가지수(전월比)',
+    'Core PPI MoM': '근원 생산자물가지수(전월比)',
+    // 고용
+    'Nonfarm Payrolls': '비농업 고용',
+    'ADP Employment Change': 'ADP 고용 변화',
+    'Initial Jobless Claims': '신규 실업수당 청구',
+    'Continuing Jobless Claims': '연속 실업수당 청구',
+    'Unemployment Rate': '실업률',
+    'Average Hourly Earnings MoM': '시간당 평균 임금(전월比)',
+    'JOLTs Job Openings': '구인 건수(JOLTs)',
+    // 성장·심리
+    'GDP Growth Rate QoQ': 'GDP 성장률(전분기比)',
+    'Retail Sales MoM': '소매판매(전월比)',
+    'ISM Manufacturing PMI': 'ISM 제조업 PMI',
+    'ISM Services PMI': 'ISM 서비스업 PMI',
+    'Michigan Consumer Sentiment': '미시간대 소비자심리지수',
+    // 정책·국채
+    'Fed Interest Rate Decision': '연준 기준금리 결정',
+    '10-Year Note Auction': '10년물 국채 입찰',
+    '30-Year Bond Auction': '30년물 국채 입찰',
+    '2-Year Note Auction': '2년물 국채 입찰',
+    '3-Month Bill Auction': '3개월물 국채 입찰',
+};
+
+/** 변화-방향 접미 토큰의 한국어 매핑. */
+const PERIOD_DIRECTION_KO: Record<string, string> = {
+    YoY: '전년比',
+    MoM: '전월比',
+    QoQ: '전분기比',
+};
+
+/** 영어 월 약어 → 1-indexed 월. */
+const MONTH_INDEX: Record<string, number> = {
+    Jan: 1,
+    Feb: 2,
+    Mar: 3,
+    Apr: 4,
+    May: 5,
+    Jun: 6,
+    Jul: 7,
+    Aug: 8,
+    Sep: 9,
+    Oct: 10,
+    Nov: 11,
+    Dec: 12,
+};
+
+/** `normalizeIndicatorName` 반환 형태. */
+export interface NormalizedIndicatorName {
+    /** 접미 괄호를 제거한 base 지표명. */
+    base: string;
+    /** 마지막 괄호 안의 기간 토큰(없으면 ''). 예 'May' | 'Q1' | 'Jun/20'. */
+    period: string;
+}
+
+/**
+ * 마지막 괄호 그룹을 base와 period로 분리한다. 중간 괄호('Index (ex Food) MoM')는
+ * 보존하고 끝 괄호만 떼어낸다. 접미 괄호가 없으면 period는 ''.
+ */
+export function normalizeIndicatorName(raw: string): NormalizedIndicatorName {
+    const match = raw.trim().match(/^(.*?)\s*\(([^()]*)\)\s*$/);
+    if (match === null) {
+        return { base: raw.trim(), period: '' };
+    }
+    return { base: match[1].trim(), period: match[2].trim() };
+}
+
+/**
+ * 기간 토큰을 한국어로 변환한다 — 변화-방향(YoY/MoM/QoQ), 월 약어(May→5월),
+ * 분기(Q1→1분기). 미지 토큰은 원문 유지(예 'Jun/20').
+ */
+export function koreanizePeriodToken(token: string): string {
+    if (token in PERIOD_DIRECTION_KO) {
+        return PERIOD_DIRECTION_KO[token];
+    }
+    if (token in MONTH_INDEX) {
+        return `${MONTH_INDEX[token]}월`;
+    }
+    const quarter = token.match(/^Q([1-4])$/);
+    if (quarter !== null) {
+        return `${quarter[1]}분기`;
+    }
+    return token;
+}
+
+/**
+ * 동기 표시 헬퍼 — dict(코드 사전) → dbMap(이미 로드된 DB 캐시) 순으로 base를 룩업한다.
+ * 둘 다 miss면 raw 영어 원문을 그대로 반환(결정론적 fallback). hit이면 한국어 base에
+ * period 토큰을 한국어로 붙인다(' (5월)'). period가 dict base 안에 이미 녹아 있으면
+ * (예 'Core PCE Price Index YoY' base는 '(전년比)' 포함) period 괄호만 추가된다.
+ *
+ * AI 트리거/캐시 쓰기는 서버 계층(resolveIndicatorLabels)이 담당 — 이 함수는 순수.
+ */
+export function indicatorLabelKoFromMaps(
+    raw: string,
+    dbMap: Record<string, string>
+): string {
+    const { base, period } = normalizeIndicatorName(raw);
+    const ko = INDICATOR_NAME_KO[base] ?? dbMap[base];
+    if (ko === undefined) {
+        return raw;
+    }
+    if (period === '') {
+        return ko;
+    }
+    return `${ko} (${koreanizePeriodToken(period)})`;
+}

--- a/src/entities/economy/lib/indicatorTranslationConstants.ts
+++ b/src/entities/economy/lib/indicatorTranslationConstants.ts
@@ -1,0 +1,31 @@
+import { SECONDS_PER_DAY, SECONDS_PER_MINUTE } from '@/shared/config/time';
+
+/**
+ * revalidateTag 대상 — indicator 번역 캐시만 무효화한다(캘린더 데이터 캐시와 분리).
+ * AI 번역이 새로 캐시되면 다음 렌더에서 reader가 한국어를 집어 오도록 이 태그를 bust.
+ */
+export const INDICATOR_TRANSLATION_CACHE_TAG = 'economy:indicator-translation';
+
+/** Redis pending-flag 키 prefix — 동일 지표명의 동시 AI 제출을 dedupe. */
+export const INDICATOR_TRANSLATION_FLAG_PREFIX = 'economy:indicator-xlate';
+
+const INDICATOR_TRANSLATION_FLAG_TTL_MINUTES = 10;
+
+/**
+ * pending-flag TTL — 이 윈도 안에 같은 지표명이 다시 miss로 들어와도 AI 재제출을
+ * 건너뛴다(in-flight 또는 직전 실패 쿨다운). market-news refresh-flag 패턴 미러.
+ */
+export const INDICATOR_TRANSLATION_FLAG_TTL_SECONDS =
+    INDICATOR_TRANSLATION_FLAG_TTL_MINUTES * SECONDS_PER_MINUTE;
+
+/**
+ * 번역 reader의 `unstable_cache` revalidate — 24h, /economy revalidate(86400)와 단일
+ * TTL 공유. 신선도는 `ensureIndicatorTranslatedAction`의 revalidateTag가 책임진다.
+ */
+export const INDICATOR_TRANSLATION_REVALIDATE_SECONDS = SECONDS_PER_DAY;
+
+/** poll loop 간격 — core 번역 워커 완료 대기. news 분석 패턴 미러. */
+export const INDICATOR_TRANSLATION_POLL_INTERVAL_MS = 2_000;
+
+/** poll 최대 시도 횟수 — 이 초 수(×interval) 후 timeout 경고 + 포기. */
+export const INDICATOR_TRANSLATION_POLL_MAX_ATTEMPTS = 30;

--- a/src/shared/db/__tests__/schema.test.ts
+++ b/src/shared/db/__tests__/schema.test.ts
@@ -65,8 +65,8 @@ describe('sessions 테이블 컬럼', () => {
     });
 });
 
-describe('economicIndicatorTranslations table', () => {
-    it('exposes the expected columns', () => {
+describe('economicIndicatorTranslations 테이블 컬럼', () => {
+    it('normalizedName, koreanName, source, updatedAt 컬럼 속성이 존재한다', () => {
         const cols = Object.keys(schema.economicIndicatorTranslations);
         expect(cols).toContain('normalizedName');
         expect(cols).toContain('koreanName');

--- a/src/shared/db/__tests__/schema.test.ts
+++ b/src/shared/db/__tests__/schema.test.ts
@@ -64,3 +64,13 @@ describe('sessions 테이블 컬럼', () => {
         expect(sessions.createdAt).toBeDefined();
     });
 });
+
+describe('economicIndicatorTranslations table', () => {
+    it('exposes the expected columns', () => {
+        const cols = Object.keys(schema.economicIndicatorTranslations);
+        expect(cols).toContain('normalizedName');
+        expect(cols).toContain('koreanName');
+        expect(cols).toContain('source');
+        expect(cols).toContain('updatedAt');
+    });
+});

--- a/src/shared/db/schema.ts
+++ b/src/shared/db/schema.ts
@@ -362,6 +362,26 @@ export const economicCalendar = pgTable(
     ]
 );
 
+/**
+ * 경제 지표명 한국어 번역 캐시 — `assetTranslations` 미러. 코드 const 사전
+ * (`INDICATOR_NAME_KO`)이 source-of-truth이고, 이 테이블은 미매핑 지표명의 core AI
+ * 번역 결과를 `source:'ai'`로 캐시한다(추후 코드 사전으로 승격). `normalizedName`은
+ * 접미 괄호를 제거한 base 지표명(`normalizeIndicatorName`의 base).
+ */
+export const economicIndicatorTranslations = pgTable(
+    'economic_indicator_translations',
+    {
+        normalizedName: text('normalized_name').primaryKey(),
+        koreanName: text('korean_name').notNull(),
+        // 'dict' | 'ai' — 출처. text 저장, 읽기 경계에서 검증.
+        source: text('source').notNull(),
+        updatedAt: timestamp('updated_at', { withTimezone: true })
+            .notNull()
+            .defaultNow()
+            .$onUpdateFn(nowFn),
+    }
+);
+
 /** Postgres enum for legal terms document kinds. */
 export const termsKindEnum = pgEnum('terms_kind', TERMS_KIND_VALUES);
 

--- a/src/shared/db/types.ts
+++ b/src/shared/db/types.ts
@@ -250,3 +250,24 @@ export interface ProfileDescriptionTranslationRepository {
     ): Promise<ProfileDescriptionTranslationRecord | null>;
     upsert(record: ProfileDescriptionTranslationRecord): Promise<void>;
 }
+
+/** 'dict' | 'ai' — indicator 번역 출처. */
+export type IndicatorTranslationSource = 'dict' | 'ai';
+
+/** 경제 지표명 한국어 번역 캐시 행. */
+export interface IndicatorTranslationRecord {
+    /** 정규화된 base 지표명(접미 괄호 제거). 예 'Core PCE Price Index YoY'. */
+    normalizedName: string;
+    /** 한국어 번역. */
+    koreanName: string;
+    /** 'dict'(코드 승격) | 'ai'(core 번역 캐시). */
+    source: IndicatorTranslationSource;
+}
+
+/** {@link IndicatorTranslationRecord}를 백킹하는 영속화 연산. */
+export interface IndicatorTranslationRepository {
+    findByNames(
+        normalizedNames: readonly string[]
+    ): Promise<IndicatorTranslationRecord[]>;
+    upsert(record: IndicatorTranslationRecord): Promise<void>;
+}

--- a/src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
+++ b/src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
@@ -424,8 +424,8 @@ describe('EconomicCalendarGrid Korean indicator labels', () => {
                 labels={{ 'Nonfarm Payrolls': '비농업 고용' }}
             />
         );
-        // The selected (today) panel shows the Korean label, not the English name.
-        expect(screen.getAllByText('비농업 고용').length).toBeGreaterThan(0);
+        // Single event on the selected (today) panel → exactly one <p> with the Korean label.
+        expect(screen.getByText('비농업 고용')).toBeInTheDocument();
         expect(screen.queryByText('Nonfarm Payrolls')).toBeNull();
     });
 
@@ -436,6 +436,7 @@ describe('EconomicCalendarGrid Korean indicator labels', () => {
                 today="2026-06-20"
             />
         );
-        expect(screen.getAllByText('Mystery Index').length).toBeGreaterThan(0);
+        // Single event on the selected (today) panel → exactly one <p> with the English fallback.
+        expect(screen.getByText('Mystery Index')).toBeInTheDocument();
     });
 });

--- a/src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
+++ b/src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
@@ -403,3 +403,38 @@ describe('EconomicCalendarGrid — 중요도 필터 (상세 패널 · DOM 유지
         );
     });
 });
+
+describe('EconomicCalendarGrid Korean indicator labels', () => {
+    const ev = (date: string, event: string): EconomicCalendarEvent => ({
+        date: `${date} 08:30:00`,
+        event,
+        impact: 'High',
+        actual: null,
+        estimate: 1,
+        previous: 1,
+        unit: '%',
+    });
+
+    it('renders the Korean label in the detail panel when provided', () => {
+        render(
+            <EconomicCalendarGrid
+                events={[ev('2026-06-20', 'Nonfarm Payrolls')]}
+                today="2026-06-20"
+                labels={{ 'Nonfarm Payrolls': '비농업 고용' }}
+            />
+        );
+        // The selected (today) panel shows the Korean label, not the English name.
+        expect(screen.getAllByText('비농업 고용').length).toBeGreaterThan(0);
+        expect(screen.queryByText('Nonfarm Payrolls')).toBeNull();
+    });
+
+    it('falls back to the English event name when no label is provided', () => {
+        render(
+            <EconomicCalendarGrid
+                events={[ev('2026-06-20', 'Mystery Index')]}
+                today="2026-06-20"
+            />
+        );
+        expect(screen.getAllByText('Mystery Index').length).toBeGreaterThan(0);
+    });
+});

--- a/src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
+++ b/src/widgets/economy/__tests__/EconomicCalendarGrid.test.tsx
@@ -5,6 +5,7 @@ import { EconomicCalendarGrid } from '@/widgets/economy/sections/EconomicCalenda
 
 vi.mock('@/entities/economy/actions', () => ({
     ensureEconomicCalendarAction: vi.fn().mockResolvedValue(undefined),
+    ensureIndicatorTranslatedAction: vi.fn().mockResolvedValue(undefined),
 }));
 
 /**

--- a/src/widgets/economy/hooks/__tests__/useIndicatorTranslationTrigger.test.tsx
+++ b/src/widgets/economy/hooks/__tests__/useIndicatorTranslationTrigger.test.tsx
@@ -1,0 +1,107 @@
+vi.mock('@/entities/economy/actions', () => ({
+    ensureIndicatorTranslatedAction: vi.fn(),
+}));
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
+import { ensureIndicatorTranslatedAction } from '@/entities/economy/actions';
+import { useIndicatorTranslationTrigger } from '../useIndicatorTranslationTrigger';
+
+const ev = (event: string): EconomicCalendarEvent => ({
+    date: '2026-06-13 08:30:00',
+    event,
+    impact: 'High',
+    actual: null,
+    estimate: 1,
+    previous: 1,
+    unit: '%',
+});
+
+interface ProbeProps {
+    events: readonly EconomicCalendarEvent[];
+    labels: Record<string, string>;
+}
+
+function Probe({ events, labels }: ProbeProps) {
+    useIndicatorTranslationTrigger(events, labels);
+    return null;
+}
+
+describe('useIndicatorTranslationTrigger', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(ensureIndicatorTranslatedAction).mockResolvedValue(undefined);
+    });
+
+    it('fires once per distinct unresolved base on mount', () => {
+        const events = [
+            ev('Totally Unknown Thing (Apr)'),
+            ev('Another Mystery Index (May)'),
+        ];
+        render(<Probe events={events} labels={{}} />);
+        expect(ensureIndicatorTranslatedAction).toHaveBeenCalledTimes(2);
+        expect(ensureIndicatorTranslatedAction).toHaveBeenCalledWith(
+            'Totally Unknown Thing'
+        );
+        expect(ensureIndicatorTranslatedAction).toHaveBeenCalledWith(
+            'Another Mystery Index'
+        );
+    });
+
+    it('dedupes multiple month variants of the same base into one call', () => {
+        const events = [
+            ev('Totally Unknown Thing (Apr)'),
+            ev('Totally Unknown Thing (May)'),
+        ];
+        render(<Probe events={events} labels={{}} />);
+        expect(ensureIndicatorTranslatedAction).toHaveBeenCalledTimes(1);
+        expect(ensureIndicatorTranslatedAction).toHaveBeenCalledWith(
+            'Totally Unknown Thing'
+        );
+    });
+
+    it('does NOT call ensure for a name already resolved in labels', () => {
+        const events = [ev('Some Obscure Index YoY (May)')];
+        const labels = { 'Some Obscure Index YoY (May)': '어떤 지수 (5월)' };
+        render(<Probe events={events} labels={labels} />);
+        expect(ensureIndicatorTranslatedAction).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call ensure for a dict-known name even when labels is empty', () => {
+        // 'Nonfarm Payrolls' is in INDICATOR_NAME_KO — server resolved it;
+        // if labels is empty (edge case), we still skip it because it's dict-covered.
+        const events = [ev('Nonfarm Payrolls')];
+        render(<Probe events={events} labels={{}} />);
+        expect(ensureIndicatorTranslatedAction).not.toHaveBeenCalled();
+    });
+
+    it('does not re-fire on re-render', () => {
+        const events = [ev('Totally Unknown Thing')];
+        const { rerender } = render(<Probe events={events} labels={{}} />);
+        rerender(<Probe events={events} labels={{}} />);
+        expect(ensureIndicatorTranslatedAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('swallows a rejected action without throwing', () => {
+        vi.mocked(ensureIndicatorTranslatedAction).mockRejectedValue(
+            new Error('boom')
+        );
+        const events = [ev('Totally Unknown Thing')];
+        expect(() =>
+            render(<Probe events={events} labels={{}} />)
+        ).not.toThrow();
+    });
+
+    it('does nothing when all events are resolved in labels', () => {
+        const events = [ev('Totally Unknown Thing (Apr)')];
+        const labels = { 'Totally Unknown Thing (Apr)': '알 수 없는 것 (4월)' };
+        render(<Probe events={events} labels={labels} />);
+        expect(ensureIndicatorTranslatedAction).not.toHaveBeenCalled();
+    });
+
+    it('handles empty events array without error', () => {
+        render(<Probe events={[]} labels={{}} />);
+        expect(ensureIndicatorTranslatedAction).not.toHaveBeenCalled();
+    });
+});

--- a/src/widgets/economy/hooks/useIndicatorTranslationTrigger.ts
+++ b/src/widgets/economy/hooks/useIndicatorTranslationTrigger.ts
@@ -4,10 +4,7 @@ import { useEffect, useEffectEvent, useRef } from 'react';
 import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
 
 import { ensureIndicatorTranslatedAction } from '@/entities/economy/actions';
-import {
-    INDICATOR_NAME_KO,
-    normalizeIndicatorName,
-} from '@/entities/economy/lib/indicatorNameKo';
+import { INDICATOR_NAME_KO, normalizeIndicatorName } from '@/entities/economy';
 
 /**
  * 마운트 시 1회: 서버 render(`resolveIndicatorLabels`)에서 dict·DB 캐시 양쪽 모두 miss한

--- a/src/widgets/economy/hooks/useIndicatorTranslationTrigger.ts
+++ b/src/widgets/economy/hooks/useIndicatorTranslationTrigger.ts
@@ -28,15 +28,12 @@ export function useIndicatorTranslationTrigger(
     const triggeredRef = useRef(false);
 
     const triggerOnce = useEffectEvent((): void => {
-        const unresolvedBases = new Set<string>();
-        for (const ev of events) {
-            if (labels[ev.event] === undefined) {
-                const { base } = normalizeIndicatorName(ev.event);
-                if (!Object.hasOwn(INDICATOR_NAME_KO, base)) {
-                    unresolvedBases.add(base);
-                }
-            }
-        }
+        const unresolvedBases = new Set(
+            events
+                .filter(ev => labels[ev.event] === undefined)
+                .map(ev => normalizeIndicatorName(ev.event).base)
+                .filter(base => !Object.hasOwn(INDICATOR_NAME_KO, base))
+        );
 
         for (const base of unresolvedBases) {
             void ensureIndicatorTranslatedAction(base).catch((e: unknown) => {

--- a/src/widgets/economy/hooks/useIndicatorTranslationTrigger.ts
+++ b/src/widgets/economy/hooks/useIndicatorTranslationTrigger.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
+
+import { ensureIndicatorTranslatedAction } from '@/entities/economy/actions';
+import {
+    INDICATOR_NAME_KO,
+    normalizeIndicatorName,
+} from '@/entities/economy/lib/indicatorNameKo';
+
+/**
+ * 마운트 시 1회: 서버 render(`resolveIndicatorLabels`)에서 dict·DB 캐시 양쪽 모두 miss한
+ * 지표명에 대해 AI 번역을 fire-and-forget으로 트리거한다.
+ *
+ * 동작 원리:
+ * - `labels[event.event]`가 undefined인 raw 이름만 대상(dict or DB hit이면 이미 레이블 존재).
+ * - `normalizeIndicatorName`으로 base를 추출해 중복 제거(동월/분기 변형 대응).
+ * - 코드 사전(`INDICATOR_NAME_KO`)에 있는 base는 제외(영어 fallback이 렌더된 경우에도 dict
+ *   번역은 다음 렌더에서 자동 반영되므로 AI 호출 불필요).
+ * - `useEffectEvent`로 최신 props를 읽으면서 `useEffect` dep-array를 비움
+ *   (SP-A `useEconomicCalendarTrigger` 패턴 미러 — 훅은 마운트 1회만 실행).
+ *
+ * SP-A 패턴(`useEconomicCalendarTrigger`) 미러 — 렌더/prerender 스코프에서 고아 프로미스·
+ * `revalidateTag`를 실행하는 ISR 부작용을 클라이언트 훅으로 격리한다.
+ */
+export function useIndicatorTranslationTrigger(
+    events: readonly EconomicCalendarEvent[],
+    labels: Record<string, string>
+): void {
+    const triggeredRef = useRef(false);
+
+    const triggerOnce = useEffectEvent((): void => {
+        const unresolvedBases = new Set<string>();
+        for (const ev of events) {
+            if (labels[ev.event] === undefined) {
+                const { base } = normalizeIndicatorName(ev.event);
+                if (!Object.hasOwn(INDICATOR_NAME_KO, base)) {
+                    unresolvedBases.add(base);
+                }
+            }
+        }
+
+        for (const base of unresolvedBases) {
+            void ensureIndicatorTranslatedAction(base).catch((e: unknown) => {
+                console.error(
+                    '[useIndicatorTranslationTrigger] ensureIndicatorTranslatedAction failed:',
+                    e
+                );
+            });
+        }
+    });
+
+    useEffect(() => {
+        if (triggeredRef.current) return;
+        triggeredRef.current = true;
+        triggerOnce();
+    }, []);
+}

--- a/src/widgets/economy/sections/EconomicCalendarGrid.tsx
+++ b/src/widgets/economy/sections/EconomicCalendarGrid.tsx
@@ -173,12 +173,15 @@ function kstDayOfWeekLabel(dateKey: string): string {
 /**
  * raw 이벤트명을 표시 레이블로 매핑한다 — `labels`(서버가 resolveIndicatorLabels로 미리
  * 해결한 한국어 우선 맵)에 있으면 그 값을, 없으면 raw 영어 원문을 반환(결정론적 fallback).
+ *
+ * `Object.hasOwn`으로 direct-property 여부를 확인해 prototype-pollution 방지
+ * (rawEvent === "toString" 등이 Object.prototype 함수를 반환하는 크래시 차단).
  */
 function displayEventLabel(
     rawEvent: string,
     labels: Record<string, string>
 ): string {
-    return labels[rawEvent] ?? rawEvent;
+    return Object.hasOwn(labels, rawEvent) ? labels[rawEvent] : rawEvent;
 }
 
 interface DayDetailPanelProps {

--- a/src/widgets/economy/sections/EconomicCalendarGrid.tsx
+++ b/src/widgets/economy/sections/EconomicCalendarGrid.tsx
@@ -16,6 +16,7 @@ import { cn } from '@/shared/lib/cn';
 import { formatNum } from '@/shared/lib/formatNum';
 import { etDateTimeToKst } from '@/shared/lib/etTimeUtils';
 import { useEconomicCalendarTrigger } from '../hooks/useEconomicCalendarTrigger';
+import { useIndicatorTranslationTrigger } from '../hooks/useIndicatorTranslationTrigger';
 import { ImpactFilter } from './ImpactFilter';
 import { IMPACT_LABELS, IMPACT_ORDER } from '../utils/impactMeta';
 
@@ -542,6 +543,7 @@ export function EconomicCalendarGrid({
         ReadonlySet<CalendarImpact>
     >(() => new Set(DEFAULT_ACTIVE_IMPACTS));
     useEconomicCalendarTrigger();
+    useIndicatorTranslationTrigger(events, labels);
     const groups = useMemo(() => groupEventsByKstDay(events), [events]);
     const groupMap = useMemo(
         () => new Map<string, DayGroup>(groups.map(g => [g.dateKey, g])),

--- a/src/widgets/economy/sections/EconomicCalendarGrid.tsx
+++ b/src/widgets/economy/sections/EconomicCalendarGrid.tsx
@@ -169,16 +169,29 @@ function kstDayOfWeekLabel(dateKey: string): string {
     return WEEKDAY_LABELS[dayOfWeekFromKey(dateKey)];
 }
 
+/**
+ * raw 이벤트명을 표시 레이블로 매핑한다 — `labels`(서버가 resolveIndicatorLabels로 미리
+ * 해결한 한국어 우선 맵)에 있으면 그 값을, 없으면 raw 영어 원문을 반환(결정론적 fallback).
+ */
+function displayEventLabel(
+    rawEvent: string,
+    labels: Record<string, string>
+): string {
+    return labels[rawEvent] ?? rawEvent;
+}
+
 interface DayDetailPanelProps {
     group: DayGroup;
     isSelected: boolean;
     activeImpacts: ReadonlySet<CalendarImpact>;
+    labels: Record<string, string>;
 }
 
 function DayDetailPanel({
     group,
     isSelected,
     activeImpacts,
+    labels,
 }: DayDetailPanelProps) {
     const { month, day, dateKey } = group;
     const dowLabel = kstDayOfWeekLabel(dateKey);
@@ -225,7 +238,10 @@ function DayDetailPanel({
                                     </time>
                                 </div>
                                 <p className="text-secondary-100 text-sm font-medium">
-                                    {ev.original.event}
+                                    {displayEventLabel(
+                                        ev.original.event,
+                                        labels
+                                    )}
                                 </p>
                                 <p className="text-secondary-400 mt-0.5 text-xs">
                                     예상{' '}
@@ -271,9 +287,16 @@ interface DayCellProps {
     isSelected: boolean;
     activeImpacts: ReadonlySet<CalendarImpact>;
     onSelect: (dateKey: string) => void;
+    labels: Record<string, string>;
 }
 
-function DayCell({ group, isSelected, activeImpacts, onSelect }: DayCellProps) {
+function DayCell({
+    group,
+    isSelected,
+    activeImpacts,
+    onSelect,
+    labels,
+}: DayCellProps) {
     const { day, month, dateKey } = group;
 
     /**
@@ -350,7 +373,7 @@ function DayCell({ group, isSelected, activeImpacts, onSelect }: DayCellProps) {
                             className="text-secondary-400 block min-w-0 truncate text-[10px] leading-tight"
                         >
                             {ev.kstTimeLabel.replace(/^(오전|오후)\s*/, '')}{' '}
-                            {ev.original.event}
+                            {displayEventLabel(ev.original.event, labels)}
                         </span>
                     ))}
                     {count > INLINE_EVENT_MAX && (
@@ -372,6 +395,7 @@ interface MonthCalendarProps {
     selectedDateKey: string;
     activeImpacts: ReadonlySet<CalendarImpact>;
     onSelect: (dateKey: string) => void;
+    labels: Record<string, string>;
 }
 
 function MonthCalendar({
@@ -381,6 +405,7 @@ function MonthCalendar({
     selectedDateKey,
     activeImpacts,
     onSelect,
+    labels,
 }: MonthCalendarProps) {
     const weeks = useMemo(() => {
         const totalDays = daysInMonth(year, month);
@@ -444,6 +469,7 @@ function MonthCalendar({
                                         }
                                         activeImpacts={activeImpacts}
                                         onSelect={onSelect}
+                                        labels={labels}
                                     />
                                 ) : (
                                     <td
@@ -484,6 +510,11 @@ interface EconomicCalendarGridProps {
      * 생략 시 가장 이른 그룹을 기본 선택(기존 동작 유지).
      */
     today?: string;
+    /**
+     * raw 이벤트명 → 표시 레이블(한국어 우선) 맵. 서버 RSC가 `resolveIndicatorLabels`로
+     * 미리 해결해 주입한다. 생략 시 모든 이벤트가 영어 원문으로 표시된다(결정론적 fallback).
+     */
+    labels?: Record<string, string>;
 }
 
 /**
@@ -504,6 +535,7 @@ interface EconomicCalendarGridProps {
 export function EconomicCalendarGrid({
     events,
     today = '',
+    labels = {},
 }: EconomicCalendarGridProps) {
     const [selectedDateKey, setSelectedDateKey] = useState('');
     const [activeImpacts, setActiveImpacts] = useState<
@@ -589,6 +621,7 @@ export function EconomicCalendarGrid({
                         selectedDateKey={selectedDateKey}
                         activeImpacts={activeImpacts}
                         onSelect={setSelectedDateKey}
+                        labels={labels}
                     />
                 ))}
             </div>
@@ -604,6 +637,7 @@ export function EconomicCalendarGrid({
                         group={group}
                         isSelected={group.dateKey === selectedDateKey}
                         activeImpacts={activeImpacts}
+                        labels={labels}
                     />
                 ))}
             </div>

--- a/src/widgets/economy/sections/EconomicCalendarGrid.tsx
+++ b/src/widgets/economy/sections/EconomicCalendarGrid.tsx
@@ -171,9 +171,6 @@ function kstDayOfWeekLabel(dateKey: string): string {
 }
 
 /**
- * raw 이벤트명을 표시 레이블로 매핑한다 — `labels`(서버가 resolveIndicatorLabels로 미리
- * 해결한 한국어 우선 맵)에 있으면 그 값을, 없으면 raw 영어 원문을 반환(결정론적 fallback).
- *
  * `Object.hasOwn`으로 direct-property 여부를 확인해 prototype-pollution 방지
  * (rawEvent === "toString" 등이 Object.prototype 함수를 반환하는 크래시 차단).
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -3509,14 +3509,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@y0ngha/siglens-core@npm:0.24.0":
-  version: 0.24.0
-  resolution: "@y0ngha/siglens-core@npm:0.24.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.24.0%2F2d8d3045b7ff5da5a7f225ad14d6f1e85d9e9fcb"
+"@y0ngha/siglens-core@npm:0.25.0":
+  version: 0.25.0
+  resolution: "@y0ngha/siglens-core@npm:0.25.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.25.0%2F21254ad965b45575e3b60ef46509b651ef9768d3"
   dependencies:
     jsonrepair: "npm:^3.14.0"
   peerDependencies:
     "@upstash/redis": ^1.37.0
-  checksum: 10c0/008f375455ae8c7a152253c609a350b896c04ee02edf8db81aa98579f74db206782f578d9f4d0b6ebdc1298be318f5599bb436a8c711bda4cbab149752f2677d
+  checksum: 10c0/cf049720eaeb35b440ac623231b7cb490409ebfdb88c3a373c5d1c366fe985256e3c31fb0a70c23c2aa1d86c8cb2cccdd0751e3bcae8445420094d8b6aa0de96
   languageName: node
   linkType: hard
 
@@ -10829,7 +10829,7 @@ __metadata:
     "@vercel/analytics": "npm:^2.0.1"
     "@vercel/functions": "npm:^3.4.3"
     "@vitest/coverage-v8": "npm:^4.1.7"
-    "@y0ngha/siglens-core": "npm:0.24.0"
+    "@y0ngha/siglens-core": "npm:0.25.0"
     babel-plugin-react-compiler: "npm:^1.0.0"
     bcryptjs: "npm:^3.0.3"
     clsx: "npm:^2.1.1"


### PR DESCRIPTION
## SP-B: 지표명 한국어화 (4-SP 이터레이션 #3)

경제 캘린더 영어 지표명을 한국어로 표시한다. 코드 사전(source-of-truth) + DB 캐시(AI 번역) 하이브리드, 미매핑만 AI 번역 후 캐시.

스펙: `docs/superpowers/specs/2026-06-20-economy-calendar-iteration-design.md` (SP-B)
플랜: `docs/superpowers/plans/2026-06-20-economy-calendar-SP-B-name-translation.md`

### 변경
- `entities/economy/lib/indicatorNameKo.ts`: `normalizeIndicatorName`(접미사 분리)+기간 한국어화(YoY→전년比 등)+`INDICATOR_NAME_KO` 시드 사전.
- `economic_indicator_translations` 테이블(마이그레이션 0019) + repository + per-name Redis pending flag.
- `ensureIndicatorTranslatedAction`: core **submit/poll**(`submitIndicatorTranslation`/`pollIndicatorTranslation`)로 미매핑 번역 → upsert(source:'ai') → revalidateTag.
- `resolveIndicatorLabels`: ISR-safe 순수 reader(dict+DB 캐시 → 레이블 맵). 번역 트리거는 **클라 마운트 훅** `useIndicatorTranslationTrigger`(렌더 부작용 격리).
- 그리드 `labels` prop 표시 + 영어 fallback.

### ⚠️ core 릴리스 의존 (머지 게이트)
이 PR은 siglens-core의 `submitIndicatorTranslation`/`pollIndicatorTranslation`(core PR #157, **머지됨**)을 사용한다. **CI는 core가 GitHub Packages에 publish되고 siglens 핀이 갱신되기 전까지 red**다(현재 로컬 오버레이로 개발·검증: tsc 0, build 0, 206 테스트). 코드 리뷰는 진행 가능. publish + 핀 갱신 후 CI green → 머지.

### 검증 (로컬)
- tsc 0 · lint 0 · build 0 · `/economy` static · DSU 0 · 206 economy 테스트.
- Opus 4.8 2단계 리뷰: spec COMPLIANT + 품질(렌더 부작용→클라 트리거 이동·empty-done 테스트·dict 타입) 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)