### PR TITLE
feat(sitemap): manual update-popular-cryptos script

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
         "release:minor": "SIGLENS_RELEASE_E2E=1 dotenv -e .env.local -- release-it minor --verbose",
         "release:major": "SIGLENS_RELEASE_E2E=1 dotenv -e .env.local -- release-it major --verbose",
         "fetch-this-week-tasks": "cd scripts/fetch-this-week-tasks && node --env-file=.env index.js",
-        "update-popular-tickers": "npx tsx update-popular-tickers.ts"
+        "update-popular-tickers": "npx tsx update-popular-tickers.ts",
+        "update-popular-cryptos": "tsx scripts/update-popular-cryptos.ts"
     },
     "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "release:major": "SIGLENS_RELEASE_E2E=1 dotenv -e .env.local -- release-it major --verbose",
         "fetch-this-week-tasks": "cd scripts/fetch-this-week-tasks && node --env-file=.env index.js",
         "update-popular-tickers": "npx tsx update-popular-tickers.ts",
-        "update-popular-cryptos": "tsx scripts/update-popular-cryptos.ts"
+        "update-popular-cryptos": "npx tsx scripts/update-popular-cryptos.ts"
     },
     "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",

--- a/scripts/__tests__/update-popular-cryptos.test.ts
+++ b/scripts/__tests__/update-popular-cryptos.test.ts
@@ -146,8 +146,8 @@ describe('renderPopularCryptosFile', () => {
     it('renders an empty array when no symbols are provided', () => {
         const result = renderPopularCryptosFile([]);
 
-        expect(result).toContain(
-            'export const POPULAR_CRYPTOS = [\n] as const;'
+        expect(result).toBe(
+            `${FILE_HEADER}\nexport const POPULAR_CRYPTOS = [\n] as const;\n`
         );
     });
 
@@ -194,7 +194,8 @@ describe('CRYPTO_CANDIDATE_POOL', () => {
     });
 
     it('all symbols end with USD', () => {
-        expect(CRYPTO_CANDIDATE_POOL.every(s => s.endsWith('USD'))).toBe(true);
+        const nonUsd = CRYPTO_CANDIDATE_POOL.filter(s => !s.endsWith('USD'));
+        expect(nonUsd).toEqual([]);
     });
 });
 

--- a/scripts/__tests__/update-popular-cryptos.test.ts
+++ b/scripts/__tests__/update-popular-cryptos.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
     CRYPTO_CANDIDATE_POOL,
     MAX_POPULAR_CRYPTOS,
+    STABLECOINS,
     filterValidCandidates,
+    formatMarketCap,
     rankByMarketCap,
     renderPopularCryptosFile,
 } from '../update-popular-cryptos';
@@ -201,9 +203,9 @@ describe('CRYPTO_CANDIDATE_POOL', () => {
             'SHIBUSD',
         ];
 
-        for (const symbol of currentPopular) {
-            expect(CRYPTO_CANDIDATE_POOL).toContain(symbol);
-        }
+        expect(CRYPTO_CANDIDATE_POOL).toEqual(
+            expect.arrayContaining(currentPopular)
+        );
     });
 
     it('has no duplicate symbols', () => {
@@ -219,14 +221,63 @@ describe('CRYPTO_CANDIDATE_POOL', () => {
     });
 
     it('all symbols end with USD', () => {
-        for (const symbol of CRYPTO_CANDIDATE_POOL) {
-            expect(symbol.endsWith('USD')).toBe(true);
-        }
+        expect(CRYPTO_CANDIDATE_POOL.every(s => s.endsWith('USD'))).toBe(true);
     });
 });
 
 describe('MAX_POPULAR_CRYPTOS', () => {
     it('matches the current popular-cryptos.ts list size (15)', () => {
         expect(MAX_POPULAR_CRYPTOS).toBe(15);
+    });
+});
+
+describe('formatMarketCap', () => {
+    it('formats values >= 1T with T suffix and two decimals', () => {
+        expect(formatMarketCap(1_300_000_000_000)).toBe('$1.30T');
+        expect(formatMarketCap(1_000_000_000_000)).toBe('$1.00T');
+    });
+
+    it('formats values >= 1B (but < 1T) with B suffix and two decimals', () => {
+        expect(formatMarketCap(500_000_000_000)).toBe('$500.00B');
+        expect(formatMarketCap(1_000_000_000)).toBe('$1.00B');
+    });
+
+    it('formats values >= 1M (but < 1B) with M suffix and two decimals', () => {
+        expect(formatMarketCap(42_000_000)).toBe('$42.00M');
+        expect(formatMarketCap(1_000_000)).toBe('$1.00M');
+    });
+
+    it('formats sub-million values as integer dollars', () => {
+        expect(formatMarketCap(999_999)).toBe('$999999');
+        expect(formatMarketCap(1.5)).toBe('$2');
+    });
+});
+
+describe('stablecoin exclusion', () => {
+    it('filterValidCandidates drops stablecoins even when present in the crypto list', () => {
+        const pool = ['BTCUSD', 'USDTUSD', 'USDCUSD', 'ETHUSD', 'DAIUSD'];
+        const cryptoList = pool.map(symbol => ({
+            symbol,
+            name: symbol,
+            circulatingSupply: null,
+        }));
+
+        const { valid, dropped } = filterValidCandidates(pool, cryptoList);
+
+        expect(valid).toEqual(['BTCUSD', 'ETHUSD']);
+        expect(dropped).toEqual(
+            expect.arrayContaining(['USDTUSD', 'USDCUSD', 'DAIUSD'])
+        );
+    });
+
+    it('STABLECOINS set contains USDT, USDC, DAI and other known pegged coins', () => {
+        expect(STABLECOINS.has('USDT')).toBe(true);
+        expect(STABLECOINS.has('USDC')).toBe(true);
+        expect(STABLECOINS.has('DAI')).toBe(true);
+    });
+
+    it('CRYPTO_CANDIDATE_POOL does not contain USDTUSD or USDCUSD', () => {
+        expect(CRYPTO_CANDIDATE_POOL).not.toContain('USDTUSD');
+        expect(CRYPTO_CANDIDATE_POOL).not.toContain('USDCUSD');
     });
 });

