### PR TITLE
refactor(shared): unify DST/ET-offset into canonical eastern.ts (P1)

### DIFF
--- a/src/shared/api/fmp/FmpMarketProvider.ts
+++ b/src/shared/api/fmp/FmpMarketProvider.ts
@@ -56,7 +56,6 @@ function getEtOffsetHours(year: number, month: number, day: number): number {
     const springDay = nthSundayDay(year, MARCH, SECOND_SUNDAY);
     const fallDay = nthSundayDay(year, NOVEMBER, FIRST_SUNDAY);
 
-    // date-only UTC 자정 기준 비교 (기존 동작 보존)
     const dateMs = Date.UTC(year, month - 1, day);
     const springMs = Date.UTC(year, MARCH, springDay);
     const fallMs = Date.UTC(year, NOVEMBER, fallDay);

--- a/src/shared/api/fmp/FmpMarketProvider.ts
+++ b/src/shared/api/fmp/FmpMarketProvider.ts
@@ -7,6 +7,15 @@ import type {
 } from '@y0ngha/siglens-core';
 import { MS_PER_SECOND } from '@/shared/config/time';
 import { fmpGet } from '@/shared/api/fmp/httpClient';
+import {
+    MARCH,
+    NOVEMBER,
+    SECOND_SUNDAY,
+    FIRST_SUNDAY,
+    EDT_OFFSET_HOURS,
+    EST_OFFSET_HOURS,
+    nthSundayDay,
+} from '@/shared/lib/eastern';
 
 const ISO_DATE_PREFIX_LENGTH = 10; // "YYYY-MM-DD"
 const ISO_DATE_PART_INDEX = 0;
@@ -14,12 +23,9 @@ const ISO_DATE_PART_INDEX = 0;
 // FMP ET→UTC timestamp conversion. Canonical home after the market-provider
 // ejection: siglens-core no longer fetches market data (it owns only the
 // MarketDataProvider port), so this logic permanently lives in siglens.
-const EDT_OFFSET_HOURS = -4;
-const EST_OFFSET_HOURS = -5;
-const DST_START_MONTH = 3;
-const DST_START_NTH_SUNDAY = 2;
-const DST_END_MONTH = 11;
-const DST_END_NTH_SUNDAY = 1;
+//
+// DST 날짜 계산은 eastern.ts의 nthSundayDay를 정규 원시 함수로 위임한다.
+// FMP API 날짜 문자열은 1-indexed month이므로 0-indexed(MARCH=2, NOVEMBER=10)로 변환해 전달한다.
 
 const FMP_DATETIME_YEAR_END = 4;
 const FMP_DATETIME_MONTH_START = 5;
@@ -33,22 +39,29 @@ const FMP_DATETIME_MINUTE_END = 16;
 const FMP_DATETIME_SECOND_START = 17;
 const FMP_DATETIME_SECOND_END = 19;
 
-function getNthSundayOfMonth(year: number, month: number, n: number): Date {
-    const firstOfMonth = new Date(Date.UTC(year, month - 1, 1));
-    const dayOfWeek = firstOfMonth.getUTCDay();
-    const firstSunday = dayOfWeek === 0 ? 1 : 8 - dayOfWeek;
-    return new Date(Date.UTC(year, month - 1, firstSunday + (n - 1) * 7));
-}
-
+/**
+ * FMP 날짜 문자열의 연도·1-indexed 월·일을 받아 ET UTC 오프셋을 반환한다.
+ *
+ * date-only 비교: FMP 장중 데이터의 시각은 항상 09:30~16:00 ET이고
+ * DST 전환 기준 시각(02:00 ET)보다 늦으므로 날짜 단위 비교로 오프셋을 정확히 결정할 수 있다.
+ * hour 인수를 받지 않는 이 설계는 의도적이며 기존 동작을 보존한다.
+ *
+ * @param year  - 연도
+ * @param month - 1-indexed 월 (FMP 날짜 문자열 원본 값)
+ * @param day   - day-of-month
+ * @returns EDT(-4) 또는 EST(-5)
+ */
 function getEtOffsetHours(year: number, month: number, day: number): number {
-    const dstStart = getNthSundayOfMonth(
-        year,
-        DST_START_MONTH,
-        DST_START_NTH_SUNDAY
-    );
-    const dstEnd = getNthSundayOfMonth(year, DST_END_MONTH, DST_END_NTH_SUNDAY);
-    const date = new Date(Date.UTC(year, month - 1, day));
-    return date >= dstStart && date < dstEnd
+    // nthSundayDay는 0-indexed month를 받으므로 MARCH(2), NOVEMBER(10)을 직접 사용
+    const springDay = nthSundayDay(year, MARCH, SECOND_SUNDAY);
+    const fallDay = nthSundayDay(year, NOVEMBER, FIRST_SUNDAY);
+
+    // date-only UTC 자정 기준 비교 (기존 동작 보존)
+    const dateMs = Date.UTC(year, month - 1, day);
+    const springMs = Date.UTC(year, MARCH, springDay);
+    const fallMs = Date.UTC(year, NOVEMBER, fallDay);
+
+    return dateMs >= springMs && dateMs < fallMs
         ? EDT_OFFSET_HOURS
         : EST_OFFSET_HOURS;
 }

--- a/src/shared/lib/__tests__/eastern.test.ts
+++ b/src/shared/lib/__tests__/eastern.test.ts
@@ -1,4 +1,22 @@
 import { getEasternOffsetHours } from '@/shared/lib/eastern';
+import { getEtOffset, nthSundayDay } from '@/shared/lib/etTimeUtils';
+
+// FmpMarketProvider의 getEtOffsetHours/getNthSundayOfMonth는 private이므로
+// fmpIntradayDateToUtcSeconds의 동작을 통해 간접적으로 검증한다.
+// 대신 실제 동작을 여기서 참조 구현으로 재현해 경계를 핀한다.
+function fmpGetEtOffsetHours(year: number, month: number, day: number): number {
+    // FmpMarketProvider의 내부 getEtOffsetHours를 그대로 복제 (date-only, 시각 무시)
+    function getNthSundayOfMonthFmp(y: number, m: number, n: number): Date {
+        const firstOfMonth = new Date(Date.UTC(y, m - 1, 1));
+        const dayOfWeek = firstOfMonth.getUTCDay();
+        const firstSunday = dayOfWeek === 0 ? 1 : 8 - dayOfWeek;
+        return new Date(Date.UTC(y, m - 1, firstSunday + (n - 1) * 7));
+    }
+    const dstStart = getNthSundayOfMonthFmp(year, 3, 2);
+    const dstEnd = getNthSundayOfMonthFmp(year, 11, 1);
+    const date = new Date(Date.UTC(year, month - 1, day));
+    return date >= dstStart && date < dstEnd ? -4 : -5;
+}
 
 describe('eastern', () => {
     describe('getEasternOffsetHours', () => {
@@ -65,6 +83,220 @@ describe('eastern', () => {
                 expect(getEasternOffsetHours(beforeDst)).toBe(-5);
                 expect(getEasternOffsetHours(onDstStart)).toBe(-4);
             });
+        });
+    });
+});
+
+// ============================================================
+// 경계 동치 핀 테스트 (PR4 통합 검증용)
+// 세 구현의 실제 출력값을 캡처해 리팩터링 이후에도 동일성을 보장한다.
+// ============================================================
+
+describe('DST 경계 동치 핀 — 통합 전 실제 출력 캡처', () => {
+    // 2024: 봄 전환 = 3월 10일, 가을 전환 = 11월 3일
+    // 2026: 봄 전환 = 3월 8일,  가을 전환 = 11월 1일  (3월/11월 1일 모두 일요일)
+
+    describe('nthSundayDay (etTimeUtils) — 경계 날짜 계산 정확성', () => {
+        it('2024 봄 전환일 = 3월 10일 (month=2, 0-indexed)', () => {
+            expect(nthSundayDay(2024, 2, 2)).toBe(10);
+        });
+        it('2024 가을 전환일 = 11월 3일 (month=10, 0-indexed)', () => {
+            expect(nthSundayDay(2024, 10, 1)).toBe(3);
+        });
+        it('2026 봄 전환일 = 3월 8일 (3월 1일이 일요일인 경우)', () => {
+            expect(nthSundayDay(2026, 2, 2)).toBe(8);
+        });
+        it('2026 가을 전환일 = 11월 1일 (11월 1일이 일요일인 경우)', () => {
+            expect(nthSundayDay(2026, 10, 1)).toBe(1);
+        });
+    });
+
+    describe('getEasternOffsetHours (eastern.ts) — UTC 순간 기반 경계', () => {
+        // 봄 전환: 3월 두 번째 일요일 07:00 UTC (= EST 02:00 local)
+        it('2024 봄 전환: UTC 06:59:59 → -5 (EST, 전환 직전)', () => {
+            expect(
+                getEasternOffsetHours(new Date('2024-03-10T06:59:59Z'))
+            ).toBe(-5);
+        });
+        it('2024 봄 전환: UTC 07:00:00 → -4 (EDT, 전환 정각)', () => {
+            expect(
+                getEasternOffsetHours(new Date('2024-03-10T07:00:00Z'))
+            ).toBe(-4);
+        });
+        it('2024 봄 전환: UTC 13:30:00 (= EDT 09:30) → -4', () => {
+            expect(
+                getEasternOffsetHours(new Date('2024-03-10T13:30:00Z'))
+            ).toBe(-4);
+        });
+
+        // 가을 전환: 11월 첫 번째 일요일 06:00 UTC (= EDT 02:00 local)
+        it('2024 가을 전환: UTC 05:59:59 → -4 (EDT, 전환 직전)', () => {
+            expect(
+                getEasternOffsetHours(new Date('2024-11-03T05:59:59Z'))
+            ).toBe(-4);
+        });
+        it('2024 가을 전환: UTC 06:00:00 → -5 (EST, 전환 정각)', () => {
+            expect(
+                getEasternOffsetHours(new Date('2024-11-03T06:00:00Z'))
+            ).toBe(-5);
+        });
+        it('2024 가을 전환: UTC 14:30:00 (= EST 09:30) → -5', () => {
+            expect(
+                getEasternOffsetHours(new Date('2024-11-03T14:30:00Z'))
+            ).toBe(-5);
+        });
+
+        // 2026: 3월/11월 모두 1일이 일요일
+        it('2026 봄 전환(3/8): UTC 06:59:59 → -5', () => {
+            expect(
+                getEasternOffsetHours(new Date('2026-03-08T06:59:59Z'))
+            ).toBe(-5);
+        });
+        it('2026 봄 전환(3/8): UTC 07:00:00 → -4', () => {
+            expect(
+                getEasternOffsetHours(new Date('2026-03-08T07:00:00Z'))
+            ).toBe(-4);
+        });
+        it('2026 가을 전환(11/1): UTC 05:59:59 → -4', () => {
+            expect(
+                getEasternOffsetHours(new Date('2026-11-01T05:59:59Z'))
+            ).toBe(-4);
+        });
+        it('2026 가을 전환(11/1): UTC 06:00:00 → -5', () => {
+            expect(
+                getEasternOffsetHours(new Date('2026-11-01T06:00:00Z'))
+            ).toBe(-5);
+        });
+
+        // 비경계 날짜 (일반 구간)
+        it('비경계: 2024-07-01 UTC 12:00 → -4 (EDT 일반 구간)', () => {
+            expect(
+                getEasternOffsetHours(new Date('2024-07-01T12:00:00Z'))
+            ).toBe(-4);
+        });
+        it('비경계: 2024-01-15 UTC 12:00 → -5 (EST 일반 구간)', () => {
+            expect(
+                getEasternOffsetHours(new Date('2024-01-15T12:00:00Z'))
+            ).toBe(-5);
+        });
+    });
+
+    describe('getEtOffset (etTimeUtils.ts) — ET 로컬 시각 기반, 시각 인식 경계', () => {
+        // 봄 전환일: 해당 연도·월·일에서 hour < 2 → EST, >= 2 → EDT
+        it('2024 봄 전환일(3/10) hour=1 → "-05:00" (02:00 전 EST)', () => {
+            expect(getEtOffset(2024, 2, 10, 1)).toBe('-05:00');
+        });
+        it('2024 봄 전환일(3/10) hour=2 → "-04:00" (02:00 이후 EDT)', () => {
+            expect(getEtOffset(2024, 2, 10, 2)).toBe('-04:00');
+        });
+        it('2024 봄 전환일(3/10) hour=3 → "-04:00"', () => {
+            expect(getEtOffset(2024, 2, 10, 3)).toBe('-04:00');
+        });
+        it('2024 봄 전환일(3/10) hour=9 → "-04:00" (장중 시각)', () => {
+            expect(getEtOffset(2024, 2, 10, 9)).toBe('-04:00');
+        });
+
+        // 가을 전환일: hour < 2 → EDT, >= 2 → EST
+        it('2024 가을 전환일(11/3) hour=1 → "-04:00" (02:00 전 EDT)', () => {
+            expect(getEtOffset(2024, 10, 3, 1)).toBe('-04:00');
+        });
+        it('2024 가을 전환일(11/3) hour=2 → "-05:00" (02:00 이후 EST)', () => {
+            expect(getEtOffset(2024, 10, 3, 2)).toBe('-05:00');
+        });
+        it('2024 가을 전환일(11/3) hour=9 → "-05:00" (장중 시각)', () => {
+            expect(getEtOffset(2024, 10, 3, 9)).toBe('-05:00');
+        });
+
+        // 2026: 1일이 일요일인 극단 케이스
+        it('2026 봄 전환일(3/8) hour=1 → "-05:00"', () => {
+            expect(getEtOffset(2026, 2, 8, 1)).toBe('-05:00');
+        });
+        it('2026 봄 전환일(3/8) hour=2 → "-04:00"', () => {
+            expect(getEtOffset(2026, 2, 8, 2)).toBe('-04:00');
+        });
+        it('2026 가을 전환일(11/1) hour=1 → "-04:00"', () => {
+            expect(getEtOffset(2026, 10, 1, 1)).toBe('-04:00');
+        });
+        it('2026 가을 전환일(11/1) hour=2 → "-05:00"', () => {
+            expect(getEtOffset(2026, 10, 1, 2)).toBe('-05:00');
+        });
+
+        // 비경계 날짜
+        it('비경계: 2024-07-01 hour=12 → "-04:00" (EDT)', () => {
+            expect(getEtOffset(2024, 6, 1, 12)).toBe('-04:00');
+        });
+        it('비경계: 2024-01-15 hour=12 → "-05:00" (EST)', () => {
+            expect(getEtOffset(2024, 0, 15, 12)).toBe('-05:00');
+        });
+    });
+
+    describe('fmpGetEtOffsetHours (FmpMarketProvider 내부, date-only) — 시각 무시 경계', () => {
+        // FMP는 날짜 전체를 하나의 오프셋으로 처리 (hour 무시)
+        // 봄 전환일 전날 → EST, 당일부터 → EDT (시각 무관)
+        it('2024 봄 전환 전날(3/9) → -5 (EST)', () => {
+            expect(fmpGetEtOffsetHours(2024, 3, 9)).toBe(-5);
+        });
+        it('2024 봄 전환일(3/10) → -4 (EDT, hour 무시)', () => {
+            expect(fmpGetEtOffsetHours(2024, 3, 10)).toBe(-4);
+        });
+        it('2024 가을 전환 전날(11/2) → -4 (EDT)', () => {
+            expect(fmpGetEtOffsetHours(2024, 11, 2)).toBe(-4);
+        });
+        it('2024 가을 전환일(11/3) → -5 (EST, 당일 전체)', () => {
+            expect(fmpGetEtOffsetHours(2024, 11, 3)).toBe(-5);
+        });
+
+        // 2026: 극단 케이스
+        it('2026 봄 전환일(3/8) → -4 (EDT)', () => {
+            expect(fmpGetEtOffsetHours(2026, 3, 8)).toBe(-4);
+        });
+        it('2026 봄 전환 전날(3/7) → -5 (EST)', () => {
+            expect(fmpGetEtOffsetHours(2026, 3, 7)).toBe(-5);
+        });
+        it('2026 가을 전환일(11/1) → -5 (EST)', () => {
+            expect(fmpGetEtOffsetHours(2026, 11, 1)).toBe(-5);
+        });
+        it('2026 가을 전환 전날(10/31) → -4 (EDT)', () => {
+            expect(fmpGetEtOffsetHours(2026, 10, 31)).toBe(-4);
+        });
+
+        // 비경계 날짜
+        it('비경계: 2024-07-01 → -4 (EDT)', () => {
+            expect(fmpGetEtOffsetHours(2024, 7, 1)).toBe(-4);
+        });
+        it('비경계: 2024-01-15 → -5 (EST)', () => {
+            expect(fmpGetEtOffsetHours(2024, 1, 15)).toBe(-5);
+        });
+    });
+
+    describe('함수 간 경계 차이 명세 — 동일 시각, 다른 반환 형태', () => {
+        // 봄 전환일 01:30 ET (= 06:30 UTC, 전환 전)
+        // getEtOffset: hour=1 → -05:00 (EST) — 시각 인식 정확
+        // getEasternOffsetHours: UTC 06:30Z → -5 (전환 전) — UTC 인식 정확
+        // fmpGetEtOffsetHours: day=10 → -4 (EDT) — date-only, 의도적 단순화
+        it('봄 전환일 01:30 ET: getEtOffset hour=1 → "-05:00"', () => {
+            expect(getEtOffset(2024, 2, 10, 1)).toBe('-05:00');
+        });
+        it('봄 전환일 01:30 ET: getEasternOffsetHours UTC 06:30Z → -5', () => {
+            expect(
+                getEasternOffsetHours(new Date('2024-03-10T06:30:00Z'))
+            ).toBe(-5);
+        });
+        it('봄 전환일 date-only: fmpGetEtOffsetHours(2024,3,10) → -4 (date-only, 설계적 차이)', () => {
+            expect(fmpGetEtOffsetHours(2024, 3, 10)).toBe(-4);
+        });
+
+        // 봄 전환일 09:30 ET (= 13:30 UTC, 전환 후) — 장중 시각은 세 함수 모두 -4
+        it('봄 전환일 09:30 ET: getEtOffset hour=9 → "-04:00"', () => {
+            expect(getEtOffset(2024, 2, 10, 9)).toBe('-04:00');
+        });
+        it('봄 전환일 09:30 ET: getEasternOffsetHours UTC 13:30Z → -4', () => {
+            expect(
+                getEasternOffsetHours(new Date('2024-03-10T13:30:00Z'))
+            ).toBe(-4);
+        });
+        it('봄 전환일 09:30 ET: fmpGetEtOffsetHours → -4 (장중 = 항상 EDT)', () => {
+            expect(fmpGetEtOffsetHours(2024, 3, 10)).toBe(-4);
         });
     });
 });

