### PR TITLE
feat(economy): 지표명 한국어 번역 DB 캐시 Gemini Batch 시드 스크립트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,8 @@ next-env.d.ts
 !/scripts/seedEconomicEventAnalysis.ts
 # One-time Gemini Batch API calendar-analysis seed script.
 !/scripts/seedCalendarAnalysisBatch.ts
+# One-time Gemini Batch API indicator-name translation seed script.
+!/scripts/seedIndicatorTranslationsBatch.ts
 !/scripts/lib/
 !/scripts/lib/**
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "db:backfill:calendar": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/backfillEconomicCalendar.ts",
         "db:seed:calendar-analysis": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seedEconomicEventAnalysis.ts",
         "db:seed:calendar-analysis:batch": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seedCalendarAnalysisBatch.ts",
+        "db:seed:indicator-translations:batch": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seedIndicatorTranslationsBatch.ts",
         "test": "NODE_OPTIONS=--no-experimental-webstorage vitest run",
         "test:quiet": "NODE_NO_WARNINGS=1 NODE_OPTIONS=--no-experimental-webstorage vitest run --reporter=dot",
         "test:related": "NODE_NO_WARNINGS=1 NODE_OPTIONS=--no-experimental-webstorage vitest related --run --passWithNoTests",

--- a/scripts/seedIndicatorTranslationsBatch.ts
+++ b/scripts/seedIndicatorTranslationsBatch.ts
@@ -62,18 +62,18 @@ if (!isDryRun && !GEMINI_API_KEY) {
     throw new Error('GEMINI_API_KEY is required in .env.local');
 }
 
+// These Gemini Batch config constants intentionally mirror the same values in
+// scripts/seedCalendarAnalysisBatch.ts — keep both in sync if you change them.
 const GEMINI_MODEL = 'gemini-2.5-flash-lite';
-
-// Truncation length for the dry-run prompt preview logged to console.
-const DRY_RUN_PROMPT_PREVIEW_LENGTH = 200;
-
 // Translation prompts are tiny (single indicator name, ~dozens of tokens each).
 // 300 requests/batch keeps each batch well under the Gemini enqueue token limit
 // (429 RESOURCE_EXHAUSTED) while keeping batch count low (~270 candidates → 1 batch).
 const CHUNK_SIZE = 300;
-
 const POLL_INTERVAL_MS = 30_000;
 const MAX_POLL_MS = 2 * 60 * 60 * 1_000; // 2h
+
+// Truncation length for the dry-run prompt preview logged to console.
+const DRY_RUN_PROMPT_PREVIEW_LENGTH = 200;
 
 const ai = GEMINI_API_KEY ? new GoogleGenAI({ apiKey: GEMINI_API_KEY }) : null;
 
@@ -94,6 +94,12 @@ function formatElapsed(ms: number): string {
 interface PendingRequest {
     id: string;
     prompt: string;
+}
+
+interface IndicatorTranslationInsert {
+    normalizedName: string;
+    koreanName: string;
+    source: 'ai';
 }
 
 /**
@@ -198,11 +204,7 @@ async function processResponses(
     }
 
     let skipped = 0;
-    const insertValues: {
-        normalizedName: string;
-        koreanName: string;
-        source: 'ai';
-    }[] = [];
+    const insertValues: IndicatorTranslationInsert[] = [];
 
     for (const { id: base } of chunk) {
         const response = responseById.get(base);
@@ -242,27 +244,28 @@ async function processResponses(
         insertValues.push({ normalizedName: base, koreanName, source: 'ai' });
     }
 
+    if (insertValues.length === 0) {
+        return { translated: 0, skipped };
+    }
+
     // Single bulk insert for all valid translations in this chunk.
     // Bases within a chunk are already distinct (deduped upstream) and pre-filtered
     // to exclude rows already in DB, so ON CONFLICT only fires on re-run or concurrent
     // races. inserted.length = newly written rows; the remainder (insertValues.length -
     // inserted.length) were pre-existing and skipped by ON CONFLICT DO NOTHING.
-    let translated = 0;
-    if (insertValues.length > 0) {
-        const inserted = await db
-            .insert(economicIndicatorTranslations)
-            .values(insertValues)
-            .onConflictDoNothing({
-                target: economicIndicatorTranslations.normalizedName,
-            })
-            .returning({
-                normalizedName: economicIndicatorTranslations.normalizedName,
-            });
-        translated = inserted.length;
-        skipped += insertValues.length - inserted.length;
-    }
-
-    return { translated, skipped };
+    const inserted = await db
+        .insert(economicIndicatorTranslations)
+        .values(insertValues)
+        .onConflictDoNothing({
+            target: economicIndicatorTranslations.normalizedName,
+        })
+        .returning({
+            normalizedName: economicIndicatorTranslations.normalizedName,
+        });
+    return {
+        translated: inserted.length,
+        skipped: skipped + (insertValues.length - inserted.length),
+    };
 }
 
 async function run(): Promise<void> {

--- a/scripts/seedIndicatorTranslationsBatch.ts
+++ b/scripts/seedIndicatorTranslationsBatch.ts
@@ -8,8 +8,8 @@
  * translate each one at first render.
  *
  * Translation-source hierarchy (hybrid, three layers):
- *   1. `INDICATOR_NAME_KO` code dict (dict) — 28 hardcoded entries, source-of-truth,
- *      excluded here (no DB row needed; display code already checks dict first).
+ *   1. The source-of-truth code dict (`INDICATOR_NAME_KO`) — excluded here (no DB row
+ *      needed; display code already checks dict first).
  *   2. `economic_indicator_translations` DB cache (ai) — THIS script fills it.
  *   3. On-access AI path (lazy fallback) — resolveIndicatorLabels triggers the
  *      submitIndicatorTranslation / pollIndicatorTranslation worker per-indicator
@@ -63,6 +63,9 @@ if (!isDryRun && !GEMINI_API_KEY) {
 }
 
 const GEMINI_MODEL = 'gemini-2.5-flash-lite';
+
+// Truncation length for the dry-run prompt preview logged to console.
+const DRY_RUN_PROMPT_PREVIEW_LENGTH = 200;
 
 // Translation prompts are tiny (single indicator name, ~dozens of tokens each).
 // 300 requests/batch keeps each batch well under the Gemini enqueue token limit
@@ -194,8 +197,12 @@ async function processResponses(
         responseById.set(respId, resp);
     }
 
-    let translated = 0;
     let skipped = 0;
+    const insertValues: {
+        normalizedName: string;
+        koreanName: string;
+        source: 'ai';
+    }[] = [];
 
     for (const { id: base } of chunk) {
         const response = responseById.get(base);
@@ -232,28 +239,27 @@ async function processResponses(
             continue;
         }
 
-        // onConflictDoNothing (NOT update): never clobber an existing dict or ai row.
-        // An empty returning array means the row already existed → count as skip.
+        insertValues.push({ normalizedName: base, koreanName, source: 'ai' });
+    }
+
+    // Single bulk insert for all valid translations in this chunk.
+    // Bases within a chunk are already distinct (deduped upstream) and pre-filtered
+    // to exclude rows already in DB, so ON CONFLICT only fires on re-run or concurrent
+    // races. inserted.length = newly written rows; the remainder (insertValues.length -
+    // inserted.length) were pre-existing and skipped by ON CONFLICT DO NOTHING.
+    let translated = 0;
+    if (insertValues.length > 0) {
         const inserted = await db
             .insert(economicIndicatorTranslations)
-            .values({
-                normalizedName: base,
-                koreanName,
-                source: 'ai',
-            })
+            .values(insertValues)
             .onConflictDoNothing({
                 target: economicIndicatorTranslations.normalizedName,
             })
             .returning({
                 normalizedName: economicIndicatorTranslations.normalizedName,
             });
-
-        if (inserted.length > 0) {
-            translated += 1;
-        } else {
-            // Row already existed (prior run or concurrent write) — idempotent skip.
-            skipped += 1;
-        }
+        translated = inserted.length;
+        skipped += insertValues.length - inserted.length;
     }
 
     return { translated, skipped };
@@ -264,14 +270,13 @@ async function run(): Promise<void> {
     try {
         const db = drizzle(client);
 
-        // Collect all distinct raw event names from the calendar.
         const eventRows = await db
             .selectDistinct({ event: economicCalendar.event })
             .from(economicCalendar);
 
-        // Compute distinct bases — normalizeIndicatorName strips the trailing period
-        // qualifier so 'CPI (May)' and 'CPI (Jun)' both reduce to base 'CPI'.
-        // The Set deduplicates across all distinct raw event names.
+        // normalizeIndicatorName strips the trailing period qualifier so 'CPI (May)'
+        // and 'CPI (Jun)' both reduce to base 'CPI'. The Set deduplicates across all
+        // distinct raw event names.
         const allBases = new Set<string>(
             eventRows.map(r => normalizeIndicatorName(r.event).base)
         );
@@ -293,7 +298,6 @@ async function run(): Promise<void> {
             b => !Object.hasOwn(INDICATOR_NAME_KO, b) && existingBases.has(b)
         ).length;
 
-        // Pending = bases NOT covered by code dict AND NOT already in DB.
         // Sorted deterministically so log output and chunk boundaries are stable.
         const pendingBases = [...allBases]
             .filter(
@@ -313,9 +317,9 @@ async function run(): Promise<void> {
             return;
         }
 
-        // Build one prompt per pending base; the base string IS the metadata id since
-        // bases are distinct. The metadata id ties each Batch API response back to
-        // its base name for id-based (not index-based) processing.
+        // The base string IS the metadata id since bases are distinct. The metadata id
+        // ties each Batch API response back to its base name for id-based (not
+        // index-based) processing.
         const requests: PendingRequest[] = pendingBases.map(base => ({
             id: base,
             prompt: buildIndicatorTranslationPrompt(base),
@@ -336,7 +340,7 @@ async function run(): Promise<void> {
                 `[dry-run] sample base="${sample.id}" promptChars=${sample.prompt.length}`
             );
             console.log(
-                `[dry-run] sample prompt head (first 200 chars):\n${sample.prompt.slice(0, 200)}`
+                `[dry-run] sample prompt head (first ${DRY_RUN_PROMPT_PREVIEW_LENGTH} chars):\n${sample.prompt.slice(0, DRY_RUN_PROMPT_PREVIEW_LENGTH)}`
             );
             // Build (but do NOT submit) the first chunk's requests as a sanity check.
             const firstChunk = requests.slice(0, CHUNK_SIZE);
@@ -349,7 +353,7 @@ async function run(): Promise<void> {
             return;
         }
 
-        const chunkCount = Math.ceil(requests.length / CHUNK_SIZE);
+        const chunkCount = Math.ceil(total / CHUNK_SIZE);
         console.log(
             `\n[plan] ${total} requests → ${chunkCount} batch(es) of up to ${CHUNK_SIZE} each (model=${GEMINI_MODEL})`
         );

--- a/scripts/seedIndicatorTranslationsBatch.ts
+++ b/scripts/seedIndicatorTranslationsBatch.ts
@@ -1,0 +1,416 @@
+/**
+ * ONE-OFF SEED script: translate every distinct, not-yet-covered economic-indicator
+ * base name from `economic_calendar` into Korean via the Gemini Batch API, then
+ * UPSERT the results into `economic_indicator_translations` (source='ai').
+ *
+ * This front-loads the DB translation cache so the calendar grid immediately shows
+ * Korean indicator names without waiting for the on-access AI path to lazily
+ * translate each one at first render.
+ *
+ * Translation-source hierarchy (hybrid, three layers):
+ *   1. `INDICATOR_NAME_KO` code dict (dict) — 28 hardcoded entries, source-of-truth,
+ *      excluded here (no DB row needed; display code already checks dict first).
+ *   2. `economic_indicator_translations` DB cache (ai) — THIS script fills it.
+ *   3. On-access AI path (lazy fallback) — resolveIndicatorLabels triggers the
+ *      submitIndicatorTranslation / pollIndicatorTranslation worker per-indicator
+ *      when neither dict nor DB cache has a hit. This seed front-loads that cache.
+ *
+ * Usage:
+ *   yarn db:seed:indicator-translations:batch            # full run (submits batches)
+ *   DRY_RUN=1 yarn db:seed:indicator-translations:batch  # query + build only, no submit
+ *
+ * Requires (.env.local): DATABASE_URL (or DIRECT_DATABASE_URL), GEMINI_API_KEY.
+ *
+ * Flow:
+ *   1. Connect to prod DB (postgres-js + drizzle, max:1).
+ *   2. SELECT DISTINCT event FROM economic_calendar; compute base = normalizeIndicatorName(event).base.
+ *   3. Exclude bases already covered by INDICATOR_NAME_KO (dict) or already in the
+ *      translations table — leaving only genuinely pending bases.
+ *   4. Build one prompt per base via buildIndicatorTranslationPrompt; chunk into CHUNK_SIZE.
+ *   5. Per chunk: submit → poll → process → UPSERT with onConflictDoNothing.
+ *   6. Resilient per-chunk: a failed/timed-out batch is logged and skipped so remaining
+ *      chunks still run.
+ */
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import {
+    buildIndicatorTranslationPrompt,
+    normalizeIndicatorTranslation,
+} from '@y0ngha/siglens-core';
+import type { InlinedRequest, InlinedResponse } from '@google/genai';
+import { GoogleGenAI, JobState } from '@google/genai';
+
+import {
+    normalizeIndicatorName,
+    INDICATOR_NAME_KO,
+} from '../src/entities/economy/lib/indicatorNameKo';
+import {
+    economicCalendar,
+    economicIndicatorTranslations,
+} from '../src/shared/db/schema';
+
+const databaseUrl = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
+if (!databaseUrl) {
+    throw new Error('DIRECT_DATABASE_URL (or DATABASE_URL) env var required');
+}
+
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY ?? '';
+const isDryRun = process.env.DRY_RUN === '1';
+
+// DRY_RUN skips the batch submit, so the key is only mandatory for a real run.
+if (!isDryRun && !GEMINI_API_KEY) {
+    throw new Error('GEMINI_API_KEY is required in .env.local');
+}
+
+const GEMINI_MODEL = 'gemini-2.5-flash-lite';
+
+// Translation prompts are tiny (single indicator name, ~dozens of tokens each).
+// 300 requests/batch keeps each batch well under the Gemini enqueue token limit
+// (429 RESOURCE_EXHAUSTED) while keeping batch count low (~270 candidates → 1 batch).
+const CHUNK_SIZE = 300;
+
+const POLL_INTERVAL_MS = 30_000;
+const MAX_POLL_MS = 2 * 60 * 60 * 1_000; // 2h
+
+const ai = GEMINI_API_KEY ? new GoogleGenAI({ apiKey: GEMINI_API_KEY }) : null;
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function formatElapsed(ms: number): string {
+    const s = Math.floor(ms / 1000);
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    const rem = s % 60;
+    if (m < 60) return `${m}m${rem}s`;
+    const h = Math.floor(m / 60);
+    return `${h}h${m % 60}m`;
+}
+
+interface PendingRequest {
+    id: string;
+    prompt: string;
+}
+
+/**
+ * Mirrors `extractResponseText` from generate-backtest.ts: pulls the first
+ * candidate's first text part, returning null when absent or blank.
+ */
+function extractResponseText(resp: InlinedResponse): string | null {
+    const text = resp.response?.candidates?.[0]?.content?.parts?.[0]?.text;
+    return typeof text === 'string' && text.trim() !== '' ? text : null;
+}
+
+function buildInlinedRequest(id: string, prompt: string): InlinedRequest {
+    // The core prompt is self-contained (no separate systemInstruction needed).
+    // flash-lite + short structured output → no thinkingConfig (kept minimal).
+    // `metadata.id` ties each response back to its base name, making chunk-processing
+    // id-based (safer than index-based for re-run idempotency).
+    return {
+        contents: [{ parts: [{ text: prompt }] }],
+        config: {
+            temperature: 0,
+            responseMimeType: 'application/json',
+        },
+        metadata: { id },
+    };
+}
+
+/**
+ * Polls a submitted batch to completion (30s interval, 2h timeout).
+ * On JobState.JOB_STATE_SUCCEEDED returns the inlinedResponses array; on a
+ * terminal failure state or timeout throws (caller logs + skips the chunk).
+ */
+async function pollUntilComplete(
+    batchName: string
+): Promise<InlinedResponse[]> {
+    if (!ai) throw new Error('Gemini client not initialized');
+    const start = Date.now();
+
+    while (Date.now() - start <= MAX_POLL_MS) {
+        const elapsed = Date.now() - start;
+        const status = await ai.batches.get({ name: batchName });
+        const state = status.state ?? 'UNKNOWN';
+        console.log(
+            `  [poll] state=${state} elapsed=${formatElapsed(elapsed)}`
+        );
+
+        if (state === JobState.JOB_STATE_SUCCEEDED) {
+            const responses = status.dest?.inlinedResponses ?? [];
+            console.log(`  [batch] Succeeded — ${responses.length} responses`);
+            return responses;
+        }
+        if (
+            state === JobState.JOB_STATE_FAILED ||
+            state === JobState.JOB_STATE_CANCELLED ||
+            state === JobState.JOB_STATE_EXPIRED
+        ) {
+            const errMsg = status.error?.message ?? 'no error message';
+            throw new Error(`Job ${state} for ${batchName}: ${errMsg}`);
+        }
+
+        await sleep(POLL_INTERVAL_MS);
+    }
+    throw new Error(
+        `Timeout — exceeded ${formatElapsed(MAX_POLL_MS)} waiting for ${batchName}`
+    );
+}
+
+type Db = ReturnType<typeof drizzle>;
+
+interface ChunkResult {
+    translated: number;
+    skipped: number;
+}
+
+/**
+ * Process one completed batch: map responses by `metadata.id` (id-based, not
+ * index-based) for re-run safety — the Gemini Batch API preserves order
+ * empirically, but id-mapping guards against any future ordering divergence.
+ * UPSERT uses onConflictDoNothing so re-runs are idempotent and existing dict/ai
+ * rows are never clobbered.
+ */
+async function processResponses(
+    db: Db,
+    chunk: readonly PendingRequest[],
+    responses: readonly InlinedResponse[]
+): Promise<ChunkResult> {
+    if (responses.length !== chunk.length) {
+        console.warn(
+            `  [warn] chunk(${chunk.length}) / responses(${responses.length}) mismatch — id-mapping; unmatched responses dropped.`
+        );
+    }
+
+    const responseById = new Map<string, InlinedResponse>();
+    for (const resp of responses) {
+        const respId = resp.metadata?.id;
+        if (!respId) {
+            console.warn(
+                `  [warn] response missing metadata.id — skipped (cannot correlate to request)`
+            );
+            continue;
+        }
+        responseById.set(respId, resp);
+    }
+
+    let translated = 0;
+    let skipped = 0;
+
+    for (const { id: base } of chunk) {
+        const response = responseById.get(base);
+        if (!response) {
+            console.warn(`    [${base}] skipped — no matching response found`);
+            skipped += 1;
+            continue;
+        }
+
+        if (response.error) {
+            console.warn(
+                `    [${base}] skipped — response error: ${response.error.message ?? 'unknown'}`
+            );
+            skipped += 1;
+            continue;
+        }
+
+        const text = extractResponseText(response);
+        if (text === null) {
+            console.warn(`    [${base}] skipped — empty response text`);
+            skipped += 1;
+            continue;
+        }
+
+        const koreanName = normalizeIndicatorTranslation(text);
+
+        // Empty koreanName = failed/garbage translation. Leave untranslated rather
+        // than writing an empty string — the on-access AI path will retry lazily.
+        if (koreanName.trim() === '') {
+            console.warn(
+                `    [${base}] skipped — empty koreanName after normalize`
+            );
+            skipped += 1;
+            continue;
+        }
+
+        // onConflictDoNothing (NOT update): never clobber an existing dict or ai row.
+        // An empty returning array means the row already existed → count as skip.
+        const inserted = await db
+            .insert(economicIndicatorTranslations)
+            .values({
+                normalizedName: base,
+                koreanName,
+                source: 'ai',
+            })
+            .onConflictDoNothing({
+                target: economicIndicatorTranslations.normalizedName,
+            })
+            .returning({
+                normalizedName: economicIndicatorTranslations.normalizedName,
+            });
+
+        if (inserted.length > 0) {
+            translated += 1;
+        } else {
+            // Row already existed (prior run or concurrent write) — idempotent skip.
+            skipped += 1;
+        }
+    }
+
+    return { translated, skipped };
+}
+
+async function run(): Promise<void> {
+    const client = postgres(databaseUrl!, { max: 1 });
+    try {
+        const db = drizzle(client);
+
+        // Collect all distinct raw event names from the calendar.
+        const eventRows = await db
+            .selectDistinct({ event: economicCalendar.event })
+            .from(economicCalendar);
+
+        // Compute distinct bases — normalizeIndicatorName strips the trailing period
+        // qualifier so 'CPI (May)' and 'CPI (Jun)' both reduce to base 'CPI'.
+        // The Set deduplicates across all distinct raw event names.
+        const allBases = new Set<string>(
+            eventRows.map(r => normalizeIndicatorName(r.event).base)
+        );
+
+        // Load bases already present in the translations table to skip re-translating.
+        const existingRows = await db
+            .select({
+                normalizedName: economicIndicatorTranslations.normalizedName,
+            })
+            .from(economicIndicatorTranslations);
+        const existingBases = new Set<string>(
+            existingRows.map(r => r.normalizedName)
+        );
+
+        const dictCoveredCount = [...allBases].filter(b =>
+            Object.hasOwn(INDICATOR_NAME_KO, b)
+        ).length;
+        const alreadyInDbCount = [...allBases].filter(
+            b => !Object.hasOwn(INDICATOR_NAME_KO, b) && existingBases.has(b)
+        ).length;
+
+        // Pending = bases NOT covered by code dict AND NOT already in DB.
+        // Sorted deterministically so log output and chunk boundaries are stable.
+        const pendingBases = [...allBases]
+            .filter(
+                b =>
+                    !Object.hasOwn(INDICATOR_NAME_KO, b) &&
+                    !existingBases.has(b)
+            )
+            .toSorted((a, b) => a.localeCompare(b));
+
+        const total = pendingBases.length;
+        console.log(
+            `Distinct bases: ${allBases.size} total, ${dictCoveredCount} dict-covered, ${alreadyInDbCount} already-in-DB, ${total} pending`
+        );
+
+        if (total === 0) {
+            console.log('Nothing to do — exiting.');
+            return;
+        }
+
+        // Build one prompt per pending base; the base string IS the metadata id since
+        // bases are distinct. The metadata id ties each Batch API response back to
+        // its base name for id-based (not index-based) processing.
+        const requests: PendingRequest[] = pendingBases.map(base => ({
+            id: base,
+            prompt: buildIndicatorTranslationPrompt(base),
+        }));
+
+        if (isDryRun) {
+            const sample = requests[0];
+            console.log(
+                '\n[dry-run] DRY_RUN=1 — query + prompt build only, no batch submitted.'
+            );
+            console.log(
+                `[dry-run] pending=${total} dictCovered=${dictCoveredCount} alreadyInDB=${alreadyInDbCount}`
+            );
+            console.log(
+                `[dry-run] model=${GEMINI_MODEL} chunkSize=${CHUNK_SIZE}`
+            );
+            console.log(
+                `[dry-run] sample base="${sample.id}" promptChars=${sample.prompt.length}`
+            );
+            console.log(
+                `[dry-run] sample prompt head (first 200 chars):\n${sample.prompt.slice(0, 200)}`
+            );
+            // Build (but do NOT submit) the first chunk's requests as a sanity check.
+            const firstChunk = requests.slice(0, CHUNK_SIZE);
+            const firstChunkRequests: InlinedRequest[] = firstChunk.map(r =>
+                buildInlinedRequest(r.id, r.prompt)
+            );
+            console.log(
+                `[dry-run] built ${firstChunkRequests.length} InlinedRequest(s) for chunk 1 (not submitted).`
+            );
+            return;
+        }
+
+        const chunkCount = Math.ceil(requests.length / CHUNK_SIZE);
+        console.log(
+            `\n[plan] ${total} requests → ${chunkCount} batch(es) of up to ${CHUNK_SIZE} each (model=${GEMINI_MODEL})`
+        );
+
+        let translated = 0;
+        let skipped = 0;
+        let failedBatches = 0;
+
+        for (let c = 0; c < chunkCount; c++) {
+            const chunk = requests.slice(c * CHUNK_SIZE, (c + 1) * CHUNK_SIZE);
+            const chunkNo = c + 1;
+            const inlined: InlinedRequest[] = chunk.map(r =>
+                buildInlinedRequest(r.id, r.prompt)
+            );
+
+            console.log(
+                `\n=== Batch ${chunkNo}/${chunkCount} (${chunk.length} requests) ===`
+            );
+
+            try {
+                const displayName = `siglens-indicator-translations-${chunkNo}-${Date.now()}`;
+                console.log(`  [submit] ${displayName}...`);
+                const batch = await ai!.batches.create({
+                    model: GEMINI_MODEL,
+                    src: inlined,
+                    config: { displayName },
+                });
+                const name = batch.name;
+                if (!name) {
+                    throw new Error('Batch create response missing .name');
+                }
+                console.log(
+                    `  [submit] created ${name} (state=${batch.state ?? 'UNKNOWN'})`
+                );
+
+                const responses = await pollUntilComplete(name);
+                const result = await processResponses(db, chunk, responses);
+                translated += result.translated;
+                skipped += result.skipped;
+                console.log(
+                    `  [written] batch ${chunkNo}: translated +${result.translated}, skipped +${result.skipped} (running: ${translated}/${total})`
+                );
+            } catch (err) {
+                // Resilience: a failed/timed-out batch is logged and skipped so
+                // remaining chunks still run. Their bases stay untranslated.
+                failedBatches += 1;
+                console.error(
+                    `  [batch ${chunkNo}] FAILED — continuing: ${err instanceof Error ? err.message : String(err)}`
+                );
+            }
+        }
+
+        console.log(
+            `\n[done] translated ${translated} / pending ${total} (${skipped} skipped, ${failedBatches} failed batch(es))`
+        );
+    } finally {
+        await client.end();
+    }
+}
+
+run().catch((error: unknown) => {
+    console.error('[seedIndicatorTranslationsBatch] failed:', error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## 관련 이슈

경제 캘린더 그리드 한국어 지표명 표시 (신규)

## 구현 내용

### 목적
캘린더 그리드의 영어 지표명을 한국어로 표시하기 위한 DB 번역 캐시(economic_indicator_translations) 선채움.
on-access AI 번역 경로가 lazy로 채우던 것을 일회성 배치로 front-load.

### 동작
1. economic_calendar에서 distinct event → normalizeIndicatorName().base
2. 코드 dict(INDICATOR_NAME_KO 25종 매칭) + 이미 DB에 있는 행 제외
3. core buildIndicatorTranslationPrompt → Gemini Batch flash-lite
4. normalizeIndicatorTranslation → onConflictDoNothing UPSERT(source='ai')
5. 빈 번역은 skip(write-once 멱등)

### 실측
- prod 적용 완료
- 270 distinct base 중 25 dict-covered
- 245 pending → 245건 전부 번역·저장(0 skip/0 실패)
- 미번역 0건, 오타 1건(Export Prices YoY) 수동 교정

### 참조
- scripts/seedCalendarAnalysisBatch.ts(PR #615) 패턴 미러

## 레이어 및 코드 품질 체크

- [x] @docs/conventions/CONVENTIONS.md 준수 확인
- [x] @docs/conventions/FF.md 준수 확인
- [x] @docs/workflows/MISTAKES.md 준수 확인
- [x] scripts/: 일회성 ops 스크립트, 머지된 backfill/seedCalendarAnalysisBatch와 동일하게 유닛 테스트 없음
- [x] yarn lint clean
- [x] yarn format clean

## 변경 파일 목록

[생성]
- scripts/seedIndicatorTranslationsBatch.ts (NEW)

[수정]
- package.json (added db:seed:indicator-translations:batch script)
- .gitignore (added !/scripts/seedIndicatorTranslationsBatch.ts allowlist entry)

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build