### PR TITLE
feat: crypto support Plan 1 — MarketProfile foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,8 @@ next-env.d.ts
 !/scripts/seedCalendarAnalysisBatch.ts
 # One-time Gemini Batch API indicator-name translation seed script.
 !/scripts/seedIndicatorTranslationsBatch.ts
+# Plan 1: FMP cryptocurrency-list sync script.
+!/scripts/seed-crypto-assets.ts
 !/scripts/lib/
 !/scripts/lib/**
 

--- a/drizzle/0021_melodic_next_avengers.sql
+++ b/drizzle/0021_melodic_next_avengers.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "crypto_assets" (
+	"symbol" varchar(32) PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"korean_name" text,
+	"circulating_supply" double precision,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,1667 @@
+{
+    "id": "71888009-d30a-4f18-9ab3-fb21ab75b4bb",
+    "prevId": "ed5e8923-b686-4271-811b-c74d08f05639",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.agreements": {
+            "name": "agreements",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "terms_id": {
+                    "name": "terms_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "agreed": {
+                    "name": "agreed",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "agreed_at": {
+                    "name": "agreed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "agreements_user_terms_uidx": {
+                    "name": "agreements_user_terms_uidx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "terms_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "agreements_user_id_idx": {
+                    "name": "agreements_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "agreements_terms_id_idx": {
+                    "name": "agreements_terms_id_idx",
+                    "columns": [
+                        {
+                            "expression": "terms_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "agreements_user_id_users_id_fk": {
+                    "name": "agreements_user_id_users_id_fk",
+                    "tableFrom": "agreements",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "agreements_terms_id_terms_id_fk": {
+                    "name": "agreements_terms_id_terms_id_fk",
+                    "tableFrom": "agreements",
+                    "tableTo": "terms",
+                    "columnsFrom": ["terms_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "restrict",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.asset_translations": {
+            "name": "asset_translations",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "fmp_symbol": {
+                    "name": "fmp_symbol",
+                    "type": "varchar(64)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.crypto_assets": {
+            "name": "crypto_assets",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "circulating_supply": {
+                    "name": "circulating_supply",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.earnings_reports": {
+            "name": "earnings_reports",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "earnings_date": {
+                    "name": "earnings_date",
+                    "type": "date",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "eps_actual": {
+                    "name": "eps_actual",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "eps_estimated": {
+                    "name": "eps_estimated",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "revenue_actual": {
+                    "name": "revenue_actual",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "revenue_estimated": {
+                    "name": "revenue_estimated",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "last_updated": {
+                    "name": "last_updated",
+                    "type": "date",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "raw_payload": {
+                    "name": "raw_payload",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {
+                "earnings_reports_symbol_earnings_date_pk": {
+                    "name": "earnings_reports_symbol_earnings_date_pk",
+                    "columns": ["symbol", "earnings_date"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.economic_calendar": {
+            "name": "economic_calendar",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "country": {
+                    "name": "country",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "date_et": {
+                    "name": "date_et",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "event": {
+                    "name": "event",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "impact": {
+                    "name": "impact",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "estimate": {
+                    "name": "estimate",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "previous": {
+                    "name": "previous",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "actual": {
+                    "name": "actual",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "unit": {
+                    "name": "unit",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "sentiment": {
+                    "name": "sentiment",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "summary_ko": {
+                    "name": "summary_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "interpretation_ko": {
+                    "name": "interpretation_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "analyzed_at": {
+                    "name": "analyzed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "economic_calendar_date_et_idx": {
+                    "name": "economic_calendar_date_et_idx",
+                    "columns": [
+                        {
+                            "expression": "date_et",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "economic_calendar_country_date_et_idx": {
+                    "name": "economic_calendar_country_date_et_idx",
+                    "columns": [
+                        {
+                            "expression": "country",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "date_et",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "economic_calendar_impact_idx": {
+                    "name": "economic_calendar_impact_idx",
+                    "columns": [
+                        {
+                            "expression": "impact",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "economic_calendar_impact_analyzed_at_idx": {
+                    "name": "economic_calendar_impact_analyzed_at_idx",
+                    "columns": [
+                        {
+                            "expression": "impact",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "analyzed_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.economic_indicator_translations": {
+            "name": "economic_indicator_translations",
+            "schema": "",
+            "columns": {
+                "normalized_name": {
+                    "name": "normalized_name",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "source": {
+                    "name": "source",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.inquiries": {
+            "name": "inquiries",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "title": {
+                    "name": "title",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "content": {
+                    "name": "content",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "email": {
+                    "name": "email",
+                    "type": "varchar(320)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "answered": {
+                    "name": "answered",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.korean_tickers": {
+            "name": "korean_tickers",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "exchange": {
+                    "name": "exchange",
+                    "type": "varchar(32)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "exchange_full_name": {
+                    "name": "exchange_full_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.market_news": {
+            "name": "market_news",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "symbol": {
+                    "name": "symbol",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "source": {
+                    "name": "source",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "url": {
+                    "name": "url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "published_at": {
+                    "name": "published_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_ko": {
+                    "name": "title_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_en": {
+                    "name": "body_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_ko": {
+                    "name": "body_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "summary_ko": {
+                    "name": "summary_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "sentiment": {
+                    "name": "sentiment",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "category": {
+                    "name": "category",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "price_impact": {
+                    "name": "price_impact",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "tickers": {
+                    "name": "tickers",
+                    "type": "text[]",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "ARRAY[]::text[]"
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "analyzed_at": {
+                    "name": "analyzed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "market_news_symbol_published_at_idx": {
+                    "name": "market_news_symbol_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "symbol",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "market_news_published_at_idx": {
+                    "name": "market_news_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "market_news_url_unique": {
+                    "name": "market_news_url_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["url"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.news": {
+            "name": "news",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "symbol": {
+                    "name": "symbol",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "source": {
+                    "name": "source",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "url": {
+                    "name": "url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "published_at": {
+                    "name": "published_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_ko": {
+                    "name": "title_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_en": {
+                    "name": "body_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_ko": {
+                    "name": "body_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "summary_ko": {
+                    "name": "summary_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "sentiment": {
+                    "name": "sentiment",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "category": {
+                    "name": "category",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "price_impact": {
+                    "name": "price_impact",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "raw_payload": {
+                    "name": "raw_payload",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "analyzed_at": {
+                    "name": "analyzed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "news_symbol_published_at_idx": {
+                    "name": "news_symbol_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "symbol",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "news_published_at_idx": {
+                    "name": "news_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "news_url_unique": {
+                    "name": "news_url_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["url"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.notices": {
+            "name": "notices",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "title": {
+                    "name": "title",
+                    "type": "varchar(200)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "body": {
+                    "name": "body",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "link_url": {
+                    "name": "link_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "link_label": {
+                    "name": "link_label",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "path_pattern": {
+                    "name": "path_pattern",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "priority": {
+                    "name": "priority",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 0
+                },
+                "is_active": {
+                    "name": "is_active",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": true
+                },
+                "starts_at": {
+                    "name": "starts_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "ends_at": {
+                    "name": "ends_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "notices_active_window_idx": {
+                    "name": "notices_active_window_idx",
+                    "columns": [
+                        {
+                            "expression": "is_active",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "starts_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "ends_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.oauth_accounts": {
+            "name": "oauth_accounts",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider": {
+                    "name": "provider",
+                    "type": "oauth_provider",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider_account_id": {
+                    "name": "provider_account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "access_token": {
+                    "name": "access_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "refresh_token": {
+                    "name": "refresh_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "token_expires_at": {
+                    "name": "token_expires_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "oauth_accounts_user_id_idx": {
+                    "name": "oauth_accounts_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "oauth_accounts_provider_account_uidx": {
+                    "name": "oauth_accounts_provider_account_uidx",
+                    "columns": [
+                        {
+                            "expression": "provider",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "provider_account_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "oauth_accounts_user_id_users_id_fk": {
+                    "name": "oauth_accounts_user_id_users_id_fk",
+                    "tableFrom": "oauth_accounts",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.profile_description_translations": {
+            "name": "profile_description_translations",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "description_ko": {
+                    "name": "description_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.sessions": {
+            "name": "sessions",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "sessions_user_id_idx": {
+                    "name": "sessions_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "sessions_expires_at_idx": {
+                    "name": "sessions_expires_at_idx",
+                    "columns": [
+                        {
+                            "expression": "expires_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "sessions_user_id_users_id_fk": {
+                    "name": "sessions_user_id_users_id_fk",
+                    "tableFrom": "sessions",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.terms": {
+            "name": "terms",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "kind": {
+                    "name": "kind",
+                    "type": "terms_kind",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "version": {
+                    "name": "version",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "effective_date": {
+                    "name": "effective_date",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "body": {
+                    "name": "body",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "terms_kind_version_uidx": {
+                    "name": "terms_kind_version_uidx",
+                    "columns": [
+                        {
+                            "expression": "kind",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "version",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "terms_kind_effective_date_idx": {
+                    "name": "terms_kind_effective_date_idx",
+                    "columns": [
+                        {
+                            "expression": "kind",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "effective_date",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.usage_logs": {
+            "name": "usage_logs",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "ip_hash": {
+                    "name": "ip_hash",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "action_type": {
+                    "name": "action_type",
+                    "type": "usage_action_type",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "model_used": {
+                    "name": "model_used",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "date": {
+                    "name": "date",
+                    "type": "date",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "usage_logs_user_id_idx": {
+                    "name": "usage_logs_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "usage_logs_ip_hash_date_idx": {
+                    "name": "usage_logs_ip_hash_date_idx",
+                    "columns": [
+                        {
+                            "expression": "ip_hash",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "date",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "usage_logs_user_id_users_id_fk": {
+                    "name": "usage_logs_user_id_users_id_fk",
+                    "tableFrom": "usage_logs",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.user_api_keys": {
+            "name": "user_api_keys",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider": {
+                    "name": "provider",
+                    "type": "llm_provider",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "encrypted_api_key": {
+                    "name": "encrypted_api_key",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "user_api_keys_user_id_idx": {
+                    "name": "user_api_keys_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "user_api_keys_user_provider_uidx": {
+                    "name": "user_api_keys_user_provider_uidx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "provider",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "user_api_keys_user_id_users_id_fk": {
+                    "name": "user_api_keys_user_id_users_id_fk",
+                    "tableFrom": "user_api_keys",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.users": {
+            "name": "users",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "email": {
+                    "name": "email",
+                    "type": "varchar(320)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "password_hash": {
+                    "name": "password_hash",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "avatar_url": {
+                    "name": "avatar_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "tier": {
+                    "name": "tier",
+                    "type": "user_tier",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'free'"
+                },
+                "email_verified": {
+                    "name": "email_verified",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "users_email_unique": {
+                    "name": "users_email_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["email"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {
+        "public.llm_provider": {
+            "name": "llm_provider",
+            "schema": "public",
+            "values": ["anthropic", "google", "openai"]
+        },
+        "public.oauth_provider": {
+            "name": "oauth_provider",
+            "schema": "public",
+            "values": ["google", "kakao", "apple"]
+        },
+        "public.terms_kind": {
+            "name": "terms_kind",
+            "schema": "public",
+            "values": ["privacy", "tos"]
+        },
+        "public.usage_action_type": {
+            "name": "usage_action_type",
+            "schema": "public",
+            "values": ["analysis", "chatbot", "premium_model"]
+        },
+        "public.user_tier": {
+            "name": "user_tier",
+            "schema": "public",
+            "values": ["free", "member", "pro"]
+        }
+    },
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
             "when": 1781935084484,
             "tag": "0020_eager_sunset_bain",
             "breakpoints": true
+        },
+        {
+            "idx": 21,
+            "version": "7",
+            "when": 1782041059768,
+            "tag": "0021_melodic_next_avengers",
+            "breakpoints": true
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "db:migrate": "dotenv -e .env.local -- node_modules/.bin/tsx db/scripts/migrate.ts",
         "db:seed:terms": "dotenv -e .env.local -- node_modules/.bin/tsx db/scripts/seedTerms.ts",
         "db:migrate:tickers": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seed-korean-tickers.ts",
+        "db:seed:crypto": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seed-crypto-assets.ts",
         "db:backfill:calendar": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/backfillEconomicCalendar.ts",
         "db:seed:calendar-analysis": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seedEconomicEventAnalysis.ts",
         "db:seed:calendar-analysis:batch": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seedCalendarAnalysisBatch.ts",

--- a/scripts/seed-crypto-assets.ts
+++ b/scripts/seed-crypto-assets.ts
@@ -10,6 +10,8 @@ if (!databaseUrl) {
     throw new Error('DATABASE_URL env var required');
 }
 
+const UPSERT_BATCH_SIZE = 500;
+
 async function main() {
     const client = postgres(databaseUrl!, { max: 1 });
     const db = drizzle(client);
@@ -23,10 +25,9 @@ async function main() {
     );
     const total = uniqueRows.length;
 
-    const CHUNK = 500;
     let written = 0;
-    for (let i = 0; i < total; i += CHUNK) {
-        const chunk = uniqueRows.slice(i, i + CHUNK);
+    for (let i = 0; i < total; i += UPSERT_BATCH_SIZE) {
+        const chunk = uniqueRows.slice(i, i + UPSERT_BATCH_SIZE);
         await db
             .insert(cryptoAssets)
             .values(chunk)

--- a/scripts/seed-crypto-assets.ts
+++ b/scripts/seed-crypto-assets.ts
@@ -17,10 +17,16 @@ async function main() {
     const rows = await fetchCryptoAssetList();
     console.log(`Fetched ${rows.length} crypto assets from FMP`);
 
+    // Dedupe by symbol to avoid "ON CONFLICT DO UPDATE cannot affect row a second time"
+    const uniqueRows = Array.from(
+        new Map(rows.map(r => [r.symbol, r])).values()
+    );
+    const total = uniqueRows.length;
+
     const CHUNK = 500;
     let written = 0;
-    for (let i = 0; i < rows.length; i += CHUNK) {
-        const chunk = rows.slice(i, i + CHUNK);
+    for (let i = 0; i < total; i += CHUNK) {
+        const chunk = uniqueRows.slice(i, i + CHUNK);
         await db
             .insert(cryptoAssets)
             .values(chunk)
@@ -29,10 +35,13 @@ async function main() {
                 set: {
                     name: sql`excluded.name`,
                     circulatingSupply: sql`excluded.circulating_supply`,
+                    // Drizzle does NOT run $onUpdateFn on conflict-update, so
+                    // updatedAt must be set explicitly to avoid going stale.
+                    updatedAt: sql`now()`,
                 },
             });
         written += chunk.length;
-        console.log(`Upserted ${written}/${rows.length}`);
+        console.log(`Upserted ${written}/${total}`);
     }
     console.log('crypto_assets seed complete');
     await client.end();

--- a/scripts/seed-crypto-assets.ts
+++ b/scripts/seed-crypto-assets.ts
@@ -1,0 +1,44 @@
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { sql } from 'drizzle-orm';
+import { cryptoAssets } from '../src/shared/db/schema';
+import { fetchCryptoAssetList } from '../src/entities/ticker/lib/fmpCryptoListClient';
+
+const databaseUrl = process.env.DIRECT_DATABASE_URL || process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+    throw new Error('DATABASE_URL env var required');
+}
+
+async function main() {
+    const client = postgres(databaseUrl!, { max: 1 });
+    const db = drizzle(client);
+
+    const rows = await fetchCryptoAssetList();
+    console.log(`Fetched ${rows.length} crypto assets from FMP`);
+
+    const CHUNK = 500;
+    let written = 0;
+    for (let i = 0; i < rows.length; i += CHUNK) {
+        const chunk = rows.slice(i, i + CHUNK);
+        await db
+            .insert(cryptoAssets)
+            .values(chunk)
+            .onConflictDoUpdate({
+                target: cryptoAssets.symbol,
+                set: {
+                    name: sql`excluded.name`,
+                    circulatingSupply: sql`excluded.circulating_supply`,
+                },
+            });
+        written += chunk.length;
+        console.log(`Upserted ${written}/${rows.length}`);
+    }
+    console.log('crypto_assets seed complete');
+    await client.end();
+}
+
+main().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/scripts/seed-crypto-assets.ts
+++ b/scripts/seed-crypto-assets.ts
@@ -2,7 +2,7 @@ import postgres from 'postgres';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { sql } from 'drizzle-orm';
 import { cryptoAssets } from '../src/shared/db/schema';
-import { fetchCryptoAssetList } from '../src/entities/ticker/lib/fmpCryptoListClient';
+import { fetchCryptoAssetList } from '../src/entities/ticker/api';
 
 const databaseUrl = process.env.DIRECT_DATABASE_URL || process.env.DATABASE_URL;
 

--- a/src/entities/ticker/__tests__/api.test.ts
+++ b/src/entities/ticker/__tests__/api.test.ts
@@ -1,11 +1,14 @@
-import type { Mock } from 'vitest';
-// withRetry 내부 sleep을 즉시 resolve로 stubbing해서 transient retry 케이스의
-// 실제 대기 시간을 없앤다. `vi.mock` 은 정적 import 보다 먼저 평가되도록
-// 호이스트되어야 한다 (`import/first` 규칙과 일치).
+// vi.mock calls are hoisted by vitest above all imports — must appear before any import statements.
 vi.mock('@/shared/lib/sleep', () => ({
     sleep: vi.fn().mockResolvedValue(undefined),
 }));
+vi.mock('@/shared/api/fmp/httpClient');
 
+import type { Mock } from 'vitest';
+import { vi } from 'vitest';
+
+import { fetchCryptoAssetList } from '@/entities/ticker/api';
+import { fmpGet } from '@/shared/api/fmp/httpClient';
 import {
     DrizzleAssetTranslationRepository,
     DrizzleKoreanTickerRepository,
@@ -289,5 +292,25 @@ describe('Neon transient retry wire-up', () => {
 
         await expect(repo.upsertMany([apple])).rejects.toBe(constraintError);
         expect(insert).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('fetchCryptoAssetList', () => {
+    it('returns mapped rows, filtering out entries without a symbol', async () => {
+        vi.mocked(fmpGet).mockResolvedValue([
+            {
+                symbol: 'BTCUSD',
+                name: 'Bitcoin USD',
+                circulatingSupply: 19_700_000,
+            },
+            { name: 'no symbol' },
+        ]);
+        const result = await fetchCryptoAssetList();
+        expect(result).toHaveLength(1);
+        expect(result[0]).toEqual({
+            symbol: 'BTCUSD',
+            name: 'Bitcoin USD',
+            circulatingSupply: 19_700_000,
+        });
     });
 });

--- a/src/entities/ticker/__tests__/api.test.ts
+++ b/src/entities/ticker/__tests__/api.test.ts
@@ -319,4 +319,18 @@ describe('fetchCryptoAssetList', () => {
         const result = await fetchCryptoAssetList();
         expect(result).toEqual([]);
     });
+
+    it('logs and re-throws when fmpGet fails', async () => {
+        const error = new Error('FMP API error');
+        vi.mocked(fmpGet).mockRejectedValue(error);
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+        await expect(fetchCryptoAssetList()).rejects.toThrow('FMP API error');
+        expect(consoleSpy).toHaveBeenCalledWith(
+            '[fetchCryptoAssetList] FMP cryptocurrency-list fetch failed:',
+            error
+        );
+        consoleSpy.mockRestore();
+    });
 });

--- a/src/entities/ticker/__tests__/api.test.ts
+++ b/src/entities/ticker/__tests__/api.test.ts
@@ -313,4 +313,10 @@ describe('fetchCryptoAssetList', () => {
             circulatingSupply: 19_700_000,
         });
     });
+
+    it('returns an empty array when FMP returns no items', async () => {
+        vi.mocked(fmpGet).mockResolvedValue([]);
+        const result = await fetchCryptoAssetList();
+        expect(result).toEqual([]);
+    });
 });

--- a/src/entities/ticker/api.ts
+++ b/src/entities/ticker/api.ts
@@ -182,10 +182,20 @@ export class DrizzleProfileDescriptionTranslationRepository implements ProfileDe
 
 /** Fetch the full FMP cryptocurrency universe and map to crypto_assets rows. */
 export async function fetchCryptoAssetList(): Promise<CryptoAssetRow[]> {
-    const raw = await fmpGet<FmpCryptoListRaw[]>('cryptocurrency-list', {});
-    return raw
-        .map(mapCryptoListRow)
-        .filter((r): r is CryptoAssetRow => r !== null);
+    try {
+        const raw = await fmpGet<FmpCryptoListRaw[]>('cryptocurrency-list', {});
+        return raw
+            .map(mapCryptoListRow)
+            .filter((r): r is CryptoAssetRow => r !== null);
+    } catch (e) {
+        // Boundary I/O logging; re-throw so the seed script fails loudly
+        // (a silent [] fallback would mask a failed crypto_assets sync).
+        console.error(
+            '[fetchCryptoAssetList] FMP cryptocurrency-list fetch failed:',
+            e
+        );
+        throw e;
+    }
 }
 
 /** Select DB row fields explicitly so future KoreanTickerEntry fields are not persisted accidentally. */

