### PR TITLE
chore(sitemap): refresh POPULAR_CRYPTOS to top-15 by market cap

### DIFF
--- a/scripts/update-popular-cryptos.ts
+++ b/scripts/update-popular-cryptos.ts
@@ -138,7 +138,8 @@ const POPULAR_CRYPTOS_PATH = resolve(
 export const FILE_HEADER = `// 큐레이션된 인기 암호화폐 — 홈 디스커버리 + sitemap popular 엔트리.
 // FMP 심볼은 *USD 접미사(BTCUSD)를 쓴다. batch-crypto-quotes가 HTTP 402(플랜 미지원)이라
 // 단건 quote를 심볼별로 호출하여 시가총액 기준 상위 N개를 자동 선정한다(update-popular-cryptos.ts).
-// 수동으로 순서를 바꾸거나 심볼을 추가/제거할 수 있습니다.`;
+// 주의: 이 파일은 스크립트가 자동 생성하므로 수동 변경은 다음 실행 때 덮어씌워진다.
+// 심볼을 추가/변경하려면 scripts/update-popular-cryptos.ts의 CRYPTO_CANDIDATE_POOL을 수정하라.`;
 
 interface FmpCryptoListEntry {
     symbol: string;

--- a/src/shared/config/popular-cryptos.ts
+++ b/src/shared/config/popular-cryptos.ts
@@ -1,20 +1,21 @@
 // 큐레이션된 인기 암호화폐 — 홈 디스커버리 + sitemap popular 엔트리.
-// FMP 심볼은 *USD 접미사(BTCUSD)를 쓴다. batch-crypto-quotes가 플랜 제한이라
-// 시가총액 자동 랭킹이 불가하므로 수동 관리한다(주식 popular-tickers와 동일 방침).
+// FMP 심볼은 *USD 접미사(BTCUSD)를 쓴다. batch-crypto-quotes가 HTTP 402(플랜 미지원)이라
+// 단건 quote를 심볼별로 호출하여 시가총액 기준 상위 N개를 자동 선정한다(update-popular-cryptos.ts).
+// 수동으로 순서를 바꾸거나 심볼을 추가/제거할 수 있습니다.
 export const POPULAR_CRYPTOS = [
     'BTCUSD',
     'ETHUSD',
-    'SOLUSD',
-    'XRPUSD',
     'BNBUSD',
-    'DOGEUSD',
-    'ADAUSD',
-    'AVAXUSD',
-    'LINKUSD',
+    'XRPUSD',
+    'SOLUSD',
     'TRXUSD',
-    'DOTUSD',
-    'POLUSD',
-    'LTCUSD',
+    'DOGEUSD',
+    'XLMUSD',
+    'ADAUSD',
+    'LINKUSD',
+    'TONUSD',
     'BCHUSD',
+    'LTCUSD',
     'SHIBUSD',
+    'SUIUSD',
 ] as const;

--- a/src/shared/config/popular-cryptos.ts
+++ b/src/shared/config/popular-cryptos.ts
@@ -1,7 +1,8 @@
 // 큐레이션된 인기 암호화폐 — 홈 디스커버리 + sitemap popular 엔트리.
 // FMP 심볼은 *USD 접미사(BTCUSD)를 쓴다. batch-crypto-quotes가 HTTP 402(플랜 미지원)이라
 // 단건 quote를 심볼별로 호출하여 시가총액 기준 상위 N개를 자동 선정한다(update-popular-cryptos.ts).
-// 수동으로 순서를 바꾸거나 심볼을 추가/제거할 수 있습니다.
+// 주의: 이 파일은 스크립트가 자동 생성하므로 수동 변경은 다음 실행 때 덮어씌워진다.
+// 심볼을 추가/변경하려면 scripts/update-popular-cryptos.ts의 CRYPTO_CANDIDATE_POOL을 수정하라.
 export const POPULAR_CRYPTOS = [
     'BTCUSD',
     'ETHUSD',


### PR DESCRIPTION
## Summary

Refreshed POPULAR_CRYPTOS list to reflect current top-15 cryptocurrencies by market cap (via FMP single-quote endpoint). Dropped AVAX/DOT/POL; added XLM/TON/SUI; re-ordered by descending market cap.

**New list:** BTCUSD, ETHUSD, BNBUSD, XRPUSD, SOLUSD, TRXUSD, DOGEUSD, XLMUSD, ADAUSD, LINKUSD, TONUSD, BCHUSD, LTCUSD, SHIBUSD, SUIUSD

## Impact on Sitemap

POPULAR_CRYPTOS drives the crypto sitemap popular entries:
- **Popular routes:** 15 symbols × 4 route templates = **60 URLs**  
- **Longtail routes:** top-1000 by 24h volume (CRYPTO_LONGTAIL_CAP) = **1000 URLs**  
- **Total:** 1060 URLs verified (HTTP 200, popular entries correctly excluded from longtail)

Stablecoins are excluded by the `yarn update-popular-cryptos` script logic (FMP filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)