### PR TITLE
fix(home): center hero in tablet band, constrain search to max-w block

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -263,7 +263,7 @@ export default async function Home() {
                         <div className="order-first lg:order-last">
                             <HeroIllustration className="mx-auto h-auto w-full max-w-md lg:max-w-none" />
                         </div>
-                        <div className="text-center md:text-left">
+                        <div className="text-center lg:text-left">
                             <p className="text-secondary-400 mb-5 font-mono text-[0.68rem] leading-relaxed tracking-[0.18em] uppercase sm:text-xs">
                                 투자의 확신을 더하는 AI 분석
                             </p>
@@ -290,11 +290,11 @@ export default async function Home() {
                             </p>
                             <div
                                 id="search"
-                                className="mt-8 flex w-full justify-center md:justify-start"
+                                className="mt-8 flex w-full justify-center lg:justify-start"
                             >
-                                <SymbolSearchPanel />
+                                <SymbolSearchPanel className="max-w-2xl lg:max-w-none" />
                             </div>
-                            <div className="mt-6 flex flex-wrap justify-center gap-x-5 gap-y-2 md:justify-start">
+                            <div className="mt-6 flex flex-wrap justify-center gap-x-5 gap-y-2 lg:justify-start">
                                 {HERO_QUICK_LINKS.map(({ href, label }) => (
                                     <Link
                                         key={href}

--- a/src/features/ticker-search/ui/SymbolSearchPanel.tsx
+++ b/src/features/ticker-search/ui/SymbolSearchPanel.tsx
@@ -19,7 +19,7 @@ export function SymbolSearchPanel({ className }: SymbolSearchPanelProps) {
             <TickerAutocomplete size="lg" onSelect={addSearch} />
 
             {recentSearches.length > 0 && (
-                <div className="mt-4 flex flex-wrap items-center justify-center gap-2 md:justify-start">
+                <div className="mt-4 flex flex-wrap items-center justify-center gap-2 lg:justify-start">
                     <span className="text-secondary-500 text-xs">
                         최근 검색
                     </span>

--- a/src/widgets/home/StatsBar.tsx
+++ b/src/widgets/home/StatsBar.tsx
@@ -18,7 +18,7 @@ export function StatsBar({ skills }: StatsBarProps) {
     return (
         <ul
             aria-label="Siglens 분석 규모"
-            className="text-secondary-400 mt-6 flex list-none flex-wrap items-center justify-center gap-x-2 p-0 font-mono text-xs md:justify-start"
+            className="text-secondary-400 mt-6 flex list-none flex-wrap items-center justify-center gap-x-2 p-0 font-mono text-xs lg:justify-start"
         >
             {stats.map((stat, i) => (
                 <Fragment key={stat.label}>
@@ -43,7 +43,7 @@ export function StatsBarSkeleton() {
     return (
         <div
             aria-hidden="true"
-            className="mt-6 flex flex-wrap items-center justify-center gap-x-2 md:justify-start"
+            className="mt-6 flex flex-wrap items-center justify-center gap-x-2 lg:justify-start"
         >
             {[80, 60, 72, 56, 68, 64].map((w, i) => (
                 <Fragment key={i}>


### PR DESCRIPTION
## 구현 내용

Unify hero alignment to CENTER in the tablet band (768–1023px) instead of left. This change:

- Reverts hero alignment triggers from `md:` back to `lg:` so the hero stays centered until desktop (≥1024px)
- Constrains the search panel to `max-w-2xl` block (`<SymbolSearchPanel className="max-w-2xl lg:max-w-none" />`) so centered hero reads as intentional rather than edge-to-edge
- Desktop (≥1024px) keeps existing 2-column left layout
- Mobile (<768px) unchanged
- Visual verification: 987px tablet viewport ✓

## 레이어 및 코드 품질 체크

- [x] Style-only changes (Tailwind className edits)
- [x] No logic changes
- [x] No new dependencies
- [x] CI checks: yarn format, yarn lint, yarn test, yarn build ✅

## 변경 파일 목록

[수정]
- `src/app/page.tsx` — hero alignment trigger `md:` → `lg:`
- `src/features/ticker-search/ui/SymbolSearchPanel.tsx` — max-w constraint added
- `src/widgets/home/StatsBar.tsx` — alignment trigger updated