### PR TITLE
fix(isr): degrade on loader throws to prevent empty-cache freeze

### DIFF
--- a/src/app/[symbol]/fundamental/__tests__/page.isr-degrade.test.tsx
+++ b/src/app/[symbol]/fundamental/__tests__/page.isr-degrade.test.tsx
@@ -16,11 +16,13 @@
  *   getProfileResilient + getAssetInfoResilient. Tests here verify that the
  *   top-level degrade guard (profile-level) works correctly.
  *
- *   Layer B — section functions (lazy async): ValuationSection, PeersSection,
- *   etc. are tested by invoking them through staticSymbolCache (which the mock
- *   routes straight to the fetcher). Each section function's .catch() is what
- *   protects ISR — we verify this by calling the section fetchers directly via
- *   the mock and asserting that console.error is called with the context prefix.
+ *   Layer B — section functions (exported async RSCs): ValuationSection,
+ *   PeersSection, etc. are exported from page.tsx as named exports and tested
+ *   by calling them directly. staticSymbolCache is mocked to call fetcher()
+ *   directly so a rejection propagates to the section's .catch() handler.
+ *   Widget mocks render a visible data-testid so the degraded path (null/[]
+ *   passed to the card) is assertable. This is falsifiable: removing a
+ *   section's .catch() causes the test to fail with an unhandled rejection.
  *
  * Mirrors page.guard.test.ts mocking pattern.
  */
@@ -72,7 +74,11 @@ vi.mock('@/shared/cache/staticSymbolCache', () => ({
         ) => fetcher()
     ),
 }));
-// Widget mocks to avoid deep import chains.
+// Widget card mocks render a data-testid that reflects the data they received.
+// When the section's .catch() fires, the loader returns null/[] and the card
+// renders with degraded props — the testid becomes assertable in Layer B tests.
+// When no .catch() fires (success path), the same mock renders the same testid
+// but it still proves the section did not throw.
 vi.mock('@/widgets/fundamental/FundamentalAiSummary', () => ({
     FundamentalAiSummary: () => null,
 }));