--- a/scripts/__tests__/update-popular-cryptos.test.ts
+++ b/scripts/__tests__/update-popular-cryptos.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest';
+import {
+    CRYPTO_CANDIDATE_POOL,
+    MAX_POPULAR_CRYPTOS,
+    filterValidCandidates,
+    rankByMarketCap,
+    renderPopularCryptosFile,
+} from '../update-popular-cryptos';
+
+describe('filterValidCandidates', () => {
+    it('keeps symbols present in the crypto list, drops absent ones', () => {
+        const pool = ['BTCUSD', 'ETHUSD', 'MATICUSD', 'POLUSD'];
+        const cryptoList = [
+            { symbol: 'BTCUSD', name: 'Bitcoin', circulatingSupply: null },
+            { symbol: 'ETHUSD', name: 'Ethereum', circulatingSupply: null },
+            { symbol: 'POLUSD', name: 'Polygon', circulatingSupply: null },
+            // MATICUSD is absent — simulates delisted/renamed symbol
+        ];
+
+        const result = filterValidCandidates(pool, cryptoList);
+
+        expect(result.valid).toEqual(['BTCUSD', 'ETHUSD', 'POLUSD']);
+        expect(result.dropped).toEqual(['MATICUSD']);
+    });
+
+    it('returns empty valid list when pool is empty', () => {
+        const result = filterValidCandidates(
+            [],
+            [{ symbol: 'BTCUSD', name: 'Bitcoin', circulatingSupply: null }]
+        );
+
+        expect(result.valid).toEqual([]);
+        expect(result.dropped).toEqual([]);
+    });
+
+    it('drops every pool entry when crypto list is empty', () => {
+        const pool = ['BTCUSD', 'ETHUSD'];
+        const result = filterValidCandidates(pool, []);
+
+        expect(result.valid).toEqual([]);
+        expect(result.dropped).toEqual(['BTCUSD', 'ETHUSD']);
+    });
+
+    it('is case-insensitive on the crypto list symbols', () => {
+        const pool = ['BTCUSD'];
+        // FMP occasionally returns mixed-case symbols
+        const cryptoList = [
+            { symbol: 'btcusd', name: 'Bitcoin', circulatingSupply: null },
+        ];
+
+        const result = filterValidCandidates(pool, cryptoList);
+
+        expect(result.valid).toEqual(['BTCUSD']);
+        expect(result.dropped).toEqual([]);
+    });
+
+    it('preserves the original pool order in the valid list', () => {
+        const pool = ['SOLUSD', 'BTCUSD', 'ETHUSD'];
+        const cryptoList = pool.map(symbol => ({
+            symbol,
+            name: symbol,
+            circulatingSupply: null,
+        }));
+
+        const result = filterValidCandidates(pool, cryptoList);
+
+        expect(result.valid).toEqual(['SOLUSD', 'BTCUSD', 'ETHUSD']);
+    });
+});
+
+describe('rankByMarketCap', () => {
+    it('sorts entries by marketCap descending and slices to topN', () => {
+        const entries = [
+            { symbol: 'ADAUSD', marketCap: 100_000_000 },
+            { symbol: 'BTCUSD', marketCap: 1_000_000_000_000 },
+            { symbol: 'ETHUSD', marketCap: 400_000_000_000 },
+            { symbol: 'SOLUSD', marketCap: 80_000_000_000 },
+        ];
+
+        const result = rankByMarketCap(entries, 3);
+
+        expect(result).toHaveLength(3);
+        expect(result.map(e => e.symbol)).toEqual([
+            'BTCUSD',
+            'ETHUSD',
+            'SOLUSD',
+        ]);
+    });
+
+    it('excludes entries with zero or negative marketCap', () => {
+        const entries = [
+            { symbol: 'BTCUSD', marketCap: 1_000_000_000_000 },
+            { symbol: 'ZEROUSD', marketCap: 0 },
+            { symbol: 'NEGATIVEUSD', marketCap: -1 },
+        ];
+
+        const result = rankByMarketCap(entries, 10);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]!.symbol).toBe('BTCUSD');
+    });
+
+    it('returns fewer than topN when not enough valid entries exist', () => {
+        const entries = [{ symbol: 'BTCUSD', marketCap: 1_000_000_000_000 }];
+
+        const result = rankByMarketCap(entries, 15);
+
+        expect(result).toHaveLength(1);
+    });
+
+    it('returns empty array when all entries have zero marketCap', () => {
+        const entries = [
+            { symbol: 'DEADUSD', marketCap: 0 },
+            { symbol: 'NULLUSD', marketCap: 0 },
+        ];
+
+        expect(rankByMarketCap(entries, 5)).toEqual([]);
+    });
+
+    it('does not mutate the original entries array', () => {
+        const entries = [
+            { symbol: 'ETHUSD', marketCap: 400_000_000_000 },
+            { symbol: 'BTCUSD', marketCap: 1_000_000_000_000 },
+        ];
+        const originalOrder = entries.map(e => e.symbol);
+
+        rankByMarketCap(entries, 10);
+
+        expect(entries.map(e => e.symbol)).toEqual(originalOrder);
+    });
+});
+
+describe('renderPopularCryptosFile', () => {
+    it('renders the exact file content with header and as const', () => {
+        const result = renderPopularCryptosFile(['BTCUSD', 'ETHUSD', 'SOLUSD']);
+
+        expect(result).toBe(
+            `// 큐레이션된 인기 암호화폐 — 홈 디스커버리 + sitemap popular 엔트리.
+// FMP 심볼은 *USD 접미사(BTCUSD)를 쓴다. batch-crypto-quotes가 HTTP 402(플랜 미지원)이라
+// 단건 quote를 심볼별로 호출하여 시가총액 기준 상위 N개를 자동 선정한다(update-popular-cryptos.ts).
+// 수동으로 순서를 바꾸거나 심볼을 추가/제거할 수 있습니다.
+export const POPULAR_CRYPTOS = [
+    'BTCUSD',
+    'ETHUSD',
+    'SOLUSD',
+] as const;
+`
+        );
+    });
+
+    it('renders an empty array when no symbols are provided', () => {
+        const result = renderPopularCryptosFile([]);
+
+        expect(result).toContain(
+            'export const POPULAR_CRYPTOS = [\n] as const;'
+        );
+    });
+
+    it('produces a valid TypeScript const assertion', () => {
+        const result = renderPopularCryptosFile(['XRPUSD']);
+
+        expect(result).toContain('] as const;');
+    });
+
+    it('renders exactly the passed symbols in the exact order', () => {
+        // Order matters — this is market-cap rank order
+        const symbols = ['BTCUSD', 'ETHUSD', 'BNBUSD', 'SOLUSD', 'XRPUSD'];
+        const result = renderPopularCryptosFile(symbols);
+
+        const lines = result.split('\n').filter(l => l.trim().startsWith("'"));
+
+        expect(lines).toEqual([
+            "    'BTCUSD',",
+            "    'ETHUSD',",
+            "    'BNBUSD',",
+            "    'SOLUSD',",
+            "    'XRPUSD',",
+        ]);
+    });
+});
+
+describe('CRYPTO_CANDIDATE_POOL', () => {
+    it('contains all 15 current POPULAR_CRYPTOS symbols', () => {
+        // These are the symbols in the existing popular-cryptos.ts at the time
+        // this script was authored. If the popular list changes, update this test.
+        const currentPopular = [
+            'BTCUSD',
+            'ETHUSD',
+            'SOLUSD',
+            'XRPUSD',
+            'BNBUSD',
+            'DOGEUSD',
+            'ADAUSD',
+            'AVAXUSD',
+            'LINKUSD',
+            'TRXUSD',
+            'DOTUSD',
+            'POLUSD',
+            'LTCUSD',
+            'BCHUSD',
+            'SHIBUSD',
+        ];
+
+        for (const symbol of currentPopular) {
+            expect(CRYPTO_CANDIDATE_POOL).toContain(symbol);
+        }
+    });
+
+    it('has no duplicate symbols', () => {
+        const unique = new Set(CRYPTO_CANDIDATE_POOL);
+
+        expect(unique.size).toBe(CRYPTO_CANDIDATE_POOL.length);
+    });
+
+    it('contains more symbols than MAX_POPULAR_CRYPTOS (to allow ranking)', () => {
+        expect(CRYPTO_CANDIDATE_POOL.length).toBeGreaterThan(
+            MAX_POPULAR_CRYPTOS
+        );
+    });
+
+    it('all symbols end with USD', () => {
+        for (const symbol of CRYPTO_CANDIDATE_POOL) {
+            expect(symbol.endsWith('USD')).toBe(true);
+        }
+    });
+});
+
+describe('MAX_POPULAR_CRYPTOS', () => {
+    it('matches the current popular-cryptos.ts list size (15)', () => {
+        expect(MAX_POPULAR_CRYPTOS).toBe(15);
+    });
+});

