### PR TITLE
fix(economy): 경제 캘린더 이터레이션 배포 전 감사 + 실증 후속 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,8 @@ next-env.d.ts
 !/scripts/backfillEconomicCalendar.ts
 # SP-D: one-time AI analysis seed script (user runs after SP-A backfill).
 !/scripts/seedEconomicEventAnalysis.ts
+# One-time Gemini Batch API calendar-analysis seed script.
+!/scripts/seedCalendarAnalysisBatch.ts
 !/scripts/lib/
 !/scripts/lib/**
 

--- a/docs/qa/sheets/2026-06-20-economy-calendar-iteration-test-cases.md
+++ b/docs/qa/sheets/2026-06-20-economy-calendar-iteration-test-cases.md
@@ -1,0 +1,290 @@
+# Economy Calendar Iteration — QA Test-Case Sheet (배포 전 실증)
+
+> 대상: `/economy` 경제 캘린더 반복 작업 (SP-A ~ SP-D, `feat/economy-calendar-audit-fix`)
+> 작성일: 2026-06-20
+> 목적: **수동 실증 QA** (curl + Chrome). E2E/단위 테스트가 커버하더라도 prod-like 빌드/실행에서 동작·SEO를 두 트랙으로 검증한다.
+> 가정: dev/prod 서버가 `http://localhost:4200`에서 기동. curl 예시의 `BASE`는 `http://localhost:4200`.
+
+---
+
+## 0. 실행 전 준비 (Preconditions — 모든 케이스 공통)
+
+- prod-like 빌드: `yarn build > /tmp/build.log 2>&1; echo $?` 로 exit code 직접 캡처 (파이프 금지). exit 0 확인.
+- 워크트리 `node_modules`는 symlink 금지 (`cp -al` 하드링크 또는 독립 `yarn install`). `siglens-core` 0.25.0 핀 일치 확인.
+- `.env.local` / `.env.production` 키셋이 형제 워크트리와 일치 (QA env 스왑 복원 누락 주의).
+- 서버 기동: `yarn build` → `yarn start`(prod 모드) 또는 `yarn dev`.
+- **AI 분석 모드 주의**:
+  - prod-like(`E2E_TEST` 미설정): AI 분석은 실제 LLM/worker 거침. 캘린더 sentiment는 DB에 저장된 기분석 값.
+  - `E2E_TEST=1` 빌드: `FakeEconomyProvider` 사용. 캘린더는 시드된 데이터(감사 후속 e2e 시드)에서 읽힘.
+- 환경 변수 참고: `NEXT_PUBLIC_SITE_URL` 미설정 시 SEO URL은 `https://siglens.io` 기본값 → 로컬 메타의 canonical/og:url은 `https://siglens.io/...`로 박힘(정상). 경로 구조만 검증한다.
+
+### 참고 상수 (검증 기준값)
+
+| 항목 | 값 |
+|---|---|
+| `revalidate` (page) | `86400` (24h) |
+| `PAST_WINDOW_DAYS` | `14` |
+| `FUTURE_WINDOW_DAYS` | `14` |
+| 기본 필터 | High + Medium ON, Low OFF |
+| `INLINE_EVENT_MAX` | `2` (셀에 인라인 미리보기 최대 2건) |
+| `CALENDAR_ANALYZED_IMPACTS` | `['High', 'Medium']` (분석 대상 임팩트) |
+| sentiment 한국어 레이블 | `bullish` → 긍정, `neutral` → 중립, `bearish` → 부정 |
+| degrade 복사본 | `미국 거시 경제 데이터를 불러오지 못했어요` |
+| degrade noindex | `generateMetadata → robots: noindex` |
+| AI 모드 prod | 실제 LLM/worker (`E2E_TEST` 미설정) |
+| AI 모드 E2E | `FakeEconomyProvider` + 시드 DB (`E2E_TEST=1`) |
+
+---
+
+## A. CURL 트랙 (응답값 / Status Code)
+
+### TC-C01 — 페이지 정상 렌더 (200 + SSR 텍스트)
+- **ID**: TC-C01 · **Track**: curl · **Priority**: P0
+- **Title**: `GET /economy` 200 + h1·지표·캘린더 SSR 텍스트
+- **Preconditions**: 서버 기동
+- **Steps**:
+  ```bash
+  curl -s -o /tmp/economy.html -w "%{http_code}\n" "$BASE/economy"
+  grep -o "미국 경제 — 지표·캘린더 한눈에" /tmp/economy.html | head -1
+  grep -o "경제 캘린더" /tmp/economy.html | head -1
+  grep -o "경제지표" /tmp/economy.html | head -1
+  ```
+- **Expected**: HTTP 200. HTML에 h1 `미국 경제 — 지표·캘린더 한눈에`, `경제지표`, `경제 캘린더` 포함.
+
+### TC-C02 — 과거 + 미래 이벤트가 SSR HTML에 존재 (크롤러 색인)
+- **ID**: TC-C02 · **Track**: curl · **Priority**: P0
+- **Title**: ±14d 윈도 내 이벤트가 SSR HTML에 박힘 — JS 없이도 검색 엔진이 색인 가능
+- **Preconditions**: TC-C01 통과
+- **Steps**:
+  ```bash
+  # 기존 시드 이벤트 — 항상 존재
+  grep -o "Fed Rate Decision" /tmp/economy.html | head -1
+  # SP-B 시드 이벤트 — INDICATOR_NAME_KO 매핑 결과 (한국어 레이블)
+  grep -o "비농업 고용" /tmp/economy.html | head -1
+  # SP-D 시드 이벤트 sentiment 배지
+  grep -o "긍정" /tmp/economy.html | head -1
+  # SP-D summaryKo
+  grep -o "비농업 고용이 예상치를 크게 상회해" /tmp/economy.html | head -1
+  ```
+- **Expected**: 4개 패턴 모두 1건 이상 매칭. DayDetailPanel은 `hidden` 속성으로 비선택 패널도 DOM에 항상 존재하므로 크롤러가 전체 이벤트 텍스트를 색인할 수 있다.
+
+### TC-C03 — SP-B 한국어 레이블 SSR (dict 매핑)
+- **ID**: TC-C03 · **Track**: curl · **Priority**: P0
+- **Title**: `INDICATOR_NAME_KO` 사전 등재 지표명이 한국어로 변환돼 SSR HTML에 포함
+- **Preconditions**: 시드 이벤트 `Nonfarm Payrolls` 존재 (E2E DB 또는 prod FMP 데이터)
+- **Steps**:
+  ```bash
+  grep -c "비농업 고용" /tmp/economy.html   # 1 이상 기대
+  grep -c "Nonfarm Payrolls" /tmp/economy.html  # 영어 원문도 존재할 수 있음(event 필드 raw)
+  ```
+- **Expected**: `비농업 고용` 1건 이상. `INDICATOR_NAME_KO['Nonfarm Payrolls']` = `비농업 고용`이 서버 `resolveIndicatorLabels`에서 합성됐음을 확인. 영어 원문은 dict miss fallback이 아님을 뜻하므로 `비농업 고용` 존재가 핵심.
+
+### TC-C04 — SP-D sentiment 배지 + summaryKo SSR
+- **ID**: TC-C04 · **Track**: curl · **Priority**: P0
+- **Title**: 분석된 이벤트의 sentiment 배지(긍정)와 summaryKo가 SSR HTML에 포함
+- **Preconditions**: 시드 이벤트 `Nonfarm Payrolls` sentiment=bullish 존재
+- **Steps**:
+  ```bash
+  grep -o "긍정" /tmp/economy.html | head -1
+  grep -o "비농업 고용이 예상치를 크게 상회해 노동시장 강세를 확인했습니다" /tmp/economy.html | head -1
+  grep -o "고용 호조는 연준의 금리 인하 속도를 늦출 수 있어 달러 강세 요인입니다" /tmp/economy.html | head -1
+  ```
+- **Expected**: 3개 패턴 모두 1건 이상 매칭. `SENTIMENT_LABEL['bullish']` = `긍정`. summaryKo + interpretationKo가 DayDetailPanel 안에 박힘(hidden 패널 포함).
+
+### TC-C05 — JSON-LD 4종 (WebSite + 3 콘텐츠 타입)
+- **ID**: TC-C05 · **Track**: curl · **Priority**: P0
+- **Title**: `<script type="application/ld+json">` 4개 존재 + valid JSON
+- **Preconditions**: TC-C01 통과
+- **Steps**:
+  ```bash
+  curl -s "$BASE/economy" \
+    | grep -o '"@type":"[^"]*"' | sort -u
+  # 기대 타입: WebSite, WebPage, BreadcrumbList, FAQPage
+  ```
+- **Expected**: `@type` 값에 `WebSite`, `WebPage`, `BreadcrumbList`, `FAQPage` 포함. 각 블록이 valid JSON (jq 파싱 통과). BreadcrumbList 첫 item=`Siglens`(position 1). FAQPage `mainEntity`에 경제 관련 Question 존재.
+
+### TC-C06 — canonical / OG / twitter 메타
+- **ID**: TC-C06 · **Track**: curl · **Priority**: P0
+- **Title**: canonical·og:title·og:url·twitter card 정합
+- **Preconditions**: 없음
+- **Steps**:
+  ```bash
+  curl -s "$BASE/economy" \
+    | grep -o '<link rel="canonical"[^>]*>\|og:title[^>]*>\|og:url[^>]*>\|twitter:card[^>]*>'
+  ```
+- **Expected**: canonical = `${SITE_URL}/economy`. og:title 포함 `미국 경제`. og:url = canonical. og:locale=ko_KR, og:siteName=Siglens. twitter:card=`summary_large_image`.
+
+### TC-C07 — degrade noindex (E2E_ECONOMY_FORCE_EMPTY)
+- **ID**: TC-C07 · **Track**: curl · **Priority**: P1
+- **Title**: `E2E_ECONOMY_FORCE_EMPTY=1` 빌드에서 메타 noindex + degrade 복사본 존재
+- **Preconditions**: `E2E_TEST=1 E2E_ECONOMY_FORCE_EMPTY=1 yarn build && yarn start -p 4300` 별도 기동
+- **Steps**:
+  ```bash
+  curl -s "$BASE/economy" | grep -o "noindex"
+  curl -s "$BASE/economy" | grep -o "미국 거시 경제 데이터를 불러오지 못했어요"
+  ```
+- **Expected**: `noindex` 존재. degrade 복사본 존재. 정상 섹션(`경제지표`) 미존재(null 스냅샷).
+
+### TC-C08 — ISR cold-gen 안정성
+- **ID**: TC-C08 · **Track**: curl · **Priority**: P0
+- **Title**: 미캐시 첫 요청에서 500/DYNAMIC_SERVER_USAGE 없음
+- **Preconditions**: `yarn start`(prod 모드), 빌드 직후 첫 방문.
+- **Steps**:
+  ```bash
+  curl -s -o /dev/null -w "%{http_code}\n" "$BASE/economy"
+  grep -i "DYNAMIC_SERVER_USAGE\|connection()" /tmp/build.log || echo "OK"
+  ```
+- **Expected**: 첫 요청 200. 서버 로그 DYNAMIC_SERVER_USAGE 0건. `connection()` 호출 없음(`/economy`는 동적 API 미사용).
+
+### TC-C09 — 봇 UA → 페이지 200, AI 분석 미트리거
+- **ID**: TC-C09 · **Track**: curl · **Priority**: P0
+- **Title**: AI 봇 User-Agent로 /economy 요청 시 200 + SSR 정상
+- **Preconditions**: prod-like 서버
+- **Steps**:
+  ```bash
+  curl -s -o /dev/null -w "%{http_code}\n" -H "User-Agent: GPTBot/1.0" "$BASE/economy"
+  curl -s -o /dev/null -w "%{http_code}\n" -H "User-Agent: ClaudeBot/1.0" "$BASE/economy"
+  ```
+- **Expected**: 둘 다 200. 지표 그리드·캘린더는 SSR이라 봇 UA 무관 정상 렌더. MacroBriefing은 클라 트리거라 SSR HTML에는 skeleton만(봇 차단 복사본은 Chrome TC-B 계열에서 확인).
+
+---
+
+## B. CHROME 트랙 (시각 / 상호작용)
+
+> 공통: DevTools Console + Network 탭 열고 시작. 각 케이스 종료 시 콘솔 에러 0 확인(TC-B09).
+
+### TC-B01 — 캘린더 그리드 렌더 (기본 상태)
+- **ID**: TC-B01 · **Track**: chrome · **Priority**: P0
+- **Title**: 캘린더 섹션이 렌더되고 High+Medium 이벤트가 표시됨
+- **Preconditions**: `$BASE/economy` 방문
+- **Steps**:
+  1. 페이지 진입.
+  2. `경제 캘린더` h2 확인.
+  3. 필터 칩 그룹(`aria-label="중요도 필터"`)에서 높음·보통 `aria-pressed=true`, 낮음 `aria-pressed=false` 확인.
+  4. 그리드 셀에 이벤트 점 + 건수가 표시되는지 확인.
+- **Expected**: h2 `경제 캘린더`(한국시간) 가시. 필터 칩 기본 상태 High+Med ON, Low OFF. 셀에 색상 점(빨강=High, 노랑=Med) + 건수 표시.
+
+### TC-B02 — SP-B 한국어 레이블 + 영어 fallback
+- **ID**: TC-B02 · **Track**: chrome · **Priority**: P0
+- **Title**: INDICATOR_NAME_KO 등재 이벤트는 한국어, 미등재는 영어 원문 표시
+- **Preconditions**: TC-B01 상태
+- **Steps**:
+  1. 'Nonfarm Payrolls' 이벤트가 있는 날짜 셀 클릭.
+  2. 상세 패널에서 `비농업 고용` 텍스트 확인.
+  3. INDICATOR_NAME_KO에 없는 이벤트 날짜 클릭 → 영어 원문 그대로 표시 확인.
+- **Expected**: 사전 등재(`Nonfarm Payrolls`) → `비농업 고용`. 미등재 이벤트 → 영어 원문 그대로. 혼용 없음.
+
+### TC-B03 — SP-B 375px truncation (모바일)
+- **ID**: TC-B03 · **Track**: chrome · **Priority**: P1
+- **Title**: 모바일 375px에서 긴 한국어 레이블이 셀 인라인 미리보기에서 잘림 처리됨
+- **Preconditions**: DevTools device toolbar 375px
+- **Steps**:
+  1. 375px 설정 후 `$BASE/economy` 방문.
+  2. 인라인 미리보기 텍스트(`INLINE_EVENT_MAX=2`)가 셀 너비에서 overflow 없이 표시되는지 확인.
+  3. `document.documentElement.scrollWidth - clientWidth > 0` 평가.
+- **Expected**: 가로 overflow 0 (body 좌우 스크롤 없음). 긴 레이블은 ellipsis 또는 줄바꿈으로 처리. 셀이 뷰포트를 벗어나지 않음.
+
+### TC-B04 — SP-C 중요도 필터 토글
+- **ID**: TC-B04 · **Track**: chrome · **Priority**: P0 ★ 필수
+- **Title**: 낮음 칩 토글 ON/OFF 시 Low 이벤트 표시/숨김 전환
+- **Preconditions**: TC-B01 상태
+- **Steps**:
+  1. 필터 그룹에서 `낮음` 버튼 확인(`aria-pressed=false`).
+  2. `낮음` 클릭 → `aria-pressed=true` 전환 확인.
+  3. 시드의 Low 이벤트(`MBA Mortgage Applications`)가 있는 today+2 날짜 셀 클릭.
+  4. 상세 패널에 `MBA Mortgage Applications` 행이 가시화(`hidden` 속성 제거) 확인.
+  5. 다시 `낮음` 클릭 → `aria-pressed=false`, 해당 `<li hidden>` 복귀 확인.
+- **Expected**: 낮음 칩 토글마다 aria-pressed 상태 변경. 상세 패널 `<li>` 요소의 `hidden` 속성이 activeImpacts 상태에 연동. 셀 건수도 Low 포함/제외에 따라 변경.
+
+### TC-B05 — SP-C 필터 색상 (High/Med/Low 시각 차별화)
+- **ID**: TC-B05 · **Track**: chrome · **Priority**: P1
+- **Title**: 임팩트 칩 색상이 스펙과 일치 (High=빨강계, Med=노랑계, Low=회색계)
+- **Preconditions**: TC-B04 상태 (낮음 ON 포함)
+- **Steps**:
+  1. `높음` 칩 배경/텍스트 색상 확인.
+  2. `보통` 칩 색상 확인.
+  3. `낮음` 칩(ON 상태) 색상 확인.
+  4. 셀 임팩트 점 색상 확인.
+- **Expected**: 높음=`bg-ui-danger/15 text-ui-danger-text`, 보통=`bg-ui-warning/15 text-ui-warning-text`, 낮음=`bg-secondary-700 text-secondary-200`. 셀 점: High=빨강(`bg-ui-danger`), Med=노랑(`bg-ui-warning`), Low=회색(`bg-secondary-500`).
+
+### TC-B06 — SP-D sentiment 배지 + summaryKo (상세 패널)
+- **ID**: TC-B06 · **Track**: chrome · **Priority**: P0 ★ 필수
+- **Title**: 분석 이벤트 날짜 선택 시 sentiment 배지·summaryKo·interpretationKo 표시
+- **Preconditions**: `$BASE/economy` 방문, `Nonfarm Payrolls` 이벤트 날짜 선택
+- **Steps**:
+  1. 'Nonfarm Payrolls' 이벤트가 있는 날짜 셀 클릭.
+  2. 상세 패널에서 sentiment 배지 텍스트 확인.
+  3. summaryKo 텍스트 확인.
+  4. interpretationKo 텍스트 확인.
+  5. 배지 배경색 확인(bullish = 초록계).
+- **Expected**: 배지 `긍정`(`SENTIMENT_LABEL['bullish']`). summaryKo `비농업 고용이 예상치를 크게 상회해 노동시장 강세를 확인했습니다.` 표시. interpretationKo `고용 호조는 연준의 금리 인하 속도를 늦출 수 있어 달러 강세 요인입니다.` 표시. 배지 색상 `bg-ui-success/10 text-ui-success-text`(AA contrast 통과).
+
+### TC-B07 — SP-D AA 대비 (sentiment 배지)
+- **ID**: TC-B07 · **Track**: chrome · **Priority**: P1
+- **Title**: sentiment 배지 텍스트 대비율 AA 기준(4.5:1) 통과
+- **Preconditions**: TC-B06 상태
+- **Steps**:
+  DevTools → Inspect → Computed → 배지 `color`/`background-color` 값 추출 후 대비율 계산. 또는 Accessibility tab에서 `긍정` 텍스트의 contrast ratio 확인.
+- **Expected**: bullish 배지(`text-ui-success-text` on `bg-ui-success/10`) 대비율 ≥ 4.5:1. neutral·bearish 배지도 동일 기준 통과.
+
+### TC-B08 — 날짜 선택 → 상세 패널 전환 (aria 정합)
+- **ID**: TC-B08 · **Track**: chrome · **Priority**: P0 ★ 필수
+- **Title**: 날짜 셀 클릭 시 해당 패널만 표시, 이전 선택 패널 hidden 복귀
+- **Preconditions**: TC-B01 상태
+- **Steps**:
+  1. 날짜 A 셀 클릭 → 패널 A `hidden` 제거 + `aria-pressed=true` 확인.
+  2. 날짜 B 셀 클릭 → 패널 B 표시 + 패널 A 다시 `hidden` 확인.
+  3. 날짜 B 셀 재클릭(토글 OFF) → 패널 B `hidden` 복귀 + `aria-pressed=false` 확인.
+- **Expected**: 단일 선택 토글. 패널 aria-labelledby가 대응 버튼 id와 일치. 상세 패널 전환에 manual sleep 없이 Playwright auto-wait 동작.
+
+### TC-B09 — 콘솔 에러/경고 0
+- **ID**: TC-B09 · **Track**: chrome · **Priority**: P0
+- **Title**: 런타임 콘솔 에러/경고 0 (의도된 warn 제외)
+- **Preconditions**: 위 Chrome 케이스 전체 수행 중 Console 모니터
+- **Steps**: Console 탭 열고 TC-B01~B08 수행. 완료 후 확인.
+- **Expected**: React hydration mismatch, key 경고, uncaught error 0건. 허용 warn: `[useIndicatorTranslationTrigger] ...` (AI 번역 트리거) 정도. 그 외 에러/경고 없음.
+
+### TC-B10 — Safari/WebKit 호환
+- **ID**: TC-B10 · **Track**: chrome · **Priority**: P1
+- **Title**: Safari(WebKit)에서 필터 토글·날짜 선택·sentiment 배지 정상
+- **Preconditions**: Safari 또는 Playwright WebKit 프로젝트
+- **Steps**: TC-B04(필터 토글) + TC-B06(sentiment) + TC-B08(날짜 선택) Safari에서 반복.
+- **Expected**: 동일 동작. iOS Safari 특유의 `fixed` overflow 버그 없음. Radix aria-hidden 시트 이슈 없음.
+
+### TC-B11 — 375px 가로 오버플로 없음
+- **ID**: TC-B11 · **Track**: chrome · **Priority**: P0
+- **Title**: 모바일 375px에서 /economy 가로 스크롤 없음
+- **Preconditions**: DevTools 375px × 667px
+- **Steps**:
+  ```js
+  document.documentElement.scrollWidth - document.documentElement.clientWidth
+  ```
+  → 0 이하여야 함.
+- **Expected**: 오버플로 0px. 캘린더 그리드 테이블이 375px 안에서 줄바꿈/스크롤 처리.
+
+---
+
+## C. 안정성 / 회귀 매핑
+
+| Spec ID | 설명 | 커버하는 Test Case |
+|---|---|---|
+| SP-A | DB 기반 캘린더(now-relative 시드) 회귀 픽스 | TC-C01, TC-C02, TC-C08 |
+| SP-B | 한국어 레이블(dict 매핑) | TC-C03, TC-B02, TC-B03 |
+| SP-C | 중요도 필터(High/Med/Low 토글) | TC-B04, TC-B05 |
+| SP-D | AI sentiment 배지 + 요약 | TC-C04, TC-B06, TC-B07 |
+| 기존 | ISR cold-gen DSU=0 | TC-C08 |
+| 기존 | 봇 UA 200 + SSR 정상 | TC-C09 |
+| 기존 | degrade noindex | TC-C07 |
+
+---
+
+## D. 합격 기준 (Exit Criteria)
+
+- Curl TC-C01~C09 전부 PASS.
+- Chrome TC-B01~B11 전부 PASS.
+- prod build exit 0, 런타임 콘솔 에러 0 (TC-B09).
+- ISR cold-gen 500 0건 (TC-C08).
+- ★ 필수 3종 PASS:
+  - **TC-B04** SP-C: 낮음 칩 토글 — Low 이벤트 표시/숨김 전환
+  - **TC-B06** SP-D: 날짜 선택 후 sentiment 배지(`긍정`) + summaryKo 표시
+  - **TC-B08** SP-B: 날짜 선택 → `비농업 고용` 한국어 레이블 상세 패널 표시

--- a/e2e/setup/seed.ts
+++ b/e2e/setup/seed.ts
@@ -181,6 +181,13 @@ async function seed(): Promise<void> {
     const todayMinus1 = addEtDays(todayEt, -1);
     const todayPlus1 = addEtDays(todayEt, 1);
 
+    // todayMinus2: ±14d 윈도 내에 있고 과거 날짜이므로 actual 채움이 자연스럽다.
+    // 분석 결과(sentiment/summaryKo/interpretationKo/analyzedAt)를 포함해
+    // SP-B(한국어 레이블)·SP-C(필터)·SP-D(sentiment 배지) e2e 검증에 사용된다.
+    const todayMinus2 = addEtDays(todayEt, -2);
+    // Low impact 이벤트 — 기본 필터(High+Med) OFF 상태. 낮음 칩 토글 테스트에 사용.
+    const todayPlus2 = addEtDays(todayEt, 2);
+
     const calendarRows = [
         {
             id: economicCalendarId(
@@ -222,6 +229,56 @@ async function seed(): Promise<void> {
             previous: 229000,
             actual: null,
             unit: '',
+        },
+        /**
+         * SP-B / SP-D e2e 앵커 이벤트 — INDICATOR_NAME_KO에 등재된 'Nonfarm Payrolls'
+         * (→ 비농업 고용)를 사용해 서버 한국어 레이블 해석을 검증한다.
+         * actual/sentiment/summaryKo/interpretationKo/analyzedAt를 모두 채워
+         * 분석 배지·요약이 SSR HTML에 박히는 것을 확인한다.
+         *
+         * today-2는 발표 완료 시점(과거)이므로 actual을 자연스럽게 채울 수 있고,
+         * PAST_WINDOW_DAYS(14일) 이내라 getCalendarFromDb 쿼리에 반드시 포함된다.
+         */
+        {
+            id: economicCalendarId(
+                'US',
+                `${todayMinus2} 12:30:00`,
+                'Nonfarm Payrolls'
+            ),
+            country: 'US',
+            dateEt: `${todayMinus2} 12:30:00`,
+            event: 'Nonfarm Payrolls',
+            impact: 'High',
+            estimate: 185000,
+            previous: 177000,
+            actual: 203000,
+            unit: '',
+            sentiment: 'bullish',
+            summaryKo:
+                '비농업 고용이 예상치를 크게 상회해 노동시장 강세를 확인했습니다.',
+            interpretationKo:
+                '고용 호조는 연준의 금리 인하 속도를 늦출 수 있어 달러 강세 요인입니다.',
+            analyzedAt: new Date(),
+        },
+        /**
+         * SP-C 필터 테스트용 Low impact 이벤트 — 기본 필터(High+Med)에서 제외되므로
+         * '낮음' 칩 클릭 전후로 이 날짜 셀의 표시 건수가 달라지는 것을 검증한다.
+         * today+2는 미래(발표 예정)이므로 actual=null이 자연스럽다.
+         */
+        {
+            id: economicCalendarId(
+                'US',
+                `${todayPlus2} 10:00:00`,
+                'MBA Mortgage Applications'
+            ),
+            country: 'US',
+            dateEt: `${todayPlus2} 10:00:00`,
+            event: 'MBA Mortgage Applications',
+            impact: 'Low',
+            estimate: null,
+            previous: -1.2,
+            actual: null,
+            unit: '%',
         },
     ];
     await db