@@ -83,25 +89,89 @@ vi.mock('@/widgets/fundamental/FundamentalAiSummarySkeleton', () => ({
     FundamentalAiSummarySkeleton: () => null,
 }));
 vi.mock('@/widgets/fundamental/sections/FinancialHealthCard', () => ({
-    FinancialHealthCard: () => null,
+    FinancialHealthCard: ({
+        ratios,
+        scores,
+        cashFlow,
+    }: {
+        ratios: unknown;
+        scores: unknown;
+        cashFlow: unknown;
+    }) => (
+        <div
+            data-testid="financial-health-card"
+            data-degraded={
+                ratios === null && scores === null && cashFlow === null
+                    ? 'true'
+                    : 'false'
+            }
+        />
+    ),
 }));
 vi.mock('@/widgets/fundamental/sections/FutureDirectionCard', () => ({
-    FutureDirectionCard: () => null,
+    FutureDirectionCard: ({
+        estimates,
+        grades,
+        ptConsensus,
+        ptSummary,
+    }: {
+        estimates: unknown;
+        grades: unknown;
+        ptConsensus: unknown;
+        ptSummary: unknown;
+    }) => (
+        <div
+            data-testid="future-direction-card"
+            data-degraded={
+                estimates === null &&
+                grades === null &&
+                ptConsensus === null &&
+                ptSummary === null
+                    ? 'true'
+                    : 'false'
+            }
+        />
+    ),
 }));
 vi.mock('@/widgets/fundamental/sections/GrowthChart', () => ({
-    GrowthChart: () => null,
+    GrowthChart: ({ growth }: { growth: unknown }) => (
+        <div
+            data-testid="growth-chart"
+            data-degraded={growth === null ? 'true' : 'false'}
+        />
+    ),
 }));
 vi.mock('@/widgets/fundamental/sections/PeersTable', () => ({
-    PeersTable: () => null,
+    PeersTable: ({ peers }: { peers: unknown[] }) => (
+        <div
+            data-testid="peers-table"
+            data-degraded={peers.length === 0 ? 'true' : 'false'}
+        />
+    ),
 }));
 vi.mock('@/widgets/fundamental/sections/ProfileCard', () => ({
-    ProfileCard: () => null,
+    ProfileCard: ({ profile }: { profile: unknown }) => (
+        <div
+            data-testid="profile-card"
+            data-degraded={profile === null ? 'true' : 'false'}
+        />
+    ),
 }));
 vi.mock('@/widgets/fundamental/sections/ProfitabilityCard', () => ({
-    ProfitabilityCard: () => null,
+    ProfitabilityCard: ({ ratios }: { ratios: unknown }) => (
+        <div
+            data-testid="profitability-card"
+            data-degraded={ratios === null ? 'true' : 'false'}
+        />
+    ),
 }));
 vi.mock('@/widgets/fundamental/sections/ValuationCard', () => ({
-    ValuationCard: () => null,
+    ValuationCard: ({ metrics }: { metrics: unknown }) => (
+        <div
+            data-testid="valuation-card"
+            data-degraded={metrics === null ? 'true' : 'false'}
+        />
+    ),
 }));
 vi.mock('@/views/symbol', () => ({
     SymbolPageHeading: ({ children }: { children: unknown }) => children,
@@ -139,8 +209,17 @@ import {
     beforeEach,
     type MockedFunction,
 } from 'vitest';
+import React from 'react';
 import { isValidElement } from 'react';
-import FundamentalPage from '@/app/[symbol]/fundamental/page';
+import { render, screen } from '@testing-library/react';
+import FundamentalPage, {
+    ValuationSection,
+    PeersSection,
+    ProfitabilitySection,
+    GrowthSection,
+    FinancialHealthSection,
+    FutureDirectionSection,
+} from '@/app/[symbol]/fundamental/page';
 import { getAssetInfoResilient } from '@/entities/ticker';
 import { getProfileResilient } from '@/app/[symbol]/fundamental/getProfileResilient';
 import {
@@ -151,8 +230,10 @@ import {
     getFinancialScores,
     getCashFlowStatement,
     getAnalystEstimates,
+    getGradesConsensus,
+    getPriceTargetConsensus,
+    getPriceTargetSummary,
 } from '@/app/[symbol]/fundamental/fundamentalData';
-import { staticSymbolCache } from '@/shared/cache/staticSymbolCache';
 
 const mockGetAssetInfoResilient = getAssetInfoResilient as MockedFunction<
     typeof getAssetInfoResilient
@@ -177,9 +258,14 @@ const mockGetCashFlowStatement = getCashFlowStatement as MockedFunction<
 const mockGetAnalystEstimates = getAnalystEstimates as MockedFunction<
     typeof getAnalystEstimates
 >;
-// staticSymbolCache is mocked to call fetcher() directly — used in section tests.
-const mockStaticSymbolCache = staticSymbolCache as MockedFunction<
-    typeof staticSymbolCache
+const mockGetGradesConsensus = getGradesConsensus as MockedFunction<
+    typeof getGradesConsensus
+>;
+const mockGetPriceTargetConsensus = getPriceTargetConsensus as MockedFunction<
+    typeof getPriceTargetConsensus
+>;
+const mockGetPriceTargetSummary = getPriceTargetSummary as MockedFunction<
+    typeof getPriceTargetSummary
 >;
 
 const EQUITY_ASSET_INFO = {
@@ -215,264 +301,199 @@ describe('Fundamental page ISR empty-cache prevention — top-level guard', () =
 /**
  * Layer B: section-level ISR degrade tests.
  *
- * Each section is a module-level async function (not exported from page.tsx).
- * We cannot call them directly, but we CAN test that when their loaders reject,
- * the .catch() in the section absorbs the error. To do this we exploit the fact
- * that staticSymbolCache is mocked to call fetcher() directly — so the rejection
- * flows through the section's .catch() handler when the section awaits its cache call.
+ * Each section is exported from page.tsx as a named async function. We render
+ * the real section directly with staticSymbolCache mocked to call fetcher()
+ * directly — so a loader rejection propagates to the section's .catch() handler.
  *
- * However, since the sections are lazy RSC children inside <Suspense> and are NOT
- * awaited by FundamentalPage directly, we cannot trigger them through FundamentalPage.
- * Instead we test the loader catch via a direct call to the mocked staticSymbolCache
- * with a rejecting fetcher, simulating what happens when Next.js resolves the Suspense
- * child during ISR streaming. This exercises exactly the .catch() handler code path.
+ * Widget card mocks render a data-testid with data-degraded="true" when the
+ * section passes null/[] (the degrade value from .catch()). This makes each
+ * test falsifiable: removing a section's .catch() causes an unhandled rejection
+ * instead of a successful render with data-degraded="true".
+ *
+ * Falsifiability check (performed once after writing this suite):
+ *   1. Temporarily remove the .catch() from ValuationSection in page.tsx.
+ *   2. Run: yarn vitest run src/app/[symbol]/fundamental/__tests__/page.isr-degrade.test.tsx
+ *   3. The "ValuationSection: loader throw → renders degraded card" test FAILS.
+ *   4. Restore .catch() → test PASSES again. ✓
  */
-describe('Fundamental page ISR empty-cache prevention — section loader catch', () => {
+describe('Fundamental page ISR empty-cache prevention — section layer (Layer B)', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        // Default: all loaders succeed with safe empty values.
+        mockGetKeyMetricsTtm.mockResolvedValue(null);
+        mockGetStockPeers.mockResolvedValue(
+            [] as Awaited<ReturnType<typeof getStockPeers>>
+        );
+        mockGetRatiosTtm.mockResolvedValue(null);
+        mockGetIncomeStatementGrowth.mockResolvedValue(null);
+        mockGetFinancialScores.mockResolvedValue(null);
+        mockGetCashFlowStatement.mockResolvedValue(null);
+        mockGetAnalystEstimates.mockResolvedValue(null);
+        mockGetGradesConsensus.mockResolvedValue(null);
+        mockGetPriceTargetConsensus.mockResolvedValue(null);
+        mockGetPriceTargetSummary.mockResolvedValue(null);
     });
 
-    /**
-     * The section loader pattern is:
-     *   staticSymbolCache([key], symbol, () => loaderFn(symbol), [], TTL)
-     *     .catch(e => { console.error('[Context]...', e); return safeEmpty; })
-     *
-     * Because staticSymbolCache is mocked as fetcher(), a rejection in loaderFn
-     * surfaces immediately. We verify the .catch() is wired correctly by checking
-     * that console.error is called with the context prefix.
-     *
-     * We call staticSymbolCache manually with a rejecting fetcher to simulate the
-     * section function's internal cache call, then apply the same .catch() from
-     * the source code. This is a structural test that the catch contract is met.
-     */
-    it('ValuationSection loader: getKeyMetricsTtm reject → .catch emits [ValuationSection] log', async () => {
-        const err = new Error('FMP 429');
-        mockGetKeyMetricsTtm.mockRejectedValue(err);
+    it('ValuationSection: loader throw → renders degraded card (data-degraded="true"), does not throw', async () => {
+        mockGetKeyMetricsTtm.mockRejectedValue(new Error('FMP 429'));
         const consoleSpy = vi
             .spyOn(console, 'error')
             .mockImplementation(() => {});
 
-        // Simulate the ValuationSection cache call path: fetcher rejects → .catch fires.
-        const result = await mockStaticSymbolCache(
-            ['fundamental:metrics', 'AAPL'],
-            'AAPL',
-            () => getKeyMetricsTtm('AAPL'),
-            [],
-            86400
-        ).catch((e: unknown) => {
-            console.error(
-                '[ValuationSection] getKeyMetricsTtm failed, degrading to null:',
-                e
-            );
-            return null;
-        });
+        // Must not throw — .catch() in ValuationSection absorbs the rejection
+        // and passes null to ValuationCard, which the mock renders as data-degraded="true".
+        render(await ValuationSection({ symbol: 'AAPL' }));
 
-        expect(result).toBeNull();
+        const card = screen.getByTestId('valuation-card');
+        expect(card).toBeInTheDocument();
+        expect(card.getAttribute('data-degraded')).toBe('true');
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining('[ValuationSection]'),
-            err
+            expect.any(Error)
         );
 
         consoleSpy.mockRestore();
     });
 
-    it('PeersSection loader: getStockPeers reject → .catch emits [PeersSection] log, returns []', async () => {
-        const err = new Error('FMP peers down');
-        mockGetStockPeers.mockRejectedValue(err);
+    it('PeersSection: loader throw → renders degraded card (data-degraded="true"), does not throw', async () => {
+        mockGetStockPeers.mockRejectedValue(new Error('FMP peers down'));
         const consoleSpy = vi
             .spyOn(console, 'error')
             .mockImplementation(() => {});
 
-        const result = await mockStaticSymbolCache(
-            ['fundamental:peers', 'AAPL'],
-            'AAPL',
-            () => getStockPeers('AAPL'),
-            [],
-            86400
-        ).catch((e: unknown) => {
-            console.error(
-                '[PeersSection] getStockPeers failed, degrading to []:',
-                e
-            );
-            return [];
-        });
+        render(await PeersSection({ symbol: 'AAPL' }));
 
-        expect(Array.isArray(result)).toBe(true);
-        expect((result as unknown[]).length).toBe(0);
+        const card = screen.getByTestId('peers-table');
+        expect(card).toBeInTheDocument();
+        expect(card.getAttribute('data-degraded')).toBe('true');
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining('[PeersSection]'),
-            err
+            expect.any(Error)
         );
 
         consoleSpy.mockRestore();
     });
 
-    it('FinancialHealthSection: getRatiosTtm reject → .catch emits log, returns null', async () => {
-        const err = new Error('FMP ratios down');
-        mockGetRatiosTtm.mockRejectedValue(err);
+    it('ProfitabilitySection: loader throw → renders degraded card (data-degraded="true"), does not throw', async () => {
+        mockGetRatiosTtm.mockRejectedValue(new Error('FMP ratios down'));
         const consoleSpy = vi
             .spyOn(console, 'error')
             .mockImplementation(() => {});
 
-        const result = await mockStaticSymbolCache(
-            ['fundamental:ratios', 'AAPL'],
-            'AAPL',
-            () => getRatiosTtm('AAPL'),
-            [],
-            86400
-        ).catch((e: unknown) => {
-            console.error(
-                '[FinancialHealthSection] getRatiosTtm failed, degrading to null:',
-                e
-            );
-            return null;
-        });
+        render(await ProfitabilitySection({ symbol: 'AAPL' }));
 
-        expect(result).toBeNull();
+        const card = screen.getByTestId('profitability-card');
+        expect(card).toBeInTheDocument();
+        expect(card.getAttribute('data-degraded')).toBe('true');
         expect(consoleSpy).toHaveBeenCalledWith(
-            expect.stringContaining('[FinancialHealthSection] getRatiosTtm'),
-            err
+            expect.stringContaining('[ProfitabilitySection]'),
+            expect.any(Error)
         );
 
         consoleSpy.mockRestore();
     });
 
-    it('GrowthSection: getIncomeStatementGrowth reject → .catch emits log, returns null', async () => {
-        const err = new Error('FMP growth down');
-        mockGetIncomeStatementGrowth.mockRejectedValue(err);
+    it('GrowthSection: loader throw → renders degraded card (data-degraded="true"), does not throw', async () => {
+        mockGetIncomeStatementGrowth.mockRejectedValue(
+            new Error('FMP growth down')
+        );
         const consoleSpy = vi
             .spyOn(console, 'error')
             .mockImplementation(() => {});
 
-        const result = await mockStaticSymbolCache(
-            ['fundamental:growth', 'AAPL'],
-            'AAPL',
-            () => getIncomeStatementGrowth('AAPL'),
-            [],
-            86400
-        ).catch((e: unknown) => {
-            console.error(
-                '[GrowthSection] getIncomeStatementGrowth failed, degrading to null:',
-                e
-            );
-            return null;
-        });
+        render(await GrowthSection({ symbol: 'AAPL' }));
 
-        expect(result).toBeNull();
+        const card = screen.getByTestId('growth-chart');
+        expect(card).toBeInTheDocument();
+        expect(card.getAttribute('data-degraded')).toBe('true');
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining('[GrowthSection]'),
-            err
+            expect.any(Error)
         );
 
         consoleSpy.mockRestore();
     });
 
-    it('FutureDirectionSection: getAnalystEstimates reject → .catch emits log, returns null', async () => {
-        const err = new Error('FMP estimates down');
-        mockGetAnalystEstimates.mockRejectedValue(err);
+    it('FinancialHealthSection: all three loaders throw → renders degraded card (data-degraded="true"), does not throw', async () => {
+        mockGetRatiosTtm.mockRejectedValue(new Error('ratios down'));
+        mockGetFinancialScores.mockRejectedValue(new Error('scores down'));
+        mockGetCashFlowStatement.mockRejectedValue(new Error('cashflow down'));
         const consoleSpy = vi
             .spyOn(console, 'error')
             .mockImplementation(() => {});
 
-        const result = await mockStaticSymbolCache(
-            ['fundamental:estimates', 'AAPL'],
-            'AAPL',
-            () => getAnalystEstimates('AAPL'),
-            [],
-            86400
-        ).catch((e: unknown) => {
-            console.error(
-                '[FutureDirectionSection] getAnalystEstimates failed, degrading to null:',
-                e
-            );
-            return null;
-        });
+        render(await FinancialHealthSection({ symbol: 'AAPL' }));
 
-        expect(result).toBeNull();
-        expect(consoleSpy).toHaveBeenCalledWith(
-            expect.stringContaining(
-                '[FutureDirectionSection] getAnalystEstimates'
-            ),
-            err
-        );
-
-        consoleSpy.mockRestore();
-    });
-
-    it('FinancialHealthSection: all three loaders reject → all three catch handlers fire independently', async () => {
-        const errRatios = new Error('ratios down');
-        const errScores = new Error('scores down');
-        const errCashFlow = new Error('cashflow down');
-        mockGetRatiosTtm.mockRejectedValue(errRatios);
-        mockGetFinancialScores.mockRejectedValue(errScores);
-        mockGetCashFlowStatement.mockRejectedValue(errCashFlow);
-        const consoleSpy = vi
-            .spyOn(console, 'error')
-            .mockImplementation(() => {});
-
-        // Simulate Promise.all inside FinancialHealthSection — each fails independently.
-        const [ratios, scores, cashFlow] = await Promise.all([
-            mockStaticSymbolCache(
-                ['fundamental:ratios', 'AAPL'],
-                'AAPL',
-                () => getRatiosTtm('AAPL'),
-                [],
-                86400
-            ).catch((e: unknown) => {
-                console.error(
-                    '[FinancialHealthSection] getRatiosTtm failed, degrading to null:',
-                    e
-                );
-                return null;
-            }),
-            mockStaticSymbolCache(
-                ['fundamental:scores', 'AAPL'],
-                'AAPL',
-                () => getFinancialScores('AAPL'),
-                [],
-                86400
-            ).catch((e: unknown) => {
-                console.error(
-                    '[FinancialHealthSection] getFinancialScores failed, degrading to null:',
-                    e
-                );
-                return null;
-            }),
-            mockStaticSymbolCache(
-                ['fundamental:cashflow', 'AAPL'],
-                'AAPL',
-                () => getCashFlowStatement('AAPL'),
-                [],
-                86400
-            ).catch((e: unknown) => {
-                console.error(
-                    '[FinancialHealthSection] getCashFlowStatement failed, degrading to null:',
-                    e
-                );
-                return null;
-            }),
-        ]);
-
-        expect(ratios).toBeNull();
-        expect(scores).toBeNull();
-        expect(cashFlow).toBeNull();
+        const card = screen.getByTestId('financial-health-card');
+        expect(card).toBeInTheDocument();
+        expect(card.getAttribute('data-degraded')).toBe('true');
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining('[FinancialHealthSection] getRatiosTtm'),
-            errRatios
+            expect.any(Error)
         );
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining(
                 '[FinancialHealthSection] getFinancialScores'
             ),
-            errScores
+            expect.any(Error)
         );
         expect(consoleSpy).toHaveBeenCalledWith(
             expect.stringContaining(
                 '[FinancialHealthSection] getCashFlowStatement'
             ),
-            errCashFlow
+            expect.any(Error)
         );
 
         consoleSpy.mockRestore();
+    });
+
+    it('FutureDirectionSection: all four loaders throw → renders degraded card (data-degraded="true"), does not throw', async () => {
+        mockGetAnalystEstimates.mockRejectedValue(new Error('estimates down'));
+        mockGetGradesConsensus.mockRejectedValue(new Error('grades down'));
+        mockGetPriceTargetConsensus.mockRejectedValue(
+            new Error('pt-consensus down')
+        );
+        mockGetPriceTargetSummary.mockRejectedValue(
+            new Error('pt-summary down')
+        );
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        render(await FutureDirectionSection({ symbol: 'AAPL' }));
+
+        const card = screen.getByTestId('future-direction-card');
+        expect(card).toBeInTheDocument();
+        expect(card.getAttribute('data-degraded')).toBe('true');
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                '[FutureDirectionSection] getAnalystEstimates'
+            ),
+            expect.any(Error)
+        );
+
+        consoleSpy.mockRestore();
+    });
+
+    it('success path — all loaders succeed → cards receive real data (data-degraded="false"), no throw', async () => {
+        // Override defaults with non-null values to prove the success path.
+        const fakeMetrics = { peRatioTTM: 30 };
+        mockGetKeyMetricsTtm.mockResolvedValue(
+            fakeMetrics as Awaited<ReturnType<typeof getKeyMetricsTtm>>
+        );
+        // Use a non-empty array cast through unknown to avoid needing full peer shape.
+        mockGetStockPeers.mockResolvedValue([
+            { symbol: 'MSFT' },
+        ] as unknown as Awaited<ReturnType<typeof getStockPeers>>);
+
+        render(await ValuationSection({ symbol: 'AAPL' }));
+        expect(
+            screen.getByTestId('valuation-card').getAttribute('data-degraded')
+        ).toBe('false');
+
+        render(await PeersSection({ symbol: 'AAPL' }));
+        expect(
+            screen.getByTestId('peers-table').getAttribute('data-degraded')
+        ).toBe('false');
     });
 });

--- a/src/app/[symbol]/fundamental/__tests__/page.isr-degrade.test.tsx
+++ b/src/app/[symbol]/fundamental/__tests__/page.isr-degrade.test.tsx
@@ -1,0 +1,478 @@
+/**
+ * ISR empty-cache prevention tests for the fundamental page.
+ *
+ * A transient throw from any FMP section loader during ISR cold-gen must NOT
+ * propagate — it must degrade to the section's existing null/empty-state UI
+ * while keeping the page non-empty.
+ *
+ * Architecture note: FundamentalPage returns a Suspense-wrapped RSC tree where
+ * each section (ValuationSection, PeersSection, …) is a lazy async RSC child.
+ * These children are NOT awaited when FundamentalPage() is invoked directly in
+ * tests — they only execute when React's async streaming pipeline renders them.
+ * Because of this, testing "loader throw → section degrade" at the RSC-call
+ * level requires a different approach per layer:
+ *
+ *   Layer A — page body (top-level async): FundamentalPage itself awaits
+ *   getProfileResilient + getAssetInfoResilient. Tests here verify that the
+ *   top-level degrade guard (profile-level) works correctly.
+ *
+ *   Layer B — section functions (lazy async): ValuationSection, PeersSection,
+ *   etc. are tested by invoking them through staticSymbolCache (which the mock
+ *   routes straight to the fetcher). Each section function's .catch() is what
+ *   protects ISR — we verify this by calling the section fetchers directly via
+ *   the mock and asserting that console.error is called with the context prefix.
+ *
+ * Mirrors page.guard.test.ts mocking pattern.
+ */
+
+// vi.mock calls are hoisted above imports by vitest.
+vi.mock('@/entities/ticker/api', () => ({
+    isTabAllowedForSymbol: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('@/entities/ticker', () => ({
+    buildAssetAboutNode: vi.fn().mockReturnValue(undefined),
+    buildDisplayName: vi.fn().mockReturnValue('Apple Inc.'),
+    getAssetInfoResilient: vi.fn(),
+}));
+vi.mock('next/navigation', () => ({
+    notFound: vi.fn(() => {
+        throw new Error('NEXT_NOT_FOUND');
+    }),
+}));
+vi.mock('@/app/[symbol]/fundamental/getProfileResilient', () => ({
+    getProfileResilient: vi.fn(),
+}));
+vi.mock('@/app/[symbol]/fundamental/fundamentalData', () => ({
+    getAnalystEstimates: vi.fn().mockResolvedValue(null),
+    getCashFlowStatement: vi.fn().mockResolvedValue(null),
+    getFinancialScores: vi.fn().mockResolvedValue(null),
+    getGradesConsensus: vi.fn().mockResolvedValue(null),
+    getIncomeStatementGrowth: vi.fn().mockResolvedValue(null),
+    getKeyMetricsTtm: vi.fn().mockResolvedValue(null),
+    getPriceTargetConsensus: vi.fn().mockResolvedValue(null),
+    getPriceTargetSummary: vi.fn().mockResolvedValue(null),
+    getProfile: vi.fn().mockResolvedValue(null),
+    getProfileDescriptionKo: vi.fn().mockResolvedValue(null),
+    getRatiosTtm: vi.fn().mockResolvedValue(null),
+    getStockPeers: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@/app/[symbol]/fundamental/FundamentalDegraded', () => ({
+    FundamentalDegraded: () => <div data-testid="fundamental-degraded" />,
+}));
+// staticSymbolCache: call fetcher() directly so tests stay pure (no I/O).
+// This is the key — section functions call staticSymbolCache(..., fetcher),
+// and we must route that call to the fetcher so the rejection propagates to
+// the section's .catch() handler.
+vi.mock('@/shared/cache/staticSymbolCache', () => ({
+    staticSymbolCache: vi.fn(
+        (
+            _key: readonly string[],
+            _symbol: string,
+            fetcher: () => Promise<unknown>
+        ) => fetcher()
+    ),
+}));
+// Widget mocks to avoid deep import chains.
+vi.mock('@/widgets/fundamental/FundamentalAiSummary', () => ({
+    FundamentalAiSummary: () => null,
+}));
+vi.mock('@/widgets/fundamental/FundamentalAiSummaryError', () => ({
+    FundamentalAiSummaryError: () => null,
+}));
+vi.mock('@/widgets/fundamental/FundamentalAiSummarySkeleton', () => ({
+    FundamentalAiSummarySkeleton: () => null,
+}));
+vi.mock('@/widgets/fundamental/sections/FinancialHealthCard', () => ({
+    FinancialHealthCard: () => null,
+}));
+vi.mock('@/widgets/fundamental/sections/FutureDirectionCard', () => ({
+    FutureDirectionCard: () => null,
+}));
+vi.mock('@/widgets/fundamental/sections/GrowthChart', () => ({
+    GrowthChart: () => null,
+}));
+vi.mock('@/widgets/fundamental/sections/PeersTable', () => ({
+    PeersTable: () => null,
+}));
+vi.mock('@/widgets/fundamental/sections/ProfileCard', () => ({
+    ProfileCard: () => null,
+}));
+vi.mock('@/widgets/fundamental/sections/ProfitabilityCard', () => ({
+    ProfitabilityCard: () => null,
+}));
+vi.mock('@/widgets/fundamental/sections/ValuationCard', () => ({
+    ValuationCard: () => null,
+}));
+vi.mock('@/views/symbol', () => ({
+    SymbolPageHeading: ({ children }: { children: unknown }) => children,
+}));
+vi.mock('@/shared/ui/CrossLinkCards', () => ({
+    CrossLinkCards: () => null,
+}));
+vi.mock('@/views/symbol/SectionSkeleton', () => ({
+    SectionSkeleton: () => null,
+}));
+vi.mock('@/shared/ui/JsonLd', () => ({ JsonLd: () => null }));
+vi.mock('@/shared/lib/seo', async importOriginal => ({
+    ...(await importOriginal<typeof import('@/shared/lib/seo')>()),
+    buildBreadcrumbJsonLd: vi.fn().mockReturnValue({}),
+    buildSymbolSeoContent: vi.fn().mockReturnValue({ url: '' }),
+    buildSymbolFundamentalSeoContent: vi.fn().mockReturnValue({
+        title: '',
+        fullTitle: '',
+        description: '',
+        url: '',
+        keywords: [],
+    }),
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+vi.mock('react-error-boundary', () => ({
+    ErrorBoundary: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import {
+    describe,
+    it,
+    expect,
+    vi,
+    beforeEach,
+    type MockedFunction,
+} from 'vitest';
+import { isValidElement } from 'react';
+import FundamentalPage from '@/app/[symbol]/fundamental/page';
+import { getAssetInfoResilient } from '@/entities/ticker';
+import { getProfileResilient } from '@/app/[symbol]/fundamental/getProfileResilient';
+import {
+    getKeyMetricsTtm,
+    getStockPeers,
+    getRatiosTtm,
+    getIncomeStatementGrowth,
+    getFinancialScores,
+    getCashFlowStatement,
+    getAnalystEstimates,
+} from '@/app/[symbol]/fundamental/fundamentalData';
+import { staticSymbolCache } from '@/shared/cache/staticSymbolCache';
+
+const mockGetAssetInfoResilient = getAssetInfoResilient as MockedFunction<
+    typeof getAssetInfoResilient
+>;
+const mockGetProfileResilient = getProfileResilient as MockedFunction<
+    typeof getProfileResilient
+>;
+const mockGetKeyMetricsTtm = getKeyMetricsTtm as MockedFunction<
+    typeof getKeyMetricsTtm
+>;
+const mockGetStockPeers = getStockPeers as MockedFunction<typeof getStockPeers>;
+const mockGetRatiosTtm = getRatiosTtm as MockedFunction<typeof getRatiosTtm>;
+const mockGetIncomeStatementGrowth = getIncomeStatementGrowth as MockedFunction<
+    typeof getIncomeStatementGrowth
+>;
+const mockGetFinancialScores = getFinancialScores as MockedFunction<
+    typeof getFinancialScores
+>;
+const mockGetCashFlowStatement = getCashFlowStatement as MockedFunction<
+    typeof getCashFlowStatement
+>;
+const mockGetAnalystEstimates = getAnalystEstimates as MockedFunction<
+    typeof getAnalystEstimates
+>;
+// staticSymbolCache is mocked to call fetcher() directly — used in section tests.
+const mockStaticSymbolCache = staticSymbolCache as MockedFunction<
+    typeof staticSymbolCache
+>;
+
+const EQUITY_ASSET_INFO = {
+    assetInfo: {
+        symbol: 'AAPL',
+        name: 'Apple Inc.',
+        koreanName: '애플',
+        fmpSymbol: 'AAPL',
+    },
+    degraded: false,
+} as Awaited<ReturnType<typeof getAssetInfoResilient>>;
+
+const PROFILE_OK = {
+    profile: { sector: 'Technology', description: 'A tech company.' },
+    degraded: false,
+} as Awaited<ReturnType<typeof getProfileResilient>>;
+
+describe('Fundamental page ISR empty-cache prevention — top-level guard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetAssetInfoResilient.mockResolvedValue(EQUITY_ASSET_INFO);
+        mockGetProfileResilient.mockResolvedValue(PROFILE_OK);
+    });
+
+    it('page does not throw and returns a non-null JSX element when all loaders succeed', async () => {
+        const tree = await FundamentalPage({
+            params: Promise.resolve({ symbol: 'AAPL' }),
+        });
+        expect(isValidElement(tree)).toBe(true);
+    });
+});
+
+/**
+ * Layer B: section-level ISR degrade tests.
+ *
+ * Each section is a module-level async function (not exported from page.tsx).
+ * We cannot call them directly, but we CAN test that when their loaders reject,
+ * the .catch() in the section absorbs the error. To do this we exploit the fact
+ * that staticSymbolCache is mocked to call fetcher() directly — so the rejection
+ * flows through the section's .catch() handler when the section awaits its cache call.
+ *
+ * However, since the sections are lazy RSC children inside <Suspense> and are NOT
+ * awaited by FundamentalPage directly, we cannot trigger them through FundamentalPage.
+ * Instead we test the loader catch via a direct call to the mocked staticSymbolCache
+ * with a rejecting fetcher, simulating what happens when Next.js resolves the Suspense
+ * child during ISR streaming. This exercises exactly the .catch() handler code path.
+ */
+describe('Fundamental page ISR empty-cache prevention — section loader catch', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    /**
+     * The section loader pattern is:
+     *   staticSymbolCache([key], symbol, () => loaderFn(symbol), [], TTL)
+     *     .catch(e => { console.error('[Context]...', e); return safeEmpty; })
+     *
+     * Because staticSymbolCache is mocked as fetcher(), a rejection in loaderFn
+     * surfaces immediately. We verify the .catch() is wired correctly by checking
+     * that console.error is called with the context prefix.
+     *
+     * We call staticSymbolCache manually with a rejecting fetcher to simulate the
+     * section function's internal cache call, then apply the same .catch() from
+     * the source code. This is a structural test that the catch contract is met.
+     */
+    it('ValuationSection loader: getKeyMetricsTtm reject → .catch emits [ValuationSection] log', async () => {
+        const err = new Error('FMP 429');
+        mockGetKeyMetricsTtm.mockRejectedValue(err);
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        // Simulate the ValuationSection cache call path: fetcher rejects → .catch fires.
+        const result = await mockStaticSymbolCache(
+            ['fundamental:metrics', 'AAPL'],
+            'AAPL',
+            () => getKeyMetricsTtm('AAPL'),
+            [],
+            86400
+        ).catch((e: unknown) => {
+            console.error(
+                '[ValuationSection] getKeyMetricsTtm failed, degrading to null:',
+                e
+            );
+            return null;
+        });
+
+        expect(result).toBeNull();
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[ValuationSection]'),
+            err
+        );
+
+        consoleSpy.mockRestore();
+    });
+
+    it('PeersSection loader: getStockPeers reject → .catch emits [PeersSection] log, returns []', async () => {
+        const err = new Error('FMP peers down');
+        mockGetStockPeers.mockRejectedValue(err);
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        const result = await mockStaticSymbolCache(
+            ['fundamental:peers', 'AAPL'],
+            'AAPL',
+            () => getStockPeers('AAPL'),
+            [],
+            86400
+        ).catch((e: unknown) => {
+            console.error(
+                '[PeersSection] getStockPeers failed, degrading to []:',
+                e
+            );
+            return [];
+        });
+
+        expect(Array.isArray(result)).toBe(true);
+        expect((result as unknown[]).length).toBe(0);
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[PeersSection]'),
+            err
+        );
+
+        consoleSpy.mockRestore();
+    });
+
+    it('FinancialHealthSection: getRatiosTtm reject → .catch emits log, returns null', async () => {
+        const err = new Error('FMP ratios down');
+        mockGetRatiosTtm.mockRejectedValue(err);
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        const result = await mockStaticSymbolCache(
+            ['fundamental:ratios', 'AAPL'],
+            'AAPL',
+            () => getRatiosTtm('AAPL'),
+            [],
+            86400
+        ).catch((e: unknown) => {
+            console.error(
+                '[FinancialHealthSection] getRatiosTtm failed, degrading to null:',
+                e
+            );
+            return null;
+        });
+
+        expect(result).toBeNull();
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[FinancialHealthSection] getRatiosTtm'),
+            err
+        );
+
+        consoleSpy.mockRestore();
+    });
+
+    it('GrowthSection: getIncomeStatementGrowth reject → .catch emits log, returns null', async () => {
+        const err = new Error('FMP growth down');
+        mockGetIncomeStatementGrowth.mockRejectedValue(err);
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        const result = await mockStaticSymbolCache(
+            ['fundamental:growth', 'AAPL'],
+            'AAPL',
+            () => getIncomeStatementGrowth('AAPL'),
+            [],
+            86400
+        ).catch((e: unknown) => {
+            console.error(
+                '[GrowthSection] getIncomeStatementGrowth failed, degrading to null:',
+                e
+            );
+            return null;
+        });
+
+        expect(result).toBeNull();
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[GrowthSection]'),
+            err
+        );
+
+        consoleSpy.mockRestore();
+    });
+
+    it('FutureDirectionSection: getAnalystEstimates reject → .catch emits log, returns null', async () => {
+        const err = new Error('FMP estimates down');
+        mockGetAnalystEstimates.mockRejectedValue(err);
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        const result = await mockStaticSymbolCache(
+            ['fundamental:estimates', 'AAPL'],
+            'AAPL',
+            () => getAnalystEstimates('AAPL'),
+            [],
+            86400
+        ).catch((e: unknown) => {
+            console.error(
+                '[FutureDirectionSection] getAnalystEstimates failed, degrading to null:',
+                e
+            );
+            return null;
+        });
+
+        expect(result).toBeNull();
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                '[FutureDirectionSection] getAnalystEstimates'
+            ),
+            err
+        );
+
+        consoleSpy.mockRestore();
+    });
+
+    it('FinancialHealthSection: all three loaders reject → all three catch handlers fire independently', async () => {
+        const errRatios = new Error('ratios down');
+        const errScores = new Error('scores down');
+        const errCashFlow = new Error('cashflow down');
+        mockGetRatiosTtm.mockRejectedValue(errRatios);
+        mockGetFinancialScores.mockRejectedValue(errScores);
+        mockGetCashFlowStatement.mockRejectedValue(errCashFlow);
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        // Simulate Promise.all inside FinancialHealthSection — each fails independently.
+        const [ratios, scores, cashFlow] = await Promise.all([
+            mockStaticSymbolCache(
+                ['fundamental:ratios', 'AAPL'],
+                'AAPL',
+                () => getRatiosTtm('AAPL'),
+                [],
+                86400
+            ).catch((e: unknown) => {
+                console.error(
+                    '[FinancialHealthSection] getRatiosTtm failed, degrading to null:',
+                    e
+                );
+                return null;
+            }),
+            mockStaticSymbolCache(
+                ['fundamental:scores', 'AAPL'],
+                'AAPL',
+                () => getFinancialScores('AAPL'),
+                [],
+                86400
+            ).catch((e: unknown) => {
+                console.error(
+                    '[FinancialHealthSection] getFinancialScores failed, degrading to null:',
+                    e
+                );
+                return null;
+            }),
+            mockStaticSymbolCache(
+                ['fundamental:cashflow', 'AAPL'],
+                'AAPL',
+                () => getCashFlowStatement('AAPL'),
+                [],
+                86400
+            ).catch((e: unknown) => {
+                console.error(
+                    '[FinancialHealthSection] getCashFlowStatement failed, degrading to null:',
+                    e
+                );
+                return null;
+            }),
+        ]);
+
+        expect(ratios).toBeNull();
+        expect(scores).toBeNull();
+        expect(cashFlow).toBeNull();
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[FinancialHealthSection] getRatiosTtm'),
+            errRatios
+        );
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                '[FinancialHealthSection] getFinancialScores'
+            ),
+            errScores
+        );
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                '[FinancialHealthSection] getCashFlowStatement'
+            ),
+            errCashFlow
+        );
+
+        consoleSpy.mockRestore();
+    });
+});

--- a/src/app/[symbol]/fundamental/__tests__/page.isr-degrade.test.tsx
+++ b/src/app/[symbol]/fundamental/__tests__/page.isr-degrade.test.tsx
@@ -213,6 +213,8 @@ import React from 'react';
 import { isValidElement } from 'react';
 import { render, screen } from '@testing-library/react';
 import FundamentalPage, {
+    ProfileSection,
+    ProfileDescriptionSection,
     ValuationSection,
     PeersSection,
     ProfitabilitySection,
@@ -223,6 +225,8 @@ import FundamentalPage, {
 import { getAssetInfoResilient } from '@/entities/ticker';
 import { getProfileResilient } from '@/app/[symbol]/fundamental/getProfileResilient';
 import {
+    getProfile,
+    getProfileDescriptionKo,
     getKeyMetricsTtm,
     getStockPeers,
     getRatiosTtm,
@@ -240,6 +244,10 @@ const mockGetAssetInfoResilient = getAssetInfoResilient as MockedFunction<
 >;
 const mockGetProfileResilient = getProfileResilient as MockedFunction<
     typeof getProfileResilient
+>;
+const mockGetProfile = getProfile as MockedFunction<typeof getProfile>;
+const mockGetProfileDescriptionKo = getProfileDescriptionKo as MockedFunction<
+    typeof getProfileDescriptionKo
 >;
 const mockGetKeyMetricsTtm = getKeyMetricsTtm as MockedFunction<
     typeof getKeyMetricsTtm
@@ -320,6 +328,8 @@ describe('Fundamental page ISR empty-cache prevention — section layer (Layer B
     beforeEach(() => {
         vi.clearAllMocks();
         // Default: all loaders succeed with safe empty values.
+        mockGetProfile.mockResolvedValue(null);
+        mockGetProfileDescriptionKo.mockResolvedValue(null);
         mockGetKeyMetricsTtm.mockResolvedValue(null);
         mockGetStockPeers.mockResolvedValue(
             [] as Awaited<ReturnType<typeof getStockPeers>>
@@ -332,6 +342,56 @@ describe('Fundamental page ISR empty-cache prevention — section layer (Layer B
         mockGetGradesConsensus.mockResolvedValue(null);
         mockGetPriceTargetConsensus.mockResolvedValue(null);
         mockGetPriceTargetSummary.mockResolvedValue(null);
+    });
+
+    it('ProfileSection: loader throw → renders degraded card (data-degraded="true"), does not throw', async () => {
+        mockGetProfile.mockRejectedValue(new Error('FMP profile 500'));
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        // Must not throw — .catch() in ProfileSection absorbs the rejection
+        // and passes null to ProfileCard, which the mock renders as data-degraded="true".
+        render(await ProfileSection({ symbol: 'AAPL' }));
+
+        const card = screen.getByTestId('profile-card');
+        expect(card).toBeInTheDocument();
+        expect(card.getAttribute('data-degraded')).toBe('true');
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[ProfileSection]'),
+            expect.any(Error)
+        );
+
+        consoleSpy.mockRestore();
+    });
+
+    it('ProfileDescriptionSection: loader throw → renders fallback text, does not throw', async () => {
+        mockGetProfileDescriptionKo.mockRejectedValue(
+            new Error('translation service 503')
+        );
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        // Must not throw — .catch() in ProfileDescriptionSection absorbs the rejection
+        // and returns null so descriptionKo ?? fallback renders the fallback string.
+        render(
+            await ProfileDescriptionSection({
+                symbol: 'AAPL',
+                fallback: 'English description fallback',
+            })
+        );
+
+        // Degraded output: the <p> renders the fallback (English description) instead of null.
+        expect(
+            screen.getByText('English description fallback')
+        ).toBeInTheDocument();
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[ProfileDescriptionSection]'),
+            expect.any(Error)
+        );
+
+        consoleSpy.mockRestore();
     });
 
     it('ValuationSection: loader throw → renders degraded card (data-degraded="true"), does not throw', async () => {

--- a/src/app/[symbol]/fundamental/page.tsx
+++ b/src/app/[symbol]/fundamental/page.tsx
@@ -189,7 +189,7 @@ interface ProfileDescriptionSectionProps {
     fallback: string;
 }
 
-async function ProfileDescriptionSection({
+export async function ProfileDescriptionSection({
     symbol,
     fallback,
 }: ProfileDescriptionSectionProps) {
@@ -215,7 +215,7 @@ async function ProfileDescriptionSection({
     );
 }
 
-async function ProfileSection({ symbol }: SymbolSectionProps) {
+export async function ProfileSection({ symbol }: SymbolSectionProps) {
     // Shares the same key as the notFound guard in the page body — cross-request ISR cache is shared.
     // ISR degrade guard: getProfile(FMP)가 throw하면 null 로 degrade → ProfileCard(null)가
     // 기존 empty-state UI를 렌더하고 페이지 크롬은 유지된다.
@@ -245,7 +245,7 @@ async function ProfileSection({ symbol }: SymbolSectionProps) {
     return <ProfileCard profile={profile} descriptionSlot={descriptionSlot} />;
 }
 
-async function ValuationSection({ symbol }: SymbolSectionProps) {
+export async function ValuationSection({ symbol }: SymbolSectionProps) {
     // ISR degrade guard: getKeyMetricsTtm(FMP)가 throw하면 null 로 degrade →
     // ValuationCard(null)가 기존 empty-state UI를 렌더한다.
     const metrics = await staticSymbolCache(
@@ -264,7 +264,7 @@ async function ValuationSection({ symbol }: SymbolSectionProps) {
     return <ValuationCard metrics={metrics} />;
 }
 
-async function PeersSection({ symbol }: SymbolSectionProps) {
+export async function PeersSection({ symbol }: SymbolSectionProps) {
     // ISR degrade guard: getStockPeers(FMP)가 throw하면 [] 로 degrade →
     // PeersTable([])가 기존 empty-state UI를 렌더한다.
     const peers = await staticSymbolCache(
@@ -283,7 +283,7 @@ async function PeersSection({ symbol }: SymbolSectionProps) {
     return <PeersTable peers={peers} />;
 }
 
-async function ProfitabilitySection({ symbol }: SymbolSectionProps) {
+export async function ProfitabilitySection({ symbol }: SymbolSectionProps) {
     // ISR degrade guard: getRatiosTtm(FMP)가 throw하면 null 로 degrade →
     // ProfitabilityCard(null)가 기존 empty-state UI를 렌더한다.
     const ratios = await staticSymbolCache(
@@ -302,7 +302,7 @@ async function ProfitabilitySection({ symbol }: SymbolSectionProps) {
     return <ProfitabilityCard ratios={ratios} />;
 }
 
-async function GrowthSection({ symbol }: SymbolSectionProps) {
+export async function GrowthSection({ symbol }: SymbolSectionProps) {
     // ISR degrade guard: getIncomeStatementGrowth(FMP)가 throw하면 null 로 degrade →
     // GrowthChart(null)가 기존 empty-state UI를 렌더한다.
     const growth = await staticSymbolCache(
@@ -321,7 +321,7 @@ async function GrowthSection({ symbol }: SymbolSectionProps) {
     return <GrowthChart growth={growth} />;
 }
 
-async function FinancialHealthSection({ symbol }: SymbolSectionProps) {
+export async function FinancialHealthSection({ symbol }: SymbolSectionProps) {
     // ISR degrade guard: 각 FMP 로더가 throw하면 null 로 degrade →
     // FinancialHealthCard(null, null, null)가 기존 empty-state UI를 렌더한다.
     const [ratios, scores, cashFlow] = await Promise.all([
@@ -374,7 +374,7 @@ async function FinancialHealthSection({ symbol }: SymbolSectionProps) {
     );
 }
 
-async function FutureDirectionSection({ symbol }: SymbolSectionProps) {
+export async function FutureDirectionSection({ symbol }: SymbolSectionProps) {
     // ISR degrade guard: 각 FMP 로더가 throw하면 null 로 degrade →
     // FutureDirectionCard(null, null, null, null)가 기존 empty-state UI를 렌더한다.
     const [estimates, grades, ptConsensus, ptSummary] = await Promise.all([

--- a/src/app/[symbol]/fundamental/page.tsx
+++ b/src/app/[symbol]/fundamental/page.tsx
@@ -193,13 +193,21 @@ async function ProfileDescriptionSection({
     symbol,
     fallback,
 }: ProfileDescriptionSectionProps) {
+    // ISR degrade guard: getProfileDescriptionKo(AI 번역)가 throw하더라도 ISR 캐시에
+    // 0-byte 빈 결과가 굳지 않도록 흡수한다. null 로 degrade → fallback(영어 원문)을 렌더.
     const descriptionKo = await staticSymbolCache(
         ['fundamental:desc-ko', symbol],
         symbol,
         () => getProfileDescriptionKo(symbol),
         [],
         SECONDS_PER_DAY
-    );
+    ).catch((e: unknown) => {
+        console.error(
+            '[ProfileDescriptionSection] getProfileDescriptionKo failed, degrading to null:',
+            e
+        );
+        return null;
+    });
     return (
         <p className="text-secondary-400 mt-4 line-clamp-4 text-sm leading-relaxed">
             {descriptionKo ?? fallback}
@@ -209,13 +217,21 @@ async function ProfileDescriptionSection({
 
 async function ProfileSection({ symbol }: SymbolSectionProps) {
     // Shares the same key as the notFound guard in the page body — cross-request ISR cache is shared.
+    // ISR degrade guard: getProfile(FMP)가 throw하면 null 로 degrade → ProfileCard(null)가
+    // 기존 empty-state UI를 렌더하고 페이지 크롬은 유지된다.
     const profile = await staticSymbolCache(
         ['fundamental:profile', symbol],
         symbol,
         () => getProfile(symbol),
         [],
         SECONDS_PER_DAY
-    );
+    ).catch((e: unknown) => {
+        console.error(
+            '[ProfileSection] getProfile failed, degrading to null:',
+            e
+        );
+        return null;
+    });
 
     const descriptionSlot = (
         <Suspense fallback={<ProfileDescriptionSkeleton />}>
@@ -230,50 +246,84 @@ async function ProfileSection({ symbol }: SymbolSectionProps) {
 }
 
 async function ValuationSection({ symbol }: SymbolSectionProps) {
+    // ISR degrade guard: getKeyMetricsTtm(FMP)가 throw하면 null 로 degrade →
+    // ValuationCard(null)가 기존 empty-state UI를 렌더한다.
     const metrics = await staticSymbolCache(
         ['fundamental:metrics', symbol],
         symbol,
         () => getKeyMetricsTtm(symbol),
         [],
         SECONDS_PER_DAY
-    );
+    ).catch((e: unknown) => {
+        console.error(
+            '[ValuationSection] getKeyMetricsTtm failed, degrading to null:',
+            e
+        );
+        return null;
+    });
     return <ValuationCard metrics={metrics} />;
 }
 
 async function PeersSection({ symbol }: SymbolSectionProps) {
+    // ISR degrade guard: getStockPeers(FMP)가 throw하면 [] 로 degrade →
+    // PeersTable([])가 기존 empty-state UI를 렌더한다.
     const peers = await staticSymbolCache(
         ['fundamental:peers', symbol],
         symbol,
         () => getStockPeers(symbol),
         [],
         SECONDS_PER_DAY
-    );
+    ).catch((e: unknown) => {
+        console.error(
+            '[PeersSection] getStockPeers failed, degrading to []:',
+            e
+        );
+        return [] as Awaited<ReturnType<typeof getStockPeers>>;
+    });
     return <PeersTable peers={peers} />;
 }
 
 async function ProfitabilitySection({ symbol }: SymbolSectionProps) {
+    // ISR degrade guard: getRatiosTtm(FMP)가 throw하면 null 로 degrade →
+    // ProfitabilityCard(null)가 기존 empty-state UI를 렌더한다.
     const ratios = await staticSymbolCache(
         ['fundamental:ratios', symbol],
         symbol,
         () => getRatiosTtm(symbol),
         [],
         SECONDS_PER_DAY
-    );
+    ).catch((e: unknown) => {
+        console.error(
+            '[ProfitabilitySection] getRatiosTtm failed, degrading to null:',
+            e
+        );
+        return null;
+    });
     return <ProfitabilityCard ratios={ratios} />;
 }
 
 async function GrowthSection({ symbol }: SymbolSectionProps) {
+    // ISR degrade guard: getIncomeStatementGrowth(FMP)가 throw하면 null 로 degrade →
+    // GrowthChart(null)가 기존 empty-state UI를 렌더한다.
     const growth = await staticSymbolCache(
         ['fundamental:growth', symbol],
         symbol,
         () => getIncomeStatementGrowth(symbol),
         [],
         SECONDS_PER_DAY
-    );
+    ).catch((e: unknown) => {
+        console.error(
+            '[GrowthSection] getIncomeStatementGrowth failed, degrading to null:',
+            e
+        );
+        return null;
+    });
     return <GrowthChart growth={growth} />;
 }
 
 async function FinancialHealthSection({ symbol }: SymbolSectionProps) {
+    // ISR degrade guard: 각 FMP 로더가 throw하면 null 로 degrade →
+    // FinancialHealthCard(null, null, null)가 기존 empty-state UI를 렌더한다.
     const [ratios, scores, cashFlow] = await Promise.all([
         staticSymbolCache(
             ['fundamental:ratios', symbol],
@@ -281,21 +331,39 @@ async function FinancialHealthSection({ symbol }: SymbolSectionProps) {
             () => getRatiosTtm(symbol),
             [],
             SECONDS_PER_DAY
-        ),
+        ).catch((e: unknown) => {
+            console.error(
+                '[FinancialHealthSection] getRatiosTtm failed, degrading to null:',
+                e
+            );
+            return null;
+        }),
         staticSymbolCache(
             ['fundamental:scores', symbol],
             symbol,
             () => getFinancialScores(symbol),
             [],
             SECONDS_PER_DAY
-        ),
+        ).catch((e: unknown) => {
+            console.error(
+                '[FinancialHealthSection] getFinancialScores failed, degrading to null:',
+                e
+            );
+            return null;
+        }),
         staticSymbolCache(
             ['fundamental:cashflow', symbol],
             symbol,
             () => getCashFlowStatement(symbol),
             [],
             SECONDS_PER_DAY
-        ),
+        ).catch((e: unknown) => {
+            console.error(
+                '[FinancialHealthSection] getCashFlowStatement failed, degrading to null:',
+                e
+            );
+            return null;
+        }),
     ]);
     return (
         <FinancialHealthCard
@@ -307,6 +375,8 @@ async function FinancialHealthSection({ symbol }: SymbolSectionProps) {
 }
 
 async function FutureDirectionSection({ symbol }: SymbolSectionProps) {
+    // ISR degrade guard: 각 FMP 로더가 throw하면 null 로 degrade →
+    // FutureDirectionCard(null, null, null, null)가 기존 empty-state UI를 렌더한다.
     const [estimates, grades, ptConsensus, ptSummary] = await Promise.all([
         staticSymbolCache(
             ['fundamental:estimates', symbol],
@@ -314,28 +384,52 @@ async function FutureDirectionSection({ symbol }: SymbolSectionProps) {
             () => getAnalystEstimates(symbol),
             [],
             SECONDS_PER_DAY
-        ),
+        ).catch((e: unknown) => {
+            console.error(
+                '[FutureDirectionSection] getAnalystEstimates failed, degrading to null:',
+                e
+            );
+            return null;
+        }),
         staticSymbolCache(
             ['fundamental:grades-consensus', symbol],
             symbol,
             () => getGradesConsensus(symbol),
             [],
             SECONDS_PER_DAY
-        ),
+        ).catch((e: unknown) => {
+            console.error(
+                '[FutureDirectionSection] getGradesConsensus failed, degrading to null:',
+                e
+            );
+            return null;
+        }),
         staticSymbolCache(
             ['fundamental:pt-consensus', symbol],
             symbol,
             () => getPriceTargetConsensus(symbol),
             [],
             SECONDS_PER_DAY
-        ),
+        ).catch((e: unknown) => {
+            console.error(
+                '[FutureDirectionSection] getPriceTargetConsensus failed, degrading to null:',
+                e
+            );
+            return null;
+        }),
         staticSymbolCache(
             ['fundamental:pt-summary', symbol],
             symbol,
             () => getPriceTargetSummary(symbol),
             [],
             SECONDS_PER_DAY
-        ),
+        ).catch((e: unknown) => {
+            console.error(
+                '[FutureDirectionSection] getPriceTargetSummary failed, degrading to null:',
+                e
+            );
+            return null;
+        }),
     ]);
     return (
         <FutureDirectionCard

--- a/src/app/[symbol]/news/__tests__/page.isr-degrade.test.tsx
+++ b/src/app/[symbol]/news/__tests__/page.isr-degrade.test.tsx
@@ -208,6 +208,9 @@ describe('/[symbol]/news ISR empty-cache prevention', () => {
             new Error('DB connection refused')
         );
         mockGetFmpUserFacingMessage.mockReturnValue(null);
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
 
         // Render the section directly — must not throw, must show generic message.
         render(await EventCalendarSection({ symbol: 'AAPL' }));
@@ -215,6 +218,12 @@ describe('/[symbol]/news ISR empty-cache prevention', () => {
         expect(
             screen.getByText('실적 일정을 불러오지 못했어요.')
         ).toBeInTheDocument();
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[EventCalendarSection]'),
+            expect.any(Error)
+        );
+
+        consoleSpy.mockRestore();
     });
 
     it('getEarningsReportComparison throw (FMP error) → EventCalendarSection renders FMP message, no throw', async () => {
@@ -225,18 +234,30 @@ describe('/[symbol]/news ISR empty-cache prevention', () => {
         mockGetFmpUserFacingMessage.mockReturnValue(
             'FMP 서비스가 일시 중단됐어요.'
         );
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
 
         render(await EventCalendarSection({ symbol: 'AAPL' }));
 
         expect(
             screen.getByText('FMP 서비스가 일시 중단됐어요.')
         ).toBeInTheDocument();
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[EventCalendarSection]'),
+            expect.any(Error)
+        );
+
+        consoleSpy.mockRestore();
     });
 
     it('getGradeEvents throw (non-FMP) → AnalystActionsSection renders generic alert, no throw', async () => {
         // non-FMP error: getFmpUserFacingMessage returns null → generic fallback
         mockGetGradeEvents.mockRejectedValue(new Error('Redis unavailable'));
         mockGetFmpUserFacingMessage.mockReturnValue(null);
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
 
         // Render the section directly — must not throw, must show generic message.
         render(await AnalystActionsSection({ symbol: 'AAPL' }));
@@ -244,6 +265,12 @@ describe('/[symbol]/news ISR empty-cache prevention', () => {
         expect(
             screen.getByText('애널리스트 동향을 불러오지 못했어요.')
         ).toBeInTheDocument();
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[AnalystActionsSection]'),
+            expect.any(Error)
+        );
+
+        consoleSpy.mockRestore();
     });
 
     it('getGradeEvents throw (FMP error) → AnalystActionsSection renders FMP message, no throw', async () => {
@@ -251,12 +278,21 @@ describe('/[symbol]/news ISR empty-cache prevention', () => {
         mockGetFmpUserFacingMessage.mockReturnValue(
             '데이터 제공 서비스에 문제가 생겼어요.'
         );
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
 
         render(await AnalystActionsSection({ symbol: 'AAPL' }));
 
         expect(
             screen.getByText('데이터 제공 서비스에 문제가 생겼어요.')
         ).toBeInTheDocument();
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[AnalystActionsSection]'),
+            expect.any(Error)
+        );
+
+        consoleSpy.mockRestore();
     });
 
     it('success path — all loaders succeed → real content rendered, no degrade alerts', async () => {

--- a/src/app/[symbol]/news/__tests__/page.isr-degrade.test.tsx
+++ b/src/app/[symbol]/news/__tests__/page.isr-degrade.test.tsx
@@ -1,0 +1,289 @@
+/**
+ * ISR empty-cache prevention tests for the /[symbol]/news page.
+ *
+ * A transient throw from getNewsList (Postgres), getEarningsReportComparison
+ * (DB/FMP), or getGradeEvents (FMP) during ISR cold-gen must NOT propagate.
+ * The page must degrade gracefully (non-empty result) rather than freezing
+ * an empty ISR cache.
+ *
+ * Strategy: render the async section RSCs directly (await the section fn →
+ * render the returned element) so their degraded output lands in the DOM.
+ * Rendering the whole NewsPage wraps sections in <Suspense>, which
+ * @testing-library/react does not flush — so degrade text never appears.
+ * Page-level chrome assertions (h1 heading) keep a NewsPage render for the
+ * two tests that need it.
+ */
+
+// vi.mock calls are hoisted above imports by vitest.
+vi.mock('@/shared/ui/JsonLd', () => ({ JsonLd: () => null }));
+vi.mock('next/navigation', () => ({
+    notFound: vi.fn(() => {
+        throw new Error('NEXT_NOT_FOUND');
+    }),
+}));
+
+vi.mock('@/entities/ticker', () => ({
+    buildAssetAboutNode: vi.fn().mockReturnValue(undefined),
+    buildDisplayName: vi.fn().mockReturnValue('Apple Inc.'),
+    getAssetInfoResilient: vi.fn(),
+}));
+
+// staticSymbolCache: call fetcher() directly so tests stay pure (no I/O).
+vi.mock('@/shared/cache/staticSymbolCache', () => ({
+    staticSymbolCache: vi.fn(
+        (
+            _key: readonly string[],
+            _symbol: string,
+            fetcher: () => Promise<unknown>
+        ) => fetcher()
+    ),
+}));
+
+// newsData functions — configured per-test to reject or resolve.
+vi.mock('@/app/[symbol]/news/newsData', () => ({
+    getEarningsReportComparison: vi.fn(),
+    getGradeEvents: vi.fn(),
+}));
+
+vi.mock('@/entities/news-article', () => ({
+    NEWS_LIST_CACHE_KEY: 'news-list',
+}));
+vi.mock('@/entities/news-article/api', () => ({
+    getNewsList: vi.fn(),
+}));
+
+vi.mock('@/widgets/news/NewsAiSummary', () => ({
+    NewsAiSummary: () => null,
+}));
+vi.mock('@/widgets/news/NewsAiSummaryErrorBoundary', () => ({
+    NewsAiSummaryErrorBoundary: ({ children }: { children: unknown }) =>
+        children,
+}));
+vi.mock('@/widgets/news/NewsAiSummarySkeleton', () => ({
+    NewsAiSummarySkeleton: () => null,
+}));
+vi.mock('@/widgets/news/sections/NewsList', () => ({
+    NewsList: ({ items }: { items: unknown[] }) => (
+        <ul data-testid="news-list" data-count={items.length} />
+    ),
+}));
+vi.mock('@/widgets/news/sections/EventCalendar', () => ({
+    EventCalendar: () => <div data-testid="event-calendar" />,
+}));
+vi.mock('@/widgets/news/sections/AnalystActions', () => ({
+    AnalystActions: () => <div data-testid="analyst-actions" />,
+}));
+vi.mock('@/views/symbol', () => ({
+    SymbolPageHeading: ({ children }: { children: React.ReactNode }) => (
+        <h1>{children}</h1>
+    ),
+}));
+vi.mock('@/shared/ui/CrossLinkCards', () => ({
+    CrossLinkCards: () => null,
+}));
+vi.mock('@/views/symbol/SectionSkeleton', () => ({
+    SectionSkeleton: () => null,
+}));
+
+vi.mock('@/shared/lib/seo', async importOriginal => ({
+    ...(await importOriginal<typeof import('@/shared/lib/seo')>()),
+    buildBreadcrumbJsonLd: vi.fn().mockReturnValue({}),
+    buildSymbolSeoContent: vi.fn().mockReturnValue({
+        title: 'T',
+        fullTitle: 'T | Siglens',
+        description: 'd',
+        url: 'https://siglens.io/AAPL',
+        keywords: [],
+    }),
+    resolveSymbolNewsSeoContent: vi.fn().mockReturnValue({
+        title: 'T',
+        fullTitle: 'T | Siglens',
+        description: 'd',
+        url: 'https://siglens.io/AAPL',
+        keywords: [],
+    }),
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+
+vi.mock('@/shared/lib/getTodayIsoDay', () => ({
+    getTodayIsoDay: () => '2026-06-22',
+}));
+vi.mock('@/shared/lib/dateKey', () => ({
+    todayKstIsoDate: () => '2026-06-22',
+}));
+vi.mock('@/shared/api/fmp/fmpUserMessage', () => ({
+    getFmpUserFacingMessage: vi.fn(),
+}));
+
+import {
+    describe,
+    it,
+    expect,
+    vi,
+    beforeEach,
+    type MockedFunction,
+} from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NewsPage, {
+    NewsListSection,
+    EventCalendarSection,
+    AnalystActionsSection,
+} from '@/app/[symbol]/news/page';
+import { getAssetInfoResilient } from '@/entities/ticker';
+import { getNewsList } from '@/entities/news-article/api';
+import {
+    getEarningsReportComparison,
+    getGradeEvents,
+} from '@/app/[symbol]/news/newsData';
+import { getFmpUserFacingMessage } from '@/shared/api/fmp/fmpUserMessage';
+
+const mockGetAssetInfoResilient = getAssetInfoResilient as MockedFunction<
+    typeof getAssetInfoResilient
+>;
+const mockGetNewsList = getNewsList as MockedFunction<typeof getNewsList>;
+const mockGetEarningsReportComparison =
+    getEarningsReportComparison as MockedFunction<
+        typeof getEarningsReportComparison
+    >;
+const mockGetGradeEvents = getGradeEvents as MockedFunction<
+    typeof getGradeEvents
+>;
+const mockGetFmpUserFacingMessage = getFmpUserFacingMessage as MockedFunction<
+    typeof getFmpUserFacingMessage
+>;
+
+const EQUITY_ASSET_INFO = {
+    assetInfo: {
+        symbol: 'AAPL',
+        name: 'Apple Inc.',
+        koreanName: '애플',
+        fmpSymbol: 'AAPL',
+        marketProfile: 'us-equity' as const,
+    },
+    degraded: false,
+} as Awaited<ReturnType<typeof getAssetInfoResilient>>;
+
+describe('/[symbol]/news ISR empty-cache prevention', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetAssetInfoResilient.mockResolvedValue(EQUITY_ASSET_INFO);
+        // Default: sections succeed with empty data.
+        mockGetNewsList.mockResolvedValue(
+            [] as Awaited<ReturnType<typeof getNewsList>>
+        );
+        mockGetEarningsReportComparison.mockResolvedValue([]);
+        mockGetGradeEvents.mockResolvedValue([]);
+        // Default: non-FMP error (message = null) to trigger generic fallback path.
+        mockGetFmpUserFacingMessage.mockReturnValue(null);
+    });
+
+    it('getNewsList throw → NewsListSection degrades to empty list, no throw', async () => {
+        // Simulate transient DB failure during ISR cold-gen.
+        mockGetNewsList.mockRejectedValue(new Error('DB connection refused'));
+
+        // Render the section directly — its .catch(() => []) must absorb the throw.
+        render(await NewsListSection({ symbol: 'AAPL' }));
+
+        // NewsList stub renders with count 0 (degrade to []).
+        const newsList = screen.getByTestId('news-list');
+        expect(newsList).toBeInTheDocument();
+        expect(newsList.getAttribute('data-count')).toBe('0');
+    });
+
+    it('getNewsList throw → page heading still renders (chrome intact)', async () => {
+        mockGetNewsList.mockRejectedValue(new Error('DB connection refused'));
+
+        // The page-level chrome (heading) lives outside Suspense — render the
+        // full page to verify the heading is present even when the section degrades.
+        render(await NewsPage({ params: Promise.resolve({ symbol: 'AAPL' }) }));
+
+        expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+    });
+
+    it('getEarningsReportComparison throw (non-FMP) → EventCalendarSection renders generic alert, no throw', async () => {
+        // non-FMP error: getFmpUserFacingMessage returns null → generic fallback
+        mockGetEarningsReportComparison.mockRejectedValue(
+            new Error('DB connection refused')
+        );
+        mockGetFmpUserFacingMessage.mockReturnValue(null);
+
+        // Render the section directly — must not throw, must show generic message.
+        render(await EventCalendarSection({ symbol: 'AAPL' }));
+
+        expect(
+            screen.getByText('실적 일정을 불러오지 못했어요.')
+        ).toBeInTheDocument();
+    });
+
+    it('getEarningsReportComparison throw (FMP error) → EventCalendarSection renders FMP message, no throw', async () => {
+        // FMP error: getFmpUserFacingMessage returns a user-facing string.
+        mockGetEarningsReportComparison.mockRejectedValue(
+            new Error('FMP API rate limit')
+        );
+        mockGetFmpUserFacingMessage.mockReturnValue(
+            'FMP 서비스가 일시 중단됐어요.'
+        );
+
+        render(await EventCalendarSection({ symbol: 'AAPL' }));
+
+        expect(
+            screen.getByText('FMP 서비스가 일시 중단됐어요.')
+        ).toBeInTheDocument();
+    });
+
+    it('getGradeEvents throw (non-FMP) → AnalystActionsSection renders generic alert, no throw', async () => {
+        // non-FMP error: getFmpUserFacingMessage returns null → generic fallback
+        mockGetGradeEvents.mockRejectedValue(new Error('Redis unavailable'));
+        mockGetFmpUserFacingMessage.mockReturnValue(null);
+
+        // Render the section directly — must not throw, must show generic message.
+        render(await AnalystActionsSection({ symbol: 'AAPL' }));
+
+        expect(
+            screen.getByText('애널리스트 동향을 불러오지 못했어요.')
+        ).toBeInTheDocument();
+    });
+
+    it('getGradeEvents throw (FMP error) → AnalystActionsSection renders FMP message, no throw', async () => {
+        mockGetGradeEvents.mockRejectedValue(new Error('FMP error'));
+        mockGetFmpUserFacingMessage.mockReturnValue(
+            '데이터 제공 서비스에 문제가 생겼어요.'
+        );
+
+        render(await AnalystActionsSection({ symbol: 'AAPL' }));
+
+        expect(
+            screen.getByText('데이터 제공 서비스에 문제가 생겼어요.')
+        ).toBeInTheDocument();
+    });
+
+    it('success path — all loaders succeed → real content rendered, no degrade alerts', async () => {
+        // All loaders succeed with empty-but-valid data.
+        mockGetNewsList.mockResolvedValue(
+            [] as Awaited<ReturnType<typeof getNewsList>>
+        );
+        mockGetEarningsReportComparison.mockResolvedValue([]);
+        mockGetGradeEvents.mockResolvedValue([]);
+
+        // Each section renders its real stub content when loaders succeed.
+        render(await NewsListSection({ symbol: 'AAPL' }));
+        expect(screen.getByTestId('news-list')).toBeInTheDocument();
+        expect(
+            screen.queryByText('실적 일정을 불러오지 못했어요.')
+        ).not.toBeInTheDocument();
+
+        render(await EventCalendarSection({ symbol: 'AAPL' }));
+        expect(screen.getByTestId('event-calendar')).toBeInTheDocument();
+        expect(
+            screen.queryByText('실적 일정을 불러오지 못했어요.')
+        ).not.toBeInTheDocument();
+
+        render(await AnalystActionsSection({ symbol: 'AAPL' }));
+        expect(screen.getByTestId('analyst-actions')).toBeInTheDocument();
+        expect(
+            screen.queryByText('애널리스트 동향을 불러오지 못했어요.')
+        ).not.toBeInTheDocument();
+    });
+});

--- a/src/app/[symbol]/news/page.tsx
+++ b/src/app/[symbol]/news/page.tsx
@@ -90,18 +90,27 @@ interface SymbolSectionProps {
     symbol: string;
 }
 
-async function NewsListSection({ symbol }: SymbolSectionProps) {
+export async function NewsListSection({ symbol }: SymbolSectionProps) {
+    // ISR degrade guard: getNewsList(Postgres)가 throw하면 ISR 캐시에 0-byte 빈 결과가
+    // 굳는 것을 막으려면 여기서 흡수해야 한다. [] 로 degrade → NewsList는 빈 배열로
+    // 기존 empty-state UI를 렌더하고 페이지 크롬(heading/CrossLinks 등)은 유지된다.
     const items = await staticSymbolCache(
         [NEWS_LIST_CACHE_KEY, symbol],
         symbol,
         () => getNewsList(symbol),
         [`news:${symbol}`],
         SECONDS_PER_HALF_DAY
-    );
+    ).catch((e: unknown) => {
+        console.error(
+            '[NewsListSection] getNewsList failed, degrading to []:',
+            e
+        );
+        return [] as Awaited<ReturnType<typeof getNewsList>>;
+    });
     return <NewsList items={items} symbol={symbol} />;
 }
 
-async function EventCalendarSection({ symbol }: SymbolSectionProps) {
+export async function EventCalendarSection({ symbol }: SymbolSectionProps) {
     const today = todayKstIsoDate();
     let earningsReports: Awaited<
         ReturnType<typeof getEarningsReportComparison>
@@ -115,14 +124,18 @@ async function EventCalendarSection({ symbol }: SymbolSectionProps) {
             SECONDS_PER_HALF_DAY
         );
     } catch (error) {
-        const message = getFmpUserFacingMessage(error);
-        if (message === null) throw error;
+        console.error(
+            '[EventCalendarSection] earnings load failed, degrading:',
+            error
+        );
+        const message =
+            getFmpUserFacingMessage(error) ?? '실적 일정을 불러오지 못했어요.';
         return <NewsDataServerAlert title="실적 일정" message={message} />;
     }
     return <EventCalendar earningsReports={earningsReports} />;
 }
 
-async function AnalystActionsSection({ symbol }: SymbolSectionProps) {
+export async function AnalystActionsSection({ symbol }: SymbolSectionProps) {
     let events: Awaited<ReturnType<typeof getGradeEvents>>;
     try {
         events = await staticSymbolCache(
@@ -133,8 +146,13 @@ async function AnalystActionsSection({ symbol }: SymbolSectionProps) {
             SECONDS_PER_HALF_DAY
         );
     } catch (error) {
-        const message = getFmpUserFacingMessage(error);
-        if (message === null) throw error;
+        console.error(
+            '[AnalystActionsSection] grades load failed, degrading:',
+            error
+        );
+        const message =
+            getFmpUserFacingMessage(error) ??
+            '애널리스트 동향을 불러오지 못했어요.';
         return (
             <NewsDataServerAlert
                 title="애널리스트 등급 변경"
@@ -256,13 +274,19 @@ export default async function NewsPage({ params }: Props) {
         },
     };
 
+    // ISR degrade guard: getNewsList(Postgres)가 throw하면 ISR 캐시에 0-byte 빈 결과가
+    // 굳는 것을 막으려면 여기서 흡수해야 한다. [] 로 degrade → newsListJsonLd가 null이
+    // 되고 페이지 크롬(heading/AI summary/CrossLinks 등)은 유지된다.
     const newsItems = await staticSymbolCache(
         [NEWS_LIST_CACHE_KEY, upper],
         upper,
         () => getNewsList(upper),
         [`news:${upper}`],
         SECONDS_PER_HALF_DAY
-    );
+    ).catch((e: unknown) => {
+        console.error('[NewsPage] getNewsList failed, degrading to []:', e);
+        return [] as Awaited<ReturnType<typeof getNewsList>>;
+    });
     // At least one AI-enriched card means aggregate analysis can start immediately.
     const hasEnrichedNews = newsItems.some(item => item.sentiment !== null);
 

--- a/src/app/[symbol]/options/__tests__/page.isr-degrade.test.tsx
+++ b/src/app/[symbol]/options/__tests__/page.isr-degrade.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * ISR empty-cache prevention tests for the options page.
+ *
+ * A transient throw from hasOptionsMarket or fetchOptionsSnapshot during ISR
+ * cold-gen must NOT propagate — it must degrade to OptionsEmptyState (a
+ * non-empty, non-0-byte page) rather than freezing an empty ISR cache.
+ *
+ * Strategy: invoke the RSC directly (no DOM render), confirm OptionsEmptyState
+ * is in the returned element tree by its type name, and confirm no throw
+ * escapes the page. Mirrors page.guard.test.ts mocking pattern.
+ */
+
+// vi.mock calls are hoisted above imports by vitest.
+vi.mock('@/entities/ticker/api', () => ({
+    isTabAllowedForSymbol: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('@/entities/ticker', () => ({
+    buildAssetAboutNode: vi.fn().mockReturnValue(undefined),
+    buildDisplayName: vi.fn().mockReturnValue('Apple Inc.'),
+    getAssetInfoResilient: vi.fn(),
+}));
+vi.mock('next/navigation', () => ({
+    notFound: vi.fn(() => {
+        throw new Error('NEXT_NOT_FOUND');
+    }),
+}));
+vi.mock('@/entities/options-chain/lib/optionsDataCache', () => ({
+    fetchOptionsSnapshot: vi.fn(),
+    hasOptionsMarket: vi.fn(),
+}));
+// staticSymbolCache: call fetcher() directly so tests stay pure (no I/O).
+vi.mock('@/shared/cache/staticSymbolCache', () => ({
+    staticSymbolCache: vi.fn(
+        (
+            _key: readonly string[],
+            _symbol: string,
+            fetcher: () => Promise<unknown>
+        ) => fetcher()
+    ),
+}));
+vi.mock('@/widgets/options/OptionsPageClient', () => ({
+    OptionsPageClient: () => null,
+}));
+vi.mock('@/widgets/options/OptionsEmptyState', () => ({
+    OptionsEmptyState: ({ symbol }: { symbol: string }) => (
+        <section data-testid="options-empty-state" data-symbol={symbol} />
+    ),
+}));
+vi.mock('@/views/symbol', () => ({
+    SymbolPageHeading: ({ children }: { children: unknown }) => children,
+}));
+vi.mock('@/shared/ui/JsonLd', () => ({ JsonLd: () => null }));
+vi.mock('@y0ngha/siglens-core', () => ({
+    mapExpirationsToSlots: vi.fn().mockReturnValue([]),
+}));
+vi.mock('@/shared/lib/seo', async importOriginal => ({
+    ...(await importOriginal<typeof import('@/shared/lib/seo')>()),
+    buildBreadcrumbJsonLd: vi.fn().mockReturnValue({}),
+    buildSymbolSeoContent: vi.fn().mockReturnValue({ url: '' }),
+    buildSymbolOptionsSeoContent: vi.fn().mockReturnValue({
+        title: '',
+        fullTitle: '',
+        description: '',
+        url: '',
+        keywords: [],
+    }),
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+
+import {
+    describe,
+    it,
+    expect,
+    vi,
+    beforeEach,
+    type MockedFunction,
+} from 'vitest';
+import { isValidElement, type ReactNode } from 'react';
+import OptionsPage from '@/app/[symbol]/options/page';
+import { getAssetInfoResilient } from '@/entities/ticker';
+import {
+    hasOptionsMarket,
+    fetchOptionsSnapshot,
+} from '@/entities/options-chain/lib/optionsDataCache';
+
+const mockGetAssetInfoResilient = getAssetInfoResilient as MockedFunction<
+    typeof getAssetInfoResilient
+>;
+const mockHasOptionsMarket = hasOptionsMarket as MockedFunction<
+    typeof hasOptionsMarket
+>;
+const mockFetchOptionsSnapshot = fetchOptionsSnapshot as MockedFunction<
+    typeof fetchOptionsSnapshot
+>;
+
+const EQUITY_ASSET_INFO = {
+    assetInfo: {
+        symbol: 'AAPL',
+        name: 'Apple Inc.',
+        koreanName: '애플',
+        fmpSymbol: 'AAPL',
+    },
+    degraded: false,
+} as Awaited<ReturnType<typeof getAssetInfoResilient>>;
+
+/**
+ * Walk the JSX tree and find an element whose type's `name` matches `fnName`.
+ * Used to detect `<OptionsEmptyState>` in the RSC output without triggering a
+ * real render (the section component returns JSX but hasn't been called yet).
+ */
+function findByComponentName(node: ReactNode, fnName: string): boolean {
+    if (Array.isArray(node)) {
+        return node.some(n => findByComponentName(n, fnName));
+    }
+    if (!isValidElement(node)) return false;
+    const t = node.type as { name?: string } | string;
+    if (typeof t === 'function' && (t as { name?: string }).name === fnName) {
+        return true;
+    }
+    const props = node.props as { children?: ReactNode };
+    return findByComponentName(props.children, fnName);
+}
+
+describe('Options page ISR empty-cache prevention', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetAssetInfoResilient.mockResolvedValue(EQUITY_ASSET_INFO);
+    });
+
+    it('hasOptionsMarket throw → page does not throw, renders OptionsEmptyState', async () => {
+        // Simulate transient Yahoo infra failure during ISR cold-gen.
+        mockHasOptionsMarket.mockRejectedValue(
+            new Error('Yahoo infra timeout')
+        );
+
+        // Must NOT reject — the .catch(() => false) in the page body must absorb the throw.
+        const tree = await OptionsPage({
+            params: Promise.resolve({ symbol: 'AAPL' }),
+        });
+
+        // The page must return OptionsEmptyState (non-empty, non-0-byte result).
+        expect(findByComponentName(tree, 'OptionsEmptyState')).toBe(true);
+    });
+
+    it('fetchOptionsSnapshot throw → page does not throw, renders OptionsEmptyState', async () => {
+        // hasOptionsMarket succeeds but snapshot fetch fails.
+        mockHasOptionsMarket.mockResolvedValue(true);
+        mockFetchOptionsSnapshot.mockRejectedValue(
+            new Error('Yahoo snapshot unavailable')
+        );
+
+        // Must NOT reject — the .catch(() => null) in the page body must absorb the throw.
+        const tree = await OptionsPage({
+            params: Promise.resolve({ symbol: 'AAPL' }),
+        });
+
+        // snapshot===null branch renders OptionsEmptyState — page is non-empty.
+        expect(findByComponentName(tree, 'OptionsEmptyState')).toBe(true);
+    });
+
+    it('hasOptionsMarket returns false (normal no-options path) → OptionsEmptyState, fetchOptionsSnapshot NOT called', async () => {
+        mockHasOptionsMarket.mockResolvedValue(false);
+
+        const tree = await OptionsPage({
+            params: Promise.resolve({ symbol: 'AAPL' }),
+        });
+
+        // Normal no-options path returns OptionsEmptyState.
+        expect(findByComponentName(tree, 'OptionsEmptyState')).toBe(true);
+        // fetchOptionsSnapshot must NOT have been called (short-circuited by !hasOptions).
+        expect(mockFetchOptionsSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('hasOptionsMarket throw → console.error emitted with [OptionsPage] prefix', async () => {
+        mockHasOptionsMarket.mockRejectedValue(
+            new Error('Yahoo infra timeout')
+        );
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        await OptionsPage({
+            params: Promise.resolve({ symbol: 'AAPL' }),
+        });
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[OptionsPage] hasOptionsMarket'),
+            expect.any(Error)
+        );
+
+        consoleSpy.mockRestore();
+    });
+
+    it('fetchOptionsSnapshot throw → console.error emitted with [OptionsPage] prefix', async () => {
+        mockHasOptionsMarket.mockResolvedValue(true);
+        mockFetchOptionsSnapshot.mockRejectedValue(
+            new Error('Yahoo snapshot unavailable')
+        );
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        await OptionsPage({
+            params: Promise.resolve({ symbol: 'AAPL' }),
+        });
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[OptionsPage] fetchOptionsSnapshot'),
+            expect.any(Error)
+        );
+
+        consoleSpy.mockRestore();
+    });
+});

--- a/src/app/[symbol]/options/page.tsx
+++ b/src/app/[symbol]/options/page.tsx
@@ -123,13 +123,22 @@ export default async function OptionsPage({ params }: Props) {
 
     const [{ assetInfo, degraded }, hasOptions] = await Promise.all([
         getAssetInfoResilient(upper),
+        // ISR degrade guard: hasOptionsMarket는 Yahoo 인프라 실패 시 throw한다.
+        // throw가 ISR 캐시에 0-byte 빈 결과를 굳히는 것을 막으려면 여기서 흡수해야 한다.
+        // false로 degrade → 이미 존재하는 OptionsEmptyState 분기로 자연스럽게 빠진다.
         staticSymbolCache(
             ['options:has', upper],
             upper,
             () => hasOptionsMarket(upper),
             [],
             SECONDS_PER_HALF_DAY
-        ),
+        ).catch((e: unknown) => {
+            console.error(
+                '[OptionsPage] hasOptionsMarket failed, degrading to false:',
+                e
+            );
+            return false;
+        }),
     ]);
 
     // degraded + digit-first 심볼 = 두 데이터 소스가 동시 다운 중이고 resolve 불가
@@ -139,13 +148,22 @@ export default async function OptionsPage({ params }: Props) {
     if (!hasOptions) return <OptionsEmptyState symbol={upper} />;
 
     const displayName = buildDisplayName(assetInfo, upper);
+    // ISR degrade guard: fetchOptionsSnapshot는 Yahoo 인프라 실패 시 throw한다.
+    // throw가 ISR 캐시에 0-byte 빈 결과를 굳히는 것을 막으려면 여기서 흡수해야 한다.
+    // null로 degrade → 이미 존재하는 null 분기(OptionsEmptyState)로 자연스럽게 빠진다.
     const snapshot = await staticSymbolCache(
         ['options:snapshot', upper],
         upper,
         () => fetchOptionsSnapshot(upper),
         [],
         SECONDS_PER_HALF_DAY
-    );
+    ).catch((e: unknown) => {
+        console.error(
+            '[OptionsPage] fetchOptionsSnapshot failed, degrading to null:',
+            e
+        );
+        return null;
+    });
     if (snapshot === null) return <OptionsEmptyState symbol={upper} />;
 
     const expirations = snapshot.chains.map(c => c.expirationDate);

--- a/src/app/__tests__/error.test.tsx
+++ b/src/app/__tests__/error.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next/link', () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+        [key: string]: unknown;
+    }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_NAME: 'Siglens',
+}));
+
+import RootError from '../error';
+
+describe('RootError (root /app error boundary)', () => {
+    const error = Object.assign(new Error('boom'), { digest: 'deadbeef' });
+
+    it('renders exactly one h1', () => {
+        const { container } = render(
+            <RootError error={error} reset={vi.fn()} />
+        );
+        expect(container.querySelectorAll('h1')).toHaveLength(1);
+    });
+
+    it('wires the retry button to reset()', () => {
+        const reset = vi.fn();
+        render(<RootError error={error} reset={reset} />);
+        screen.getByRole('button', { name: '다시 시도' }).click();
+        expect(reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('offers a working home link', () => {
+        render(<RootError error={error} reset={vi.fn()} />);
+        expect(screen.getByRole('link', { name: /홈으로/ })).toHaveAttribute(
+            'href',
+            '/'
+        );
+    });
+
+    it('logs the error for server-side correlation', () => {
+        const errorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined);
+
+        render(<RootError error={error} reset={vi.fn()} />);
+
+        expect(errorSpy).toHaveBeenCalledWith(
+            '[RootRoute] render error:',
+            error
+        );
+        errorSpy.mockRestore();
+    });
+});

--- a/src/app/__tests__/global-error.test.tsx
+++ b/src/app/__tests__/global-error.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import GlobalError from '../global-error';
+
+describe('GlobalError (root-layout error boundary)', () => {
+    const error = Object.assign(new Error('layout crash'), {
+        digest: 'cafebabe',
+    });
+
+    it('renders its own <html lang="ko"> and <body> (replaces root layout)', () => {
+        const { container } = render(
+            <GlobalError error={error} reset={vi.fn()} />
+        );
+        // jsdom renders into a document fragment — the html/body wrapper is the
+        // component's own output, verified via the rendered text content.
+        expect(container.textContent).toContain('다시 시도');
+        expect(container.textContent).toContain('홈으로');
+    });
+
+    it('renders a heading (non-empty branded message)', () => {
+        render(<GlobalError error={error} reset={vi.fn()} />);
+        expect(screen.getByRole('heading')).toBeInTheDocument();
+    });
+
+    it('wires the retry button to reset()', () => {
+        const reset = vi.fn();
+        render(<GlobalError error={error} reset={reset} />);
+        screen.getByRole('button', { name: '다시 시도' }).click();
+        expect(reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('offers a home link pointing to "/"', () => {
+        render(<GlobalError error={error} reset={vi.fn()} />);
+        expect(screen.getByRole('link', { name: /홈으로/ })).toHaveAttribute(
+            'href',
+            '/'
+        );
+    });
+
+    it('logs the error on mount', () => {
+        const errorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined);
+
+        render(<GlobalError error={error} reset={vi.fn()} />);
+
+        expect(errorSpy).toHaveBeenCalledWith(
+            '[GlobalError] root layout error:',
+            error
+        );
+        errorSpy.mockRestore();
+    });
+});

--- a/src/app/__tests__/page.isr-degrade.test.tsx
+++ b/src/app/__tests__/page.isr-degrade.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * ISR empty-cache prevention tests for the home page (app/page.tsx).
+ *
+ * loadSkills() and countSkillFiles() failures during ISR cold-gen must NOT
+ * propagate — the Home() RSC must resolve to a non-empty element using the
+ * graceful fallback paths already in place ([] / zeroed counts).
+ *
+ * Strategy: mock @/entities/skill to reject, invoke Home() directly, and
+ * confirm it resolves without throwing. Mirrors page.test.ts mocking pattern.
+ */
+
+vi.mock('@/widgets/home/HeroIllustration', () => ({
+    HeroIllustration: () => null,
+}));
+vi.mock('@/widgets/home/HowItWorks', () => ({ HowItWorks: () => null }));
+vi.mock('@/widgets/home/SkillsShowcase', () => ({
+    SkillsShowcase: () => null,
+    SkillsShowcaseSkeleton: () => null,
+}));
+vi.mock('@/widgets/home/StatsBar', () => ({
+    StatsBar: () => null,
+    StatsBarSkeleton: () => null,
+}));
+vi.mock('@/widgets/home/TickerCategories', () => ({
+    TickerCategories: () => null,
+}));
+vi.mock('@/widgets/home', () => ({
+    CryptoShowcase: () => null,
+    HeroIllustration: () => null,
+    HowItWorks: () => null,
+    SkillsShowcase: () => null,
+    SkillsShowcaseSkeleton: () => null,
+    StatsBar: () => null,
+    StatsBarSkeleton: () => null,
+    TickerCategories: () => null,
+}));
+vi.mock('@/features/ticker-search', () => ({ SymbolSearchPanel: () => null }));
+vi.mock('@/shared/ui/JsonLd', () => ({ JsonLd: () => null }));
+vi.mock('@/entities/skill', () => ({
+    countSkillFiles: vi.fn(),
+    FileSkillsLoader: vi.fn(),
+}));
+vi.mock('@/shared/lib/seo', () => ({
+    SITE_DESCRIPTION: 'test description',
+    SITE_NAME: 'Siglens',
+    SITE_URL: 'https://siglens.io',
+}));
+vi.mock('next/link', () => ({ default: () => null }));
+
+import {
+    describe,
+    it,
+    expect,
+    vi,
+    beforeEach,
+    type MockedFunction,
+    type MockedClass,
+} from 'vitest';
+import { isValidElement } from 'react';
+import Home from '@/app/page';
+import { countSkillFiles, FileSkillsLoader } from '@/entities/skill';
+
+const mockCountSkillFiles = countSkillFiles as MockedFunction<
+    typeof countSkillFiles
+>;
+const MockFileSkillsLoader = FileSkillsLoader as MockedClass<
+    typeof FileSkillsLoader
+>;
+
+describe('Home page ISR empty-cache prevention', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('countSkillFiles throw → Home resolves (non-empty element, does not throw)', async () => {
+        // Simulate a transient fs failure during ISR cold-gen.
+        mockCountSkillFiles.mockRejectedValue(
+            new Error('ENOENT: skill dir missing')
+        );
+        MockFileSkillsLoader.mockImplementation(
+            () =>
+                ({
+                    loadSkills: vi.fn().mockResolvedValue([]),
+                }) as unknown as InstanceType<typeof FileSkillsLoader>
+        );
+
+        // Must NOT reject — the .catch() in Home() must absorb and use zero counts.
+        const element = await Home();
+
+        expect(isValidElement(element)).toBe(true);
+    });
+
+    it('loadSkills throw → Home resolves (non-empty element, does not throw)', async () => {
+        // countSkillFiles succeeds but FileSkillsLoader.loadSkills rejects.
+        mockCountSkillFiles.mockResolvedValue({
+            indicators: 0,
+            candlesticks: 0,
+            patterns: 0,
+            strategies: 0,
+            supportResistance: 0,
+            fundamental: 0,
+            news: 0,
+        });
+        MockFileSkillsLoader.mockImplementation(
+            () =>
+                ({
+                    loadSkills: vi
+                        .fn()
+                        .mockRejectedValue(new Error('skills dir unreadable')),
+                }) as unknown as InstanceType<typeof FileSkillsLoader>
+        );
+
+        // Must NOT reject — the try/catch in loadSkills() must absorb and return [].
+        const element = await Home();
+
+        expect(isValidElement(element)).toBe(true);
+    });
+
+    it('both countSkillFiles and loadSkills throw → Home still resolves non-empty', async () => {
+        mockCountSkillFiles.mockRejectedValue(new Error('fs error'));
+        MockFileSkillsLoader.mockImplementation(
+            () =>
+                ({
+                    loadSkills: vi
+                        .fn()
+                        .mockRejectedValue(new Error('fs error')),
+                }) as unknown as InstanceType<typeof FileSkillsLoader>
+        );
+
+        const element = await Home();
+
+        // Page is non-empty — returns a valid React element (not null / undefined).
+        expect(isValidElement(element)).toBe(true);
+    });
+});

--- a/src/app/economy/__tests__/page.test.tsx
+++ b/src/app/economy/__tests__/page.test.tsx
@@ -159,6 +159,38 @@ describe('/economy page.tsx integration', () => {
                 screen.getByText(/잠시 후 다시 시도해 주세요/)
             ).toBeInTheDocument();
         });
+
+        it('getEconomySnapshotStatic이 throw하면 EconomyDegraded를 렌더한다 (빈 캐시 동결 방지)', async () => {
+            // P0 incident path: snapshot loader throws (Redis timeout, FMP 5xx 등) →
+            // .catch(() => null) → null 처리 → EconomyDegraded. throw가 전파되면
+            // ISR 0-byte 빈 캐시가 동결된다.
+            mockGetSnapshot.mockRejectedValue(new Error('redis timeout'));
+            // isEmptyEconomySnapshot은 null 경로에서 호출되지 않아야 한다.
+            mockIsEmpty.mockReturnValue(false);
+
+            const consoleSpy = vi
+                .spyOn(console, 'error')
+                .mockImplementation(() => undefined);
+
+            const { default: EconomyPage } = await import('@/app/economy/page');
+            const { act } = await import('@testing-library/react');
+            await act(async () => {
+                render(<EconomyPage />);
+            });
+
+            // EconomyDegraded가 렌더돼야 한다(non-empty page, not a throw).
+            expect(
+                screen.getByText(/잠시 후 다시 시도해 주세요/)
+            ).toBeInTheDocument();
+
+            // .catch() 가 console.error를 호출했어야 한다.
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining('[EconomyContent] snapshot failed:'),
+                expect.any(Error)
+            );
+
+            consoleSpy.mockRestore();
+        });
     });
 
     describe('EconomyContent — peek error resilience', () => {

--- a/src/app/economy/page.tsx
+++ b/src/app/economy/page.tsx
@@ -131,8 +131,14 @@ export async function generateMetadata(): Promise<Metadata> {
 
 /** cold-gen(ISR 정적 생성 컨텍스트)에서 dynamic API(`cookies`/`headers`/`connection()`) 금지. */
 async function EconomyContent() {
-    const snapshot = await getEconomySnapshotStatic();
-    if (isEmptyEconomySnapshot(snapshot)) return <EconomyDegraded />;
+    // 외부 I/O 오류(Redis 등)는 graceful 처리 — 빈 캐시 동결을 막기 위해 throw 대신
+    // null로 폴백해 EconomyDegraded를 반환한다. generateMetadata와 동일한 catch 패턴.
+    const snapshot = await getEconomySnapshotStatic().catch(e => {
+        console.error('[EconomyContent] snapshot failed:', e);
+        return null;
+    });
+    if (snapshot === null || isEmptyEconomySnapshot(snapshot))
+        return <EconomyDegraded />;
 
     // 1-hour date-hour 버킷 키로 macro briefing peek seed 조회. miss는 null → 클라가 submit.
     const dateHour = new Date().toISOString().slice(0, ISO_DATE_HOUR_SLICE_END);

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { SITE_NAME } from '@/shared/lib/seo';
+
+interface RootErrorProps {
+    error: Error & { digest?: string };
+    reset: () => void;
+}
+
+/**
+ * Root error boundary — covers `/`, `/backtesting`, `/privacy`, `/terms`,
+ * `/account*`, `/signup*`, `/forgot-password`, `/reset-password`.
+ *
+ * Sits one level above route-specific boundaries (market/error.tsx,
+ * economy/error.tsx). Catches interactive client-side throws that escape
+ * those nested boundaries and presents a branded, retryable UI instead of
+ * a blank page. `reset()` re-renders the failed segment in place.
+ *
+ * Mirrors `src/app/market/error.tsx` structure and styling.
+ */
+export default function RootError({ error, reset }: RootErrorProps) {
+    useEffect(() => {
+        // `digest` ties this client log to the server-side error entry.
+        console.error('[RootRoute] render error:', error);
+    }, [error]);
+
+    return (
+        <main className="flex flex-1 flex-col items-center px-6 py-20 text-center">
+            <p className="text-primary-400 font-mono text-sm tracking-widest">
+                일시 오류
+            </p>
+            <h1 className="text-secondary-100 mt-4 text-2xl font-bold sm:text-3xl">
+                페이지를 불러오지 못했어요
+            </h1>
+            <p className="text-secondary-400 mt-3 max-w-md text-sm leading-relaxed">
+                일시적인 문제가 발생했어요. 잠시 후 다시 시도해 주세요.
+            </p>
+            <div className="mt-8 flex gap-3">
+                <button
+                    type="button"
+                    onClick={reset}
+                    className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-950 inline-flex min-h-11 items-center rounded-lg px-6 text-sm font-medium text-white transition-colors focus-visible:ring-1 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                    다시 시도
+                </button>
+                <Link
+                    href="/"
+                    className="text-secondary-200 hover:text-secondary-50 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-950 inline-flex min-h-11 items-center rounded-lg px-6 text-sm font-medium transition-colors focus-visible:ring-1 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                    {SITE_NAME} 홈으로
+                </Link>
+            </div>
+        </main>
+    );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+interface GlobalErrorProps {
+    error: Error & { digest?: string };
+    reset: () => void;
+}
+
+/**
+ * Global error boundary — replaces the root layout on a root-level throw.
+ *
+ * Because it replaces the root layout entirely, it MUST render its own
+ * `<html>` and `<body>` tags. Kept dependency-light: no app providers,
+ * no shared/ui imports that pull in layout-level CSS-in-JS or context.
+ * Mirrors the visual style of `src/app/market/error.tsx` using inline
+ * Tailwind classes that match the design system.
+ *
+ * `reset()` retriggers a render of the root segment which typically
+ * recovers from transient throws (Redis/DB client init, cold-gen errors).
+ */
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+    useEffect(() => {
+        console.error('[GlobalError] root layout error:', error);
+    }, [error]);
+
+    return (
+        <html lang="ko">
+            <body
+                style={{
+                    margin: 0,
+                    backgroundColor: '#0a0a0f',
+                    color: '#e2e8f0',
+                    fontFamily:
+                        'ui-sans-serif, system-ui, -apple-system, sans-serif',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    minHeight: '100dvh',
+                    padding: '1.5rem',
+                    textAlign: 'center',
+                }}
+            >
+                <p
+                    style={{
+                        fontFamily: 'ui-monospace, monospace',
+                        fontSize: '0.75rem',
+                        letterSpacing: '0.15em',
+                        color: '#818cf8',
+                        textTransform: 'uppercase',
+                    }}
+                >
+                    일시 오류
+                </p>
+                <h1
+                    style={{
+                        marginTop: '1rem',
+                        fontSize: '1.5rem',
+                        fontWeight: 700,
+                        color: '#f1f5f9',
+                    }}
+                >
+                    서비스를 불러오지 못했어요
+                </h1>
+                <p
+                    style={{
+                        marginTop: '0.75rem',
+                        maxWidth: '28rem',
+                        fontSize: '0.875rem',
+                        lineHeight: 1.6,
+                        color: '#94a3b8',
+                    }}
+                >
+                    일시적인 문제가 발생했어요. 잠시 후 다시 시도해 주세요.
+                </p>
+                <div
+                    style={{
+                        marginTop: '2rem',
+                        display: 'flex',
+                        gap: '0.75rem',
+                    }}
+                >
+                    <button
+                        type="button"
+                        onClick={reset}
+                        style={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            minHeight: '2.75rem',
+                            padding: '0 1.5rem',
+                            borderRadius: '0.5rem',
+                            fontSize: '0.875rem',
+                            fontWeight: 500,
+                            color: '#fff',
+                            background: '#4f46e5',
+                            border: 'none',
+                            cursor: 'pointer',
+                        }}
+                    >
+                        다시 시도
+                    </button>
+                    <Link
+                        href="/"
+                        style={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            minHeight: '2.75rem',
+                            padding: '0 1.5rem',
+                            borderRadius: '0.5rem',
+                            fontSize: '0.875rem',
+                            fontWeight: 500,
+                            color: '#e2e8f0',
+                            textDecoration: 'none',
+                        }}
+                    >
+                        홈으로
+                    </Link>
+                </div>
+            </body>
+        </html>
+    );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+// global-error.tsx는 루트 레이아웃을 완전히 교체하므로, 루트 레이아웃이 담당하던
+// globals.css 로드를 이 파일이 직접 맡는다. 없으면 Tailwind 클래스가 해석되지 않는다.
+import './globals.css';
 import { useEffect } from 'react';
 import Link from 'next/link';
 
@@ -12,10 +15,13 @@ interface GlobalErrorProps {
  * Global error boundary — replaces the root layout on a root-level throw.
  *
  * Because it replaces the root layout entirely, it MUST render its own
- * `<html>` and `<body>` tags. Kept dependency-light: no app providers,
- * no shared/ui imports that pull in layout-level CSS-in-JS or context.
- * Mirrors the visual style of `src/app/market/error.tsx` using inline
- * Tailwind classes that match the design system.
+ * `<html>` and `<body>` tags AND import the global stylesheet itself —
+ * the root layout (which normally imports globals.css) is bypassed, so
+ * Tailwind classes would not resolve without this import.
+ *
+ * Kept dependency-light: no app providers, no shared/ui imports that pull
+ * in layout-level CSS-in-JS or context. Mirrors `src/app/error.tsx`'s
+ * visual pattern using Tailwind classes with design tokens.
  *
  * `reset()` retriggers a render of the root segment which typically
  * recovers from transient throws (Redis/DB client init, cold-gen errors).
@@ -27,93 +33,27 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
 
     return (
         <html lang="ko">
-            <body
-                style={{
-                    margin: 0,
-                    backgroundColor: '#0a0a0f',
-                    color: '#e2e8f0',
-                    fontFamily:
-                        'ui-sans-serif, system-ui, -apple-system, sans-serif',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    minHeight: '100dvh',
-                    padding: '1.5rem',
-                    textAlign: 'center',
-                }}
-            >
-                <p
-                    style={{
-                        fontFamily: 'ui-monospace, monospace',
-                        fontSize: '0.75rem',
-                        letterSpacing: '0.15em',
-                        color: '#818cf8',
-                        textTransform: 'uppercase',
-                    }}
-                >
+            <body className="bg-secondary-900 text-secondary-50 flex min-h-dvh flex-col items-center justify-center px-6 text-center">
+                <p className="text-primary-400 font-mono text-xs tracking-widest uppercase">
                     일시 오류
                 </p>
-                <h1
-                    style={{
-                        marginTop: '1rem',
-                        fontSize: '1.5rem',
-                        fontWeight: 700,
-                        color: '#f1f5f9',
-                    }}
-                >
+                <h1 className="text-secondary-100 mt-4 text-2xl font-bold">
                     서비스를 불러오지 못했어요
                 </h1>
-                <p
-                    style={{
-                        marginTop: '0.75rem',
-                        maxWidth: '28rem',
-                        fontSize: '0.875rem',
-                        lineHeight: 1.6,
-                        color: '#94a3b8',
-                    }}
-                >
+                <p className="text-secondary-400 mt-3 max-w-md text-sm leading-relaxed">
                     일시적인 문제가 발생했어요. 잠시 후 다시 시도해 주세요.
                 </p>
-                <div
-                    style={{
-                        marginTop: '2rem',
-                        display: 'flex',
-                        gap: '0.75rem',
-                    }}
-                >
+                <div className="mt-8 flex gap-3">
                     <button
                         type="button"
                         onClick={reset}
-                        style={{
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            minHeight: '2.75rem',
-                            padding: '0 1.5rem',
-                            borderRadius: '0.5rem',
-                            fontSize: '0.875rem',
-                            fontWeight: 500,
-                            color: '#fff',
-                            background: '#4f46e5',
-                            border: 'none',
-                            cursor: 'pointer',
-                        }}
+                        className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-950 inline-flex min-h-11 items-center rounded-lg px-6 text-sm font-medium text-white transition-colors focus-visible:ring-1 focus-visible:ring-offset-2 focus-visible:outline-none"
                     >
                         다시 시도
                     </button>
                     <Link
                         href="/"
-                        style={{
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            minHeight: '2.75rem',
-                            padding: '0 1.5rem',
-                            borderRadius: '0.5rem',
-                            fontSize: '0.875rem',
-                            fontWeight: 500,
-                            color: '#e2e8f0',
-                            textDecoration: 'none',
-                        }}
+                        className="text-secondary-200 hover:text-secondary-50 focus-visible:ring-primary-500 focus-visible:ring-offset-secondary-950 inline-flex min-h-11 items-center rounded-lg px-6 text-sm font-medium transition-colors focus-visible:ring-1 focus-visible:ring-offset-2 focus-visible:outline-none"
                     >
                         홈으로
                     </Link>

--- a/src/app/market/__tests__/page.test.ts
+++ b/src/app/market/__tests__/page.test.ts
@@ -253,6 +253,46 @@ describe('Market page', () => {
             mockPeekBriefingStatic.mockRejectedValue(new Error('redis down'));
             await expect(MarketContent()).resolves.toBeDefined();
         });
+
+        it('getMarketSummaryStatic throwing → .catch() degraded empty summary, page does not throw', async () => {
+            // ISR 빈 캐시 동결 방지: summary loader throw 시 { indices: [], sectors: [] }로
+            // 폴백해 MarketContent가 non-empty 결과를 반환해야 한다.
+            mockGetMarketSummaryStatic.mockRejectedValue(new Error('FMP 5xx'));
+            const consoleSpy = vi
+                .spyOn(console, 'error')
+                .mockImplementation(() => undefined);
+
+            await expect(MarketContent()).resolves.toBeDefined();
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining(
+                    '[MarketContent] getMarketSummaryStatic failed:'
+                ),
+                expect.any(Error)
+            );
+
+            consoleSpy.mockRestore();
+        });
+
+        it('getSectorSignalsStatic throwing → .catch() degraded empty stocks, page does not throw', async () => {
+            // ISR 빈 캐시 동결 방지: signals loader throw 시 { computedAt, stocks: [] }로
+            // 폴백해 MarketContent가 non-empty 결과를 반환해야 한다.
+            mockGetSectorSignalsStatic.mockRejectedValue(
+                new Error('cache miss')
+            );
+            const consoleSpy = vi
+                .spyOn(console, 'error')
+                .mockImplementation(() => undefined);
+
+            await expect(MarketContent()).resolves.toBeDefined();
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining(
+                    '[MarketContent] getSectorSignalsStatic failed:'
+                ),
+                expect.any(Error)
+            );
+
+            consoleSpy.mockRestore();
+        });
     });
 
     describe('page structure — no searchParams dependency', () => {

--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -115,10 +115,19 @@ export async function MarketContent(): Promise<ReactElement> {
     // the full summary object on every ISR render.
     const dateHour = new Date().toISOString().slice(0, ISO_DATE_HOUR_SLICE_END);
 
-    const summary = await getMarketSummaryStatic();
+    // 외부 I/O(FMP/Redis) 오류는 graceful 처리 — 빈 캐시 동결 방지를 위해 throw 대신
+    // empty safe default로 폴백한다. MarketSummaryPanel / SectorSignalPanel은
+    // 빈 indices/sectors/stocks 배열을 정상적으로 렌더한다(non-empty degraded view).
+    const summary = await getMarketSummaryStatic().catch(e => {
+        console.error('[MarketContent] getMarketSummaryStatic failed:', e);
+        return { indices: [], sectors: [] };
+    });
     const sectorData = await getSectorSignalsStatic(
         DEFAULT_DASHBOARD_TIMEFRAME
-    );
+    ).catch(e => {
+        console.error('[MarketContent] getSectorSignalsStatic failed:', e);
+        return { computedAt: dateHour, stocks: [] };
+    });
     // peekBriefingStatic is read-only — null on cache miss (client will trigger submit)
     const peekSeed = await peekBriefingStatic(summary, dateHour).catch(
         () => null

--- a/src/app/news/[category]/__tests__/page.isr-degrade.test.tsx
+++ b/src/app/news/[category]/__tests__/page.isr-degrade.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * ISR empty-cache prevention tests for the /news/[category] page.
+ *
+ * A transient throw from getMarketNewsList during ISR cold-gen must NOT
+ * propagate — it must degrade to MarketNewsDegraded (a non-empty, non-0-byte
+ * page) rather than freezing an empty ISR cache.
+ *
+ * Strategy: mock getMarketNewsList to reject, invoke the RSC directly
+ * (via render), and confirm MarketNewsDegraded renders.
+ * Mirrors page.test.tsx mocking pattern.
+ */
+
+vi.mock('next/navigation', () => ({
+    notFound: vi.fn(() => {
+        throw new Error('NEXT_NOT_FOUND');
+    }),
+}));
+
+// staticSymbolCache: call fetcher() directly so tests stay pure.
+vi.mock('@/shared/cache/staticSymbolCache', () => ({
+    staticSymbolCache: vi.fn(
+        (
+            _key: readonly string[],
+            _symbol: string,
+            fetcher: () => Promise<unknown>
+        ) => fetcher()
+    ),
+}));
+
+// getMarketNewsList will be configured per-test to reject.
+vi.mock('@/entities/market-news/api', () => ({
+    getMarketNewsList: vi.fn(),
+}));
+
+vi.mock('@/widgets/market-news', () => ({
+    MarketNewsDigest: () => <div data-testid="digest-stub" />,
+    MarketNewsList: () => <div data-testid="list-stub" />,
+}));
+
+vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }));
+
+import {
+    describe,
+    it,
+    expect,
+    vi,
+    beforeEach,
+    type MockedFunction,
+} from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CategoryNewsPage from '../page';
+import { getMarketNewsList } from '@/entities/market-news/api';
+
+const mockGetMarketNewsList = getMarketNewsList as MockedFunction<
+    typeof getMarketNewsList
+>;
+
+describe('/news/[category] ISR empty-cache prevention', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('getMarketNewsList throw → page does not throw, renders MarketNewsDegraded (non-empty)', async () => {
+        // Simulate transient DB failure during ISR cold-gen.
+        mockGetMarketNewsList.mockRejectedValue(
+            new Error('DB connection refused')
+        );
+
+        // Must NOT reject — the .catch(() => []) in loadCategorySnapshot must absorb the throw.
+        render(
+            await CategoryNewsPage({
+                params: Promise.resolve({ category: 'crypto' }),
+            })
+        );
+
+        // MarketNewsDegraded renders the degrade notice — page is non-empty.
+        expect(
+            screen.getByText(/최근 뉴스를 불러오지 못했어요/)
+        ).toBeInTheDocument();
+    });
+
+    it('getMarketNewsList throw → page still renders category tabs and h1 (chrome intact)', async () => {
+        mockGetMarketNewsList.mockRejectedValue(
+            new Error('DB connection refused')
+        );
+
+        render(
+            await CategoryNewsPage({
+                params: Promise.resolve({ category: 'crypto' }),
+            })
+        );
+
+        // h1 must be present — page is not a blank 0-byte result.
+        expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+    });
+
+    it('generateMetadata: getMarketNewsList throw → returns noindex metadata (isEmpty:true path)', async () => {
+        mockGetMarketNewsList.mockRejectedValue(
+            new Error('DB connection refused')
+        );
+
+        const { generateMetadata } = await import('../page');
+        const meta = await generateMetadata({
+            params: Promise.resolve({ category: 'crypto' }),
+        });
+
+        // isEmpty:true → noindex + canonical null (same as the existing empty-data path).
+        expect((meta.robots as { index: boolean } | undefined)?.index).toBe(
+            false
+        );
+        expect(meta.alternates?.canonical).toBeNull();
+    });
+
+    it('success path unchanged — normal data → MarketNewsDegraded NOT shown', async () => {
+        mockGetMarketNewsList.mockResolvedValue([
+            {
+                id: 'r1',
+                symbol: '__NEWS_CRYPTO__',
+                source: 'CoinWire',
+                url: 'https://example.com/btc',
+                publishedAt: '2026-06-15T10:00:00.000Z',
+                titleEn: 'BTC up',
+                titleKo: '비트코인 상승',
+                bodyEn: null,
+                bodyKo: null,
+                summaryKo: null,
+                sentiment: null,
+                category: null,
+                priceImpact: null,
+                tickers: ['BTCUSD'],
+                analyzedAt: null,
+            },
+        ] as Awaited<ReturnType<typeof getMarketNewsList>>);
+
+        render(
+            await CategoryNewsPage({
+                params: Promise.resolve({ category: 'crypto' }),
+            })
+        );
+
+        // Normal data path — degrade notice should NOT be visible.
+        expect(
+            screen.queryByText(/최근 뉴스를 불러오지 못했어요/)
+        ).not.toBeInTheDocument();
+    });
+});

--- a/src/app/news/[category]/page.tsx
+++ b/src/app/news/[category]/page.tsx
@@ -57,13 +57,22 @@ async function loadCategorySnapshot(
     category: NewsFeedCategory
 ): Promise<CategorySnapshot> {
     const cfg = CATEGORY_CONFIG[category];
+    // ISR degrade guard: getMarketNewsList(DB)가 throw하면 ISR 캐시에 0-byte 빈 결과가
+    // 굳는 것을 막으려면 여기서 흡수해야 한다. [] 로 degrade → isEmpty:true 가 되어
+    // 이미 존재하는 MarketNewsDegraded empty-state 분기로 자연스럽게 빠진다.
     const rows = await staticSymbolCache(
         ['market-news:list', cfg.sentinel],
         cfg.sentinel,
         () => getMarketNewsList(cfg.sentinel),
         [`${MARKET_NEWS_CACHE_TAG_PREFIX}:${cfg.sentinel}`],
         SECONDS_PER_HALF_DAY
-    );
+    ).catch((e: unknown) => {
+        console.error(
+            `[CategoryNewsPage] loadCategorySnapshot(${category}) failed, degrading to []:`,
+            e
+        );
+        return [] as Awaited<ReturnType<typeof getMarketNewsList>>;
+    });
     // Project to the same allowlist `getMarketNewsCardsAction` uses so the
     // client component never sees server-only DB columns (bodyEn/symbol/analyzedAt).
     const items = rows.map(toMarketNewsCardItem);

--- a/src/app/news/__tests__/page.isr-degrade.test.tsx
+++ b/src/app/news/__tests__/page.isr-degrade.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * ISR empty-cache prevention tests for the /news hub page.
+ *
+ * A transient throw from getMarketNewsList during ISR cold-gen must NOT
+ * propagate to the hub page — the per-category `.catch(() => [])` in
+ * fetchCategoryPreviews isolates each bucket. The page must still render
+ * all category cards (non-empty, non-0-byte result).
+ *
+ * Strategy: mock getMarketNewsList to reject, invoke NewsHubPage() directly
+ * (via render), and confirm the h1 and all 5 category card links are present.
+ * Mirrors page.test.tsx mocking pattern.
+ */
+
+// staticSymbolCache: call fetcher() directly so tests stay pure (no I/O).
+vi.mock('@/shared/cache/staticSymbolCache', () => ({
+    staticSymbolCache: vi.fn(
+        (
+            _key: readonly string[],
+            _symbol: string,
+            fetcher: () => Promise<unknown>
+        ) => fetcher()
+    ),
+}));
+
+// getMarketNewsList — configured per-test to reject.
+vi.mock('@/entities/market-news/api', () => ({
+    getMarketNewsList: vi.fn(),
+}));
+
+vi.mock('@/shared/ui/JsonLd', () => ({ JsonLd: () => null }));
+
+import {
+    describe,
+    it,
+    expect,
+    vi,
+    beforeEach,
+    type MockedFunction,
+} from 'vitest';
+import { render, screen } from '@testing-library/react';
+import NewsHubPage from '../page';
+import { getMarketNewsList } from '@/entities/market-news/api';
+
+const mockGetMarketNewsList = getMarketNewsList as MockedFunction<
+    typeof getMarketNewsList
+>;
+
+describe('/news hub page ISR empty-cache prevention', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('getMarketNewsList throw → page does not throw, renders h1 (non-empty)', async () => {
+        // Simulate transient DB failure during ISR cold-gen.
+        mockGetMarketNewsList.mockRejectedValue(
+            new Error('DB connection refused')
+        );
+
+        // Must NOT reject — per-category .catch(() => []) must absorb the throw.
+        render(await NewsHubPage());
+
+        // h1 must be present — page is not a blank 0-byte result.
+        expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+    });
+
+    it('getMarketNewsList throw → all 5 category card links still render', async () => {
+        mockGetMarketNewsList.mockRejectedValue(
+            new Error('DB connection refused')
+        );
+
+        render(await NewsHubPage());
+
+        // Each CategoryCard renders <a href="/news/{slug}"> — all 5 must be present.
+        const allLinks = screen.getAllByRole('link');
+        const hrefs = allLinks.map(l => l.getAttribute('href'));
+
+        for (const slug of [
+            'general',
+            'stock',
+            'crypto',
+            'forex',
+            'articles',
+        ]) {
+            expect(hrefs).toContain(`/news/${slug}`);
+        }
+    });
+
+    it('getMarketNewsList throw → each category degrades independently (all cards with empty headlines)', async () => {
+        mockGetMarketNewsList.mockRejectedValue(
+            new Error('DB connection refused')
+        );
+
+        // Must NOT reject — Promise.all over all categories must complete.
+        const element = await NewsHubPage();
+
+        // A non-null element means the page rendered completely.
+        expect(element).not.toBeNull();
+    });
+
+    it('success path unchanged — normal data → page renders without errors', async () => {
+        mockGetMarketNewsList.mockResolvedValue([
+            {
+                id: 'r1',
+                symbol: '__NEWS_GENERAL__',
+                source: 'Reuters',
+                url: 'https://example.com/news1',
+                publishedAt: '2026-06-22T10:00:00.000Z',
+                titleEn: 'Markets rally',
+                titleKo: '시장 랠리',
+                bodyEn: null,
+                bodyKo: null,
+                summaryKo: null,
+                sentiment: null,
+                category: null,
+                priceImpact: null,
+                tickers: [],
+                analyzedAt: null,
+            },
+        ] as Awaited<ReturnType<typeof getMarketNewsList>>);
+
+        render(await NewsHubPage());
+
+        // Normal path — h1 and all 5 category links present.
+        expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+
+        const allLinks = screen.getAllByRole('link');
+        const hrefs = allLinks.map(l => l.getAttribute('href'));
+        for (const slug of [
+            'general',
+            'stock',
+            'crypto',
+            'forex',
+            'articles',
+        ]) {
+            expect(hrefs).toContain(`/news/${slug}`);
+        }
+    });
+});

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -67,6 +67,11 @@ export function generateMetadata(): Metadata {
  * Uses `staticSymbolCache` (axis 1) to avoid DYNAMIC_SERVER_USAGE from the
  * DB call during ISR cold-gen. Returns Korean titles where available, falls
  * back to English.
+ *
+ * ISR degrade guard: getMarketNewsList(DB) が throw しても ISR キャッシュに 0-byte
+ * 空結果が固まらないよう、ここで吸収する。[] に degrade → CategoryCard は空の
+ * previewHeadlines で描画され、ハブ全体のクロムは維持される。
+ * (一つのカテゴリが失敗してもハブ全体が壊れないように per-category で catch する)
  */
 async function fetchCategoryPreviews(
     category: NewsFeedCategory
@@ -78,7 +83,13 @@ async function fetchCategoryPreviews(
         () => getMarketNewsList(cfg.sentinel),
         [`${MARKET_NEWS_CACHE_TAG_PREFIX}:${cfg.sentinel}`],
         SECONDS_PER_DAY
-    );
+    ).catch((e: unknown) => {
+        console.error(
+            `[NewsHubPage] fetchCategoryPreviews(${category}) failed, degrading to []:`,
+            e
+        );
+        return [] as Awaited<ReturnType<typeof getMarketNewsList>>;
+    });
     return rows
         .slice(0, PREVIEW_HEADLINE_LIMIT)
         .map(row => row.titleKo ?? row.titleEn);

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -68,10 +68,10 @@ export function generateMetadata(): Metadata {
  * DB call during ISR cold-gen. Returns Korean titles where available, falls
  * back to English.
  *
- * ISR degrade guard: getMarketNewsList(DB) が throw しても ISR キャッシュに 0-byte
- * 空結果が固まらないよう、ここで吸収する。[] に degrade → CategoryCard は空の
- * previewHeadlines で描画され、ハブ全体のクロムは維持される。
- * (一つのカテゴリが失敗してもハブ全体が壊れないように per-category で catch する)
+ * ISR degrade guard: getMarketNewsList(DB)가 throw하더라도 ISR 캐시에 0-byte
+ * 빈 결과가 굳지 않도록 여기서 흡수한다. [] 로 degrade → CategoryCard는 빈
+ * previewHeadlines로 렌더되고, 허브 전체 크롬은 유지된다.
+ * (하나의 카테고리가 실패해도 허브 전체가 깨지지 않도록 per-category로 catch한다)
  */
 async function fetchCategoryPreviews(
     category: NewsFeedCategory

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,7 +35,16 @@ const HERO_QUICK_LINKS = [
 // 이 페이지 자체는 dynamic 의존성이 없다. revalidate로 skills 파일 변경 반영.
 export const revalidate = 86400; // 24h — skills는 배포 시 갱신되므로 장중 신선도와 무관
 
-const loadSkills = cache(() => new FileSkillsLoader().loadSkills());
+// skills 파일시스템 읽기 오류는 graceful 처리 — 빈 배열/0으로 폴백해 페이지 렌더를
+// 계속한다. ISR 빈 캐시 동결 방지: throw하면 0-byte HTML이 캐시에 박힌다.
+const loadSkills = cache(async () => {
+    try {
+        return await new FileSkillsLoader().loadSkills();
+    } catch (e) {
+        console.error('[Home] loadSkills failed:', e);
+        return [];
+    }
+});
 
 async function AsyncStatsBar() {
     const skills = await loadSkills();
@@ -50,7 +59,20 @@ async function SkillsShowcaseServer() {
 // WebSite SearchAction(urlTemplate=`?q={search_term_string}`)의 ?q= 처리는 proxy.ts가 담당한다.
 // page.tsx에서 searchParams를 소비하면 라우트가 dynamic으로 바뀌어 ISR 캐싱이 불가능하기 때문이다.
 export default async function Home() {
-    const skillCounts = await countSkillFiles();
+    // countSkillFiles 오류(fs 접근 실패 등)는 graceful 처리 — 0 폴백으로 페이지를 계속 렌더한다.
+    // throw가 전파되면 ISR 빈 캐시(0-byte body)가 동결된다.
+    const skillCounts = await countSkillFiles().catch(e => {
+        console.error('[Home] countSkillFiles failed:', e);
+        return {
+            indicators: 0,
+            candlesticks: 0,
+            patterns: 0,
+            strategies: 0,
+            supportResistance: 0,
+            fundamental: 0,
+            news: 0,
+        };
+    });
 
     const jsonLd = {
         '@context': 'https://schema.org',


### PR DESCRIPTION
## 배경
프로덕션 인시던트(`/`·`/economy`가 0-byte 빈 페이지 서빙)의 근본원인: FMP 402 등 일시적 데이터 실패가 24h ISR 재검증 중 server-render 로더에서 throw → Next가 빈 본문을 full-route ISR 캐시에 동결. 클라 `error.tsx`는 ISR prerender 빈-캐시를 못 막음(인시던트 페이지도 error.tsx 보유).

## 변경
throw 가능한 모든 server-render 로더를 **`.catch()`→degrade**(non-empty 폴백)로 감싸 render가 절대 throw하지 않게 함. 전수 감사(Opus)로 10개 page + 2개 신규 경계 식별.
- **catch→degrade**: economy(P0)·market(FMP)·options(Yahoo)·[symbol]/news·fundamental(FMP 7섹션)·news hub/category·home skills
- **[symbol]/news 섹션**: 비-FMP(DB/Redis) 에러도 re-throw 대신 degrade
- **신규** `error.tsx`+`global-error.tsx`: 미보호 10개 라우트 인터랙티브 방어선
- **테스트**: "로더 throw → non-empty degrade, no throw" falsifiable 검증(Suspense flush 위해 섹션 직접 렌더)

## 검증
- full build EXIT=0, 9개 영향 라우트 non-empty 200 실증
- Opus review APPROVED(R3), app 레이어 546 테스트 통과
- SCOPE: 전부 siglens(렌더링/degrade/I/O), core 무관

🤖 Generated with [Claude Code](https://claude.com/claude-code)