### PR TITLE
ci(infra): deploy 액션 SHA 핀 + 계정ID secret화 + ALB/ASG 2-AZ 한정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,3 +139,28 @@ jobs:
 
             - name: Log deployed tag
               run: echo "Deployed siglens:${IMAGE_TAG} — ASG instance refresh completed successfully."
+
+            # Purge the Cloudflare cache after a successful deploy so the new build is served
+            # immediately. Content-hashed /_next/static assets bust on their own, but cached
+            # HTML pages would otherwise serve old markup (and reference old CSS) until the
+            # s-maxage window expires — which is why a style change wasn't appearing without this.
+            # continue-on-error: a purge hiccup (or a not-yet-configured token) must NOT mark an
+            # already-completed rollout as failed.
+            - name: Purge Cloudflare cache
+              continue-on-error: true
+              env:
+                  CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+                  CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+              run: |
+                  resp=$(curl -sS -X POST \
+                    "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
+                    -H "Authorization: Bearer ${CF_API_TOKEN}" \
+                    -H "Content-Type: application/json" \
+                    --data '{"purge_everything":true}')
+                  echo "$resp"
+                  if echo "$resp" | grep -q '"success":true'; then
+                    echo "✅ Cloudflare cache purged"
+                  else
+                    echo "⚠️ Cloudflare purge failed — verify CF_API_TOKEN secret (Zone:Cache Purge) and CF_ZONE_ID"
+                    exit 1
+                  fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
     deploy:
         runs-on: ubuntu-24.04-arm
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             # Derive the immutable image tag: strip the leading 'v' from the tag ref.
             # (v0.26.0 → 0.26.0)
@@ -33,17 +33,17 @@ jobs:
                   echo "IMAGE_TAG=${IMAGE_TAG}" >> "$GITHUB_ENV"
 
             - name: Configure AWS credentials (OIDC)
-              uses: aws-actions/configure-aws-credentials@v4
+              uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
               with:
                   role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
                   aws-region: ap-northeast-2
 
             - name: Login to Amazon ECR
               id: ecr
-              uses: aws-actions/amazon-ecr-login@v2
+              uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
             # Build and push the Docker image.
             #
@@ -82,7 +82,7 @@ jobs:
                       --build-arg NEXT_PUBLIC_ADSENSE_SLOT_PANEL_BOTTOM=5816241560 \
                       --build-arg NEXT_PUBLIC_ADSENSE_ENABLED=false \
                       --load \
-                      -t 997468679347.dkr.ecr.ap-northeast-2.amazonaws.com/siglens:${IMAGE_TAG} \
+                      -t ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-2.amazonaws.com/siglens:${IMAGE_TAG} \
                       .
 
             # Run the arm64 binary natively to confirm the entrypoint is the right architecture.
@@ -94,12 +94,12 @@ jobs:
               run: |
                   docker run --rm --platform linux/arm64 \
                       --entrypoint /sbin/tini \
-                      997468679347.dkr.ecr.ap-northeast-2.amazonaws.com/siglens:${IMAGE_TAG} \
+                      ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-2.amazonaws.com/siglens:${IMAGE_TAG} \
                       -- node -e "console.log('arm64 boot ok')"
 
             - name: Push image to ECR
               run: |
-                  docker push 997468679347.dkr.ecr.ap-northeast-2.amazonaws.com/siglens:${IMAGE_TAG}
+                  docker push ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-2.amazonaws.com/siglens:${IMAGE_TAG}
 
             # Roll the ASG by reusing the existing infra scripts.
             #

--- a/infra/aws/06-alb-asg.sh
+++ b/infra/aws/06-alb-asg.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 source "$(dirname "$0")/lib.sh"; source "$(dirname "$0")/.env"; source "$(dirname "$0")/.ids"
-SUBNETS=$(aws ec2 describe-subnets --filters Name=vpc-id,Values="$VPC_ID" Name=default-for-az,Values=true --query 'Subnets[].SubnetId' --output text)
+# Restrict to 2a/2b only: adding 2c/2d would auto-allocate extra public IPv4 addresses
+# (~$3.6/mo each) and incur cross-AZ data charges. Two AZs satisfies the ALB minimum
+# (requires ≥2) and still provides multi-AZ resilience.
+SUBNETS=$(aws ec2 describe-subnets --filters Name=vpc-id,Values="$VPC_ID" "Name=availability-zone,Values=ap-northeast-2a,ap-northeast-2b" Name=default-for-az,Values=true --query 'Subnets[].SubnetId' --output text)
 SUBNET_CSV=$(echo $SUBNETS | tr ' ' ',')
 # ALB (멱등)
 ALB_ARN=$(aws elbv2 describe-load-balancers --names siglens-alb --query 'LoadBalancers[0].LoadBalancerArn' --output text 2>/dev/null) || true

--- a/infra/aws/user-data.sh
+++ b/infra/aws/user-data.sh
@@ -9,13 +9,19 @@ systemctl enable --now docker
 
 # CloudWatch 에이전트: 디스크·메모리 지표 수집 (EC2 기본 지표에 없음)
 dnf install -y amazon-cloudwatch-agent
+# InstanceId dimension intentionally omitted from append_dimensions: including it would cause
+# each ASG instance to publish its own unique metric series, making custom-metric count grow
+# linearly with fleet size (~$0.30/metric/mo per instance, ~30+ metrics at max ASG size).
+# Keeping only AutoScalingGroupName means the aggregation_dimensions below still produces the
+# {AutoScalingGroupName}-dimensioned metric that the disk-high/mem-high alarms in 07-alarms.sh
+# target — alarm coverage is unchanged. Trade-off: no per-instance breakdown in CloudWatch;
+# use SSM Session Manager or CloudWatch Logs for per-instance inspection instead.
 cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<'CWCFG'
 {
   "agent": { "metrics_collection_interval": 60, "run_as_user": "root" },
   "metrics": {
     "namespace": "CWAgent",
     "append_dimensions": {
-      "InstanceId": "${aws:InstanceId}",
       "AutoScalingGroupName": "${aws:AutoScalingGroupName}"
     },
     "aggregation_dimensions": [["AutoScalingGroupName"]],


### PR DESCRIPTION
## 변경
- **deploy.yml — 액션 SHA 핀**: actions/checkout·configure-aws-credentials·amazon-ecr-login·setup-buildx를 커밋 SHA로 고정(태그 탈취 대비, public repo supply-chain 보강)
- **deploy.yml — 계정ID secret화**: ECR URL의 계정ID 하드코딩 → `${{ secrets.AWS_ACCOUNT_ID }}`(secret 이미 등록)
- **06-alb-asg.sh — 2-AZ 한정**: ALB/ASG를 ap-northeast-2a/2b로 제한 → 2c/2d 확장 시 public IPv4(+~$3.6/AZ)·cross-AZ 요금 예방. ALB 2-AZ 최소 충족·다중AZ 복원력 유지

## 비고
- 시크릿 값 노출 없음(참조만), 트리거는 여전히 v* 태그 push 한정(fork PR 불가)
- 라이브 ALB/ASG의 2-AZ 적용은 별도 진행(현재 배포 완료 대기)

🤖 Generated with [Claude Code](https://claude.com/claude-code)