--- a/src/entities/ticker/api.ts
+++ b/src/entities/ticker/api.ts
@@ -1,4 +1,10 @@
 import type { KoreanTickerEntry } from '@/shared/lib/types';
+import { fmpGet } from '@/shared/api/fmp/httpClient';
+import {
+    mapCryptoListRow,
+    type CryptoAssetRow,
+    type FmpCryptoListRaw,
+} from './lib/fmpCryptoListClient';
 import { eq, inArray, sql } from 'drizzle-orm';
 import { NEON_TRANSIENT_RETRY } from '@/shared/db/isNeonTransientError';
 import {
@@ -172,6 +178,14 @@ export class DrizzleProfileDescriptionTranslationRepository implements ProfileDe
             NEON_TRANSIENT_RETRY
         );
     }
+}
+
+/** Fetch the full FMP cryptocurrency universe and map to crypto_assets rows. */
+export async function fetchCryptoAssetList(): Promise<CryptoAssetRow[]> {
+    const raw = await fmpGet<FmpCryptoListRaw[]>('cryptocurrency-list', {});
+    return raw
+        .map(mapCryptoListRow)
+        .filter((r): r is CryptoAssetRow => r !== null);
 }
 
 /** Select DB row fields explicitly so future KoreanTickerEntry fields are not persisted accidentally. */

