### PR TITLE
refactor(infra): remove Vercel runtime deps (waitUntil seam, analytics, vercel.json)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,7 @@ LLM_API_KEY_ENCRYPTION_KEY=
 OAUTH_STATE_HMAC_SECRET=
 
 # Bearer token required by cleanupExpiredSessionsAction. Set to the same value
-# used by the cron caller (e.g. Vercel Cron). Action throws unauthorized when
+# used by the external cron caller (e.g. EventBridge). Action throws unauthorized when
 # missing, so production deployments must define this even if cron is not yet
 # wired.
 CRON_SECRET=

--- a/package.json
+++ b/package.json
@@ -61,8 +61,6 @@
         "@neondatabase/serverless": "^1.1.0",
         "@tanstack/react-query": "^5.95.2",
         "@upstash/redis": "^1.37.0",
-        "@vercel/analytics": "^2.0.1",
-        "@vercel/functions": "^3.4.3",
         "@y0ngha/siglens-core": "0.27.0",
         "bcryptjs": "^3.0.3",
         "clsx": "^2.1.1",

--- a/src/__tests__/worst-case/aiSlowResponse.test.ts
+++ b/src/__tests__/worst-case/aiSlowResponse.test.ts
@@ -40,10 +40,6 @@ vi.mock('@y0ngha/siglens-core', () => ({
     pollAnalysis: vi.fn(),
 }));
 
-vi.mock('@vercel/functions', () => ({
-    waitUntil: vi.fn(),
-}));
-
 import { callAiProviderRouter } from '@/entities/llm-provider/api/router';
 import { pollAnalysisAction } from '@/entities/analysis/actions/pollAnalysisAction';
 import { pollAnalysis } from '@y0ngha/siglens-core';

--- a/src/__tests__/worst-case/assetInfoDegradation.test.ts
+++ b/src/__tests__/worst-case/assetInfoDegradation.test.ts
@@ -1,7 +1,3 @@
-vi.mock('@vercel/functions', () => ({
-    waitUntil: vi.fn((p: Promise<unknown>) => p.catch(() => {})),
-}));
-
 const mockCacheGet = vi.fn();
 const mockCacheSet = vi.fn();
 const mockCreateCacheProvider = vi.fn();

--- a/src/__tests__/worst-case/cacheWriteFailure.test.ts
+++ b/src/__tests__/worst-case/cacheWriteFailure.test.ts
@@ -1,7 +1,3 @@
-vi.mock('@vercel/functions', () => ({
-    waitUntil: vi.fn((p: Promise<unknown>) => p.catch(() => {})),
-}));
-
 vi.mock('@y0ngha/siglens-core', () => ({
     createCacheProvider: vi.fn(),
 }));

--- a/src/__tests__/worst-case/pollAnalysisRedisError.test.ts
+++ b/src/__tests__/worst-case/pollAnalysisRedisError.test.ts
@@ -2,10 +2,6 @@ vi.mock('@y0ngha/siglens-core', () => ({
     pollAnalysis: vi.fn(),
 }));
 
-vi.mock('@vercel/functions', () => ({
-    waitUntil: vi.fn(),
-}));
-
 import { pollAnalysisAction } from '@/entities/analysis/actions/pollAnalysisAction';
 import { pollAnalysis } from '@y0ngha/siglens-core';
 
@@ -59,14 +55,11 @@ describe('pollAnalysisAction error handling and edge cases', () => {
         expect((result as unknown as { data: unknown }).data).toBeNull();
     });
 
-    it('passes jobId and waitUntil correctly', async () => {
+    it('passes jobId correctly', async () => {
         mockPollAnalysis.mockResolvedValue({ status: 'pending' });
 
         await pollAnalysisAction('specific-job-id');
 
-        expect(mockPollAnalysis).toHaveBeenCalledWith(
-            'specific-job-id',
-            expect.objectContaining({ waitUntil: expect.any(Function) })
-        );
+        expect(mockPollAnalysis).toHaveBeenCalledWith('specific-job-id');
     });
 });

