### PR TITLE
refactor(arch): exclude server-only repositories from client-reachable barrels (P0)

### DIFF
--- a/e2e/setup/seed.ts
+++ b/e2e/setup/seed.ts
@@ -1,5 +1,5 @@
 import { like } from 'drizzle-orm';
-import { bcryptPasswordHasher } from '@/entities/session';
+import { bcryptPasswordHasher } from '@/entities/session/lib/bcrypt';
 import { economicCalendarId } from '@/entities/economy/lib/economicCalendarId';
 import { addEtDays, etDateOf } from '@/entities/economy/lib/calendarWindow';
 import { getDatabaseClient } from '@/shared/db/client';

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -212,6 +212,10 @@ const eslintConfig = defineConfig([
             // widgets 간 cross-import: hook에 server-side 의존이 있어 barrel re-export 시
             // Jest ESM 해석 실패. deep path 허용으로 우회 (Phase 7).
             'src/widgets/**',
+            // byokGate는 import 'server-only' 선언 + CLAUDE.md §의도적 예외에서 허용된
+            // shared → entities 의존성을 가진다. barrel에서 제외된 api-key/api deep import
+            // 가 필요하므로 no-restricted-imports 예외로 추가한다.
+            'src/shared/lib/byokGate.ts',
         ],
         rules: {
             'no-restricted-imports': [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -212,8 +212,8 @@ const eslintConfig = defineConfig([
             // widgets 간 cross-import: hook에 server-side 의존이 있어 barrel re-export 시
             // Jest ESM 해석 실패. deep path 허용으로 우회 (Phase 7).
             'src/widgets/**',
-            // byokGate는 import 'server-only' 선언 + CLAUDE.md §의도적 예외에서 허용된
-            // shared → entities 의존성을 가진다. barrel에서 제외된 api-key/api deep import
+            // byokGate는 import 'server-only' 선언 + src/shared/CLAUDE.md §의도적 예외 (shared → entities)에서
+            // 허용된 shared → entities 의존성을 가진다. barrel에서 제외된 api-key/api deep import
             // 가 필요하므로 no-restricted-imports 예외로 추가한다.
             'src/shared/lib/byokGate.ts',
         ],

--- a/src/__tests__/worst-case/authHintCookieFailure.test.ts
+++ b/src/__tests__/worst-case/authHintCookieFailure.test.ts
@@ -9,8 +9,6 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('@/entities/session', () => ({
-    DrizzleSessionRepository: vi.fn(),
-    bcryptPasswordVerifier: { verifyPassword: vi.fn() },
     applyAuthCookie: vi.fn((cookie: unknown) => cookie),
     isSecureCookieEnv: vi.fn(() => false),
     createAuthHintCookie: vi.fn(() => ({
@@ -18,6 +16,12 @@ vi.mock('@/entities/session', () => ({
         value: '1',
     })),
     DEFAULT_SESSION_TTL_SECONDS: 604800,
+}));
+vi.mock('@/entities/session/api', () => ({
+    DrizzleSessionRepository: vi.fn(),
+}));
+vi.mock('@/entities/session/lib/bcrypt', () => ({
+    bcryptPasswordVerifier: { verifyPassword: vi.fn() },
 }));
 // getAuthDatabaseClient는 barrel이 아닌 @/entities/session/lib/db에서 직접 import되므로
 // (server-only 체인을 client 번들에서 분리) 해당 경로를 별도로 mock한다.

--- a/src/app/[symbol]/news/__tests__/page.body.test.tsx
+++ b/src/app/[symbol]/news/__tests__/page.body.test.tsx
@@ -39,8 +39,10 @@ vi.mock('@/app/[symbol]/news/newsData', () => ({
 }));
 
 vi.mock('@/entities/news-article', () => ({
-    getNewsList: vi.fn().mockResolvedValue([]),
     NEWS_LIST_CACHE_KEY: 'news-list',
+}));
+vi.mock('@/entities/news-article/api', () => ({
+    getNewsList: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('@/widgets/news/NewsAiSummary', () => ({

--- a/src/app/[symbol]/news/page.tsx
+++ b/src/app/[symbol]/news/page.tsx
@@ -2,7 +2,8 @@ import {
     getEarningsReportComparison,
     getGradeEvents,
 } from '@/app/[symbol]/news/newsData';
-import { getNewsList, NEWS_LIST_CACHE_KEY } from '@/entities/news-article';
+import { getNewsList } from '@/entities/news-article/api';
+import { NEWS_LIST_CACHE_KEY } from '@/entities/news-article';
 import { NewsAiSummary } from '@/widgets/news/NewsAiSummary';
 import { NewsAiSummaryErrorBoundary } from '@/widgets/news/NewsAiSummaryErrorBoundary';
 import { NewsAiSummarySkeleton } from '@/widgets/news/NewsAiSummarySkeleton';

--- a/src/app/[symbol]/overall/__tests__/page.body.test.tsx
+++ b/src/app/[symbol]/overall/__tests__/page.body.test.tsx
@@ -33,8 +33,10 @@ vi.mock('@/shared/cache/staticSymbolCache', () => ({
 }));
 
 vi.mock('@/entities/news-article', () => ({
-    getNewsList: vi.fn().mockResolvedValue([]),
     NEWS_LIST_CACHE_KEY: 'news-list',
+}));
+vi.mock('@/entities/news-article/api', () => ({
+    getNewsList: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('@/widgets/overall/OverallContent', () => ({

--- a/src/app/[symbol]/overall/__tests__/page.test.ts
+++ b/src/app/[symbol]/overall/__tests__/page.test.ts
@@ -49,7 +49,7 @@ vi.mock('next/navigation', () => ({
     notFound: vi.fn(),
 }));
 // /news와 동일 게이트(useWaitForNewsCards) 적용을 위해 newsItems를 SSR에서 조회한다.
-// getNewsList は barrel 除外対象 — @/entities/news-article/api から deep import する.
+// getNewsList는 barrel 제외 대상이므로 @/entities/news-article/api에서 직접 import한다.
 vi.mock('@/entities/news-article/api', () => ({
     getNewsList: vi.fn().mockResolvedValue([]),
 }));

--- a/src/app/[symbol]/overall/__tests__/page.test.ts
+++ b/src/app/[symbol]/overall/__tests__/page.test.ts
@@ -49,9 +49,8 @@ vi.mock('next/navigation', () => ({
     notFound: vi.fn(),
 }));
 // /news와 동일 게이트(useWaitForNewsCards) 적용을 위해 newsItems를 SSR에서 조회한다.
-// getNewsList는 entities/news-article로 이동 — barrel mock.
-vi.mock('@/entities/news-article', async importOriginal => ({
-    ...(await importOriginal<typeof import('@/entities/news-article')>()),
+// getNewsList は barrel 除外対象 — @/entities/news-article/api から deep import する.
+vi.mock('@/entities/news-article/api', () => ({
     getNewsList: vi.fn().mockResolvedValue([]),
 }));
 
@@ -203,7 +202,7 @@ describe('Overall page (narrative seed)', () => {
 
     it('모든 row가 미분석(sentiment=null)이면 hasEnrichedNews=false 전달', async () => {
         mockPeekOverall.mockResolvedValue(null);
-        const { getNewsList } = await import('@/entities/news-article');
+        const { getNewsList } = await import('@/entities/news-article/api');
         (
             getNewsList as MockedFunction<typeof getNewsList>
         ).mockResolvedValueOnce([
@@ -216,7 +215,7 @@ describe('Overall page (narrative seed)', () => {
 
     it('hasEnrichedNews=true: enriched row(sentiment!==null)가 1개라도 있으면 true 전달 (게이트 즉시 통과)', async () => {
         mockPeekOverall.mockResolvedValue(null);
-        const { getNewsList } = await import('@/entities/news-article');
+        const { getNewsList } = await import('@/entities/news-article/api');
         (
             getNewsList as MockedFunction<typeof getNewsList>
         ).mockResolvedValueOnce([
@@ -230,7 +229,7 @@ describe('Overall page (narrative seed)', () => {
 
     it('getNewsList가 throw해도 ISR-safe하게 hasEnrichedNews=false로 degrade한다', async () => {
         mockPeekOverall.mockResolvedValue(null);
-        const { getNewsList } = await import('@/entities/news-article');
+        const { getNewsList } = await import('@/entities/news-article/api');
         (
             getNewsList as MockedFunction<typeof getNewsList>
         ).mockRejectedValueOnce(new Error('db down'));

--- a/src/app/[symbol]/overall/page.tsx
+++ b/src/app/[symbol]/overall/page.tsx
@@ -14,7 +14,8 @@ import {
     buildDisplayName,
     getAssetInfoResilient,
 } from '@/entities/ticker';
-import { getNewsList, NEWS_LIST_CACHE_KEY } from '@/entities/news-article';
+import { getNewsList } from '@/entities/news-article/api';
+import { NEWS_LIST_CACHE_KEY } from '@/entities/news-article';
 import {
     buildBreadcrumbJsonLd,
     buildSymbolSeoContent,

--- a/src/app/api/auth/callback/[provider]/route.ts
+++ b/src/app/api/auth/callback/[provider]/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import {
-    DrizzleSessionRepository,
     applyAuthCookie,
     createAuthHintCookie,
     createAuthSession,
     DEFAULT_SESSION_TTL_SECONDS,
     isSecureCookieEnv,
 } from '@/entities/session';
+import { DrizzleSessionRepository } from '@/entities/session/api';
 import { getAuthDatabaseClient } from '@/entities/session/lib/db';
 import { DrizzleUserRepository } from '@/entities/user';
 import { createPendingOAuthSignupStoreFromEnv } from '@/entities/oauth-account';

--- a/src/app/api/auth/callback/__tests__/route.test.ts
+++ b/src/app/api/auth/callback/__tests__/route.test.ts
@@ -3,12 +3,14 @@ vi.mock('@/entities/user', () => ({
     DrizzleUserRepository: vi.fn(),
 }));
 vi.mock('@/entities/session', () => ({
-    DrizzleSessionRepository: vi.fn(),
     applyAuthCookie: vi.fn().mockReturnValue({ name: 'auth', value: 'v' }),
     createAuthHintCookie: vi.fn().mockReturnValue({ name: 'hint', value: '1' }),
     createAuthSession: vi.fn(),
     DEFAULT_SESSION_TTL_SECONDS: 86400,
     isSecureCookieEnv: vi.fn().mockReturnValue(false),
+}));
+vi.mock('@/entities/session/api', () => ({
+    DrizzleSessionRepository: vi.fn(),
 }));
 // getAuthDatabaseClient는 barrel이 아닌 @/entities/session/lib/db에서 직접 import되므로
 // (server-only 체인을 client 번들에서 분리) 해당 경로를 별도로 mock한다.
@@ -38,10 +40,8 @@ vi.mock('@/shared/lib/auth/redirect', () => ({
 import { NextRequest } from 'next/server';
 import { GET } from '@/app/api/auth/callback/[provider]/route';
 import { DrizzleUserRepository } from '@/entities/user';
-import {
-    DrizzleSessionRepository,
-    createAuthSession,
-} from '@/entities/session';
+import { createAuthSession } from '@/entities/session';
+import { DrizzleSessionRepository } from '@/entities/session/api';
 import { createPendingOAuthSignupStoreFromEnv } from '@/entities/oauth-account';
 import {
     getOAuthAdapter,

--- a/src/app/api/auth/callback/__tests__/routeBranches.test.ts
+++ b/src/app/api/auth/callback/__tests__/routeBranches.test.ts
@@ -14,12 +14,14 @@ vi.mock('@/entities/user', () => ({
     DrizzleUserRepository: vi.fn(),
 }));
 vi.mock('@/entities/session', () => ({
-    DrizzleSessionRepository: vi.fn(),
     applyAuthCookie: vi.fn().mockReturnValue({ name: 'auth', value: 'v' }),
     createAuthHintCookie: vi.fn().mockReturnValue({ name: 'hint', value: '1' }),
     createAuthSession: vi.fn(),
     DEFAULT_SESSION_TTL_SECONDS: 86400,
     isSecureCookieEnv: vi.fn().mockReturnValue(false),
+}));
+vi.mock('@/entities/session/api', () => ({
+    DrizzleSessionRepository: vi.fn(),
 }));
 // getAuthDatabaseClient는 barrel이 아닌 @/entities/session/lib/db에서 직접 import되므로
 // (server-only 체인을 client 번들에서 분리) 해당 경로를 별도로 mock한다.
@@ -60,7 +62,7 @@ vi.mock('@/shared/lib/auth/redirect', () => ({
 import { NextRequest } from 'next/server';
 import { GET } from '@/app/api/auth/callback/[provider]/route';
 import { DrizzleUserRepository } from '@/entities/user';
-import { DrizzleSessionRepository } from '@/entities/session';
+import { DrizzleSessionRepository } from '@/entities/session/api';
 import { createPendingOAuthSignupStoreFromEnv } from '@/entities/oauth-account';
 import {
     getOAuthAdapter,

--- a/src/entities/CLAUDE.md
+++ b/src/entities/CLAUDE.md
@@ -64,7 +64,10 @@ export async function myAction() { ... }
 | 슬라이스 | 제외 export | 사유 |
 |---|---|---|
 | `options-chain` | `hasOptionsMarket`, `fetchOptionsSnapshot`, `optionsDataCache` 관련 | `yahoo-finance2` → `@deno/shim-deno`가 `child_process`, `dns` 등 Node.js 전용 모듈 요구 |
-| `session` | `getCurrentUser` | `next/headers` 의존 |
+| `session` | `DrizzleSessionRepository`, `getCurrentUser`, `bcryptPasswordHasher`, `bcryptPasswordVerifier` | `api.ts` → `schema.ts` (`server-only`) / `next/headers` 의존 / bcrypt는 Node.js 전용 |
+| `api-key` | `DrizzleUserApiKeyRepository`, `LlmApiKeyDecryptionFailedError` | `api.ts`가 drizzle/encryption import — `server-only` 보호 대상 |
+| `inquiry` | `DrizzleContactRepository` | `api.ts`가 drizzle/schema import — `server-only` 보호 대상 |
+| `news-article` | `DrizzleNewsRepository`, `getNewsList` | `api.ts`가 drizzle/DB client import, `import 'server-only'` 선언 |
 
 ## 슬라이스 구조
 

--- a/src/entities/analysis/__tests__/submitOverallAnalysisAction.test.ts
+++ b/src/entities/analysis/__tests__/submitOverallAnalysisAction.test.ts
@@ -36,8 +36,8 @@ vi.mock('@/shared/db/client', () => ({
     getDatabaseClient: vi.fn().mockReturnValue({ db: {} }),
 }));
 
-vi.mock('@/entities/news-article', async () => {
-    const actual = await vi.importActual('@/entities/news-article');
+vi.mock('@/entities/news-article/api', async () => {
+    const actual = await vi.importActual('@/entities/news-article/api');
     return {
         ...actual,
         DrizzleNewsRepository: vi.fn().mockImplementation(function () {
@@ -111,10 +111,8 @@ import {
     type FinancialsScorecard,
 } from '@y0ngha/siglens-core';
 import { headers } from 'next/headers';
-import {
-    DrizzleNewsRepository,
-    MAX_AGGREGATE_NEWS_ITEMS,
-} from '@/entities/news-article';
+import { DrizzleNewsRepository } from '@/entities/news-article/api';
+import { MAX_AGGREGATE_NEWS_ITEMS } from '@/entities/news-article';
 import { getNextEarningsReport } from '@/entities/earnings-report';
 import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 import { resolveTierAndByok } from '@/shared/lib/byokGate';

--- a/src/entities/analysis/actions/submitOverallAnalysisAction.ts
+++ b/src/entities/analysis/actions/submitOverallAnalysisAction.ts
@@ -20,8 +20,8 @@ import { resolveMarketProfile } from '@/entities/ticker/lib/resolveAssetClass';
 import { getDescriptor } from '@/shared/config/marketProfile';
 import { getDatabaseClient } from '@/shared/db/client';
 import { getFinancialsSnapshot } from '@/entities/financials-statements/lib/getFinancialsSnapshot';
+import { DrizzleNewsRepository } from '@/entities/news-article/api';
 import {
-    DrizzleNewsRepository,
     NEWS_ANALYSIS_LOOKBACK_MS,
     buildAnalysisNewsItems,
 } from '@/entities/news-article';

--- a/src/entities/api-key/__tests__/actions/deleteApiKeyAction.test.ts
+++ b/src/entities/api-key/__tests__/actions/deleteApiKeyAction.test.ts
@@ -17,7 +17,7 @@ vi.mock('next/navigation', () => ({
         throw new Error(`NEXT_REDIRECT:${path}`);
     }),
 }));
-vi.mock('@/entities/api-key', () => ({
+vi.mock('@/entities/api-key/api', () => ({
     DrizzleUserApiKeyRepository: vi.fn().mockImplementation(function () {
         return {
             deleteByUserAndProvider: mockDeleteByUserAndProvider,

--- a/src/entities/api-key/__tests__/actions/getRegisteredProvidersAction.test.ts
+++ b/src/entities/api-key/__tests__/actions/getRegisteredProvidersAction.test.ts
@@ -7,7 +7,7 @@ vi.mock('@/entities/session/lib/getCurrentUser', () => ({
 vi.mock('@/shared/db/client', () => ({
     getDatabaseClient: vi.fn(() => ({ db: {}, sql: () => null })),
 }));
-vi.mock('@/entities/api-key', () => ({
+vi.mock('@/entities/api-key/api', () => ({
     DrizzleUserApiKeyRepository: vi.fn().mockImplementation(function () {
         return {
             findByUser: mockFindByUser,

--- a/src/entities/api-key/__tests__/actions/saveApiKeyAction.test.ts
+++ b/src/entities/api-key/__tests__/actions/saveApiKeyAction.test.ts
@@ -15,7 +15,7 @@ vi.mock('next/navigation', () => ({
         throw new Error(`NEXT_REDIRECT:${path}`);
     }),
 }));
-vi.mock('@/entities/api-key', () => ({
+vi.mock('@/entities/api-key/api', () => ({
     DrizzleUserApiKeyRepository: vi.fn().mockImplementation(function () {
         return {
             upsert: mockUpsert,

--- a/src/entities/api-key/__tests__/api.test.ts
+++ b/src/entities/api-key/__tests__/api.test.ts
@@ -9,7 +9,7 @@ import { encryptToken } from '@/shared/db/tokenEncryption';
 import {
     DrizzleUserApiKeyRepository,
     LlmApiKeyDecryptionFailedError,
-} from '@/entities/api-key';
+} from '@/entities/api-key/api';
 import type { SiglensDatabase } from '@/shared/db/types';
 
 const VALID_KEY_HEX = 'b'.repeat(64);

--- a/src/entities/api-key/actions/deleteApiKeyAction.ts
+++ b/src/entities/api-key/actions/deleteApiKeyAction.ts
@@ -2,7 +2,7 @@
 
 import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 import { getDatabaseClient } from '@/shared/db/client';
-import { DrizzleUserApiKeyRepository } from '@/entities/api-key';
+import { DrizzleUserApiKeyRepository } from '@/entities/api-key/api';
 import { isLlmProvider } from '../lib/apiKey';
 import type { ApiKeyActionState } from '../lib/types';
 import { revalidatePath } from 'next/cache';

--- a/src/entities/api-key/actions/getRegisteredProvidersAction.ts
+++ b/src/entities/api-key/actions/getRegisteredProvidersAction.ts
@@ -2,7 +2,7 @@
 
 import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 import { getDatabaseClient } from '@/shared/db/client';
-import { DrizzleUserApiKeyRepository } from '@/entities/api-key';
+import { DrizzleUserApiKeyRepository } from '@/entities/api-key/api';
 import type { RegisteredProvider } from '../lib/types';
 
 export async function getRegisteredProvidersAction(): Promise<

--- a/src/entities/api-key/actions/saveApiKeyAction.ts
+++ b/src/entities/api-key/actions/saveApiKeyAction.ts
@@ -2,7 +2,7 @@
 
 import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 import { getDatabaseClient } from '@/shared/db/client';
-import { DrizzleUserApiKeyRepository } from '@/entities/api-key';
+import { DrizzleUserApiKeyRepository } from '@/entities/api-key/api';
 import { isLlmProvider, normalizeLlmApiKey } from '../lib/apiKey';
 import type { ApiKeyActionErrorCode, ApiKeyActionState } from '../lib/types';
 import { revalidatePath } from 'next/cache';

--- a/src/entities/api-key/index.ts
+++ b/src/entities/api-key/index.ts
@@ -1,6 +1,6 @@
-// DrizzleUserApiKeyRepository と LlmApiKeyDecryptionFailedError は barrel から除外 —
-// api.ts が drizzle/encryption を import するため client bundle に入ると build が壊れる。
-// server consumer は @/entities/api-key/api から直接 deep import する。
+// DrizzleUserApiKeyRepository와 LlmApiKeyDecryptionFailedError는 barrel에서 제외 —
+// api.ts가 drizzle/encryption을 import하므로 client bundle에 포함되면 build가 깨진다.
+// server 소비자는 @/entities/api-key/api에서 직접 import한다.
 
 export { isLlmProvider, normalizeLlmApiKey } from './lib/apiKey';
 export {

--- a/src/entities/api-key/index.ts
+++ b/src/entities/api-key/index.ts
@@ -1,7 +1,6 @@
-export {
-    DrizzleUserApiKeyRepository,
-    LlmApiKeyDecryptionFailedError,
-} from './api';
+// DrizzleUserApiKeyRepository と LlmApiKeyDecryptionFailedError は barrel から除外 —
+// api.ts が drizzle/encryption を import するため client bundle に入ると build が壊れる。
+// server consumer は @/entities/api-key/api から直接 deep import する。
 
 export { isLlmProvider, normalizeLlmApiKey } from './lib/apiKey';
 export {

--- a/src/entities/chat-message/__tests__/chatAction.test.ts
+++ b/src/entities/chat-message/__tests__/chatAction.test.ts
@@ -3,7 +3,7 @@ import { callAiProviderRouter } from '@/entities/llm-provider';
 import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 import { chatAction } from '../actions/chatAction';
 import { getDatabaseClient } from '@/shared/db/client';
-import { DrizzleUserApiKeyRepository } from '@/entities/api-key';
+import { DrizzleUserApiKeyRepository } from '@/entities/api-key/api';
 import type {
     AnalysisResponse,
     ChatActionResult,
@@ -55,7 +55,7 @@ vi.mock('@/shared/db/client', () => ({
     getDatabaseClient: vi.fn(),
 }));
 
-vi.mock('@/entities/api-key', () => ({
+vi.mock('@/entities/api-key/api', () => ({
     DrizzleUserApiKeyRepository: vi.fn(),
 }));
 

--- a/src/entities/chat-message/actions/chatAction.ts
+++ b/src/entities/chat-message/actions/chatAction.ts
@@ -3,7 +3,7 @@
 import { getLlmProvider } from '@/entities/llm-provider';
 import { getCurrentUser } from '@/entities/session/lib/getCurrentUser';
 import { getDatabaseClient } from '@/shared/db/client';
-import { DrizzleUserApiKeyRepository } from '@/entities/api-key';
+import { DrizzleUserApiKeyRepository } from '@/entities/api-key/api';
 import { DrizzleUserRepository } from '@/entities/user';
 import { getUserTier } from '@/entities/user-tier';
 import type {

--- a/src/entities/inquiry/__tests__/api.test.ts
+++ b/src/entities/inquiry/__tests__/api.test.ts
@@ -1,10 +1,8 @@
 import type { Mock } from 'vitest';
 import { inquiries } from '@/shared/db/schema';
 import type { SiglensDatabase } from '@/shared/db/types';
-import {
-    DrizzleContactRepository,
-    type ContactInput,
-} from '@/entities/inquiry';
+import { DrizzleContactRepository } from '@/entities/inquiry/api';
+import type { ContactInput } from '@/entities/inquiry';
 
 function makeInsertDb(): {
     db: SiglensDatabase;

--- a/src/entities/inquiry/__tests__/submitContactAction.test.ts
+++ b/src/entities/inquiry/__tests__/submitContactAction.test.ts
@@ -7,7 +7,7 @@ const { mockSubmitInquiry, mockCreate } = vi.hoisted(() => ({
 vi.mock('@/shared/db/client', () => ({
     getDatabaseClient: vi.fn(() => ({ db: {}, sql: () => null })),
 }));
-vi.mock('@/entities/inquiry', () => ({
+vi.mock('@/entities/inquiry/api', () => ({
     DrizzleContactRepository: vi.fn().mockImplementation(function () {
         return {
             create: mockCreate,

--- a/src/entities/inquiry/actions/submitContactAction.ts
+++ b/src/entities/inquiry/actions/submitContactAction.ts
@@ -3,7 +3,7 @@
 import type { ContactFormState } from '@/shared/lib/types';
 import { validateContactInput } from '../lib/validation';
 import { getDatabaseClient } from '@/shared/db/client';
-import { DrizzleContactRepository } from '@/entities/inquiry';
+import { DrizzleContactRepository } from '@/entities/inquiry/api';
 import { submitInquiry } from '../lib/submitInquiry';
 
 function getVal(formData: FormData, key: string): string {

--- a/src/entities/inquiry/index.ts
+++ b/src/entities/inquiry/index.ts
@@ -1,8 +1,7 @@
-export {
-    DrizzleContactRepository,
-    type ContactInput,
-    type ContactRepository,
-} from './api';
+// DrizzleContactRepository は barrel から除外 —
+// api.ts が drizzle/schema を import するため client bundle に入ると build が壊れる。
+// server consumer は @/entities/inquiry/api から直接 deep import する。
+export type { ContactInput, ContactRepository } from './api';
 
 export {
     CONTACT_CONTENT_MAX_LENGTH,

--- a/src/entities/inquiry/index.ts
+++ b/src/entities/inquiry/index.ts
@@ -1,6 +1,5 @@
-// DrizzleContactRepository は barrel から除外 —
-// api.ts が drizzle/schema を import するため client bundle に入ると build が壊れる。
-// server consumer は @/entities/inquiry/api から直接 deep import する。
+// DrizzleContactRepository는 barrel에서 제외 — api.ts가 drizzle/schema를 import하므로
+// client bundle에 포함되면 build가 깨진다. server 소비자는 @/entities/inquiry/api에서 직접 import한다.
 export type { ContactInput, ContactRepository } from './api';
 
 export {

--- a/src/entities/news-article/__tests__/api.test.ts
+++ b/src/entities/news-article/__tests__/api.test.ts
@@ -9,7 +9,8 @@ vi.mock('@/shared/lib/sleep', () => ({
 
 import type { NewsCardAnalysis, NewsItem } from '@y0ngha/siglens-core';
 import type { SiglensDatabase } from '@/shared/db/types';
-import { DrizzleNewsRepository, type NewsRow } from '@/entities/news-article';
+import { DrizzleNewsRepository } from '@/entities/news-article/api';
+import type { NewsRow } from '@/entities/news-article';
 
 const baseItem: NewsItem = {
     id: 'abc123',

--- a/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
+++ b/src/entities/news-article/__tests__/ensureNewsCardsAnalyzedAction.test.ts
@@ -41,7 +41,7 @@ vi.mock('@/entities/ticker/lib/getAssetInfo', () => ({
     getAssetInfo: vi.fn().mockResolvedValue({ symbol: 'AAPL', name: 'Apple' }),
 }));
 
-vi.mock('@/entities/news-article', () => ({
+vi.mock('@/entities/news-article/api', () => ({
     DrizzleNewsRepository: vi.fn().mockImplementation(function () {
         return {
             upsertNewsItem: vi.fn(),
@@ -70,7 +70,7 @@ import type {
     SubmitNewsCardAnalysisResult,
     PollNewsCardAnalysisResult,
 } from '@y0ngha/siglens-core';
-import { DrizzleNewsRepository } from '@/entities/news-article';
+import { DrizzleNewsRepository } from '@/entities/news-article/api';
 import { isRecentlyFetched, markFetched } from '../lib/newsRefreshFlag';
 import { getAssetInfo } from '@/entities/ticker/lib/getAssetInfo';
 

--- a/src/entities/news-article/__tests__/getNewsCardsAction.test.ts
+++ b/src/entities/news-article/__tests__/getNewsCardsAction.test.ts
@@ -7,7 +7,7 @@ vi.mock('@/shared/db/client', () => ({
     getDatabaseClient: mockGetDatabaseClient,
 }));
 
-vi.mock('@/entities/news-article', () => ({
+vi.mock('@/entities/news-article/api', () => ({
     DrizzleNewsRepository: class {
         listBySymbol = mockListBySymbol;
     },

--- a/src/entities/news-article/__tests__/lib/getNewsList.test.ts
+++ b/src/entities/news-article/__tests__/lib/getNewsList.test.ts
@@ -20,7 +20,10 @@ vi.mock('@/shared/db/client', () => ({
     getDatabaseClient: () => ({ db: { __mock: true } }),
 }));
 
-import { DrizzleNewsRepository, getNewsList } from '@/entities/news-article';
+import {
+    DrizzleNewsRepository,
+    getNewsList,
+} from '@/entities/news-article/api';
 // 같은 슬라이스 내부 segment는 relative import (CONVENTIONS.md §FSD Slice Internal Imports).
 import { NEWS_LOOKBACK_MS } from '../../lib/newsLookback';
 

--- a/src/entities/news-article/__tests__/submitNewsAnalysisAction.test.ts
+++ b/src/entities/news-article/__tests__/submitNewsAnalysisAction.test.ts
@@ -16,7 +16,7 @@ vi.mock('@/shared/db/client', () => ({
     getDatabaseClient: vi.fn().mockReturnValue({ db: {} }),
 }));
 
-vi.mock('@/entities/news-article', () => ({
+vi.mock('@/entities/news-article/api', () => ({
     DrizzleNewsRepository: vi.fn().mockImplementation(function () {
         return {
             listBySymbol: vi.fn(),
@@ -45,7 +45,7 @@ vi.mock('@/entities/ticker/lib/resolveAssetClass', () => ({
 }));
 
 import { headers } from 'next/headers';
-import { DrizzleNewsRepository } from '@/entities/news-article';
+import { DrizzleNewsRepository } from '@/entities/news-article/api';
 import { getNextEarningsReport } from '@/entities/earnings-report';
 import {
     submitNewsAnalysis,

--- a/src/entities/news-article/actions/ensureNewsCardsAnalyzedAction.ts
+++ b/src/entities/news-article/actions/ensureNewsCardsAnalyzedAction.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { getDatabaseClient } from '@/shared/db/client';
-import { DrizzleNewsRepository } from '@/entities/news-article';
+import { DrizzleNewsRepository } from '@/entities/news-article/api';
 import { getNewsClient } from '../lib/getNewsClient';
 import {
     getFmpUserFacingMessage,

--- a/src/entities/news-article/actions/getNewsCardsAction.ts
+++ b/src/entities/news-article/actions/getNewsCardsAction.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { getDatabaseClient } from '@/shared/db/client';
-import { DrizzleNewsRepository } from '@/entities/news-article';
+import { DrizzleNewsRepository } from '@/entities/news-article/api';
 import { NEWS_LOOKBACK_MS } from '../lib/newsLookback';
 import type { NewsDisplayItem } from '@/shared/lib/types';
 

--- a/src/entities/news-article/actions/submitNewsAnalysisAction.ts
+++ b/src/entities/news-article/actions/submitNewsAnalysisAction.ts
@@ -9,7 +9,7 @@ import {
     type SubmitNewsAnalysisResult,
 } from '@y0ngha/siglens-core';
 import { getDatabaseClient } from '@/shared/db/client';
-import { DrizzleNewsRepository } from '@/entities/news-article';
+import { DrizzleNewsRepository } from '@/entities/news-article/api';
 import { NEWS_ANALYSIS_LOOKBACK_MS } from '../lib/newsLookback';
 import { buildAnalysisNewsItems } from '../lib/buildAnalysisNewsItems';
 import { getNextEarningsReport } from '@/entities/earnings-report';

--- a/src/entities/news-article/api.ts
+++ b/src/entities/news-article/api.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 import { cache } from 'react';
 import { and, desc, eq, gte, sql } from 'drizzle-orm';
 import type {

--- a/src/entities/news-article/index.ts
+++ b/src/entities/news-article/index.ts
@@ -1,4 +1,8 @@
-export { DrizzleNewsRepository, getNewsList, type NewsRow } from './api';
+// DrizzleNewsRepository と getNewsList は barrel から除外 —
+// api.ts が drizzle/DB client を import し import 'server-only' で保護されるため
+// client bundle に入ると build が壊れる。
+// server consumer は @/entities/news-article/api から直接 deep import する。
+export type { NewsRow } from './api';
 
 // lib
 export {

--- a/src/entities/news-article/index.ts
+++ b/src/entities/news-article/index.ts
@@ -1,7 +1,6 @@
-// DrizzleNewsRepository と getNewsList は barrel から除外 —
-// api.ts が drizzle/DB client を import し import 'server-only' で保護されるため
-// client bundle に入ると build が壊れる。
-// server consumer は @/entities/news-article/api から直接 deep import する。
+// DrizzleNewsRepository와 getNewsList는 barrel에서 제외 — api.ts가 drizzle/DB client를 import하고
+// 'server-only'로 보호되므로 client bundle에 포함되면 build가 깨진다.
+// server 소비자는 @/entities/news-article/api에서 직접 import한다.
 export type { NewsRow } from './api';
 
 // lib

--- a/src/entities/session/__tests__/api.test.ts
+++ b/src/entities/session/__tests__/api.test.ts
@@ -1,4 +1,4 @@
-import { DrizzleSessionRepository } from '@/entities/session';
+import { DrizzleSessionRepository } from '@/entities/session/api';
 import { sessions } from '@/shared/db/schema';
 import type { SiglensDatabase } from '@/shared/db/types';
 

--- a/src/entities/session/index.ts
+++ b/src/entities/session/index.ts
@@ -1,5 +1,8 @@
-export { DrizzleSessionRepository } from './api';
-// getCurrentUser는 barrel에서 제외 — next/headers 의존이 client 번들에 포함되는 문제 방지.
+// DrizzleSessionRepository は barrel から除外 —
+// api.ts が @/shared/db/schema (import 'server-only') を import するため
+// client component が barrel を import すると build が壊れる。
+// server consumer は @/entities/session/api から直接 deep import する。
+// getCurrentUser は barrel から除外 — next/headers 의존이 client 번들에 포함되는 문제 방지.
 // 서버 소비자는 @/entities/session/lib/getCurrentUser에서 직접 import.
 // getAuthDatabaseClient도 barrel에서 제외 — @/shared/db/client → require('./clientTest') →
 // import 'server-only' 체인이 client 번들에 유입되는 문제 방지 (useCurrentUser를 import하는
@@ -36,6 +39,8 @@ export type {
     PasswordHasher,
     PasswordVerifier,
 } from './lib/types';
-export { bcryptPasswordHasher, bcryptPasswordVerifier } from './lib/bcrypt';
+// bcryptPasswordHasher / bcryptPasswordVerifier は barrel から除外 —
+// bcrypt は Node.js ネイティブ依存のため client bundle に入ると build が壊れる。
+// server consumer は @/entities/session/lib/bcrypt から直接 deep import する。
 export { useCurrentUser } from './hooks/useCurrentUser';
 export { useAuthHint } from './hooks/useAuthHint';

--- a/src/entities/session/index.ts
+++ b/src/entities/session/index.ts
@@ -1,7 +1,6 @@
-// DrizzleSessionRepository は barrel から除外 —
-// api.ts が @/shared/db/schema (import 'server-only') を import するため
-// client component が barrel を import すると build が壊れる。
-// server consumer は @/entities/session/api から直接 deep import する。
+// DrizzleSessionRepository는 barrel에서 제외 — api.ts가 @/shared/db/schema(import 'server-only')를
+// import하므로 client component가 barrel을 import하면 build가 깨진다.
+// server 소비자는 @/entities/session/api에서 직접 deep import한다.
 // getCurrentUser は barrel から除外 — next/headers 의존이 client 번들에 포함되는 문제 방지.
 // 서버 소비자는 @/entities/session/lib/getCurrentUser에서 직접 import.
 // getAuthDatabaseClient도 barrel에서 제외 — @/shared/db/client → require('./clientTest') →
@@ -39,8 +38,8 @@ export type {
     PasswordHasher,
     PasswordVerifier,
 } from './lib/types';
-// bcryptPasswordHasher / bcryptPasswordVerifier は barrel から除外 —
-// bcrypt は Node.js ネイティブ依存のため client bundle に入ると build が壊れる。
-// server consumer は @/entities/session/lib/bcrypt から直接 deep import する。
+// bcryptPasswordHasher / bcryptPasswordVerifier는 barrel에서 제외 — bcrypt는 Node.js 네이티브
+// 의존성이 있어 client bundle에 포함되면 build가 깨진다.
+// server 소비자는 @/entities/session/lib/bcrypt에서 직접 import한다.
 export { useCurrentUser } from './hooks/useCurrentUser';
 export { useAuthHint } from './hooks/useAuthHint';

--- a/src/features/account-delete/__tests__/actions/deleteAccountAction.test.ts
+++ b/src/features/account-delete/__tests__/actions/deleteAccountAction.test.ts
@@ -16,15 +16,17 @@ vi.mock('@/entities/user', () => ({
     deleteAccount: vi.fn(),
 }));
 vi.mock('@/entities/session', () => ({
-    DrizzleSessionRepository: vi.fn().mockImplementation(function () {
-        return {};
-    }),
     applyAuthCookie: vi.fn((c: unknown) => c),
     isSecureCookieEnv: vi.fn(() => false),
     createExpiredAuthHintCookie: vi.fn(() => ({
         name: 'auth_hint',
         value: '',
     })),
+}));
+vi.mock('@/entities/session/api', () => ({
+    DrizzleSessionRepository: vi.fn().mockImplementation(function () {
+        return {};
+    }),
 }));
 // getAuthDatabaseClient는 barrel이 아닌 @/entities/session/lib/db에서 직접 import되므로
 // (server-only 체인을 client 번들에서 분리) 해당 경로를 별도로 mock한다.

--- a/src/features/auth-login/__tests__/actions/loginAction.test.ts
+++ b/src/features/auth-login/__tests__/actions/loginAction.test.ts
@@ -10,10 +10,6 @@ vi.mock('@/shared/db/client', () => ({
     resetDatabaseClientForTests: vi.fn(),
 }));
 vi.mock('@/entities/session', () => ({
-    DrizzleSessionRepository: vi.fn().mockImplementation(function () {
-        return {};
-    }),
-    bcryptPasswordVerifier: { verifyPassword: vi.fn() },
     applyAuthCookie: vi.fn((c: unknown) => c),
     isSecureCookieEnv: vi.fn(() => false),
     createAuthHintCookie: vi.fn(() => ({
@@ -21,6 +17,14 @@ vi.mock('@/entities/session', () => ({
         value: 'true',
     })),
     DEFAULT_SESSION_TTL_SECONDS: 7776000,
+}));
+vi.mock('@/entities/session/api', () => ({
+    DrizzleSessionRepository: vi.fn().mockImplementation(function () {
+        return {};
+    }),
+}));
+vi.mock('@/entities/session/lib/bcrypt', () => ({
+    bcryptPasswordVerifier: { verifyPassword: vi.fn() },
 }));
 // getAuthDatabaseClient는 barrel이 아닌 @/entities/session/lib/db에서 직접 import되므로
 // (server-only 체인을 client 번들에서 분리) 해당 경로를 별도로 mock한다.

--- a/src/features/auth-login/actions/loginAction.ts
+++ b/src/features/auth-login/actions/loginAction.ts
@@ -3,13 +3,13 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import {
-    DrizzleSessionRepository,
-    bcryptPasswordVerifier,
     applyAuthCookie,
     isSecureCookieEnv,
     createAuthHintCookie,
     DEFAULT_SESSION_TTL_SECONDS,
 } from '@/entities/session';
+import { bcryptPasswordVerifier } from '@/entities/session/lib/bcrypt';
+import { DrizzleSessionRepository } from '@/entities/session/api';
 import { getAuthDatabaseClient } from '@/entities/session/lib/db';
 import { DrizzleUserRepository, loginUser } from '@/entities/user';
 import type { LoginFormState } from '@/shared/lib/auth/formTypes';

--- a/src/features/auth-logout/__tests__/actions/logoutAction.test.ts
+++ b/src/features/auth-logout/__tests__/actions/logoutAction.test.ts
@@ -10,9 +10,6 @@ vi.mock('@/shared/db/client', () => ({
     resetDatabaseClientForTests: vi.fn(),
 }));
 vi.mock('@/entities/session', () => ({
-    DrizzleSessionRepository: vi.fn().mockImplementation(function () {
-        return {};
-    }),
     AUTH_SESSION_COOKIE_NAME: 'siglens_session',
     applyAuthCookie: vi.fn((c: unknown) => c),
     isSecureCookieEnv: vi.fn(() => false),
@@ -20,6 +17,11 @@ vi.mock('@/entities/session', () => ({
         name: 'auth_hint',
         value: '',
     })),
+}));
+vi.mock('@/entities/session/api', () => ({
+    DrizzleSessionRepository: vi.fn().mockImplementation(function () {
+        return {};
+    }),
 }));
 // getAuthDatabaseClient는 barrel이 아닌 @/entities/session/lib/db에서 직접 import되므로
 // (server-only 체인을 client 번들에서 분리) 해당 경로를 별도로 mock한다.

--- a/src/features/auth-logout/actions/logoutAction.ts
+++ b/src/features/auth-logout/actions/logoutAction.ts
@@ -3,12 +3,12 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import {
-    DrizzleSessionRepository,
     AUTH_SESSION_COOKIE_NAME,
     applyAuthCookie,
     isSecureCookieEnv,
     createExpiredAuthHintCookie,
 } from '@/entities/session';
+import { DrizzleSessionRepository } from '@/entities/session/api';
 import { getAuthDatabaseClient } from '@/entities/session/lib/db';
 import { logoutUser } from '@/entities/user';
 

--- a/src/features/auth-oauth-consent/__tests__/actions/finalizeOAuthSignupAction.test.ts
+++ b/src/features/auth-oauth-consent/__tests__/actions/finalizeOAuthSignupAction.test.ts
@@ -26,6 +26,8 @@ vi.mock('@/entities/session', () => ({
     createAuthSession: vi.fn(),
     DEFAULT_SESSION_TTL_SECONDS: 7776000,
     isSecureCookieEnv: vi.fn(() => false),
+}));
+vi.mock('@/entities/session/api', () => ({
     DrizzleSessionRepository: vi.fn().mockImplementation(function () {
         return {};
     }),

--- a/src/features/auth-oauth-consent/__tests__/actions/finalizeOAuthSignupActionBranches.test.ts
+++ b/src/features/auth-oauth-consent/__tests__/actions/finalizeOAuthSignupActionBranches.test.ts
@@ -33,6 +33,8 @@ vi.mock('@/entities/session', () => ({
     createAuthSession: vi.fn(),
     DEFAULT_SESSION_TTL_SECONDS: 7776000,
     isSecureCookieEnv: vi.fn(() => false),
+}));
+vi.mock('@/entities/session/api', () => ({
     DrizzleSessionRepository: vi.fn().mockImplementation(function () {
         return {};
     }),

--- a/src/features/auth-oauth-consent/actions/finalizeOAuthSignupAction.ts
+++ b/src/features/auth-oauth-consent/actions/finalizeOAuthSignupAction.ts
@@ -10,8 +10,8 @@ import {
     createAuthSession,
     DEFAULT_SESSION_TTL_SECONDS,
     isSecureCookieEnv,
-    DrizzleSessionRepository,
 } from '@/entities/session';
+import { DrizzleSessionRepository } from '@/entities/session/api';
 import { getAuthDatabaseClient } from '@/entities/session/lib/db';
 import { createPendingOAuthSignupStoreFromEnv } from '@/entities/oauth-account';
 import { DrizzleAgreementRepository } from '@/entities/agreement';

--- a/src/features/auth-password-reset/__tests__/actions/confirmPasswordResetAction.test.ts
+++ b/src/features/auth-password-reset/__tests__/actions/confirmPasswordResetAction.test.ts
@@ -9,10 +9,12 @@ vi.mock('@/shared/db/client', () => ({
     resetDatabaseClientForTests: vi.fn(),
 }));
 vi.mock('@/entities/session', () => ({
-    bcryptPasswordHasher: { hashPassword: vi.fn() },
-    bcryptPasswordVerifier: { verifyPassword: vi.fn() },
     AUTH_SERVICE_UNAVAILABLE_MESSAGE:
         '서비스에 일시적인 문제가 발생했습니다. 잠시 후 다시 시도해주세요.',
+}));
+vi.mock('@/entities/session/lib/bcrypt', () => ({
+    bcryptPasswordHasher: { hashPassword: vi.fn() },
+    bcryptPasswordVerifier: { verifyPassword: vi.fn() },
 }));
 // getAuthDatabaseClient는 barrel이 아닌 @/entities/session/lib/db에서 직접 import되므로
 // (server-only 체인을 client 번들에서 분리) 해당 경로를 별도로 mock한다.

--- a/src/features/auth-password-reset/actions/confirmPasswordResetAction.ts
+++ b/src/features/auth-password-reset/actions/confirmPasswordResetAction.ts
@@ -1,11 +1,11 @@
 'use server';
 
 import { DrizzleUserRepository, confirmPasswordReset } from '@/entities/user';
+import { AUTH_SERVICE_UNAVAILABLE_MESSAGE } from '@/entities/session';
 import {
     bcryptPasswordHasher,
     bcryptPasswordVerifier,
-    AUTH_SERVICE_UNAVAILABLE_MESSAGE,
-} from '@/entities/session';
+} from '@/entities/session/lib/bcrypt';
 import { getAuthDatabaseClient } from '@/entities/session/lib/db';
 import { createEmailTokenStore } from '@/entities/email-token';
 import { redirect } from 'next/navigation';

--- a/src/features/auth-signup/__tests__/actions/registerAction.test.ts
+++ b/src/features/auth-signup/__tests__/actions/registerAction.test.ts
@@ -13,11 +13,6 @@ vi.mock('@/shared/db/client', () => ({
     resetDatabaseClientForTests: vi.fn(),
 }));
 vi.mock('@/entities/session', () => ({
-    DrizzleSessionRepository: vi.fn().mockImplementation(function () {
-        return {};
-    }),
-    bcryptPasswordHasher: { hashPassword: vi.fn() },
-    bcryptPasswordVerifier: { verifyPassword: vi.fn() },
     applyAuthCookie: vi.fn((c: unknown) => c),
     createAuthHintCookie: vi.fn(() => ({
         name: 'auth_hint',
@@ -28,6 +23,15 @@ vi.mock('@/entities/session', () => ({
     CONSENT_REQUIRED_MESSAGE: '서비스 이용을 위해 필수 약관에 동의해 주세요.',
     DEFAULT_SESSION_TTL_SECONDS: 7776000,
     isSecureCookieEnv: vi.fn(() => false),
+}));
+vi.mock('@/entities/session/api', () => ({
+    DrizzleSessionRepository: vi.fn().mockImplementation(function () {
+        return {};
+    }),
+}));
+vi.mock('@/entities/session/lib/bcrypt', () => ({
+    bcryptPasswordHasher: { hashPassword: vi.fn() },
+    bcryptPasswordVerifier: { verifyPassword: vi.fn() },
 }));
 // getAuthDatabaseClient는 barrel이 아닌 @/entities/session/lib/db에서 직접 import되므로
 // (server-only 체인을 client 번들에서 분리) 해당 경로를 별도로 mock한다.

--- a/src/features/auth-signup/actions/registerAction.ts
+++ b/src/features/auth-signup/actions/registerAction.ts
@@ -5,14 +5,16 @@ import { sanitizeNextPath } from '@/shared/lib/auth/redirect';
 import {
     applyAuthCookie,
     createAuthHintCookie,
-    bcryptPasswordHasher,
-    bcryptPasswordVerifier,
     AUTH_SERVICE_UNAVAILABLE_MESSAGE,
     CONSENT_REQUIRED_MESSAGE,
     DEFAULT_SESSION_TTL_SECONDS,
     isSecureCookieEnv,
-    DrizzleSessionRepository,
 } from '@/entities/session';
+import { DrizzleSessionRepository } from '@/entities/session/api';
+import {
+    bcryptPasswordHasher,
+    bcryptPasswordVerifier,
+} from '@/entities/session/lib/bcrypt';
 import { getAuthDatabaseClient } from '@/entities/session/lib/db';
 import {
     loginUser,

--- a/src/shared/db/schema.ts
+++ b/src/shared/db/schema.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 import { sql } from 'drizzle-orm';
 import {
     boolean,

--- a/src/shared/db/types.ts
+++ b/src/shared/db/types.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 import type { NeonQueryFunction } from '@neondatabase/serverless';
 import type { NeonHttpDatabase } from 'drizzle-orm/neon-http';
 import type { Tier } from '@y0ngha/siglens-core';

--- a/src/shared/lib/__tests__/byokGate.test.ts
+++ b/src/shared/lib/__tests__/byokGate.test.ts
@@ -19,8 +19,8 @@ vi.mock('@/entities/user-tier', () => ({
     getUserTier: (...args: unknown[]) => mockGetUserTier(...args),
 }));
 
-vi.mock('@/entities/api-key', async () => {
-    const actual = await vi.importActual('@/entities/api-key');
+vi.mock('@/entities/api-key/api', async () => {
+    const actual = await vi.importActual('@/entities/api-key/api');
     return {
         ...actual,
         DrizzleUserApiKeyRepository: vi.fn().mockImplementation(function () {
@@ -31,7 +31,7 @@ vi.mock('@/entities/api-key', async () => {
     };
 });
 
-import { LlmApiKeyDecryptionFailedError } from '@/entities/api-key';
+import { LlmApiKeyDecryptionFailedError } from '@/entities/api-key/api';
 import {
     resolveTierAndByok,
     buildGateError,

--- a/src/shared/lib/byokGate.ts
+++ b/src/shared/lib/byokGate.ts
@@ -11,7 +11,7 @@ import { getDatabaseClient } from '@/shared/db/client';
 import {
     DrizzleUserApiKeyRepository,
     LlmApiKeyDecryptionFailedError,
-} from '@/entities/api-key';
+} from '@/entities/api-key/api';
 import { getUserTier } from '@/entities/user-tier';
 import { DrizzleUserRepository } from '@/entities/user';
 import type { AnalysisGateError, AnalysisGateErrorCode } from './types';


### PR DESCRIPTION
## What
Pure refactoring (import-path hygiene) — applies the documented invariant uniformly: server-only DB repositories (pulling node:crypto/drizzle/postgres) must not be re-exported from a slice barrel that client components import. `options-chain`/`session` already did this; this extends it to the remaining slices.

- Removed value re-exports of `DrizzleSessionRepository`, `bcryptPasswordHasher`/`bcryptPasswordVerifier`, `DrizzleUserApiKeyRepository`, `DrizzleContactRepository`, `DrizzleNewsRepository`/`getNewsList` from their barrels; server/test consumers now deep-import from `@/entities/<slice>/api`.
- Added `import 'server-only'` to `shared/db/schema.ts`, `types.ts`, `news-article/api.ts` (fail-fast on future client value-leaks).
- The build surfaced a real pre-existing leak (`DrizzleSessionRepository` reachable from `ContactForm` via the session barrel) — fixed by the same exclusion.
- Updated `eslint.config.mjs` (byokGate deep-import ignore) and `entities/CLAUDE.md` barrel-exclusion table to match.

## Behavior
Import-path changes only; no runtime logic changed. `tsc --noEmit`, full test, build, lint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)