### PR TITLE
refactor(news): unify news card shell with injected label/class maps (P1)

### DIFF
--- a/src/shared/lib/__tests__/timeFormat.test.ts
+++ b/src/shared/lib/__tests__/timeFormat.test.ts
@@ -1,4 +1,7 @@
-import { getTimeFormatter } from '@/shared/lib/timeFormat';
+import {
+    getTimeFormatter,
+    formatNewsPublishedAt,
+} from '@/shared/lib/timeFormat';
 
 // 2024-03-30 09:30:00 UTC = 2024-03-30 18:30:00 KST (UTC+9)
 const UTC_TIMESTAMP_SECONDS = 1711791000;
@@ -11,6 +14,22 @@ const LATE_UTC_TIMESTAMP_SECONDS =
     new Date('2024-01-15T17:00:00Z').getTime() / 1000;
 
 describe('timeFormat', () => {
+    describe('formatNewsPublishedAt', () => {
+        it('UTC ISO 시각을 KST 기준 한국어 날짜+시간 문자열로 변환한다', () => {
+            // 2026-05-05T22:35:21.000Z → KST 2026-05-06 07:35
+            expect(formatNewsPublishedAt('2026-05-05T22:35:21.000Z')).toBe(
+                '2026년 5월 6일 오전 07:35 KST'
+            );
+        });
+
+        it('날짜 경계 케이스: UTC 전날이지만 KST 기준 다음날로 표시된다', () => {
+            // 2026-05-05T15:00:00.000Z → KST 2026-05-06 00:00
+            expect(formatNewsPublishedAt('2026-05-05T15:00:00.000Z')).toBe(
+                '2026년 5월 6일 오전 12:00 KST'
+            );
+        });
+    });
+
     describe('getTimeFormatter', () => {
         describe('5Min 타임프레임', () => {
             it('KST 기준 시:분 형식(HH:mm)을 반환한다', () => {

--- a/src/shared/lib/timeFormat.ts
+++ b/src/shared/lib/timeFormat.ts
@@ -58,6 +58,30 @@ const DATE_TIME_TIMEFRAMES: ReadonlySet<Timeframe> = new Set([
     '4Hour',
 ]);
 
+// 뉴스 발행 시각 → KST 기준 한국어 날짜+시간 문자열 ("2026년 5월 6일 오전 07:35 KST")
+const NEWS_PUBLISHED_AT_FORMATTER = new Intl.DateTimeFormat('ko-KR', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'Asia/Seoul',
+});
+
+/**
+ * ISO 발행 시각을 KST 기준 한국어 날짜+시간 문자열로 변환한다.
+ *
+ * 두 뉴스 서피스(NewsList · MarketNewsCard)가 동일한 포맷터 인스턴스를
+ * 공유할 수 있도록 shared/lib에 단일 소스로 배치됐다.
+ *
+ * @example
+ * formatNewsPublishedAt('2026-05-05T22:35:21.000Z')
+ * // → '2026년 5월 6일 오전 07:35 KST'
+ */
+export function formatNewsPublishedAt(publishedAt: string): string {
+    return `${NEWS_PUBLISHED_AT_FORMATTER.format(new Date(publishedAt))} KST`;
+}
+
 export function getTimeFormatter(
     timeframe: Timeframe
 ): (timestamp: number) => string {

--- a/src/shared/lib/timeFormat.ts
+++ b/src/shared/lib/timeFormat.ts
@@ -58,7 +58,6 @@ const DATE_TIME_TIMEFRAMES: ReadonlySet<Timeframe> = new Set([
     '4Hour',
 ]);
 
-// 뉴스 발행 시각 → KST 기준 한국어 날짜+시간 문자열 ("2026년 5월 6일 오전 07:35 KST")
 const NEWS_PUBLISHED_AT_FORMATTER = new Intl.DateTimeFormat('ko-KR', {
     year: 'numeric',
     month: 'short',

--- a/src/shared/ui/NewsCardShell.tsx
+++ b/src/shared/ui/NewsCardShell.tsx
@@ -47,8 +47,9 @@ export interface NewsCardShellProps {
 
     /**
      * "원문 보기" 링크의 자식 노드.
-     * NewsList: `원문 보기 →` (텍스트 노드)
-     * MarketNewsCard: `원문 보기 <span aria-hidden>→</span>`
+     * NewsList: `원문 보기 →` (텍스트 노드) — 화살표를 가시 텍스트로 포함해 스크린리더가 읽는다.
+     * MarketNewsCard: `원문 보기 <span aria-hidden>→</span>` — 화살표를 aria-hidden으로 감싸
+     * 스크린리더가 "화살표"를 두 번 읽지 않도록 한다 (버튼 레이블에 방향 기호가 혼재하는 맥락).
      */
     linkChildren: ReactNode;
 

--- a/src/shared/ui/NewsCardShell.tsx
+++ b/src/shared/ui/NewsCardShell.tsx
@@ -35,7 +35,7 @@ export interface NewsCardShellProps {
 
     /**
      * 티커 칩 슬롯 (선택).
-     * market-news 카드만 사용한다; NewsList 카드는 null을 전달해 생략한다.
+     * market-news 카드만 사용한다; NewsList 카드는 이 prop을 생략한다.
      */
     tickerChipSlot?: ReactNode;
 
@@ -61,11 +61,8 @@ export interface NewsCardShellProps {
  *
  * NewsList의 `NewsCard`와 `MarketNewsCard` 양쪽이 공유하는
  * 외곽 article wrapper · 제목 · pending/ready 분기 구조를 단일 소스로 관리한다.
- * 서피스별로 다른 레이블·클래스 맵·DOM 세부사항은 props/children으로 주입된다.
- *
- * 중요: 이 컴포넌트는 각 서피스의 렌더된 DOM이 byte-identical하게 유지되도록
- * 구조적 컨테이너 역할만 한다. badge 레이블, aria-hidden 등 차이 요소는
- * 호출 측 props를 통해 서피스별로 독립적으로 제어된다.
+ * 서피스별로 다른 레이블·클래스 맵·DOM 세부사항은 props/children으로 주입되므로
+ * 최종 렌더 DOM은 서피스마다 다를 수 있다.
  */
 export function NewsCardShell({
     title,

--- a/src/widgets/market-news/MarketNewsCard.tsx
+++ b/src/widgets/market-news/MarketNewsCard.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import type { MarketNewsCardItem } from '@/entities/market-news';
 import type { NewsFeedCategory } from '@y0ngha/siglens-core';
 import { cn } from '@/shared/lib/cn';
+import { formatNewsPublishedAt } from '@/shared/lib/timeFormat';
+import { NewsCardShell } from '@/widgets/news/ui/NewsCardShell';
 import {
     SENTIMENT_LABEL,
     SENTIMENT_CLASS,
@@ -13,21 +15,8 @@ import {
     isNewsImpact,
 } from './utils/impactConstants';
 
-const PUBLISHED_AT_FORMATTER = new Intl.DateTimeFormat('ko-KR', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    timeZone: 'Asia/Seoul',
-});
-
 function isPending(item: MarketNewsCardItem): boolean {
     return item.sentiment === null || item.priceImpact === null;
-}
-
-function formatPublishedAt(publishedAt: string): string {
-    return `${PUBLISHED_AT_FORMATTER.format(new Date(publishedAt))} KST`;
 }
 
 interface SentimentBadgeProps {
@@ -64,29 +53,6 @@ function ImpactBadge({ value }: ImpactBadgeProps) {
         >
             {IMPACT_LABEL[value]}
         </span>
-    );
-}
-
-/** Skeleton shown while AI analysis is still pending for this card. */
-function AnalysisSkeleton() {
-    return (
-        <div
-            aria-hidden="true"
-            className="mt-1.5 flex flex-wrap items-center gap-2"
-        >
-            <div className="bg-secondary-700 h-5 w-10 animate-pulse rounded motion-reduce:animate-none" />
-            <div className="bg-secondary-700 h-5 w-20 animate-pulse rounded motion-reduce:animate-none" />
-            <span className="text-secondary-400 text-xs">AI 분석 중…</span>
-        </div>
-    );
-}
-
-function SummarySkeletonLine() {
-    return (
-        <div aria-hidden="true" className="mt-2 space-y-1.5">
-            <div className="bg-secondary-700/70 h-3.5 w-full animate-pulse rounded motion-reduce:animate-none" />
-            <div className="bg-secondary-700/70 h-3.5 w-4/5 animate-pulse rounded motion-reduce:animate-none" />
-        </div>
     );
 }
 
@@ -161,27 +127,36 @@ export interface MarketNewsCardProps {
 export function MarketNewsCard({ category, item }: MarketNewsCardProps) {
     const pending = isPending(item);
     const isHighImpact = !pending && item.priceImpact === 'high';
-    const publishedDate = formatPublishedAt(item.publishedAt);
+    const publishedDate = formatNewsPublishedAt(item.publishedAt);
 
     return (
-        <article
-            className={cn(
-                'border-secondary-700 bg-secondary-800 hover:border-primary-500/50 w-full max-w-full min-w-0 overflow-hidden rounded-xl border p-4 transition-[colors,transform] hover:-translate-y-px',
-                isHighImpact && 'border-l-ui-warning border-l-[3px] pl-5'
-            )}
-        >
-            <h3
-                className={cn(
-                    'leading-snug font-semibold text-balance wrap-break-word',
-                    pending && 'opacity-80'
-                )}
-            >
-                {item.titleKo ?? item.titleEn}
-            </h3>
-
-            {pending ? (
-                <AnalysisSkeleton />
-            ) : (
+        <NewsCardShell
+            title={item.titleKo ?? item.titleEn}
+            isHighImpact={isHighImpact}
+            pending={pending}
+            url={item.url}
+            // MarketNewsCard의 AnalysisSkeleton: aria-hidden=true, text-secondary-400 텍스트
+            analysisSkeleton={
+                <div
+                    aria-hidden="true"
+                    className="mt-1.5 flex flex-wrap items-center gap-2"
+                >
+                    <div className="bg-secondary-700 h-5 w-10 animate-pulse rounded motion-reduce:animate-none" />
+                    <div className="bg-secondary-700 h-5 w-20 animate-pulse rounded motion-reduce:animate-none" />
+                    <span className="text-secondary-400 text-xs">
+                        AI 분석 중…
+                    </span>
+                </div>
+            }
+            // MarketNewsCard의 SummarySkeletonLine: aria-hidden=true
+            summarySkeletonLine={
+                <div aria-hidden="true" className="mt-2 space-y-1.5">
+                    <div className="bg-secondary-700/70 h-3.5 w-full animate-pulse rounded motion-reduce:animate-none" />
+                    <div className="bg-secondary-700/70 h-3.5 w-4/5 animate-pulse rounded motion-reduce:animate-none" />
+                </div>
+            }
+            // MarketNewsCard 배지 행: min-w-0 포함, text-secondary-300 카테고리, translate="no" source
+            badgeRow={
                 <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-2">
                     <SentimentBadge value={item.sentiment!} />
                     <ImpactBadge value={item.priceImpact!} />
@@ -200,15 +175,15 @@ export function MarketNewsCard({ category, item }: MarketNewsCardProps) {
                         {item.source}
                     </span>
                 </div>
-            )}
-
-            {item.tickers.length > 0 && (
-                <TickerChips category={category} tickers={item.tickers} />
-            )}
-
-            {pending ? (
-                <SummarySkeletonLine />
-            ) : (
+            }
+            // 티커 칩 슬롯: tickers가 있을 때만 렌더한다.
+            tickerChipSlot={
+                item.tickers.length > 0 ? (
+                    <TickerChips category={category} tickers={item.tickers} />
+                ) : undefined
+            }
+            // 본문/요약 섹션: section 엘리먼트를 직접 인라인으로 사용한다.
+            bodySection={
                 <>
                     {item.bodyKo !== null && (
                         <section className="border-secondary-700/70 mt-3 border-t pt-3">
@@ -230,16 +205,14 @@ export function MarketNewsCard({ category, item }: MarketNewsCardProps) {
                             </p>
                         </section>
                     )}
-                    <a
-                        href={item.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary-400 focus-visible:ring-primary-500 mt-2 inline-block text-xs transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:outline-none"
-                    >
-                        원문 보기 <span aria-hidden="true">→</span>
-                    </a>
                 </>
-            )}
-        </article>
+            }
+            // MarketNewsCard 링크: aria-hidden span으로 감싼 화살표
+            linkChildren={
+                <>
+                    원문 보기 <span aria-hidden="true">→</span>
+                </>
+            }
+        />
     );
 }

--- a/src/widgets/market-news/MarketNewsCard.tsx
+++ b/src/widgets/market-news/MarketNewsCard.tsx
@@ -3,7 +3,7 @@ import type { MarketNewsCardItem } from '@/entities/market-news';
 import type { NewsFeedCategory } from '@y0ngha/siglens-core';
 import { cn } from '@/shared/lib/cn';
 import { formatNewsPublishedAt } from '@/shared/lib/timeFormat';
-import { NewsCardShell } from '@/widgets/news/ui/NewsCardShell';
+import { NewsCardShell } from '@/shared/ui/NewsCardShell';
 import {
     SENTIMENT_LABEL,
     SENTIMENT_CLASS,

--- a/src/widgets/market-news/MarketNewsCard.tsx
+++ b/src/widgets/market-news/MarketNewsCard.tsx
@@ -111,6 +111,33 @@ function TickerChips({ category, tickers }: TickerChipsProps) {
     );
 }
 
+/**
+ * aria-hidden=true — 스크린리더는 로딩 중 애니메이션 마커를 읽지 않는다.
+ * text-secondary-400 텍스트 컬러는 NewsList(text-secondary-500)와 의도적으로 다르다.
+ */
+function AnalysisSkeleton() {
+    return (
+        <div
+            aria-hidden="true"
+            className="mt-1.5 flex flex-wrap items-center gap-2"
+        >
+            <div className="bg-secondary-700 h-5 w-10 animate-pulse rounded motion-reduce:animate-none" />
+            <div className="bg-secondary-700 h-5 w-20 animate-pulse rounded motion-reduce:animate-none" />
+            <span className="text-secondary-400 text-xs">AI 분석 중…</span>
+        </div>
+    );
+}
+
+/** aria-hidden=true — 스크린리더는 본문 로딩 중 스켈레톤 줄을 읽지 않는다. */
+function SummarySkeletonLine() {
+    return (
+        <div aria-hidden="true" className="mt-2 space-y-1.5">
+            <div className="bg-secondary-700/70 h-3.5 w-full animate-pulse rounded motion-reduce:animate-none" />
+            <div className="bg-secondary-700/70 h-3.5 w-4/5 animate-pulse rounded motion-reduce:animate-none" />
+        </div>
+    );
+}
+
 export interface MarketNewsCardProps {
     category: NewsFeedCategory;
     item: MarketNewsCardItem;
@@ -135,24 +162,8 @@ export function MarketNewsCard({ category, item }: MarketNewsCardProps) {
             isHighImpact={isHighImpact}
             pending={pending}
             url={item.url}
-            analysisSkeleton={
-                <div
-                    aria-hidden="true"
-                    className="mt-1.5 flex flex-wrap items-center gap-2"
-                >
-                    <div className="bg-secondary-700 h-5 w-10 animate-pulse rounded motion-reduce:animate-none" />
-                    <div className="bg-secondary-700 h-5 w-20 animate-pulse rounded motion-reduce:animate-none" />
-                    <span className="text-secondary-400 text-xs">
-                        AI 분석 중…
-                    </span>
-                </div>
-            }
-            summarySkeletonLine={
-                <div aria-hidden="true" className="mt-2 space-y-1.5">
-                    <div className="bg-secondary-700/70 h-3.5 w-full animate-pulse rounded motion-reduce:animate-none" />
-                    <div className="bg-secondary-700/70 h-3.5 w-4/5 animate-pulse rounded motion-reduce:animate-none" />
-                </div>
-            }
+            analysisSkeleton={<AnalysisSkeleton />}
+            summarySkeletonLine={<SummarySkeletonLine />}
             badgeRow={
                 <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-2">
                     {item.sentiment !== null && (

--- a/src/widgets/market-news/MarketNewsCard.tsx
+++ b/src/widgets/market-news/MarketNewsCard.tsx
@@ -135,7 +135,6 @@ export function MarketNewsCard({ category, item }: MarketNewsCardProps) {
             isHighImpact={isHighImpact}
             pending={pending}
             url={item.url}
-            // MarketNewsCard의 AnalysisSkeleton: aria-hidden=true, text-secondary-400 텍스트
             analysisSkeleton={
                 <div
                     aria-hidden="true"
@@ -148,18 +147,20 @@ export function MarketNewsCard({ category, item }: MarketNewsCardProps) {
                     </span>
                 </div>
             }
-            // MarketNewsCard의 SummarySkeletonLine: aria-hidden=true
             summarySkeletonLine={
                 <div aria-hidden="true" className="mt-2 space-y-1.5">
                     <div className="bg-secondary-700/70 h-3.5 w-full animate-pulse rounded motion-reduce:animate-none" />
                     <div className="bg-secondary-700/70 h-3.5 w-4/5 animate-pulse rounded motion-reduce:animate-none" />
                 </div>
             }
-            // MarketNewsCard 배지 행: min-w-0 포함, text-secondary-300 카테고리, translate="no" source
             badgeRow={
                 <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-2">
-                    <SentimentBadge value={item.sentiment!} />
-                    <ImpactBadge value={item.priceImpact!} />
+                    {item.sentiment !== null && (
+                        <SentimentBadge value={item.sentiment} />
+                    )}
+                    {item.priceImpact !== null && (
+                        <ImpactBadge value={item.priceImpact} />
+                    )}
                     {item.category !== null && (
                         <span className="bg-secondary-700 text-secondary-300 rounded px-2 py-0.5 text-xs">
                             {item.category}
@@ -176,13 +177,11 @@ export function MarketNewsCard({ category, item }: MarketNewsCardProps) {
                     </span>
                 </div>
             }
-            // 티커 칩 슬롯: tickers가 있을 때만 렌더한다.
             tickerChipSlot={
                 item.tickers.length > 0 ? (
                     <TickerChips category={category} tickers={item.tickers} />
                 ) : undefined
             }
-            // 본문/요약 섹션: section 엘리먼트를 직접 인라인으로 사용한다.
             bodySection={
                 <>
                     {item.bodyKo !== null && (
@@ -207,7 +206,6 @@ export function MarketNewsCard({ category, item }: MarketNewsCardProps) {
                     )}
                 </>
             }
-            // MarketNewsCard 링크: aria-hidden span으로 감싼 화살표
             linkChildren={
                 <>
                     원문 보기 <span aria-hidden="true">→</span>

--- a/src/widgets/news/__tests__/NewsList.test.tsx
+++ b/src/widgets/news/__tests__/NewsList.test.tsx
@@ -3,10 +3,8 @@ import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { NewsDisplayItem } from '@/shared/lib/types';
 import { useNewsPollingWithInvalidation } from '@/widgets/news/hooks/useNewsPollingWithInvalidation';
-import {
-    formatNewsPublishedAt,
-    NewsList,
-} from '@/widgets/news/sections/NewsList';
+import { formatNewsPublishedAt } from '@/shared/lib/timeFormat';
+import { NewsList } from '@/widgets/news/sections/NewsList';
 
 vi.mock('@/widgets/news/hooks/useNewsPollingWithInvalidation', () => ({
     useNewsPollingWithInvalidation: vi.fn(),

--- a/src/widgets/news/sections/NewsList.tsx
+++ b/src/widgets/news/sections/NewsList.tsx
@@ -7,7 +7,7 @@ import { NEWS_LIST_PERIOD_LABEL } from '@/shared/lib/news/periodLabels';
 import type { NewsImpact, NewsSentiment } from '@y0ngha/siglens-core';
 import { useState } from 'react';
 import { formatNewsPublishedAt } from '@/shared/lib/timeFormat';
-import { NewsCardShell } from '../ui/NewsCardShell';
+import { NewsCardShell } from '@/shared/ui/NewsCardShell';
 
 const SENTIMENT_LABEL: Record<NewsSentiment, string> = {
     bullish: '긍정',

--- a/src/widgets/news/sections/NewsList.tsx
+++ b/src/widgets/news/sections/NewsList.tsx
@@ -6,6 +6,8 @@ import { cn } from '@/shared/lib/cn';
 import { NEWS_LIST_PERIOD_LABEL } from '@/shared/lib/news/periodLabels';
 import type { NewsImpact, NewsSentiment } from '@y0ngha/siglens-core';
 import { useState } from 'react';
+import { formatNewsPublishedAt } from '@/shared/lib/timeFormat';
+import { NewsCardShell } from '../ui/NewsCardShell';
 
 const SENTIMENT_LABEL: Record<NewsSentiment, string> = {
     bullish: '긍정',
@@ -40,14 +42,9 @@ const VALID_SENTIMENTS = new Set<string>(['bullish', 'bearish', 'neutral']);
 const VALID_IMPACTS = new Set<string>(['high', 'medium', 'low', 'negligible']);
 const PAGE_SIZE = 5;
 const NEWS_LIST_SKELETON_COUNT = 3;
-const NEWS_PUBLISHED_AT_FORMATTER = new Intl.DateTimeFormat('ko-KR', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    timeZone: 'Asia/Seoul',
-});
+
+// 테스트가 NewsList에서 직접 import하므로 re-export로 유지한다.
+export { formatNewsPublishedAt } from '@/shared/lib/timeFormat';
 
 function isNewsSentiment(value: string): value is NewsSentiment {
     return VALID_SENTIMENTS.has(value);
@@ -59,10 +56,6 @@ function isNewsImpact(value: string): value is NewsImpact {
 
 function isPendingAnalysis(item: NewsDisplayItem): boolean {
     return item.sentiment === null || item.priceImpact === null;
-}
-
-export function formatNewsPublishedAt(publishedAt: string): string {
-    return `${NEWS_PUBLISHED_AT_FORMATTER.format(new Date(publishedAt))} KST`;
 }
 
 function SentimentBadge({ value }: { value: string }) {
@@ -90,25 +83,6 @@ function ImpactBadge({ value }: { value: string }) {
         >
             {IMPACT_LABEL[value]}
         </span>
-    );
-}
-
-function AnalysisSkeleton() {
-    return (
-        <div className="mt-1.5 flex flex-wrap items-center gap-2">
-            <div className="bg-secondary-700 h-5 w-10 animate-pulse rounded motion-reduce:animate-none" />
-            <div className="bg-secondary-700 h-5 w-20 animate-pulse rounded motion-reduce:animate-none" />
-            <span className="text-secondary-500 text-xs">AI 분석 중…</span>
-        </div>
-    );
-}
-
-function SummarySkeletonLine() {
-    return (
-        <div className="mt-2 space-y-1.5">
-            <div className="bg-secondary-700/70 h-3.5 w-full animate-pulse rounded motion-reduce:animate-none" />
-            <div className="bg-secondary-700/70 h-3.5 w-4/5 animate-pulse rounded motion-reduce:animate-none" />
-        </div>
     );
 }
 
@@ -217,25 +191,30 @@ function NewsCard({ item }: { item: NewsDisplayItem }) {
     const publishedDate = formatNewsPublishedAt(item.publishedAt);
 
     return (
-        <article
-            className={cn(
-                'border-secondary-700 bg-secondary-800 hover:border-primary-500/50 w-full max-w-full min-w-0 overflow-hidden rounded-xl border p-4 transition-[colors,transform] hover:-translate-y-px',
-                // Bump left padding so content doesn't sit flush against the 3px accent strip.
-                isHighImpact && 'border-l-ui-warning border-l-[3px] pl-5'
-            )}
-        >
-            <h3
-                className={cn(
-                    'leading-snug font-semibold text-balance wrap-break-word',
-                    pending && 'opacity-80'
-                )}
-            >
-                {item.titleKo ?? item.titleEn}
-            </h3>
-
-            {pending ? (
-                <AnalysisSkeleton />
-            ) : (
+        <NewsCardShell
+            title={item.titleKo ?? item.titleEn}
+            isHighImpact={isHighImpact}
+            pending={pending}
+            url={item.url}
+            // NewsList의 AnalysisSkeleton: aria-hidden 없음, text-secondary-500 텍스트
+            analysisSkeleton={
+                <div className="mt-1.5 flex flex-wrap items-center gap-2">
+                    <div className="bg-secondary-700 h-5 w-10 animate-pulse rounded motion-reduce:animate-none" />
+                    <div className="bg-secondary-700 h-5 w-20 animate-pulse rounded motion-reduce:animate-none" />
+                    <span className="text-secondary-500 text-xs">
+                        AI 분석 중…
+                    </span>
+                </div>
+            }
+            // NewsList의 SummarySkeletonLine: aria-hidden 없음
+            summarySkeletonLine={
+                <div className="mt-2 space-y-1.5">
+                    <div className="bg-secondary-700/70 h-3.5 w-full animate-pulse rounded motion-reduce:animate-none" />
+                    <div className="bg-secondary-700/70 h-3.5 w-4/5 animate-pulse rounded motion-reduce:animate-none" />
+                </div>
+            }
+            // NewsList 배지 행: min-w-0 없음, text-secondary-400 source span
+            badgeRow={
                 <div className="mt-1.5 flex flex-wrap items-center gap-2">
                     {item.sentiment !== null && (
                         <SentimentBadge value={item.sentiment} />
@@ -258,11 +237,11 @@ function NewsCard({ item }: { item: NewsDisplayItem }) {
                         {item.source}
                     </span>
                 </div>
-            )}
-
-            {pending ? (
-                <SummarySkeletonLine />
-            ) : (
+            }
+            // NewsList는 티커 칩 슬롯을 사용하지 않는다.
+            tickerChipSlot={undefined}
+            // NewsList 본문: NewsTextSection 컴포넌트 사용
+            bodySection={
                 <>
                     {item.bodyKo !== null && (
                         <NewsTextSection label="본문" text={item.bodyKo} />
@@ -271,19 +250,10 @@ function NewsCard({ item }: { item: NewsDisplayItem }) {
                         <NewsTextSection label="요약" text={item.summaryKo} />
                     )}
                 </>
-            )}
-
-            {!pending && (
-                <a
-                    href={item.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-primary-400 focus-visible:ring-primary-500 mt-2 inline-block text-xs transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:outline-none"
-                >
-                    원문 보기 →
-                </a>
-            )}
-        </article>
+            }
+            // NewsList 링크: 텍스트 노드 형태의 화살표
+            linkChildren="원문 보기 →"
+        />
     );
 }
 

--- a/src/widgets/news/sections/NewsList.tsx
+++ b/src/widgets/news/sections/NewsList.tsx
@@ -43,9 +43,6 @@ const VALID_IMPACTS = new Set<string>(['high', 'medium', 'low', 'negligible']);
 const PAGE_SIZE = 5;
 const NEWS_LIST_SKELETON_COUNT = 3;
 
-// 테스트가 NewsList에서 직접 import하므로 re-export로 유지한다.
-export { formatNewsPublishedAt } from '@/shared/lib/timeFormat';
-
 function isNewsSentiment(value: string): value is NewsSentiment {
     return VALID_SENTIMENTS.has(value);
 }
@@ -196,7 +193,6 @@ function NewsCard({ item }: { item: NewsDisplayItem }) {
             isHighImpact={isHighImpact}
             pending={pending}
             url={item.url}
-            // NewsList의 AnalysisSkeleton: aria-hidden 없음, text-secondary-500 텍스트
             analysisSkeleton={
                 <div className="mt-1.5 flex flex-wrap items-center gap-2">
                     <div className="bg-secondary-700 h-5 w-10 animate-pulse rounded motion-reduce:animate-none" />
@@ -206,14 +202,12 @@ function NewsCard({ item }: { item: NewsDisplayItem }) {
                     </span>
                 </div>
             }
-            // NewsList의 SummarySkeletonLine: aria-hidden 없음
             summarySkeletonLine={
                 <div className="mt-2 space-y-1.5">
                     <div className="bg-secondary-700/70 h-3.5 w-full animate-pulse rounded motion-reduce:animate-none" />
                     <div className="bg-secondary-700/70 h-3.5 w-4/5 animate-pulse rounded motion-reduce:animate-none" />
                 </div>
             }
-            // NewsList 배지 행: min-w-0 없음, text-secondary-400 source span
             badgeRow={
                 <div className="mt-1.5 flex flex-wrap items-center gap-2">
                     {item.sentiment !== null && (
@@ -238,9 +232,6 @@ function NewsCard({ item }: { item: NewsDisplayItem }) {
                     </span>
                 </div>
             }
-            // NewsList는 티커 칩 슬롯을 사용하지 않는다.
-            tickerChipSlot={undefined}
-            // NewsList 본문: NewsTextSection 컴포넌트 사용
             bodySection={
                 <>
                     {item.bodyKo !== null && (
@@ -251,7 +242,6 @@ function NewsCard({ item }: { item: NewsDisplayItem }) {
                     )}
                 </>
             }
-            // NewsList 링크: 텍스트 노드 형태의 화살표
             linkChildren="원문 보기 →"
         />
     );

--- a/src/widgets/news/sections/NewsList.tsx
+++ b/src/widgets/news/sections/NewsList.tsx
@@ -181,6 +181,30 @@ function NewsRefreshStatusCard() {
     );
 }
 
+/**
+ * aria-hidden 없음 — NewsList는 스크린리더가 로딩 상태를 읽도록 허용한다.
+ * text-secondary-500 텍스트 컬러는 MarketNewsCard(text-secondary-400)와 의도적으로 다르다.
+ */
+function AnalysisSkeleton() {
+    return (
+        <div className="mt-1.5 flex flex-wrap items-center gap-2">
+            <div className="bg-secondary-700 h-5 w-10 animate-pulse rounded motion-reduce:animate-none" />
+            <div className="bg-secondary-700 h-5 w-20 animate-pulse rounded motion-reduce:animate-none" />
+            <span className="text-secondary-500 text-xs">AI 분석 중…</span>
+        </div>
+    );
+}
+
+/** aria-hidden 없음 — NewsList는 스크린리더가 본문 로딩 중 스켈레톤을 읽도록 허용한다. */
+function SummarySkeletonLine() {
+    return (
+        <div className="mt-2 space-y-1.5">
+            <div className="bg-secondary-700/70 h-3.5 w-full animate-pulse rounded motion-reduce:animate-none" />
+            <div className="bg-secondary-700/70 h-3.5 w-4/5 animate-pulse rounded motion-reduce:animate-none" />
+        </div>
+    );
+}
+
 function NewsCard({ item }: { item: NewsDisplayItem }) {
     const pending = isPendingAnalysis(item);
     const isHighImpact = !pending && item.priceImpact === 'high';
@@ -193,21 +217,8 @@ function NewsCard({ item }: { item: NewsDisplayItem }) {
             isHighImpact={isHighImpact}
             pending={pending}
             url={item.url}
-            analysisSkeleton={
-                <div className="mt-1.5 flex flex-wrap items-center gap-2">
-                    <div className="bg-secondary-700 h-5 w-10 animate-pulse rounded motion-reduce:animate-none" />
-                    <div className="bg-secondary-700 h-5 w-20 animate-pulse rounded motion-reduce:animate-none" />
-                    <span className="text-secondary-500 text-xs">
-                        AI 분석 중…
-                    </span>
-                </div>
-            }
-            summarySkeletonLine={
-                <div className="mt-2 space-y-1.5">
-                    <div className="bg-secondary-700/70 h-3.5 w-full animate-pulse rounded motion-reduce:animate-none" />
-                    <div className="bg-secondary-700/70 h-3.5 w-4/5 animate-pulse rounded motion-reduce:animate-none" />
-                </div>
-            }
+            analysisSkeleton={<AnalysisSkeleton />}
+            summarySkeletonLine={<SummarySkeletonLine />}
             badgeRow={
                 <div className="mt-1.5 flex flex-wrap items-center gap-2">
                     {item.sentiment !== null && (

--- a/src/widgets/news/ui/NewsCardShell.tsx
+++ b/src/widgets/news/ui/NewsCardShell.tsx
@@ -83,7 +83,6 @@ export function NewsCardShell({
         <article
             className={cn(
                 'border-secondary-700 bg-secondary-800 hover:border-primary-500/50 w-full max-w-full min-w-0 overflow-hidden rounded-xl border p-4 transition-[colors,transform] hover:-translate-y-px',
-                // 고영향 뉴스에는 왼쪽 amber accent 바를 추가한다.
                 // content가 3px 바에 붙지 않도록 pl-5로 패딩을 보정한다.
                 isHighImpact && 'border-l-ui-warning border-l-[3px] pl-5'
             )}

--- a/src/widgets/news/ui/NewsCardShell.tsx
+++ b/src/widgets/news/ui/NewsCardShell.tsx
@@ -1,0 +1,118 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/shared/lib/cn';
+
+export interface NewsCardShellProps {
+    /**
+     * 카드 제목 — titleKo가 있으면 titleKo, 없으면 titleEn.
+     * 호출 측에서 `item.titleKo ?? item.titleEn`으로 전달한다.
+     */
+    title: string | null;
+
+    /** priceImpact === 'high'일 때 amber 왼쪽 border accent를 표시한다. */
+    isHighImpact: boolean;
+
+    /** pending=true일 때 제목 텍스트를 opacity-80으로 표시한다. */
+    pending: boolean;
+
+    /**
+     * pending 상태 중 배지 행 대신 표시할 스켈레톤 노드.
+     * 각 서피스가 자체 aria-hidden·텍스트 컬러를 가지므로 props로 주입한다.
+     */
+    analysisSkeleton: ReactNode;
+
+    /**
+     * pending 상태 중 본문 영역 대신 표시할 스켈레톤 노드.
+     * 각 서피스가 자체 aria-hidden 속성을 가지므로 props로 주입한다.
+     */
+    summarySkeletonLine: ReactNode;
+
+    /**
+     * ready 상태의 배지 행 (감성·영향도·카테고리·시각·출처 등).
+     * 배지 행의 wrapper div 클래스와 내부 요소가 서피스마다 다르므로
+     * 호출 측에서 완성된 JSX 노드를 전달한다.
+     */
+    badgeRow: ReactNode;
+
+    /**
+     * 티커 칩 슬롯 (선택).
+     * market-news 카드만 사용한다; NewsList 카드는 null을 전달해 생략한다.
+     */
+    tickerChipSlot?: ReactNode;
+
+    /**
+     * 본문/요약 섹션 노드.
+     * 호출 측에서 bodyKo·summaryKo에 따라 조건부로 구성해 전달한다.
+     */
+    bodySection: ReactNode;
+
+    /**
+     * "원문 보기" 링크의 자식 노드.
+     * NewsList: `원문 보기 →` (텍스트 노드)
+     * MarketNewsCard: `원문 보기 <span aria-hidden>→</span>`
+     */
+    linkChildren: ReactNode;
+
+    /** 원문 URL — pending일 때는 링크 자체를 렌더하지 않는다. */
+    url: string;
+}
+
+/**
+ * 뉴스 카드의 공통 article 셸.
+ *
+ * NewsList의 `NewsCard`와 `MarketNewsCard` 양쪽이 공유하는
+ * 외곽 article wrapper · 제목 · pending/ready 분기 구조를 단일 소스로 관리한다.
+ * 서피스별로 다른 레이블·클래스 맵·DOM 세부사항은 props/children으로 주입된다.
+ *
+ * 중요: 이 컴포넌트는 각 서피스의 렌더된 DOM이 byte-identical하게 유지되도록
+ * 구조적 컨테이너 역할만 한다. badge 레이블, aria-hidden 등 차이 요소는
+ * 호출 측 props를 통해 서피스별로 독립적으로 제어된다.
+ */
+export function NewsCardShell({
+    title,
+    isHighImpact,
+    pending,
+    analysisSkeleton,
+    summarySkeletonLine,
+    badgeRow,
+    tickerChipSlot,
+    bodySection,
+    linkChildren,
+    url,
+}: NewsCardShellProps) {
+    return (
+        <article
+            className={cn(
+                'border-secondary-700 bg-secondary-800 hover:border-primary-500/50 w-full max-w-full min-w-0 overflow-hidden rounded-xl border p-4 transition-[colors,transform] hover:-translate-y-px',
+                // 고영향 뉴스에는 왼쪽 amber accent 바를 추가한다.
+                // content가 3px 바에 붙지 않도록 pl-5로 패딩을 보정한다.
+                isHighImpact && 'border-l-ui-warning border-l-[3px] pl-5'
+            )}
+        >
+            <h3
+                className={cn(
+                    'leading-snug font-semibold text-balance wrap-break-word',
+                    pending && 'opacity-80'
+                )}
+            >
+                {title}
+            </h3>
+
+            {pending ? analysisSkeleton : badgeRow}
+
+            {tickerChipSlot}
+
+            {pending ? summarySkeletonLine : bodySection}
+
+            {!pending && (
+                <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary-400 focus-visible:ring-primary-500 mt-2 inline-block text-xs transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:outline-none"
+                >
+                    {linkChildren}
+                </a>
+            )}
+        </article>
+    );
+}


### PR DESCRIPTION
Pure refactoring. NewsList's NewsCard and MarketNewsCard shared the card shell + skeletons + a KST formatter. Extracted a presentational NewsCardShell (label/class maps + ticker-chip injected as props) and single-sourced formatNewsPublishedAt in shared/lib/timeFormat. The intentionally divergent maps (news 가격/text-chart-bullish vs market-news 주가/text-ui-success-text) stay per-surface. DOM/classes/testids byte-identical. tsc + scoped tests + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)