--- a/src/entities/ticker/lib/__tests__/fmpCryptoListClient.test.ts
+++ b/src/entities/ticker/lib/__tests__/fmpCryptoListClient.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
-import { mapCryptoListRow, fetchCryptoAssetList } from '../fmpCryptoListClient';
-
+// vi.mock is hoisted by vitest above all imports — must appear before any import statements.
 vi.mock('@/shared/api/fmp/httpClient');
-import { fmpGet } from '@/shared/api/fmp/httpClient';
+
+import { describe, it, expect } from 'vitest';
+import { mapCryptoListRow } from '../fmpCryptoListClient';
 
 describe('fmpCryptoListClient', () => {
     describe('mapCryptoListRow', () => {
@@ -34,24 +34,13 @@ describe('fmpCryptoListClient', () => {
         it('skips rows without a symbol', () => {
             expect(mapCryptoListRow({ name: 'no symbol' })).toBeNull();
         });
-    });
 
-    describe('fetchCryptoAssetList', () => {
-        it('returns mapped rows, filtering out entries without a symbol', async () => {
-            vi.mocked(fmpGet).mockResolvedValue([
-                {
-                    symbol: 'BTCUSD',
-                    name: 'Bitcoin USD',
-                    circulatingSupply: 19_700_000,
-                },
-                { name: 'no symbol' },
-            ]);
-            const result = await fetchCryptoAssetList();
-            expect(result).toHaveLength(1);
-            expect(result[0]).toEqual({
+        it('falls back to symbol when name is absent', () => {
+            const row = mapCryptoListRow({ symbol: 'BTCUSD' });
+            expect(row).toEqual({
                 symbol: 'BTCUSD',
-                name: 'Bitcoin USD',
-                circulatingSupply: 19_700_000,
+                name: 'BTCUSD',
+                circulatingSupply: null,
             });
         });
     });

--- a/src/entities/ticker/lib/__tests__/fmpCryptoListClient.test.ts
+++ b/src/entities/ticker/lib/__tests__/fmpCryptoListClient.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { mapCryptoListRow } from '../fmpCryptoListClient';
+
+describe('mapCryptoListRow', () => {
+    it('maps an FMP cryptocurrency-list row to a CryptoAssetRow', () => {
+        const row = mapCryptoListRow({
+            symbol: 'BTCUSD',
+            name: 'Bitcoin USD',
+            exchange: 'CCC',
+            icoDate: '2009-01-03',
+            circulatingSupply: 19700000,
+            totalSupply: 21000000,
+        });
+        expect(row).toEqual({
+            symbol: 'BTCUSD',
+            name: 'Bitcoin USD',
+            circulatingSupply: 19700000,
+        });
+    });
+
+    it('tolerates missing circulatingSupply', () => {
+        const row = mapCryptoListRow({ symbol: 'XYZUSD', name: 'XYZ USD' });
+        expect(row).toEqual({
+            symbol: 'XYZUSD',
+            name: 'XYZ USD',
+            circulatingSupply: null,
+        });
+    });
+
+    it('skips rows without a symbol', () => {
+        expect(mapCryptoListRow({ name: 'no symbol' })).toBeNull();
+    });
+});

--- a/src/entities/ticker/lib/__tests__/fmpCryptoListClient.test.ts
+++ b/src/entities/ticker/lib/__tests__/fmpCryptoListClient.test.ts
@@ -1,6 +1,3 @@
-// vi.mock is hoisted by vitest above all imports — must appear before any import statements.
-vi.mock('@/shared/api/fmp/httpClient');
-
 import { describe, it, expect } from 'vitest';
 import { mapCryptoListRow } from '../fmpCryptoListClient';
 

--- a/src/entities/ticker/lib/__tests__/fmpCryptoListClient.test.ts
+++ b/src/entities/ticker/lib/__tests__/fmpCryptoListClient.test.ts
@@ -1,33 +1,58 @@
-import { describe, it, expect } from 'vitest';
-import { mapCryptoListRow } from '../fmpCryptoListClient';
+import { describe, it, expect, vi } from 'vitest';
+import { mapCryptoListRow, fetchCryptoAssetList } from '../fmpCryptoListClient';
 
-describe('mapCryptoListRow', () => {
-    it('maps an FMP cryptocurrency-list row to a CryptoAssetRow', () => {
-        const row = mapCryptoListRow({
-            symbol: 'BTCUSD',
-            name: 'Bitcoin USD',
-            exchange: 'CCC',
-            icoDate: '2009-01-03',
-            circulatingSupply: 19700000,
-            totalSupply: 21000000,
+vi.mock('@/shared/api/fmp/httpClient');
+import { fmpGet } from '@/shared/api/fmp/httpClient';
+
+describe('fmpCryptoListClient', () => {
+    describe('mapCryptoListRow', () => {
+        it('maps an FMP cryptocurrency-list row to a CryptoAssetRow', () => {
+            const row = mapCryptoListRow({
+                symbol: 'BTCUSD',
+                name: 'Bitcoin USD',
+                exchange: 'CCC',
+                icoDate: '2009-01-03',
+                circulatingSupply: 19700000,
+                totalSupply: 21000000,
+            });
+            expect(row).toEqual({
+                symbol: 'BTCUSD',
+                name: 'Bitcoin USD',
+                circulatingSupply: 19700000,
+            });
         });
-        expect(row).toEqual({
-            symbol: 'BTCUSD',
-            name: 'Bitcoin USD',
-            circulatingSupply: 19700000,
+
+        it('tolerates missing circulatingSupply', () => {
+            const row = mapCryptoListRow({ symbol: 'XYZUSD', name: 'XYZ USD' });
+            expect(row).toEqual({
+                symbol: 'XYZUSD',
+                name: 'XYZ USD',
+                circulatingSupply: null,
+            });
+        });
+
+        it('skips rows without a symbol', () => {
+            expect(mapCryptoListRow({ name: 'no symbol' })).toBeNull();
         });
     });
 
-    it('tolerates missing circulatingSupply', () => {
-        const row = mapCryptoListRow({ symbol: 'XYZUSD', name: 'XYZ USD' });
-        expect(row).toEqual({
-            symbol: 'XYZUSD',
-            name: 'XYZ USD',
-            circulatingSupply: null,
+    describe('fetchCryptoAssetList', () => {
+        it('returns mapped rows, filtering out entries without a symbol', async () => {
+            vi.mocked(fmpGet).mockResolvedValue([
+                {
+                    symbol: 'BTCUSD',
+                    name: 'Bitcoin USD',
+                    circulatingSupply: 19_700_000,
+                },
+                { name: 'no symbol' },
+            ]);
+            const result = await fetchCryptoAssetList();
+            expect(result).toHaveLength(1);
+            expect(result[0]).toEqual({
+                symbol: 'BTCUSD',
+                name: 'Bitcoin USD',
+                circulatingSupply: 19_700_000,
+            });
         });
-    });
-
-    it('skips rows without a symbol', () => {
-        expect(mapCryptoListRow({ name: 'no symbol' })).toBeNull();
     });
 });

--- a/src/entities/ticker/lib/fmpCryptoListClient.ts
+++ b/src/entities/ticker/lib/fmpCryptoListClient.ts
@@ -5,6 +5,7 @@ interface FmpCryptoListRaw {
     symbol?: string;
     name?: string;
     circulatingSupply?: number | null;
+    [key: string]: unknown;
 }
 
 /** Normalized row for the crypto_assets table. */

--- a/src/entities/ticker/lib/fmpCryptoListClient.ts
+++ b/src/entities/ticker/lib/fmpCryptoListClient.ts
@@ -1,0 +1,36 @@
+import { fmpGet } from '@/shared/api/fmp/httpClient';
+
+/** Raw FMP cryptocurrency-list row (fields beyond these are ignored). */
+interface FmpCryptoListRaw {
+    symbol?: string;
+    name?: string;
+    circulatingSupply?: number | null;
+}
+
+/** Normalized row for the crypto_assets table. */
+export interface CryptoAssetRow {
+    symbol: string;
+    name: string;
+    circulatingSupply: number | null;
+}
+
+/** Map a raw FMP list row; returns null when there is no usable symbol. */
+export function mapCryptoListRow(raw: FmpCryptoListRaw): CryptoAssetRow | null {
+    if (!raw.symbol) return null;
+    return {
+        symbol: raw.symbol,
+        name: raw.name ?? raw.symbol,
+        circulatingSupply:
+            typeof raw.circulatingSupply === 'number'
+                ? raw.circulatingSupply
+                : null,
+    };
+}
+
+/** Fetch the full FMP cryptocurrency universe and map to crypto_assets rows. */
+export async function fetchCryptoAssetList(): Promise<CryptoAssetRow[]> {
+    const raw = await fmpGet<FmpCryptoListRaw[]>('cryptocurrency-list', {});
+    return raw
+        .map(mapCryptoListRow)
+        .filter((r): r is CryptoAssetRow => r !== null);
+}

--- a/src/entities/ticker/lib/fmpCryptoListClient.ts
+++ b/src/entities/ticker/lib/fmpCryptoListClient.ts
@@ -1,7 +1,5 @@
-import { fmpGet } from '@/shared/api/fmp/httpClient';
-
 /** Raw FMP cryptocurrency-list row (fields beyond these are ignored). */
-interface FmpCryptoListRaw {
+export interface FmpCryptoListRaw {
     symbol?: string;
     name?: string;
     circulatingSupply?: number | null;
@@ -26,12 +24,4 @@ export function mapCryptoListRow(raw: FmpCryptoListRaw): CryptoAssetRow | null {
                 ? raw.circulatingSupply
                 : null,
     };
-}
-
-/** Fetch the full FMP cryptocurrency universe and map to crypto_assets rows. */
-export async function fetchCryptoAssetList(): Promise<CryptoAssetRow[]> {
-    const raw = await fmpGet<FmpCryptoListRaw[]>('cryptocurrency-list', {});
-    return raw
-        .map(mapCryptoListRow)
-        .filter((r): r is CryptoAssetRow => r !== null);
 }

--- a/src/shared/config/marketProfile/__tests__/registry.test.ts
+++ b/src/shared/config/marketProfile/__tests__/registry.test.ts
@@ -6,37 +6,49 @@ import {
 } from '../registry';
 
 describe('market profile registry', () => {
-    it('returns the us-equity descriptor', () => {
-        const d = getDescriptor('us-equity');
-        expect(d.assetClass).toBe('equity');
-        expect(d.exchangeWhitelist).not.toBeNull();
-        expect(d.tabs).toContain('fundamental');
-    });
+    describe('getDescriptor', () => {
+        it('returns the us-equity descriptor', () => {
+            const d = getDescriptor('us-equity');
+            expect(d.assetClass).toBe('equity');
+            expect(d.exchangeWhitelist).not.toBeNull();
+            expect(d.tabs).toContain('fundamental');
+        });
 
-    it('returns the crypto descriptor with crypto-specific policy', () => {
-        const d = getDescriptor('crypto');
-        expect(d.assetClass).toBe('crypto');
-        expect(d.exchangeWhitelist).toBeNull();
-        expect(d.searchSource).toBe('crypto-store');
-        expect(d.tabs).not.toContain('fundamental');
-        expect(d.tabs).not.toContain('options');
-        expect(d.allowedTimeframes).not.toContain('4Hour');
-        expect(d.priceFormat.precision).toEqual({
-            kind: 'dynamic-by-magnitude',
+        it('returns the crypto descriptor with crypto-specific policy', () => {
+            const d = getDescriptor('crypto');
+            expect(d.assetClass).toBe('crypto');
+            expect(d.exchangeWhitelist).toBeNull();
+            expect(d.searchSource).toBe('crypto-store');
+            expect(d.tabs).not.toContain('fundamental');
+            expect(d.tabs).not.toContain('options');
+            expect(d.allowedTimeframes).not.toContain('4Hour');
+            expect(d.priceFormat.precision).toEqual({
+                kind: 'dynamic-by-magnitude',
+            });
         });
     });
 
-    it('defaults a profile-less AssetInfo to us-equity', () => {
-        expect(DEFAULT_MARKET_PROFILE).toBe('us-equity');
-        expect(marketProfileOf({ symbol: 'AAPL', name: 'Apple' })).toBe(
-            'us-equity'
-        );
-        expect(
-            marketProfileOf({
-                symbol: 'BTCUSD',
-                name: 'Bitcoin',
-                marketProfile: 'crypto',
-            })
-        ).toBe('crypto');
+    describe('DEFAULT_MARKET_PROFILE', () => {
+        it('is us-equity', () => {
+            expect(DEFAULT_MARKET_PROFILE).toBe('us-equity');
+        });
+    });
+
+    describe('marketProfileOf', () => {
+        it('defaults to us-equity when marketProfile is absent', () => {
+            expect(marketProfileOf({ symbol: 'AAPL', name: 'Apple' })).toBe(
+                'us-equity'
+            );
+        });
+
+        it('returns the explicit marketProfile when present', () => {
+            expect(
+                marketProfileOf({
+                    symbol: 'BTCUSD',
+                    name: 'Bitcoin',
+                    marketProfile: 'crypto',
+                })
+            ).toBe('crypto');
+        });
     });
 });

--- a/src/shared/config/marketProfile/__tests__/registry.test.ts
+++ b/src/shared/config/marketProfile/__tests__/registry.test.ts
@@ -11,7 +11,16 @@ describe('market profile registry', () => {
             const d = getDescriptor('us-equity');
             expect(d.assetClass).toBe('equity');
             expect(d.exchangeWhitelist).not.toBeNull();
-            expect(d.tabs).toContain('fundamental');
+            expect(d.tabs).toEqual([
+                'chart',
+                'news',
+                'fundamental',
+                'financials',
+                'congress',
+                'options',
+                'fear-greed',
+                'overall',
+            ]);
         });
 
         it('returns the crypto descriptor with crypto-specific policy', () => {
@@ -19,9 +28,8 @@ describe('market profile registry', () => {
             expect(d.assetClass).toBe('crypto');
             expect(d.exchangeWhitelist).toBeNull();
             expect(d.searchSource).toBe('crypto-store');
-            expect(d.tabs).not.toContain('fundamental');
-            expect(d.tabs).not.toContain('options');
-            expect(d.allowedTimeframes).not.toContain('4Hour');
+            expect(d.tabs).toEqual(['chart', 'news', 'fear-greed', 'overall']);
+            expect(d.allowedTimeframes).toEqual(['5Min', '1Hour', '1Day']);
             expect(d.priceFormat.precision).toEqual({
                 kind: 'dynamic-by-magnitude',
             });

--- a/src/shared/config/marketProfile/__tests__/registry.test.ts
+++ b/src/shared/config/marketProfile/__tests__/registry.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import {
+    getDescriptor,
+    marketProfileOf,
+    DEFAULT_MARKET_PROFILE,
+} from '../registry';
+
+describe('market profile registry', () => {
+    it('returns the us-equity descriptor', () => {
+        const d = getDescriptor('us-equity');
+        expect(d.assetClass).toBe('equity');
+        expect(d.exchangeWhitelist).not.toBeNull();
+        expect(d.tabs).toContain('fundamental');
+    });
+
+    it('returns the crypto descriptor with crypto-specific policy', () => {
+        const d = getDescriptor('crypto');
+        expect(d.assetClass).toBe('crypto');
+        expect(d.exchangeWhitelist).toBeNull();
+        expect(d.searchSource).toBe('crypto-store');
+        expect(d.tabs).not.toContain('fundamental');
+        expect(d.tabs).not.toContain('options');
+        expect(d.allowedTimeframes).not.toContain('4Hour');
+        expect(d.priceFormat.precision).toEqual({
+            kind: 'dynamic-by-magnitude',
+        });
+    });
+
+    it('defaults a profile-less AssetInfo to us-equity', () => {
+        expect(DEFAULT_MARKET_PROFILE).toBe('us-equity');
+        expect(marketProfileOf({ symbol: 'AAPL', name: 'Apple' })).toBe(
+            'us-equity'
+        );
+        expect(
+            marketProfileOf({
+                symbol: 'BTCUSD',
+                name: 'Bitcoin',
+                marketProfile: 'crypto',
+            })
+        ).toBe('crypto');
+    });
+});

--- a/src/shared/config/marketProfile/__tests__/registry.test.ts
+++ b/src/shared/config/marketProfile/__tests__/registry.test.ts
@@ -21,6 +21,19 @@ describe('market profile registry', () => {
                 'fear-greed',
                 'overall',
             ]);
+            expect(d.allowedTimeframes).toEqual([
+                '5Min',
+                '15Min',
+                '30Min',
+                '1Hour',
+                '4Hour',
+                '1Day',
+            ]);
+            expect(d.defaultTimeframe).toBe('1Day');
+            expect(d.priceFormat.precision).toEqual({
+                kind: 'fixed',
+                digits: 2,
+            });
         });
 
         it('returns the crypto descriptor with crypto-specific policy', () => {

--- a/src/shared/config/marketProfile/crypto.ts
+++ b/src/shared/config/marketProfile/crypto.ts
@@ -1,0 +1,26 @@
+import type { MarketProfileDescriptor } from './types';
+
+export const CRYPTO_DESCRIPTOR: MarketProfileDescriptor = {
+    id: 'crypto',
+    assetClass: 'crypto',
+    region: 'global',
+    priceFormat: {
+        currency: 'USD',
+        locale: 'en-US',
+        precision: { kind: 'dynamic-by-magnitude' },
+    },
+    sessionModel: 'always-open',
+    dataProvider: 'fmp',
+    toProviderSymbol: canonical => canonical, // BTCUSD passthrough
+    newsSource: 'crypto',
+    exchangeWhitelist: null, // FMP crypto exchange is "CRYPTO"/"CCC"; classify via DB
+    searchSource: 'crypto-store',
+    // 15Min/30Min/4Hour are NOT supported by FMP crypto intraday endpoints.
+    tabs: ['chart', 'news', 'fear-greed', 'overall'],
+    defaultTimeframe: '1Day',
+    allowedTimeframes: ['5Min', '1Hour', '1Day'],
+    seo: {
+        aboutNodeType: null, // no standard schema.org crypto type → omit about node
+    },
+    sitemapLastmod: 'rolling',
+};

--- a/src/shared/config/marketProfile/crypto.ts
+++ b/src/shared/config/marketProfile/crypto.ts
@@ -11,7 +11,7 @@ export const CRYPTO_DESCRIPTOR: MarketProfileDescriptor = {
     },
     sessionModel: 'always-open',
     dataProvider: 'fmp',
-    toProviderSymbol: canonical => canonical, // BTCUSD passthrough
+    toProviderSymbol: canonical => canonical, // FMP crypto symbols are already canonical (BTCUSD) — no mapping needed
     newsSource: 'crypto',
     exchangeWhitelist: null, // FMP crypto exchange is "CRYPTO"/"CCC"; classify via DB
     searchSource: 'crypto-store',

--- a/src/shared/config/marketProfile/index.ts
+++ b/src/shared/config/marketProfile/index.ts
@@ -1,0 +1,13 @@
+export type {
+    MarketProfileId,
+    AssetClass,
+    MarketRegion,
+    SessionModel,
+    PricePrecision,
+    MarketProfileDescriptor,
+} from './types';
+export {
+    getDescriptor,
+    marketProfileOf,
+    DEFAULT_MARKET_PROFILE,
+} from './registry';

--- a/src/shared/config/marketProfile/index.ts
+++ b/src/shared/config/marketProfile/index.ts
@@ -4,6 +4,7 @@ export type {
     MarketRegion,
     SessionModel,
     PricePrecision,
+    PriceFormatConfig,
     MarketProfileDescriptor,
 } from './types';
 export {

--- a/src/shared/config/marketProfile/registry.ts
+++ b/src/shared/config/marketProfile/registry.ts
@@ -1,0 +1,21 @@
+import type { AssetInfo } from '@/shared/lib/types';
+import type { MarketProfileDescriptor, MarketProfileId } from './types';
+import { US_EQUITY_DESCRIPTOR } from './usEquity';
+import { CRYPTO_DESCRIPTOR } from './crypto';
+
+export const DEFAULT_MARKET_PROFILE: MarketProfileId = 'us-equity';
+
+const REGISTRY: Record<MarketProfileId, MarketProfileDescriptor> = {
+    'us-equity': US_EQUITY_DESCRIPTOR,
+    crypto: CRYPTO_DESCRIPTOR,
+};
+
+/** Look up the descriptor for a market-profile id. */
+export function getDescriptor(id: MarketProfileId): MarketProfileDescriptor {
+    return REGISTRY[id];
+}
+
+/** Resolve an AssetInfo's market profile, defaulting legacy/profile-less assets to us-equity. */
+export function marketProfileOf(asset: AssetInfo): MarketProfileId {
+    return asset.marketProfile ?? DEFAULT_MARKET_PROFILE;
+}

--- a/src/shared/config/marketProfile/types.ts
+++ b/src/shared/config/marketProfile/types.ts
@@ -27,17 +27,20 @@ export type PricePrecision =
     | { kind: 'integer' }
     | { kind: 'dynamic-by-magnitude' };
 
+/** Price formatting configuration for a market profile. */
+export interface PriceFormatConfig {
+    currency: 'USD';
+    locale: string;
+    precision: PricePrecision;
+}
+
 /** Per-market policy bundle. Downstream code reads this; never branches on raw ids. */
 export interface MarketProfileDescriptor {
     id: MarketProfileId;
     assetClass: AssetClass;
     region: MarketRegion;
 
-    priceFormat: {
-        currency: 'USD';
-        locale: string;
-        precision: PricePrecision;
-    };
+    priceFormat: PriceFormatConfig;
 
     /** Interim; upgraded to core MarketSessionSpec in the session plan. */
     sessionModel: SessionModel;

--- a/src/shared/config/marketProfile/types.ts
+++ b/src/shared/config/marketProfile/types.ts
@@ -1,0 +1,68 @@
+import type { Timeframe } from '@y0ngha/siglens-core';
+
+/**
+ * Composite market-profile key — one entry per REAL tradable market.
+ * Not a raw {assetClass × region} cartesian: crypto has no meaningful
+ * region, and currency/session/language/provider/SEO all co-vary by the
+ * combination. Korean stocks slot in later as `'kr-equity'`.
+ */
+export type MarketProfileId = 'us-equity' | 'crypto';
+
+/** Top-level instrument kind. Drives tab whitelist + (later) core prompt branch. */
+export type AssetClass = 'equity' | 'crypto';
+
+/** Market/region axis. Drives currency, session, language, data provider. */
+export type MarketRegion = 'us' | 'global';
+
+/**
+ * Interim session model (siglens-local). A later core plan replaces this
+ * with `MarketSessionSpec` from `@y0ngha/siglens-core`. Kept minimal so
+ * Plans 1–2 ship without the cross-repo core change.
+ */
+export type SessionModel = 'us-equity-et' | 'always-open';
+
+/** Price precision rule applied by `formatPrice`. */
+export type PricePrecision =
+    | { kind: 'fixed'; digits: number }
+    | { kind: 'integer' }
+    | { kind: 'dynamic-by-magnitude' };
+
+/** Per-market policy bundle. Downstream code reads this; never branches on raw ids. */
+export interface MarketProfileDescriptor {
+    id: MarketProfileId;
+    assetClass: AssetClass;
+    region: MarketRegion;
+
+    priceFormat: {
+        currency: 'USD';
+        locale: string;
+        precision: PricePrecision;
+    };
+
+    /** Interim; upgraded to core MarketSessionSpec in the session plan. */
+    sessionModel: SessionModel;
+
+    dataProvider: 'fmp';
+    /** Canonical symbol → FMP provider symbol. Crypto = passthrough. */
+    toProviderSymbol: (canonical: string) => string;
+    newsSource: 'stock' | 'crypto';
+
+    /** US equity exchange whitelist; `null` = no exchange filter (crypto). */
+    exchangeWhitelist: ReadonlySet<string> | null;
+    searchSource: 'fmp-us' | 'crypto-store';
+
+    /** Tab keys (string ids matching symbolTabsConfig). */
+    tabs: readonly string[];
+    defaultTimeframe: Timeframe;
+    allowedTimeframes: readonly Timeframe[];
+
+    seo: {
+        /**
+         * JSON-LD `about` node @type (consumed by buildAssetAboutNode). crypto = null.
+         * Title/description/keywords copy lives in seo.ts (Plan 5) — the descriptor
+         * must NOT carry copy builders, or usEquity.ts → seo.ts → registry would cycle.
+         */
+        aboutNodeType: 'Corporation' | null;
+    };
+    sitemapLastmod: 'us-close' | 'rolling';
+}

--- a/src/shared/config/marketProfile/usEquity.ts
+++ b/src/shared/config/marketProfile/usEquity.ts
@@ -1,0 +1,44 @@
+import type { MarketProfileDescriptor } from './types';
+
+/** US listing exchanges that survive search filtering (mirror of fmpTickerApi US_EXCHANGES). */
+const US_EXCHANGES: ReadonlySet<string> = new Set([
+    'NYSE',
+    'NASDAQ',
+    'AMEX',
+    'CBOE',
+    'OTC',
+    'PNK',
+]);
+
+export const US_EQUITY_DESCRIPTOR: MarketProfileDescriptor = {
+    id: 'us-equity',
+    assetClass: 'equity',
+    region: 'us',
+    priceFormat: {
+        currency: 'USD',
+        locale: 'en-US',
+        precision: { kind: 'fixed', digits: 2 },
+    },
+    sessionModel: 'us-equity-et',
+    dataProvider: 'fmp',
+    toProviderSymbol: canonical => canonical,
+    newsSource: 'stock',
+    exchangeWhitelist: US_EXCHANGES,
+    searchSource: 'fmp-us',
+    tabs: [
+        'chart',
+        'news',
+        'fundamental',
+        'financials',
+        'congress',
+        'options',
+        'fear-greed',
+        'overall',
+    ],
+    defaultTimeframe: '1Day',
+    allowedTimeframes: ['5Min', '15Min', '30Min', '1Hour', '4Hour', '1Day'],
+    seo: {
+        aboutNodeType: 'Corporation',
+    },
+    sitemapLastmod: 'us-close',
+};

--- a/src/shared/config/marketProfile/usEquity.ts
+++ b/src/shared/config/marketProfile/usEquity.ts
@@ -1,6 +1,13 @@
 import type { MarketProfileDescriptor } from './types';
 
-/** US listing exchanges that survive search filtering (mirror of fmpTickerApi US_EXCHANGES). */
+/**
+ * US listing exchanges that survive search filtering.
+ *
+ * Mirrors `US_EXCHANGES` in `src/entities/ticker/lib/fmpTickerApi.ts`.
+ * If you add or remove an exchange here, apply the same change there (and
+ * vice-versa) to keep ticker search and market-profile routing in sync.
+ * See MISTAKES.md §16.5 for the duplication rationale.
+ */
 const US_EXCHANGES: ReadonlySet<string> = new Set([
     'NYSE',
     'NASDAQ',

--- a/src/shared/db/schema.ts
+++ b/src/shared/db/schema.ts
@@ -184,6 +184,10 @@ export const koreanTickers = pgTable('korean_tickers', {
  * Mirrors `koreanTickers` shape. Membership in this table is the
  * authoritative crypto classifier (FMP's exchange field is inconsistent:
  * "CCC" in the list vs "CRYPTO" in quote/search).
+ *
+ * `korean_name` is nullable by design: the cryptocurrency-list seed intentionally
+ * leaves it NULL; Korean names are populated lazily in a later plan, mirroring the
+ * `asset_translations` lazy-translation pattern.
  */
 export const cryptoAssets = pgTable('crypto_assets', {
     symbol: varchar('symbol', { length: SYMBOL_MAX_LENGTH }).primaryKey(),

--- a/src/shared/db/schema.ts
+++ b/src/shared/db/schema.ts
@@ -180,6 +180,23 @@ export const koreanTickers = pgTable('korean_tickers', {
 });
 
 /**
+ * Cryptocurrency asset universe — seeded from FMP `cryptocurrency-list`.
+ * Mirrors `koreanTickers` shape. Membership in this table is the
+ * authoritative crypto classifier (FMP's exchange field is inconsistent:
+ * "CCC" in the list vs "CRYPTO" in quote/search).
+ */
+export const cryptoAssets = pgTable('crypto_assets', {
+    symbol: varchar('symbol', { length: SYMBOL_MAX_LENGTH }).primaryKey(),
+    name: text('name').notNull(),
+    koreanName: text('korean_name'),
+    circulatingSupply: doublePrecision('circulating_supply'),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+        .notNull()
+        .defaultNow()
+        .$onUpdateFn(nowFn),
+});
+
+/**
  * Korean company description translations — one row per symbol, populated
  * lazily on first visit and persisted permanently (no TTL / no deployment eviction).
  */

--- a/src/shared/lib/types.ts
+++ b/src/shared/lib/types.ts
@@ -61,7 +61,7 @@ export interface AssetInfo {
      * `marketProfileOf()` which defaults to `'us-equity'`. Populated for
      * crypto in the routing/data plan (Plan 2).
      */
-    marketProfile?: import('@/shared/config/marketProfile/types').MarketProfileId;
+    marketProfile?: MarketProfileId;
 }
 
 /** Curated category id used to group tickers in UI explorers. */
@@ -100,6 +100,7 @@ export type {
 export type { AuthUserRecord } from '@/shared/lib/auth/types';
 
 import type { LlmProvider } from '@/shared/config/llmProviders';
+import type { MarketProfileId } from '@/shared/config/marketProfile/types';
 
 export type { LlmProvider };
 

--- a/src/shared/lib/types.ts
+++ b/src/shared/lib/types.ts
@@ -56,6 +56,12 @@ export interface AssetInfo {
     koreanName?: string;
     /** FMP API 심볼 (지수의 경우 ^ 접두사 포함, 예: ^SPX). 일반 주식은 undefined. */
     fmpSymbol?: string;
+    /**
+     * Market profile id. Absent on legacy/equity rows — resolve with
+     * `marketProfileOf()` which defaults to `'us-equity'`. Populated for
+     * crypto in the routing/data plan (Plan 2).
+     */
+    marketProfile?: import('@/shared/config/marketProfile').MarketProfileId;
 }
 
 /** Curated category id used to group tickers in UI explorers. */

--- a/src/shared/lib/types.ts
+++ b/src/shared/lib/types.ts
@@ -61,7 +61,7 @@ export interface AssetInfo {
      * `marketProfileOf()` which defaults to `'us-equity'`. Populated for
      * crypto in the routing/data plan (Plan 2).
      */
-    marketProfile?: import('@/shared/config/marketProfile').MarketProfileId;
+    marketProfile?: import('@/shared/config/marketProfile/types').MarketProfileId;
 }
 
 /** Curated category id used to group tickers in UI explorers. */

--- a/src/shared/lib/types.ts
+++ b/src/shared/lib/types.ts
@@ -100,6 +100,8 @@ export type {
 export type { AuthUserRecord } from '@/shared/lib/auth/types';
 
 import type { LlmProvider } from '@/shared/config/llmProviders';
+// Direct import from /types (not the barrel) to avoid a circular dependency:
+// shared/lib/types → marketProfile/index(barrel) → registry → shared/lib/types
 import type { MarketProfileId } from '@/shared/config/marketProfile/types';
 
 export type { LlmProvider };


### PR DESCRIPTION
## Summary

Plan 1 of the 5-plan crypto epic — foundation schema, market profile descriptor framework, and FMP data ingestion. siglens-only, no core changes.

## Implementation

- **MarketProfile descriptors** (siglens-only): `src/shared/config/marketProfile/{types.ts, usEquity.ts, crypto.ts, registry.ts, index.ts}` — Descriptor skeleton + registry resolver
- **AssetInfo schema**: `src/shared/lib/types.ts` — Added optional `marketProfile` field
- **Crypto assets table**: `src/shared/db/schema.ts` + `drizzle/migrations/` — New `crypto_assets` table
- **FMP client**: `src/entities/ticker/lib/fmpCryptoListClient.ts` — Cryptocurrency-list endpoint
- **Seed script**: `scripts/seed-crypto-assets.ts` — Loads 4,785 rows from FMP

## Test Coverage
- Circular import detection (resolver, registry)
- Seed upsert logic
- Schema type consistency

## Notes
- No siglens-core changes (analysis/signals untouched)
- Plan 1 foundation only; Plans 2–5 (UI, search, analysis, signals) follow in subsequent PRs
- The MarketProfile registry (`getDescriptor`/`marketProfileOf`/`DEFAULT_MARKET_PROFILE`) is intentionally landed in Plan 1 as the shared foundation consumed by Plan 2+ (descriptor-driven routing/tabs/SEO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)