--- a/scripts/__tests__/update-popular-cryptos.test.ts
+++ b/scripts/__tests__/update-popular-cryptos.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { POPULAR_CRYPTOS } from '../../src/shared/config/popular-cryptos';
 import {
     CRYPTO_CANDIDATE_POOL,
+    FILE_HEADER,
     MAX_POPULAR_CRYPTOS,
     STABLECOINS,
     filterValidCandidates,
@@ -137,16 +139,7 @@ describe('renderPopularCryptosFile', () => {
         const result = renderPopularCryptosFile(['BTCUSD', 'ETHUSD', 'SOLUSD']);
 
         expect(result).toBe(
-            `// 큐레이션된 인기 암호화폐 — 홈 디스커버리 + sitemap popular 엔트리.
-// FMP 심볼은 *USD 접미사(BTCUSD)를 쓴다. batch-crypto-quotes가 HTTP 402(플랜 미지원)이라
-// 단건 quote를 심볼별로 호출하여 시가총액 기준 상위 N개를 자동 선정한다(update-popular-cryptos.ts).
-// 수동으로 순서를 바꾸거나 심볼을 추가/제거할 수 있습니다.
-export const POPULAR_CRYPTOS = [
-    'BTCUSD',
-    'ETHUSD',
-    'SOLUSD',
-] as const;
-`
+            `${FILE_HEADER}\nexport const POPULAR_CRYPTOS = [\n    'BTCUSD',\n    'ETHUSD',\n    'SOLUSD',\n] as const;\n`
         );
     });
 
@@ -182,29 +175,9 @@ export const POPULAR_CRYPTOS = [
 });
 
 describe('CRYPTO_CANDIDATE_POOL', () => {
-    it('contains all 15 current POPULAR_CRYPTOS symbols', () => {
-        // These are the symbols in the existing popular-cryptos.ts at the time
-        // this script was authored. If the popular list changes, update this test.
-        const currentPopular = [
-            'BTCUSD',
-            'ETHUSD',
-            'SOLUSD',
-            'XRPUSD',
-            'BNBUSD',
-            'DOGEUSD',
-            'ADAUSD',
-            'AVAXUSD',
-            'LINKUSD',
-            'TRXUSD',
-            'DOTUSD',
-            'POLUSD',
-            'LTCUSD',
-            'BCHUSD',
-            'SHIBUSD',
-        ];
-
+    it('contains all current POPULAR_CRYPTOS symbols', () => {
         expect(CRYPTO_CANDIDATE_POOL).toEqual(
-            expect.arrayContaining(currentPopular)
+            expect.arrayContaining([...POPULAR_CRYPTOS])
         );
     });
 
@@ -265,9 +238,7 @@ describe('stablecoin exclusion', () => {
         const { valid, dropped } = filterValidCandidates(pool, cryptoList);
 
         expect(valid).toEqual(['BTCUSD', 'ETHUSD']);
-        expect(dropped).toEqual(
-            expect.arrayContaining(['USDTUSD', 'USDCUSD', 'DAIUSD'])
-        );
+        expect(dropped).toEqual(['USDTUSD', 'USDCUSD', 'DAIUSD']);
     });
 
     it('STABLECOINS set contains USDT, USDC, DAI and other known pegged coins', () => {

--- a/scripts/__tests__/update-popular-cryptos.test.ts
+++ b/scripts/__tests__/update-popular-cryptos.test.ts
@@ -4,7 +4,6 @@ import {
     CRYPTO_CANDIDATE_POOL,
     FILE_HEADER,
     MAX_POPULAR_CRYPTOS,
-    STABLECOINS,
     filterValidCandidates,
     formatMarketCap,
     rankByMarketCap,
@@ -242,10 +241,35 @@ describe('stablecoin exclusion', () => {
         expect(dropped).toEqual(['USDTUSD', 'USDCUSD', 'DAIUSD']);
     });
 
-    it('STABLECOINS set contains USDT, USDC, DAI and other known pegged coins', () => {
-        expect(STABLECOINS.has('USDT')).toBe(true);
-        expect(STABLECOINS.has('USDC')).toBe(true);
-        expect(STABLECOINS.has('DAI')).toBe(true);
+    it('STABLECOINS set contains all known pegged coins: USDT, USDC, DAI, BUSD, TUSD, USDD, FDUSD', () => {
+        const pool = [
+            'BTCUSD',
+            'USDTUSD',
+            'USDCUSD',
+            'DAIUSD',
+            'BUSDUSD',
+            'TUSDUSD',
+            'USDDUSD',
+            'FDUSDUSD',
+        ];
+        const cryptoList = pool.map(symbol => ({
+            symbol,
+            name: symbol,
+            circulatingSupply: null,
+        }));
+
+        const { valid, dropped } = filterValidCandidates(pool, cryptoList);
+
+        expect(valid).toEqual(['BTCUSD']);
+        expect(dropped).toEqual([
+            'USDTUSD',
+            'USDCUSD',
+            'DAIUSD',
+            'BUSDUSD',
+            'TUSDUSD',
+            'USDDUSD',
+            'FDUSDUSD',
+        ]);
     });
 
     it('CRYPTO_CANDIDATE_POOL does not contain USDTUSD or USDCUSD', () => {

--- a/scripts/__tests__/update-popular-cryptos.test.ts
+++ b/scripts/__tests__/update-popular-cryptos.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { POPULAR_CRYPTOS } from '../../src/shared/config/popular-cryptos';
+import { POPULAR_CRYPTOS } from '@/shared/config/popular-cryptos';
 import {
     CRYPTO_CANDIDATE_POOL,
     FILE_HEADER,
@@ -199,8 +199,8 @@ describe('CRYPTO_CANDIDATE_POOL', () => {
 });
 
 describe('MAX_POPULAR_CRYPTOS', () => {
-    it('matches the current popular-cryptos.ts list size (15)', () => {
-        expect(MAX_POPULAR_CRYPTOS).toBe(15);
+    it('matches the current popular-cryptos.ts list size', () => {
+        expect(MAX_POPULAR_CRYPTOS).toBe(POPULAR_CRYPTOS.length);
     });
 });
 

--- a/scripts/update-popular-cryptos.ts
+++ b/scripts/update-popular-cryptos.ts
@@ -1,0 +1,412 @@
+/**
+ * 인기 암호화폐 갱신 스크립트 (수동 실행)
+ *
+ * FMP cryptocurrency-list API로 후보 풀을 검증한 뒤,
+ * 각 심볼의 단건 quote 엔드포인트에서 marketCap을 수집하여
+ * 시가총액 상위 MAX_POPULAR_CRYPTOS 개를 POPULAR_CRYPTOS로 덮어씁니다.
+ *
+ * FMP 플랜 제약:
+ *   - batch-crypto-quotes → HTTP 402 (플랜 미지원). 사용 불가.
+ *   - quote?symbol=<SYM> → HTTP 200, marketCap/volume/price 반환. 심볼별 단건 호출.
+ *   - cryptocurrency-list → 전체 유니버스(symbol/name/circulatingSupply). 후보 유효성 검증용.
+ *   - 크립토 스크리너는 플랜 미지원이므로 자동 발견 불가 → CRYPTO_CANDIDATE_POOL 수동 관리.
+ *
+ * 사용법:
+ *   npx tsx scripts/update-popular-cryptos.ts
+ *
+ * 환경변수 (.env.local):
+ *   FMP_API_KEY
+ *
+ * 결과:
+ *   시가총액 기준 상위 N개로 src/shared/config/popular-cryptos.ts를 완전 교체합니다.
+ *   (누적 추가가 아니라 매 실행마다 현재 상위 코인으로 리프레시)
+ */
+
+import { execSync } from 'child_process';
+import { config } from 'dotenv';
+import {
+    mkdirSync,
+    renameSync,
+    rmSync,
+    writeFileSync,
+} from 'fs';
+import { dirname, resolve } from 'path';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const FMP_BASE_URL = 'https://financialmodelingprep.com/stable';
+
+/**
+ * 최대 인기 암호화폐 수. 현재 popular-cryptos.ts의 큐레이션 목록과 동일.
+ * 변경 시 함께 검토: src/shared/config/popular-cryptos.ts
+ */
+export const MAX_POPULAR_CRYPTOS = 15;
+
+/**
+ * API 호출 간 딜레이(ms). FMP 무료/엔트리 플랜의 rate limit을 준수하기 위해
+ * 심볼별 순차 호출 사이에 삽입한다.
+ */
+const REQUEST_DELAY_MS = 250;
+
+/**
+ * 후보 풀 — 유지 관리 필요.
+ *
+ * FMP 플랜에 crypto screener가 없어 시가총액 기준 자동 발견이 불가하므로,
+ * 주요 *USD 심볼을 수동으로 관리하는 넓은 후보 집합이다. 현재 POPULAR_CRYPTOS의
+ * 15종 + 잘 알려진 추가 코인을 포함한다. 랭킹에 새 코인을 반영하려면 여기에 추가.
+ *
+ * 기준:
+ *   - FMP cryptocurrency-list에 존재하는 *USD 심볼
+ *   - 이름 변경/폐지 코인은 제거: 예) MATICUSD → POLUSD (Polygon rebranding, 제거 완료)
+ */
+export const CRYPTO_CANDIDATE_POOL: readonly string[] = [
+    // Top-10 by market cap (as of mid-2025 typical rankings)
+    'BTCUSD',
+    'ETHUSD',
+    'USDTUSD',
+    'BNBUSD',
+    'SOLUSD',
+    'XRPUSD',
+    'USDCUSD',
+    'DOGEUSD',
+    'ADAUSD',
+    'TRXUSD',
+    // Established layer-1s / large caps
+    'AVAXUSD',
+    'LINKUSD',
+    'DOTUSD',
+    'POLUSD',
+    'LTCUSD',
+    'BCHUSD',
+    'XLMUSD',
+    'ATOMUSD',
+    'ALGOUSD',
+    // DeFi / ecosystem tokens
+    'UNIUSD',
+    'AAVEUSD',
+    'MKRUSD',
+    'COMPUSD',
+    // Layer-2 / scaling
+    'ARBUSD',
+    'OPUSD',
+    'IMXUSD',
+    // Emerging layer-1s
+    'APTUSD',
+    'SUIUSD',
+    'SEIUSD',
+    'NEARUSD',
+    'TONUSD',
+    'INJUSD',
+    'TIAUSD',
+    'JASMYUSD',
+    // Memes & high-cap speculative
+    'SHIBUSD',
+    'PEPEUSD',
+    'FLOKIUSD',
+    // Other well-known
+    'FILUSD',
+    'GRTUSD',
+    'SANDUSD',
+    'MANAUSD',
+    'APEUSD',
+];
+
+const POPULAR_CRYPTOS_PATH = resolve(
+    process.cwd(),
+    'src/shared/config/popular-cryptos.ts'
+);
+
+/**
+ * popular-cryptos.ts에 기록되는 헤더 주석.
+ *
+ * 이 스크립트를 실행할 때마다 파일 전체를 이 헤더 + 새 배열로 교체하므로,
+ * 라이브 파일 헤더의 WHY(아래 제약 두 가지)를 반드시 보존해야 한다:
+ *   1. FMP 심볼은 *USD 접미사(BTCUSD) 형태를 사용한다.
+ *   2. batch-crypto-quotes 엔드포인트는 HTTP 402(플랜 미지원)이므로
+ *      단건 quote 엔드포인트를 심볼별로 순차 호출하는 방식으로 시가총액을 수집한다.
+ */
+const FILE_HEADER = `// 큐레이션된 인기 암호화폐 — 홈 디스커버리 + sitemap popular 엔트리.
+// FMP 심볼은 *USD 접미사(BTCUSD)를 쓴다. batch-crypto-quotes가 HTTP 402(플랜 미지원)이라
+// 단건 quote를 심볼별로 호출하여 시가총액 기준 상위 N개를 자동 선정한다(update-popular-cryptos.ts).
+// 수동으로 순서를 바꾸거나 심볼을 추가/제거할 수 있습니다.`;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface FmpCryptoListEntry {
+    symbol: string;
+    name: string;
+    circulatingSupply: number | null;
+}
+
+interface FmpQuoteResult {
+    symbol: string;
+    price: number | null;
+    marketCap: number | null;
+    volume: number | null;
+}
+
+export interface CryptoRankEntry {
+    symbol: string;
+    marketCap: number;
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(r => setTimeout(r, ms));
+}
+
+function formatMarketCap(cap: number): string {
+    if (cap >= 1_000_000_000_000) return `$${(cap / 1_000_000_000_000).toFixed(2)}T`;
+    if (cap >= 1_000_000_000) return `$${(cap / 1_000_000_000).toFixed(2)}B`;
+    if (cap >= 1_000_000) return `$${(cap / 1_000_000).toFixed(2)}M`;
+    return `$${cap.toFixed(0)}`;
+}
+
+// ---------------------------------------------------------------------------
+// FMP API
+// ---------------------------------------------------------------------------
+
+async function fetchCryptoList(apiKey: string): Promise<FmpCryptoListEntry[]> {
+    const url = `${FMP_BASE_URL}/cryptocurrency-list?apikey=${encodeURIComponent(apiKey)}`;
+    const res = await fetch(url);
+
+    if (!res.ok) {
+        throw new Error(
+            `cryptocurrency-list API error: ${res.status} ${res.statusText}`
+        );
+    }
+
+    // FMP returns unvalidated JSON; shape matches FmpCryptoListEntry
+    const raw = (await res.json()) as FmpCryptoListEntry[];
+    if (!Array.isArray(raw)) return [];
+    return raw;
+}
+
+async function fetchSingleQuote(
+    apiKey: string,
+    symbol: string
+): Promise<FmpQuoteResult | null> {
+    const url = `${FMP_BASE_URL}/quote?symbol=${encodeURIComponent(symbol)}&apikey=${encodeURIComponent(apiKey)}`;
+    const res = await fetch(url);
+
+    if (!res.ok) {
+        console.warn(`  quote fetch failed for ${symbol}: ${res.status}`);
+        return null;
+    }
+
+    // FMP quote endpoint returns an array; first element is the result
+    const raw = (await res.json()) as FmpQuoteResult[];
+    if (!Array.isArray(raw) || raw.length === 0) return null;
+    return raw[0] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Core logic (exported for testability)
+// ---------------------------------------------------------------------------
+
+/**
+ * cryptocurrency-list로부터 유효 심볼 집합을 구성한다.
+ * 풀에 있으나 리스트에 없는 심볼은 폐지/이름변경된 것으로 간주, 제거한다.
+ */
+export function filterValidCandidates(
+    pool: readonly string[],
+    cryptoList: FmpCryptoListEntry[]
+): { valid: string[]; dropped: string[] } {
+    const listedSymbols = new Set(cryptoList.map(e => e.symbol.toUpperCase()));
+    const valid: string[] = [];
+    const dropped: string[] = [];
+
+    for (const symbol of pool) {
+        if (listedSymbols.has(symbol.toUpperCase())) {
+            valid.push(symbol);
+        } else {
+            dropped.push(symbol);
+        }
+    }
+
+    return { valid, dropped };
+}
+
+/**
+ * marketCap 기준 내림차순으로 정렬한 뒤 상위 topN 개를 반환한다.
+ * marketCap이 null이거나 0인 항목은 제외한다.
+ */
+export function rankByMarketCap(
+    entries: CryptoRankEntry[],
+    topN: number
+): CryptoRankEntry[] {
+    return entries
+        .filter(e => e.marketCap > 0)
+        .slice()
+        .sort((a, b) => b.marketCap - a.marketCap)
+        .slice(0, topN);
+}
+
+/**
+ * popular-cryptos.ts 파일 내용을 렌더링한다.
+ * 헤더 주석은 보존하고 POPULAR_CRYPTOS 배열만 교체한다.
+ */
+export function renderPopularCryptosFile(symbols: readonly string[]): string {
+    const lines = symbols.map(s => `    '${s}',`).join('\n');
+    const body = lines.length > 0 ? `${lines}\n` : '';
+
+    return `${FILE_HEADER}
+export const POPULAR_CRYPTOS = [
+${body}] as const;
+`;
+}
+
+// ---------------------------------------------------------------------------
+// File write
+// ---------------------------------------------------------------------------
+
+function writeAndFormatFileAtomically(
+    path: string,
+    fileContent: string
+): string {
+    const tempPath = `${path}.${process.pid}.${Date.now()}.tmp.ts`;
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(tempPath, fileContent, 'utf-8');
+
+    try {
+        execSync(`yarn prettier --write "${tempPath}"`, { stdio: 'inherit' });
+    } catch {
+        console.warn(
+            `Prettier failed for ${path} — temp file was written but may need manual formatting.`
+        );
+    }
+
+    return tempPath;
+}
+
+function commitFileAtomically(path: string, fileContent: string): void {
+    const tempPath = writeAndFormatFileAtomically(path, fileContent);
+
+    try {
+        renameSync(tempPath, path);
+        console.log(`\nUpdated ${path}`);
+    } finally {
+        try {
+            rmSync(tempPath, { force: true });
+        } catch {
+            // best-effort cleanup
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Result display
+// ---------------------------------------------------------------------------
+
+/**
+ * 결과 테이블 구분선 너비.
+ * "Rank | Symbol    | Market Cap" 헤더의 컬럼 패딩 합산값(4+3+9+3+14 = 33 + 구분자 9 = 42).
+ */
+const TABLE_SEPARATOR_WIDTH = 42;
+
+function printResults(ranked: CryptoRankEntry[]): void {
+    console.log(`\n--- Top ${ranked.length} Cryptos by Market Cap ---\n`);
+    console.log('Rank | Symbol    | Market Cap');
+    console.log('-'.repeat(TABLE_SEPARATOR_WIDTH));
+
+    ranked.forEach((e, i) => {
+        const rank = String(i + 1).padStart(4);
+        const symbol = e.symbol.padEnd(9);
+        const cap = formatMarketCap(e.marketCap).padStart(14);
+        console.log(`${rank} | ${symbol} | ${cap}`);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+    config({ path: resolve(process.cwd(), '.env.local') });
+
+    const apiKey = process.env.FMP_API_KEY;
+    if (!apiKey) {
+        throw new Error('FMP_API_KEY must be set in .env.local');
+    }
+
+    console.log('\n=== Update Popular Cryptos ===\n');
+    console.log(`Candidate pool size: ${CRYPTO_CANDIDATE_POOL.length}`);
+
+    // 1. Validate candidates against the full crypto list (drop delisted/renamed)
+    console.log('\nFetching cryptocurrency-list for candidate validation...');
+    const cryptoList = await fetchCryptoList(apiKey);
+    console.log(`cryptocurrency-list returned: ${cryptoList.length} entries`);
+
+    const { valid, dropped } = filterValidCandidates(
+        CRYPTO_CANDIDATE_POOL,
+        cryptoList
+    );
+
+    if (dropped.length > 0) {
+        console.log(
+            `\nDropped (not in cryptocurrency-list): ${dropped.join(', ')}`
+        );
+    }
+    console.log(`Valid candidates after validation: ${valid.length}`);
+
+    // 2. Fetch single quote per valid candidate for marketCap
+    console.log(`\nFetching quotes for ${valid.length} candidates...`);
+
+    const ranked: CryptoRankEntry[] = [];
+
+    for (let i = 0; i < valid.length; i++) {
+        const symbol = valid[i]!;
+        process.stdout.write(
+            `  [${i + 1}/${valid.length}] ${symbol.padEnd(10)}`
+        );
+
+        const quote = await fetchSingleQuote(apiKey, symbol);
+
+        if (quote === null || !quote.marketCap || quote.marketCap <= 0) {
+            console.log('→ skipped (no marketCap)');
+        } else {
+            console.log(`→ ${formatMarketCap(quote.marketCap)}`);
+            ranked.push({ symbol, marketCap: quote.marketCap });
+        }
+
+        if (i < valid.length - 1) {
+            await sleep(REQUEST_DELAY_MS);
+        }
+    }
+
+    // 3. Rank and select top N
+    const topCryptos = rankByMarketCap(ranked, MAX_POPULAR_CRYPTOS);
+
+    if (topCryptos.length === 0) {
+        throw new Error(
+            'No cryptos with valid marketCap found. Aborting to avoid overwriting the file with an empty list.'
+        );
+    }
+
+    // 4. Display results
+    printResults(topCryptos);
+
+    // 5. Render and atomically write the config file
+    const topSymbols = topCryptos.map(e => e.symbol);
+    const fileContent = renderPopularCryptosFile(topSymbols);
+    commitFileAtomically(POPULAR_CRYPTOS_PATH, fileContent);
+
+    console.log(
+        `\nDone! POPULAR_CRYPTOS updated to top ${topCryptos.length} by market cap.`
+    );
+    console.log(`Symbols: ${topSymbols.join(', ')}`);
+}
+
+if (require.main === module) {
+    main().catch(error => {
+        console.error(error);
+        process.exit(1);
+    });
+}

--- a/scripts/update-popular-cryptos.ts
+++ b/scripts/update-popular-cryptos.ts
@@ -187,7 +187,7 @@ async function fetchCryptoList(apiKey: string): Promise<FmpCryptoListEntry[]> {
     // FMP returns unvalidated JSON; runtime guard before trusting shape
     const raw: unknown = await res.json();
     if (!Array.isArray(raw)) return [];
-    const typed = raw as FmpCryptoListEntry[];
+    const typed = raw as FmpCryptoListEntry[]; // Array.isArray guard above; element shape trusts the stable FMP cryptocurrency-list contract
     return typed;
 }
 
@@ -206,9 +206,15 @@ async function fetchSingleQuote(
     // FMP quote endpoint returns an array; runtime guard before trusting shape
     const raw: unknown = await res.json();
     if (!Array.isArray(raw) || raw.length === 0) return null;
-    const first = raw[0] as FmpQuoteResult;
+    const first = raw[0] as FmpQuoteResult; // Array.isArray + length>0 guards above; element shape trusts the stable FMP quote API contract
     if (typeof first?.symbol !== 'string') return null;
     return first;
+}
+
+function isEligible(symbol: string, listedSymbols: ReadonlySet<string>): boolean {
+    const upper = symbol.toUpperCase();
+    const base = upper.endsWith('USD') ? upper.slice(0, -3) : upper;
+    return listedSymbols.has(upper) && !STABLECOINS.has(base);
 }
 
 /**
@@ -222,19 +228,10 @@ export function filterValidCandidates(
 ): CandidateFilterResult {
     const listedSymbols = new Set(cryptoList.map(e => e.symbol.toUpperCase()));
 
-    const isEligible = (symbol: string): boolean => {
-        const upper = symbol.toUpperCase();
-        const base = upper.endsWith('USD') ? upper.slice(0, -3) : upper;
-        return listedSymbols.has(upper) && !STABLECOINS.has(base);
+    return {
+        valid: pool.filter(s => isEligible(s, listedSymbols)),
+        dropped: pool.filter(s => !isEligible(s, listedSymbols)),
     };
-
-    return pool.reduce<CandidateFilterResult>(
-        (acc, s) => {
-            const key = isEligible(s) ? 'valid' : 'dropped';
-            return { ...acc, [key]: [...acc[key], s] };
-        },
-        { valid: [], dropped: [] }
-    );
 }
 
 /**
@@ -301,7 +298,8 @@ function commitFileAtomically(path: string, fileContent: string): void {
 
 /**
  * 결과 테이블 구분선 너비.
- * "Rank | Symbol    | Market Cap" 헤더의 컬럼 패딩 합산값(4+3+9+3+14 = 33 + 구분자 9 = 42).
+ * 데이터 행 = padStart(4) + ' | ' + padEnd(9) + ' | ' + padStart(14) = 33자.
+ * 헤더 텍스트 길이를 감안하여 42로 설정.
  */
 const TABLE_SEPARATOR_WIDTH = 42;
 
@@ -349,8 +347,7 @@ async function main(): Promise<void> {
 
     const ranked: CryptoRankEntry[] = [];
 
-    for (let i = 0; i < valid.length; i++) {
-        const symbol = valid[i]!;
+    for (const [i, symbol] of valid.entries()) {
         process.stdout.write(
             `  [${i + 1}/${valid.length}] ${symbol.padEnd(10)}`
         );

--- a/scripts/update-popular-cryptos.ts
+++ b/scripts/update-popular-cryptos.ts
@@ -228,9 +228,12 @@ export function filterValidCandidates(
 ): CandidateFilterResult {
     const listedSymbols = new Set(cryptoList.map(e => e.symbol.toUpperCase()));
 
+    // Compute eligibility once per element — O(N), isEligible called exactly once per symbol.
+    const validSet = new Set(pool.filter(s => isEligible(s, listedSymbols)));
+
     return {
-        valid: pool.filter(s => isEligible(s, listedSymbols)),
-        dropped: pool.filter(s => !isEligible(s, listedSymbols)),
+        valid: pool.filter(s => validSet.has(s)),
+        dropped: pool.filter(s => !validSet.has(s)),
     };
 }
 
@@ -296,12 +299,18 @@ function commitFileAtomically(path: string, fileContent: string): void {
     }
 }
 
-/**
- * 결과 테이블 구분선 너비.
- * 데이터 행 = padStart(4) + ' | ' + padEnd(9) + ' | ' + padStart(14) = 33자.
- * 헤더 텍스트 길이를 감안하여 42로 설정.
- */
-const TABLE_SEPARATOR_WIDTH = 42;
+const TABLE_RANK_COL_WIDTH = 4;
+const TABLE_SYMBOL_COL_WIDTH = 9;
+const TABLE_MARKET_CAP_COL_WIDTH = 14;
+const COLUMN_DIVIDER = ' | ';
+
+// Separator spans the full data row: rank + ' | ' + symbol + ' | ' + market-cap.
+const TABLE_SEPARATOR_WIDTH =
+    TABLE_RANK_COL_WIDTH +
+    COLUMN_DIVIDER.length +
+    TABLE_SYMBOL_COL_WIDTH +
+    COLUMN_DIVIDER.length +
+    TABLE_MARKET_CAP_COL_WIDTH;
 
 function printResults(ranked: CryptoRankEntry[]): void {
     console.log(`\n--- Top ${ranked.length} Cryptos by Market Cap ---\n`);
@@ -309,10 +318,10 @@ function printResults(ranked: CryptoRankEntry[]): void {
     console.log('-'.repeat(TABLE_SEPARATOR_WIDTH));
 
     ranked.forEach((e, i) => {
-        const rank = String(i + 1).padStart(4);
-        const symbol = e.symbol.padEnd(9);
-        const cap = formatMarketCap(e.marketCap).padStart(14);
-        console.log(`${rank} | ${symbol} | ${cap}`);
+        const rank = String(i + 1).padStart(TABLE_RANK_COL_WIDTH);
+        const symbol = e.symbol.padEnd(TABLE_SYMBOL_COL_WIDTH);
+        const cap = formatMarketCap(e.marketCap).padStart(TABLE_MARKET_CAP_COL_WIDTH);
+        console.log(`${rank}${COLUMN_DIVIDER}${symbol}${COLUMN_DIVIDER}${cap}`);
     });
 }
 

--- a/scripts/update-popular-cryptos.ts
+++ b/scripts/update-popular-cryptos.ts
@@ -32,10 +32,6 @@ import {
 } from 'fs';
 import { dirname, resolve } from 'path';
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
 const FMP_BASE_URL = 'https://financialmodelingprep.com/stable';
 
 /**
@@ -43,6 +39,20 @@ const FMP_BASE_URL = 'https://financialmodelingprep.com/stable';
  * 변경 시 함께 검토: src/shared/config/popular-cryptos.ts
  */
 export const MAX_POPULAR_CRYPTOS = 15;
+
+/**
+ * Stablecoins are dollar-pegged — no meaningful price action for technical analysis,
+ * so excluded from the popular list.
+ */
+export const STABLECOINS: ReadonlySet<string> = new Set([
+    'USDT',
+    'USDC',
+    'DAI',
+    'BUSD',
+    'TUSD',
+    'USDD',
+    'FDUSD',
+]);
 
 /**
  * API 호출 간 딜레이(ms). FMP 무료/엔트리 플랜의 rate limit을 준수하기 위해
@@ -62,14 +72,12 @@ const REQUEST_DELAY_MS = 250;
  *   - 이름 변경/폐지 코인은 제거: 예) MATICUSD → POLUSD (Polygon rebranding, 제거 완료)
  */
 export const CRYPTO_CANDIDATE_POOL: readonly string[] = [
-    // Top-10 by market cap (as of mid-2025 typical rankings)
+    // Top-10 by market cap (as of mid-2025 typical rankings, stablecoins excluded)
     'BTCUSD',
     'ETHUSD',
-    'USDTUSD',
     'BNBUSD',
     'SOLUSD',
     'XRPUSD',
-    'USDCUSD',
     'DOGEUSD',
     'ADAUSD',
     'TRXUSD',
@@ -132,10 +140,6 @@ const FILE_HEADER = `// 큐레이션된 인기 암호화폐 — 홈 디스커버
 // 단건 quote를 심볼별로 호출하여 시가총액 기준 상위 N개를 자동 선정한다(update-popular-cryptos.ts).
 // 수동으로 순서를 바꾸거나 심볼을 추가/제거할 수 있습니다.`;
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
 interface FmpCryptoListEntry {
     symbol: string;
     name: string;
@@ -154,24 +158,21 @@ export interface CryptoRankEntry {
     marketCap: number;
 }
 
-// ---------------------------------------------------------------------------
-// Utilities
-// ---------------------------------------------------------------------------
+export interface CandidateFilterResult {
+    valid: string[];
+    dropped: string[];
+}
 
 function sleep(ms: number): Promise<void> {
     return new Promise(r => setTimeout(r, ms));
 }
 
-function formatMarketCap(cap: number): string {
+export function formatMarketCap(cap: number): string {
     if (cap >= 1_000_000_000_000) return `$${(cap / 1_000_000_000_000).toFixed(2)}T`;
     if (cap >= 1_000_000_000) return `$${(cap / 1_000_000_000).toFixed(2)}B`;
     if (cap >= 1_000_000) return `$${(cap / 1_000_000).toFixed(2)}M`;
     return `$${cap.toFixed(0)}`;
 }
-
-// ---------------------------------------------------------------------------
-// FMP API
-// ---------------------------------------------------------------------------
 
 async function fetchCryptoList(apiKey: string): Promise<FmpCryptoListEntry[]> {
     const url = `${FMP_BASE_URL}/cryptocurrency-list?apikey=${encodeURIComponent(apiKey)}`;
@@ -207,31 +208,27 @@ async function fetchSingleQuote(
     return raw[0] ?? null;
 }
 
-// ---------------------------------------------------------------------------
-// Core logic (exported for testability)
-// ---------------------------------------------------------------------------
-
 /**
  * cryptocurrency-list로부터 유효 심볼 집합을 구성한다.
  * 풀에 있으나 리스트에 없는 심볼은 폐지/이름변경된 것으로 간주, 제거한다.
+ * 스테이블코인(STABLECOINS)은 가격 변동이 없어 기술적 분석이 무의미하므로 제외한다.
  */
 export function filterValidCandidates(
     pool: readonly string[],
     cryptoList: FmpCryptoListEntry[]
-): { valid: string[]; dropped: string[] } {
+): CandidateFilterResult {
     const listedSymbols = new Set(cryptoList.map(e => e.symbol.toUpperCase()));
-    const valid: string[] = [];
-    const dropped: string[] = [];
 
-    for (const symbol of pool) {
-        if (listedSymbols.has(symbol.toUpperCase())) {
-            valid.push(symbol);
-        } else {
-            dropped.push(symbol);
-        }
-    }
+    const isEligible = (symbol: string): boolean => {
+        const upper = symbol.toUpperCase();
+        const base = upper.endsWith('USD') ? upper.slice(0, -3) : upper;
+        return listedSymbols.has(upper) && !STABLECOINS.has(base);
+    };
 
-    return { valid, dropped };
+    return {
+        valid: pool.filter(s => isEligible(s)),
+        dropped: pool.filter(s => !isEligible(s)),
+    };
 }
 
 /**
@@ -244,8 +241,7 @@ export function rankByMarketCap(
 ): CryptoRankEntry[] {
     return entries
         .filter(e => e.marketCap > 0)
-        .slice()
-        .sort((a, b) => b.marketCap - a.marketCap)
+        .toSorted((a, b) => b.marketCap - a.marketCap)
         .slice(0, topN);
 }
 
@@ -262,10 +258,6 @@ export const POPULAR_CRYPTOS = [
 ${body}] as const;
 `;
 }
-
-// ---------------------------------------------------------------------------
-// File write
-// ---------------------------------------------------------------------------
 
 function writeAndFormatFileAtomically(
     path: string,
@@ -301,10 +293,6 @@ function commitFileAtomically(path: string, fileContent: string): void {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Result display
-// ---------------------------------------------------------------------------
-
 /**
  * 결과 테이블 구분선 너비.
  * "Rank | Symbol    | Market Cap" 헤더의 컬럼 패딩 합산값(4+3+9+3+14 = 33 + 구분자 9 = 42).
@@ -324,10 +312,6 @@ function printResults(ranked: CryptoRankEntry[]): void {
     });
 }
 
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
-
 async function main(): Promise<void> {
     config({ path: resolve(process.cwd(), '.env.local') });
 
@@ -339,7 +323,6 @@ async function main(): Promise<void> {
     console.log('\n=== Update Popular Cryptos ===\n');
     console.log(`Candidate pool size: ${CRYPTO_CANDIDATE_POOL.length}`);
 
-    // 1. Validate candidates against the full crypto list (drop delisted/renamed)
     console.log('\nFetching cryptocurrency-list for candidate validation...');
     const cryptoList = await fetchCryptoList(apiKey);
     console.log(`cryptocurrency-list returned: ${cryptoList.length} entries`);
@@ -356,7 +339,6 @@ async function main(): Promise<void> {
     }
     console.log(`Valid candidates after validation: ${valid.length}`);
 
-    // 2. Fetch single quote per valid candidate for marketCap
     console.log(`\nFetching quotes for ${valid.length} candidates...`);
 
     const ranked: CryptoRankEntry[] = [];
@@ -381,7 +363,6 @@ async function main(): Promise<void> {
         }
     }
 
-    // 3. Rank and select top N
     const topCryptos = rankByMarketCap(ranked, MAX_POPULAR_CRYPTOS);
 
     if (topCryptos.length === 0) {
@@ -390,10 +371,8 @@ async function main(): Promise<void> {
         );
     }
 
-    // 4. Display results
     printResults(topCryptos);
 
-    // 5. Render and atomically write the config file
     const topSymbols = topCryptos.map(e => e.symbol);
     const fileContent = renderPopularCryptosFile(topSymbols);
     commitFileAtomically(POPULAR_CRYPTOS_PATH, fileContent);

--- a/scripts/update-popular-cryptos.ts
+++ b/scripts/update-popular-cryptos.ts
@@ -135,7 +135,7 @@ const POPULAR_CRYPTOS_PATH = resolve(
  *   2. batch-crypto-quotes 엔드포인트는 HTTP 402(플랜 미지원)이므로
  *      단건 quote 엔드포인트를 심볼별로 순차 호출하는 방식으로 시가총액을 수집한다.
  */
-const FILE_HEADER = `// 큐레이션된 인기 암호화폐 — 홈 디스커버리 + sitemap popular 엔트리.
+export const FILE_HEADER = `// 큐레이션된 인기 암호화폐 — 홈 디스커버리 + sitemap popular 엔트리.
 // FMP 심볼은 *USD 접미사(BTCUSD)를 쓴다. batch-crypto-quotes가 HTTP 402(플랜 미지원)이라
 // 단건 quote를 심볼별로 호출하여 시가총액 기준 상위 N개를 자동 선정한다(update-popular-cryptos.ts).
 // 수동으로 순서를 바꾸거나 심볼을 추가/제거할 수 있습니다.`;
@@ -184,10 +184,11 @@ async function fetchCryptoList(apiKey: string): Promise<FmpCryptoListEntry[]> {
         );
     }
 
-    // FMP returns unvalidated JSON; shape matches FmpCryptoListEntry
-    const raw = (await res.json()) as FmpCryptoListEntry[];
+    // FMP returns unvalidated JSON; runtime guard before trusting shape
+    const raw: unknown = await res.json();
     if (!Array.isArray(raw)) return [];
-    return raw;
+    const typed = raw as FmpCryptoListEntry[];
+    return typed;
 }
 
 async function fetchSingleQuote(
@@ -202,10 +203,12 @@ async function fetchSingleQuote(
         return null;
     }
 
-    // FMP quote endpoint returns an array; first element is the result
-    const raw = (await res.json()) as FmpQuoteResult[];
+    // FMP quote endpoint returns an array; runtime guard before trusting shape
+    const raw: unknown = await res.json();
     if (!Array.isArray(raw) || raw.length === 0) return null;
-    return raw[0] ?? null;
+    const first = raw[0] as FmpQuoteResult;
+    if (typeof first?.symbol !== 'string') return null;
+    return first;
 }
 
 /**
@@ -225,10 +228,13 @@ export function filterValidCandidates(
         return listedSymbols.has(upper) && !STABLECOINS.has(base);
     };
 
-    return {
-        valid: pool.filter(s => isEligible(s)),
-        dropped: pool.filter(s => !isEligible(s)),
-    };
+    return pool.reduce<CandidateFilterResult>(
+        (acc, s) => {
+            const key = isEligible(s) ? 'valid' : 'dropped';
+            return { ...acc, [key]: [...acc[key], s] };
+        },
+        { valid: [], dropped: [] }
+    );
 }
 
 /**

--- a/scripts/update-popular-cryptos.ts
+++ b/scripts/update-popular-cryptos.ts
@@ -293,8 +293,8 @@ function commitFileAtomically(path: string, fileContent: string): void {
     } finally {
         try {
             rmSync(tempPath, { force: true });
-        } catch {
-            // best-effort cleanup
+        } catch (cleanupError) {
+            console.warn(`[update-popular-cryptos] temp file cleanup failed: ${tempPath}`, cleanupError);
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds manual CLI script `scripts/update-popular-cryptos.ts` to refresh POPULAR_CRYPTOS config (cryptocurrency sitemap popular source) by per-symbol market-cap ranking.

## Implementation

- **Analog of `update-popular-tickers.ts`**: Maintains a candidate pool of crypto symbols, fetches FMP per-symbol quotes, ranks by market-cap
- **Candidate validation**: Validated against cryptocurrency-list to drop delisted assets
- **Source**: batch-crypto-quotes (402 symbols) → FMP per-symbol-quote call
- **Output**: `src/shared/config/popular-cryptos.ts` POPULAR_CRYPTOS
- **Usage**: Run manually like `yarn update-popular-cryptos` when refresh needed
- **Longtail freshness**: Separately handled by existing `seed-crypto-assets.ts`

## Files

- `scripts/update-popular-cryptos.ts` (force-added, was gitignored)
- `scripts/__tests__/update-popular-cryptos.test.ts` (new test)
- `package.json` (script entry added)

## Verification

- Typecheck: ✓
- Lint: ✓  
- Tests: 61 passing

## Notes

Longtail cryptos (beyond popular 50) receive freshness from the existing `seed-crypto-assets.ts` cron job, which is scheduled separately and does not block this script.