### PR TITLE
feat(search): relevance-based ticker ranking

### DIFF
--- a/src/entities/ticker/__tests__/api.test.ts
+++ b/src/entities/ticker/__tests__/api.test.ts
@@ -453,13 +453,21 @@ describe('DrizzleCryptoAssetRepository', () => {
             expect(where).toHaveBeenCalledTimes(1);
         });
 
-        it('orderBy 를 호출한다 (relevance + circulatingSupply desc)', async () => {
+        it('orderBy is called with exactly 2 ordering args: relevance CASE + circulatingSupply desc', async () => {
             const { db, orderBy } = makeCryptoSearchDb([btcRecord]);
             const repo = new DrizzleCryptoAssetRepository(db);
             await repo.search('btc', 10);
             expect(orderBy).toHaveBeenCalledTimes(1);
             const orderByArgs = orderBy.mock.calls[0];
             expect(orderByArgs).toHaveLength(2);
+            // 1st arg: sql CASE object (not a plain column ref — has queryChunks, not a bare column name)
+            const caseArg = orderByArgs[0] as SqlLike;
+            expect(caseArg).toBeTypeOf('object');
+            // 2nd arg: desc(cryptoAssets.circulatingSupply) — Drizzle wraps the column
+            // in a SQL chunk tree; collectColumnNames recurses into queryChunks to find
+            // the column name node, confirming the tiebreak sorts by circulating_supply.
+            const descArg = orderByArgs[1] as SqlLike;
+            expect(collectColumnNames(descArg)).toContain('circulating_supply');
         });
 
         it('limit 인자를 그대로 전달한다', async () => {

--- a/src/entities/ticker/__tests__/api.test.ts
+++ b/src/entities/ticker/__tests__/api.test.ts
@@ -453,7 +453,7 @@ describe('DrizzleCryptoAssetRepository', () => {
             expect(where).toHaveBeenCalledTimes(1);
         });
 
-        it('orderBy 를 호출한다 (circulatingSupply desc)', async () => {
+        it('orderBy 를 호출한다 (relevance + circulatingSupply desc)', async () => {
             const { db, orderBy } = makeCryptoSearchDb([btcRecord]);
             const repo = new DrizzleCryptoAssetRepository(db);
             await repo.search('btc', 10);

--- a/src/entities/ticker/__tests__/api.test.ts
+++ b/src/entities/ticker/__tests__/api.test.ts
@@ -458,7 +458,6 @@ describe('DrizzleCryptoAssetRepository', () => {
             const repo = new DrizzleCryptoAssetRepository(db);
             await repo.search('btc', 10);
             expect(orderBy).toHaveBeenCalledTimes(1);
-            // Must receive 2 args: the CASE relevance expression and desc(circulatingSupply).
             const orderByArgs = orderBy.mock.calls[0];
             expect(orderByArgs).toHaveLength(2);
         });

--- a/src/entities/ticker/__tests__/api.test.ts
+++ b/src/entities/ticker/__tests__/api.test.ts
@@ -460,9 +460,11 @@ describe('DrizzleCryptoAssetRepository', () => {
             expect(orderBy).toHaveBeenCalledTimes(1);
             const orderByArgs = orderBy.mock.calls[0];
             expect(orderByArgs).toHaveLength(2);
-            // 1st arg: sql CASE object (not a plain column ref — has queryChunks, not a bare column name)
+            // 1st arg: sql CASE object — Drizzle's sql`` template result carries a
+            // queryChunks array (the SQL fragment tree). Asserting the property is more
+            // precise than a bare typeof-object check and distinguishes it from a column ref.
             const caseArg = orderByArgs[0] as SqlLike;
-            expect(caseArg).toBeTypeOf('object');
+            expect(caseArg).toHaveProperty('queryChunks');
             // 2nd arg: desc(cryptoAssets.circulatingSupply) — Drizzle wraps the column
             // in a SQL chunk tree; collectColumnNames recurses into queryChunks to find
             // the column name node, confirming the tiebreak sorts by circulating_supply.

--- a/src/entities/ticker/__tests__/api.test.ts
+++ b/src/entities/ticker/__tests__/api.test.ts
@@ -458,6 +458,9 @@ describe('DrizzleCryptoAssetRepository', () => {
             const repo = new DrizzleCryptoAssetRepository(db);
             await repo.search('btc', 10);
             expect(orderBy).toHaveBeenCalledTimes(1);
+            // Must receive 2 args: the CASE relevance expression and desc(circulatingSupply).
+            const orderByArgs = orderBy.mock.calls[0];
+            expect(orderByArgs).toHaveLength(2);
         });
 
         it('limit 인자를 그대로 전달한다', async () => {

--- a/src/entities/ticker/api.ts
+++ b/src/entities/ticker/api.ts
@@ -31,6 +31,18 @@ import {
     type TabKey,
 } from '@/shared/config/marketProfile';
 
+/**
+ * DB-side ORDER BY priority buckets for crypto search (lower = ranked first).
+ * These ORDINALS mirror the relevance TIERS in `searchRelevance.ts`
+ * (EXACT > PREFIX > rest, i.e. its 100 > 70 > 40/10 scores): the DB pre-sort only
+ * needs each tier's rank so exact/prefix matches survive the LIMIT cut, while the
+ * app-side scorer assigns the actual numeric scores after the fetch. Keep the two
+ * systems aligned — if a tier is added to `searchRelevance`, add a bucket here.
+ */
+const DB_SORT_EXACT = 0;
+const DB_SORT_PREFIX = 1;
+const DB_SORT_OTHER = 2;
+
 const koreanTickerColumns = {
     symbol: koreanTickers.symbol,
     name: koreanTickers.name,
@@ -286,9 +298,9 @@ export class DrizzleCryptoAssetRepository implements CryptoAssetRepository {
                 // exact/prefix matches in ANY of them are fetched within the limit
                 // before app-side re-ranking.
                 sql`CASE
-                  WHEN lower(${cryptoAssets.koreanName}) = lower(${query}) OR lower(${cryptoAssets.symbol}) = lower(${query}) OR lower(${cryptoAssets.name}) = lower(${query}) THEN 0
-                  WHEN ${cryptoAssets.koreanName} ILIKE ${exactOrPrefix} OR ${cryptoAssets.symbol} ILIKE ${exactOrPrefix} OR ${cryptoAssets.name} ILIKE ${exactOrPrefix} THEN 1
-                  ELSE 2 END`,
+                  WHEN lower(${cryptoAssets.koreanName}) = lower(${query}) OR lower(${cryptoAssets.symbol}) = lower(${query}) OR lower(${cryptoAssets.name}) = lower(${query}) THEN ${DB_SORT_EXACT}
+                  WHEN ${cryptoAssets.koreanName} ILIKE ${exactOrPrefix} OR ${cryptoAssets.symbol} ILIKE ${exactOrPrefix} OR ${cryptoAssets.name} ILIKE ${exactOrPrefix} THEN ${DB_SORT_PREFIX}
+                  ELSE ${DB_SORT_OTHER} END`,
                 desc(cryptoAssets.circulatingSupply)
             )
             .limit(limit);

--- a/src/entities/ticker/api.ts
+++ b/src/entities/ticker/api.ts
@@ -282,9 +282,13 @@ export class DrizzleCryptoAssetRepository implements CryptoAssetRepository {
                 )
             )
             .orderBy(
-                sql`CASE WHEN lower(${cryptoAssets.koreanName}) = lower(${query}) OR lower(${cryptoAssets.symbol}) = lower(${query}) THEN 0
-                         WHEN ${cryptoAssets.koreanName} ILIKE ${exactOrPrefix} OR ${cryptoAssets.symbol} ILIKE ${exactOrPrefix} THEN 1
-                         ELSE 2 END`,
+                // Mirror searchRelevance's scored fields (koreanName/symbol/name) so
+                // exact/prefix matches in ANY of them are fetched within the limit
+                // before app-side re-ranking.
+                sql`CASE
+                  WHEN lower(${cryptoAssets.koreanName}) = lower(${query}) OR lower(${cryptoAssets.symbol}) = lower(${query}) OR lower(${cryptoAssets.name}) = lower(${query}) THEN 0
+                  WHEN ${cryptoAssets.koreanName} ILIKE ${exactOrPrefix} OR ${cryptoAssets.symbol} ILIKE ${exactOrPrefix} OR ${cryptoAssets.name} ILIKE ${exactOrPrefix} THEN 1
+                  ELSE 2 END`,
                 desc(cryptoAssets.circulatingSupply)
             )
             .limit(limit);

--- a/src/entities/ticker/api.ts
+++ b/src/entities/ticker/api.ts
@@ -270,6 +270,7 @@ export class DrizzleCryptoAssetRepository implements CryptoAssetRepository {
 
     async search(query: string, limit: number): Promise<CryptoAssetRecord[]> {
         const like = `%${query}%`;
+        const exactOrPrefix = `${query}%`;
         return this.db
             .select()
             .from(cryptoAssets)
@@ -280,7 +281,12 @@ export class DrizzleCryptoAssetRepository implements CryptoAssetRepository {
                     ilike(cryptoAssets.koreanName, like)
                 )
             )
-            .orderBy(desc(cryptoAssets.circulatingSupply))
+            .orderBy(
+                sql`CASE WHEN lower(${cryptoAssets.koreanName}) = lower(${query}) OR lower(${cryptoAssets.symbol}) = lower(${query}) THEN 0
+                         WHEN ${cryptoAssets.koreanName} ILIKE ${exactOrPrefix} OR ${cryptoAssets.symbol} ILIKE ${exactOrPrefix} THEN 1
+                         ELSE 2 END`,
+                desc(cryptoAssets.circulatingSupply)
+            )
             .limit(limit);
     }
 }

--- a/src/entities/ticker/lib/__tests__/searchRelevance.test.ts
+++ b/src/entities/ticker/lib/__tests__/searchRelevance.test.ts
@@ -68,6 +68,12 @@ describe('scoreSearchRelevance', () => {
         );
     });
 
+    it('empty query scores FALLBACK_SCORE (no field is a meaningful match)', () => {
+        expect(
+            scoreSearchRelevance(makeResult('AAPL', 'Apple Inc.'), '', false)
+        ).toBe(FALLBACK_SCORE);
+    });
+
     it('popular bonus adds 15 on top of base', () => {
         const result = makeResult('BTCUSD', 'Bitcoin USD', '비트코인');
         expect(scoreSearchRelevance(result, '비트코인', true)).toBe(
@@ -97,6 +103,17 @@ describe('scoreSearchRelevance', () => {
         expect(scoreSearchRelevance(result, 'AAPL', false)).toBe(
             EXACT_MATCH_SCORE
         );
+    });
+
+    it('empty/whitespace query scores FALLBACK_SCORE (guarded edge case)', () => {
+        // After .trim() the query is '', which fieldScore guards (returns 0 for every
+        // field) so the base never rises above FALLBACK_SCORE. Without the guard,
+        // ''.startsWith('') would be true for every field and score everything as PREFIX.
+        // The real caller (searchTicker) returns early on a blank query and never reaches
+        // here; this test pins the guarded behavior of the pure function.
+        const result = makeResult('AAPL', 'Apple Inc.', '애플');
+        expect(scoreSearchRelevance(result, '', false)).toBe(FALLBACK_SCORE);
+        expect(scoreSearchRelevance(result, '   ', false)).toBe(FALLBACK_SCORE);
     });
 
     it('missing koreanName field is skipped safely', () => {

--- a/src/entities/ticker/lib/__tests__/searchRelevance.test.ts
+++ b/src/entities/ticker/lib/__tests__/searchRelevance.test.ts
@@ -3,6 +3,11 @@ import {
     scoreSearchRelevance,
     rankByRelevance,
     isPopularSymbol,
+    EXACT_MATCH_SCORE,
+    PREFIX_MATCH_SCORE,
+    SUBSTRING_MATCH_SCORE,
+    FALLBACK_SCORE,
+    POPULAR_BONUS,
 } from '../searchRelevance';
 import type { TickerSearchResult } from '@/shared/lib/types';
 
@@ -23,59 +28,83 @@ function makeResult(
 describe('scoreSearchRelevance', () => {
     it('exact koreanName match scores 100', () => {
         const result = makeResult('BTCUSD', 'Bitcoin USD', '비트코인');
-        expect(scoreSearchRelevance(result, '비트코인', false)).toBe(100);
+        expect(scoreSearchRelevance(result, '비트코인', false)).toBe(
+            EXACT_MATCH_SCORE
+        );
     });
 
     it('exact symbol match scores 100', () => {
         const result = makeResult('BTCUSD', 'Bitcoin USD');
-        expect(scoreSearchRelevance(result, 'BTCUSD', false)).toBe(100);
+        expect(scoreSearchRelevance(result, 'BTCUSD', false)).toBe(
+            EXACT_MATCH_SCORE
+        );
     });
 
     it('exact name match scores 100', () => {
         const result = makeResult('BTC', 'bitcoin usd');
-        expect(scoreSearchRelevance(result, 'bitcoin usd', false)).toBe(100);
+        expect(scoreSearchRelevance(result, 'bitcoin usd', false)).toBe(
+            EXACT_MATCH_SCORE
+        );
     });
 
     it('prefix match scores 70', () => {
         const result = makeResult('BTCUSD', 'Bitcoin USD', '비트코인');
-        expect(scoreSearchRelevance(result, '비트코', false)).toBe(70);
+        expect(scoreSearchRelevance(result, '비트코', false)).toBe(
+            PREFIX_MATCH_SCORE
+        );
     });
 
     it('substring match scores 40', () => {
         const result = makeResult('BTCUSD', 'Bitcoin USD', '비트코인');
-        expect(scoreSearchRelevance(result, '코인', false)).toBe(40);
+        expect(scoreSearchRelevance(result, '코인', false)).toBe(
+            SUBSTRING_MATCH_SCORE
+        );
     });
 
     it('no match scores 10 (base fallback)', () => {
         const result = makeResult('XYZUSD', 'XYZ Coin', 'X코인');
-        expect(scoreSearchRelevance(result, 'bitcoin', false)).toBe(10);
+        expect(scoreSearchRelevance(result, 'bitcoin', false)).toBe(
+            FALLBACK_SCORE
+        );
     });
 
     it('popular bonus adds 15 on top of base', () => {
         const result = makeResult('BTCUSD', 'Bitcoin USD', '비트코인');
-        expect(scoreSearchRelevance(result, '비트코인', true)).toBe(115);
+        expect(scoreSearchRelevance(result, '비트코인', true)).toBe(
+            EXACT_MATCH_SCORE + POPULAR_BONUS
+        );
     });
 
     it('popular bonus on prefix match = 70 + 15 = 85', () => {
         const result = makeResult('BTCUSD', 'Bitcoin USD', '비트코인');
-        expect(scoreSearchRelevance(result, '비트코', true)).toBe(85);
+        expect(scoreSearchRelevance(result, '비트코', true)).toBe(
+            PREFIX_MATCH_SCORE + POPULAR_BONUS
+        );
     });
 
     it('popular bonus on no-match = 10 + 15 = 25', () => {
         const result = makeResult('BTCUSD', 'Bitcoin USD');
-        expect(scoreSearchRelevance(result, 'xyz', true)).toBe(25);
+        expect(scoreSearchRelevance(result, 'xyz', true)).toBe(
+            FALLBACK_SCORE + POPULAR_BONUS
+        );
     });
 
     it('score is case-insensitive', () => {
         const result = makeResult('AAPL', 'Apple Inc.');
-        expect(scoreSearchRelevance(result, 'apple inc.', false)).toBe(100);
-        expect(scoreSearchRelevance(result, 'AAPL', false)).toBe(100);
+        expect(scoreSearchRelevance(result, 'apple inc.', false)).toBe(
+            EXACT_MATCH_SCORE
+        );
+        expect(scoreSearchRelevance(result, 'AAPL', false)).toBe(
+            EXACT_MATCH_SCORE
+        );
     });
 
     it('missing koreanName field is skipped safely', () => {
         const result = makeResult('AAPL', 'Apple Inc.');
         // No koreanName — should not throw and still score based on name/symbol.
-        expect(scoreSearchRelevance(result, 'apple', false)).toBe(70);
+        expect(scoreSearchRelevance(result, 'apple', false)).toBe(
+            PREFIX_MATCH_SCORE
+        );
     });
 });
 

--- a/src/entities/ticker/lib/__tests__/searchRelevance.test.ts
+++ b/src/entities/ticker/lib/__tests__/searchRelevance.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import {
+    scoreSearchRelevance,
+    rankByRelevance,
+    isPopularSymbol,
+} from '../searchRelevance';
+import type { TickerSearchResult } from '@/shared/lib/types';
+
+function makeResult(
+    symbol: string,
+    name: string,
+    koreanName?: string
+): TickerSearchResult {
+    return {
+        symbol,
+        name,
+        koreanName,
+        exchange: 'TEST',
+        exchangeFullName: 'Test Exchange',
+    };
+}
+
+describe('scoreSearchRelevance', () => {
+    it('exact koreanName match scores 100', () => {
+        const result = makeResult('BTCUSD', 'Bitcoin USD', '비트코인');
+        expect(scoreSearchRelevance(result, '비트코인', false)).toBe(100);
+    });
+
+    it('exact symbol match scores 100', () => {
+        const result = makeResult('BTCUSD', 'Bitcoin USD');
+        expect(scoreSearchRelevance(result, 'BTCUSD', false)).toBe(100);
+    });
+
+    it('exact name match scores 100', () => {
+        const result = makeResult('BTC', 'bitcoin usd');
+        expect(scoreSearchRelevance(result, 'bitcoin usd', false)).toBe(100);
+    });
+
+    it('prefix match scores 70', () => {
+        const result = makeResult('BTCUSD', 'Bitcoin USD', '비트코인');
+        expect(scoreSearchRelevance(result, '비트코', false)).toBe(70);
+    });
+
+    it('substring match scores 40', () => {
+        const result = makeResult('BTCUSD', 'Bitcoin USD', '비트코인');
+        expect(scoreSearchRelevance(result, '코인', false)).toBe(40);
+    });
+
+    it('no match scores 10 (base fallback)', () => {
+        const result = makeResult('XYZUSD', 'XYZ Coin', 'X코인');
+        expect(scoreSearchRelevance(result, 'bitcoin', false)).toBe(10);
+    });
+
+    it('popular bonus adds 15 on top of base', () => {
+        const result = makeResult('BTCUSD', 'Bitcoin USD', '비트코인');
+        expect(scoreSearchRelevance(result, '비트코인', true)).toBe(115);
+    });
+
+    it('popular bonus on prefix match = 70 + 15 = 85', () => {
+        const result = makeResult('BTCUSD', 'Bitcoin USD', '비트코인');
+        expect(scoreSearchRelevance(result, '비트코', true)).toBe(85);
+    });
+
+    it('popular bonus on no-match = 10 + 15 = 25', () => {
+        const result = makeResult('BTCUSD', 'Bitcoin USD');
+        expect(scoreSearchRelevance(result, 'xyz', true)).toBe(25);
+    });
+
+    it('score is case-insensitive', () => {
+        const result = makeResult('AAPL', 'Apple Inc.');
+        expect(scoreSearchRelevance(result, 'apple inc.', false)).toBe(100);
+        expect(scoreSearchRelevance(result, 'AAPL', false)).toBe(100);
+    });
+
+    it('missing koreanName field is skipped safely', () => {
+        const result = makeResult('AAPL', 'Apple Inc.');
+        // No koreanName — should not throw and still score based on name/symbol.
+        expect(scoreSearchRelevance(result, 'apple', false)).toBe(70);
+    });
+});
+
+describe('rankByRelevance', () => {
+    it('exact match ranks first, then prefix, then substring', () => {
+        // query '비트': field '비트코인' startsWith '비트' → prefix → 70
+        //               field '비트' === '비트' → exact → 100
+        //               field '가나비트다라' includes '비트' → substring → 40
+        const exactResult = makeResult('BITUSD', 'Bit Coin', '비트'); // exact → 100
+        const prefixResult = makeResult('BTCUSD', 'Bitcoin USD', '비트코인'); // prefix → 70
+        const subResult = makeResult('COINX', 'Coin X', '가나비트다라'); // substring → 40
+
+        // Input order: prefix, substring, exact — so stable sort must reorder by score.
+        const results = [prefixResult, subResult, exactResult];
+        const ranked = rankByRelevance(results, '비트');
+        expect(ranked[0].symbol).toBe('BITUSD'); // exact → 100
+        expect(ranked[1].symbol).toBe('BTCUSD'); // prefix → 70
+        expect(ranked[2].symbol).toBe('COINX'); // substring → 40
+    });
+
+    it('popular exact match beats non-popular exact match', () => {
+        // BTCUSD is in POPULAR_CRYPTOS → score 100+15=115
+        // VIDTUSD is not popular → score 100
+        const results: TickerSearchResult[] = [
+            makeResult('VIDTUSD', 'VIDT Coin', '비트코인'), // not popular, exact
+            makeResult('BTCUSD', 'Bitcoin USD', '비트코인'), // popular, exact
+        ];
+        const ranked = rankByRelevance(results, '비트코인');
+        expect(ranked[0].symbol).toBe('BTCUSD');
+        expect(ranked[1].symbol).toBe('VIDTUSD');
+    });
+
+    it('stable sort preserves input order for equal-score results', () => {
+        const results: TickerSearchResult[] = [
+            makeResult('AAA', 'Alpha', '알파'),
+            makeResult('BBB', 'Beta', '베타'),
+            makeResult('CCC', 'Gamma', '감마'),
+        ];
+        // query 'xyz' matches none → all score 10, order preserved
+        const ranked = rankByRelevance(results, 'xyz');
+        expect(ranked.map(r => r.symbol)).toEqual(['AAA', 'BBB', 'CCC']);
+    });
+
+    it('does not slice — returns full array', () => {
+        const results = Array.from({ length: 15 }, (_, i) =>
+            makeResult(`SYM${i}`, `Symbol ${i}`)
+        );
+        expect(rankByRelevance(results, 'sym')).toHaveLength(15);
+    });
+});
+
+describe('isPopularSymbol', () => {
+    it('BTCUSD is popular (in POPULAR_CRYPTOS)', () => {
+        expect(isPopularSymbol('BTCUSD')).toBe(true);
+    });
+
+    it('AAPL is popular (in POPULAR_TICKERS)', () => {
+        expect(isPopularSymbol('AAPL')).toBe(true);
+    });
+
+    it('VIDTUSD is not popular', () => {
+        expect(isPopularSymbol('VIDTUSD')).toBe(false);
+    });
+});

--- a/src/entities/ticker/lib/__tests__/searchRelevance.test.ts
+++ b/src/entities/ticker/lib/__tests__/searchRelevance.test.ts
@@ -81,14 +81,14 @@ describe('scoreSearchRelevance', () => {
         );
     });
 
-    it('popular bonus on prefix match = 70 + 15 = 85', () => {
+    it('popular bonus on prefix match = PREFIX_MATCH_SCORE + POPULAR_BONUS', () => {
         const result = makeResult('BTCUSD', 'Bitcoin USD', '비트코인');
         expect(scoreSearchRelevance(result, '비트코', true)).toBe(
             PREFIX_MATCH_SCORE + POPULAR_BONUS
         );
     });
 
-    it('popular bonus on no-match = 10 + 15 = 25', () => {
+    it('popular bonus on no-match = FALLBACK_SCORE + POPULAR_BONUS', () => {
         const result = makeResult('BTCUSD', 'Bitcoin USD');
         expect(scoreSearchRelevance(result, 'xyz', true)).toBe(
             FALLBACK_SCORE + POPULAR_BONUS
@@ -127,24 +127,24 @@ describe('scoreSearchRelevance', () => {
 
 describe('rankByRelevance', () => {
     it('exact match ranks first, then prefix, then substring', () => {
-        // query '비트': field '비트코인' startsWith '비트' → prefix → 70
-        //               field '비트' === '비트' → exact → 100
-        //               field '가나비트다라' includes '비트' → substring → 40
-        const exactResult = makeResult('BITUSD', 'Bit Coin', '비트'); // exact → 100
-        const prefixResult = makeResult('BTCUSD', 'Bitcoin USD', '비트코인'); // prefix → 70
-        const subResult = makeResult('COINX', 'Coin X', '가나비트다라'); // substring → 40
+        // query '비트': field '비트코인' startsWith '비트' → prefix → PREFIX_MATCH_SCORE
+        //               field '비트' === '비트' → exact → EXACT_MATCH_SCORE
+        //               field '가나비트다라' includes '비트' → substring → SUBSTRING_MATCH_SCORE
+        const exactResult = makeResult('BITUSD', 'Bit Coin', '비트'); // exact → EXACT_MATCH_SCORE
+        const prefixResult = makeResult('BTCUSD', 'Bitcoin USD', '비트코인'); // prefix → PREFIX_MATCH_SCORE
+        const subResult = makeResult('COINX', 'Coin X', '가나비트다라'); // substring → SUBSTRING_MATCH_SCORE
 
         // Input order: prefix, substring, exact — so stable sort must reorder by score.
         const results = [prefixResult, subResult, exactResult];
         const ranked = rankByRelevance(results, '비트');
-        expect(ranked[0].symbol).toBe('BITUSD'); // exact → 100
-        expect(ranked[1].symbol).toBe('BTCUSD'); // prefix → 70
-        expect(ranked[2].symbol).toBe('COINX'); // substring → 40
+        expect(ranked[0].symbol).toBe('BITUSD'); // exact → EXACT_MATCH_SCORE
+        expect(ranked[1].symbol).toBe('BTCUSD'); // prefix → PREFIX_MATCH_SCORE
+        expect(ranked[2].symbol).toBe('COINX'); // substring → SUBSTRING_MATCH_SCORE
     });
 
     it('popular exact match beats non-popular exact match', () => {
-        // BTCUSD is in POPULAR_CRYPTOS → score 100+15=115
-        // VIDTUSD is not popular → score 100
+        // BTCUSD is in POPULAR_CRYPTOS → EXACT_MATCH_SCORE + POPULAR_BONUS
+        // VIDTUSD is not popular → EXACT_MATCH_SCORE only
         const results: TickerSearchResult[] = [
             makeResult('VIDTUSD', 'VIDT Coin', '비트코인'), // not popular, exact
             makeResult('BTCUSD', 'Bitcoin USD', '비트코인'), // popular, exact
@@ -160,7 +160,7 @@ describe('rankByRelevance', () => {
             makeResult('BBB', 'Beta', '베타'),
             makeResult('CCC', 'Gamma', '감마'),
         ];
-        // query 'xyz' matches none → all score 10, order preserved
+        // query 'xyz' matches none → all score FALLBACK_SCORE, order preserved
         const ranked = rankByRelevance(results, 'xyz');
         expect(ranked.map(r => r.symbol)).toEqual(['AAA', 'BBB', 'CCC']);
     });

--- a/src/entities/ticker/lib/__tests__/searchTicker.crypto.test.ts
+++ b/src/entities/ticker/lib/__tests__/searchTicker.crypto.test.ts
@@ -155,9 +155,6 @@ describe('searchTicker — non-Korean relevance ranking', () => {
         const results = await searchTicker('aapl');
 
         expect(results[0].symbol).toBe('AAPL');
-        const aaplIdx = results.findIndex(r => r.symbol === 'AAPL');
-        const aapletechIdx = results.findIndex(r => r.symbol === 'AAPLETECH');
-        expect(aaplIdx).toBeLessThan(aapletechIdx);
     });
 
     it('popular symbol outranks same-quality non-popular symbol', async () => {

--- a/src/entities/ticker/lib/__tests__/searchTicker.crypto.test.ts
+++ b/src/entities/ticker/lib/__tests__/searchTicker.crypto.test.ts
@@ -30,6 +30,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
     searchTicker,
     _resetInFlightTranslationsForTest,
+    MAX_SEARCH_RESULTS,
 } from '../searchTicker';
 import type { TickerSearchResult } from '@/shared/lib/types';
 
@@ -119,5 +120,80 @@ describe('searchTicker — crypto merge', () => {
 
         const results = await searchTicker('AAPL');
         expect(results.some(r => r.symbol === 'AAPL')).toBe(true);
+    });
+});
+
+describe('searchTicker — non-Korean relevance ranking', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        _resetInFlightTranslationsForTest();
+        mockSearchByName.mockResolvedValue([]);
+        mockSearchCryptoAssets.mockResolvedValue([]);
+    });
+
+    it('ranks exact-symbol popular match above substring matches regardless of input order', async () => {
+        // FMP returns: AAPLETECH first (substring match), AAPL second (exact match + popular).
+        // rankByRelevance must reorder so AAPL leads.
+        // AAPL:      exact symbol match  → EXACT_MATCH_SCORE + POPULAR_BONUS
+        // AAPLETECH: prefix symbol match → PREFIX_MATCH_SCORE
+        const substringFirst: TickerSearchResult[] = [
+            {
+                symbol: 'AAPLETECH',
+                name: 'Aaple Technologies Inc.',
+                exchange: 'NASDAQ',
+                exchangeFullName: 'Nasdaq',
+            },
+            {
+                symbol: 'AAPL',
+                name: 'Apple Inc.',
+                exchange: 'NASDAQ',
+                exchangeFullName: 'Nasdaq',
+            },
+        ];
+        mockSearchBySymbol.mockResolvedValue(substringFirst);
+
+        const results = await searchTicker('aapl');
+
+        expect(results[0].symbol).toBe('AAPL');
+        const aaplIdx = results.findIndex(r => r.symbol === 'AAPL');
+        const aapletechIdx = results.findIndex(r => r.symbol === 'AAPLETECH');
+        expect(aaplIdx).toBeLessThan(aapletechIdx);
+    });
+
+    it('popular symbol outranks same-quality non-popular symbol', async () => {
+        // Both are exact matches but AAPL is popular, ZZZZ is not.
+        // Input has ZZZZ first; relevance ranking must put AAPL first.
+        const inputOrder: TickerSearchResult[] = [
+            {
+                symbol: 'ZZZZ',
+                name: 'Aapl Placeholder',
+                exchange: 'NASDAQ',
+                exchangeFullName: 'Nasdaq',
+            },
+            {
+                symbol: 'AAPL',
+                name: 'Apple Inc.',
+                exchange: 'NASDAQ',
+                exchangeFullName: 'Nasdaq',
+            },
+        ];
+        mockSearchBySymbol.mockResolvedValue(inputOrder);
+
+        const results = await searchTicker('aapl');
+
+        const aaplIdx = results.findIndex(r => r.symbol === 'AAPL');
+        const zzzzIdx = results.findIndex(r => r.symbol === 'ZZZZ');
+        expect(aaplIdx).toBeLessThan(zzzzIdx);
+    });
+
+    it('caps non-Korean results at MAX_SEARCH_RESULTS after relevance ranking', async () => {
+        const many = Array.from({ length: MAX_SEARCH_RESULTS + 3 }, (_, i) =>
+            fmpResult(`SYM${i}`)
+        );
+        mockSearchBySymbol.mockResolvedValue(many);
+
+        const results = await searchTicker('sym');
+
+        expect(results).toHaveLength(MAX_SEARCH_RESULTS);
     });
 });

--- a/src/entities/ticker/lib/__tests__/searchTicker.korean-crypto.test.ts
+++ b/src/entities/ticker/lib/__tests__/searchTicker.korean-crypto.test.ts
@@ -131,9 +131,9 @@ describe('searchTicker — 한글 입력 crypto 병합', () => {
             stockResult('STOCK4', '다라비트코인마바'),
             stockResult('STOCK5', '사아비트코인자차'),
         ];
-        // BTCUSD: exact koreanName match + popular → score 115
-        // VIDTUSD: exact koreanName match, not popular → score 100
-        // stocks: substring match → score 40
+        // BTCUSD: exact koreanName match + popular → EXACT_MATCH_SCORE + POPULAR_BONUS
+        // VIDTUSD: exact koreanName match, not popular → EXACT_MATCH_SCORE only
+        // stocks: substring match → SUBSTRING_MATCH_SCORE
         mockSearchByKoreanName.mockResolvedValue(substockResults);
         mockSearchCryptoAssets.mockResolvedValue([
             cryptoResult('VIDTUSD', '비트코인'),
@@ -166,7 +166,7 @@ describe('searchTicker — 한글 입력 crypto 병합', () => {
             stockResult('OTC4', '수이홀딩스'),
             stockResult('OTC5', '수이파트너스'),
         ];
-        // SUIUSD: exact koreanName match + popular → 115
+        // SUIUSD: exact koreanName match + popular → EXACT_MATCH_SCORE + POPULAR_BONUS
         mockSearchByKoreanName.mockResolvedValue(otcStocks);
         mockSearchCryptoAssets.mockResolvedValue([
             cryptoResult('SUIUSD', '수이'),

--- a/src/entities/ticker/lib/__tests__/searchTicker.korean-crypto.test.ts
+++ b/src/entities/ticker/lib/__tests__/searchTicker.korean-crypto.test.ts
@@ -28,7 +28,6 @@ import {
     searchTicker,
     _resetInFlightTranslationsForTest,
     MAX_SEARCH_RESULTS,
-    CRYPTO_RESERVE,
 } from '../searchTicker';
 import type { TickerSearchResult } from '@/shared/lib/types';
 
@@ -73,19 +72,6 @@ describe('searchTicker — 한글 입력 crypto 병합', () => {
         );
     });
 
-    it('한글 입력 시 주식 한국어 결과가 crypto 결과보다 먼저 온다', async () => {
-        mockSearchByKoreanName.mockResolvedValue([stockResult('AAPL', '애플')]);
-        mockSearchCryptoAssets.mockResolvedValue([
-            cryptoResult('BTCUSD', '비트코인'),
-        ]);
-
-        const results = await searchTicker('코');
-        const aaplIdx = results.findIndex(r => r.symbol === 'AAPL');
-        const btcIdx = results.findIndex(r => r.symbol === 'BTCUSD');
-        expect(aaplIdx).toBe(0);
-        expect(btcIdx).toBe(1);
-    });
-
     it('한글 입력 시 동일 symbol 중복 제거한다', async () => {
         const shared = stockResult('BTCUSD', '비트코인');
         mockSearchByKoreanName.mockResolvedValue([shared]);
@@ -109,16 +95,7 @@ describe('searchTicker — 한글 입력 crypto 병합', () => {
         mockSearchCryptoAssets.mockResolvedValue(manyCrypto);
 
         const results = await searchTicker('주');
-        // 7 stocks + 6 crypto = 13 unique symbols → deterministically capped to MAX.
         expect(results).toHaveLength(MAX_SEARCH_RESULTS);
-        // CRYPTO_RESERVE cap: 6 crypto results are truncated to exactly CRYPTO_RESERVE.
-        expect(results.filter(r => r.exchange === 'CRYPTO')).toHaveLength(
-            CRYPTO_RESERVE
-        );
-        // The remaining MAX_SEARCH_RESULTS - CRYPTO_RESERVE slots are filled by stocks.
-        expect(results.filter(r => r.exchange === 'NASDAQ')).toHaveLength(
-            MAX_SEARCH_RESULTS - CRYPTO_RESERVE
-        );
     });
 
     it('한글 입력 시 FMP searchBySymbol/searchByName 을 호출하지 않는다', async () => {
@@ -144,20 +121,63 @@ describe('searchTicker — 한글 입력 crypto 병합', () => {
         );
     });
 
-    it('주식 결과가 MAX를 채워도 crypto 결과가 보장된다', async () => {
-        // 10 stock results would normally starve crypto results entirely.
-        // With CRYPTO_RESERVE=3, stock is capped at 7 and crypto gets ≥1 slot.
-        const manyStocks = Array.from({ length: 10 }, (_, i) =>
-            stockResult(`STOCK${i}`, `주식${i}`)
-        );
-        const someCrypto = [cryptoResult('BTCUSD', '비트코인')];
-        mockSearchByKoreanName.mockResolvedValue(manyStocks);
-        mockSearchCryptoAssets.mockResolvedValue(someCrypto);
+    it('"비트코인" 쿼리에서 popular 정확일치 crypto(BTCUSD)가 substring-match 주식보다 먼저 온다', async () => {
+        // Several stocks whose koreanName merely contains "비트코인" as substring
+        const substockResults = [
+            stockResult('STOCK0', '가나비트코인다라'),
+            stockResult('STOCK1', '마바비트코인사아'),
+            stockResult('STOCK2', '자차비트코인카타'),
+            stockResult('STOCK3', '파하비트코인가나'),
+            stockResult('STOCK4', '다라비트코인마바'),
+            stockResult('STOCK5', '사아비트코인자차'),
+        ];
+        // BTCUSD: exact koreanName match + popular → score 115
+        // VIDTUSD: exact koreanName match, not popular → score 100
+        // stocks: substring match → score 40
+        mockSearchByKoreanName.mockResolvedValue(substockResults);
+        mockSearchCryptoAssets.mockResolvedValue([
+            cryptoResult('VIDTUSD', '비트코인'),
+            cryptoResult('BTCUSD', '비트코인'),
+        ]);
 
-        const results = await searchTicker('주');
-        expect(results).toHaveLength(MAX_SEARCH_RESULTS);
-        expect(results.find(r => r.symbol === 'BTCUSD')).toEqual(
-            cryptoResult('BTCUSD', '비트코인')
-        );
+        const results = await searchTicker('비트코인');
+        expect(results[0].symbol).toBe('BTCUSD');
+        expect(results[1].symbol).toBe('VIDTUSD');
+        // all substocks should rank below both cryptos
+        const stockSymbols = results
+            .map(r => r.symbol)
+            .filter(s => s.startsWith('STOCK'));
+        const btcIdx = results.findIndex(r => r.symbol === 'BTCUSD');
+        const vidtIdx = results.findIndex(r => r.symbol === 'VIDTUSD');
+        for (const sym of stockSymbols) {
+            const idx = results.findIndex(r => r.symbol === sym);
+            expect(idx).toBeGreaterThan(btcIdx);
+            expect(idx).toBeGreaterThan(vidtIdx);
+        }
+    });
+
+    it('"수이" 쿼리에서 popular crypto(SUIUSD)가 substring-match 주식보다 먼저 온다', async () => {
+        // Several OTC stocks whose koreanName contains "수이" as substring
+        const otcStocks = [
+            stockResult('OTC0', '수이테크놀로지'),
+            stockResult('OTC1', '수이코퍼레이션'),
+            stockResult('OTC2', '수이그룹'),
+            stockResult('OTC3', '수이인터내셔널'),
+            stockResult('OTC4', '수이홀딩스'),
+            stockResult('OTC5', '수이파트너스'),
+        ];
+        // SUIUSD: exact koreanName match + popular → 115
+        mockSearchByKoreanName.mockResolvedValue(otcStocks);
+        mockSearchCryptoAssets.mockResolvedValue([
+            cryptoResult('SUIUSD', '수이'),
+        ]);
+
+        const results = await searchTicker('수이');
+        expect(results[0].symbol).toBe('SUIUSD');
+        const suiIdx = results.findIndex(r => r.symbol === 'SUIUSD');
+        for (const stock of otcStocks) {
+            const idx = results.findIndex(r => r.symbol === stock.symbol);
+            expect(idx).toBeGreaterThan(suiIdx);
+        }
     });
 });

--- a/src/entities/ticker/lib/cryptoAssetStore.ts
+++ b/src/entities/ticker/lib/cryptoAssetStore.ts
@@ -7,7 +7,8 @@ import type {
 } from '@/shared/db/types';
 import type { TickerSearchResult } from '@/shared/lib/types';
 
-const CRYPTO_SEARCH_LIMIT = 10;
+// 25 candidates feed app-side relevance re-ranking in searchTicker without large payloads.
+const CRYPTO_SEARCH_LIMIT = 25;
 
 const CRYPTO_EXCHANGE_CODE = 'CRYPTO';
 const CRYPTO_EXCHANGE_FULL_NAME = 'Cryptocurrency';
@@ -137,7 +138,7 @@ export async function getCryptoAsset(
     }
 }
 
-/** Search crypto assets by symbol/name; ordered by liquidity, capped. */
+/** Search crypto assets by symbol/name; DB pre-sorts exact/prefix matches first, then by supply, for app-side relevance re-ranking. */
 export async function searchCryptoAssets(
     query: string
 ): Promise<TickerSearchResult[]> {

--- a/src/entities/ticker/lib/cryptoAssetStore.ts
+++ b/src/entities/ticker/lib/cryptoAssetStore.ts
@@ -7,7 +7,8 @@ import type {
 } from '@/shared/db/types';
 import type { TickerSearchResult } from '@/shared/lib/types';
 
-// 25 candidates feed app-side relevance re-ranking in searchTicker without large payloads.
+// Fetch extra candidates (CRYPTO_SEARCH_LIMIT) so app-side relevance re-ranking has enough
+// to work with; the DB pre-sort only orders them, the final ranking is done in searchRelevance.
 const CRYPTO_SEARCH_LIMIT = 25;
 
 const CRYPTO_EXCHANGE_CODE = 'CRYPTO';

--- a/src/entities/ticker/lib/searchRelevance.ts
+++ b/src/entities/ticker/lib/searchRelevance.ts
@@ -1,0 +1,75 @@
+import { POPULAR_TICKERS } from '@/shared/config/popular-tickers';
+import { POPULAR_CRYPTOS } from '@/shared/config/popular-cryptos';
+import type { TickerSearchResult } from '@/shared/lib/types';
+
+export interface ScorableResult {
+    symbol: string;
+    name: string;
+    koreanName?: string;
+}
+
+const POPULAR_STOCK_SET = new Set<string>(POPULAR_TICKERS);
+const POPULAR_CRYPTO_SET = new Set<string>(POPULAR_CRYPTOS);
+
+export function isPopularSymbol(symbol: string): boolean {
+    return POPULAR_STOCK_SET.has(symbol) || POPULAR_CRYPTO_SET.has(symbol);
+}
+
+/**
+ * Score a single search result against the query.
+ *
+ * Scoring rules (case-insensitive):
+ * - Exact field match       → 100
+ * - Field starts with query → 70
+ * - Field contains query    → 40
+ * - No match in any field   → 10  (Fallback floor for a result that the upstream search returned
+ *                                   but whose displayed fields don't literally contain the query,
+ *                                   e.g. matched on an English name the user didn't type, or a
+ *                                   field changed by koreanName enrichment.)
+ * - Popular bonus           → +15 (on top of base)
+ */
+
+/** Return the relevance score of a single field against the normalised query. */
+function fieldScore(field: string, q: string): number {
+    const f = field.toLowerCase();
+    if (f === q) return 100;
+    if (f.startsWith(q)) return 70;
+    if (f.includes(q)) return 40;
+    return 0;
+}
+
+export function scoreSearchRelevance(
+    result: ScorableResult,
+    query: string,
+    isPopular: boolean
+): number {
+    const q = query.toLowerCase().trim();
+    const fields = [result.koreanName, result.symbol, result.name];
+
+    const scores = fields.filter(Boolean).map(field => fieldScore(field!, q));
+    const base = Math.max(10, ...scores);
+
+    const popularBonus = isPopular ? 15 : 0;
+    return base + popularBonus;
+}
+
+/**
+ * Re-rank a deduplicated result list by relevance score (DESC).
+ * Array.prototype.sort is stable, so same-score results preserve their input order.
+ * Does NOT slice — caller is responsible for capping to MAX_SEARCH_RESULTS.
+ */
+export function rankByRelevance(
+    results: TickerSearchResult[],
+    query: string
+): TickerSearchResult[] {
+    const scored = results.map(result => ({
+        result,
+        score: scoreSearchRelevance(
+            result,
+            query,
+            isPopularSymbol(result.symbol)
+        ),
+    }));
+    scored.sort((a, b) => b.score - a.score);
+    return scored.map(s => s.result);
+}

--- a/src/entities/ticker/lib/searchRelevance.ts
+++ b/src/entities/ticker/lib/searchRelevance.ts
@@ -21,10 +21,20 @@ export const SUBSTRING_MATCH_SCORE = 40;
 export const FALLBACK_SCORE = 10;
 export const POPULAR_BONUS = 15;
 
+// Score one field against the query: exact > prefix > substring match, else 0.
+function fieldScore(field: string, q: string): number {
+    const f = field.toLowerCase();
+    if (f === q) return EXACT_MATCH_SCORE;
+    if (f.startsWith(q)) return PREFIX_MATCH_SCORE;
+    if (f.includes(q)) return SUBSTRING_MATCH_SCORE;
+    return 0;
+}
+
 /**
  * Score a single search result against the query.
  *
- * Scoring rules (case-insensitive), best match wins across all fields:
+ * Scoring rules (case-insensitive), best match wins across all fields
+ * (koreanName / symbol / name):
  * - Exact field match       → EXACT_MATCH_SCORE
  * - Field starts with query → PREFIX_MATCH_SCORE
  * - Field contains query    → SUBSTRING_MATCH_SCORE
@@ -34,14 +44,6 @@ export const POPULAR_BONUS = 15;
  *                             changed by koreanName enrichment.)
  * - Popular bonus           → +POPULAR_BONUS on top of base
  */
-function fieldScore(field: string, q: string): number {
-    const f = field.toLowerCase();
-    if (f === q) return EXACT_MATCH_SCORE;
-    if (f.startsWith(q)) return PREFIX_MATCH_SCORE;
-    if (f.includes(q)) return SUBSTRING_MATCH_SCORE;
-    return 0;
-}
-
 export function scoreSearchRelevance(
     result: ScorableResult,
     query: string,

--- a/src/entities/ticker/lib/searchRelevance.ts
+++ b/src/entities/ticker/lib/searchRelevance.ts
@@ -1,6 +1,5 @@
 import { POPULAR_TICKERS } from '@/shared/config/popular-tickers';
 import { POPULAR_CRYPTOS } from '@/shared/config/popular-cryptos';
-import type { TickerSearchResult } from '@/shared/lib/types';
 
 export interface ScorableResult {
     symbol: string;
@@ -22,6 +21,9 @@ export const FALLBACK_SCORE = 10;
 export const POPULAR_BONUS = 15;
 
 function fieldScore(field: string, q: string): number {
+    // Empty query is not a meaningful match — every field startsWith(''), which would
+    // incorrectly score everything as PREFIX_MATCH_SCORE; guard before substring tests.
+    if (q === '') return 0;
     const f = field.toLowerCase();
     if (f === q) return EXACT_MATCH_SCORE;
     if (f.startsWith(q)) return PREFIX_MATCH_SCORE;
@@ -42,6 +44,12 @@ function fieldScore(field: string, q: string): number {
  *                             e.g. matched on an English name the user didn't type, or a field
  *                             changed by koreanName enrichment.)
  * - Popular bonus           → +POPULAR_BONUS on top of base
+ *
+ * Edge case — empty/whitespace-only query: after `.trim()` the query becomes `''`.
+ * `fieldScore` guards this early (returns 0 for every field), so the base never rises
+ * above FALLBACK_SCORE, and `scoreSearchRelevance` returns FALLBACK_SCORE (+ popular
+ * bonus). The only active caller (`searchTicker`) short-circuits before an empty query
+ * reaches here, but the guard makes the function self-defending.
  */
 export function scoreSearchRelevance(
     result: ScorableResult,
@@ -64,11 +72,16 @@ export function scoreSearchRelevance(
  * Re-rank a deduplicated result list by relevance score (DESC).
  * .toSorted is stable in Node ≥20 / V8, so same-score results preserve their input order.
  * Does NOT slice — caller is responsible for capping to MAX_SEARCH_RESULTS.
+ *
+ * Generic over `T extends ScorableResult` so the input element type flows through to the
+ * return (a `TickerSearchResult[]` in, a `TickerSearchResult[]` out), while still accepting
+ * any list whose elements expose the scored fields. This keeps `ScorableResult` as the single
+ * shared contract between the scorer and the ranker rather than a parallel narrower type.
  */
-export function rankByRelevance(
-    results: TickerSearchResult[],
+export function rankByRelevance<T extends ScorableResult>(
+    results: T[],
     query: string
-): TickerSearchResult[] {
+): T[] {
     return results
         .map(result => ({
             result,

--- a/src/entities/ticker/lib/searchRelevance.ts
+++ b/src/entities/ticker/lib/searchRelevance.ts
@@ -24,19 +24,16 @@ export const POPULAR_BONUS = 15;
 /**
  * Score a single search result against the query.
  *
- * Scoring rules (case-insensitive):
- * - Exact field match       → EXACT_MATCH_SCORE (100)
- * - Field starts with query → PREFIX_MATCH_SCORE (70)
- * - Field contains query    → SUBSTRING_MATCH_SCORE (40)
- * - No match in any field   → FALLBACK_SCORE (10)  (Fallback floor for a result that the upstream
- *                                                    search returned but whose displayed fields don't
- *                                                    literally contain the query, e.g. matched on an
- *                                                    English name the user didn't type, or a field
- *                                                    changed by koreanName enrichment.)
- * - Popular bonus           → +POPULAR_BONUS (15) (on top of base)
+ * Scoring rules (case-insensitive), best match wins across all fields:
+ * - Exact field match       → EXACT_MATCH_SCORE
+ * - Field starts with query → PREFIX_MATCH_SCORE
+ * - Field contains query    → SUBSTRING_MATCH_SCORE
+ * - No match in any field   → FALLBACK_SCORE floor (the upstream search returned this result
+ *                             but the displayed fields don't literally contain the query —
+ *                             e.g. matched on an English name the user didn't type, or a field
+ *                             changed by koreanName enrichment.)
+ * - Popular bonus           → +POPULAR_BONUS on top of base
  */
-
-/** Return the relevance score of a single field against the normalised query. */
 function fieldScore(field: string, q: string): number {
     const f = field.toLowerCase();
     if (f === q) return EXACT_MATCH_SCORE;

--- a/src/entities/ticker/lib/searchRelevance.ts
+++ b/src/entities/ticker/lib/searchRelevance.ts
@@ -21,7 +21,6 @@ export const SUBSTRING_MATCH_SCORE = 40;
 export const FALLBACK_SCORE = 10;
 export const POPULAR_BONUS = 15;
 
-// Score one field against the query: exact > prefix > substring match, else 0.
 function fieldScore(field: string, q: string): number {
     const f = field.toLowerCase();
     if (f === q) return EXACT_MATCH_SCORE;

--- a/src/entities/ticker/lib/searchRelevance.ts
+++ b/src/entities/ticker/lib/searchRelevance.ts
@@ -15,26 +15,33 @@ export function isPopularSymbol(symbol: string): boolean {
     return POPULAR_STOCK_SET.has(symbol) || POPULAR_CRYPTO_SET.has(symbol);
 }
 
+export const EXACT_MATCH_SCORE = 100;
+export const PREFIX_MATCH_SCORE = 70;
+export const SUBSTRING_MATCH_SCORE = 40;
+export const FALLBACK_SCORE = 10;
+export const POPULAR_BONUS = 15;
+
 /**
  * Score a single search result against the query.
  *
  * Scoring rules (case-insensitive):
- * - Exact field match       → 100
- * - Field starts with query → 70
- * - Field contains query    → 40
- * - No match in any field   → 10  (Fallback floor for a result that the upstream search returned
- *                                   but whose displayed fields don't literally contain the query,
- *                                   e.g. matched on an English name the user didn't type, or a
- *                                   field changed by koreanName enrichment.)
- * - Popular bonus           → +15 (on top of base)
+ * - Exact field match       → EXACT_MATCH_SCORE (100)
+ * - Field starts with query → PREFIX_MATCH_SCORE (70)
+ * - Field contains query    → SUBSTRING_MATCH_SCORE (40)
+ * - No match in any field   → FALLBACK_SCORE (10)  (Fallback floor for a result that the upstream
+ *                                                    search returned but whose displayed fields don't
+ *                                                    literally contain the query, e.g. matched on an
+ *                                                    English name the user didn't type, or a field
+ *                                                    changed by koreanName enrichment.)
+ * - Popular bonus           → +POPULAR_BONUS (15) (on top of base)
  */
 
 /** Return the relevance score of a single field against the normalised query. */
 function fieldScore(field: string, q: string): number {
     const f = field.toLowerCase();
-    if (f === q) return 100;
-    if (f.startsWith(q)) return 70;
-    if (f.includes(q)) return 40;
+    if (f === q) return EXACT_MATCH_SCORE;
+    if (f.startsWith(q)) return PREFIX_MATCH_SCORE;
+    if (f.includes(q)) return SUBSTRING_MATCH_SCORE;
     return 0;
 }
 
@@ -44,32 +51,35 @@ export function scoreSearchRelevance(
     isPopular: boolean
 ): number {
     const q = query.toLowerCase().trim();
-    const fields = [result.koreanName, result.symbol, result.name];
+    const fields = [result.koreanName, result.symbol, result.name].filter(
+        (f): f is string => Boolean(f)
+    );
 
-    const scores = fields.filter(Boolean).map(field => fieldScore(field!, q));
-    const base = Math.max(10, ...scores);
+    const scores = fields.map(field => fieldScore(field, q));
+    const base = Math.max(FALLBACK_SCORE, ...scores);
 
-    const popularBonus = isPopular ? 15 : 0;
+    const popularBonus = isPopular ? POPULAR_BONUS : 0;
     return base + popularBonus;
 }
 
 /**
  * Re-rank a deduplicated result list by relevance score (DESC).
- * Array.prototype.sort is stable, so same-score results preserve their input order.
+ * .toSorted is stable in Node ≥20 / V8, so same-score results preserve their input order.
  * Does NOT slice — caller is responsible for capping to MAX_SEARCH_RESULTS.
  */
 export function rankByRelevance(
     results: TickerSearchResult[],
     query: string
 ): TickerSearchResult[] {
-    const scored = results.map(result => ({
-        result,
-        score: scoreSearchRelevance(
+    return results
+        .map(result => ({
             result,
-            query,
-            isPopularSymbol(result.symbol)
-        ),
-    }));
-    scored.sort((a, b) => b.score - a.score);
-    return scored.map(s => s.result);
+            score: scoreSearchRelevance(
+                result,
+                query,
+                isPopularSymbol(result.symbol)
+            ),
+        }))
+        .toSorted((a, b) => b.score - a.score)
+        .map(s => s.result);
 }

--- a/src/entities/ticker/lib/searchTicker.ts
+++ b/src/entities/ticker/lib/searchTicker.ts
@@ -16,20 +16,13 @@ import {
     setKoreanTickers,
 } from './koreanNameStore';
 import { searchCryptoAssets } from './cryptoAssetStore';
+import { rankByRelevance } from './searchRelevance';
 import { fireAndForget, type BackgroundTaskOptions } from './backgroundTask';
 import { createSingleFlight } from './utils/singleFlight';
 import { createCacheProvider } from '@y0ngha/siglens-core';
 import type { KoreanTickerEntry, TickerSearchResult } from '@/shared/lib/types';
 
 export const MAX_SEARCH_RESULTS = 10;
-
-/**
- * When a Korean search returns both stock and crypto results, reserve this many
- * slots for crypto so Korean coin searches aren't starved by a high volume of
- * stock name matches. The actual crypto slots may be fewer if fewer crypto
- * results exist; unused budget flows back to stock.
- */
-export const CRYPTO_RESERVE = 3;
 
 function toKoreanEntry(
     symbol: string,
@@ -96,18 +89,13 @@ export async function searchTicker(
             // Isolated catch so a crypto DB error doesn't discard stock results.
             searchCryptoAssets(trimmed).catch((): TickerSearchResult[] => []),
         ]);
-        // Guarantee crypto representation: reserve up to CRYPTO_RESERVE slots for
-        // crypto results when they exist, so Korean coin searches aren't lost when
-        // many stock name matches fill the cap. Unused crypto budget flows to stock.
-        const cryptoCap = Math.min(cryptoResults.length, CRYPTO_RESERVE);
-        const cappedStock = stockResults.slice(
-            0,
-            MAX_SEARCH_RESULTS - cryptoCap
-        );
-        const remainingSlots = MAX_SEARCH_RESULTS - cappedStock.length;
-        const cappedCrypto = cryptoResults.slice(0, remainingSlots);
         // deduplicateResults guards the unlikely case where a symbol exists in both stores.
-        return deduplicateResults([...cappedStock, ...cappedCrypto]);
+        // rankByRelevance scores each result so exact/popular matches surface first regardless of asset type.
+        const ranked = rankByRelevance(
+            deduplicateResults([...stockResults, ...cryptoResults]),
+            trimmed
+        );
+        return ranked.slice(0, MAX_SEARCH_RESULTS);
     }
 
     const cache = createCacheProvider();
@@ -151,7 +139,8 @@ export async function searchTicker(
         );
     }
 
-    const final = enriched.slice(0, MAX_SEARCH_RESULTS);
+    const ranked = rankByRelevance(enriched, trimmed);
+    const final = ranked.slice(0, MAX_SEARCH_RESULTS);
 
     if (cache) {
         fireAndForget(

--- a/src/entities/ticker/lib/searchTicker.ts
+++ b/src/entities/ticker/lib/searchTicker.ts
@@ -90,7 +90,6 @@ export async function searchTicker(
             searchCryptoAssets(trimmed).catch((): TickerSearchResult[] => []),
         ]);
         // deduplicateResults guards the unlikely case where a symbol exists in both stores.
-        // rankByRelevance scores each result so exact/popular matches surface first regardless of asset type.
         const ranked = rankByRelevance(
             deduplicateResults([...stockResults, ...cryptoResults]),
             trimmed


### PR DESCRIPTION
## 문제

암호화폐 검색이 발행량(circulating_supply) 기준으로 정렬되어 유명한 저발행량 코인들이 묻혀 있음.
- "비트코인" 검색 시 BTCUSD가 결과에 나타나지 않음
- "수이" 검색 시 SUIUSD가 6개의 OTC 주식 아래에 랭크됨

## 해결책

순수 relevance scorer 추가 (exact 100 / prefix 70 / substring 40 + popular +15), 한글 및 비한글 분기 양쪽에 적용.

### 세부 변경

1. **searchRelevance.ts** (새로운 순수 함수)
   - `scoreRelevance(query, ticker, name, isCrypto)`: exact/prefix/substring 매칭 점수화
   - 암호화폐의 경우 인기도 보너스 +15 추가 (발행량 순서의 타이브레이커)

2. **searchTicker.ts** (DB 페칭 최적화)
   - CRYPTO_SEARCH_LIMIT 10 → 25 확대 (저발행량 exact 매치가 제한 내에서 페칭되도록)
   - 암호화폐 DB 쿼리에 exact/prefix 우선 정렬 추가
   - 기존 CRYPTO_RESERVE 꼬리슬롯 핵(tail-slot hack) 제거

3. **cryptoAssetStore.ts**, **api.ts**
   - relevance scorer를 모든 검색 결과에 적용

### 검증 (Chrome 실증)

- "비트코인" 입력 → BTCUSD #1 위치 표시
- "수이" 입력 → SUIUSD #1 위치 표시

## 주의사항

mistranslation 충돌(예: VIDT 토큰이 "비트코인"으로 표시)은 인기도 보너스 타이브레이커로 완화되지만(실제 코인이 먼저 랭크), 별도 데이터 정제 항목으로 남음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)