### PR TITLE
test(probe): verify CI/E2E SKIP on docs-only change

### DIFF
--- a/docs/superpowers/specs/2026-06-25-ci-e2e-path-gating-design.md
+++ b/docs/superpowers/specs/2026-06-25-ci-e2e-path-gating-design.md
@@ -232,3 +232,5 @@ No unit tests apply (CI config). Verification is empirical against real PR diffs
 3. Open a `src/**` PR → both run as today.
 4. Confirm `ci-required` / `e2e-required` are green in all three so they are safe
    to mark as required checks.
+
+<!-- gating verification probe: docs-only change, expect ci+e2e SKIP -->


### PR DESCRIPTION
Throwaway verification. Expect: `ci` and `e2e` jobs SKIP, both `ci-required`/`e2e-required` GREEN. Will be closed, not merged.