### PR TITLE
docs(arch): correct widgets→widgets exception comment post symbol-page move (Spec-2 C)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -141,8 +141,11 @@ const eslintConfig = defineConfig([
                             ],
                         },
                         {
-                            // widgets 간 cross-import 허용: symbol-page가 chart/analysis/fear-greed 위젯을 조합하고,
-                            // fundamental/news/options/overall이 symbol-page barrel에서 공통 hook(useDefaultModelId 등)을 소비.
+                            // widgets 간 cross-import 허용: Spec-2 PR-B2에서 symbol-page가 src/views/symbol/로 이관되어
+                            // 해당 엣지는 제거됨. 현재 허용 목적은 두 pre-existing 엣지에 한정:
+                            //   - fear-greed → chart: FearGreedPage.tsx가 @/widgets/chart/FearGreedHistoricalChart를 deep import
+                            //   - overall → news: OverallContent.tsx가 @/widgets/news barrel에서 useNewsAnalysisTrigger/useWaitForNewsCards를 소비
+                            // 두 엣지 모두 symbol-page와 무관. 규칙 완전 제거는 해당 컴포넌트 이전이 선행되어야 하므로 보류.
                             from: { type: 'widgets' },
                             allow: [
                                 { to: { type: 'widgets' } },
@@ -209,8 +212,10 @@ const eslintConfig = defineConfig([
             // 예: getCurrentUser, optionsDataCache 등 server-only 마킹된 함수들
             'src/app/**/!(api)/**',
             'src/app/*.tsx',
-            // widgets 간 cross-import: hook에 server-side 의존이 있어 barrel re-export 시
-            // Jest ESM 해석 실패. deep path 허용으로 우회 (Phase 7).
+            // widgets 간 cross-import: Spec-2 PR-B2 이후 symbol-page 엣지는 제거됨.
+            // 잔존 deep-import: fear-greed → @/widgets/chart/FearGreedHistoricalChart
+            //   (barrel에서 제외된 heavy-chart 컴포넌트, server-side 의존으로 re-export 시 Jest ESM 해석 실패).
+            // barrel 소비 엣지(overall → @/widgets/news)도 이 ignore 범위 내에서 허용됨 (Phase 7).
             'src/widgets/**',
             // views composition layer: symbol-page 이관(Spec-2 PR-B2) 후 ChartContent/useAnalysis가
             // @/widgets/analysis/hooks/* + @/widgets/analysis/model/* deep import를 유지해야 한다.

--- a/src/widgets/CLAUDE.md
+++ b/src/widgets/CLAUDE.md
@@ -14,7 +14,12 @@ cross-widget import는 현재 허용되지만, `symbol-page` 슬라이스는 Spe
   - 이유: `symbol-page` 컴포지션이 FSD `pages` 레이어(`src/views/symbol/`)로 이관됨 (Spec-2 PR-B2)
   - 관련 hook은 `src/features/symbol-model/`로, CrossLinkCards는 `src/shared/ui/`로 이동
 
-이 예외는 ESLint `from: 'widgets', allow: ['widgets', ...]`로 관리됨. (widgets 간 cross-import는 여전히 허용 — PR-C에서 재검토 예정)
+이 예외는 ESLint `from: 'widgets', allow: ['widgets', ...]`로 관리됨. Spec-2 PR-C 재검토 결과, 예외는 아래 두 pre-existing 엣지에 한해 유지됨:
+
+- **`fear-greed → chart`**: `FearGreedPage.tsx`가 `@/widgets/chart/FearGreedHistoricalChart`를 deep import (barrel 미포함 heavy component)
+- **`overall → news`**: `OverallContent.tsx`가 `@/widgets/news` barrel에서 `useNewsAnalysisTrigger`, `useWaitForNewsCards`를 소비
+
+두 엣지 모두 symbol-page와 무관(symbol-page는 PR-B2에서 `src/views/symbol/`로 이관). 규칙 완전 제거는 위 두 컴포넌트의 이전을 선행해야 하므로 보류.
 
 ## barrel 제외 대상
 


### PR DESCRIPTION
## What
Final step of Spec-2. After PR-B2 removed the `symbol-page` widget, the ESLint `widgets→widgets` exception comment (and the `src/widgets/**` deep-import ignore comment) still referenced symbol-page — now false. This corrects them to reflect reality.

The `widgets→widgets` allowance must STAY because two pre-existing, unrelated widget→widget edges remain:
- `fear-greed → chart` (`FearGreedHistoricalChart`)
- `overall → news` (news-analysis trigger hooks)

Fully removing the exception would require relocating those two (deferred — out of the symbol-page scope). `src/widgets/CLAUDE.md` is finalized accordingly.

## Behavior
Comment/doc only — no ESLint rule behavior change. lint + tsc green (rule still passes with the 2 edges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)