### PR TITLE
feat(search): cryptocurrency Korean-name search

### DIFF
--- a/e2e/specs/crypto-korean-search.spec.ts
+++ b/e2e/specs/crypto-korean-search.spec.ts
@@ -69,9 +69,8 @@ test.describe('crypto Korean-name search', () => {
     }) => {
         await page.goto('/');
 
-        // Use the hero-panel combobox (scoped to #search) for the click path
-        // so onSelect fires and the navigate() handler routes correctly.
-        // (The banner combobox has no onSelect; both navigate via router.push.)
+        // Use the banner (header) combobox — same selector as the badge test above.
+        // Both route to the symbol page via router.push when a result is selected.
         const search = page
             .getByRole('banner')
             .getByRole('combobox', { name: TICKER_COMBOBOX_NAME });

--- a/e2e/specs/crypto-korean-search.spec.ts
+++ b/e2e/specs/crypto-korean-search.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '../support/fixtures';
+
+/**
+ * E2E spec: Korean-name search for cryptocurrency assets.
+ *
+ * Proves that typing a Korean coin name prefix (e.g. "비트코") in the header
+ * search combobox surfaces the corresponding crypto result (BTCUSD) in the
+ * autocomplete dropdown with the "코인" badge.
+ *
+ * How this works end-to-end:
+ *   - seed.ts populates crypto_assets with koreanName='비트코인' for BTCUSD
+ *     (and '이더리움' for ETHUSD) so the DB is consistent with the fixture.
+ *   - searchTickerAction short-circuits under E2E_TEST=1 and returns a
+ *     deterministic fixture that includes BTCUSD/ETHUSD with koreanName and
+ *     marketProfile:'crypto'. The filter checks koreanName so "비트코" matches.
+ *   - TickerAutocomplete renders a role="option" button per result; when
+ *     result.marketProfile === 'crypto' it renders a <CryptoBadge> ("코인").
+ *
+ * Selector conventions (mirrored from symbol-search.spec.ts):
+ *   - Header combobox: role="combobox" aria-label="종목 티커 검색" scoped to
+ *     role="banner" to avoid the duplicate hero panel combobox on the home page.
+ *   - Autocomplete options: role="option" inside the listbox that appears
+ *     after typing. Playwright auto-waits for the option — no sleep needed.
+ *   - 코인 badge: text "코인" near the BTCUSD option.
+ *
+ * Non-flakiness strategy:
+ *   - Playwright's built-in auto-waiting on toBeVisible() naturally absorbs the
+ *     300ms debounce (useTickerSearch) + server-action round-trip latency.
+ *   - No hard sleeps.
+ *   - The E2E_TEST fixture is fully deterministic; no real FMP or DB query.
+ */
+
+const TICKER_COMBOBOX_NAME = '종목 티커 검색';
+
+test.describe('crypto Korean-name search', () => {
+    test('typing a Korean prefix surfaces the crypto result with 코인 badge', async ({
+        page,
+    }) => {
+        await page.goto('/');
+
+        // Use the banner (header) combobox — scoped to role="banner" to avoid
+        // the strict-mode violation from the duplicate hero-panel combobox.
+        const search = page
+            .getByRole('banner')
+            .getByRole('combobox', { name: TICKER_COMBOBOX_NAME });
+
+        await search.fill('비트코');
+
+        // The listbox appears after the 300ms debounce. Playwright auto-waits
+        // on toBeVisible so no sleep is needed; the default expect timeout
+        // (5s local, 15s CI) comfortably covers debounce + server-action time.
+        const btcOption = page
+            .getByRole('option')
+            .filter({ hasText: 'BTCUSD' })
+            .first();
+
+        await expect(btcOption).toBeVisible();
+
+        // The CryptoBadge ("코인") must be present inside the BTCUSD option.
+        // Use exact:true to match only the badge span (not the substring "코인"
+        // that appears inside "비트코인" in the display name).
+        await expect(
+            btcOption.getByText('코인', { exact: true })
+        ).toBeVisible();
+    });
+
+    test('clicking the crypto result navigates to /BTCUSD', async ({
+        page,
+    }) => {
+        await page.goto('/');
+
+        // Use the hero-panel combobox (scoped to #search) for the click path
+        // so onSelect fires and the navigate() handler routes correctly.
+        // (The banner combobox has no onSelect; both navigate via router.push.)
+        const search = page
+            .getByRole('banner')
+            .getByRole('combobox', { name: TICKER_COMBOBOX_NAME });
+
+        await search.fill('비트코');
+
+        const btcOption = page
+            .getByRole('option')
+            .filter({ hasText: 'BTCUSD' })
+            .first();
+
+        await expect(btcOption).toBeVisible();
+        await btcOption.click();
+
+        await page.waitForURL('**/BTCUSD');
+        await expect(
+            page.getByRole('heading', { level: 1, name: /BTCUSD/ })
+        ).toBeVisible({ timeout: 15_000 });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "db:seed:terms": "dotenv -e .env.local -- node_modules/.bin/tsx db/scripts/seedTerms.ts",
         "db:migrate:tickers": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seed-korean-tickers.ts",
         "db:seed:crypto": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seed-crypto-assets.ts",
+        "db:seed:crypto-korean": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seed-crypto-korean-names.ts",
         "db:backfill:calendar": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/backfillEconomicCalendar.ts",
         "db:seed:calendar-analysis": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seedEconomicEventAnalysis.ts",
         "db:seed:calendar-analysis:batch": "dotenv -e .env.local -- node_modules/.bin/tsx scripts/seedCalendarAnalysisBatch.ts",

--- a/scripts/__tests__/seed-crypto-korean-names.test.ts
+++ b/scripts/__tests__/seed-crypto-korean-names.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for the seed-crypto-korean-names translate→upsert mapping.
+ *
+ * Imports the REAL exported helpers from the seed script (extractKoreanName,
+ * buildUpsertValues, toUpsertRow) rather than re-implementing them locally, so a
+ * drift in production logic fails these tests. The script's run() entry point is
+ * guarded (executedDirectly), so importing here does not connect to the DB or
+ * Gemini; env vars are validated inside run(), not at module load.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { InlinedResponse } from '@google/genai';
+import {
+    extractKoreanName,
+    buildUpsertValues,
+    toUpsertRow,
+} from '../seed-crypto-korean-names';
+
+/** Build a minimal InlinedResponse with the given metadata.id and text body. */
+function makeResponse(id: string, text: string): InlinedResponse {
+    return {
+        metadata: { id },
+        response: {
+            candidates: [{ content: { parts: [{ text }] } }],
+        },
+    } as unknown as InlinedResponse;
+}
+
+/** Build a JSON body of the shape the prompt requests: { SYMBOL: koreanName }. */
+function jsonBody(symbol: string, koreanName: string): string {
+    return JSON.stringify({ [symbol]: koreanName });
+}
+
+describe('seed-crypto-korean-names — extractKoreanName', () => {
+    it('잘 형성된 JSON 응답에서 Korean 이름을 추출한다', () => {
+        expect(
+            extractKoreanName('BTCUSD', jsonBody('BTCUSD', '비트코인'))
+        ).toBe('비트코인');
+    });
+
+    it('이더리움 번역도 올바르게 추출한다', () => {
+        expect(
+            extractKoreanName('ETHUSD', jsonBody('ETHUSD', '이더리움'))
+        ).toBe('이더리움');
+    });
+
+    it('다른 symbol 키를 가진 응답은 null을 반환한다', () => {
+        expect(
+            extractKoreanName('BTCUSD', jsonBody('ETHUSD', '이더리움'))
+        ).toBeNull();
+    });
+
+    it('빈 문자열 값은 null을 반환한다', () => {
+        expect(extractKoreanName('BTCUSD', jsonBody('BTCUSD', ''))).toBeNull();
+    });
+
+    it('공백만 있는 값은 null을 반환한다', () => {
+        expect(
+            extractKoreanName('BTCUSD', jsonBody('BTCUSD', '   '))
+        ).toBeNull();
+    });
+
+    it('값을 trim 한다', () => {
+        expect(
+            extractKoreanName('BTCUSD', jsonBody('BTCUSD', '  비트코인  '))
+        ).toBe('비트코인');
+    });
+
+    it('malformed JSON 은 null을 반환한다', () => {
+        expect(extractKoreanName('BTCUSD', 'not json')).toBeNull();
+    });
+
+    it('배열 응답은 null을 반환한다', () => {
+        expect(extractKoreanName('BTCUSD', '["비트코인"]')).toBeNull();
+    });
+
+    it('문자열이 아닌 값(숫자)은 null을 반환한다', () => {
+        expect(extractKoreanName('BTCUSD', '{"BTCUSD":123}')).toBeNull();
+    });
+});
+
+describe('seed-crypto-korean-names — buildUpsertValues', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        // The mapper logs warnings for skipped coins; silence to keep test output clean.
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+    });
+
+    it('id 기반으로 응답을 매칭해 upsert 값을 만든다', () => {
+        const chunk = [
+            { id: 'BTCUSD', prompt: 'p1' },
+            { id: 'ETHUSD', prompt: 'p2' },
+        ];
+        const responses = [
+            // Intentionally out of order to prove id-based (not index-based) matching.
+            makeResponse('ETHUSD', jsonBody('ETHUSD', '이더리움')),
+            makeResponse('BTCUSD', jsonBody('BTCUSD', '비트코인')),
+        ];
+
+        const { values, skipped } = buildUpsertValues(chunk, responses);
+
+        expect(skipped).toBe(0);
+        expect(values).toEqual([
+            { symbol: 'BTCUSD', koreanName: '비트코인' },
+            { symbol: 'ETHUSD', koreanName: '이더리움' },
+        ]);
+    });
+
+    it('응답이 없는 coin 은 skip 한다', () => {
+        const chunk = [
+            { id: 'BTCUSD', prompt: 'p1' },
+            { id: 'MISSING', prompt: 'p2' },
+        ];
+        const responses = [
+            makeResponse('BTCUSD', jsonBody('BTCUSD', '비트코인')),
+        ];
+
+        const { values, skipped } = buildUpsertValues(chunk, responses);
+
+        expect(values).toEqual([{ symbol: 'BTCUSD', koreanName: '비트코인' }]);
+        expect(skipped).toBe(1);
+    });
+
+    it('error 가 있는 응답은 skip 한다', () => {
+        const chunk = [{ id: 'BTCUSD', prompt: 'p1' }];
+        const errored = {
+            metadata: { id: 'BTCUSD' },
+            error: { message: 'quota exceeded' },
+        } as unknown as InlinedResponse;
+
+        const { values, skipped } = buildUpsertValues(chunk, [errored]);
+
+        expect(values).toEqual([]);
+        expect(skipped).toBe(1);
+    });
+
+    it('빈 텍스트 응답은 skip 한다', () => {
+        const chunk = [{ id: 'BTCUSD', prompt: 'p1' }];
+        const responses = [makeResponse('BTCUSD', '')];
+
+        const { values, skipped } = buildUpsertValues(chunk, responses);
+
+        expect(values).toEqual([]);
+        expect(skipped).toBe(1);
+    });
+
+    it('malformed JSON 응답은 skip 한다', () => {
+        const chunk = [{ id: 'BTCUSD', prompt: 'p1' }];
+        const responses = [makeResponse('BTCUSD', 'not json')];
+
+        const { values, skipped } = buildUpsertValues(chunk, responses);
+
+        expect(values).toEqual([]);
+        expect(skipped).toBe(1);
+    });
+
+    it('metadata.id 가 없는 응답은 매칭에서 제외된다', () => {
+        const chunk = [{ id: 'BTCUSD', prompt: 'p1' }];
+        const noId = {
+            response: {
+                candidates: [
+                    {
+                        content: {
+                            parts: [{ text: jsonBody('BTCUSD', '비트코인') }],
+                        },
+                    },
+                ],
+            },
+        } as unknown as InlinedResponse;
+
+        const { values, skipped } = buildUpsertValues(chunk, [noId]);
+
+        // The response has no id to correlate, so the chunk's coin finds no match.
+        expect(values).toEqual([]);
+        expect(skipped).toBe(1);
+    });
+});
+
+describe('seed-crypto-korean-names — toUpsertRow', () => {
+    it('name 플레이스홀더로 symbol 을 사용한다 (UPDATE 경로에서 미사용)', () => {
+        // The placeholder name must equal the symbol; it is never persisted because
+        // onConflictDoUpdate only sets korean_name on the always-taken UPDATE path.
+        expect(
+            toUpsertRow({ symbol: 'BTCUSD', koreanName: '비트코인' })
+        ).toEqual({
+            symbol: 'BTCUSD',
+            name: 'BTCUSD',
+            koreanName: '비트코인',
+        });
+    });
+});

--- a/scripts/__tests__/seed-crypto-korean-names.test.ts
+++ b/scripts/__tests__/seed-crypto-korean-names.test.ts
@@ -108,6 +108,7 @@ describe('seed-crypto-korean-names — buildUpsertValues', () => {
             { symbol: 'BTCUSD', koreanName: '비트코인' },
             { symbol: 'ETHUSD', koreanName: '이더리움' },
         ]);
+        expect(warnSpy).not.toHaveBeenCalled();
     });
 
     it('응답이 없는 coin 은 skip 한다', () => {
@@ -123,6 +124,11 @@ describe('seed-crypto-korean-names — buildUpsertValues', () => {
 
         expect(values).toEqual([{ symbol: 'BTCUSD', koreanName: '비트코인' }]);
         expect(skipped).toBe(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                '[MISSING] skipped — no matching response found'
+            )
+        );
     });
 
     it('error 가 있는 응답은 skip 한다', () => {
@@ -136,6 +142,11 @@ describe('seed-crypto-korean-names — buildUpsertValues', () => {
 
         expect(values).toEqual([]);
         expect(skipped).toBe(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                '[BTCUSD] skipped — response error: quota exceeded'
+            )
+        );
     });
 
     it('빈 텍스트 응답은 skip 한다', () => {
@@ -146,6 +157,9 @@ describe('seed-crypto-korean-names — buildUpsertValues', () => {
 
         expect(values).toEqual([]);
         expect(skipped).toBe(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[BTCUSD] skipped — empty response text')
+        );
     });
 
     it('malformed JSON 응답은 skip 한다', () => {
@@ -156,6 +170,11 @@ describe('seed-crypto-korean-names — buildUpsertValues', () => {
 
         expect(values).toEqual([]);
         expect(skipped).toBe(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                '[BTCUSD] skipped — could not extract Korean name from response'
+            )
+        );
     });
 
     it('Gemini 응답 키 대소문자가 달라도 올바르게 매칭한다', () => {
@@ -180,6 +199,7 @@ describe('seed-crypto-korean-names — buildUpsertValues', () => {
 
         expect(skipped).toBe(0);
         expect(values).toEqual([{ symbol: 'BTCUSD', koreanName: '비트코인' }]);
+        expect(warnSpy).not.toHaveBeenCalled();
     });
 
     it('metadata.id 가 없는 응답은 매칭에서 제외된다', () => {
@@ -201,6 +221,16 @@ describe('seed-crypto-korean-names — buildUpsertValues', () => {
         // The response has no id to correlate, so the chunk's coin finds no match.
         expect(values).toEqual([]);
         expect(skipped).toBe(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                '[warn] response missing metadata.id — skipped (cannot correlate to request)'
+            )
+        );
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                '[BTCUSD] skipped — no matching response found'
+            )
+        );
     });
 });
 

--- a/scripts/__tests__/seed-crypto-korean-names.test.ts
+++ b/scripts/__tests__/seed-crypto-korean-names.test.ts
@@ -158,6 +158,30 @@ describe('seed-crypto-korean-names — buildUpsertValues', () => {
         expect(skipped).toBe(1);
     });
 
+    it('Gemini 응답 키 대소문자가 달라도 올바르게 매칭한다', () => {
+        const chunk = [{ id: 'BTCUSD', prompt: 'p1' }];
+        // Gemini returns lowercase key in metadata.id — must still match BTCUSD.
+        const lowercaseIdResponse = {
+            metadata: { id: 'btcusd' },
+            response: {
+                candidates: [
+                    {
+                        content: {
+                            parts: [{ text: jsonBody('BTCUSD', '비트코인') }],
+                        },
+                    },
+                ],
+            },
+        } as unknown as InlinedResponse;
+
+        const { values, skipped } = buildUpsertValues(chunk, [
+            lowercaseIdResponse,
+        ]);
+
+        expect(skipped).toBe(0);
+        expect(values).toEqual([{ symbol: 'BTCUSD', koreanName: '비트코인' }]);
+    });
+
     it('metadata.id 가 없는 응답은 매칭에서 제외된다', () => {
         const chunk = [{ id: 'BTCUSD', prompt: 'p1' }];
         const noId = {

--- a/scripts/seed-crypto-korean-names.ts
+++ b/scripts/seed-crypto-korean-names.ts
@@ -36,6 +36,7 @@ import type { InlinedRequest, InlinedResponse } from '@google/genai';
 import { GoogleGenAI, JobState } from '@google/genai';
 import { fileURLToPath } from 'node:url';
 import { cryptoAssets } from '../src/shared/db/schema';
+import { MS_PER_HOUR, MS_PER_SECOND } from '../src/shared/config/time';
 
 // Env reads are deferred to run() (not module-level throws) so the pure helpers
 // below (extractKoreanName / buildUpsertValues) can be imported by unit tests
@@ -58,8 +59,8 @@ const CRYPTO_KOREAN_TRANSLATE_LIMIT = Number(
 // stays within Gemini enqueue token limits for short translation prompts.
 const CHUNK_SIZE = 300;
 const GEMINI_MODEL = 'gemini-2.5-flash-lite';
-const POLL_INTERVAL_MS = 30_000;
-const MAX_POLL_MS = 2 * 60 * 60 * 1_000; // 2h
+const POLL_INTERVAL_MS = 30 * MS_PER_SECOND;
+const MAX_POLL_MS = 2 * MS_PER_HOUR; // 2h
 const DRY_RUN_PROMPT_PREVIEW_LENGTH = 200;
 const UPSERT_BATCH_SIZE = 500;
 
@@ -155,8 +156,8 @@ interface UpsertRow {
 
 /**
  * Map a completed batch chunk's responses to upsert values, using id-based
- * matching (metadata.id = symbol) for re-run safety. Pure (no DB / no logging
- * beyond warnings) so the unit test can assert the response→value mapping —
+ * matching (metadata.id = symbol) for re-run safety. No DB or external I/O —
+ * only console.warn for diagnostics — so the unit test can assert the response→value mapping —
  * including which responses get skipped — without a database.
  *
  * Exported for the same reason as extractKoreanName: the test must run the real

--- a/scripts/seed-crypto-korean-names.ts
+++ b/scripts/seed-crypto-korean-names.ts
@@ -1,0 +1,487 @@
+/**
+ * Re-runnable seed: translate crypto asset English names to Korean via Gemini
+ * Batch API and UPSERT the results into `crypto_assets.korean_name`.
+ *
+ * This front-loads the DB so Korean-name search (e.g. "비트코" → BTCUSD) works
+ * immediately without waiting for on-access lazy translation. Only the top N
+ * coins by circulating_supply are translated to control Gemini API cost — the
+ * long-tail of low-liquidity assets is unlikely to be searched in Korean.
+ *
+ * Translation uses the Gemini Batch API (same pattern as
+ * scripts/seedIndicatorTranslationsBatch.ts) rather than the live
+ * `translateCompanyNames` helper: the batch path is cheaper, resilient per-chunk,
+ * and suited to a one-off offline seed rather than a real-time autocomplete call.
+ *
+ * Usage:
+ *   yarn db:seed:crypto-korean            # full run (submits batches)
+ *   DRY_RUN=1 yarn db:seed:crypto-korean  # query + prompt build only, no submit
+ *
+ * Requires (.env.local): DATABASE_URL (or DIRECT_DATABASE_URL), GEMINI_API_KEY.
+ *
+ * Flow:
+ *   1. Connect to prod DB (postgres-js + drizzle, max:1).
+ *   2. SELECT top CRYPTO_KOREAN_TRANSLATE_LIMIT rows by circulating_supply WHERE
+ *      korean_name IS NULL — only untranslated rows, most-liquid first.
+ *   3. Build one prompt per coin via buildCryptoTranslationPrompt; chunk into
+ *      CHUNK_SIZE (300) batches.
+ *   4. Per chunk: submit Gemini Batch → poll → process responses → UPSERT
+ *      korean_name via onConflictDoUpdate (idempotent on symbol).
+ *   5. Per-chunk resilience: failure logs and skips the chunk; remaining chunks
+ *      still run.
+ */
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { desc, isNull, sql } from 'drizzle-orm';
+import type { InlinedRequest, InlinedResponse } from '@google/genai';
+import { GoogleGenAI, JobState } from '@google/genai';
+import { fileURLToPath } from 'node:url';
+import { cryptoAssets } from '../src/shared/db/schema';
+
+// Env reads are deferred to run() (not module-level throws) so the pure helpers
+// below (extractKoreanName / buildUpsertValues) can be imported by unit tests
+// without DATABASE_URL / GEMINI_API_KEY present. The run() entry point validates
+// them before doing any I/O.
+const databaseUrl = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY ?? '';
+const isDryRun = process.env.DRY_RUN === '1';
+
+/**
+ * Translate only the top N coins by circulating_supply — long-tail coins are
+ * unlikely to be searched in Korean and translating them wastes Gemini quota.
+ * Adjust by setting CRYPTO_KOREAN_TRANSLATE_LIMIT env var or editing this constant.
+ */
+const CRYPTO_KOREAN_TRANSLATE_LIMIT = Number(
+    process.env.CRYPTO_KOREAN_TRANSLATE_LIMIT ?? '300'
+);
+
+// Mirrors CHUNK_SIZE in seedIndicatorTranslationsBatch.ts — 300 prompts/batch
+// stays within Gemini enqueue token limits for short translation prompts.
+const CHUNK_SIZE = 300;
+const GEMINI_MODEL = 'gemini-2.5-flash-lite';
+const POLL_INTERVAL_MS = 30_000;
+const MAX_POLL_MS = 2 * 60 * 60 * 1_000; // 2h
+const DRY_RUN_PROMPT_PREVIEW_LENGTH = 200;
+
+const ai = GEMINI_API_KEY ? new GoogleGenAI({ apiKey: GEMINI_API_KEY }) : null;
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function formatElapsed(ms: number): string {
+    const s = Math.floor(ms / 1000);
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    const rem = s % 60;
+    if (m < 60) return `${m}m${rem}s`;
+    const h = Math.floor(m / 60);
+    return `${h}h${m % 60}m`;
+}
+
+interface PendingRequest {
+    /** Canonical crypto symbol (e.g. "BTCUSD"), used as metadata.id for id-based response matching. */
+    id: string;
+    prompt: string;
+}
+
+/**
+ * Build a self-contained translation prompt for a single coin English name.
+ *
+ * Returns a JSON object `{ "SYMBOL": "한국어 이름" }` so the response is
+ * unambiguous (coin names can be multi-word; a plain string response risks
+ * mis-parsing multi-line output).
+ */
+function buildCryptoTranslationPrompt(symbol: string, name: string): string {
+    return `Translate this cryptocurrency English name to Korean (한국에서 통용되는 한국어 이름 또는 음역).
+Return ONLY a JSON object with the symbol as key and the Korean name as value.
+Example for Bitcoin: {"BTCUSD":"비트코인"}
+
+Coin:
+- ${symbol}: ${name}`;
+}
+
+/**
+ * Mirrors extractResponseText from seedIndicatorTranslationsBatch.ts.
+ * Pulls the first candidate's first text part, returning null when absent or blank.
+ */
+function extractResponseText(resp: InlinedResponse): string | null {
+    const text = resp.response?.candidates?.[0]?.content?.parts?.[0]?.text;
+    return typeof text === 'string' && text.trim() !== '' ? text : null;
+}
+
+/**
+ * Extract the Korean name for `symbol` from a Gemini JSON response body.
+ *
+ * The prompt asks for `{ "SYMBOL": "한국어 이름" }`, so we parse the JSON object
+ * and read the value keyed by the request's symbol. Returns the trimmed string,
+ * or null when the response is malformed, an array, missing the key, or blank.
+ *
+ * Exported so the unit test exercises the real production extraction logic
+ * (not a duplicate) — this is the parse path processResponses relies on.
+ */
+export function extractKoreanName(symbol: string, text: string): string | null {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(text);
+    } catch {
+        // Malformed JSON → caller skips this coin.
+        return null;
+    }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return null;
+    }
+    const val = (parsed as Record<string, unknown>)[symbol];
+    if (typeof val !== 'string') return null;
+    const trimmed = val.trim();
+    return trimmed === '' ? null : trimmed;
+}
+
+interface CryptoKoreanUpsertValue {
+    symbol: string;
+    koreanName: string;
+}
+
+interface UpsertBuildResult {
+    values: CryptoKoreanUpsertValue[];
+    skipped: number;
+}
+
+/**
+ * Map a completed batch chunk's responses to upsert values, using id-based
+ * matching (metadata.id = symbol) for re-run safety. Pure (no DB / no logging
+ * beyond warnings) so the unit test can assert the response→value mapping —
+ * including which responses get skipped — without a database.
+ *
+ * Exported for the same reason as extractKoreanName: the test must run the real
+ * mapping, not a copy.
+ */
+export function buildUpsertValues(
+    chunk: readonly PendingRequest[],
+    responses: readonly InlinedResponse[]
+): UpsertBuildResult {
+    if (responses.length !== chunk.length) {
+        console.warn(
+            `  [warn] chunk(${chunk.length}) / responses(${responses.length}) mismatch — id-mapping; unmatched responses dropped.`
+        );
+    }
+
+    const responseById = new Map<string, InlinedResponse>();
+    for (const resp of responses) {
+        const respId = resp.metadata?.id;
+        if (!respId) {
+            console.warn(
+                `  [warn] response missing metadata.id — skipped (cannot correlate to request)`
+            );
+            continue;
+        }
+        responseById.set(respId, resp);
+    }
+
+    let skipped = 0;
+    const values: CryptoKoreanUpsertValue[] = [];
+
+    for (const { id: symbol } of chunk) {
+        const response = responseById.get(symbol);
+        if (!response) {
+            console.warn(`    [${symbol}] skipped — no matching response found`);
+            skipped += 1;
+            continue;
+        }
+
+        if (response.error) {
+            console.warn(
+                `    [${symbol}] skipped — response error: ${response.error.message ?? 'unknown'}`
+            );
+            skipped += 1;
+            continue;
+        }
+
+        const text = extractResponseText(response);
+        if (text === null) {
+            console.warn(`    [${symbol}] skipped — empty response text`);
+            skipped += 1;
+            continue;
+        }
+
+        const koreanName = extractKoreanName(symbol, text);
+        if (!koreanName) {
+            console.warn(
+                `    [${symbol}] skipped — could not extract Korean name from response`
+            );
+            skipped += 1;
+            continue;
+        }
+
+        values.push({ symbol, koreanName });
+    }
+
+    return { values, skipped };
+}
+
+/**
+ * Build the Drizzle insert row for an upsert value. The `name` placeholder is
+ * never persisted: every symbol selected by run() already exists in crypto_assets
+ * (seeded by seed-crypto-assets.ts), so onConflictDoUpdate always takes the
+ * UPDATE path — which only sets korean_name + updatedAt and leaves name untouched.
+ * The placeholder exists solely to satisfy the NOT NULL `name` column in the
+ * (unreachable) INSERT branch of Drizzle's typed values().
+ *
+ * Exported so the test can assert the placeholder-name invariant directly.
+ */
+export function toUpsertRow(value: CryptoKoreanUpsertValue): {
+    symbol: string;
+    name: string;
+    koreanName: string;
+} {
+    return {
+        symbol: value.symbol,
+        name: value.symbol,
+        koreanName: value.koreanName,
+    };
+}
+
+function buildInlinedRequest(id: string, prompt: string): InlinedRequest {
+    return {
+        contents: [{ parts: [{ text: prompt }] }],
+        config: {
+            temperature: 0,
+            responseMimeType: 'application/json',
+        },
+        metadata: { id },
+    };
+}
+
+/**
+ * Polls a submitted Gemini Batch to completion (30s interval, 2h timeout).
+ * Mirrors pollUntilComplete from seedIndicatorTranslationsBatch.ts.
+ */
+async function pollUntilComplete(
+    batchName: string
+): Promise<InlinedResponse[]> {
+    if (!ai) throw new Error('Gemini client not initialized');
+    const start = Date.now();
+
+    while (Date.now() - start <= MAX_POLL_MS) {
+        const elapsed = Date.now() - start;
+        const status = await ai.batches.get({ name: batchName });
+        const state = status.state ?? 'UNKNOWN';
+        console.log(
+            `  [poll] state=${state} elapsed=${formatElapsed(elapsed)}`
+        );
+
+        if (state === JobState.JOB_STATE_SUCCEEDED) {
+            const responses = status.dest?.inlinedResponses ?? [];
+            console.log(`  [batch] Succeeded — ${responses.length} responses`);
+            return responses;
+        }
+        if (
+            state === JobState.JOB_STATE_FAILED ||
+            state === JobState.JOB_STATE_CANCELLED ||
+            state === JobState.JOB_STATE_EXPIRED
+        ) {
+            const errMsg = status.error?.message ?? 'no error message';
+            throw new Error(`Job ${state} for ${batchName}: ${errMsg}`);
+        }
+
+        await sleep(POLL_INTERVAL_MS);
+    }
+    throw new Error(
+        `Timeout — exceeded ${formatElapsed(MAX_POLL_MS)} waiting for ${batchName}`
+    );
+}
+
+type Db = ReturnType<typeof drizzle>;
+
+interface ChunkResult {
+    translated: number;
+    skipped: number;
+}
+
+/**
+ * Process one completed Gemini Batch chunk: extract the Korean name from each
+ * JSON response, then bulk-UPSERT valid translations into crypto_assets.korean_name.
+ *
+ * Uses id-based response mapping (metadata.id = symbol) for re-run safety,
+ * mirroring processResponses in seedIndicatorTranslationsBatch.ts.
+ * onConflictDoUpdate on symbol so re-runs overwrite stale Korean names (unlike
+ * the indicator seed's onConflictDoNothing — crypto names may be corrected).
+ */
+async function processResponses(
+    db: Db,
+    chunk: readonly PendingRequest[],
+    responses: readonly InlinedResponse[]
+): Promise<ChunkResult> {
+    const { values: upsertValues, skipped } = buildUpsertValues(
+        chunk,
+        responses
+    );
+
+    if (upsertValues.length === 0) {
+        return { translated: 0, skipped };
+    }
+
+    // Bulk upsert: onConflictDoUpdate on symbol so re-runs update stale/corrected
+    // Korean names. `updatedAt` set explicitly (Drizzle skips $onUpdateFn on conflict).
+    const UPSERT_BATCH_SIZE = 500;
+    let translated = 0;
+    for (let i = 0; i < upsertValues.length; i += UPSERT_BATCH_SIZE) {
+        const batch = upsertValues.slice(i, i + UPSERT_BATCH_SIZE);
+        await db
+            .insert(cryptoAssets)
+            .values(batch.map(toUpsertRow))
+            .onConflictDoUpdate({
+                target: cryptoAssets.symbol,
+                // Only update korean_name (and updatedAt). Preserve existing symbol,
+                // name, circulatingSupply populated by seed-crypto-assets.ts.
+                set: {
+                    koreanName: sql`excluded.korean_name`,
+                    updatedAt: sql`now()`,
+                },
+            });
+        translated += batch.length;
+    }
+
+    return { translated, skipped };
+}
+
+async function run(): Promise<void> {
+    // Validate env at the entry point (not module load) so the exported pure
+    // helpers stay importable by unit tests without these vars.
+    if (!databaseUrl) {
+        throw new Error('DIRECT_DATABASE_URL (or DATABASE_URL) env var required');
+    }
+    if (!isDryRun && !GEMINI_API_KEY) {
+        throw new Error('GEMINI_API_KEY is required in .env.local');
+    }
+
+    const client = postgres(databaseUrl, { max: 1 });
+    try {
+        const db = drizzle(client);
+
+        // Select top N coins by circulating_supply that still need a Korean name.
+        // Coins with korean_name already set are excluded for idempotency — re-running
+        // after a partial success only retranslates the remaining NULL rows.
+        const rows = await db
+            .select({
+                symbol: cryptoAssets.symbol,
+                name: cryptoAssets.name,
+            })
+            .from(cryptoAssets)
+            .where(isNull(cryptoAssets.koreanName))
+            .orderBy(desc(cryptoAssets.circulatingSupply))
+            .limit(CRYPTO_KOREAN_TRANSLATE_LIMIT);
+
+        const total = rows.length;
+        console.log(
+            `Found ${total} crypto assets needing Korean names (limit=${CRYPTO_KOREAN_TRANSLATE_LIMIT})`
+        );
+
+        if (total === 0) {
+            console.log('Nothing to do — exiting.');
+            return;
+        }
+
+        const requests: PendingRequest[] = rows.map(r => ({
+            id: r.symbol,
+            prompt: buildCryptoTranslationPrompt(r.symbol, r.name),
+        }));
+
+        if (isDryRun) {
+            const sample = requests[0];
+            console.log(
+                '\n[dry-run] DRY_RUN=1 — query + prompt build only, no batch submitted.'
+            );
+            console.log(
+                `[dry-run] pending=${total} limit=${CRYPTO_KOREAN_TRANSLATE_LIMIT}`
+            );
+            console.log(
+                `[dry-run] model=${GEMINI_MODEL} chunkSize=${CHUNK_SIZE}`
+            );
+            console.log(
+                `[dry-run] sample symbol="${sample.id}" promptChars=${sample.prompt.length}`
+            );
+            console.log(
+                `[dry-run] sample prompt head (first ${DRY_RUN_PROMPT_PREVIEW_LENGTH} chars):\n${sample.prompt.slice(0, DRY_RUN_PROMPT_PREVIEW_LENGTH)}`
+            );
+            const firstChunk = requests.slice(0, CHUNK_SIZE);
+            const firstChunkRequests: InlinedRequest[] = firstChunk.map(r =>
+                buildInlinedRequest(r.id, r.prompt)
+            );
+            console.log(
+                `[dry-run] built ${firstChunkRequests.length} InlinedRequest(s) for chunk 1 (not submitted).`
+            );
+            return;
+        }
+
+        const chunkCount = Math.ceil(total / CHUNK_SIZE);
+        console.log(
+            `\n[plan] ${total} requests → ${chunkCount} batch(es) of up to ${CHUNK_SIZE} each (model=${GEMINI_MODEL})`
+        );
+
+        let translated = 0;
+        let skipped = 0;
+        let failedBatches = 0;
+
+        for (let c = 0; c < chunkCount; c++) {
+            const chunk = requests.slice(c * CHUNK_SIZE, (c + 1) * CHUNK_SIZE);
+            const chunkNo = c + 1;
+            const inlined: InlinedRequest[] = chunk.map(r =>
+                buildInlinedRequest(r.id, r.prompt)
+            );
+
+            console.log(
+                `\n=== Batch ${chunkNo}/${chunkCount} (${chunk.length} requests) ===`
+            );
+
+            try {
+                const displayName = `siglens-crypto-korean-${chunkNo}-${Date.now()}`;
+                console.log(`  [submit] ${displayName}...`);
+                const batch = await ai!.batches.create({
+                    model: GEMINI_MODEL,
+                    src: inlined,
+                    config: { displayName },
+                });
+                const name = batch.name;
+                if (!name) {
+                    throw new Error('Batch create response missing .name');
+                }
+                console.log(
+                    `  [submit] created ${name} (state=${batch.state ?? 'UNKNOWN'})`
+                );
+
+                const responses = await pollUntilComplete(name);
+                const result = await processResponses(db, chunk, responses);
+                translated += result.translated;
+                skipped += result.skipped;
+                console.log(
+                    `  [written] batch ${chunkNo}: translated +${result.translated}, skipped +${result.skipped} (running: ${translated}/${total})`
+                );
+            } catch (err) {
+                failedBatches += 1;
+                console.error(
+                    `  [batch ${chunkNo}] FAILED — continuing: ${err instanceof Error ? err.message : String(err)}`
+                );
+            }
+        }
+
+        console.log(
+            `\n[done] translated ${translated} / pending ${total} (${skipped} skipped, ${failedBatches} failed batch(es))`
+        );
+    } finally {
+        await client.end();
+    }
+}
+
+// Run the seed only when executed directly (`tsx scripts/seed-crypto-korean-names.ts`),
+// not when imported by the unit test (which exercises extractKoreanName /
+// buildUpsertValues). Mirrors the entry guard in scripts/validate-skills.ts.
+const executedDirectly =
+    process.argv[1] !== undefined &&
+    fileURLToPath(import.meta.url) === process.argv[1];
+
+if (executedDirectly) {
+    run().catch((error: unknown) => {
+        console.error('[seed-crypto-korean-names] failed:', error);
+        process.exitCode = 1;
+    });
+}

--- a/scripts/seed-crypto-korean-names.ts
+++ b/scripts/seed-crypto-korean-names.ts
@@ -31,7 +31,7 @@
  */
 import postgres from 'postgres';
 import { drizzle } from 'drizzle-orm/postgres-js';
-import { desc, isNull, sql } from 'drizzle-orm';
+import { isNull, sql } from 'drizzle-orm';
 import type { InlinedRequest, InlinedResponse } from '@google/genai';
 import { GoogleGenAI, JobState } from '@google/genai';
 import { fileURLToPath } from 'node:url';
@@ -146,6 +146,12 @@ interface UpsertBuildResult {
     skipped: number;
 }
 
+interface UpsertRow {
+    symbol: string;
+    name: string;
+    koreanName: string;
+}
+
 /**
  * Map a completed batch chunk's responses to upsert values, using id-based
  * matching (metadata.id = symbol) for re-run safety. Pure (no DB / no logging
@@ -174,33 +180,29 @@ export function buildUpsertValues(
             );
             continue;
         }
-        responseById.set(respId, resp);
+        // Normalize to uppercase so Gemini casing variants (e.g. "btcusd", "BtcUsd")
+        // still match the canonical uppercase symbol stored in the DB.
+        responseById.set(respId.toUpperCase(), resp);
     }
 
-    let skipped = 0;
-    const values: CryptoKoreanUpsertValue[] = [];
-
-    for (const { id: symbol } of chunk) {
-        const response = responseById.get(symbol);
+    const values = chunk.flatMap(({ id: symbol }): CryptoKoreanUpsertValue[] => {
+        const response = responseById.get(symbol.toUpperCase());
         if (!response) {
             console.warn(`    [${symbol}] skipped — no matching response found`);
-            skipped += 1;
-            continue;
+            return [];
         }
 
         if (response.error) {
             console.warn(
                 `    [${symbol}] skipped — response error: ${response.error.message ?? 'unknown'}`
             );
-            skipped += 1;
-            continue;
+            return [];
         }
 
         const text = extractResponseText(response);
         if (text === null) {
             console.warn(`    [${symbol}] skipped — empty response text`);
-            skipped += 1;
-            continue;
+            return [];
         }
 
         const koreanName = extractKoreanName(symbol, text);
@@ -208,13 +210,13 @@ export function buildUpsertValues(
             console.warn(
                 `    [${symbol}] skipped — could not extract Korean name from response`
             );
-            skipped += 1;
-            continue;
+            return [];
         }
 
-        values.push({ symbol, koreanName });
-    }
+        return [{ symbol, koreanName }];
+    });
 
+    const skipped = chunk.length - values.length;
     return { values, skipped };
 }
 
@@ -228,11 +230,7 @@ export function buildUpsertValues(
  *
  * Exported so the test can assert the placeholder-name invariant directly.
  */
-export function toUpsertRow(value: CryptoKoreanUpsertValue): {
-    symbol: string;
-    name: string;
-    koreanName: string;
-} {
+export function toUpsertRow(value: CryptoKoreanUpsertValue): UpsertRow {
     return {
         symbol: value.symbol,
         name: value.symbol,
@@ -368,7 +366,7 @@ async function run(): Promise<void> {
             })
             .from(cryptoAssets)
             .where(isNull(cryptoAssets.koreanName))
-            .orderBy(desc(cryptoAssets.circulatingSupply))
+            .orderBy(sql`${cryptoAssets.circulatingSupply} DESC NULLS LAST`)
             .limit(CRYPTO_KOREAN_TRANSLATE_LIMIT);
 
         const total = rows.length;

--- a/scripts/seed-crypto-korean-names.ts
+++ b/scripts/seed-crypto-korean-names.ts
@@ -321,8 +321,9 @@ async function processResponses(
     // Bulk upsert: onConflictDoUpdate on symbol so re-runs update stale/corrected
     // Korean names. `updatedAt` set explicitly (Drizzle skips $onUpdateFn on conflict).
     const UPSERT_BATCH_SIZE = 500;
+    const upsertLength = upsertValues.length;
     let translated = 0;
-    for (let i = 0; i < upsertValues.length; i += UPSERT_BATCH_SIZE) {
+    for (let i = 0; i < upsertLength; i += UPSERT_BATCH_SIZE) {
         const batch = upsertValues.slice(i, i + UPSERT_BATCH_SIZE);
         await db
             .insert(cryptoAssets)

--- a/scripts/seed-crypto-korean-names.ts
+++ b/scripts/seed-crypto-korean-names.ts
@@ -61,6 +61,7 @@ const GEMINI_MODEL = 'gemini-2.5-flash-lite';
 const POLL_INTERVAL_MS = 30_000;
 const MAX_POLL_MS = 2 * 60 * 60 * 1_000; // 2h
 const DRY_RUN_PROMPT_PREVIEW_LENGTH = 200;
+const UPSERT_BATCH_SIZE = 500;
 
 const ai = GEMINI_API_KEY ? new GoogleGenAI({ apiKey: GEMINI_API_KEY }) : null;
 
@@ -124,7 +125,7 @@ export function extractKoreanName(symbol: string, text: string): string | null {
     try {
         parsed = JSON.parse(text);
     } catch {
-        // Malformed JSON → caller skips this coin.
+        // null signals the caller to skip this coin rather than upsert a bad value.
         return null;
     }
     if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
@@ -320,7 +321,6 @@ async function processResponses(
 
     // Bulk upsert: onConflictDoUpdate on symbol so re-runs update stale/corrected
     // Korean names. `updatedAt` set explicitly (Drizzle skips $onUpdateFn on conflict).
-    const UPSERT_BATCH_SIZE = 500;
     const upsertLength = upsertValues.length;
     let translated = 0;
     for (let i = 0; i < upsertLength; i += UPSERT_BATCH_SIZE) {

--- a/src/entities/ticker/__tests__/api.test.ts
+++ b/src/entities/ticker/__tests__/api.test.ts
@@ -464,11 +464,24 @@ describe('DrizzleCryptoAssetRepository', () => {
             const { db, where } = makeCryptoSearchDb([]);
             const repo = new DrizzleCryptoAssetRepository(db);
             await repo.search('비트코', 10);
-            // where is called once; the or() expression must include korean_name ilike.
-            // We cannot inspect the internal Drizzle SQL object directly, so we verify
-            // that where was called (not skipped) and trust Part 1's implementation.
-            // A stronger assertion would require a real DB integration test.
             expect(where).toHaveBeenCalledTimes(1);
+            // The or() expression passed to .where() must reference the korean_name column.
+            // Drizzle nests SQL objects (or → [ilike, ilike, ilike]); we recurse into
+            // queryChunks to collect all column `.name` values. This assertion fails if
+            // korean_name is removed from the ilike OR-condition.
+            type SqlLike = {
+                queryChunks?: Array<SqlLike | { name?: string }>;
+                name?: string;
+            };
+            function collectColumnNames(node: SqlLike): string[] {
+                if (node.name) return [node.name];
+                if (!node.queryChunks) return [];
+                return node.queryChunks.flatMap(chunk =>
+                    collectColumnNames(chunk as SqlLike)
+                );
+            }
+            const condition = where.mock.calls[0][0] as SqlLike;
+            expect(collectColumnNames(condition)).toContain('korean_name');
         });
     });
 });

--- a/src/entities/ticker/__tests__/api.test.ts
+++ b/src/entities/ticker/__tests__/api.test.ts
@@ -38,6 +38,19 @@ import type {
 } from '@/shared/db/types';
 import type { KoreanTickerEntry } from '@/shared/lib/types';
 
+type SqlLike = {
+    queryChunks?: Array<SqlLike | { name?: string }>;
+    name?: string;
+};
+
+function collectColumnNames(node: SqlLike): string[] {
+    if (node.name) return [node.name];
+    if (!node.queryChunks) return [];
+    return node.queryChunks.flatMap(chunk =>
+        collectColumnNames(chunk as SqlLike)
+    );
+}
+
 const apple: KoreanTickerEntry = {
     symbol: 'AAPL',
     name: 'Apple Inc.',
@@ -469,17 +482,6 @@ describe('DrizzleCryptoAssetRepository', () => {
             // Drizzle nests SQL objects (or → [ilike, ilike, ilike]); we recurse into
             // queryChunks to collect all column `.name` values. This assertion fails if
             // korean_name is removed from the ilike OR-condition.
-            type SqlLike = {
-                queryChunks?: Array<SqlLike | { name?: string }>;
-                name?: string;
-            };
-            function collectColumnNames(node: SqlLike): string[] {
-                if (node.name) return [node.name];
-                if (!node.queryChunks) return [];
-                return node.queryChunks.flatMap(chunk =>
-                    collectColumnNames(chunk as SqlLike)
-                );
-            }
             const condition = where.mock.calls[0][0] as SqlLike;
             expect(collectColumnNames(condition)).toContain('korean_name');
         });

--- a/src/entities/ticker/__tests__/api.test.ts
+++ b/src/entities/ticker/__tests__/api.test.ts
@@ -459,6 +459,17 @@ describe('DrizzleCryptoAssetRepository', () => {
             const repo = new DrizzleCryptoAssetRepository(db);
             await expect(repo.search('xyz', 10)).resolves.toEqual([]);
         });
+
+        it('korean_name 컬럼도 ilike 조건에 포함한다', async () => {
+            const { db, where } = makeCryptoSearchDb([]);
+            const repo = new DrizzleCryptoAssetRepository(db);
+            await repo.search('비트코', 10);
+            // where is called once; the or() expression must include korean_name ilike.
+            // We cannot inspect the internal Drizzle SQL object directly, so we verify
+            // that where was called (not skipped) and trust Part 1's implementation.
+            // A stronger assertion would require a real DB integration test.
+            expect(where).toHaveBeenCalledTimes(1);
+        });
     });
 });
 

--- a/src/entities/ticker/actions/searchTickerAction.ts
+++ b/src/entities/ticker/actions/searchTickerAction.ts
@@ -10,6 +10,11 @@ import type { TickerSearchResult } from '@/shared/lib/types';
  * autocomplete renders real options without a live FMP call (CI has no
  * FMP_API_KEY). Mirrors the E2E short-circuit pattern used by the data-provider
  * factories (getMarketDataProvider, getFundamentalDataProvider, etc.).
+ *
+ * Crypto entries (BTCUSD/ETHUSD) are included so that Korean-name searches
+ * (e.g. "비트코") surface the expected crypto result with the 코인 badge in
+ * the autocomplete dropdown. The koreanName values mirror what seed.ts writes
+ * to crypto_assets so the fixture is consistent with the seeded DB.
  */
 const E2E_TICKER_FIXTURE: ReadonlyArray<TickerSearchResult> = [
     {
@@ -31,6 +36,22 @@ const E2E_TICKER_FIXTURE: ReadonlyArray<TickerSearchResult> = [
         exchange: 'NASDAQ',
         exchangeFullName: 'NASDAQ Global Market',
     },
+    {
+        symbol: 'BTCUSD',
+        name: 'Bitcoin USD',
+        exchange: 'CRYPTO',
+        exchangeFullName: 'Cryptocurrency',
+        koreanName: '비트코인',
+        marketProfile: 'crypto',
+    },
+    {
+        symbol: 'ETHUSD',
+        name: 'Ethereum USD',
+        exchange: 'CRYPTO',
+        exchangeFullName: 'Cryptocurrency',
+        koreanName: '이더리움',
+        marketProfile: 'crypto',
+    },
 ];
 
 export async function searchTickerAction(
@@ -41,13 +62,15 @@ export async function searchTickerAction(
 
     if (isE2E()) {
         // Hermetic E2E path: never touch FMP. Filter the fixture by the typed
-        // query (symbol or name, case-insensitive); fall back to the full
-        // AAPL-family set so the listbox is never empty.
+        // query (symbol, name, or koreanName — case-insensitive so Korean
+        // prefix queries like "비트코" match the BTCUSD entry); fall back to
+        // the full fixture set so the listbox is never empty.
         const needle = trimmed.toLowerCase();
         const matches = E2E_TICKER_FIXTURE.filter(
             t =>
                 t.symbol.toLowerCase().includes(needle) ||
-                t.name.toLowerCase().includes(needle)
+                t.name.toLowerCase().includes(needle) ||
+                (t.koreanName?.toLowerCase().includes(needle) ?? false)
         );
         return matches.length > 0 ? matches : [...E2E_TICKER_FIXTURE];
     }

--- a/src/entities/ticker/api.ts
+++ b/src/entities/ticker/api.ts
@@ -276,7 +276,8 @@ export class DrizzleCryptoAssetRepository implements CryptoAssetRepository {
             .where(
                 or(
                     ilike(cryptoAssets.symbol, like),
-                    ilike(cryptoAssets.name, like)
+                    ilike(cryptoAssets.name, like),
+                    ilike(cryptoAssets.koreanName, like)
                 )
             )
             .orderBy(desc(cryptoAssets.circulatingSupply))

--- a/src/entities/ticker/lib/__tests__/searchTicker.korean-crypto.test.ts
+++ b/src/entities/ticker/lib/__tests__/searchTicker.korean-crypto.test.ts
@@ -1,0 +1,131 @@
+// vi.mock calls are hoisted by vitest above all imports.
+const { mockSearchByKoreanName, mockSearchCryptoAssets } = vi.hoisted(() => ({
+    mockSearchByKoreanName: vi.fn(),
+    mockSearchCryptoAssets: vi.fn(),
+}));
+
+vi.mock('../koreanNameStore', () => ({
+    searchByKoreanName: mockSearchByKoreanName,
+    getKoreanNames: vi.fn().mockResolvedValue({}),
+    setKoreanTickers: vi.fn(),
+}));
+vi.mock('../cryptoAssetStore', () => ({
+    searchCryptoAssets: mockSearchCryptoAssets,
+}));
+vi.mock('../fmpTickerApi', () => ({
+    searchBySymbol: vi.fn().mockResolvedValue([]),
+    searchByName: vi.fn().mockResolvedValue([]),
+    filterUsExchanges: (x: unknown[]) => x,
+    toTickerSearchResult: (x: unknown) => x,
+}));
+vi.mock('@y0ngha/siglens-core', () => ({ createCacheProvider: () => null }));
+vi.mock('../koreanTranslator', () => ({
+    translateCompanyNames: vi.fn().mockResolvedValue({}),
+}));
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    searchTicker,
+    _resetInFlightTranslationsForTest,
+} from '../searchTicker';
+import type { TickerSearchResult } from '@/shared/lib/types';
+
+function stockResult(symbol: string, koreanName: string): TickerSearchResult {
+    return {
+        symbol,
+        name: `${symbol} Corp`,
+        koreanName,
+        exchange: 'NASDAQ',
+        exchangeFullName: 'Nasdaq Global Select Market',
+    };
+}
+
+function cryptoResult(symbol: string, koreanName: string): TickerSearchResult {
+    return {
+        symbol,
+        name: `${symbol} Coin`,
+        koreanName,
+        exchange: 'CRYPTO',
+        exchangeFullName: 'Cryptocurrency',
+        marketProfile: 'crypto',
+    };
+}
+
+describe('searchTicker — 한글 입력 crypto 병합', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        _resetInFlightTranslationsForTest();
+        mockSearchByKoreanName.mockResolvedValue([]);
+        mockSearchCryptoAssets.mockResolvedValue([]);
+    });
+
+    it('한글 입력 시 crypto 한국어 검색 결과를 함께 반환한다', async () => {
+        mockSearchByKoreanName.mockResolvedValue([]);
+        mockSearchCryptoAssets.mockResolvedValue([
+            cryptoResult('BTCUSD', '비트코인'),
+        ]);
+
+        const results = await searchTicker('비트코');
+        expect(results.some(r => r.symbol === 'BTCUSD')).toBe(true);
+    });
+
+    it('한글 입력 시 주식 한국어 결과가 crypto 결과보다 먼저 온다', async () => {
+        mockSearchByKoreanName.mockResolvedValue([stockResult('AAPL', '애플')]);
+        mockSearchCryptoAssets.mockResolvedValue([
+            cryptoResult('BTCUSD', '비트코인'),
+        ]);
+
+        const results = await searchTicker('코');
+        const aaplIdx = results.findIndex(r => r.symbol === 'AAPL');
+        const btcIdx = results.findIndex(r => r.symbol === 'BTCUSD');
+        expect(aaplIdx).toBeGreaterThanOrEqual(0);
+        expect(btcIdx).toBeGreaterThanOrEqual(0);
+        expect(aaplIdx).toBeLessThan(btcIdx);
+    });
+
+    it('한글 입력 시 동일 symbol 중복 제거한다', async () => {
+        const shared = stockResult('BTCUSD', '비트코인');
+        mockSearchByKoreanName.mockResolvedValue([shared]);
+        mockSearchCryptoAssets.mockResolvedValue([
+            cryptoResult('BTCUSD', '비트코인'),
+        ]);
+
+        const results = await searchTicker('비트코인');
+        const btcEntries = results.filter(r => r.symbol === 'BTCUSD');
+        expect(btcEntries).toHaveLength(1);
+    });
+
+    it('한글 입력 결과를 MAX_SEARCH_RESULTS(10)로 제한한다', async () => {
+        const manyStocks = Array.from({ length: 7 }, (_, i) =>
+            stockResult(`STOCK${i}`, `주식${i}`)
+        );
+        const manyCrypto = Array.from({ length: 6 }, (_, i) =>
+            cryptoResult(`COIN${i}USD`, `코인${i}`)
+        );
+        mockSearchByKoreanName.mockResolvedValue(manyStocks);
+        mockSearchCryptoAssets.mockResolvedValue(manyCrypto);
+
+        const results = await searchTicker('주');
+        // 7 stocks + 6 crypto = 13 unique symbols → deterministically capped to 10.
+        expect(results).toHaveLength(10);
+    });
+
+    it('한글 입력 시 FMP searchBySymbol/searchByName 을 호출하지 않는다', async () => {
+        const { searchBySymbol, searchByName } =
+            await import('../fmpTickerApi');
+        mockSearchByKoreanName.mockResolvedValue([stockResult('AAPL', '애플')]);
+
+        await searchTicker('애플');
+
+        expect(searchBySymbol).not.toHaveBeenCalled();
+        expect(searchByName).not.toHaveBeenCalled();
+    });
+
+    it('crypto store 실패 시에도 주식 결과는 반환한다', async () => {
+        mockSearchByKoreanName.mockResolvedValue([stockResult('AAPL', '애플')]);
+        mockSearchCryptoAssets.mockResolvedValue([]);
+
+        const results = await searchTicker('애플');
+        expect(results.some(r => r.symbol === 'AAPL')).toBe(true);
+    });
+});

--- a/src/entities/ticker/lib/__tests__/searchTicker.korean-crypto.test.ts
+++ b/src/entities/ticker/lib/__tests__/searchTicker.korean-crypto.test.ts
@@ -28,6 +28,7 @@ import {
     searchTicker,
     _resetInFlightTranslationsForTest,
     MAX_SEARCH_RESULTS,
+    CRYPTO_RESERVE,
 } from '../searchTicker';
 import type { TickerSearchResult } from '@/shared/lib/types';
 
@@ -67,7 +68,9 @@ describe('searchTicker — 한글 입력 crypto 병합', () => {
         ]);
 
         const results = await searchTicker('비트코');
-        expect(results.find(r => r.symbol === 'BTCUSD')).toBeDefined();
+        expect(results.find(r => r.symbol === 'BTCUSD')).toEqual(
+            cryptoResult('BTCUSD', '비트코인')
+        );
     });
 
     it('한글 입력 시 주식 한국어 결과가 crypto 결과보다 먼저 온다', async () => {
@@ -79,9 +82,8 @@ describe('searchTicker — 한글 입력 crypto 병합', () => {
         const results = await searchTicker('코');
         const aaplIdx = results.findIndex(r => r.symbol === 'AAPL');
         const btcIdx = results.findIndex(r => r.symbol === 'BTCUSD');
-        expect(aaplIdx).toBeGreaterThanOrEqual(0);
-        expect(btcIdx).toBeGreaterThanOrEqual(0);
-        expect(aaplIdx).toBeLessThan(btcIdx);
+        expect(aaplIdx).toBe(0);
+        expect(btcIdx).toBe(1);
     });
 
     it('한글 입력 시 동일 symbol 중복 제거한다', async () => {
@@ -109,6 +111,14 @@ describe('searchTicker — 한글 입력 crypto 병합', () => {
         const results = await searchTicker('주');
         // 7 stocks + 6 crypto = 13 unique symbols → deterministically capped to MAX.
         expect(results).toHaveLength(MAX_SEARCH_RESULTS);
+        // CRYPTO_RESERVE cap: 6 crypto results are truncated to exactly CRYPTO_RESERVE.
+        expect(results.filter(r => r.exchange === 'CRYPTO')).toHaveLength(
+            CRYPTO_RESERVE
+        );
+        // The remaining MAX_SEARCH_RESULTS - CRYPTO_RESERVE slots are filled by stocks.
+        expect(results.filter(r => r.exchange === 'NASDAQ')).toHaveLength(
+            MAX_SEARCH_RESULTS - CRYPTO_RESERVE
+        );
     });
 
     it('한글 입력 시 FMP searchBySymbol/searchByName 을 호출하지 않는다', async () => {
@@ -129,7 +139,9 @@ describe('searchTicker — 한글 입력 crypto 병합', () => {
         );
 
         const results = await searchTicker('애플');
-        expect(results.find(r => r.symbol === 'AAPL')).toBeDefined();
+        expect(results.find(r => r.symbol === 'AAPL')).toEqual(
+            stockResult('AAPL', '애플')
+        );
     });
 
     it('주식 결과가 MAX를 채워도 crypto 결과가 보장된다', async () => {
@@ -144,6 +156,8 @@ describe('searchTicker — 한글 입력 crypto 병합', () => {
 
         const results = await searchTicker('주');
         expect(results).toHaveLength(MAX_SEARCH_RESULTS);
-        expect(results.find(r => r.symbol === 'BTCUSD')).toBeDefined();
+        expect(results.find(r => r.symbol === 'BTCUSD')).toEqual(
+            cryptoResult('BTCUSD', '비트코인')
+        );
     });
 });

--- a/src/entities/ticker/lib/__tests__/searchTicker.korean-crypto.test.ts
+++ b/src/entities/ticker/lib/__tests__/searchTicker.korean-crypto.test.ts
@@ -27,6 +27,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
     searchTicker,
     _resetInFlightTranslationsForTest,
+    MAX_SEARCH_RESULTS,
 } from '../searchTicker';
 import type { TickerSearchResult } from '@/shared/lib/types';
 
@@ -95,7 +96,7 @@ describe('searchTicker — 한글 입력 crypto 병합', () => {
         expect(btcEntries).toHaveLength(1);
     });
 
-    it('한글 입력 결과를 MAX_SEARCH_RESULTS(10)로 제한한다', async () => {
+    it('한글 입력 결과를 MAX_SEARCH_RESULTS로 제한한다', async () => {
         const manyStocks = Array.from({ length: 7 }, (_, i) =>
             stockResult(`STOCK${i}`, `주식${i}`)
         );
@@ -106,8 +107,8 @@ describe('searchTicker — 한글 입력 crypto 병합', () => {
         mockSearchCryptoAssets.mockResolvedValue(manyCrypto);
 
         const results = await searchTicker('주');
-        // 7 stocks + 6 crypto = 13 unique symbols → deterministically capped to 10.
-        expect(results).toHaveLength(10);
+        // 7 stocks + 6 crypto = 13 unique symbols → deterministically capped to MAX.
+        expect(results).toHaveLength(MAX_SEARCH_RESULTS);
     });
 
     it('한글 입력 시 FMP searchBySymbol/searchByName 을 호출하지 않는다', async () => {
@@ -121,11 +122,28 @@ describe('searchTicker — 한글 입력 crypto 병합', () => {
         expect(searchByName).not.toHaveBeenCalled();
     });
 
-    it('crypto store 실패 시에도 주식 결과는 반환한다', async () => {
+    it('crypto store 가 에러를 던져도 주식 결과는 반환한다', async () => {
         mockSearchByKoreanName.mockResolvedValue([stockResult('AAPL', '애플')]);
-        mockSearchCryptoAssets.mockResolvedValue([]);
+        mockSearchCryptoAssets.mockRejectedValue(
+            new Error('DB connection failed')
+        );
 
         const results = await searchTicker('애플');
         expect(results.some(r => r.symbol === 'AAPL')).toBe(true);
+    });
+
+    it('주식 결과가 MAX를 채워도 crypto 결과가 보장된다', async () => {
+        // 10 stock results would normally starve crypto results entirely.
+        // With CRYPTO_RESERVE=3, stock is capped at 7 and crypto gets ≥1 slot.
+        const manyStocks = Array.from({ length: 10 }, (_, i) =>
+            stockResult(`STOCK${i}`, `주식${i}`)
+        );
+        const someCrypto = [cryptoResult('BTCUSD', '비트코인')];
+        mockSearchByKoreanName.mockResolvedValue(manyStocks);
+        mockSearchCryptoAssets.mockResolvedValue(someCrypto);
+
+        const results = await searchTicker('주');
+        expect(results).toHaveLength(MAX_SEARCH_RESULTS);
+        expect(results.some(r => r.symbol === 'BTCUSD')).toBe(true);
     });
 });

--- a/src/entities/ticker/lib/__tests__/searchTicker.korean-crypto.test.ts
+++ b/src/entities/ticker/lib/__tests__/searchTicker.korean-crypto.test.ts
@@ -67,7 +67,7 @@ describe('searchTicker — 한글 입력 crypto 병합', () => {
         ]);
 
         const results = await searchTicker('비트코');
-        expect(results.some(r => r.symbol === 'BTCUSD')).toBe(true);
+        expect(results.find(r => r.symbol === 'BTCUSD')).toBeDefined();
     });
 
     it('한글 입력 시 주식 한국어 결과가 crypto 결과보다 먼저 온다', async () => {
@@ -129,7 +129,7 @@ describe('searchTicker — 한글 입력 crypto 병합', () => {
         );
 
         const results = await searchTicker('애플');
-        expect(results.some(r => r.symbol === 'AAPL')).toBe(true);
+        expect(results.find(r => r.symbol === 'AAPL')).toBeDefined();
     });
 
     it('주식 결과가 MAX를 채워도 crypto 결과가 보장된다', async () => {
@@ -144,6 +144,6 @@ describe('searchTicker — 한글 입력 crypto 병합', () => {
 
         const results = await searchTicker('주');
         expect(results).toHaveLength(MAX_SEARCH_RESULTS);
-        expect(results.some(r => r.symbol === 'BTCUSD')).toBe(true);
+        expect(results.find(r => r.symbol === 'BTCUSD')).toBeDefined();
     });
 });

--- a/src/entities/ticker/lib/searchTicker.ts
+++ b/src/entities/ticker/lib/searchTicker.ts
@@ -107,8 +107,7 @@ export async function searchTicker(
         const remainingSlots = MAX_SEARCH_RESULTS - cappedStock.length;
         const cappedCrypto = cryptoResults.slice(0, remainingSlots);
         // deduplicateResults guards the unlikely case where a symbol exists in both stores.
-        const merged = deduplicateResults([...cappedStock, ...cappedCrypto]);
-        return merged.slice(0, MAX_SEARCH_RESULTS);
+        return deduplicateResults([...cappedStock, ...cappedCrypto]);
     }
 
     const cache = createCacheProvider();

--- a/src/entities/ticker/lib/searchTicker.ts
+++ b/src/entities/ticker/lib/searchTicker.ts
@@ -80,8 +80,17 @@ export async function searchTicker(
     if (!trimmed) return [];
 
     if (isKoreanInput(trimmed)) {
-        const results = await searchByKoreanName(trimmed);
-        return results.slice(0, MAX_SEARCH_RESULTS);
+        // Stock Korean names come from the korean_tickers table; crypto Korean names
+        // come from crypto_assets.korean_name. Run both in parallel so a single
+        // Korean keypress (e.g. "비트코") surfaces both stock and crypto matches.
+        const [stockResults, cryptoResults] = await Promise.all([
+            searchByKoreanName(trimmed),
+            searchCryptoAssets(trimmed),
+        ]);
+        // Stock results first (higher relevance for equity-centric users), then crypto.
+        // deduplicateResults guards the unlikely case where a symbol exists in both stores.
+        const merged = deduplicateResults([...stockResults, ...cryptoResults]);
+        return merged.slice(0, MAX_SEARCH_RESULTS);
     }
 
     const cache = createCacheProvider();

--- a/src/entities/ticker/lib/searchTicker.ts
+++ b/src/entities/ticker/lib/searchTicker.ts
@@ -21,7 +21,15 @@ import { createSingleFlight } from './utils/singleFlight';
 import { createCacheProvider } from '@y0ngha/siglens-core';
 import type { KoreanTickerEntry, TickerSearchResult } from '@/shared/lib/types';
 
-const MAX_SEARCH_RESULTS = 10;
+export const MAX_SEARCH_RESULTS = 10;
+
+/**
+ * When a Korean search returns both stock and crypto results, reserve this many
+ * slots for crypto so Korean coin searches aren't starved by a high volume of
+ * stock name matches. The actual crypto slots may be fewer if fewer crypto
+ * results exist; unused budget flows back to stock.
+ */
+const CRYPTO_RESERVE = 3;
 
 function toKoreanEntry(
     symbol: string,
@@ -85,11 +93,21 @@ export async function searchTicker(
         // Korean keypress (e.g. "비트코") surfaces both stock and crypto matches.
         const [stockResults, cryptoResults] = await Promise.all([
             searchByKoreanName(trimmed),
-            searchCryptoAssets(trimmed),
+            // Isolated catch so a crypto DB error doesn't discard stock results.
+            searchCryptoAssets(trimmed).catch((): TickerSearchResult[] => []),
         ]);
-        // Stock results first (higher relevance for equity-centric users), then crypto.
+        // Guarantee crypto representation: reserve up to CRYPTO_RESERVE slots for
+        // crypto results when they exist, so Korean coin searches aren't lost when
+        // many stock name matches fill the cap. Unused crypto budget flows to stock.
+        const cryptoCap = Math.min(cryptoResults.length, CRYPTO_RESERVE);
+        const cappedStock = stockResults.slice(
+            0,
+            MAX_SEARCH_RESULTS - cryptoCap
+        );
+        const remainingSlots = MAX_SEARCH_RESULTS - cappedStock.length;
+        const cappedCrypto = cryptoResults.slice(0, remainingSlots);
         // deduplicateResults guards the unlikely case where a symbol exists in both stores.
-        const merged = deduplicateResults([...stockResults, ...cryptoResults]);
+        const merged = deduplicateResults([...cappedStock, ...cappedCrypto]);
         return merged.slice(0, MAX_SEARCH_RESULTS);
     }
 

--- a/src/entities/ticker/lib/searchTicker.ts
+++ b/src/entities/ticker/lib/searchTicker.ts
@@ -29,7 +29,7 @@ export const MAX_SEARCH_RESULTS = 10;
  * stock name matches. The actual crypto slots may be fewer if fewer crypto
  * results exist; unused budget flows back to stock.
  */
-const CRYPTO_RESERVE = 3;
+export const CRYPTO_RESERVE = 3;
 
 function toKoreanEntry(
     symbol: string,


### PR DESCRIPTION
## 관련 이슈

N/A (feature implementation)

## 구현 내용

Cryptocurrency Korean-name search capability. Users can now type Korean input (e.g., `비트코`) to search and match crypto symbols.

### 3 Core Components

1. **SQL korean_name Match** (`src/entities/ticker/api.ts`)
   - Crypto search now matches `korean_name` (ilike) alongside symbol+name
   - Backend routing filters crypto_assets by korean_name for Korean input paths

2. **Korean-Input Routing Merge** (`src/entities/ticker/lib/searchTicker.ts`)
   - Korean-input path merges stock-korean + crypto-korean results
   - Deduplication + configurable result cap per type

3. **Gemini-Batch Seed Script** (`scripts/seed-crypto-korean-names.ts`)
   - NEW: Populates crypto_assets.korean_name for top-N coins via Gemini batch API
   - Re-runnable, DRY_RUN support, safe for staging/prod
   - Referenced by new `db:seed:crypto-korean` npm script in package.json
   - **Post-merge action**: Must run `yarn db:seed:crypto-korean` against prod to populate korean_name for live crypto symbols

## 테스트 커버리지

### Unit Tests
- `src/entities/ticker/lib/__tests__/searchTicker.korean-crypto.test.ts`: Korean-input routing merge logic
- `src/entities/ticker/__tests__/api.test.ts` (modified): crypto korean_name SQL match
- `scripts/__tests__/seed-crypto-korean-names.test.ts`: Seed script batch logic + DRY_RUN mode

### E2E Tests
- `e2e/specs/crypto-korean-search.spec.ts`: UI flow (type Korean → BTCUSD match)
- E2E ticker fixture extended with crypto entries + korean_name field

## 레이어 및 코드 품질 체크

- [x] @docs/conventions/CONVENTIONS.md 준수 확인
- [x] @docs/conventions/FF.md 준수 확인
- [x] @docs/workflows/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it

## 변경 파일 목록

[생성]
- `scripts/seed-crypto-korean-names.ts` (force-added; gitignored by /scripts/**)
- `scripts/__tests__/seed-crypto-korean-names.test.ts`
- `e2e/specs/crypto-korean-search.spec.ts`
- `src/entities/ticker/lib/__tests__/searchTicker.korean-crypto.test.ts`

[수정]
- `package.json` (added db:seed:crypto-korean script)
- `src/entities/ticker/api.ts` (korean_name ilike match)
- `src/entities/ticker/lib/searchTicker.ts` (Korean routing merge)
- `src/entities/ticker/actions/searchTickerAction.ts` (E2E fixture crypto + korean_name)
- `src/entities/ticker/__tests__/api.test.ts` (crypto korean_name test)

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build
- [x] yarn e2e (pre-push)

## 참고

Post-merge, run `yarn db:seed:crypto-korean` against production to populate korean_name for all tracked cryptocurrency symbols. This enables live Korean search.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>