--- a/e2e/specs/economy.spec.ts
+++ b/e2e/specs/economy.spec.ts
@@ -230,6 +230,155 @@ test.describe('economy overview', () => {
 });
 
 /**
+ * SP-B / SP-D / SP-C — 시드 기반 캘린더 기능 검증.
+ *
+ * 시드 기여 이벤트:
+ *   - 'Nonfarm Payrolls' (today-2, High, actual=203000, sentiment='bullish',
+ *     summaryKo='비농업 고용이 예상치를 크게 상회해 노동시장 강세를 확인했습니다.',
+ *     interpretationKo='고용 호조는 연준의 금리 인하 속도를 늦출 수 있어 달러 강세 요인입니다.')
+ *     → SP-B(한국어 레이블 '비농업 고용') + SP-D(sentiment 배지 '긍정' + summaryKo) 검증.
+ *   - 'MBA Mortgage Applications' (today+2, Low impact)
+ *     → SP-C 필터 토글 검증(기본 OFF → 클릭 ON).
+ *
+ * 서버는 실제 wall-clock 기준으로 렌더하므로(브라우저 clock freeze 불필요),
+ * today±2 이벤트가 항상 ±14d 윈도 안에 포함된다.
+ */
+test.describe('economy calendar — SP-B/C/D feature coverage', () => {
+    /**
+     * SP-B: 한국어 레이블 SSR 검증.
+     *
+     * `page.request.get`은 JS 없는 크롤러 요청과 동일한 SSR HTML을 받는다.
+     * 시드의 'Nonfarm Payrolls' 이벤트가 서버의 INDICATOR_NAME_KO 사전으로
+     * '비농업 고용'으로 변환돼 HTML에 포함돼야 한다.
+     *
+     * EconomicCalendarGrid는 서버 컴포넌트에서 labels 맵을 resolve해 주입한다.
+     * all-hidden `<div hidden>` 패널도 DOM에 항상 유지되므로 크롤러가 읽을 수 있다.
+     */
+    test('SP-B: 한국어 레이블이 SSR HTML에 노출된다 (비농업 고용)', async ({
+        page,
+    }) => {
+        const res = await page.request.get('/economy');
+        expect(res.status()).toBe(200);
+        const html = await res.text();
+
+        // INDICATOR_NAME_KO['Nonfarm Payrolls'] = '비농업 고용'
+        expect(html).toContain('비농업 고용');
+    });
+
+    /**
+     * SP-D: sentiment 배지 + summaryKo SSR 검증.
+     *
+     * 시드의 'Nonfarm Payrolls' 이벤트(bullish)는 SSR 시점에 sentiment='bullish',
+     * summaryKo가 비어있지 않으므로 EconomicCalendarGrid의 DayDetailPanel이
+     * 배지('긍정') + summaryKo 텍스트를 모든 패널 DOM에 포함한다(hidden 포함).
+     *
+     * DayDetailPanel은 isSelected에 무관하게 항상 렌더돼 SSR HTML에 존재한다.
+     */
+    test('SP-D: sentiment 배지와 summaryKo가 SSR HTML에 포함된다', async ({
+        page,
+    }) => {
+        const res = await page.request.get('/economy');
+        expect(res.status()).toBe(200);
+        const html = await res.text();
+
+        // SENTIMENT_LABEL['bullish'] = '긍정'
+        expect(html).toContain('긍정');
+        // summaryKo 시드 텍스트
+        expect(html).toContain(
+            '비농업 고용이 예상치를 크게 상회해 노동시장 강세를 확인했습니다.'
+        );
+    });
+
+    /**
+     * SP-C: 중요도 필터 토글 — ImpactFilter 인터랙션.
+     *
+     * 기본 상태: High+Medium ON, Low OFF (DEFAULT_ACTIVE_IMPACTS).
+     * '낮음' 칩 클릭 후 aria-pressed=true로 전환되는 것을 검증한다.
+     *
+     * DayCell의 aria-label은 `${N}월 ${D}일, 이벤트 ${count}건`이며 count는
+     * activeImpacts 필터를 통과한 이벤트 수다. Low 이벤트가 있는 today+2 날짜의
+     * 버튼 aria-label에서 count 변화를 확인하는 대신, 필터 칩의 aria-pressed 상태
+     * 전환만 검증한다 — count는 동일 날짜에 다른 impact 이벤트가 없을 때만 0→1이므로
+     * 시드 구성에 결합도가 생기기 때문이다.
+     */
+    test('SP-C: 낮음 칩 토글 후 aria-pressed=true로 전환된다', async ({
+        page,
+    }) => {
+        await page.goto('/economy');
+
+        const filterGroup = page.getByRole('group', { name: '중요도 필터' });
+        await expect(filterGroup).toBeVisible();
+
+        const highBtn = filterGroup.getByRole('button', { name: '높음' });
+        const medBtn = filterGroup.getByRole('button', { name: '보통' });
+        const lowBtn = filterGroup.getByRole('button', { name: '낮음' });
+
+        // 기본 상태: High+Med ON, Low OFF
+        await expect(highBtn).toHaveAttribute('aria-pressed', 'true');
+        await expect(medBtn).toHaveAttribute('aria-pressed', 'true');
+        await expect(lowBtn).toHaveAttribute('aria-pressed', 'false');
+
+        // '낮음' 클릭 → ON
+        await lowBtn.click();
+        await expect(lowBtn).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    /**
+     * SP-B + SP-D: 날짜 선택 → 상세 패널 가시화 + 한국어 레이블·sentiment 배지 표시.
+     *
+     * DayCell 버튼 클릭 시 해당 날짜의 DayDetailPanel(hidden 해제)이 나타난다.
+     * 시드의 'Nonfarm Payrolls'(today-2, High) 날짜 셀을 클릭해 상세 패널이
+     * aria-pressed=true가 되는 것을 검증한다.
+     *
+     * DayDetailPanel은 항상 DOM에 존재하고(SSR visible), 셀 클릭 시 `hidden` 속성이
+     * 제거돼 Playwright의 toBeVisible()이 통과한다.
+     *
+     * 주의: aria-label은 `${N}월 ${D}일, 이벤트 ${count}건` 형태이므로 날짜를 특정하려면
+     * 정규식을 쓴다. 'Nonfarm Payrolls'(High)가 있는 날의 버튼이 최소 1건이어야 한다.
+     */
+    test('SP-D: 날짜 클릭 후 상세 패널에서 sentiment 배지와 summaryKo가 표시된다', async ({
+        page,
+    }) => {
+        await page.goto('/economy');
+
+        // Nonfarm Payrolls 이벤트가 있는 날짜 셀 — High impact이므로 기본 필터 ON에서
+        // 건수가 1 이상이다. 상세 패널의 '비농업 고용' 텍스트를 찾아 해당 패널 컨테이너를
+        // 특정한 뒤, 부모 섹션의 날짜 버튼을 클릭한다.
+        //
+        // DayDetailPanel은 항상 DOM에 존재하므로 패널 div의 id에서 dateKey를 추출하고
+        // 해당 dateKey를 가진 day-btn 버튼을 클릭한다.
+        //
+        // 구현: '비농업 고용' 텍스트가 있는 패널 div의 id(panel-{dateKey})를 파악하고
+        // 대응 버튼(id=day-btn-{dateKey})을 클릭한다.
+        const nonfarmPanel = page
+            .locator('div[id^="panel-"]')
+            .filter({ hasText: '비농업 고용' })
+            .first();
+
+        // 패널 id에서 dateKey 추출 → 버튼 id 구성
+        const panelId = await nonfarmPanel.getAttribute('id');
+        expect(panelId).not.toBeNull();
+        const dateKey = panelId!.replace('panel-', '');
+        const dayBtn = page.locator(`#day-btn-${dateKey}`);
+
+        await dayBtn.click();
+
+        // 클릭 후 패널 visible (hidden 속성 제거)
+        await expect(nonfarmPanel).toBeVisible();
+
+        // 상세 패널에 sentiment 배지 '긍정' + summaryKo가 표시된다
+        await expect(
+            nonfarmPanel.getByText('긍정', { exact: true })
+        ).toBeVisible();
+        await expect(
+            nonfarmPanel.getByText(
+                '비농업 고용이 예상치를 크게 상회해 노동시장 강세를 확인했습니다.'
+            )
+        ).toBeVisible();
+    });
+});
+
+/**
  * T3: EconomyDegraded degrade fallback — Tier 3 env-seam 패턴.
  *
  * `E2E_ECONOMY_FORCE_EMPTY=1`으로 빌드된 서버에서만 활성화된다.

--- a/e2e/specs/economy.spec.ts
+++ b/e2e/specs/economy.spec.ts
@@ -290,18 +290,17 @@ test.describe('economy calendar — SP-B/C/D feature coverage', () => {
     });
 
     /**
-     * SP-C: 중요도 필터 토글 — ImpactFilter 인터랙션.
+     * SP-C: 중요도 필터 토글 — ImpactFilter 인터랙션 + Low 이벤트 가시성 변화.
      *
      * 기본 상태: High+Medium ON, Low OFF (DEFAULT_ACTIVE_IMPACTS).
-     * '낮음' 칩 클릭 후 aria-pressed=true로 전환되는 것을 검증한다.
+     * '낮음' 칩 클릭 후 aria-pressed=true로 전환되고, 시드의 Low impact 이벤트
+     * 'MBA Mortgage Applications'(today+2)의 <li>가 visible해지는 것을 검증한다.
      *
-     * DayCell의 aria-label은 `${N}월 ${D}일, 이벤트 ${count}건`이며 count는
-     * activeImpacts 필터를 통과한 이벤트 수다. Low 이벤트가 있는 today+2 날짜의
-     * 버튼 aria-label에서 count 변화를 확인하는 대신, 필터 칩의 aria-pressed 상태
-     * 전환만 검증한다 — count는 동일 날짜에 다른 impact 이벤트가 없을 때만 0→1이므로
-     * 시드 구성에 결합도가 생기기 때문이다.
+     * Low 이벤트 <li>는 Low 필터 OFF(기본) 시 `hidden` 속성을 갖고,
+     * Low 필터 ON 시 `hidden`이 제거돼 visible해진다.
+     * today+2 날짜 패널을 먼저 클릭해 패널 자체의 `hidden`을 해제한 뒤 검증한다.
      */
-    test('SP-C: 낮음 칩 토글 후 aria-pressed=true로 전환된다', async ({
+    test('SP-C: 낮음 칩 토글 후 aria-pressed=true로 전환되고 Low 이벤트가 visible해진다', async ({
         page,
     }) => {
         await page.goto('/economy');
@@ -318,9 +317,33 @@ test.describe('economy calendar — SP-B/C/D feature coverage', () => {
         await expect(medBtn).toHaveAttribute('aria-pressed', 'true');
         await expect(lowBtn).toHaveAttribute('aria-pressed', 'false');
 
+        // Low 이벤트 패널(today+2)을 찾아 날짜 버튼을 클릭해 패널을 선택 상태로 만든다.
+        // DayDetailPanel은 항상 DOM에 존재하므로 panel id에서 dateKey를 추출한다.
+        const mbaMortgagePanel = page
+            .locator('div[id^="panel-"]')
+            .filter({ hasText: 'MBA Mortgage Applications' })
+            .first();
+        const mbaPanelId = await mbaMortgagePanel.getAttribute('id');
+        expect(mbaPanelId).not.toBeNull();
+        const mbaDateKey = mbaPanelId!.replace('panel-', '');
+        await page.locator(`#day-btn-${mbaDateKey}`).click();
+
+        // 패널이 선택됐으므로 패널 자체는 visible.
+        await expect(mbaMortgagePanel).toBeVisible();
+
+        // Low 이벤트 <li>는 Low 필터 OFF(기본) 시 hidden — 아직 클릭 전.
+        const mbaLi = mbaMortgagePanel
+            .locator('li')
+            .filter({ hasText: 'MBA Mortgage Applications' })
+            .first();
+        await expect(mbaLi).toBeHidden();
+
         // '낮음' 클릭 → ON
         await lowBtn.click();
         await expect(lowBtn).toHaveAttribute('aria-pressed', 'true');
+
+        // Low 이벤트 <li>가 이제 visible해야 한다.
+        await expect(mbaLi).toBeVisible();
     });
 
     /**
@@ -355,7 +378,6 @@ test.describe('economy calendar — SP-B/C/D feature coverage', () => {
             .filter({ hasText: '비농업 고용' })
             .first();
 
-        // 패널 id에서 dateKey 추출 → 버튼 id 구성
         const panelId = await nonfarmPanel.getAttribute('id');
         expect(panelId).not.toBeNull();
         const dateKey = panelId!.replace('panel-', '');

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "db:migrate:tickers": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seed-korean-tickers.ts",
         "db:backfill:calendar": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/backfillEconomicCalendar.ts",
         "db:seed:calendar-analysis": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seedEconomicEventAnalysis.ts",
+        "db:seed:calendar-analysis:batch": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seedCalendarAnalysisBatch.ts",
         "test": "NODE_OPTIONS=--no-experimental-webstorage vitest run",
         "test:quiet": "NODE_NO_WARNINGS=1 NODE_OPTIONS=--no-experimental-webstorage vitest run --reporter=dot",
         "test:related": "NODE_NO_WARNINGS=1 NODE_OPTIONS=--no-experimental-webstorage vitest related --run --passWithNoTests",

--- a/scripts/backfillEconomicCalendar.ts
+++ b/scripts/backfillEconomicCalendar.ts
@@ -71,9 +71,21 @@ async function run(): Promise<void> {
 
     const baseNames = new Set<string>();
     let upserted = 0;
+    let skipped = 0;
 
     for (const { from, to } of chunks) {
-        const events = await fetchCalendarChunk(from, to);
+        let events: EconomicCalendarEvent[];
+        try {
+            events = await fetchCalendarChunk(from, to);
+        } catch (error) {
+            // FMP 플랜이 커버하지 않는 과거 범위(HTTP 402) 또는 일시 오류인 청크는
+            // 건너뛰고 계속한다 — 커버되는 범위만이라도 채워 백필이 전체 중단되지 않게 한다.
+            console.warn(
+                `  ${from}..${to}: skipped — ${error instanceof Error ? error.message : String(error)}`
+            );
+            skipped += 1;
+            continue;
+        }
         console.log(`  ${from}..${to}: ${events.length} US events`);
         for (const event of events) {
             baseNames.add(normalizeIndicatorBaseName(event.event));
@@ -124,7 +136,7 @@ async function run(): Promise<void> {
     await writeFile(OUTPUT_FILE, `${JSON.stringify(sortedNames, null, 2)}\n`);
 
     console.log(
-        `Done — upserted ${upserted} event rows; dumped ${sortedNames.length} distinct base indicator names to ${OUTPUT_FILE}`
+        `Done — upserted ${upserted} event rows; ${skipped} chunk(s) skipped; dumped ${sortedNames.length} distinct base indicator names to ${OUTPUT_FILE}`
     );
     await client.end();
 }

--- a/scripts/seedCalendarAnalysisBatch.ts
+++ b/scripts/seedCalendarAnalysisBatch.ts
@@ -37,6 +37,7 @@ import type {
 import type { InlinedRequest, InlinedResponse } from '@google/genai';
 import { GoogleGenAI, JobState } from '@google/genai';
 
+import { CALENDAR_ANALYZED_IMPACTS } from '../src/entities/economy/lib/economyCalendarConstants';
 import { economicCalendar } from '../src/shared/db/schema';
 
 const databaseUrl = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
@@ -59,9 +60,6 @@ const GEMINI_MODEL = 'gemini-2.5-flash-lite';
 // well under the Gemini enqueue token limit (429 RESOURCE_EXHAUSTED) while
 // keeping the batch count low (~933 events → 4 batches).
 const CHUNK_SIZE = 300;
-
-// Medium+ impacts that get analyzed (mirrors core CALENDAR_ANALYZED_IMPACTS).
-const ANALYZED_IMPACTS: readonly CalendarImpact[] = ['High', 'Medium'];
 
 const POLL_INTERVAL_MS = 30_000;
 const MAX_POLL_MS = 2 * 60 * 60 * 1_000; // 2h
@@ -127,14 +125,8 @@ async function pollUntilComplete(
     if (!ai) throw new Error('Gemini client not initialized');
     const start = Date.now();
 
-    while (true) {
+    while (Date.now() - start <= MAX_POLL_MS) {
         const elapsed = Date.now() - start;
-        if (elapsed > MAX_POLL_MS) {
-            throw new Error(
-                `Timeout — exceeded ${formatElapsed(MAX_POLL_MS)} waiting for ${batchName}`
-            );
-        }
-
         const status = await ai.batches.get({ name: batchName });
         const state = status.state ?? 'UNKNOWN';
         console.log(
@@ -157,6 +149,9 @@ async function pollUntilComplete(
 
         await sleep(POLL_INTERVAL_MS);
     }
+    throw new Error(
+        `Timeout — exceeded ${formatElapsed(MAX_POLL_MS)} waiting for ${batchName}`
+    );
 }
 
 type Db = ReturnType<typeof drizzle>;
@@ -266,7 +261,7 @@ async function run(): Promise<void> {
         const db = drizzle(client);
 
         // Query pending events directly. impact is text in the DB; the WHERE
-        // clause restricts it to ANALYZED_IMPACTS, so the cast to CalendarImpact
+        // clause restricts it to CALENDAR_ANALYZED_IMPACTS, so the cast to CalendarImpact
         // at the boundary is sound.
         const rows = await db
             .select({
@@ -281,7 +276,9 @@ async function run(): Promise<void> {
             .from(economicCalendar)
             .where(
                 and(
-                    inArray(economicCalendar.impact, [...ANALYZED_IMPACTS]),
+                    inArray(economicCalendar.impact, [
+                        ...CALENDAR_ANALYZED_IMPACTS,
+                    ]),
                     isNotNull(economicCalendar.actual),
                     isNull(economicCalendar.analyzedAt)
                 )

--- a/scripts/seedCalendarAnalysisBatch.ts
+++ b/scripts/seedCalendarAnalysisBatch.ts
@@ -1,0 +1,385 @@
+/**
+ * ONE-OFF SEED script: analyze all Medium+ announced, unanalyzed
+ * `economic_calendar` rows via the Gemini Batch API and write the results back.
+ *
+ * Unlike `seedEconomicEventAnalysis.ts` (which drives the core
+ * submit/poll worker path per-event), this script submits the prompts directly
+ * to the Gemini Batch API in chunks — far cheaper/faster for a one-time backfill
+ * of ~900 small, self-contained prompts. It mirrors the exact Batch API call
+ * shape used by `scripts/backtests/generate-backtest.ts`.
+ *
+ * Usage:
+ *   yarn db:seed:calendar-analysis:batch            # full run (submits batches)
+ *   DRY_RUN=1 yarn db:seed:calendar-analysis:batch  # query + build only, no submit
+ *
+ * Requires (.env.local): DATABASE_URL (or DIRECT_DATABASE_URL), GEMINI_API_KEY.
+ *
+ * Flow:
+ *   1. Connect to prod DB (postgres-js + drizzle, max:1).
+ *   2. Query pending rows: impact IN ('High','Medium') AND actual IS NOT NULL
+ *      AND analyzed_at IS NULL.
+ *   3. Build a core prompt per event, preserving order.
+ *   4. Chunk into CHUNK_SIZE requests; per chunk: submit → poll → process → write.
+ *   5. Write-once UPDATE guarded by `analyzed_at IS NULL`.
+ *   6. Resilient per-chunk: a failed/timed-out batch is logged and skipped.
+ */
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { and, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
+import {
+    buildEconomicEventAnalysisPrompt,
+    normalizeEconomicEventAnalysis,
+} from '@y0ngha/siglens-core';
+import type {
+    CalendarImpact,
+    EconomicEventAnalysisInput,
+} from '@y0ngha/siglens-core';
+import type { InlinedRequest, InlinedResponse } from '@google/genai';
+import { GoogleGenAI, JobState } from '@google/genai';
+
+import { economicCalendar } from '../src/shared/db/schema';
+
+const databaseUrl = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
+if (!databaseUrl) {
+    throw new Error('DIRECT_DATABASE_URL (or DATABASE_URL) env var required');
+}
+
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY ?? '';
+const isDryRun = process.env.DRY_RUN === '1';
+
+// DRY_RUN skips the batch submit, so the key is only mandatory for a real run.
+if (!isDryRun && !GEMINI_API_KEY) {
+    throw new Error('GEMINI_API_KEY is required in .env.local');
+}
+
+const GEMINI_MODEL = 'gemini-2.5-flash-lite';
+
+// The calendar prompts are SMALL (~hundreds of tokens each), unlike the
+// backtest's huge per-candidate prompts. 300 requests/batch keeps each batch
+// well under the Gemini enqueue token limit (429 RESOURCE_EXHAUSTED) while
+// keeping the batch count low (~933 events → 4 batches).
+const CHUNK_SIZE = 300;
+
+// Medium+ impacts that get analyzed (mirrors core CALENDAR_ANALYZED_IMPACTS).
+const ANALYZED_IMPACTS: readonly CalendarImpact[] = ['High', 'Medium'];
+
+const POLL_INTERVAL_MS = 30_000;
+const MAX_POLL_MS = 2 * 60 * 60 * 1_000; // 2h
+
+const ai = GEMINI_API_KEY ? new GoogleGenAI({ apiKey: GEMINI_API_KEY }) : null;
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function formatElapsed(ms: number): string {
+    const s = Math.floor(ms / 1000);
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    const rem = s % 60;
+    if (m < 60) return `${m}m${rem}s`;
+    const h = Math.floor(m / 60);
+    return `${h}h${m % 60}m`;
+}
+
+// ─── Pending events ─────────────────────────────────────────────────────────
+
+interface PendingEvent {
+    id: string;
+    input: EconomicEventAnalysisInput;
+}
+
+interface PendingRequest {
+    id: string;
+    prompt: string;
+}
+
+/**
+ * Mirrors `extractResponseText` from generate-backtest.ts: pulls the first
+ * candidate's first text part, returning null when absent or blank.
+ */
+function extractResponseText(resp: InlinedResponse): string | null {
+    const text = resp.response?.candidates?.[0]?.content?.parts?.[0]?.text;
+    return typeof text === 'string' && text.trim() !== '' ? text : null;
+}
+
+function buildInlinedRequest(prompt: string): InlinedRequest {
+    // The core prompt is self-contained (no separate systemInstruction needed).
+    // flash-lite + short structured output → no thinkingConfig (kept minimal).
+    return {
+        contents: [{ parts: [{ text: prompt }] }],
+        config: {
+            temperature: 0,
+            responseMimeType: 'application/json',
+        },
+    };
+}
+
+/**
+ * Polls a submitted batch to completion (30s interval, 2h timeout).
+ * On JobState.JOB_STATE_SUCCEEDED returns the inlinedResponses array; on a
+ * terminal failure state or timeout throws (caller logs + skips the chunk).
+ */
+async function pollUntilComplete(
+    batchName: string
+): Promise<InlinedResponse[]> {
+    if (!ai) throw new Error('Gemini client not initialized');
+    const start = Date.now();
+
+    while (true) {
+        const elapsed = Date.now() - start;
+        if (elapsed > MAX_POLL_MS) {
+            throw new Error(
+                `Timeout — exceeded ${formatElapsed(MAX_POLL_MS)} waiting for ${batchName}`
+            );
+        }
+
+        const status = await ai.batches.get({ name: batchName });
+        const state = status.state ?? 'UNKNOWN';
+        console.log(
+            `  [poll] state=${state} elapsed=${formatElapsed(elapsed)}`
+        );
+
+        if (state === JobState.JOB_STATE_SUCCEEDED) {
+            const responses = status.dest?.inlinedResponses ?? [];
+            console.log(`  [batch] Succeeded — ${responses.length} responses`);
+            return responses;
+        }
+        if (
+            state === JobState.JOB_STATE_FAILED ||
+            state === JobState.JOB_STATE_CANCELLED ||
+            state === JobState.JOB_STATE_EXPIRED
+        ) {
+            const errMsg = status.error?.message ?? 'no error message';
+            throw new Error(`Job ${state} for ${batchName}: ${errMsg}`);
+        }
+
+        await sleep(POLL_INTERVAL_MS);
+    }
+}
+
+type Db = ReturnType<typeof drizzle>;
+
+interface ChunkResult {
+    analyzed: number;
+    skipped: number;
+}
+
+/**
+ * Process one completed batch: zip responses ↔ chunk by index, normalize, and
+ * write-once. Responses[i] aligns with chunk[i] (preserved within the chunk).
+ */
+async function processResponses(
+    db: Db,
+    chunk: readonly PendingRequest[],
+    responses: readonly InlinedResponse[]
+): Promise<ChunkResult> {
+    if (responses.length !== chunk.length) {
+        console.warn(
+            `  [warn] chunk(${chunk.length}) / responses(${responses.length}) mismatch — zipping by index; extras dropped.`
+        );
+    }
+
+    const n = Math.min(chunk.length, responses.length);
+    let analyzed = 0;
+    let skipped = 0;
+
+    for (let i = 0; i < n; i++) {
+        const { id } = chunk[i];
+        const response = responses[i];
+
+        if (response.error) {
+            console.warn(
+                `    [${id}] skipped — response error: ${response.error.message ?? 'unknown'}`
+            );
+            skipped += 1;
+            continue;
+        }
+
+        const text = extractResponseText(response);
+        if (text === null) {
+            console.warn(`    [${id}] skipped — empty response text`);
+            skipped += 1;
+            continue;
+        }
+
+        const { sentiment, summaryKo, interpretationKo } =
+            normalizeEconomicEventAnalysis(text);
+
+        // Empty summary = failed analysis. Leave row unanalyzed (analyzed_at NULL).
+        if (summaryKo.trim() === '') {
+            console.warn(`    [${id}] skipped — empty summaryKo`);
+            skipped += 1;
+            continue;
+        }
+
+        // Write-once: the analyzed_at IS NULL guard makes re-runs idempotent.
+        const updated = await db
+            .update(economicCalendar)
+            .set({
+                sentiment,
+                summaryKo,
+                interpretationKo,
+                analyzedAt: sql`now()`,
+            })
+            .where(
+                and(
+                    eq(economicCalendar.id, id),
+                    isNull(economicCalendar.analyzedAt)
+                )
+            )
+            .returning({ id: economicCalendar.id });
+
+        if (updated.length > 0) {
+            analyzed += 1;
+        } else {
+            // Row was analyzed by a concurrent/previous run — count as skip.
+            skipped += 1;
+        }
+    }
+
+    return { analyzed, skipped };
+}
+
+async function run(): Promise<void> {
+    const client = postgres(databaseUrl!, { max: 1 });
+    try {
+        const db = drizzle(client);
+
+        // Query pending events directly. impact is text in the DB; the WHERE
+        // clause restricts it to ANALYZED_IMPACTS, so the cast to CalendarImpact
+        // at the boundary is sound.
+        const rows = await db
+            .select({
+                id: economicCalendar.id,
+                event: economicCalendar.event,
+                impact: economicCalendar.impact,
+                actual: economicCalendar.actual,
+                estimate: economicCalendar.estimate,
+                previous: economicCalendar.previous,
+                unit: economicCalendar.unit,
+            })
+            .from(economicCalendar)
+            .where(
+                and(
+                    inArray(economicCalendar.impact, [...ANALYZED_IMPACTS]),
+                    isNotNull(economicCalendar.actual),
+                    isNull(economicCalendar.analyzedAt)
+                )
+            );
+
+        const pending: PendingEvent[] = rows.map(row => ({
+            id: row.id,
+            input: {
+                event: row.event,
+                impact: row.impact as CalendarImpact,
+                actual: row.actual,
+                estimate: row.estimate,
+                previous: row.previous,
+                unit: row.unit,
+            },
+        }));
+
+        const total = pending.length;
+        console.log(`Pending: ${total} Medium+ announced unanalyzed event(s)`);
+        if (total === 0) {
+            console.log('Nothing to do — exiting.');
+            return;
+        }
+
+        // Build a prompt per event, preserving order (id ↔ request alignment).
+        const requests: PendingRequest[] = pending.map(p => ({
+            id: p.id,
+            prompt: buildEconomicEventAnalysisPrompt(p.input),
+        }));
+
+        if (isDryRun) {
+            const sample = requests[0];
+            console.log(
+                '\n[dry-run] DRY_RUN=1 — query + prompt build only, no batch submitted.'
+            );
+            console.log(
+                `[dry-run] pending=${total} model=${GEMINI_MODEL} chunkSize=${CHUNK_SIZE}`
+            );
+            console.log(
+                `[dry-run] sample id=${sample.id} promptChars=${sample.prompt.length}`
+            );
+            console.log(
+                `[dry-run] sample prompt head (first 200 chars):\n${sample.prompt.slice(0, 200)}`
+            );
+            // Build (but do NOT submit) the first chunk's requests as a sanity check.
+            const firstChunk = requests.slice(0, CHUNK_SIZE);
+            const firstChunkRequests: InlinedRequest[] = firstChunk.map(r =>
+                buildInlinedRequest(r.prompt)
+            );
+            console.log(
+                `[dry-run] built ${firstChunkRequests.length} InlinedRequest(s) for chunk 1 (not submitted).`
+            );
+            return;
+        }
+
+        const chunkCount = Math.ceil(requests.length / CHUNK_SIZE);
+        console.log(
+            `\n[plan] ${total} requests → ${chunkCount} batch(es) of up to ${CHUNK_SIZE} each (model=${GEMINI_MODEL})`
+        );
+
+        let analyzed = 0;
+        let skipped = 0;
+        let failedBatches = 0;
+
+        for (let c = 0; c < chunkCount; c++) {
+            const chunk = requests.slice(c * CHUNK_SIZE, (c + 1) * CHUNK_SIZE);
+            const chunkNo = c + 1;
+            const inlined: InlinedRequest[] = chunk.map(r =>
+                buildInlinedRequest(r.prompt)
+            );
+
+            console.log(
+                `\n=== Batch ${chunkNo}/${chunkCount} (${chunk.length} requests) ===`
+            );
+
+            try {
+                const displayName = `siglens-calendar-analysis-${chunkNo}-${Date.now()}`;
+                console.log(`  [submit] ${displayName}...`);
+                const batch = await ai!.batches.create({
+                    model: GEMINI_MODEL,
+                    src: inlined,
+                    config: { displayName },
+                });
+                const name = batch.name;
+                if (!name) {
+                    throw new Error('Batch create response missing .name');
+                }
+                console.log(
+                    `  [submit] created ${name} (state=${batch.state ?? 'UNKNOWN'})`
+                );
+
+                const responses = await pollUntilComplete(name);
+                const result = await processResponses(db, chunk, responses);
+                analyzed += result.analyzed;
+                skipped += result.skipped;
+                console.log(
+                    `  [written] batch ${chunkNo}: analyzed +${result.analyzed}, skipped +${result.skipped} (running: ${analyzed}/${total})`
+                );
+            } catch (err) {
+                // Resilience: a failed/timed-out batch is logged and skipped so
+                // remaining chunks still run. Their rows stay unanalyzed.
+                failedBatches += 1;
+                console.error(
+                    `  [batch ${chunkNo}] FAILED — continuing: ${err instanceof Error ? err.message : String(err)}`
+                );
+            }
+        }
+
+        console.log(
+            `\n[done] analyzed ${analyzed} / pending ${total} (${skipped} skipped, ${failedBatches} failed batch(es))`
+        );
+    } finally {
+        await client.end();
+    }
+}
+
+run().catch((error: unknown) => {
+    console.error('[seedCalendarAnalysisBatch] failed:', error);
+    process.exitCode = 1;
+});

--- a/scripts/seedCalendarAnalysisBatch.ts
+++ b/scripts/seedCalendarAnalysisBatch.ts
@@ -178,7 +178,6 @@ async function processResponses(
         );
     }
 
-    // Build a lookup map from response metadata.id → response.
     const responseById = new Map<string, InlinedResponse>();
     for (const resp of responses) {
         const respId = resp.metadata?.id;

--- a/scripts/seedCalendarAnalysisBatch.ts
+++ b/scripts/seedCalendarAnalysisBatch.ts
@@ -82,8 +82,6 @@ function formatElapsed(ms: number): string {
     return `${h}h${m % 60}m`;
 }
 
-// ─── Pending events ─────────────────────────────────────────────────────────
-
 interface PendingEvent {
     id: string;
     input: EconomicEventAnalysisInput;
@@ -103,15 +101,18 @@ function extractResponseText(resp: InlinedResponse): string | null {
     return typeof text === 'string' && text.trim() !== '' ? text : null;
 }
 
-function buildInlinedRequest(prompt: string): InlinedRequest {
+function buildInlinedRequest(id: string, prompt: string): InlinedRequest {
     // The core prompt is self-contained (no separate systemInstruction needed).
     // flash-lite + short structured output → no thinkingConfig (kept minimal).
+    // `metadata.id` ties each response back to its request by DB row id, making
+    // chunk-processing id-based (safer than index-based for re-run idempotency).
     return {
         contents: [{ parts: [{ text: prompt }] }],
         config: {
             temperature: 0,
             responseMimeType: 'application/json',
         },
+        metadata: { id },
     };
 }
 
@@ -166,8 +167,10 @@ interface ChunkResult {
 }
 
 /**
- * Process one completed batch: zip responses ↔ chunk by index, normalize, and
- * write-once. Responses[i] aligns with chunk[i] (preserved within the chunk).
+ * Process one completed batch: map responses by `metadata.id` (id-based, not
+ * index-based) for re-run safety — the Gemini Batch API preserves order
+ * empirically, but id-mapping guards against any future ordering divergence.
+ * write-once: analyzed_at IS NULL guard makes re-runs idempotent.
  */
 async function processResponses(
     db: Db,
@@ -176,17 +179,33 @@ async function processResponses(
 ): Promise<ChunkResult> {
     if (responses.length !== chunk.length) {
         console.warn(
-            `  [warn] chunk(${chunk.length}) / responses(${responses.length}) mismatch — zipping by index; extras dropped.`
+            `  [warn] chunk(${chunk.length}) / responses(${responses.length}) mismatch — id-mapping; unmatched responses dropped.`
         );
     }
 
-    const n = Math.min(chunk.length, responses.length);
+    // Build a lookup map from response metadata.id → response.
+    const responseById = new Map<string, InlinedResponse>();
+    for (const resp of responses) {
+        const respId = resp.metadata?.id;
+        if (!respId) {
+            console.warn(
+                `  [warn] response missing metadata.id — skipped (cannot correlate to request)`
+            );
+            continue;
+        }
+        responseById.set(respId, resp);
+    }
+
     let analyzed = 0;
     let skipped = 0;
 
-    for (let i = 0; i < n; i++) {
-        const { id } = chunk[i];
-        const response = responses[i];
+    for (const { id } of chunk) {
+        const response = responseById.get(id);
+        if (!response) {
+            console.warn(`    [${id}] skipped — no matching response found`);
+            skipped += 1;
+            continue;
+        }
 
         if (response.error) {
             console.warn(
@@ -310,7 +329,7 @@ async function run(): Promise<void> {
             // Build (but do NOT submit) the first chunk's requests as a sanity check.
             const firstChunk = requests.slice(0, CHUNK_SIZE);
             const firstChunkRequests: InlinedRequest[] = firstChunk.map(r =>
-                buildInlinedRequest(r.prompt)
+                buildInlinedRequest(r.id, r.prompt)
             );
             console.log(
                 `[dry-run] built ${firstChunkRequests.length} InlinedRequest(s) for chunk 1 (not submitted).`
@@ -331,7 +350,7 @@ async function run(): Promise<void> {
             const chunk = requests.slice(c * CHUNK_SIZE, (c + 1) * CHUNK_SIZE);
             const chunkNo = c + 1;
             const inlined: InlinedRequest[] = chunk.map(r =>
-                buildInlinedRequest(r.prompt)
+                buildInlinedRequest(r.id, r.prompt)
             );
 
             console.log(

--- a/src/app/economy/__tests__/error.test.tsx
+++ b/src/app/economy/__tests__/error.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import EconomyError from '../error';
+
+describe('EconomyError (/economy route error boundary)', () => {
+    const error = Object.assign(new Error('boom'), { digest: 'deadbeef' });
+
+    it('renders exactly one h1 (single-h1 contract is preserved even on error)', () => {
+        const { container } = render(
+            <EconomyError error={error} reset={vi.fn()} />
+        );
+        expect(container.querySelectorAll('h1')).toHaveLength(1);
+    });
+
+    it('wires the retry button to reset()', () => {
+        const reset = vi.fn();
+        render(<EconomyError error={error} reset={reset} />);
+
+        screen.getByRole('button', { name: '다시 시도' }).click();
+
+        expect(reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('offers a working home link', () => {
+        render(<EconomyError error={error} reset={vi.fn()} />);
+
+        expect(screen.getByRole('link', { name: /홈으로/ })).toHaveAttribute(
+            'href',
+            '/'
+        );
+    });
+
+    it('logs the error (with its digest) for server-side correlation', () => {
+        const errorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined);
+
+        render(<EconomyError error={error} reset={vi.fn()} />);
+
+        expect(errorSpy).toHaveBeenCalledWith(
+            '[EconomyRoute] render error:',
+            error
+        );
+        errorSpy.mockRestore();
+    });
+});

--- a/src/app/economy/error.tsx
+++ b/src/app/economy/error.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { SITE_NAME } from '@/shared/lib/seo';
+
+interface EconomyErrorProps {
+    error: Error & { digest?: string };
+    reset: () => void;
+}
+
+/**
+ * Error boundary for the `/economy` ISR route.
+ *
+ * `EconomicCalendarGrid` and related widgets degrade gracefully in most cases,
+ * but an unexpected throw during an uncached ISR cold-gen (DB/Redis client init,
+ * unforeseen core error) would surface as a bare 500 without this boundary.
+ * `reset()` re-renders the segment, which typically succeeds on a transient outage.
+ * Mirrors `src/app/market/error.tsx`.
+ */
+export default function EconomyError({ error, reset }: EconomyErrorProps) {
+    useEffect(() => {
+        // `digest` ties this client log to the server-side error entry.
+        console.error('[EconomyRoute] render error:', error);
+    }, [error]);
+
+    return (
+        <main className="flex flex-1 flex-col items-center px-6 py-20 text-center">
+            <p className="text-primary-400 font-mono text-sm tracking-widest">
+                일시 오류
+            </p>
+            <h1 className="text-secondary-100 mt-4 text-2xl font-bold sm:text-3xl">
+                경제 캘린더를 불러오지 못했어요
+            </h1>
+            <p className="text-secondary-400 mt-3 max-w-md text-sm leading-relaxed">
+                경제 일정 데이터를 가져오는 중 일시적인 오류가 생겼어요. 잠시 후
+                다시 시도해 주세요.
+            </p>
+            <div className="mt-8 flex gap-3">
+                <button
+                    type="button"
+                    onClick={reset}
+                    className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-950 inline-flex min-h-11 items-center rounded-lg px-6 text-sm font-medium text-white transition-colors focus-visible:ring-1 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                    다시 시도
+                </button>
+                <Link
+                    href="/"
+                    className="text-secondary-200 hover:text-secondary-50 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-950 inline-flex min-h-11 items-center rounded-lg px-6 text-sm font-medium transition-colors focus-visible:ring-1 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                    {SITE_NAME} 홈으로
+                </Link>
+            </div>
+        </main>
+    );
+}

--- a/src/entities/economy/actions/__tests__/ensureEconomicCalendarAction.test.ts
+++ b/src/entities/economy/actions/__tests__/ensureEconomicCalendarAction.test.ts
@@ -1,7 +1,10 @@
 // All vi.mock() calls are hoisted before static imports — factory cannot reference
 // outer-scope variables. Access mocked fns via vi.mocked() after import.
+const { isE2E } = vi.hoisted(() => ({ isE2E: vi.fn(() => false) }));
+
 vi.mock('server-only', () => ({}));
 vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }));
+vi.mock('@/shared/api/e2eEnv', () => ({ isE2E: () => isE2E() }));
 vi.mock('@/entities/economy/api/calendarRefreshFlag', () => ({
     isCalendarRecentlyFetched: vi.fn(),
     markCalendarFetched: vi.fn(),
@@ -21,6 +24,7 @@ vi.mock('@/shared/db/client', () => ({
 }));
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+// isE2E is defined in vi.hoisted above — re-export through the mock
 import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
 import { revalidateTag } from 'next/cache';
 import {
@@ -55,6 +59,7 @@ describe('ensureEconomicCalendarAction', () => {
         vi.setSystemTime(new Date('2026-06-20T12:00:00Z'));
 
         vi.clearAllMocks();
+        isE2E.mockReturnValue(false);
         vi.mocked(isCalendarRecentlyFetched).mockResolvedValue(false);
         vi.mocked(markCalendarFetched).mockResolvedValue(undefined);
 
@@ -75,6 +80,14 @@ describe('ensureEconomicCalendarAction', () => {
 
     afterEach(() => {
         vi.useRealTimers();
+    });
+
+    it('short-circuits under E2E (no FMP calls)', async () => {
+        isE2E.mockReturnValue(true);
+        await ensureEconomicCalendarAction();
+        expect(getCalendar).not.toHaveBeenCalled();
+        expect(upsertEvent).not.toHaveBeenCalled();
+        expect(vi.mocked(revalidateTag)).not.toHaveBeenCalled();
     });
 
     it('skips fetch when recently fetched', async () => {

--- a/src/entities/economy/actions/__tests__/ensureEconomicCalendarAction.test.ts
+++ b/src/entities/economy/actions/__tests__/ensureEconomicCalendarAction.test.ts
@@ -24,7 +24,6 @@ vi.mock('@/shared/db/client', () => ({
 }));
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-// isE2E is defined in vi.hoisted above — re-export through the mock
 import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
 import { revalidateTag } from 'next/cache';
 import {

--- a/src/entities/economy/actions/__tests__/ensureEconomicEventsAnalyzedAction.test.ts
+++ b/src/entities/economy/actions/__tests__/ensureEconomicEventsAnalyzedAction.test.ts
@@ -242,6 +242,20 @@ describe('ensureEconomicEventsAnalyzedAction', () => {
         expect(revalidateTag).not.toHaveBeenCalled();
     });
 
+    it('skips persist and revalidate when summaryKo is whitespace-only (C1 guard)', async () => {
+        submitEconomicEventAnalysis.mockResolvedValue({
+            status: 'cached',
+            result: {
+                sentiment: 'neutral',
+                summaryKo: '   ',
+                interpretationKo: '',
+            },
+        });
+        await ensureEconomicEventsAnalyzedAction();
+        expect(attachEventAnalysis).not.toHaveBeenCalled();
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
     it('warns but does not error on minority failure, and still revalidates persisted rows', async () => {
         // 3 pending, first fails → 1/3 < majority(1.5)
         const ROW_2 = { ...ROW, id: 'id2', event: 'PPI MoM (May)' };

--- a/src/entities/economy/actions/__tests__/ensureEconomicEventsAnalyzedAction.test.ts
+++ b/src/entities/economy/actions/__tests__/ensureEconomicEventsAnalyzedAction.test.ts
@@ -224,6 +224,24 @@ describe('ensureEconomicEventsAnalyzedAction', () => {
         consoleError.mockRestore();
     });
 
+    it('skips persist and revalidate when cached result has empty summaryKo (C1 guard)', async () => {
+        // core normalizeEconomicEventAnalysis crash-safe fallback: empty summaryKo.
+        // Must NOT call attachEventAnalysis (write-once guard) or revalidateTag.
+        submitEconomicEventAnalysis.mockResolvedValue({
+            status: 'cached',
+            result: {
+                sentiment: 'neutral',
+                summaryKo: '',
+                interpretationKo: '',
+            },
+        });
+
+        await ensureEconomicEventsAnalyzedAction();
+
+        expect(attachEventAnalysis).not.toHaveBeenCalled();
+        expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
     it('warns but does not error on minority failure, and still revalidates persisted rows', async () => {
         // 3 pending, first fails → 1/3 < majority(1.5)
         const ROW_2 = { ...ROW, id: 'id2', event: 'PPI MoM (May)' };

--- a/src/entities/economy/actions/__tests__/ensureIndicatorTranslatedAction.test.ts
+++ b/src/entities/economy/actions/__tests__/ensureIndicatorTranslatedAction.test.ts
@@ -1,9 +1,11 @@
-const { mockUpsert } = vi.hoisted(() => ({
+const { mockUpsert, isE2E } = vi.hoisted(() => ({
     mockUpsert: vi.fn().mockResolvedValue(undefined),
+    isE2E: vi.fn(() => false),
 }));
 
 vi.mock('server-only', () => ({}));
 vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }));
+vi.mock('@/shared/api/e2eEnv', () => ({ isE2E: () => isE2E() }));
 
 vi.mock('@y0ngha/siglens-core', () => ({
     submitIndicatorTranslation: vi.fn(),
@@ -45,6 +47,7 @@ describe('ensureIndicatorTranslatedAction', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockUpsert.mockClear();
+        isE2E.mockReturnValue(false);
         vi.mocked(isIndicatorTranslationPending).mockResolvedValue(false);
         vi.mocked(markIndicatorTranslationPending).mockResolvedValue(undefined);
         // Default: cached result (short-circuit, no poll needed)
@@ -52,6 +55,13 @@ describe('ensureIndicatorTranslatedAction', () => {
             status: 'cached',
             nameKo: '어떤 모호한 지수(전년比)',
         });
+    });
+
+    it('short-circuits under E2E (no LLM calls)', async () => {
+        isE2E.mockReturnValue(true);
+        await ensureIndicatorTranslatedAction('Some Obscure Index YoY');
+        expect(submitIndicatorTranslation).not.toHaveBeenCalled();
+        expect(revalidateTag).not.toHaveBeenCalled();
     });
 
     it('skips when the name is already in the code dictionary', async () => {

--- a/src/entities/economy/actions/ensureEconomicCalendarAction.ts
+++ b/src/entities/economy/actions/ensureEconomicCalendarAction.ts
@@ -2,6 +2,7 @@
 
 import { revalidateTag } from 'next/cache';
 
+import { isE2E } from '@/shared/api/e2eEnv';
 import { getDatabaseClient } from '@/shared/db/client';
 import { FmpEconomyProvider } from '@/shared/api/fmp/FmpEconomyProvider';
 
@@ -31,6 +32,7 @@ const MAJORITY_DIVISOR = 2;
  */
 export async function ensureEconomicCalendarAction(): Promise<void> {
     try {
+        if (isE2E()) return;
         if (await isCalendarRecentlyFetched()) {
             return;
         }

--- a/src/entities/economy/actions/ensureEconomicEventsAnalyzedAction.ts
+++ b/src/entities/economy/actions/ensureEconomicEventsAnalyzedAction.ts
@@ -93,6 +93,15 @@ async function analyzeAndPersistEvent(
         }
     }
 
+    // 빈 summaryKo는 core normalizer의 crash-safe fallback 결과 — write-once로 영구
+    // 기록하면 재시도 기회가 사라진다. translation 경로와 같은 방식으로 skip 처리.
+    if (analysis.summaryKo.trim() === '') {
+        console.warn(
+            `[ensureEconomicEventsAnalyzedAction] empty summaryKo — skipping persist for ${row.id}`
+        );
+        return false;
+    }
+
     await repo.attachEventAnalysis(row.id, analysis);
     return true;
 }

--- a/src/entities/economy/actions/ensureIndicatorTranslatedAction.ts
+++ b/src/entities/economy/actions/ensureIndicatorTranslatedAction.ts
@@ -10,6 +10,7 @@ import {
     pollIndicatorTranslation,
 } from '@y0ngha/siglens-core';
 
+import { isE2E } from '@/shared/api/e2eEnv';
 import { getDatabaseClient } from '@/shared/db/client';
 import { sleep } from '@/shared/lib/sleep';
 import { MS_PER_SECOND } from '@/shared/config/time';
@@ -82,6 +83,7 @@ export async function ensureIndicatorTranslatedAction(
     normalizedName: string
 ): Promise<void> {
     try {
+        if (isE2E()) return;
         if (normalizedName in INDICATOR_NAME_KO) {
             return;
         }

--- a/src/shared/lib/__tests__/formatNum.test.ts
+++ b/src/shared/lib/__tests__/formatNum.test.ts
@@ -21,10 +21,16 @@ describe('formatNum', () => {
         expect(formatNum(-1234, '%')).toBe('-1,234%');
     });
 
-    it('NaN → "NaN<unit>" (Intl.NumberFormat은 NaN을 "NaN"으로 직렬화)', () => {
-        // NaN은 null이 아니므로 N/A를 반환하지 않고 format(NaN) 결과를 반환한다.
-        const result = formatNum(NaN, '원');
-        expect(result).toBe('NaN원');
+    it('NaN → "N/A" (비유한수 가드)', () => {
+        expect(formatNum(NaN, '원')).toBe('N/A');
+    });
+
+    it('Infinity → "N/A" (비유한수 가드)', () => {
+        expect(formatNum(Infinity, '%')).toBe('N/A');
+    });
+
+    it('-Infinity → "N/A" (비유한수 가드)', () => {
+        expect(formatNum(-Infinity, '%')).toBe('N/A');
     });
 
     it('단위가 빈 문자열이면 숫자만 반환', () => {

--- a/src/shared/lib/formatNum.ts
+++ b/src/shared/lib/formatNum.ts
@@ -2,9 +2,9 @@ const NUMBER_FORMATTER = new Intl.NumberFormat('ko-KR');
 
 /**
  * 숫자를 ko-KR 로케일(천 단위 구분자)로 포맷한 뒤 단위 접미사를 붙여 반환한다.
- * `v`가 null/undefined 또는 NaN/±Infinity(비유한수)이면 'N/A'를 반환한다.
+ * `v`가 null 또는 NaN/±Infinity(비유한수)이면 'N/A'를 반환한다.
  *
- * @param v - 포맷할 숫자. null/undefined/NaN/±Infinity이면 'N/A' 반환.
+ * @param v - 포맷할 숫자. null/NaN/±Infinity이면 'N/A' 반환.
  * @param unit - 숫자 뒤에 붙을 단위 문자열 (예: '원', '%', 'B').
  */
 export function formatNum(v: number | null, unit: string): string {

--- a/src/shared/lib/formatNum.ts
+++ b/src/shared/lib/formatNum.ts
@@ -2,12 +2,12 @@ const NUMBER_FORMATTER = new Intl.NumberFormat('ko-KR');
 
 /**
  * 숫자를 ko-KR 로케일(천 단위 구분자)로 포맷한 뒤 단위 접미사를 붙여 반환한다.
- * `v`가 null이면 'N/A'를 반환한다.
+ * `v`가 null/undefined 또는 NaN/±Infinity(비유한수)이면 'N/A'를 반환한다.
  *
- * @param v - 포맷할 숫자. null이면 'N/A' 반환.
+ * @param v - 포맷할 숫자. null/undefined/NaN/±Infinity이면 'N/A' 반환.
  * @param unit - 숫자 뒤에 붙을 단위 문자열 (예: '원', '%', 'B').
  */
 export function formatNum(v: number | null, unit: string): string {
-    if (v === null) return 'N/A';
-    return `${NUMBER_FORMATTER.format(v)}${unit}`;
+    if (!Number.isFinite(v)) return 'N/A';
+    return `${NUMBER_FORMATTER.format(v as number)}${unit}`;
 }

--- a/src/shared/lib/formatNum.ts
+++ b/src/shared/lib/formatNum.ts
@@ -9,5 +9,6 @@ const NUMBER_FORMATTER = new Intl.NumberFormat('ko-KR');
  */
 export function formatNum(v: number | null, unit: string): string {
     if (!Number.isFinite(v)) return 'N/A';
+    // `!Number.isFinite` guard above ensures v is a finite number here.
     return `${NUMBER_FORMATTER.format(v as number)}${unit}`;
 }

--- a/src/widgets/economy/sections/EconomicCalendarGrid.tsx
+++ b/src/widgets/economy/sections/EconomicCalendarGrid.tsx
@@ -238,85 +238,94 @@ function DayDetailPanel({
                 {month + 1}월 {day}일 ({dowLabel})
             </h3>
             <ul className="space-y-2">
-                {group.events.map(ev => (
-                    <li
-                        key={`${ev.iso}:${ev.original.event}:${ev.original.actual ?? ''}`}
-                        hidden={!activeImpacts.has(ev.original.impact)}
-                        className="border-secondary-700 bg-secondary-800/50 rounded-lg border p-3"
-                    >
-                        <div className="flex flex-wrap items-start justify-between gap-2">
-                            <div className="min-w-0 flex-1">
-                                <div className="mb-0.5 flex items-center gap-2">
-                                    <time
-                                        dateTime={ev.iso}
-                                        className="text-secondary-300 shrink-0 text-xs tabular-nums"
-                                    >
-                                        {ev.kstTimeLabel}
-                                    </time>
-                                </div>
-                                <p className="text-secondary-100 text-sm font-medium">
-                                    {displayEventLabel(
-                                        ev.original.event,
-                                        labels
-                                    )}
-                                </p>
-                                <p className="text-secondary-400 mt-0.5 text-xs">
-                                    예상{' '}
-                                    {formatNum(
-                                        ev.original.estimate,
-                                        ev.original.unit
-                                    )}{' '}
-                                    · 이전{' '}
-                                    {formatNum(
-                                        ev.original.previous,
-                                        ev.original.unit
-                                    )}
-                                    {ev.original.actual !== null && (
-                                        <>
-                                            {' '}
-                                            · 실제{' '}
-                                            {formatNum(
-                                                ev.original.actual,
-                                                ev.original.unit
-                                            )}
-                                        </>
-                                    )}
-                                </p>
-                            </div>
-                            <span
-                                className={cn(
-                                    'shrink-0 rounded px-2 py-0.5 text-xs font-medium',
-                                    IMPACT_BADGE[ev.original.impact]
-                                )}
-                            >
-                                {IMPACT_LABELS[ev.original.impact]}
-                            </span>
-                        </div>
-                        {ev.original.sentiment != null &&
-                            (ev.original.summaryKo?.trim().length ?? 0) > 0 && (
-                                <div className="border-secondary-700/60 mt-2 space-y-1 border-t pt-2">
-                                    <span
-                                        className={cn(
-                                            'inline-block rounded px-2 py-0.5 text-xs font-medium',
-                                            SENTIMENT_CLASS[
-                                                ev.original.sentiment
-                                            ]
+                {group.events.map(ev => {
+                    const hasSummaryContent =
+                        (ev.original.summaryKo?.trim().length ?? 0) > 0;
+                    return (
+                        <li
+                            key={`${ev.iso}:${ev.original.event}:${ev.original.actual ?? ''}`}
+                            hidden={!activeImpacts.has(ev.original.impact)}
+                            className="border-secondary-700 bg-secondary-800/50 rounded-lg border p-3"
+                        >
+                            <div className="flex flex-wrap items-start justify-between gap-2">
+                                <div className="min-w-0 flex-1">
+                                    <div className="mb-0.5 flex items-center gap-2">
+                                        <time
+                                            dateTime={ev.iso}
+                                            className="text-secondary-300 shrink-0 text-xs tabular-nums"
+                                        >
+                                            {ev.kstTimeLabel}
+                                        </time>
+                                    </div>
+                                    <p className="text-secondary-100 text-sm font-medium">
+                                        {displayEventLabel(
+                                            ev.original.event,
+                                            labels
                                         )}
-                                    >
-                                        {SENTIMENT_LABEL[ev.original.sentiment]}
-                                    </span>
-                                    <p className="text-secondary-200 text-sm">
-                                        {ev.original.summaryKo}
                                     </p>
-                                    {ev.original.interpretationKo != null && (
-                                        <p className="text-secondary-400 text-xs leading-relaxed">
-                                            {ev.original.interpretationKo}
-                                        </p>
-                                    )}
+                                    <p className="text-secondary-400 mt-0.5 text-xs">
+                                        예상{' '}
+                                        {formatNum(
+                                            ev.original.estimate,
+                                            ev.original.unit
+                                        )}{' '}
+                                        · 이전{' '}
+                                        {formatNum(
+                                            ev.original.previous,
+                                            ev.original.unit
+                                        )}
+                                        {ev.original.actual !== null && (
+                                            <>
+                                                {' '}
+                                                · 실제{' '}
+                                                {formatNum(
+                                                    ev.original.actual,
+                                                    ev.original.unit
+                                                )}
+                                            </>
+                                        )}
+                                    </p>
                                 </div>
-                            )}
-                    </li>
-                ))}
+                                <span
+                                    className={cn(
+                                        'shrink-0 rounded px-2 py-0.5 text-xs font-medium',
+                                        IMPACT_BADGE[ev.original.impact]
+                                    )}
+                                >
+                                    {IMPACT_LABELS[ev.original.impact]}
+                                </span>
+                            </div>
+                            {ev.original.sentiment != null &&
+                                hasSummaryContent && (
+                                    <div className="border-secondary-700/60 mt-2 space-y-1 border-t pt-2">
+                                        <span
+                                            className={cn(
+                                                'inline-block rounded px-2 py-0.5 text-xs font-medium',
+                                                SENTIMENT_CLASS[
+                                                    ev.original.sentiment
+                                                ]
+                                            )}
+                                        >
+                                            {
+                                                SENTIMENT_LABEL[
+                                                    ev.original.sentiment
+                                                ]
+                                            }
+                                        </span>
+                                        <p className="text-secondary-200 text-sm">
+                                            {ev.original.summaryKo}
+                                        </p>
+                                        {ev.original.interpretationKo !=
+                                            null && (
+                                            <p className="text-secondary-400 text-xs leading-relaxed">
+                                                {ev.original.interpretationKo}
+                                            </p>
+                                        )}
+                                    </div>
+                                )}
+                        </li>
+                    );
+                })}
             </ul>
         </div>
     );

--- a/src/widgets/economy/sections/EconomicCalendarGrid.tsx
+++ b/src/widgets/economy/sections/EconomicCalendarGrid.tsx
@@ -293,7 +293,7 @@ function DayDetailPanel({
                             </span>
                         </div>
                         {ev.original.sentiment != null &&
-                            ev.original.summaryKo != null && (
+                            (ev.original.summaryKo?.trim().length ?? 0) > 0 && (
                                 <div className="border-secondary-700/60 mt-2 space-y-1 border-t pt-2">
                                     <span
                                         className={cn(

--- a/src/widgets/economy/sections/__tests__/EconomicCalendarGrid.analysis.test.tsx
+++ b/src/widgets/economy/sections/__tests__/EconomicCalendarGrid.analysis.test.tsx
@@ -2,8 +2,6 @@ vi.mock('@/entities/economy/actions', () => ({
     ensureEconomicCalendarAction: vi.fn().mockResolvedValue(undefined),
     ensureEconomicEventsAnalyzedAction: vi.fn().mockResolvedValue(undefined),
 }));
-// resolveIndicatorLabels is NOT imported by EconomicCalendarGrid — the grid
-// receives `labels` as a prop from the parent RSC. No mock needed here.
 
 import { vi, describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -118,7 +116,6 @@ describe('EconomicCalendarGrid analysis display', () => {
                 today="2026-06-20"
             />
         );
-        // '중립' badge must not appear — empty summaryKo is treated as no analysis.
         expect(screen.queryByText('중립')).not.toBeInTheDocument();
     });
 
@@ -140,8 +137,6 @@ describe('EconomicCalendarGrid analysis display', () => {
         expect(screen.queryByText('긍정')).not.toBeInTheDocument();
     });
 });
-
-// ─── I5: displayEventLabel prototype-pollution guard ────────────────────────
 
 function baseEvent(eventName: string): EconomicCalendarEvent {
     return {
@@ -166,7 +161,6 @@ describe('EconomicCalendarGrid — displayEventLabel prototype-pollution guard (
                 labels={{}}
             />
         );
-        // The cell/panel must render the raw string, not crash, not render a function.
         expect(screen.getByText('toString')).toBeInTheDocument();
     });
 

--- a/src/widgets/economy/sections/__tests__/EconomicCalendarGrid.analysis.test.tsx
+++ b/src/widgets/economy/sections/__tests__/EconomicCalendarGrid.analysis.test.tsx
@@ -2,13 +2,13 @@ vi.mock('@/entities/economy/actions', () => ({
     ensureEconomicCalendarAction: vi.fn().mockResolvedValue(undefined),
     ensureEconomicEventsAnalyzedAction: vi.fn().mockResolvedValue(undefined),
 }));
-vi.mock('@/entities/economy/lib/resolveIndicatorLabels', () => ({
-    resolveIndicatorLabels: vi.fn().mockResolvedValue({}),
-}));
+// resolveIndicatorLabels is NOT imported by EconomicCalendarGrid — the grid
+// receives `labels` as a prop from the parent RSC. No mock needed here.
 
 import { vi, describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import type { EconomicCalendarEventWithAnalysis } from '@/entities/economy/model';
+import type { EconomicCalendarEvent } from '@y0ngha/siglens-core';
 import { EconomicCalendarGrid } from '@/widgets/economy/sections/EconomicCalendarGrid';
 
 function ev(
@@ -101,5 +101,83 @@ describe('EconomicCalendarGrid analysis display', () => {
             />
         );
         expect(screen.queryByText('부정')).not.toBeInTheDocument();
+    });
+
+    // C1 guard: empty summaryKo (pre-fix DB row) must NOT render a badge over blank content.
+    it('renders no sentiment badge when summaryKo is an empty string (C1 guard)', () => {
+        render(
+            <EconomicCalendarGrid
+                events={[
+                    ev({
+                        sentiment: 'neutral',
+                        summaryKo: '',
+                        interpretationKo: null,
+                        analyzedAt: new Date('2026-06-20T13:00:00Z'),
+                    }),
+                ]}
+                today="2026-06-20"
+            />
+        );
+        // '중립' badge must not appear — empty summaryKo is treated as no analysis.
+        expect(screen.queryByText('중립')).not.toBeInTheDocument();
+    });
+
+    // C1 guard: whitespace-only summaryKo must also not render.
+    it('renders no sentiment badge when summaryKo is whitespace-only (C1 guard)', () => {
+        render(
+            <EconomicCalendarGrid
+                events={[
+                    ev({
+                        sentiment: 'bullish',
+                        summaryKo: '   ',
+                        interpretationKo: null,
+                        analyzedAt: new Date('2026-06-20T13:00:00Z'),
+                    }),
+                ]}
+                today="2026-06-20"
+            />
+        );
+        expect(screen.queryByText('긍정')).not.toBeInTheDocument();
+    });
+});
+
+// ─── I5: displayEventLabel prototype-pollution guard ────────────────────────
+
+function baseEvent(eventName: string): EconomicCalendarEvent {
+    return {
+        date: '2026-06-20 08:30:00',
+        event: eventName,
+        impact: 'High',
+        actual: null,
+        estimate: 1,
+        previous: 1,
+        unit: '%',
+    };
+}
+
+describe('EconomicCalendarGrid — displayEventLabel prototype-pollution guard (I5)', () => {
+    it('renders the literal "toString" event name when labels map does not contain it', () => {
+        // "toString" exists on Object.prototype — `labels["toString"]` would return a
+        // function without the Object.hasOwn guard, potentially crashing the renderer.
+        render(
+            <EconomicCalendarGrid
+                events={[baseEvent('toString')]}
+                today="2026-06-20"
+                labels={{}}
+            />
+        );
+        // The cell/panel must render the raw string, not crash, not render a function.
+        expect(screen.getByText('toString')).toBeInTheDocument();
+    });
+
+    it('renders the literal "constructor" event name when labels map does not contain it', () => {
+        render(
+            <EconomicCalendarGrid
+                events={[baseEvent('constructor')]}
+                today="2026-06-20"
+                labels={{}}
+            />
+        );
+        expect(screen.getByText('constructor')).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## 경제 캘린더 4-SP 이터레이션 — 배포 전 감사 + 실증 후속

4-SP(SP-A/B/C/D) + core 0.25.0 머지 완료 후, prod DB에 마이그레이션(0019/0020)·백필(4,357 이벤트)·**Gemini Batch 분석 시드(933건 전량, flash-lite)** 적용하고, **배포 전 감사 4종 + 실증(Chrome/curl)** 을 수행한 결과를 반영한다.

### 감사 결과
- **배포 안정성**: SHIP (ISR 4축·서버리스 lifecycle·캐시 코히런스·DB 견고성 clean)
- **SEO**: SHIP (필터 visual-only로 전체 이벤트 DOM 유지=크롤 보존, 한국어 레이블 SSR, sentiment SSR, JSON-LD ×4, degrade↔noindex 단일 predicate)
- **오류**: SHIP-WITH-FIXES → 반영
- **테스트시트**: GAPS-FOUND → e2e + 수동 시트 작성
- **실증(Chrome/curl)**: PASS — 캘린더(월·KST·멀티월)·필터(기본 High+Med·토글 5→14건)·오늘 기본선택·sentiment 배지(긍정/부정/중립)·한국어 요약/해석·모바일 무오버플로우·콘솔 0오류

### 수정
- **C1(Critical)**: 빈 summaryKo 영구 기록(write-once) 갭 — ensure 액션 skip + 표시 가드.
- **I1**: `formatNum` NaN/Infinity → N/A.
- **M-1**: `ensureEconomicCalendarAction`/`ensureIndicatorTranslatedAction` E2E 게이팅 패리티.
- **M-2**: `/economy/error.tsx` 에러 바운더리(peer 패턴).
- **I3/I5**: dead mock 제거, `displayEventLabel` prototype-pollution 가드 테스트.
- **백필 견고성**: FMP 402 청크 skip+계속.
- **Gemini Batch 시드**: `db:seed:calendar-analysis:batch`(933건 완료).
- **e2e**: 시드 분석이벤트(비농업 고용/bullish)+Low 이벤트, economy.spec 4테스트(한국어레이블·sentiment SSR·필터·날짜선택).
- **수동 QA 시트**: `docs/qa/sheets/2026-06-20-economy-calendar-iteration-test-cases.md`.

### 검증
- tsc 0 · lint 0 · prettier 0 · vitest 755+ · build EXIT=0 · `/economy` static · DSU 0. (pre-push hook의 full build+e2e 통과로 push 성공.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)