--- a/src/app/[symbol]/__tests__/symbol-metadata.test.ts
+++ b/src/app/[symbol]/__tests__/symbol-metadata.test.ts
@@ -171,10 +171,6 @@ vi.mock('@/entities/news-article/actions', () => ({
     ensureNewsCardsAnalyzedAction: vi.fn(() => Promise.resolve()),
 }));
 
-vi.mock('@vercel/functions', () => ({
-    waitUntil: vi.fn(),
-}));
-
 // tanstack query (페이지 default export에서 사용, generateMetadata에는 불필요)
 vi.mock('@tanstack/react-query', () => ({
     QueryClient: vi.fn().mockImplementation(function () {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from 'react';
 import Script from 'next/script';
 import { Geist, Geist_Mono } from 'next/font/google';
 import localFont from 'next/font/local';
-import { Analytics } from '@vercel/analytics/next';
 import { AuthSessionHeaderClient } from '@/app/_components/AuthSessionHeaderClient';
 import { Footer } from '@/widgets/layout/Footer';
 import { SiteJsonLd } from '@/widgets/layout/SiteJsonLd';
@@ -161,7 +160,6 @@ export default function RootLayout({ children }: RootLayoutProps) {
                         strategy="lazyOnload"
                     />
                 )}
-                <Analytics />
             </body>
         </html>
     );

--- a/src/entities/analysis/__tests__/pollAnalysisAction.test.ts
+++ b/src/entities/analysis/__tests__/pollAnalysisAction.test.ts
@@ -3,10 +3,6 @@ import { pollAnalysisAction } from '../actions/pollAnalysisAction';
 import { pollAnalysis } from '@y0ngha/siglens-core';
 import type { PollAnalysisResult } from '@y0ngha/siglens-core';
 
-vi.mock('@vercel/functions', () => ({
-    waitUntil: vi.fn(),
-}));
-
 vi.mock('@y0ngha/siglens-core', async () => ({
     ...(await vi.importActual('@y0ngha/siglens-core')),
     pollAnalysis: vi.fn(),
@@ -26,9 +22,7 @@ describe('pollAnalysisAction 함수는', () => {
 
         await pollAnalysisAction('job-123');
 
-        expect(mockPollAnalysis).toHaveBeenCalledWith('job-123', {
-            waitUntil: expect.any(Function),
-        });
+        expect(mockPollAnalysis).toHaveBeenCalledWith('job-123');
     });
 
     it('underlying 함수의 결과를 그대로 반환한다', async () => {

--- a/src/entities/analysis/__tests__/pollBriefingAction.test.ts
+++ b/src/entities/analysis/__tests__/pollBriefingAction.test.ts
@@ -3,10 +3,6 @@ import { pollBriefingAction } from '../actions/pollBriefingAction';
 import { pollBriefing } from '@y0ngha/siglens-core';
 import type { PollBriefingResult } from '@y0ngha/siglens-core';
 
-vi.mock('@vercel/functions', () => ({
-    waitUntil: vi.fn(),
-}));
-
 vi.mock('@y0ngha/siglens-core', async () => ({
     ...(await vi.importActual('@y0ngha/siglens-core')),
     pollBriefing: vi.fn(),
@@ -26,9 +22,7 @@ describe('pollBriefingAction 함수는', () => {
 
         await pollBriefingAction('job-456');
 
-        expect(mockPollBriefing).toHaveBeenCalledWith('job-456', {
-            waitUntil: expect.any(Function),
-        });
+        expect(mockPollBriefing).toHaveBeenCalledWith('job-456');
     });
 
     it('underlying 함수의 결과를 그대로 반환한다', async () => {

--- a/src/entities/analysis/__tests__/submitAnalysisAction.test.ts
+++ b/src/entities/analysis/__tests__/submitAnalysisAction.test.ts
@@ -1,7 +1,4 @@
 import type { MockedFunction } from 'vitest';
-vi.mock('@vercel/functions', () => ({
-    waitUntil: vi.fn(),
-}));
 
 vi.mock('next/headers', () => ({
     headers: vi.fn(() => Promise.resolve(new Headers())),

--- a/src/entities/analysis/__tests__/submitCongressTrendAction.test.ts
+++ b/src/entities/analysis/__tests__/submitCongressTrendAction.test.ts
@@ -1,8 +1,4 @@
 // vi.mock → imports 순서 (MISTAKES.md Tests §17)
-vi.mock('@vercel/functions', () => ({
-    waitUntil: vi.fn(),
-}));
-
 vi.mock('next/headers', () => ({
     headers: vi.fn(() => Promise.resolve(new Headers())),
     cookies: vi.fn(() => Promise.resolve({ get: vi.fn(() => undefined) })),

--- a/src/entities/analysis/__tests__/submitFinancialsAnalysisAction.test.ts
+++ b/src/entities/analysis/__tests__/submitFinancialsAnalysisAction.test.ts
@@ -1,8 +1,4 @@
 // vi.mock → imports 순서 (MISTAKES.md Tests §17)
-vi.mock('@vercel/functions', () => ({
-    waitUntil: vi.fn(),
-}));
-
 vi.mock('next/headers', () => ({
     headers: vi.fn(() => Promise.resolve(new Headers())),
     cookies: vi.fn(() => Promise.resolve({ get: vi.fn(() => undefined) })),

--- a/src/entities/analysis/__tests__/submitFundamentalAnalysisAction.test.ts
+++ b/src/entities/analysis/__tests__/submitFundamentalAnalysisAction.test.ts
@@ -1,7 +1,4 @@
 import type { MockedFunction } from 'vitest';
-vi.mock('@vercel/functions', () => ({
-    waitUntil: vi.fn(),
-}));
 
 vi.mock('next/headers', () => ({
     headers: vi.fn(() => Promise.resolve(new Headers())),

--- a/src/entities/analysis/__tests__/submitOverallAnalysisAction.test.ts
+++ b/src/entities/analysis/__tests__/submitOverallAnalysisAction.test.ts
@@ -5,10 +5,6 @@ vi.mock('next/headers', () => ({
     headers: vi.fn(() => Promise.resolve(new Headers())),
 }));
 
-vi.mock('@vercel/functions', () => ({
-    waitUntil: vi.fn(),
-}));
-
 // action이 core로 forwarding하는 인자 shape, OI-stale 게이팅, financials scorecard
 // 주입을 검증한다. requireActual로 타입 surface를 합치고 핵심 3개 export를 override한다.
 vi.mock('@y0ngha/siglens-core', async () => {

--- a/src/entities/analysis/actions/pollAnalysisAction.ts
+++ b/src/entities/analysis/actions/pollAnalysisAction.ts
@@ -1,10 +1,9 @@
 'use server';
 
-import { waitUntil } from '@vercel/functions';
 import { type PollAnalysisResult, pollAnalysis } from '@y0ngha/siglens-core';
 
 export async function pollAnalysisAction(
     jobId: string
 ): Promise<PollAnalysisResult> {
-    return pollAnalysis(jobId, { waitUntil });
+    return pollAnalysis(jobId);
 }

--- a/src/entities/analysis/actions/pollBriefingAction.ts
+++ b/src/entities/analysis/actions/pollBriefingAction.ts
@@ -1,10 +1,9 @@
 'use server';
 
-import { waitUntil } from '@vercel/functions';
 import { type PollBriefingResult, pollBriefing } from '@y0ngha/siglens-core';
 
 export async function pollBriefingAction(
     jobId: string
 ): Promise<PollBriefingResult> {
-    return pollBriefing(jobId, { waitUntil });
+    return pollBriefing(jobId);
 }

--- a/src/entities/analysis/actions/submitAnalysisAction.ts
+++ b/src/entities/analysis/actions/submitAnalysisAction.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { waitUntil } from '@vercel/functions';
 import { headers } from 'next/headers';
 import {
     submitAnalysis,
@@ -74,7 +73,6 @@ export async function submitAnalysisAction(
                 force,
                 fmpSymbol,
                 {
-                    waitUntil,
                     modelId,
                     skipEnqueueIfMiss,
                     marketDataProvider,
@@ -98,7 +96,6 @@ export async function submitAnalysisAction(
             force,
             fmpSymbol,
             {
-                waitUntil,
                 modelId,
                 skipEnqueueIfMiss,
                 marketDataProvider,

--- a/src/entities/analysis/actions/submitCongressTrendAction.ts
+++ b/src/entities/analysis/actions/submitCongressTrendAction.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { waitUntil } from '@vercel/functions';
 import { headers, cookies } from 'next/headers';
 import {
     submitCongressTrend,
@@ -56,7 +55,6 @@ export async function submitCongressTrendAction(
             symbol,
             modelId,
             dataProvider: getCongressTradesProvider(),
-            waitUntil,
             skipEnqueueIfMiss,
         });
     } catch (error) {

--- a/src/entities/analysis/actions/submitFinancialsAnalysisAction.ts
+++ b/src/entities/analysis/actions/submitFinancialsAnalysisAction.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { waitUntil } from '@vercel/functions';
 import { headers, cookies } from 'next/headers';
 import {
     submitFinancialsAnalysis,
@@ -57,7 +56,6 @@ export async function submitFinancialsAnalysisAction(
             symbol,
             modelId,
             dataProvider: getFinancialStatementsProvider(),
-            waitUntil,
             tier: gate.tier,
             skipEnqueueIfMiss,
             ...(gate.userApiKey !== undefined

--- a/src/entities/analysis/actions/submitFundamentalAnalysisAction.ts
+++ b/src/entities/analysis/actions/submitFundamentalAnalysisAction.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { waitUntil } from '@vercel/functions';
 import { headers } from 'next/headers';
 import {
     submitFundamentalAnalysis,
@@ -51,7 +50,6 @@ export async function submitFundamentalAnalysisAction(
             symbol,
             modelId,
             dataProvider: getFundamentalDataProvider(),
-            waitUntil,
             tier: gate.tier,
             skipEnqueueIfMiss,
             ...(gate.userApiKey !== undefined

--- a/src/entities/analysis/actions/submitOverallAnalysisAction.ts
+++ b/src/entities/analysis/actions/submitOverallAnalysisAction.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { waitUntil } from '@vercel/functions';
 import { headers } from 'next/headers';
 import {
     isEtRegularSessionOpen,
@@ -160,7 +159,6 @@ export async function submitOverallAnalysisAction(
             newsItems: enrichedNews,
             upcomingCalendar: next !== null ? [next] : [],
             technical: { tierContext: { userId, tier: gate.tier } },
-            waitUntil,
             tier: gate.tier,
             skipEnqueueIfMiss,
             assetClass,

--- a/src/entities/market-news/actions/submitMarketNewsDigestAction.ts
+++ b/src/entities/market-news/actions/submitMarketNewsDigestAction.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { waitUntil } from '@vercel/functions';
 import { headers } from 'next/headers';
 import {
     submitMarketNewsDigest,
@@ -84,7 +83,6 @@ export async function submitMarketNewsDigestAction(
             modelId: DEFAULT_DIGEST_MODEL_ID,
             news,
             skipEnqueueIfMiss,
-            waitUntil,
         });
     } catch (error) {
         console.error('[submitMarketNewsDigestAction]', error);

--- a/src/entities/news-article/__tests__/submitNewsAnalysisAction.test.ts
+++ b/src/entities/news-article/__tests__/submitNewsAnalysisAction.test.ts
@@ -1,7 +1,4 @@
 import type { MockedFunction, MockedClass, Mock } from 'vitest';
-vi.mock('@vercel/functions', () => ({
-    waitUntil: vi.fn(),
-}));
 
 vi.mock('next/headers', () => ({
     headers: vi.fn(() => Promise.resolve(new Headers())),

--- a/src/entities/news-article/actions/submitNewsAnalysisAction.ts
+++ b/src/entities/news-article/actions/submitNewsAnalysisAction.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { waitUntil } from '@vercel/functions';
 import { headers } from 'next/headers';
 import {
     submitNewsAnalysis,
@@ -75,7 +74,6 @@ export async function submitNewsAnalysisAction(
             modelId,
             news: enrichedNews,
             upcomingCalendar: next !== null ? [next] : [],
-            waitUntil,
             tier: gate.tier,
             skipEnqueueIfMiss,
             assetClass,

--- a/src/entities/options-chain/__tests__/optionsActions.test.ts
+++ b/src/entities/options-chain/__tests__/optionsActions.test.ts
@@ -1,7 +1,4 @@
 import type { MockedFunction } from 'vitest';
-vi.mock('@vercel/functions', () => ({
-    waitUntil: vi.fn(),
-}));
 
 vi.mock('next/headers', () => ({
     headers: vi.fn(() => Promise.resolve(new Headers())),

--- a/src/entities/options-chain/actions/optionsActions.ts
+++ b/src/entities/options-chain/actions/optionsActions.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { waitUntil } from '@vercel/functions';
 import { headers, cookies } from 'next/headers';
 import {
     submitOptionsAnalysis,
@@ -80,7 +79,6 @@ export async function submitOptionsAnalysisAction(
             expirationDate,
             modelId,
             snapshot,
-            waitUntil,
             tier: gate.tier,
             skipEnqueueIfMiss,
             ...(gate.userApiKey !== undefined

--- a/src/entities/ticker/__tests__/actions/searchTickerAction.test.ts
+++ b/src/entities/ticker/__tests__/actions/searchTickerAction.test.ts
@@ -3,10 +3,6 @@ import { searchTickerAction } from '../../actions/searchTickerAction';
 import { searchTicker } from '../../lib/searchTicker';
 import type { TickerSearchResult } from '@/shared/lib/types';
 
-vi.mock('@vercel/functions', () => ({
-    waitUntil: vi.fn(),
-}));
-
 vi.mock('../../lib/searchTicker', () => ({
     searchTicker: vi.fn(),
 }));
@@ -38,9 +34,7 @@ describe('searchTickerAction 함수는', () => {
 
         await searchTickerAction('  apple  ');
 
-        expect(mockSearchTicker).toHaveBeenCalledWith('apple', {
-            waitUntil: expect.any(Function),
-        });
+        expect(mockSearchTicker).toHaveBeenCalledWith('apple');
     });
 
     it('underlying 함수의 결과를 그대로 반환한다', async () => {

--- a/src/entities/ticker/__tests__/lib/backgroundTask.test.ts
+++ b/src/entities/ticker/__tests__/lib/backgroundTask.test.ts
@@ -20,4 +20,11 @@ describe('fireAndForget', () => {
             expect.any(Error)
         );
     });
+
+    it('options가 없고 promise가 resolve되면 console.error를 호출하지 않는다', async () => {
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        fireAndForget(Promise.resolve());
+        await new Promise(r => setTimeout(r, 0));
+        expect(errSpy).not.toHaveBeenCalled();
+    });
 });

--- a/src/entities/ticker/__tests__/lib/backgroundTask.test.ts
+++ b/src/entities/ticker/__tests__/lib/backgroundTask.test.ts
@@ -11,16 +11,13 @@ describe('fireAndForget', () => {
         expect(waitUntil).toHaveBeenCalledWith(p);
     });
 
-    it('options가 없으면 waitUntil을 호출하지 않고 throw하지 않는다', () => {
-        const waitUntil = vi.fn();
-        fireAndForget(Promise.resolve());
-        expect(waitUntil).not.toHaveBeenCalled();
-    });
-
     it('options가 없고 promise가 reject되면 console.error로 로깅하고 unhandledRejection을 막는다', async () => {
         const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
         fireAndForget(Promise.reject(new Error('boom')));
         await new Promise(r => setTimeout(r, 0));
-        expect(errSpy).toHaveBeenCalled();
+        expect(errSpy).toHaveBeenCalledWith(
+            '[fireAndForget] background task error:',
+            expect.any(Error)
+        );
     });
 });

--- a/src/entities/ticker/__tests__/lib/backgroundTask.test.ts
+++ b/src/entities/ticker/__tests__/lib/backgroundTask.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fireAndForget } from '../../lib/backgroundTask';
+
+describe('fireAndForget', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it('options.waitUntil이 제공되면 해당 훅에 promise를 위임한다', () => {
+        const waitUntil = vi.fn();
+        const p = Promise.resolve();
+        fireAndForget(p, { waitUntil });
+        expect(waitUntil).toHaveBeenCalledWith(p);
+    });
+
+    it('options가 없으면 waitUntil을 호출하지 않고 throw하지 않는다', () => {
+        const waitUntil = vi.fn();
+        fireAndForget(Promise.resolve());
+        expect(waitUntil).not.toHaveBeenCalled();
+    });
+
+    it('options가 없고 promise가 reject되면 console.error로 로깅하고 unhandledRejection을 막는다', async () => {
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        fireAndForget(Promise.reject(new Error('boom')));
+        await new Promise(r => setTimeout(r, 0));
+        expect(errSpy).toHaveBeenCalled();
+    });
+});

--- a/src/entities/ticker/actions/searchTickerAction.ts
+++ b/src/entities/ticker/actions/searchTickerAction.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { waitUntil } from '@vercel/functions';
 import { searchTicker } from '../lib/searchTicker';
 import { isE2E } from '@/shared/api/e2eEnv';
 import type { TickerSearchResult } from '@/shared/lib/types';
@@ -75,5 +74,5 @@ export async function searchTickerAction(
         return matches.length > 0 ? matches : [...E2E_TICKER_FIXTURE];
     }
 
-    return searchTicker(trimmed, { waitUntil });
+    return searchTicker(trimmed);
 }

--- a/src/entities/ticker/lib/backgroundTask.ts
+++ b/src/entities/ticker/lib/backgroundTask.ts
@@ -21,11 +21,16 @@ export interface AssetInfoMatch {
 }
 
 /**
- * Fire a background promise without awaiting it. If the caller supplies a
- * runtime `waitUntil` hook (e.g. a future AWS graceful-drain adapter), the
- * promise is handed off there so the runtime can track it. Otherwise the
- * promise floats with a no-op catch-net — errors are swallowed because the
- * caller-side `.catch(console.warn)` already handles logging before this point.
+ * 백그라운드 promise를 await 없이 실행한다.
+ *
+ * - `options.waitUntil`이 제공된 경우: 런타임 훅(예: AWS graceful-drain 어댑터)에
+ *   promise를 위임해 런타임이 종료 전 완료를 추적할 수 있도록 한다.
+ * - `options.waitUntil`이 없는 경우: promise를 떠 있는 채로 두되,
+ *   거부(rejection)는 `console.error`로 로깅해 unhandledRejection을 방지한다.
+ *
+ * @요구사항 호출자는 컨텍스트에 맞는 로깅을 위해 promise를 넘기기 전에
+ * 자체 `.catch()`를 붙여야 한다(SHOULD). 이 함수의 catch-net은 호출자가
+ * `.catch()`를 빠뜨렸을 때의 최후 안전망이다.
  */
 export function fireAndForget(
     promise: Promise<unknown>,
@@ -35,5 +40,7 @@ export function fireAndForget(
         options.waitUntil(promise);
         return;
     }
-    void promise.catch(() => {});
+    void promise.catch(err => {
+        console.error('[fireAndForget] background task error:', err);
+    });
 }

--- a/src/entities/ticker/lib/backgroundTask.ts
+++ b/src/entities/ticker/lib/backgroundTask.ts
@@ -3,9 +3,11 @@ import type { WaitUntil } from '@y0ngha/siglens-core';
 /** Runtime hooks for background tasks started by the ticker use-cases. */
 export interface BackgroundTaskOptions {
     /**
-     * Optional serverless lifetime extender for fire-and-forget work. On
-     * Vercel, pass `waitUntil` from `@vercel/functions` so cache writes and
-     * translation jobs can continue after the response is returned.
+     * Optional graceful-drain hook injected by the runtime. A future AWS
+     * integration may supply a `waitUntil` implementation here so the runtime
+     * can keep the process alive until background work (cache writes, translation
+     * jobs) completes before shutdown. When absent, `fireAndForget` owns the
+     * floating promise with a no-op catch-net.
      */
     waitUntil?: WaitUntil;
 }
@@ -18,10 +20,20 @@ export interface AssetInfoMatch {
     exchangeFullName: string;
 }
 
-/** Register a background promise with the runtime when a waitUntil hook exists. */
+/**
+ * Fire a background promise without awaiting it. If the caller supplies a
+ * runtime `waitUntil` hook (e.g. a future AWS graceful-drain adapter), the
+ * promise is handed off there so the runtime can track it. Otherwise the
+ * promise floats with a no-op catch-net — errors are swallowed because the
+ * caller-side `.catch(console.warn)` already handles logging before this point.
+ */
 export function fireAndForget(
     promise: Promise<unknown>,
     options?: BackgroundTaskOptions
 ): void {
-    options?.waitUntil?.(promise);
+    if (options?.waitUntil) {
+        options.waitUntil(promise);
+        return;
+    }
+    void promise.catch(() => {});
 }

--- a/src/entities/ticker/lib/backgroundTask.ts
+++ b/src/entities/ticker/lib/backgroundTask.ts
@@ -7,7 +7,8 @@ export interface BackgroundTaskOptions {
      * integration may supply a `waitUntil` implementation here so the runtime
      * can keep the process alive until background work (cache writes, translation
      * jobs) completes before shutdown. When absent, `fireAndForget` owns the
-     * floating promise with a no-op catch-net.
+     * floating promise with a `console.error` logging catch-net to prevent
+     * unhandled rejection crashes.
      */
     waitUntil?: WaitUntil;
 }

--- a/src/entities/ticker/lib/getAssetInfo.ts
+++ b/src/entities/ticker/lib/getAssetInfo.ts
@@ -1,4 +1,3 @@
-import { waitUntil } from '@vercel/functions';
 import { isAdmissibleSymbolShape } from '@/shared/config/ticker';
 import { DrizzleAssetTranslationRepository } from '../api';
 import { getCryptoAsset } from './cryptoAssetStore';
@@ -18,6 +17,7 @@ import { filterUsExchanges, searchBySymbol } from './fmpTickerApi';
 import { translateCompanyNames } from './koreanTranslator';
 import { getKoreanNames, setKoreanTickers } from './koreanNameStore';
 import type { AssetInfoMatch } from './backgroundTask';
+import { fireAndForget } from './backgroundTask';
 import { createSingleFlight } from './utils/singleFlight';
 import { createCacheProvider, type CacheProvider } from '@y0ngha/siglens-core';
 import type { AssetInfo, KoreanTickerEntry } from '@/shared/lib/types';
@@ -259,7 +259,7 @@ export async function getAssetInfo(symbol: string): Promise<AssetInfo | null> {
     };
 
     if (koreanName) {
-        waitUntil(
+        fireAndForget(
             persistTranslation(upper, fmpSymbol, name, koreanName, cache).catch(
                 e => console.warn('[getAssetInfo] persist failed', e)
             )
@@ -267,7 +267,7 @@ export async function getAssetInfo(symbol: string): Promise<AssetInfo | null> {
         return info;
     }
 
-    waitUntil(
+    fireAndForget(
         translateAndPersist(
             upper,
             { symbol: fmpSymbol, name, exchange, exchangeFullName },

--- a/src/shared/db/isNeonTransientError.ts
+++ b/src/shared/db/isNeonTransientError.ts
@@ -128,8 +128,7 @@ export function isNeonTransientError(error: unknown): boolean {
  * `fn()` itself runs slow and the elapsed time approaches 5s, withRetry
  * bails out rather than queueing more sleeps. Maximum sleep cap is ~2.8s
  * (200+400+800 + up to 1× jitter), so this budget covers the worst case
- * comfortably while leaving headroom inside Vercel serverless 10s function
- * limits.
+ * comfortably on a long-lived server (suitable for any runtime).
  *
  * Import this constant from every `*Repository.upsert*` site so the retry
  * behavior stays uniform across repositories.

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-    "git": {
-        "deploymentEnabled": {
-            "master": false
-        }
-    },
-    "ignoreCommand": "git log -1 --pretty=%B | grep -q '^chore: release' && exit 1 || exit 0"
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3596,60 +3596,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/analytics@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@vercel/analytics@npm:2.0.1"
-  peerDependencies:
-    "@remix-run/react": ^2
-    "@sveltejs/kit": ^1 || ^2
-    next: ">= 13"
-    nuxt: ">= 3"
-    react: ^18 || ^19 || ^19.0.0-rc
-    svelte: ">= 4"
-    vue: ^3
-    vue-router: ^4
-  peerDependenciesMeta:
-    "@remix-run/react":
-      optional: true
-    "@sveltejs/kit":
-      optional: true
-    next:
-      optional: true
-    nuxt:
-      optional: true
-    react:
-      optional: true
-    svelte:
-      optional: true
-    vue:
-      optional: true
-    vue-router:
-      optional: true
-  checksum: 10c0/c788c03d0f072f6f2be52d3f6f4f0680d2343f0d8765a759a044204223b14a6e14b285d0c5d5d05c0b66d4419746c5b245656ebdc48398328d85d96f1ede982b
-  languageName: node
-  linkType: hard
-
-"@vercel/functions@npm:^3.4.3":
-  version: 3.6.0
-  resolution: "@vercel/functions@npm:3.6.0"
-  dependencies:
-    "@vercel/oidc": "npm:3.4.1"
-  peerDependencies:
-    "@aws-sdk/credential-provider-web-identity": "*"
-  peerDependenciesMeta:
-    "@aws-sdk/credential-provider-web-identity":
-      optional: true
-  checksum: 10c0/a2383cd0498b1f65303a97932eb01344efd6f0f67bec6e47d4afd3f7284fd0541272676d6f28056d4d751723da552dbedce80583c4e3117101892f7b89ae2073
-  languageName: node
-  linkType: hard
-
-"@vercel/oidc@npm:3.4.1":
-  version: 3.4.1
-  resolution: "@vercel/oidc@npm:3.4.1"
-  checksum: 10c0/088a24ef846a2f2194e733ae47df451e3e4f97f4d930dda5bc3da3066f38cd4fe7ad335ba7f5268d4123f71a4e585fca0ce6dce90c34e85239f70346d100395c
-  languageName: node
-  linkType: hard
-
 "@vitest/coverage-v8@npm:^4.1.7":
   version: 4.1.7
   resolution: "@vitest/coverage-v8@npm:4.1.7"
@@ -11169,8 +11115,6 @@ __metadata:
     "@types/react": "npm:^19"
     "@types/react-dom": "npm:^19"
     "@upstash/redis": "npm:^1.37.0"
-    "@vercel/analytics": "npm:^2.0.1"
-    "@vercel/functions": "npm:^3.4.3"
     "@vitest/coverage-v8": "npm:^4.1.7"
     "@y0ngha/siglens-core": "npm:0.27.0"
     babel-plugin-react-compiler: "npm:^1.0.0"


### PR DESCRIPTION
## What
Pure refactoring — removes Vercel runtime dependencies after the AWS migration.

- `fireAndForget` (backgroundTask.ts) now owns the floating promise (`void promise.catch(()=>{})`) when no `waitUntil` hook is injected. On a long-lived Node server (AWS) the floating promise completes on the event loop, so background work (translation persist, AI job poll, asset-info cache) still runs. The `WaitUntil`/`BackgroundTaskOptions` type seam stays for a future graceful-drain hook.
- 11 actions stop importing/passing `@vercel/functions` waitUntil (core's WaitUntil option is optional).
- Removed `@vercel/analytics` from layout, deleted `vercel.json`, dropped both `@vercel/*` deps.
- ~16 test files drop the `@vercel/functions` mock.

## Behavior
No behavior change on AWS — Vercel's `waitUntil` only mattered on serverless (sandbox freeze). Confirmed via full test + build.

## Note on test changes
Per the refactor's "test assertions unchanged" rule, the ONE exception is the `@vercel/functions` mock removal: where a test asserted `waitUntil` was called, the assertion was converted to the equivalent (drop the waitUntil arg from `toHaveBeenCalledWith`). This is necessary because the mocked module is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)