### PR TITLE
fix(isr-cache): activate externalization in prod — S3 perms, runner GIT_SHA, optional ALARM_EMAIL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,12 @@ RUN node scripts/assert-standalone-skills.mjs
 FROM node:22-alpine AS runner
 RUN apk add --no-cache tini
 WORKDIR /app
+# GIT_SHA must be re-declared in the runner stage — ARG scope is per-stage in Docker.
+# Without this, process.env.GIT_SHA is unset at runtime and cache-handler/config.mjs
+# falls back to buildId 'dev', causing every deploy to collide on the same
+# siglens-isr/dev/ S3 prefix and breaking per-release cache isolation.
+ARG GIT_SHA
+ENV GIT_SHA=$GIT_SHA
 ENV NODE_ENV=production \
     PORT=3000 \
     HOSTNAME=0.0.0.0

--- a/infra/aws/check-env.sh
+++ b/infra/aws/check-env.sh
@@ -34,6 +34,10 @@ OPTIONAL_KEYS=(
   ANTHROPIC_CHAT_API_KEY
   OPENAI_CHAT_API_KEY
   DEBUG_VERBOSE_LOGS
+  # Optional SNS email subscription address for ISR cache alarms. The SNS topic
+  # and CloudWatch alarm wiring (07-alarms.sh) are created regardless; only the
+  # email subscription is skipped when this is absent. Never block deploy for it.
+  ALARM_EMAIL
 )
 
 # 필수 키 수집: KEY=... 형태 라인에서 KEY만 추출(주석/빈 줄 스킵, EXCLUDE 제외).

--- a/infra/aws/iam/ec2-role-policy.json
+++ b/infra/aws/iam/ec2-role-policy.json
@@ -59,6 +59,12 @@
             "Effect": "Allow",
             "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
             "Resource": "arn:aws:s3:::siglens-isr-cache/*"
+        },
+        {
+            "Sid": "IsrCacheList",
+            "Effect": "Allow",
+            "Action": ["s3:ListBucket"],
+            "Resource": "arn:aws:s3:::siglens-isr-cache"
         }
     ]
 }


### PR DESCRIPTION
## 배경
v0.31.0 배포 후 ISR S3 외부화가 prod에서 작동하지 않음을 발견. cacheHandler 코드는 정상이나 3가지 wiring 버그가 있었다. 진단 결과 컨테이너 env(ISR_CACHE_BUCKET)는 정상 주입됐으나 ec2-role에 S3 권한이 없어 전부 AccessDenied → fail-open SSR이었다.

## 수정
1. **`infra/aws/iam/ec2-role-policy.json`** — `IsrCacheList`(s3:ListBucket on 버킷 ARN) statement 추가. 없으면 미존재 키 GET이 404 대신 403 → 에러 로그/알람 오발. (※ 실제 IAM role에는 이미 hot-fix로 적용 완료, 이 PR은 코드 정합)
2. **`Dockerfile`** — runner stage에 `ARG/ENV GIT_SHA` 추가. builder stage에만 있어 런타임 `process.env.GIT_SHA`가 unset → buildId가 `dev`로 폴백, 배포 간 `siglens-isr/dev/` prefix 충돌(격리 깨짐). ARG는 stage별 스코프라 runner에서 재선언 필요.
3. **`infra/aws/check-env.sh`** — `ALARM_EMAIL`을 `OPTIONAL_KEYS`에 추가. 본질적으로 optional(빈 값이면 SNS 이메일 구독만 스킵)인데 required로 잡혀 배포 게이트를 막았다.

## 검증
- IAM hot-fix 적용 직후 S3에 221개 캐시 객체(23.5MB) 생성 확인 — 외부화 작동 실증.
- 이 PR 머지 + 재배포 후 buildId가 버전 태그(`siglens-isr/<version>/`)로 정상화 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)