### PR TITLE
fix(deploy): mount FMP_API_KEY at build time for /economy + /market prerender

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,10 +88,13 @@ jobs:
             #
             # Secrets are passed via BuildKit secret mounts so they never appear
             # in image layers or build logs (see Dockerfile RUN --mount=type=secret).
-            # DATABASE_URL is needed at build time for ISR prerender of news/[category] routes.
+            # DATABASE_URL is needed at build time for ISR prerender of news/[category] + legal routes.
+            # FMP_API_KEY is needed at build time for ISR prerender of /economy + /market (without it,
+            # the snapshot/quote fetches fail and a degraded page is baked into the image until the
+            # 24h revalidation re-renders it at runtime).
             #
-            # NOTE: The DATABASE_URL secret must be added to the repo's Actions secrets
-            # before this workflow can succeed. See: Settings → Secrets → Actions.
+            # NOTE: DATABASE_URL and FMP_API_KEY secrets must both be present in the repo's Actions
+            # secrets before this workflow can succeed (required=true mounts). See: Settings → Secrets → Actions.
             #
             # Build pipeline (arm64-native, zero-downtime):
             #   1. Build for linux/arm64 with --load (image lands in runner's Docker daemon natively).
@@ -103,12 +106,15 @@ jobs:
               env:
                   SIGLENS_GITHUB_TOKEN: ${{ secrets.SIGLENS_GITHUB_TOKEN }}
                   DATABASE_URL: ${{ secrets.DATABASE_URL }}
+                  # FMP_API_KEY: /economy·/market 빌드타임 prerender에 필요(없으면 degraded baked).
+                  FMP_API_KEY: ${{ secrets.FMP_API_KEY }}
               run: |
                   docker buildx build \
                       --platform linux/arm64 \
                       --provenance=false \
                       --secret id=SIGLENS_GITHUB_TOKEN,env=SIGLENS_GITHUB_TOKEN \
                       --secret id=DATABASE_URL,env=DATABASE_URL \
+                      --secret id=FMP_API_KEY,env=FMP_API_KEY \
                       --build-arg NEXT_PUBLIC_SITE_URL=https://siglens.io \
                       --build-arg NEXT_PUBLIC_ADSENSE_PUBLISHER_ID=ca-pub-6121223912694381 \
                       --build-arg NEXT_PUBLIC_ADSENSE_SLOT_PROGRESS=2260139933 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,18 @@ ENV NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL \
     NEXT_PUBLIC_ADSENSE_PUBLISHER_ID=$NEXT_PUBLIC_ADSENSE_PUBLISHER_ID \
     NEXT_PUBLIC_ADSENSE_SLOT_PANEL_BOTTOM=$NEXT_PUBLIC_ADSENSE_SLOT_PANEL_BOTTOM \
     NEXT_PUBLIC_ADSENSE_SLOT_PROGRESS=$NEXT_PUBLIC_ADSENSE_SLOT_PROGRESS
-# DATABASE_URL은 빌드 타임 ISR prerender(news/[category] 등)에 필요. secret mount로 주입해
-# 빌드 로그·이미지 레이어에 자격증명이 남지 않게 한다.
+# 빌드 타임 ISR prerender에 필요한 자격증명. secret mount로 주입해 빌드 로그·이미지
+# 레이어에 자격증명이 남지 않게 한다.
+#   - DATABASE_URL: news/[category]·legal 등 DB-backed prerender
+#   - FMP_API_KEY: /economy(거시경제 지표/treasury)·/market(지수·섹터 quote) prerender.
+#     없으면 빌드타임 FMP fetch가 실패해 EconomyDegraded/빈 패널이 이미지에 baked되고,
+#     ISR revalidate(24h)까지 degraded 페이지가 서빙된다. (런타임 SSM에는 이미 존재)
 RUN --mount=type=secret,id=SIGLENS_GITHUB_TOKEN,required=true \
     --mount=type=secret,id=DATABASE_URL,required=true \
+    --mount=type=secret,id=FMP_API_KEY,required=true \
     SIGLENS_GITHUB_TOKEN="$(cat /run/secrets/SIGLENS_GITHUB_TOKEN)" \
     DATABASE_URL="$(cat /run/secrets/DATABASE_URL)" \
+    FMP_API_KEY="$(cat /run/secrets/FMP_API_KEY)" \
     yarn build
 RUN node scripts/assert-standalone-skills.mjs
 


### PR DESCRIPTION
## 문제
v0.29.0 배포 후 프로덕션 `/economy`가 degraded("잠시 후 다시 시도해 주세요")로 서빙. `/market`도 부분 degrade.

## 근본원인 (재현 완료)
`/economy`·`/market`는 빌드타임 prerender ISR(revalidate=86400)인데, Docker 빌드 시크릿이 `SIGLENS_GITHUB_TOKEN`+`DATABASE_URL`뿐 **`FMP_API_KEY` 없음** → 빌드타임 FMP fetch(economy 지표/treasury, market quote) 실패 → degraded가 이미지에 baked → 24h revalidate까지 서빙. (런타임 SSM엔 FMP_API_KEY 존재 → degrade는 배포 직후 윈도우만)

재현: FMP 없이 빌드 → `/economy` 92KB degraded(프로덕션 일치). FMP 있으면 567KB full.

## 수정
Dockerfile 빌드 RUN + deploy.yml 빌드 단계에 `FMP_API_KEY` BuildKit 시크릿 추가(DATABASE_URL 패턴 동일, `required=true`, secret mount = 이미지/로그에 자격증명 미잔류).

## 검증
실제 arm64 Docker 빌드(FMP 시크릿 주입): 이미지 `/economy` = **566KB full**(전 지표), `/market` = **207KB full**, build exit 0. Opus review **approved**. 빌드타임/런타임 env 전수 감사 = FMP_API_KEY가 유일한 누락.

## ⚠️ 운영자 액션
배포 전 **`FMP_API_KEY`를 repo Actions secrets에 추가** 필요(`required=true` 마운트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)