--- a/src/shared/lib/__tests__/eastern.test.ts
+++ b/src/shared/lib/__tests__/eastern.test.ts
@@ -1,23 +1,6 @@
 import { getEasternOffsetHours } from '@/shared/lib/eastern';
 import { getEtOffset, nthSundayDay } from '@/shared/lib/etTimeUtils';
 
-// FmpMarketProvider의 getEtOffsetHours/getNthSundayOfMonth는 private이므로
-// fmpIntradayDateToUtcSeconds의 동작을 통해 간접적으로 검증한다.
-// 대신 실제 동작을 여기서 참조 구현으로 재현해 경계를 핀한다.
-function fmpGetEtOffsetHours(year: number, month: number, day: number): number {
-    // FmpMarketProvider의 내부 getEtOffsetHours를 그대로 복제 (date-only, 시각 무시)
-    function getNthSundayOfMonthFmp(y: number, m: number, n: number): Date {
-        const firstOfMonth = new Date(Date.UTC(y, m - 1, 1));
-        const dayOfWeek = firstOfMonth.getUTCDay();
-        const firstSunday = dayOfWeek === 0 ? 1 : 8 - dayOfWeek;
-        return new Date(Date.UTC(y, m - 1, firstSunday + (n - 1) * 7));
-    }
-    const dstStart = getNthSundayOfMonthFmp(year, 3, 2);
-    const dstEnd = getNthSundayOfMonthFmp(year, 11, 1);
-    const date = new Date(Date.UTC(year, month - 1, day));
-    return date >= dstStart && date < dstEnd ? -4 : -5;
-}
-
 describe('eastern', () => {
     describe('getEasternOffsetHours', () => {
         describe('EST 기간 (11월 첫 번째 일요일 ~ 3월 두 번째 일요일)', () => {
@@ -89,7 +72,10 @@ describe('eastern', () => {
 
 // ============================================================
 // 경계 동치 핀 테스트 (PR4 통합 검증용)
-// 세 구현의 실제 출력값을 캡처해 리팩터링 이후에도 동일성을 보장한다.
+// eastern.ts / etTimeUtils.ts 두 정식 공개 함수의 실제 출력값을 캡처해
+// 리팩터링 이후에도 동일성을 보장한다.
+// FMP date-only 경계는 FmpMarketProvider.test.ts DST-boundary 케이스가
+// getBars 실 경로를 통해 종단 검증하므로 여기서 중복 복제하지 않는다.
 // ============================================================
 
 describe('DST 경계 동치 핀 — 통합 전 실제 출력 캡처', () => {
@@ -227,76 +213,6 @@ describe('DST 경계 동치 핀 — 통합 전 실제 출력 캡처', () => {
         });
         it('비경계: 2024-01-15 hour=12 → "-05:00" (EST)', () => {
             expect(getEtOffset(2024, 0, 15, 12)).toBe('-05:00');
-        });
-    });
-
-    describe('fmpGetEtOffsetHours (FmpMarketProvider 내부, date-only) — 시각 무시 경계', () => {
-        // FMP는 날짜 전체를 하나의 오프셋으로 처리 (hour 무시)
-        // 봄 전환일 전날 → EST, 당일부터 → EDT (시각 무관)
-        it('2024 봄 전환 전날(3/9) → -5 (EST)', () => {
-            expect(fmpGetEtOffsetHours(2024, 3, 9)).toBe(-5);
-        });
-        it('2024 봄 전환일(3/10) → -4 (EDT, hour 무시)', () => {
-            expect(fmpGetEtOffsetHours(2024, 3, 10)).toBe(-4);
-        });
-        it('2024 가을 전환 전날(11/2) → -4 (EDT)', () => {
-            expect(fmpGetEtOffsetHours(2024, 11, 2)).toBe(-4);
-        });
-        it('2024 가을 전환일(11/3) → -5 (EST, 당일 전체)', () => {
-            expect(fmpGetEtOffsetHours(2024, 11, 3)).toBe(-5);
-        });
-
-        // 2026: 극단 케이스
-        it('2026 봄 전환일(3/8) → -4 (EDT)', () => {
-            expect(fmpGetEtOffsetHours(2026, 3, 8)).toBe(-4);
-        });
-        it('2026 봄 전환 전날(3/7) → -5 (EST)', () => {
-            expect(fmpGetEtOffsetHours(2026, 3, 7)).toBe(-5);
-        });
-        it('2026 가을 전환일(11/1) → -5 (EST)', () => {
-            expect(fmpGetEtOffsetHours(2026, 11, 1)).toBe(-5);
-        });
-        it('2026 가을 전환 전날(10/31) → -4 (EDT)', () => {
-            expect(fmpGetEtOffsetHours(2026, 10, 31)).toBe(-4);
-        });
-
-        // 비경계 날짜
-        it('비경계: 2024-07-01 → -4 (EDT)', () => {
-            expect(fmpGetEtOffsetHours(2024, 7, 1)).toBe(-4);
-        });
-        it('비경계: 2024-01-15 → -5 (EST)', () => {
-            expect(fmpGetEtOffsetHours(2024, 1, 15)).toBe(-5);
-        });
-    });
-
-    describe('함수 간 경계 차이 명세 — 동일 시각, 다른 반환 형태', () => {
-        // 봄 전환일 01:30 ET (= 06:30 UTC, 전환 전)
-        // getEtOffset: hour=1 → -05:00 (EST) — 시각 인식 정확
-        // getEasternOffsetHours: UTC 06:30Z → -5 (전환 전) — UTC 인식 정확
-        // fmpGetEtOffsetHours: day=10 → -4 (EDT) — date-only, 의도적 단순화
-        it('봄 전환일 01:30 ET: getEtOffset hour=1 → "-05:00"', () => {
-            expect(getEtOffset(2024, 2, 10, 1)).toBe('-05:00');
-        });
-        it('봄 전환일 01:30 ET: getEasternOffsetHours UTC 06:30Z → -5', () => {
-            expect(
-                getEasternOffsetHours(new Date('2024-03-10T06:30:00Z'))
-            ).toBe(-5);
-        });
-        it('봄 전환일 date-only: fmpGetEtOffsetHours(2024,3,10) → -4 (date-only, 설계적 차이)', () => {
-            expect(fmpGetEtOffsetHours(2024, 3, 10)).toBe(-4);
-        });
-
-        // 봄 전환일 09:30 ET (= 13:30 UTC, 전환 후) — 장중 시각은 세 함수 모두 -4
-        it('봄 전환일 09:30 ET: getEtOffset hour=9 → "-04:00"', () => {
-            expect(getEtOffset(2024, 2, 10, 9)).toBe('-04:00');
-        });
-        it('봄 전환일 09:30 ET: getEasternOffsetHours UTC 13:30Z → -4', () => {
-            expect(
-                getEasternOffsetHours(new Date('2024-03-10T13:30:00Z'))
-            ).toBe(-4);
-        });
-        it('봄 전환일 09:30 ET: fmpGetEtOffsetHours → -4 (장중 = 항상 EDT)', () => {
-            expect(fmpGetEtOffsetHours(2024, 3, 10)).toBe(-4);
         });
     });
 });

--- a/src/shared/lib/__tests__/eastern.test.ts
+++ b/src/shared/lib/__tests__/eastern.test.ts
@@ -99,16 +99,7 @@ describe('DST 경계 동치 핀 — 통합 전 실제 출력 캡처', () => {
 
     describe('getEasternOffsetHours (eastern.ts) — UTC 순간 기반 경계', () => {
         // 봄 전환: 3월 두 번째 일요일 07:00 UTC (= EST 02:00 local)
-        it('2024 봄 전환: UTC 06:59:59 → -5 (EST, 전환 직전)', () => {
-            expect(
-                getEasternOffsetHours(new Date('2024-03-10T06:59:59Z'))
-            ).toBe(-5);
-        });
-        it('2024 봄 전환: UTC 07:00:00 → -4 (EDT, 전환 정각)', () => {
-            expect(
-                getEasternOffsetHours(new Date('2024-03-10T07:00:00Z'))
-            ).toBe(-4);
-        });
+        // 전환 직전(06:59:59)/정각(07:00:00) 경계는 상단 describe('eastern')에서 이미 검증
         it('2024 봄 전환: UTC 13:30:00 (= EDT 09:30) → -4', () => {
             expect(
                 getEasternOffsetHours(new Date('2024-03-10T13:30:00Z'))
@@ -116,23 +107,14 @@ describe('DST 경계 동치 핀 — 통합 전 실제 출력 캡처', () => {
         });
 
         // 가을 전환: 11월 첫 번째 일요일 06:00 UTC (= EDT 02:00 local)
-        it('2024 가을 전환: UTC 05:59:59 → -4 (EDT, 전환 직전)', () => {
-            expect(
-                getEasternOffsetHours(new Date('2024-11-03T05:59:59Z'))
-            ).toBe(-4);
-        });
-        it('2024 가을 전환: UTC 06:00:00 → -5 (EST, 전환 정각)', () => {
-            expect(
-                getEasternOffsetHours(new Date('2024-11-03T06:00:00Z'))
-            ).toBe(-5);
-        });
+        // 전환 직전(05:59:59)/정각(06:00:00) 경계는 상단 describe('eastern')에서 이미 검증
         it('2024 가을 전환: UTC 14:30:00 (= EST 09:30) → -5', () => {
             expect(
                 getEasternOffsetHours(new Date('2024-11-03T14:30:00Z'))
             ).toBe(-5);
         });
 
-        // 2026: 3월/11월 모두 1일이 일요일
+        // 2026: 3월/11월 모두 1일이 일요일 — nthSundayDay 극단 케이스 신규 검증
         it('2026 봄 전환(3/8): UTC 06:59:59 → -5', () => {
             expect(
                 getEasternOffsetHours(new Date('2026-03-08T06:59:59Z'))
@@ -159,11 +141,6 @@ describe('DST 경계 동치 핀 — 통합 전 실제 출력 캡처', () => {
             expect(
                 getEasternOffsetHours(new Date('2024-07-01T12:00:00Z'))
             ).toBe(-4);
-        });
-        it('비경계: 2024-01-15 UTC 12:00 → -5 (EST 일반 구간)', () => {
-            expect(
-                getEasternOffsetHours(new Date('2024-01-15T12:00:00Z'))
-            ).toBe(-5);
         });
     });
 

--- a/src/shared/lib/eastern.ts
+++ b/src/shared/lib/eastern.ts
@@ -47,13 +47,11 @@ export function getEasternOffsetHours(utcDate: Date): -4 | -5 {
     const fallDay = nthSundayDay(year, NOVEMBER, FIRST_SUNDAY);
 
     // UTC 순간으로 경계 계산: 전환은 각각 UTC 07:00, 06:00에 발생
-    const dstStart = new Date(
-        Date.UTC(year, MARCH, springDay, DST_START_UTC_HOUR)
-    );
-    const dstEnd = new Date(
-        Date.UTC(year, NOVEMBER, fallDay, DST_END_UTC_HOUR)
-    );
+    // Date 객체 할당 없이 원시 ms 비교로 동일 결과 (호출 당 GC 압력 최소화)
+    const dstStartMs = Date.UTC(year, MARCH, springDay, DST_START_UTC_HOUR);
+    const dstEndMs = Date.UTC(year, NOVEMBER, fallDay, DST_END_UTC_HOUR);
 
-    const isEDT = utcDate >= dstStart && utcDate < dstEnd;
+    const timeMs = utcDate.getTime();
+    const isEDT = timeMs >= dstStartMs && timeMs < dstEndMs;
     return isEDT ? EDT_OFFSET_HOURS : EST_OFFSET_HOURS;
 }

--- a/src/shared/lib/eastern.ts
+++ b/src/shared/lib/eastern.ts
@@ -1,47 +1,59 @@
+// EDT: 3월 두 번째 일요일 02:00 ~ 11월 첫 번째 일요일 02:00 → UTC-4 (IANA America/New_York)
+// EST: 그 외 구간 → UTC-5
+// month은 JS Date 0-indexed 기준 (0 = January)
 export const MARCH = 2; // 0-indexed
 export const NOVEMBER = 10; // 0-indexed
 
-const SUNDAY = 0;
 export const SECOND_SUNDAY = 2;
 export const FIRST_SUNDAY = 1;
 
-// DST transitions occur at local time 02:00:
-// Spring (EST → EDT): local 02:00 EST = UTC 07:00
-// Fall  (EDT → EST):  local 02:00 EDT = UTC 06:00
+// DST 전환은 현지 02:00에 발생한다:
+// Spring (EST → EDT): 현지 02:00 EST = UTC 07:00
+// Fall  (EDT → EST):  현지 02:00 EDT = UTC 06:00
 const DST_START_UTC_HOUR = 7;
 const DST_END_UTC_HOUR = 6;
+const DAYS_IN_WEEK = 7;
 
 export const EDT_OFFSET_HOURS = -4 as const;
 export const EST_OFFSET_HOURS = -5 as const;
 
-function getNthSundayOfMonth(
-    year: number,
-    month: number,
-    n: number,
-    utcHour: number
-): Date {
-    const firstDay = new Date(Date.UTC(year, month, 1));
-    const dayOfWeek = firstDay.getUTCDay();
-    const daysUntilFirstSunday = dayOfWeek === SUNDAY ? 0 : 7 - dayOfWeek;
-    const firstSundayDate = 1 + daysUntilFirstSunday;
-    const nthSundayDate = firstSundayDate + (n - 1) * 7;
-    return new Date(Date.UTC(year, month, nthSundayDate, utcHour, 0, 0));
+/**
+ * 해당 연도·월(0-indexed)의 N번째 일요일의 날짜(day-of-month)를 반환하는 정규 원시 함수.
+ *
+ * 세 DST 구현(eastern.ts, etTimeUtils.ts, FmpMarketProvider.ts)의 공통 기반이다.
+ * etTimeUtils.getEtOffset와 FmpMarketProvider.getEtOffsetHours는 이 함수를 위임해 사용한다.
+ *
+ * @param year  - 연도
+ * @param month - 0-indexed 월 (0 = January)
+ * @param nth   - 1-indexed 번째 일요일
+ * @returns 1-indexed 날짜(day-of-month)
+ */
+export function nthSundayDay(year: number, month: number, nth: number): number {
+    const firstDayOfMonth = new Date(Date.UTC(year, month, 1));
+    const firstSundayOffset =
+        (DAYS_IN_WEEK - firstDayOfMonth.getUTCDay()) % DAYS_IN_WEEK;
+    return 1 + firstSundayOffset + (nth - 1) * DAYS_IN_WEEK;
 }
 
+/**
+ * UTC 순간(Date 객체)을 받아 해당 시점의 Eastern Time UTC 오프셋을 반환한다.
+ *
+ * UTC 기준 비교를 사용하므로 nthSundayDay로 날짜를 구한 후
+ * DST 전환 UTC 시각(07:00 / 06:00)을 합산해 정확한 경계를 계산한다.
+ */
 export function getEasternOffsetHours(utcDate: Date): -4 | -5 {
     const year = utcDate.getUTCFullYear();
-    const dstStart = getNthSundayOfMonth(
-        year,
-        MARCH,
-        SECOND_SUNDAY,
-        DST_START_UTC_HOUR
+    const springDay = nthSundayDay(year, MARCH, SECOND_SUNDAY);
+    const fallDay = nthSundayDay(year, NOVEMBER, FIRST_SUNDAY);
+
+    // UTC 순간으로 경계 계산: 전환은 각각 UTC 07:00, 06:00에 발생
+    const dstStart = new Date(
+        Date.UTC(year, MARCH, springDay, DST_START_UTC_HOUR)
     );
-    const dstEnd = getNthSundayOfMonth(
-        year,
-        NOVEMBER,
-        FIRST_SUNDAY,
-        DST_END_UTC_HOUR
+    const dstEnd = new Date(
+        Date.UTC(year, NOVEMBER, fallDay, DST_END_UTC_HOUR)
     );
+
     const isEDT = utcDate >= dstStart && utcDate < dstEnd;
     return isEDT ? EDT_OFFSET_HOURS : EST_OFFSET_HOURS;
 }

--- a/src/shared/lib/etTimeUtils.ts
+++ b/src/shared/lib/etTimeUtils.ts
@@ -1,27 +1,23 @@
 // EDT: 3월 두 번째 일요일 02:00 ~ 11월 첫 번째 일요일 02:00 → UTC-4 (IANA America/New_York)
 // EST: 그 외 구간 → UTC-5
 // 월은 JS Date 0-indexed 기준 (0 = January)
-import { FIRST_SUNDAY, MARCH, NOVEMBER, SECOND_SUNDAY } from './eastern';
+import {
+    FIRST_SUNDAY,
+    MARCH,
+    NOVEMBER,
+    SECOND_SUNDAY,
+    nthSundayDay,
+} from './eastern';
 
-const DAYS_IN_WEEK = 7;
+// nthSundayDay는 eastern.ts의 정규 원시 함수를 위임해 사용한다.
+// 하위 호환성을 위해 re-export한다 (기존 import 경로 유지).
+export { nthSundayDay };
+
 const SPRING_FORWARD_MONTH = MARCH;
 const SPRING_FORWARD_NTH = SECOND_SUNDAY;
 const FALL_BACK_MONTH = NOVEMBER;
 const FALL_BACK_NTH = FIRST_SUNDAY;
 const DST_TRANSITION_LOCAL_HOUR = 2;
-
-/**
- * 해당 연도·월의 N번째 일요일의 날짜(day-of-month)를 반환한다.
- * @param year - 연도
- * @param month - 0-indexed 월 (0 = January)
- * @param nth - 1-indexed 번째 일요일
- */
-export function nthSundayDay(year: number, month: number, nth: number): number {
-    const firstDayOfMonth = new Date(Date.UTC(year, month, 1));
-    const firstSundayOffset =
-        (DAYS_IN_WEEK - firstDayOfMonth.getUTCDay()) % DAYS_IN_WEEK;
-    return 1 + firstSundayOffset + (nth - 1) * DAYS_IN_WEEK;
-}
 
 /**
  * ET 로컬 벽시계 날짜·시각을 직접 받아 해당 시점의 ET UTC 오프셋을 반환한다.


### PR DESCRIPTION
Pure refactoring. Three duplicated "Nth Sunday + EST/EDT offset" implementations unified into eastern.ts as the canonical source; etTimeUtils.getEtOffset and FmpMarketProvider.getEtOffsetHours now delegate, each deriving its own return shape. Boundary behavior preserved exactly (UTC-instant / hour-aware / date-only distinctions kept). Boundary equivalence tests added. tsc + scoped tests + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)