### PR TITLE
refactor(options): extract shared strike-bar chart behavior (P1)

### DIFF
--- a/src/widgets/options/OpenInterestChart.tsx
+++ b/src/widgets/options/OpenInterestChart.tsx
@@ -9,12 +9,7 @@ import {
     GUIDE_LINE_STROKE_WIDTH,
     MIDLINE_STROKE_WIDTH,
 } from './utils/chartStrokeWidths';
-import {
-    computeTooltipPos,
-    TOOLTIP_ELEMENT_ID,
-    TOOLTIP_MIN_WIDTH_PX,
-    type TooltipPosition,
-} from './utils/computeTooltipPos';
+import { TOOLTIP_ELEMENT_ID } from './utils/computeTooltipPos';
 import { formatCompactCount } from './utils/formatCompactCount';
 import {
     CallOpenInterestTooltip,
@@ -22,6 +17,14 @@ import {
     PutOpenInterestTooltip,
 } from './utils/optionsTooltips';
 import { pickLabelIndices } from './utils/pickLabelIndices';
+import { useStrikeBarChart } from './hooks/useStrikeBarChart';
+import {
+    barCenterX,
+    barPixelHeight,
+    slotWidth,
+} from './lib/strikeChartGeometry';
+import { StrikeBarTooltip } from './ui/StrikeBarTooltip';
+import { StrikeBarSrTable } from './ui/StrikeBarSrTable';
 import { InfoTooltip } from '@/shared/ui/InfoTooltip';
 import { findNearestStrikeIndex } from '@/entities/options-chain';
 import {
@@ -29,13 +32,7 @@ import {
     type OptionsChain,
     type OptionsExpirationMetrics,
 } from '@y0ngha/siglens-core';
-import {
-    useMemo,
-    useRef,
-    useState,
-    type CSSProperties,
-    type PointerEvent,
-} from 'react';
+import { useMemo } from 'react';
 
 interface OpenInterestChartProps {
     /** Spot price used to anchor the current-price guide line. */
@@ -46,6 +43,10 @@ interface OpenInterestChartProps {
     metrics: OptionsExpirationMetrics | null;
 }
 
+// SVG 레이아웃 상수. StrikeVolumeChart와 현재 동일하지만 의도적으로 복제한다 —
+// 두 차트가 나란히 렌더되면서 지금은 같은 크기를 공유하지만, 추후 어느 한쪽
+// 차트의 패딩만 미세조정할 가능성이 충분히 있고, 한 변경이 양쪽에 동시에
+// 영향을 주는 결합도를 미리 만들 필요는 없다.
 const SVG_WIDTH = 600;
 const SVG_HEIGHT = 240;
 const PAD_TOP = 30;
@@ -99,32 +100,19 @@ const X_AXIS_LABEL_OFFSET_PX = 14;
 const ROTATED_LABEL_FONT_SIZE = 8;
 const STRAIGHT_LABEL_FONT_SIZE = 9;
 
-function slotWidth(count: number): number {
-    return CHART_WIDTH / count;
-}
-
-function barCenterX(index: number, count: number): number {
-    const sw = slotWidth(count);
-    return PAD_LEFT + sw * index + sw / 2;
-}
-
-function barPixelHeight(oi: number, maxOi: number): number {
-    if (maxOi === 0) return 0;
-    return Math.min((oi / maxOi) * HALF_HEIGHT, HALF_HEIGHT);
-}
-
 export function OpenInterestChart({
     underlyingPrice,
     chain,
     metrics,
 }: OpenInterestChartProps) {
-    const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
-    const [tooltipPos, setTooltipPos] = useState<TooltipPosition | null>(null);
-    const containerRef = useRef<HTMLDivElement | null>(null);
-    // 컨테이너 DOMRect 캐시. pointerEnter 시 한 번 측정해 두고 pointerMove에서
-    // 재사용한다 — move마다 `getBoundingClientRect`를 부르면 reflow를 매번
-    // 트리거해 마우스가 빠르게 움직일 때 frame drop을 유발한다.
-    const cachedRectRef = useRef<DOMRect | null>(null);
+    const {
+        containerRef,
+        hoveredIndex,
+        tooltipPos,
+        handlePointerEnter,
+        handlePointerMove,
+        handlePointerLeave,
+    } = useStrikeBarChart();
 
     const derived = useMemo(() => {
         if (!chain) return null;
@@ -226,7 +214,7 @@ export function OpenInterestChart({
         labelIndices,
     } = derived;
     const count = oiByStrike.length;
-    const sw = slotWidth(count);
+    const sw = slotWidth(count, CHART_WIDTH);
     const bw = sw * BAR_WIDTH_FILL_RATIO;
 
     // hoveredIndex 가드: oiByStrike가 chip 전환으로 짧아지는 사이에 hover state
@@ -237,51 +225,17 @@ export function OpenInterestChart({
     const hoveredRow =
         hoveredIndex !== null ? (oiByStrike[hoveredIndex] ?? null) : null;
 
-    const maxPainX = maxPainIdx >= 0 ? barCenterX(maxPainIdx, count) : null;
+    const maxPainX =
+        maxPainIdx >= 0
+            ? barCenterX(maxPainIdx, count, PAD_LEFT, CHART_WIDTH)
+            : null;
     const currentPriceX =
-        currentPriceIdx >= 0 ? barCenterX(currentPriceIdx, count) : null;
+        currentPriceIdx >= 0
+            ? barCenterX(currentPriceIdx, count, PAD_LEFT, CHART_WIDTH)
+            : null;
 
     const rotateLabels = labelIndices.size > LABEL_ROTATION_THRESHOLD;
     const peakOiLabel = formatCompactCount(globalMax);
-
-    const handlePointerEnter = (
-        event: PointerEvent<SVGRectElement>,
-        index: number
-    ): void => {
-        const container = containerRef.current;
-        if (!container) return;
-        const rect = container.getBoundingClientRect();
-        cachedRectRef.current = rect;
-        setHoveredIndex(index);
-        setTooltipPos(computeTooltipPos(event, rect));
-    };
-
-    const handlePointerMove = (
-        event: PointerEvent<SVGRectElement>,
-        index: number
-    ): void => {
-        const rect = cachedRectRef.current;
-        // enter 핸들러가 캐시를 채우기 전에 move가 발사되는 경로(예: 모바일
-        // touchmove)에서는 한 번 측정해 즉시 캐시한다 — 이후 move부터는
-        // 캐시된 rect만 사용해 reflow 비용 없음.
-        if (rect === null) {
-            const container = containerRef.current;
-            if (!container) return;
-            const measured = container.getBoundingClientRect();
-            cachedRectRef.current = measured;
-            setHoveredIndex(index);
-            setTooltipPos(computeTooltipPos(event, measured));
-            return;
-        }
-        if (hoveredIndex !== index) setHoveredIndex(index);
-        setTooltipPos(computeTooltipPos(event, rect));
-    };
-
-    const handlePointerLeave = (): void => {
-        cachedRectRef.current = null;
-        setHoveredIndex(null);
-        setTooltipPos(null);
-    };
 
     return (
         <div
@@ -347,16 +301,21 @@ export function OpenInterestChart({
                 </text>
 
                 {oiByStrike.map((row, i) => {
-                    const cx = barCenterX(i, count);
+                    const cx = barCenterX(i, count, PAD_LEFT, CHART_WIDTH);
                     const isTopOi = topOiSet.has(row.strike);
                     const opacity = isTopOi
                         ? BAR_OPACITY_TOP_OI
                         : BAR_OPACITY_DEFAULT;
                     const callH = barPixelHeight(
                         row.callOpenInterest,
-                        globalMax
+                        globalMax,
+                        HALF_HEIGHT
                     );
-                    const putH = barPixelHeight(row.putOpenInterest, globalMax);
+                    const putH = barPixelHeight(
+                        row.putOpenInterest,
+                        globalMax,
+                        HALF_HEIGHT
+                    );
 
                     return (
                         <g key={row.strike}>
@@ -422,7 +381,7 @@ export function OpenInterestChart({
 
                 {oiByStrike.map((row, i) => {
                     if (!labelIndices.has(i)) return null;
-                    const cx = barCenterX(i, count);
+                    const cx = barCenterX(i, count, PAD_LEFT, CHART_WIDTH);
                     const labelY =
                         SVG_HEIGHT - PAD_BOTTOM + X_AXIS_LABEL_OFFSET_PX;
 
@@ -457,27 +416,10 @@ export function OpenInterestChart({
                 })}
             </svg>
 
-            {/* `aria-describedby`가 가리키는 대상은 항상 DOM에 있어야 한다.
-                `hidden` 속성으로 숨기면 접근성 트리에서도 제거되어 screen
-                reader가 참조를 따라올 수 없지만, 하단 `sr-only` 테이블이
-                전체 OI 데이터를 제공하므로 이 pointer-only tooltip에서는
-                허용 가능한 트레이드오프다. */}
-            <div
+            <StrikeBarTooltip
                 id={TOOLTIP_ELEMENT_ID}
-                role="tooltip"
-                hidden={hoveredRow === null || tooltipPos === null}
-                className="border-secondary-600 bg-secondary-900/95 text-secondary-100 pointer-events-none absolute top-[var(--tooltip-y)] left-[var(--tooltip-x)] z-10 min-w-[var(--tooltip-min-w)] -translate-x-1/2 -translate-y-full rounded-md border px-3 py-2 text-xs shadow-lg backdrop-blur"
-                style={
-                    // CSS 커스텀 프로퍼티(--*)는 런타임에 유효하나 React의
-                    // CSSProperties 타입은 임의 `--*` 키를 포함하지 않아
-                    // 인덱스 시그니처가 막힘 — TS 한계 우회용 cast이며
-                    // 런타임 리스크는 없다.
-                    {
-                        '--tooltip-x': `${tooltipPos?.x ?? 0}px`,
-                        '--tooltip-y': `${tooltipPos?.y ?? 0}px`,
-                        '--tooltip-min-w': `${TOOLTIP_MIN_WIDTH_PX}px`,
-                    } as CSSProperties
-                }
+                hoveredRow={hoveredRow}
+                tooltipPos={tooltipPos}
             >
                 {hoveredRow !== null && (
                     <>
@@ -510,7 +452,7 @@ export function OpenInterestChart({
                         </div>
                     </>
                 )}
-            </div>
+            </StrikeBarTooltip>
 
             <div className="text-secondary-500 mt-2 flex flex-wrap items-center gap-3 text-[10px]">
                 <span className="flex items-center gap-1">
@@ -545,31 +487,18 @@ export function OpenInterestChart({
                 </span>
             </div>
 
-            {/* sr-only를 <table>이 아니라 wrapper <div>에 둔다 —
-                <table>은 `display: table`이라 `position: absolute`와 결합돼도
-                일부 환경에서 normal flow에 잔재가 남아 페이지 height에
-                영향을 준다. <div>로 감싸 absolute 컨텍스트를 분리한다. */}
-            <div className="sr-only">
-                <table>
-                    <caption>Strike별 Open Interest 데이터</caption>
-                    <thead>
-                        <tr>
-                            <th scope="col">Strike</th>
-                            <th scope="col">Call OI</th>
-                            <th scope="col">Put OI</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {oiByStrike.map(row => (
-                            <tr key={row.strike}>
-                                <td>{row.strike}</td>
-                                <td>{row.callOpenInterest}</td>
-                                <td>{row.putOpenInterest}</td>
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
-            </div>
+            <StrikeBarSrTable
+                caption="Strike별 Open Interest 데이터"
+                headers={['Strike', 'Call OI', 'Put OI']}
+                rows={oiByStrike.map(row => ({
+                    key: row.strike,
+                    cells: [
+                        row.strike,
+                        row.callOpenInterest,
+                        row.putOpenInterest,
+                    ],
+                }))}
+            />
         </div>
     );
 }

--- a/src/widgets/options/OpenInterestChart.tsx
+++ b/src/widgets/options/OpenInterestChart.tsx
@@ -43,10 +43,12 @@ interface OpenInterestChartProps {
     metrics: OptionsExpirationMetrics | null;
 }
 
-// SVG 레이아웃 상수. StrikeVolumeChart와 현재 동일하지만 의도적으로 복제한다 —
-// 두 차트가 나란히 렌더되면서 지금은 같은 크기를 공유하지만, 추후 어느 한쪽
-// 차트의 패딩만 미세조정할 가능성이 충분히 있고, 한 변경이 양쪽에 동시에
-// 영향을 주는 결합도를 미리 만들 필요는 없다.
+// SVG 레이아웃 상수는 StrikeVolumeChart와 동일하게 복제한다 — 두 차트가
+// 나란히 렌더되면서 같은 viewport / 같은 막대 비율을 공유해야 사용자가
+// 두 차트를 비교하는 시선 흐름이 어색해지지 않는다. 상수를 별도 유틸로
+// 빼지 않는 이유: 추후 어느 한쪽 차트의 패딩만 미세조정할 가능성이
+// 충분히 있고, 한 변경이 두 차트에 동시에 영향을 주는 결합도를 미리
+// 만들 필요는 없다.
 const SVG_WIDTH = 600;
 const SVG_HEIGHT = 240;
 const PAD_TOP = 30;

--- a/src/widgets/options/StrikeVolumeChart.tsx
+++ b/src/widgets/options/StrikeVolumeChart.tsx
@@ -1,20 +1,10 @@
 'use client';
 
-import {
-    useMemo,
-    useRef,
-    useState,
-    type CSSProperties,
-    type PointerEvent,
-} from 'react';
+import { useMemo } from 'react';
 import type { OptionsChain } from '@y0ngha/siglens-core';
 import { InfoTooltip } from '@/shared/ui/InfoTooltip';
 import { CallVolumeTooltip, PutVolumeTooltip } from './utils/optionsTooltips';
-import {
-    computeTooltipPos,
-    TOOLTIP_MIN_WIDTH_PX,
-    type TooltipPosition,
-} from './utils/computeTooltipPos';
+// TOOLTIP_MIN_WIDTH_PX는 StrikeBarTooltip 내부에서 computeTooltipPos를 통해 가져온다.
 import { pickLabelIndices } from './utils/pickLabelIndices';
 import { aggregateStrikeVolume } from './utils/aggregateStrikeVolume';
 import { formatCompactCount } from './utils/formatCompactCount';
@@ -28,6 +18,14 @@ import {
     GUIDE_LINE_STROKE_WIDTH,
 } from './utils/chartStrokeWidths';
 import { findNearestStrikeIndex } from '@/entities/options-chain';
+import { useStrikeBarChart } from './hooks/useStrikeBarChart';
+import {
+    barCenterX,
+    barPixelHeight,
+    slotWidth,
+} from './lib/strikeChartGeometry';
+import { StrikeBarTooltip } from './ui/StrikeBarTooltip';
+import { StrikeBarSrTable } from './ui/StrikeBarSrTable';
 
 interface StrikeVolumeChartProps {
     /** Spot price used to anchor the current-price guide line. */
@@ -82,29 +80,18 @@ const STRAIGHT_LABEL_FONT_SIZE = 9;
 // anchor가 어느 tooltip을 가리키는지 모호해진다.
 const TOOLTIP_ELEMENT_ID = 'volume-chart-tooltip';
 
-function slotWidth(count: number): number {
-    return CHART_WIDTH / count;
-}
-
-function barCenterX(index: number, count: number): number {
-    const sw = slotWidth(count);
-    return PAD_LEFT + sw * index + sw / 2;
-}
-
-function barPixelHeight(volume: number, maxVolume: number): number {
-    if (maxVolume === 0) return 0;
-    return Math.min((volume / maxVolume) * HALF_HEIGHT, HALF_HEIGHT);
-}
-
 export function StrikeVolumeChart({
     underlyingPrice,
     chain,
 }: StrikeVolumeChartProps) {
-    const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
-    const [tooltipPos, setTooltipPos] = useState<TooltipPosition | null>(null);
-    const containerRef = useRef<HTMLDivElement | null>(null);
-    // 컨테이너 DOMRect 캐시 — OpenInterestChart와 동일한 reflow 회피 패턴.
-    const cachedRectRef = useRef<DOMRect | null>(null);
+    const {
+        containerRef,
+        hoveredIndex,
+        tooltipPos,
+        handlePointerEnter,
+        handlePointerMove,
+        handlePointerLeave,
+    } = useStrikeBarChart();
 
     const derived = useMemo(() => {
         if (!chain) return null;
@@ -170,7 +157,7 @@ export function StrikeVolumeChart({
     const { volumeByStrike, globalMax, currentPriceIdx, labelIndices } =
         derived;
     const count = volumeByStrike.length;
-    const sw = slotWidth(count);
+    const sw = slotWidth(count, CHART_WIDTH);
     const bw = sw * BAR_WIDTH_FILL_RATIO;
 
     // hoveredIndex 가드 — 만기 chip 전환으로 배열이 짧아지는 사이 stale
@@ -179,48 +166,12 @@ export function StrikeVolumeChart({
         hoveredIndex !== null ? (volumeByStrike[hoveredIndex] ?? null) : null;
 
     const currentPriceX =
-        currentPriceIdx >= 0 ? barCenterX(currentPriceIdx, count) : null;
+        currentPriceIdx >= 0
+            ? barCenterX(currentPriceIdx, count, PAD_LEFT, CHART_WIDTH)
+            : null;
 
     const rotateLabels = labelIndices.size > LABEL_ROTATION_THRESHOLD;
     const peakVolumeLabel = formatCompactCount(globalMax);
-
-    const handlePointerEnter = (
-        event: PointerEvent<SVGRectElement>,
-        index: number
-    ): void => {
-        const container = containerRef.current;
-        if (!container) return;
-        const rect = container.getBoundingClientRect();
-        cachedRectRef.current = rect;
-        setHoveredIndex(index);
-        setTooltipPos(computeTooltipPos(event, rect));
-    };
-
-    const handlePointerMove = (
-        event: PointerEvent<SVGRectElement>,
-        index: number
-    ): void => {
-        const rect = cachedRectRef.current;
-        // enter 전에 move가 먼저 발사되는 모바일 touchmove 경로 대응 —
-        // 한 번 측정해 캐시한 뒤 이후 move부터는 캐시만 읽는다.
-        if (rect === null) {
-            const container = containerRef.current;
-            if (!container) return;
-            const measured = container.getBoundingClientRect();
-            cachedRectRef.current = measured;
-            setHoveredIndex(index);
-            setTooltipPos(computeTooltipPos(event, measured));
-            return;
-        }
-        if (hoveredIndex !== index) setHoveredIndex(index);
-        setTooltipPos(computeTooltipPos(event, rect));
-    };
-
-    const handlePointerLeave = (): void => {
-        cachedRectRef.current = null;
-        setHoveredIndex(null);
-        setTooltipPos(null);
-    };
 
     return (
         <div
@@ -283,9 +234,17 @@ export function StrikeVolumeChart({
                 </text>
 
                 {volumeByStrike.map((row, i) => {
-                    const cx = barCenterX(i, count);
-                    const callH = barPixelHeight(row.callVolume, globalMax);
-                    const putH = barPixelHeight(row.putVolume, globalMax);
+                    const cx = barCenterX(i, count, PAD_LEFT, CHART_WIDTH);
+                    const callH = barPixelHeight(
+                        row.callVolume,
+                        globalMax,
+                        HALF_HEIGHT
+                    );
+                    const putH = barPixelHeight(
+                        row.putVolume,
+                        globalMax,
+                        HALF_HEIGHT
+                    );
 
                     return (
                         <g key={row.strike}>
@@ -339,7 +298,7 @@ export function StrikeVolumeChart({
 
                 {volumeByStrike.map((row, i) => {
                     if (!labelIndices.has(i)) return null;
-                    const cx = barCenterX(i, count);
+                    const cx = barCenterX(i, count, PAD_LEFT, CHART_WIDTH);
                     const labelY =
                         SVG_HEIGHT - PAD_BOTTOM + X_AXIS_LABEL_OFFSET_PX;
 
@@ -374,22 +333,10 @@ export function StrikeVolumeChart({
                 })}
             </svg>
 
-            {/* `aria-describedby`가 가리키는 대상은 항상 DOM에 있어야 한다.
-                `hidden`으로 숨기면 접근성 트리에서도 빠지지만, 하단 sr-only
-                테이블이 전체 volume 데이터를 제공하므로 이 pointer-only
-                tooltip에서는 허용 가능한 트레이드오프다. */}
-            <div
+            <StrikeBarTooltip
                 id={TOOLTIP_ELEMENT_ID}
-                role="tooltip"
-                hidden={hoveredRow === null || tooltipPos === null}
-                className="border-secondary-600 bg-secondary-900/95 text-secondary-100 pointer-events-none absolute top-[var(--tooltip-y)] left-[var(--tooltip-x)] z-10 min-w-[var(--tooltip-min-w)] -translate-x-1/2 -translate-y-full rounded-md border px-3 py-2 text-xs shadow-lg backdrop-blur"
-                style={
-                    {
-                        '--tooltip-x': `${tooltipPos?.x ?? 0}px`,
-                        '--tooltip-y': `${tooltipPos?.y ?? 0}px`,
-                        '--tooltip-min-w': `${TOOLTIP_MIN_WIDTH_PX}px`,
-                    } as CSSProperties
-                }
+                hoveredRow={hoveredRow}
+                tooltipPos={tooltipPos}
             >
                 {hoveredRow !== null && (
                     <>
@@ -419,7 +366,7 @@ export function StrikeVolumeChart({
                         </div>
                     </>
                 )}
-            </div>
+            </StrikeBarTooltip>
 
             <div className="text-secondary-500 mt-2 flex flex-wrap items-center gap-3 text-[10px]">
                 <span className="flex items-center gap-1">
@@ -447,30 +394,14 @@ export function StrikeVolumeChart({
                 </span>
             </div>
 
-            {/* OpenInterestChart와 동일 — <table>에 sr-only를 직접 두면
-                `display: table`이 normal flow에 잔재를 남겨 페이지 height에
-                영향을 주므로 <div>로 감싼다. */}
-            <div className="sr-only">
-                <table>
-                    <caption>Strike별 거래량 데이터</caption>
-                    <thead>
-                        <tr>
-                            <th scope="col">Strike</th>
-                            <th scope="col">Call Volume</th>
-                            <th scope="col">Put Volume</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {volumeByStrike.map(row => (
-                            <tr key={row.strike}>
-                                <td>{row.strike}</td>
-                                <td>{row.callVolume}</td>
-                                <td>{row.putVolume}</td>
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
-            </div>
+            <StrikeBarSrTable
+                caption="Strike별 거래량 데이터"
+                headers={['Strike', 'Call Volume', 'Put Volume']}
+                rows={volumeByStrike.map(row => ({
+                    key: row.strike,
+                    cells: [row.strike, row.callVolume, row.putVolume],
+                }))}
+            />
         </div>
     );
 }

--- a/src/widgets/options/StrikeVolumeChart.tsx
+++ b/src/widgets/options/StrikeVolumeChart.tsx
@@ -4,7 +4,6 @@ import { useMemo } from 'react';
 import type { OptionsChain } from '@y0ngha/siglens-core';
 import { InfoTooltip } from '@/shared/ui/InfoTooltip';
 import { CallVolumeTooltip, PutVolumeTooltip } from './utils/optionsTooltips';
-// TOOLTIP_MIN_WIDTH_PX는 StrikeBarTooltip 내부에서 computeTooltipPos를 통해 가져온다.
 import { pickLabelIndices } from './utils/pickLabelIndices';
 import { aggregateStrikeVolume } from './utils/aggregateStrikeVolume';
 import { formatCompactCount } from './utils/formatCompactCount';

--- a/src/widgets/options/__tests__/hooks/useStrikeBarChart.test.ts
+++ b/src/widgets/options/__tests__/hooks/useStrikeBarChart.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+/**
+ * Unit tests for `useStrikeBarChart` — 공용 pointer 핸들러 훅.
+ *
+ * renderHook으로 마운트 후 포인터 이벤트 시뮬레이션을 통해
+ * hoveredIndex / tooltipPos 상태 전환과 캐시 초기화를 검증한다.
+ */
+import { renderHook, act } from '@testing-library/react';
+import type { PointerEvent } from 'react';
+import { useStrikeBarChart } from '@/widgets/options/hooks/useStrikeBarChart';
+
+vi.mock('@/widgets/options/utils/computeTooltipPos', () => ({
+    computeTooltipPos: (_event: unknown, _rect: unknown) => ({ x: 100, y: 80 }),
+}));
+
+/** 최소 PointerEvent 형태 — 훅은 event를 computeTooltipPos에 그대로 전달하므로
+ *  실제 필드 값은 mock이 처리한다. */
+function makePointerEvent(): PointerEvent<SVGRectElement> {
+    return {
+        clientX: 200,
+        clientY: 150,
+    } as unknown as PointerEvent<SVGRectElement>;
+}
+
+/** containerRef.current에 할당할 최소 HTMLDivElement 스텁. */
+function makeContainerDiv(): HTMLDivElement {
+    const div = document.createElement('div');
+    // getBoundingClientRect 스텁 — jsdom은 레이아웃을 계산하지 않아 기본값이 0이지만
+    // 명시적 스텁으로 의도를 분명히 한다.
+    div.getBoundingClientRect = () =>
+        ({
+            left: 0,
+            top: 0,
+            width: 600,
+            height: 240,
+        }) as DOMRect;
+    return div;
+}
+
+describe('useStrikeBarChart', () => {
+    it('초기 상태: hoveredIndex와 tooltipPos가 모두 null이다', () => {
+        const { result } = renderHook(() => useStrikeBarChart());
+        expect(result.current.hoveredIndex).toBeNull();
+        expect(result.current.tooltipPos).toBeNull();
+    });
+
+    describe('handlePointerEnter', () => {
+        it('containerRef.current가 null이면 상태를 변경하지 않는다 (early return)', () => {
+            const { result } = renderHook(() => useStrikeBarChart());
+            // containerRef.current는 기본적으로 null이므로 별도 설정 불필요.
+            act(() => {
+                result.current.handlePointerEnter(makePointerEvent(), 2);
+            });
+            expect(result.current.hoveredIndex).toBeNull();
+            expect(result.current.tooltipPos).toBeNull();
+        });
+
+        it('containerRef.current가 있으면 hoveredIndex와 tooltipPos를 업데이트한다', () => {
+            const { result } = renderHook(() => useStrikeBarChart());
+            // containerRef에 div 주입
+            Object.defineProperty(result.current.containerRef, 'current', {
+                value: makeContainerDiv(),
+                writable: true,
+            });
+            act(() => {
+                result.current.handlePointerEnter(makePointerEvent(), 3);
+            });
+            expect(result.current.hoveredIndex).toBe(3);
+            expect(result.current.tooltipPos).toEqual({ x: 100, y: 80 });
+        });
+    });
+
+    describe('handlePointerMove', () => {
+        it('cachedRectRef가 null이고 containerRef도 null이면 상태 변경 없음', () => {
+            const { result } = renderHook(() => useStrikeBarChart());
+            act(() => {
+                result.current.handlePointerMove(makePointerEvent(), 1);
+            });
+            expect(result.current.hoveredIndex).toBeNull();
+            expect(result.current.tooltipPos).toBeNull();
+        });
+
+        it('enter 후 move는 캐시된 rect를 사용해 tooltipPos를 업데이트한다', () => {
+            const { result } = renderHook(() => useStrikeBarChart());
+            Object.defineProperty(result.current.containerRef, 'current', {
+                value: makeContainerDiv(),
+                writable: true,
+            });
+            // enter로 캐시 생성
+            act(() => {
+                result.current.handlePointerEnter(makePointerEvent(), 0);
+            });
+            // move — 캐시 경로
+            act(() => {
+                result.current.handlePointerMove(makePointerEvent(), 1);
+            });
+            expect(result.current.hoveredIndex).toBe(1);
+            expect(result.current.tooltipPos).toEqual({ x: 100, y: 80 });
+        });
+
+        it('enter 없이 move가 먼저 발사되면(모바일 경로) containerRef로 한 번 측정한다', () => {
+            const { result } = renderHook(() => useStrikeBarChart());
+            Object.defineProperty(result.current.containerRef, 'current', {
+                value: makeContainerDiv(),
+                writable: true,
+            });
+            // cachedRectRef는 null인 채로 move만 호출
+            act(() => {
+                result.current.handlePointerMove(makePointerEvent(), 2);
+            });
+            expect(result.current.hoveredIndex).toBe(2);
+            expect(result.current.tooltipPos).toEqual({ x: 100, y: 80 });
+        });
+    });
+
+    describe('handlePointerLeave', () => {
+        it('leave 시 hoveredIndex·tooltipPos가 null로 초기화된다', () => {
+            const { result } = renderHook(() => useStrikeBarChart());
+            Object.defineProperty(result.current.containerRef, 'current', {
+                value: makeContainerDiv(),
+                writable: true,
+            });
+            // 먼저 enter로 상태 설정
+            act(() => {
+                result.current.handlePointerEnter(makePointerEvent(), 5);
+            });
+            expect(result.current.hoveredIndex).toBe(5);
+            // leave로 초기화
+            act(() => {
+                result.current.handlePointerLeave();
+            });
+            expect(result.current.hoveredIndex).toBeNull();
+            expect(result.current.tooltipPos).toBeNull();
+        });
+
+        it('leave 후 move가 발사되면 cachedRectRef가 초기화됐으므로 containerRef 경유 경로로 처리된다', () => {
+            const { result } = renderHook(() => useStrikeBarChart());
+            Object.defineProperty(result.current.containerRef, 'current', {
+                value: makeContainerDiv(),
+                writable: true,
+            });
+            act(() => {
+                result.current.handlePointerEnter(makePointerEvent(), 0);
+            });
+            act(() => {
+                result.current.handlePointerLeave();
+            });
+            // cachedRectRef가 null이므로 containerRef 경유 경로 실행
+            act(() => {
+                result.current.handlePointerMove(makePointerEvent(), 4);
+            });
+            expect(result.current.hoveredIndex).toBe(4);
+            expect(result.current.tooltipPos).toEqual({ x: 100, y: 80 });
+        });
+    });
+});

--- a/src/widgets/options/__tests__/lib/strikeChartGeometry.test.ts
+++ b/src/widgets/options/__tests__/lib/strikeChartGeometry.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for `strikeChartGeometry` — 순수 기하학 헬퍼.
+ *
+ * 순수 함수라 DOM 렌더링 없이 수치만 검증한다.
+ */
+import {
+    slotWidth,
+    barCenterX,
+    barPixelHeight,
+} from '@/widgets/options/lib/strikeChartGeometry';
+
+describe('slotWidth', () => {
+    it('chartWidth를 count로 균등 분할해 반환한다', () => {
+        expect(slotWidth(5, 600)).toBe(120);
+    });
+
+    it('count가 1이면 chartWidth 전체를 반환한다', () => {
+        expect(slotWidth(1, 400)).toBe(400);
+    });
+
+    it('count가 정확히 나누어 떨어지지 않으면 소수점 결과를 반환한다', () => {
+        // 600 / 7 ≈ 85.714...
+        expect(slotWidth(7, 600)).toBeCloseTo(85.714, 2);
+    });
+});
+
+describe('barCenterX', () => {
+    // 예: chartWidth=600, count=4 → slotWidth=150
+    // index=0 → padLeft + 0 + 75 = padLeft + 75
+    // index=3 → padLeft + 450 + 75 = padLeft + 525
+
+    it('첫 번째 인덱스(0)일 때 padLeft + slotWidth/2를 반환한다', () => {
+        // slotWidth = 600/4 = 150, center = 0*150 + 75 = 75 → 12 + 75 = 87
+        expect(barCenterX(0, 4, 12, 600)).toBe(87);
+    });
+
+    it('마지막 인덱스일 때 올바른 중앙 x를 반환한다', () => {
+        // slotWidth=150, center = 3*150 + 75 = 525 → 12 + 525 = 537
+        expect(barCenterX(3, 4, 12, 600)).toBe(537);
+    });
+
+    it('중간 인덱스(1)일 때 올바른 중앙 x를 반환한다', () => {
+        // slotWidth=150, center = 1*150 + 75 = 225 → 12 + 225 = 237
+        expect(barCenterX(1, 4, 12, 600)).toBe(237);
+    });
+
+    it('padLeft가 0이면 SVG 원점부터 계산한다', () => {
+        // slotWidth=200, center = 2*200 + 100 = 500
+        expect(barCenterX(2, 3, 0, 600)).toBe(500);
+    });
+});
+
+describe('barPixelHeight', () => {
+    it('maxValue가 0이면 0-division 없이 0을 반환한다', () => {
+        expect(barPixelHeight(500, 0, 120)).toBe(0);
+    });
+
+    it('value가 maxValue와 같으면 halfHeight를 반환한다', () => {
+        expect(barPixelHeight(1000, 1000, 120)).toBe(120);
+    });
+
+    it('value가 maxValue보다 크면 halfHeight로 클램핑한다', () => {
+        // Math.min 클램핑 경로
+        expect(barPixelHeight(2000, 1000, 120)).toBe(120);
+    });
+
+    it('value가 maxValue의 절반이면 halfHeight의 절반을 반환한다', () => {
+        expect(barPixelHeight(500, 1000, 120)).toBe(60);
+    });
+
+    it('value가 0이면 높이 0을 반환한다', () => {
+        expect(barPixelHeight(0, 1000, 120)).toBe(0);
+    });
+});

--- a/src/widgets/options/__tests__/ui/StrikeBarSrTable.test.tsx
+++ b/src/widgets/options/__tests__/ui/StrikeBarSrTable.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+/**
+ * Unit tests for `StrikeBarSrTable` — 공용 sr-only 접근성 테이블.
+ *
+ * caption / headers / rows props가 올바른 시맨틱 구조로 렌더되는지 검증한다.
+ */
+import { render, screen } from '@testing-library/react';
+import { StrikeBarSrTable } from '@/widgets/options/ui/StrikeBarSrTable';
+
+const CAPTION = 'Strike별 미결제약정';
+const HEADERS = ['Strike', 'Call OI', 'Put OI'];
+const ROWS = [
+    { key: 140, cells: ['$140', '500', '300'] },
+    { key: 150, cells: ['$150', '1000', '800'] },
+];
+
+describe('StrikeBarSrTable', () => {
+    it('caption이 렌더된다', () => {
+        render(
+            <StrikeBarSrTable caption={CAPTION} headers={HEADERS} rows={ROWS} />
+        );
+        expect(
+            screen.getByText(CAPTION, { selector: 'caption' })
+        ).toBeInTheDocument();
+    });
+
+    it('헤더가 scope="col" th 요소로 렌더된다', () => {
+        render(
+            <StrikeBarSrTable caption={CAPTION} headers={HEADERS} rows={ROWS} />
+        );
+        const thElements = screen.getAllByRole('columnheader', {
+            hidden: true,
+        });
+        expect(thElements).toHaveLength(HEADERS.length);
+        HEADERS.forEach((header, i) => {
+            expect(thElements[i]).toHaveTextContent(header);
+            expect(thElements[i]).toHaveAttribute('scope', 'col');
+        });
+    });
+
+    it('rows 수만큼 tbody 행이 렌더된다', () => {
+        render(
+            <StrikeBarSrTable caption={CAPTION} headers={HEADERS} rows={ROWS} />
+        );
+        const table = screen.getByRole('table', { hidden: true });
+        const tbody = table.querySelector('tbody');
+        const trElements = tbody?.querySelectorAll('tr');
+        expect(trElements).toHaveLength(ROWS.length);
+    });
+
+    it('각 행의 셀 수가 cells 배열 길이와 일치한다', () => {
+        render(
+            <StrikeBarSrTable caption={CAPTION} headers={HEADERS} rows={ROWS} />
+        );
+        const table = screen.getByRole('table', { hidden: true });
+        const allRows = table.querySelectorAll('tbody tr');
+        allRows.forEach((tr, i) => {
+            const cells = tr.querySelectorAll('td');
+            expect(cells).toHaveLength(ROWS[i]!.cells.length);
+        });
+    });
+
+    it('rows가 빈 배열이면 tbody에 행이 없다', () => {
+        render(
+            <StrikeBarSrTable caption={CAPTION} headers={HEADERS} rows={[]} />
+        );
+        const table = screen.getByRole('table', { hidden: true });
+        const tbody = table.querySelector('tbody');
+        expect(tbody?.querySelectorAll('tr')).toHaveLength(0);
+    });
+
+    it('전체 컨테이너가 sr-only 클래스를 가진다', () => {
+        const { container } = render(
+            <StrikeBarSrTable caption={CAPTION} headers={HEADERS} rows={ROWS} />
+        );
+        const wrapper = container.firstElementChild;
+        expect(wrapper).toHaveClass('sr-only');
+    });
+});

--- a/src/widgets/options/__tests__/ui/StrikeBarTooltip.test.tsx
+++ b/src/widgets/options/__tests__/ui/StrikeBarTooltip.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+/**
+ * Unit tests for `StrikeBarTooltip` — 공용 floating tooltip 셸.
+ *
+ * hoveredRow / tooltipPos null 조합별 hidden 속성과 CSS 변수 값을 검증한다.
+ */
+import { render } from '@testing-library/react';
+import { StrikeBarTooltip } from '@/widgets/options/ui/StrikeBarTooltip';
+
+vi.mock('@/widgets/options/utils/computeTooltipPos', () => ({
+    TOOLTIP_MIN_WIDTH_PX: 180,
+}));
+
+const TOOLTIP_ID = 'test-tooltip';
+
+describe('StrikeBarTooltip', () => {
+    it('hoveredRow가 null이면 hidden 속성이 true여서 DOM에서 숨겨진다', () => {
+        const { getByRole } = render(
+            <StrikeBarTooltip
+                id={TOOLTIP_ID}
+                hoveredRow={null}
+                tooltipPos={{ x: 100, y: 80 }}
+            >
+                <span>내용</span>
+            </StrikeBarTooltip>
+        );
+        const tooltip = getByRole('tooltip', { hidden: true });
+        expect(tooltip).toHaveAttribute('hidden');
+    });
+
+    it('tooltipPos가 null이면 hidden 속성이 true여서 DOM에서 숨겨진다', () => {
+        const { getByRole } = render(
+            <StrikeBarTooltip
+                id={TOOLTIP_ID}
+                hoveredRow={{ strike: 150 }}
+                tooltipPos={null}
+            >
+                <span>내용</span>
+            </StrikeBarTooltip>
+        );
+        const tooltip = getByRole('tooltip', { hidden: true });
+        expect(tooltip).toHaveAttribute('hidden');
+    });
+
+    it('hoveredRow와 tooltipPos가 모두 non-null이면 hidden 속성이 없어 표시된다', () => {
+        const { getByRole } = render(
+            <StrikeBarTooltip
+                id={TOOLTIP_ID}
+                hoveredRow={{ strike: 150 }}
+                tooltipPos={{ x: 100, y: 80 }}
+            >
+                <span>내용</span>
+            </StrikeBarTooltip>
+        );
+        const tooltip = getByRole('tooltip', { hidden: true });
+        expect(tooltip).not.toHaveAttribute('hidden');
+    });
+
+    it('표시 상태일 때 children이 렌더된다', () => {
+        const { getByText } = render(
+            <StrikeBarTooltip
+                id={TOOLTIP_ID}
+                hoveredRow={{ strike: 150 }}
+                tooltipPos={{ x: 100, y: 80 }}
+            >
+                <span>툴팁 내용</span>
+            </StrikeBarTooltip>
+        );
+        expect(getByText('툴팁 내용')).toBeInTheDocument();
+    });
+
+    it('hoveredRow가 null이면 children이 렌더되지 않는다', () => {
+        const { queryByText } = render(
+            <StrikeBarTooltip
+                id={TOOLTIP_ID}
+                hoveredRow={null}
+                tooltipPos={{ x: 100, y: 80 }}
+            >
+                <span>숨겨진 내용</span>
+            </StrikeBarTooltip>
+        );
+        expect(queryByText('숨겨진 내용')).not.toBeInTheDocument();
+    });
+
+    it('id prop이 tooltip 요소의 id 속성으로 설정된다', () => {
+        const { getByRole } = render(
+            <StrikeBarTooltip
+                id="custom-tooltip-id"
+                hoveredRow={{ strike: 150 }}
+                tooltipPos={{ x: 50, y: 60 }}
+            >
+                <span>내용</span>
+            </StrikeBarTooltip>
+        );
+        const tooltip = getByRole('tooltip', { hidden: true });
+        expect(tooltip).toHaveAttribute('id', 'custom-tooltip-id');
+    });
+
+    it('CSS 변수 --tooltip-x / --tooltip-y가 tooltipPos 값으로 설정된다', () => {
+        const { getByRole } = render(
+            <StrikeBarTooltip
+                id={TOOLTIP_ID}
+                hoveredRow={{ strike: 150 }}
+                tooltipPos={{ x: 123, y: 456 }}
+            >
+                <span>내용</span>
+            </StrikeBarTooltip>
+        );
+        const tooltip = getByRole('tooltip', { hidden: true });
+        expect(tooltip).toHaveStyle('--tooltip-x: 123px');
+        expect(tooltip).toHaveStyle('--tooltip-y: 456px');
+    });
+});

--- a/src/widgets/options/hooks/useStrikeBarChart.ts
+++ b/src/widgets/options/hooks/useStrikeBarChart.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useRef, useState, type PointerEvent } from 'react';
+import {
+    computeTooltipPos,
+    type TooltipPosition,
+} from '../utils/computeTooltipPos';
+
+/**
+ * Strike 바 차트 공용 포인터 핸들러 훅.
+ *
+ * OpenInterestChart·StrikeVolumeChart 양쪽에서 동일한 reflow-회피 패턴
+ * (cachedRectRef + 3-handler)을 복제하고 있어 여기로 추출한다.
+ *
+ * ## reflow 회피 전략
+ * - pointerEnter 시 컨테이너 DOMRect를 한 번 측정해 `cachedRectRef`에 저장.
+ * - pointerMove는 캐시를 읽기만 한다 — 매 move마다 `getBoundingClientRect`를
+ *   부르면 레이아웃 쓰래싱이 발생해 빠른 마우스 이동 시 frame drop으로 이어진다.
+ * - 모바일 touchmove처럼 enter 전에 move가 먼저 발사되는 경우에만 한 번 측정 후
+ *   캐시한다.
+ * - pointerLeave 시 캐시와 hover state를 모두 초기화한다.
+ */
+export function useStrikeBarChart() {
+    const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+    const [tooltipPos, setTooltipPos] = useState<TooltipPosition | null>(null);
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    // 컨테이너 DOMRect 캐시 — pointerEnter에서 한 번 측정, pointerMove에서 재사용.
+    const cachedRectRef = useRef<DOMRect | null>(null);
+
+    const handlePointerEnter = (
+        event: PointerEvent<SVGRectElement>,
+        index: number
+    ): void => {
+        const container = containerRef.current;
+        if (!container) return;
+        const rect = container.getBoundingClientRect();
+        cachedRectRef.current = rect;
+        setHoveredIndex(index);
+        setTooltipPos(computeTooltipPos(event, rect));
+    };
+
+    const handlePointerMove = (
+        event: PointerEvent<SVGRectElement>,
+        index: number
+    ): void => {
+        const rect = cachedRectRef.current;
+        // enter 전에 move가 먼저 발사되는 모바일 touchmove 경로 대응 —
+        // 한 번 측정해 캐시한 뒤 이후 move부터는 캐시만 읽는다.
+        if (rect === null) {
+            const container = containerRef.current;
+            if (!container) return;
+            const measured = container.getBoundingClientRect();
+            cachedRectRef.current = measured;
+            setHoveredIndex(index);
+            setTooltipPos(computeTooltipPos(event, measured));
+            return;
+        }
+        if (hoveredIndex !== index) setHoveredIndex(index);
+        setTooltipPos(computeTooltipPos(event, rect));
+    };
+
+    const handlePointerLeave = (): void => {
+        cachedRectRef.current = null;
+        setHoveredIndex(null);
+        setTooltipPos(null);
+    };
+
+    return {
+        containerRef,
+        hoveredIndex,
+        tooltipPos,
+        handlePointerEnter,
+        handlePointerMove,
+        handlePointerLeave,
+    };
+}

--- a/src/widgets/options/hooks/useStrikeBarChart.ts
+++ b/src/widgets/options/hooks/useStrikeBarChart.ts
@@ -1,10 +1,26 @@
 'use client';
 
-import { useRef, useState, type PointerEvent } from 'react';
+import { useRef, useState, type PointerEvent, type RefObject } from 'react';
 import {
     computeTooltipPos,
     type TooltipPosition,
 } from '../utils/computeTooltipPos';
+
+/** `useStrikeBarChart` 훅의 반환 타입. */
+export interface UseStrikeBarChartReturn {
+    containerRef: RefObject<HTMLDivElement | null>;
+    hoveredIndex: number | null;
+    tooltipPos: TooltipPosition | null;
+    handlePointerEnter: (
+        event: PointerEvent<SVGRectElement>,
+        index: number
+    ) => void;
+    handlePointerMove: (
+        event: PointerEvent<SVGRectElement>,
+        index: number
+    ) => void;
+    handlePointerLeave: () => void;
+}
 
 /**
  * Strike 바 차트 공용 포인터 핸들러 훅.
@@ -20,7 +36,7 @@ import {
  *   캐시한다.
  * - pointerLeave 시 캐시와 hover state를 모두 초기화한다.
  */
-export function useStrikeBarChart() {
+export function useStrikeBarChart(): UseStrikeBarChartReturn {
     const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
     const [tooltipPos, setTooltipPos] = useState<TooltipPosition | null>(null);
     const containerRef = useRef<HTMLDivElement | null>(null);

--- a/src/widgets/options/lib/strikeChartGeometry.ts
+++ b/src/widgets/options/lib/strikeChartGeometry.ts
@@ -1,0 +1,53 @@
+/**
+ * Strike 바 차트용 순수 기하학 헬퍼.
+ *
+ * OpenInterestChart·StrikeVolumeChart 양쪽에서 완전히 동일한 수식을 사용하므로
+ * 여기로 추출한다. 레이아웃 상수(PAD_LEFT, CHART_WIDTH, HALF_HEIGHT)는 각
+ * 차트가 독립적으로 튜닝할 수 있도록 인수로 주입받는다 — 상수 자체를 공유하면
+ * 한 차트 패딩 변경이 다른 차트에 의도치 않게 영향을 미친다.
+ */
+
+/**
+ * 슬라이드 하나의 픽셀 너비.
+ *
+ * @param count      - strike 총 개수
+ * @param chartWidth - 차트 영역 전체 너비 (px)
+ */
+export function slotWidth(count: number, chartWidth: number): number {
+    return chartWidth / count;
+}
+
+/**
+ * 슬롯 중앙 x 좌표.
+ *
+ * @param index      - 0-based strike 인덱스
+ * @param count      - strike 총 개수
+ * @param padLeft    - SVG 좌측 패딩 (px)
+ * @param chartWidth - 차트 영역 전체 너비 (px)
+ */
+export function barCenterX(
+    index: number,
+    count: number,
+    padLeft: number,
+    chartWidth: number
+): number {
+    const sw = slotWidth(count, chartWidth);
+    return padLeft + sw * index + sw / 2;
+}
+
+/**
+ * 값을 차트 절반 높이 기준으로 픽셀 높이로 변환한다.
+ * maxValue가 0이면 0을 반환해 0-division 경로를 차단한다.
+ *
+ * @param value      - 렌더할 값 (OI 또는 volume)
+ * @param maxValue   - 같은 차트 전체의 최대값
+ * @param halfHeight - 차트 절반 높이 (px)
+ */
+export function barPixelHeight(
+    value: number,
+    maxValue: number,
+    halfHeight: number
+): number {
+    if (maxValue === 0) return 0;
+    return Math.min((value / maxValue) * halfHeight, halfHeight);
+}

--- a/src/widgets/options/ui/StrikeBarSrTable.tsx
+++ b/src/widgets/options/ui/StrikeBarSrTable.tsx
@@ -2,16 +2,21 @@
 
 import { type ReactNode } from 'react';
 
+/** `StrikeBarSrTable`의 단일 행 타입. */
+export interface StrikeBarSrTableRow {
+    /** `key` prop으로 사용되는 고유 식별자. */
+    key: string | number;
+    /** 순서대로 렌더할 셀 내용. */
+    cells: ReactNode[];
+}
+
 interface StrikeBarSrTableProps {
     /** <caption> 텍스트 — 스크린 리더에 표 목적을 설명한다. */
     caption: string;
     /** <thead> 컬럼 헤더 목록. */
     headers: string[];
     /** <tbody> 행 목록. 각 row는 고유 key와 렌더할 셀(cells)로 구성된다. */
-    rows: Array<{
-        key: string | number;
-        cells: ReactNode[];
-    }>;
+    rows: StrikeBarSrTableRow[];
 }
 
 /**

--- a/src/widgets/options/ui/StrikeBarSrTable.tsx
+++ b/src/widgets/options/ui/StrikeBarSrTable.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { type ReactNode } from 'react';
+
+interface StrikeBarSrTableProps {
+    /** <caption> 텍스트 — 스크린 리더에 표 목적을 설명한다. */
+    caption: string;
+    /** <thead> 컬럼 헤더 목록. */
+    headers: string[];
+    /** <tbody> 행 목록. 각 row는 고유 key와 렌더할 셀(cells)로 구성된다. */
+    rows: Array<{
+        key: string | number;
+        cells: ReactNode[];
+    }>;
+}
+
+/**
+ * Strike 바 차트 공용 sr-only 접근성 테이블.
+ *
+ * OpenInterestChart·StrikeVolumeChart 양쪽이 동일한 `<div className="sr-only">
+ * <table>` 패턴을 복제하고 있어 여기로 추출한다. caption·헤더·행 데이터만
+ * 차트별로 다르므로 props로 주입받는다.
+ *
+ * ## 왜 <table>이 아니라 <div>로 감싸는가
+ * `<table>`은 `display: table`이라 `position: absolute`와 결합돼도 일부
+ * 환경에서 normal flow에 잔재가 남아 페이지 height에 영향을 준다. `<div>`로
+ * 감싸 absolute 컨텍스트를 분리한다.
+ */
+export function StrikeBarSrTable({
+    caption,
+    headers,
+    rows,
+}: StrikeBarSrTableProps) {
+    return (
+        <div className="sr-only">
+            <table>
+                <caption>{caption}</caption>
+                <thead>
+                    <tr>
+                        {headers.map(header => (
+                            <th key={header} scope="col">
+                                {header}
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {rows.map(row => (
+                        <tr key={row.key}>
+                            {row.cells.map((cell, i) => (
+                                // 셀 순서가 고정돼 있어 index를 key로 사용해도 안전하다.
+                                <td key={i}>{cell}</td>
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/src/widgets/options/ui/StrikeBarTooltip.tsx
+++ b/src/widgets/options/ui/StrikeBarTooltip.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { type CSSProperties, type ReactNode } from 'react';
+import {
+    TOOLTIP_MIN_WIDTH_PX,
+    type TooltipPosition,
+} from '../utils/computeTooltipPos';
+
+interface StrikeBarTooltipProps {
+    /** DOM id — aria-describedby와 role="tooltip" 양쪽에서 일치해야 함. */
+    id: string;
+    /** 현재 hover 중인 row (null이면 hidden). */
+    hoveredRow: unknown | null;
+    /** computeTooltipPos가 반환한 컨테이너 기준 좌표. */
+    tooltipPos: TooltipPosition | null;
+    /** 툴팁 내용. 각 차트가 자신의 데이터 포맷으로 렌더링한다. */
+    children: ReactNode;
+}
+
+/**
+ * Strike 바 차트 공용 floating tooltip 셸.
+ *
+ * OpenInterestChart·StrikeVolumeChart 양쪽이 완전히 동일한 div 구조
+ * (hidden 속성, CSS 변수, 클래스셋)를 복제하고 있어 여기로 추출한다.
+ * id와 내용(children)만 차트별로 다르므로 props로 주입받는다.
+ *
+ * ## 접근성 트레이드오프
+ * `hidden` 속성으로 숨기면 접근성 트리에서도 제거되어 screen reader가
+ * aria-describedby 참조를 따라올 수 없지만, 하단 sr-only 테이블이 전체
+ * 데이터를 제공하므로 이 pointer-only 툴팁에서는 허용 가능한 트레이드오프다.
+ */
+export function StrikeBarTooltip({
+    id,
+    hoveredRow,
+    tooltipPos,
+    children,
+}: StrikeBarTooltipProps) {
+    return (
+        <div
+            id={id}
+            role="tooltip"
+            hidden={hoveredRow === null || tooltipPos === null}
+            className="border-secondary-600 bg-secondary-900/95 text-secondary-100 pointer-events-none absolute top-[var(--tooltip-y)] left-[var(--tooltip-x)] z-10 min-w-[var(--tooltip-min-w)] -translate-x-1/2 -translate-y-full rounded-md border px-3 py-2 text-xs shadow-lg backdrop-blur"
+            style={
+                // CSS 커스텀 프로퍼티(--*)는 런타임에 유효하나 React의
+                // CSSProperties 타입은 임의 `--*` 키를 포함하지 않아
+                // 인덱스 시그니처가 막힘 — TS 한계 우회용 cast이며
+                // 런타임 리스크는 없다.
+                {
+                    '--tooltip-x': `${tooltipPos?.x ?? 0}px`,
+                    '--tooltip-y': `${tooltipPos?.y ?? 0}px`,
+                    '--tooltip-min-w': `${TOOLTIP_MIN_WIDTH_PX}px`,
+                } as CSSProperties
+            }
+        >
+            {hoveredRow !== null && children}
+        </div>
+    );
+}

--- a/src/widgets/options/ui/StrikeBarTooltip.tsx
+++ b/src/widgets/options/ui/StrikeBarTooltip.tsx
@@ -9,8 +9,9 @@ import {
 interface StrikeBarTooltipProps {
     /** DOM id — aria-describedby와 role="tooltip" 양쪽에서 일치해야 함. */
     id: string;
-    /** 현재 hover 중인 row (null이면 hidden). */
-    hoveredRow: unknown | null;
+    /** 현재 hover 중인 row (null이면 hidden). non-null일 때는 항상 객체이며,
+     *  컴포넌트 내부에서는 null 여부만 확인하므로 `object`로 받는다. */
+    hoveredRow: object | null;
     /** computeTooltipPos가 반환한 컨테이너 기준 좌표. */
     tooltipPos: TooltipPosition | null;
     /** 툴팁 내용. 각 차트가 자신의 데이터 포맷으로 렌더링한다. */


### PR DESCRIPTION
Pure refactoring. OpenInterestChart and StrikeVolumeChart shared ~200 lines (pointer handlers, tooltip shell, sr-only table, geometry). Extracted into lib/strikeChartGeometry, hooks/useStrikeBarChart, ui/StrikeBarTooltip, ui/StrikeBarSrTable. Layout constants intentionally kept per-chart; DOM/ids/testids, Max Pain line, and orientation byte-identical. tsc + scoped tests + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)