### PR TITLE
perf(fmp): cache optimization — 24h fundamental TTL, peer split, EOD immutable-history split

### DIFF
--- a/docs/qa/2026-06-30-fmp-cache-verification.md
+++ b/docs/qa/2026-06-30-fmp-cache-verification.md
@@ -1,0 +1,285 @@
+# FMP 캐시 개선 — 배포 전 검증 Spec & Test Cases
+
+> 대상 브랜치: `perf/fmp-cache-optimization` (워크트리 `/Users/y0ngha/Project/siglens-fmp-cache`)
+> 설계 문서: [`docs/superpowers/specs/2026-06-30-fmp-cache-optimization-design.md`](../superpowers/specs/2026-06-30-fmp-cache-optimization-design.md)
+> 작성일: 2026-06-30
+> 목적: FMP 호출·egress 절감을 위한 캐시 개선이 **사용자 화면·SEO·데이터 정확성을 무손상**으로
+> 유지하는지 prod-like 로컬 실행에서 curl(응답/Status) + Chrome(시각/DOM) 두 트랙으로 실증한다.
+>
+> 핵심 검증 가설: **이 변경은 순수 I/O/캐시 최적화다. 사용자에게 보이는 모든 것은 변경 전과 동일해야 한다.**
+> 단위/E2E 테스트가 로직을 커버하더라도, 실제 production 빌드에서 페이지·차트·SEO에 회귀가 없는지 확인한다.
+
+---
+
+## 1. 변경 범위 & 리스크 요약 (Scope & Risk)
+
+### 1.1 변경된 것 (3 파트)
+
+| # | 변경 | 코드 위치 |
+|---|---|---|
+| **1** | fundamental 캐시 TTL **1h → 24h** (단일 상수 `FMP_FUNDAMENTAL_REVALIDATE_SECONDS = SECONDS_PER_DAY`가 Next Data Cache `revalidate` + Redis `getOrSetCache` TTL 둘 다 구동) | `src/shared/api/fmp/fundamentalClient.ts:45`, `src/shared/api/fmp/CachedFundamentalProvider.ts:29` (`TTL`) |
+| **2** | **peer 목록 split** — 페이지(`PeersTable`)는 enrich 없는 raw peer(티커·회사명·시총만), 분석/FactLayer는 enriched(per/psr 유지). 신규 `getStockPeersRaw` 추가, 페이지 위임 전환 | `src/shared/api/fmp/CachedFundamentalProvider.ts:206-211` (`getStockPeersRaw`), `src/app/[symbol]/fundamental/fundamentalData.ts:70-73`, `src/shared/api/fmp/fundamentalProvider.types.ts` (`FundamentalProviderWithRawPeers`), `FakeFundamentalDataProvider.ts:83` |
+| **3** | **1Day EOD 봉 split** — 긴 lookback의 일봉을 불변 과거(`before=오늘−7d`, long-TTL=2d) + 최근 live(`from=오늘−10d`, 세션 TTL)로 나눠 fetch 후 `mergeBarsByTime`으로 병합. 짧은 lookback·인트라데이·`before` 페이지네이션은 기존 단일 경로 유지 | `src/shared/api/market/CachedMarketDataProvider.ts:90-142`, `src/shared/api/market/mergeBarsByTime.ts` |
+
+커밋:
+```
+ba3128dd perf(fmp): extend fundamental cache TTL 1h -> 24h
+a3c25195 feat(fmp): add getStockPeersRaw (un-enriched, page-only peer list)
+c4c310aa perf(fundamental): page peers use raw (un-enriched) list, drop per/psr fan-out
+c704f2c7 feat(market): add mergeBarsByTime pure helper for EOD cache split
+6332f950 perf(market): split 1Day EOD into immutable-history(long) + recent(live) caches
+d28707cc test(market): cover EOD-split edge cases + guard short 1Day windows
+```
+
+`@y0ngha/siglens-core`(0.27.0)·`FmpMarketProvider`·`FmpFundamentalClient`(inner)는 **무변경**. 캐싱·병합은 전부 데코레이터 레이어에 있다.
+
+### 1.2 사용자에게 보이는 동작 — **반드시 동일** (회귀 금지)
+
+이 항목들이 변경 전과 **시각·구조·값이 동일**해야 검증 통과다.
+
+- **Peer 테이블 내용**: 3컬럼(티커 / 회사명 / 시가총액). 티커는 `/{PEER}/fundamental` 내부 링크. 시총은 `Intl.NumberFormat('ko-KR', compact, USD)` 포맷(예: `US$3.5조` / `US$3.5T` 류 compact 통화). **변경 전과 동일한 peer 목록·동일 컬럼**. (per/psr은 원래도 이 표에 없었음 — 표에는 영향 0.)
+- **밸류에이션 카드(ValuationCard)**: **본 종목**의 PER/PSR/EPS 등 — `getKeyMetricsTtm(symbol)` 경로로 변경 무관, 그대로 노출.
+- **차트 일봉(1Day)**: 차트 페이지 `/{SYMBOL}`의 일봉 캔들 — split 병합 결과가 단일 `getBars(from=now−730d)`와 **동일 집합**이어야 한다(개수·순서·오늘 봉 포함 동일).
+- **가격 신선도**: 오늘 봉/현재가/등락률 — 최근 live 윈도우(세션 TTL 60s) + 클라 React Query refetch 30s 그대로. 지연 없음.
+- **SEO/메타/JSON-LD**: title/description/canonical/robots/og·twitter, WebPage·BreadcrumbList·FAQPage JSON-LD — 모두 불변(SEO 콘텐츠는 데이터 fetch와 분리됨).
+- **분석/FactLayer 품질**: AI 펀더멘털 분석의 peer per/psr — enriched `getStockPeers`(core 분석 경로)는 유지되므로 N/A 회귀 없어야 함(**회귀 가드**, 설계 §변경2).
+
+### 1.3 내부 동작 — 변경됨 (curl로 직접 관측 불가)
+
+- **FMP 호출/egress 감소**: peer fan-out 페이지 제거, EOD 730일 재fetch를 거래일당 1회로. → **로컬 curl로는 직접 보이지 않는다.** FMP usage 대시보드(prod)나 서버 로그/타이밍으로만 간접 관측 가능(§5).
+- **캐시 키 구조 변경**: `fundamental:peers-raw:<SYM>` 신규, `bars:eodhist:<SYM>:<from>:<histTo>` / `bars:eodrecent:<SYM>:<recentFrom>` 신규(기존 `bars:raw:*`는 짧은 lookback·인트라데이용으로 잔존). 동작 정확성은 사용자 화면(§3·§4)으로 검증하고, 키는 §5에서 best-effort 확인.
+
+### 1.4 리스크 핫스폿 (집중 검증 포인트)
+
+| 리스크 | 시나리오 | 검증 |
+|---|---|---|
+| R-A | merge 버그로 차트 일봉이 **누락/중복/순서 어긋남** | C-CHART / B-CHART (개수·오늘 봉) |
+| R-B | 윈도우 경계(주말·공휴일·DST) **갭** — 3일 overlap이 못 막음 | B-CHART(연속성 시각 확인), §5 |
+| R-C | peer split로 **페이지 peer 목록이 비거나 달라짐** | C-PEER / B-PEER |
+| R-D | enriched 경로 회귀로 **분석 peer per/psr이 N/A** | B-ANALYSIS(분석 결과 peer 비교 문구) |
+| R-E | 24h TTL로 **본 종목 valuation 카드 빈값** degrade | C-VAL / B-VAL |
+| R-F | 짧은 lookback이 split를 타서 **과거 윈도우 역전**(빈 결과) | C-CHART(차트 200·데이터 존재), §5 |
+| R-G | SEO/JSON-LD 회귀 | C-SEO / B-SEO |
+
+---
+
+## 2. 환경 설정 (Prod-like 로컬 실행)
+
+> 베이스 가이드: [QA_ENV_SETUP.md](./QA_ENV_SETUP.md). 본 절은 이 변경에 필요한 부분만 추린다.
+
+### 2.1 필요한 env
+
+| 키 | 필요성 | 비고 |
+|---|---|---|
+| `FMP_API_KEY` | **필수** | 변경 1·3 모두 실데이터 검증 시 실제 FMP 응답 필요. 없으면 fundamental/차트가 degrade되어 검증 무의미. `.env.local`/`.env.production`에 존재 확인. |
+| `DATABASE_URL` | **필수** | 펀더멘털 페이지가 `getProfileDescriptionKo`(DB 번역)·`getAssetInfoResilient`에서 DB 접근. prod build의 정적 prerender도 DB를 읽으므로 연결 가능한 DB 필요(Neon 또는 docker). |
+| `UPSTASH_REDIS_REST_URL` / `_TOKEN` / `_READONLY_TOKEN` | **선택(권장)** | 캐싱 동작(§5)을 실증하려면 필요. **미설정 시 `getOrSetCache`가 fetcher 직접 호출로 graceful fallback** → 기능은 정상, 단 캐시 hit/TTL은 관측 불가. docker SRH(`localhost:8079`)로 실제 Redis 검증 가능(QA_ENV_SETUP §1). |
+| `NEXT_PUBLIC_SITE_URL` | 선택 | 미설정 시 `https://siglens.io` 기본값(SEO canonical 검증 시 이 도메인으로 나옴). 로컬 검증은 그대로 둬도 됨. |
+
+> ⚠️ **env 원복 주의**(MEMORY): `.env.local`·`.env.production`은 gitignore라 swap 후 복원 누락이 잦다.
+> 검증 끝나면 형제 워크트리(메인 레포)와 키셋 비교로 원복 확인. OAuth 등 메인 전용 값은 통째 복사 금지.
+
+### 2.2 prod-like 빌드 → 실행
+
+```bash
+# 워크트리 node_modules는 symlink 금지(Turbopack 거부/dual-React). 독립 install 권장:
+#   cd /Users/y0ngha/Project/siglens-fmp-cache && yarn install
+# (core 0.27.0 핀이 메인 레포 node_modules와 다를 수 있음 → 워크트리 독립 install이 안전, MEMORY 트랩)
+
+cd /Users/y0ngha/Project/siglens-fmp-cache
+
+# 빌드 (exit code는 파이프 없이 직접 캡처 — yarn build | tail 은 실패를 exit 0으로 가린다)
+yarn build > /tmp/fmp-cache-build.log 2>&1; echo "EXIT=$?"
+# EXIT=0 이어야 함. tail /tmp/fmp-cache-build.log 로 prerender 에러 0 확인.
+
+# prod 서버 (포트 4300 권장 — 메인 dev 4200과 충돌 회피)
+yarn start -p 4300
+```
+
+- 기본 포트: `yarn start`는 3000. 본 문서는 **4300**을 사용(아래 모든 curl이 `localhost:4300`).
+- 빌드 시점 env 주의(MEMORY): `/economy`·`/market` 등 빌드타임 prerender 페이지는 FMP_API_KEY가 빌드 env에도 있어야 full 데이터가 baked된다. **단 fundamental·차트는 on-demand ISR**(`generateStaticParams = []`)이라 빌드타임 prerender 대상이 아니며 첫 요청에 렌더된다 → 런타임 env로 충분.
+
+### 2.3 ISR 리터럴 규칙 (회귀 false-positive 방지, MEMORY/MISTAKES §15)
+
+`FMP_FUNDAMENTAL_REVALIDATE_SECONDS`는 route segment의 `export const revalidate`로 **쓰이지 않는다**(사용처 = `fmpGet` opts + Redis TTL 2곳뿐). 따라서 이 상수의 24h 변경은 "revalidate는 리터럴이어야 한다" 규칙과 **무관**하다. 페이지의 `export const revalidate = 86400`(리터럴)은 그대로 유지됨(`fundamental/page.tsx:60`). 리뷰봇이 이를 blocker로 들면 근거와 함께 반려.
+
+### 2.4 dev 폴백 (full prod 빌드가 어려울 때)
+
+```bash
+cd /Users/y0ngha/Project/siglens-fmp-cache && yarn dev   # 포트 4200
+```
+
+폴백 시 손실되는 충실도:
+- **ISR/캐시 hit 거동이 prod와 다름**(dev는 매 요청 재렌더, Next Data Cache 미적용) → §5 캐싱 spot-check는 사실상 무의미.
+- prerender 에러(S-BUILD)는 못 잡음.
+- 단, **기능 정확성(peer 표·차트 봉·SEO 마크업)은 dev에서도 검증 가능** → C-/B- 케이스 대부분은 유효. 포트만 4200으로 바꿔 실행.
+
+---
+
+## 3. Method A — curl 테스트 케이스
+
+> 베이스 URL `http://localhost:4300`. 실증 심볼: **AAPL, MSFT, NVDA**(대형·유동성), 엣지 **SPY**(ETF), **ZZZZ**(무효).
+> 모든 응답은 HTML(또는 redirect). 마커는 실제 컴포넌트 출력 문자열에 근거.
+> 공통: `-s`(silent) `-i`(헤더 포함) `-A`(데스크톱 UA로 봇 분기 회피).
+
+```bash
+UA='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126 Safari/537.36'
+```
+
+### 3.1 펀더멘털 페이지 — peer 표 & 밸류에이션 (변경 1·2)
+
+| ID | 라우트 / 명령 | 기대 Status | 기대 마커 (substring) | Pass 기준 |
+|---|---|---|---|---|
+| C-PEER-1 | `curl -s -A "$UA" http://localhost:4300/AAPL/fundamental` | 200 | `동종업계 비교`(peer 섹션 제목), peer 내부 링크 `href="/MSFT/fundamental"`(또는 타 peer), 컬럼 헤더 `티커`·`회사명`·`시가총액`, 시총 compact 통화 문자열(`US$`+`조`/`T`/`B` 류) | peer 표 제목·3컬럼 헤더·≥1개 `/{PEER}/fundamental` 링크·compact 시총 모두 존재. **per/psr 컬럼 헤더는 없어야 함(원래도 없음)** |
+| C-PEER-2 | `curl -s -A "$UA" http://localhost:4300/MSFT/fundamental \| grep -o 'href="/[A-Z]\{1,5\}/fundamental"' \| sort -u` | 200 | peer 티커 링크 목록 | 2개 이상 서로 다른 peer `/{X}/fundamental` 링크(크롤 가능) |
+| C-PEER-3 | `curl -s -A "$UA" http://localhost:4300/NVDA/fundamental` | 200 | `동종업계 비교` + peer 링크 | NVDA에도 peer 표 정상 렌더(빈 EmptySectionCard 아님 — 단, 데이터 희소 시 EmptySection 허용하나 500 금지) |
+| C-VAL-1 | `curl -s -A "$UA" http://localhost:4300/AAPL/fundamental` | 200 | ValuationCard 영역(밸류에이션 지표 — PER/PSR/EPS 등 카드). `재무지표와 애널리스트 의견`(H1), `밸류에이션` 관련 텍스트 | 본 종목 밸류에이션 카드 존재, 빈 N/A 일색 아님 |
+| C-VAL-2 | `curl -s -A "$UA" http://localhost:4300/SPY/fundamental` | 200 또는 404 | ETF는 fundamental 탭 정책에 따라 — profile 있으면 200(degrade/empty 섹션 가능), 없으면 notFound | **500 없음**. 200이면 페이지 크롬 정상 렌더, 404면 noindex |
+
+### 3.2 차트 페이지 — 일봉(1Day) split (변경 3)
+
+> 차트 일봉은 SSR HTML에 직접 캔들 값이 안 박힐 수 있다(클라 hydrate). curl로는 **페이지 200 + 차트 컨테이너 존재 + 500 부재**까지 확인하고, 봉 개수·연속성은 Chrome 트랙(B-CHART)에서 본다.
+
+| ID | 라우트 / 명령 | 기대 Status | 기대 마커 | Pass 기준 |
+|---|---|---|---|---|
+| C-CHART-1 | `curl -s -i -A "$UA" http://localhost:4300/AAPL \| head -1` | `HTTP/1.1 200` | — | 차트(심볼) 페이지 200. cold-gen에서도 500 없음(ISR connection() 미사용, MEMORY) |
+| C-CHART-2 | `curl -s -A "$UA" http://localhost:4300/MSFT` | 200 | 차트 위젯 마커(예: 가격/차트 섹션 컨테이너, `차트` 또는 캔들 위젯 root), SymbolPageHeading | 페이지 본문 정상, 차트 영역 존재 |
+| C-CHART-3 | `curl -s -i -A "$UA" http://localhost:4300/NVDA \| head -1` | `HTTP/1.1 200` | — | 200, 500 없음 |
+| C-CHART-4 (edge: 무효) | `curl -s -i -A "$UA" http://localhost:4300/ZZZZ \| head -1` | 404(또는 graceful degraded 200) | — | **500 없음**. 무효 심볼이 split 경로를 타도 빈 결과 graceful 처리 |
+
+### 3.3 SEO / 크롤 (변경 무관 — 회귀 가드)
+
+| ID | 라우트 / 명령 | 기대 Status | 기대 마커 | Pass 기준 |
+|---|---|---|---|---|
+| C-SEO-1 | `curl -s -A "$UA" http://localhost:4300/AAPL/fundamental \| grep -i '<title>'` | 200 | `<title>` 에 종목명/티커 포함(`buildSymbolFundamentalSeoContent`) | title 비어있지 않음, AAPL/Apple 관련 |
+| C-SEO-2 | `curl -s -A "$UA" http://localhost:4300/AAPL/fundamental \| grep -io 'rel="canonical"[^>]*'` | 200 | `canonical` → `…/AAPL/fundamental` | canonical 존재, 경로 일치 |
+| C-SEO-3 | `curl -s -A "$UA" http://localhost:4300/AAPL/fundamental \| grep -o '"@type":"[A-Za-z]*"' \| sort -u` | 200 | `"@type":"WebPage"`, `"@type":"BreadcrumbList"`, `"@type":"FAQPage"`(+ FAQ 내 Question/Answer) | 3종 JSON-LD `@type` 모두 존재, 유효 JSON |
+| C-SEO-4 | `curl -s -A "$UA" http://localhost:4300/AAPL/fundamental \| grep -io 'name="robots"[^>]*'` | 200 | robots 메타 — 유효 심볼은 noindex 아님(index 허용) | 유효 심볼에 noindex 없음(또는 index,follow) |
+| C-SEO-5 (무효) | `curl -s -A "$UA" http://localhost:4300/ZZZZ/fundamental \| grep -io 'name="robots"[^>]*'` | 200/404 | `noindex` (NOINDEX_SYMBOL_METADATA) | 무효/미존재 심볼은 **noindex** |
+| C-SEO-6 | `curl -s -A "$UA" http://localhost:4300/AAPL/fundamental \| grep -o 'href="/[A-Z]\{1,5\}/fundamental"' \| wc -l` | 200 | peer 내부 링크 수 | ≥1 — peer 링크가 크롤용으로 HTML에 존재(변경 2 후에도 internal link 보존) |
+
+### 3.4 회귀 — 기존 탭 (변경이 깨지 않았는지)
+
+| ID | 라우트 | 기대 | Pass |
+|---|---|---|---|
+| C-REG-1 | `curl -s -i -A "$UA" http://localhost:4300/AAPL/overall \| head -1` | 200 | overall 페이지 정상(분석 경로 enriched peer 소비처) |
+| C-REG-2 | `curl -s -i -A "$UA" http://localhost:4300/AAPL/news \| head -1` | 200 | 기존 탭 회귀 없음 |
+| C-REG-3 | `curl -s -i -A "$UA" http://localhost:4300/AAPL/financials \| head -1` | 200 | 기존 탭 회귀 없음 |
+
+---
+
+## 4. Method B — Chrome 테스트 케이스 (browser automation)
+
+> claude-in-chrome MCP로 navigate → get_page_text / read_page(DOM) → read_console_messages.
+> 시각·구조 확인 + 콘솔 에러 0 + 차트 캔들 실렌더 확인이 핵심. 베이스 `http://localhost:4300`.
+
+| ID | 라우트 | 액션 | 확인 항목 | Pass 기준 |
+|---|---|---|---|---|
+| B-PEER-1 | `/AAPL/fundamental` | navigate → DOM 읽기(peer 섹션) | "동종업계 비교" 섹션에 표가 **정확히 3컬럼**(티커/회사명/시가총액)으로 렌더. 각 행 티커는 링크, 시총은 compact 통화 표기, 값 채워짐 | 3컬럼·데이터 행 ≥1·시총 포맷 정상. per/psr 컬럼 부재 |
+| B-PEER-2 | `/MSFT/fundamental` | peer 티커 클릭(예: 첫 행) | 해당 peer의 fundamental 페이지로 이동(`/{PEER}/fundamental`) | 내부 링크 네비게이션 동작 |
+| B-VAL-1 | `/AAPL/fundamental` | DOM 읽기(ValuationCard) | **본 종목** 밸류에이션 카드에 PER/PSR(및 EPS 등) 값이 **실제 숫자**로 표시(N/A 일색 아님) | 본 종목 PER·PSR 숫자 노출 |
+| B-CHART-1 | `/AAPL` | navigate → 차트 로드 대기 → DOM/canvas 확인 | 일봉(1Day) 차트가 캔들로 렌더. 봉이 **연속**(주말·공휴일 갭은 정상, 중간 누락/중복 없음), 가장 오른쪽 봉 = 최신(오늘/직전 거래일) | 캔들 렌더, 우측 끝 최신 봉 존재, 시각적 갭/중복 없음 |
+| B-CHART-2 | `/MSFT` → 기간 토글이 있으면 1D/일봉 선택 | 일봉 뷰에서 장기 구간(예: 1Y/Max) 스크롤 | split 경계(오늘−7d~−10d 구간)에서 봉 누락/중복 없음 | 경계 구간 연속, 단일 시리즈처럼 보임 |
+| B-CHART-3 | `/NVDA` | navigate → 차트+현재가 확인 | 현재가/등락률이 최신값으로 표시(최근 live 윈도우+클라 refetch). 차트 우측 끝 봉과 현재가 정합 | 가격 신선, 차트-가격 불일치 없음 |
+| B-ANALYSIS-1 (회귀 가드) | `/AAPL/fundamental` | AI 펀더멘털 요약 submit→poll 완료 대기, 분석 텍스트 확인 | 분석 결과에 **동종업계 PER/PSR 비교** 관련 문구가 정상(peer per/psr이 enriched로 채워져 N/A·결측 회귀 없음) | 분석 완료, peer 비교 내용에 결측/N/A 폭증 없음 |
+| B-SEO-1 | `/AAPL/fundamental` | `<head>` 읽기 | title·description·canonical·og·twitter 메타 존재, JSON-LD 3종 | 메타+JSON-LD 정상(C-SEO와 교차 확인) |
+| B-CONSOLE-1 | `/AAPL/fundamental`, `/AAPL` | navigate 후 콘솔 읽기 | 런타임 콘솔 **에러 0**(의도된 warn 제외) | error 레벨 메시지 없음 |
+| B-REG-1 | `/AAPL/overall` | navigate → 렌더 확인 | overall 페이지 정상(분석 통합) | 페이지 정상, 콘솔 에러 없음 |
+
+---
+
+## 5. 캐싱 동작 spot-check (best-effort, 선택)
+
+> ⚠️ curl/Chrome로 캐시 hit·TTL·FMP 호출 감소를 **직접** 관측할 수 없다(내부 거동). 아래는 간접 신호이며,
+> Redis(docker SRH 또는 Upstash)가 연결돼 있을 때만 의미가 있다. Redis 미설정 시 전 경로가 fallback 직접 fetch라 이 절은 스킵.
+
+### 5.1 EOD split 키 존재 확인 (docker Redis 사용 시 가장 확실)
+
+QA_ENV_SETUP §1대로 docker 백엔드를 띄우고 앱이 SRH를 보게 한 뒤:
+
+```bash
+# 차트 1회 요청으로 캐시 워밍
+curl -s -A "$UA" http://localhost:4300/AAPL > /dev/null
+
+# docker redis에서 키 확인 (split가 동작하면 eodhist/eodrecent 키가 생긴다)
+docker exec -it <redis_container> redis-cli KEYS 'bars:eod*:AAPL*'
+#  기대: bars:eodhist:AAPL:<from>:<histTo>  와  bars:eodrecent:AAPL:<recentFrom>  둘 다 존재
+docker exec -it <redis_container> redis-cli KEYS 'fundamental:peers-raw:AAPL'
+#  기대: 변경 2의 raw peer 키 존재
+docker exec -it <redis_container> redis-cli TTL 'bars:eodhist:AAPL:<from>:<histTo>'
+#  기대: 24h~48h 범위(EOD_HIST_TTL=2d). recent 키 TTL은 세션 의존(장중 ~60s).
+docker exec -it <redis_container> redis-cli TTL 'fundamental:key-metrics:AAPL'
+#  기대: ~24h(변경 1, 이전엔 ~1h)
+```
+
+Pass: `bars:eodhist:*`·`bars:eodrecent:*`·`fundamental:peers-raw:*` 키가 생성되고, hist TTL이 long(>1d)·fundamental TTL이 ~24h.
+
+### 5.2 응답 타이밍 (Redis 없을 때 약한 신호)
+
+```bash
+# 동일 페이지 2회 — warm일수록 빨라짐(단 ISR/Next Data Cache 등 교란 많아 결정적이지 않음)
+for i in 1 2; do curl -s -A "$UA" -o /dev/null -w "req$i: %{time_total}s\n" http://localhost:4300/AAPL/fundamental; done
+```
+
+한계: ISR HTML 캐시·OS 캐시 등 교란이 커서 FMP 절감을 직접 증명하지 못함. **본 변경의 호출/egress 절감은 prod FMP usage 대시보드로만 정량 확인 가능**(설계 §6). 로컬 검증의 본질은 "절감하면서 화면이 안 깨졌나"이며, 그건 §3·§4가 담당.
+
+### 5.3 merge 정확성 단위 신뢰
+
+봉 병합 동일성(`mergeBarsByTime`)·짧은 lookback 가드는 단위 테스트가 커버:
+```bash
+cd /Users/y0ngha/Project/siglens-fmp-cache
+yarn vitest run src/shared/api/market/__tests__/mergeBarsByTime.test.ts \
+  src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts \
+  src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
+#  전부 green이면 split/merge/peer-raw 로직 정확. B-CHART는 실런타임 회귀만 잡으면 됨.
+```
+
+---
+
+## 6. SEO 체크 (요약)
+
+변경은 SEO 출력과 무관하나 회귀 가드로 명시 확인한다.
+
+- **유효 심볼**(`/AAPL/fundamental`): `<title>`·description·canonical(`…/AAPL/fundamental`)·og/twitter 메타 존재. robots **noindex 아님**. JSON-LD WebPage·BreadcrumbList·FAQPage 3종(C-SEO-1~4, B-SEO-1).
+- **무효/미존재 심볼**(`/ZZZZ/fundamental`): `NOINDEX_SYMBOL_METADATA` → robots **noindex**(C-SEO-5).
+- **Peer 내부 링크**: peer 표의 각 티커가 `/{PEER}/fundamental` 링크로 HTML에 존재(크롤 가능) — 변경 2(raw peer 전환) 후에도 보존(C-SEO-6, C-PEER-2).
+
+---
+
+## 7. Pass/Fail 체크리스트 (실행자 기입)
+
+### 환경
+- [ ] 워크트리 독립 `yarn install` 완료, core `0.27.0` 핀 일치
+- [ ] `FMP_API_KEY`·`DATABASE_URL` 설정 확인 / (선택) `UPSTASH_*` 또는 docker Redis
+- [ ] `yarn build` EXIT=0, prerender 에러 0 (`/tmp/fmp-cache-build.log`)
+- [ ] `yarn start -p 4300` 기동
+
+### Method A — curl (총 18개)
+- [ ] C-PEER-1 / C-PEER-2 / C-PEER-3 (peer 표 3컬럼·내부 링크)
+- [ ] C-VAL-1 / C-VAL-2 (본 종목 밸류에이션, ETF 500 없음)
+- [ ] C-CHART-1 / C-CHART-2 / C-CHART-3 / C-CHART-4 (차트 200, 무효 500 없음)
+- [ ] C-SEO-1 / C-SEO-2 / C-SEO-3 / C-SEO-4 / C-SEO-5 / C-SEO-6 (title/canonical/JSON-LD/robots/peer 링크)
+- [ ] C-REG-1 / C-REG-2 / C-REG-3 (overall/news/financials 회귀)
+
+### Method B — Chrome (총 10개)
+- [ ] B-PEER-1 / B-PEER-2 (3컬럼 렌더, peer 링크 네비)
+- [ ] B-VAL-1 (본 종목 PER/PSR 숫자)
+- [ ] B-CHART-1 / B-CHART-2 / B-CHART-3 (일봉 연속·최신 봉·가격 신선)
+- [ ] B-ANALYSIS-1 (분석 peer per/psr 회귀 없음 — 가드)
+- [ ] B-SEO-1 (head 메타+JSON-LD)
+- [ ] B-CONSOLE-1 (콘솔 에러 0)
+- [ ] B-REG-1 (overall 회귀)
+
+### 캐싱 (선택, Redis 연결 시)
+- [ ] §5.1 `bars:eodhist:*`·`bars:eodrecent:*`·`fundamental:peers-raw:*` 키 존재 + hist long-TTL + fundamental ~24h
+- [ ] §5.3 `mergeBarsByTime`/`CachedMarketDataProvider`/`CachedFundamentalProvider` 단위 테스트 green
+
+### 종료 (원복 필수, QA_ENV_SETUP §7)
+- [ ] `.env.local`/`.env.production` 원복(메인 워크트리와 키셋 비교)
+- [ ] prod 서버 종료(`lsof -ti :4300` → kill)
+- [ ] (docker 사용 시) `yarn e2e:down`
+
+### Exit Criteria
+- [ ] curl 18 + Chrome 10 전부 PASS, 콘솔 에러 0, build EXIT=0
+- [ ] §1.2 "동일해야 하는 동작" 모두 변경 전과 일치(peer 표 / 밸류에이션 / 차트 일봉 / 가격 신선 / SEO / 분석 peer)
+- [ ] 회귀 가드(B-ANALYSIS-1, C-REG-*) PASS

--- a/docs/superpowers/plans/2026-06-30-fmp-cache-optimization.md
+++ b/docs/superpowers/plans/2026-06-30-fmp-cache-optimization.md
@@ -1,0 +1,600 @@
+# FMP Cache Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** FMP 호출·egress를 줄인다 — valuation TTL 24h, peer enrich를 페이지(raw)/분석(enriched)으로 분리, EOD 일봉을 불변 과거(long-cache)+최근(live)로 분리.
+
+**Architecture:** siglens I/O 레이어만 변경(`shared/api/fmp/*`, `shared/api/market/*`, `app/[symbol]/fundamental/*`). core(`@y0ngha/siglens-core`)·`FmpFundamentalClient`·`FmpMarketProvider` 무변경. 기존 캐시 패턴(`getOrSetCache` + `React.cache`, poison 방지, graceful fallback) 유지.
+
+**Tech Stack:** TypeScript, Next.js 16, Upstash Redis(`getOrSetCache`), Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-06-30-fmp-cache-optimization-design.md`
+
+---
+
+## File Structure
+
+| File | 책임 | 변경 |
+|---|---|---|
+| `src/shared/api/fmp/fundamentalClient.ts` | valuation TTL 상수 | Modify (상수 1h→24h) |
+| `src/shared/api/fmp/fundamentalProvider.types.ts` | provider 인터페이스 | Modify (소비자 인터페이스에 `getStockPeersRaw` 추가) |
+| `src/shared/api/fmp/CachedFundamentalProvider.ts` | Redis 데코레이터 | Modify (`getStockPeersRaw` 구현) |
+| `src/shared/api/fmp/getFundamentalDataProvider.ts` | provider 팩토리 | Modify (반환 타입) |
+| `src/shared/api/fmp/FakeFundamentalDataProvider.ts` | E2E fake | Modify (`getStockPeersRaw` 구현) |
+| `src/app/[symbol]/fundamental/fundamentalData.ts` | 페이지 데이터 위임 | Modify (`getStockPeers`→raw) |
+| `src/shared/api/market/mergeBarsByTime.ts` | 순수 병합 함수 | Create |
+| `src/shared/api/market/CachedMarketDataProvider.ts` | bars Redis 데코레이터 | Modify (1Day 2-윈도우 분리) |
+
+---
+
+## Task 1: Valuation TTL 1h → 24h
+
+**Files:**
+- Modify: `src/shared/api/fmp/fundamentalClient.ts:3,45`
+- Test: `src/shared/api/fmp/__tests__/fundamentalClient.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`fundamentalClient.test.ts` 상단 import에 추가하고 테스트를 더한다:
+
+```ts
+import { FMP_FUNDAMENTAL_REVALIDATE_SECONDS } from '@/shared/api/fmp/fundamentalClient';
+import { SECONDS_PER_DAY } from '@/shared/config/time';
+
+describe('FMP_FUNDAMENTAL_REVALIDATE_SECONDS', () => {
+    it('is 24h (SECONDS_PER_DAY) — fundamentals are quarterly; aligns with statements/congress', () => {
+        expect(FMP_FUNDAMENTAL_REVALIDATE_SECONDS).toBe(SECONDS_PER_DAY);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn test src/shared/api/fmp/__tests__/fundamentalClient.test.ts`
+Expected: FAIL — `expected 3600 to be 86400`.
+
+- [ ] **Step 3: Change the constant**
+
+`fundamentalClient.ts` line 3, import `SECONDS_PER_DAY` instead of `SECONDS_PER_HOUR` (확인: `SECONDS_PER_HOUR`는 이 파일에서 line 45에서만 사용됨):
+
+```ts
+import { SECONDS_PER_DAY } from '@/shared/config/time';
+```
+
+line 45:
+
+```ts
+export const FMP_FUNDAMENTAL_REVALIDATE_SECONDS = SECONDS_PER_DAY;
+```
+
+JSDoc(line 40-44)의 "1시간 freshness 창" 문구를 "24시간 freshness 창(분기 단위 재무 + statements/congress 정합)"으로 갱신.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn test src/shared/api/fmp/__tests__/fundamentalClient.test.ts`
+Expected: PASS. 기존 다른 단언이 `3600`을 기대했다면 함께 `SECONDS_PER_DAY`로 수정.
+
+- [ ] **Step 5: tsc + commit**
+
+```bash
+yarn tsc --noEmit
+git add src/shared/api/fmp/fundamentalClient.ts src/shared/api/fmp/__tests__/fundamentalClient.test.ts
+git commit -m "perf(fmp): extend fundamental cache TTL 1h -> 24h"
+```
+
+---
+
+## Task 2: `getStockPeersRaw` (interface + Cached impl + Fake)
+
+페이지 전용 raw peer 메서드. 소비자 인터페이스에만 추가하고 inner(raw client) 계약은 불변으로 둔다(FmpFundamentalClient 무변경).
+
+**Files:**
+- Modify: `src/shared/api/fmp/fundamentalProvider.types.ts`
+- Modify: `src/shared/api/fmp/CachedFundamentalProvider.ts`
+- Modify: `src/shared/api/fmp/getFundamentalDataProvider.ts`
+- Modify: `src/shared/api/fmp/FakeFundamentalDataProvider.ts`
+- Test: `src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts`, `src/shared/api/fmp/__tests__/FakeFundamentalDataProvider.test.ts`
+
+- [ ] **Step 1: Write the failing test (Cached raw = no enrich)**
+
+`CachedFundamentalProvider.test.ts`에 추가. 이 파일의 기존 `makeInner`/`fakeRedis` 헬퍼를 그대로 사용한다(`getStockPeersRaw`는 inner에 없음 — 데코레이터가 `inner.getStockPeers`를 호출):
+
+```ts
+it('getStockPeersRaw caches raw peers WITHOUT enrich (no getKeyMetricsTtm calls)', async () => {
+    resetSharedState();
+    const inner = makeInner({
+        getStockPeers: vi.fn(async () => [
+            { symbol: 'MSFT', companyName: 'Microsoft', marketCap: 3e12 },
+        ]),
+        getKeyMetricsTtm: vi.fn(async () => ({
+            peRatioTTM: 10,
+            priceToSalesRatioTTM: 3,
+            pbRatioTTM: null,
+            pegRatioTTM: null,
+            enterpriseValueOverEBITDATTM: null,
+            epsTTM: null,
+        })),
+    });
+    const provider = new CachedFundamentalProvider(inner);
+
+    const peers = await provider.getStockPeersRaw('AAPL');
+
+    expect(peers).toEqual([
+        { symbol: 'MSFT', companyName: 'Microsoft', marketCap: 3e12 },
+    ]);
+    // enrich가 일어나지 않아야 한다(per/psr fan-out 제거)
+    expect(inner.getKeyMetricsTtm).not.toHaveBeenCalled();
+    // raw 목록은 별도 키로 캐싱
+    expect(store.has('fundamental:peers-raw:AAPL')).toBe(true);
+
+    // 2번째 호출은 캐시 hit → inner.getStockPeers 추가 호출 없음
+    await provider.getStockPeersRaw('AAPL');
+    expect(inner.getStockPeers).toHaveBeenCalledTimes(1);
+});
+```
+
+`FakeFundamentalDataProvider.test.ts`에 추가:
+
+```ts
+it('getStockPeersRaw returns [] (deterministic E2E fixture)', async () => {
+    const provider = new FakeFundamentalDataProvider();
+    await expect(provider.getStockPeersRaw('AAPL')).resolves.toEqual([]);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn test src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts src/shared/api/fmp/__tests__/FakeFundamentalDataProvider.test.ts`
+Expected: FAIL — `getStockPeersRaw` does not exist (타입 에러 또는 런타임 undefined).
+
+- [ ] **Step 3a: Add consumer interface in `fundamentalProvider.types.ts`**
+
+`FundamentalProvider`(inner/raw surface)는 **그대로 두고**, 소비자용 확장 인터페이스를 추가한다:
+
+```ts
+import type {
+    FundamentalDataProvider,
+    FundamentalPeerInput,
+} from '@y0ngha/siglens-core';
+import type { FmpEarningsReportItem } from './fundamentalClient';
+
+// (기존 FundamentalProvider 인터페이스는 변경 없음 — inner/raw client 계약)
+
+/**
+ * 소비자(페이지·팩토리)가 받는 표면. `FundamentalProvider`에 페이지 전용 raw peer
+ * 조회를 더한다. raw peer(symbol/companyName/marketCap)는 PeersTable이 렌더하는
+ * 전부이며 per/psr enrich가 필요 없다 — enriched `getStockPeers`는 FactLayer(분석)
+ * 전용으로 유지된다. `CachedFundamentalProvider`가 이 표면을 구현하고,
+ * `FakeFundamentalDataProvider`(E2E)도 만족한다.
+ */
+export interface FundamentalProviderWithRawPeers extends FundamentalProvider {
+    getStockPeersRaw(symbol: string): Promise<FundamentalPeerInput[]>;
+}
+```
+
+- [ ] **Step 3b: Implement in `CachedFundamentalProvider.ts`**
+
+클래스 선언을 `implements FundamentalProviderWithRawPeers`로 바꾸고(import 추가), `getStockPeers`(enriched) 바로 아래에 추가한다. **constructor inner 타입은 `FundamentalProvider` 그대로**(inner는 raw `getStockPeers`만 제공):
+
+```ts
+import type {
+    FundamentalProvider,
+    FundamentalProviderWithRawPeers,
+} from './fundamentalProvider.types';
+
+export class CachedFundamentalProvider
+    implements FundamentalProviderWithRawPeers
+{
+    constructor(private readonly inner: FundamentalProvider) {}
+    // ...기존 메서드 유지(enriched getStockPeers 포함)...
+
+    /**
+     * 페이지 전용 raw peer 목록(symbol/companyName/marketCap). per/psr enrich 없음 →
+     * peer당 valuation fan-out 제거. PeersTable은 이 3개 필드만 렌더한다. enriched
+     * `getStockPeers`는 FactLayer(분석 프롬프트) 전용으로 그대로 둔다.
+     */
+    getStockPeersRaw = cache(
+        (symbol: string): Promise<FundamentalPeerInput[]> =>
+            getOrSetCache(`fundamental:peers-raw:${sym(symbol)}`, TTL, () =>
+                this.inner.getStockPeers(symbol)
+            )
+    );
+}
+```
+
+- [ ] **Step 3c: Update factory return type in `getFundamentalDataProvider.ts`**
+
+```ts
+import type { FundamentalProviderWithRawPeers } from './fundamentalProvider.types';
+export type { FundamentalProviderWithRawPeers } from './fundamentalProvider.types';
+
+export const getFundamentalDataProvider: () => FundamentalProviderWithRawPeers =
+    createE2EGatedSingleton(
+        () => new CachedFundamentalProvider(new FmpFundamentalClient()),
+        () => {
+            const { FakeFundamentalDataProvider } =
+                require('./FakeFundamentalDataProvider') as typeof import('./FakeFundamentalDataProvider');
+            return new FakeFundamentalDataProvider();
+        }
+    );
+```
+
+- [ ] **Step 3d: Implement in `FakeFundamentalDataProvider.ts`**
+
+`getStockPeers` 바로 아래에 추가(import는 이미 `FundamentalPeerInput` 존재):
+
+```ts
+async getStockPeersRaw(_symbol: string): Promise<FundamentalPeerInput[]> {
+    return [];
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `yarn test src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts src/shared/api/fmp/__tests__/FakeFundamentalDataProvider.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: tsc + commit**
+
+```bash
+yarn tsc --noEmit
+git add src/shared/api/fmp/fundamentalProvider.types.ts src/shared/api/fmp/CachedFundamentalProvider.ts src/shared/api/fmp/getFundamentalDataProvider.ts src/shared/api/fmp/FakeFundamentalDataProvider.ts src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts src/shared/api/fmp/__tests__/FakeFundamentalDataProvider.test.ts
+git commit -m "feat(fmp): add getStockPeersRaw (un-enriched, page-only peer list)"
+```
+
+---
+
+## Task 3: 페이지 peer를 raw로 전환
+
+페이지 `PeersSection`이 쓰는 `fundamentalData.getStockPeers`를 raw 위임으로 바꾼다. enriched `getStockPeers`(core 포트)는 분석 경로 전용으로 남는다.
+
+**Files:**
+- Modify: `src/app/[symbol]/fundamental/fundamentalData.ts:68-70`
+- Test: `src/app/[symbol]/fundamental/__tests__/fundamentalData.delegation.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`fundamentalData.delegation.test.ts`에 추가(이 파일의 기존 provider mock 패턴을 따른다 — `getFundamentalDataProvider`를 mock해 `getStockPeersRaw`/`getStockPeers` spy를 노출):
+
+```ts
+it('getStockPeers (page) delegates to provider.getStockPeersRaw (no enrich), not enriched getStockPeers', async () => {
+    const { getStockPeers } = await import(
+        '@/app/[symbol]/fundamental/fundamentalData'
+    );
+    await getStockPeers('AAPL');
+    expect(mockProvider.getStockPeersRaw).toHaveBeenCalledWith('AAPL');
+    expect(mockProvider.getStockPeers).not.toHaveBeenCalled();
+});
+```
+
+> 기존 파일의 mock 변수명(`mockProvider` 등)에 맞춰 조정한다. mock provider 객체에 `getStockPeersRaw: vi.fn(async () => [])`를 추가해야 한다.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn test src/app/[symbol]/fundamental/__tests__/fundamentalData.delegation.test.ts`
+Expected: FAIL — 현재 `getStockPeers`가 `provider.getStockPeers`(enriched)를 호출.
+
+- [ ] **Step 3: Switch delegation in `fundamentalData.ts`**
+
+line 67-70:
+
+```ts
+// 페이지 PeersTable은 티커·회사명·시총만 렌더하므로 per/psr enrich가 불필요하다 →
+// raw 경로로 위임해 peer valuation fan-out을 제거한다. enriched getStockPeers는
+// FactLayer(분석 프롬프트) 전용으로 남는다.
+export const getStockPeers = (
+    symbol: string
+): Promise<FundamentalPeerInput[]> =>
+    fundamentalClient.getStockPeersRaw(symbol);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn test src/app/[symbol]/fundamental/__tests__/fundamentalData.delegation.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: tsc + commit**
+
+```bash
+yarn tsc --noEmit
+git add src/app/[symbol]/fundamental/fundamentalData.ts src/app/[symbol]/fundamental/__tests__/fundamentalData.delegation.test.ts
+git commit -m "perf(fundamental): page peers use raw (un-enriched) list, drop per/psr fan-out"
+```
+
+---
+
+## Task 4: `mergeBarsByTime` 순수 함수
+
+**Files:**
+- Create: `src/shared/api/market/mergeBarsByTime.ts`
+- Test: `src/shared/api/market/__tests__/mergeBarsByTime.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import type { Bar } from '@y0ngha/siglens-core';
+import { mergeBarsByTime } from '@/shared/api/market/mergeBarsByTime';
+
+const bar = (time: number, close: number): Bar => ({
+    time,
+    open: close,
+    high: close,
+    low: close,
+    close,
+    volume: 1,
+});
+
+describe('mergeBarsByTime', () => {
+    it('concatenates disjoint ranges in ascending time order', () => {
+        const result = mergeBarsByTime([bar(1, 10), bar(2, 11)], [bar(3, 12)]);
+        expect(result.map(b => b.time)).toEqual([1, 2, 3]);
+    });
+
+    it('dedups overlapping times, preferring recent', () => {
+        const result = mergeBarsByTime(
+            [bar(1, 10), bar(2, 11)],
+            [bar(2, 99), bar(3, 12)]
+        );
+        expect(result.map(b => [b.time, b.close])).toEqual([
+            [1, 10],
+            [2, 99], // recent wins
+            [3, 12],
+        ]);
+    });
+
+    it('sorts unsorted inputs by time', () => {
+        const result = mergeBarsByTime([bar(3, 12), bar(1, 10)], [bar(2, 11)]);
+        expect(result.map(b => b.time)).toEqual([1, 2, 3]);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn test src/shared/api/market/__tests__/mergeBarsByTime.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+import type { Bar } from '@y0ngha/siglens-core';
+
+/**
+ * 두 Bar 배열을 time 기준 오름차순으로 병합·중복제거한다. 같은 time이 양쪽에 있으면
+ * `recent` 값을 우선한다(live 갱신분이 long-cache된 과거 값을 덮어쓰도록). EOD 캐시
+ * 분리에서 과거(long-cache) 윈도우와 최근(live) 윈도우를 합쳐 단일 연속 시리즈를
+ * 복원하는 데 쓴다 — 결과는 단일 `getBars(from=now-730d)`와 동일 집합이어야 한다.
+ */
+export function mergeBarsByTime(historical: Bar[], recent: Bar[]): Bar[] {
+    const byTime = new Map<number, Bar>();
+    for (const b of historical) byTime.set(b.time, b);
+    for (const b of recent) byTime.set(b.time, b); // recent wins on overlap
+    return [...byTime.values()].sort((a, b) => a.time - b.time);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn test src/shared/api/market/__tests__/mergeBarsByTime.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: commit**
+
+```bash
+git add src/shared/api/market/mergeBarsByTime.ts src/shared/api/market/__tests__/mergeBarsByTime.test.ts
+git commit -m "feat(market): add mergeBarsByTime pure helper for EOD cache split"
+```
+
+---
+
+## Task 5: EOD 캐시 분리 (`CachedMarketDataProvider` 1Day 2-윈도우)
+
+1Day & `before===undefined`일 때만 과거(long-cache)+최근(live)로 분리. 나머지 경로 불변. core 포트 `getBars`만 날짜 윈도우 달리해 호출 → `FmpMarketProvider` 무변경.
+
+**Files:**
+- Modify: `src/shared/api/market/CachedMarketDataProvider.ts`
+- Test: `src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`CachedMarketDataProvider.test.ts`에 추가(기존 fakeRedis mock 패턴 사용; 없으면 `CachedFundamentalProvider.test.ts`의 `vi.hoisted` fakeRedis 패턴 복제). `vi.setSystemTime`으로 `now` 고정:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Bar, GetBarsOptions } from '@y0ngha/siglens-core';
+import { CachedMarketDataProvider } from '@/shared/api/market/CachedMarketDataProvider';
+
+const bar = (time: number): Bar => ({
+    time,
+    open: 1,
+    high: 1,
+    low: 1,
+    close: 1,
+    volume: 1,
+});
+
+describe('CachedMarketDataProvider — 1Day EOD split', () => {
+    beforeEach(() => {
+        resetSharedState(); // fakeRedis store clear
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-30T15:00:00Z'));
+    });
+    afterEach(() => vi.useRealTimers());
+
+    it('splits 1Day into historical(before set) + recent(from set) and merges', async () => {
+        const getBars = vi.fn(async (o: GetBarsOptions) =>
+            o.before !== undefined ? [bar(1), bar(2)] : [bar(2), bar(3)]
+        );
+        const provider = new CachedMarketDataProvider({
+            getBars,
+            getQuote: vi.fn(async () => null),
+        });
+        const opts: GetBarsOptions = {
+            symbol: 'AAPL',
+            timeframe: '1Day',
+            from: '2024-06-30',
+        };
+
+        const result = await provider.getBars(opts);
+
+        // 두 윈도우 호출: 하나는 before(과거), 하나는 from override(최근)
+        const calls = getBars.mock.calls.map(c => c[0]);
+        expect(calls.some(c => c.before !== undefined)).toBe(true);
+        expect(calls.some(c => c.before === undefined && c.from !== '2024-06-30')).toBe(true);
+        // merge + dedup(시간 2 중복 → 1개), 오름차순
+        expect(result.map(b => b.time)).toEqual([1, 2, 3]);
+    });
+
+    it('serves historical window from long cache on the 2nd call (same day)', async () => {
+        const getBars = vi.fn(async (o: GetBarsOptions) =>
+            o.before !== undefined ? [bar(1)] : [bar(2)]
+        );
+        const provider = new CachedMarketDataProvider({
+            getBars,
+            getQuote: vi.fn(async () => null),
+        });
+        const opts: GetBarsOptions = { symbol: 'AAPL', timeframe: '1Day', from: '2024-06-30' };
+
+        await provider.getBars(opts);
+        await provider.getBars(opts);
+
+        const histCalls = getBars.mock.calls.filter(c => c[0].before !== undefined);
+        expect(histCalls).toHaveLength(1); // 과거 윈도우는 long-cache hit
+    });
+
+    it('leaves non-1Day timeframes on the single-key path', async () => {
+        const getBars = vi.fn(async () => [bar(1)]);
+        const provider = new CachedMarketDataProvider({
+            getBars,
+            getQuote: vi.fn(async () => null),
+        });
+        await provider.getBars({ symbol: 'AAPL', timeframe: '5Min', from: '2026-06-20' });
+        expect(getBars).toHaveBeenCalledTimes(1);
+        expect(getBars.mock.calls[0][0].before).toBeUndefined();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn test src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts`
+Expected: FAIL — 현재 `getBars`는 단일 `bars:raw` 경로라 윈도우 분리/2회 호출 없음.
+
+- [ ] **Step 3: Implement the split**
+
+`CachedMarketDataProvider.ts` 상단 import·상수·헬퍼 추가:
+
+```ts
+import { SECONDS_PER_DAY } from '@/shared/config/time';
+import { mergeBarsByTime } from './mergeBarsByTime';
+
+/** 과거(불변) 윈도우 종료점: 오늘 − 7일. 최근 윈도우와 겹쳐 주말·공휴일 갭 방지. */
+const EOD_HIST_TO_DAYS = 7;
+/** 최근(live) 윈도우 시작점: 오늘 − 10일(약 3일 overlap → dedup). */
+const EOD_RECENT_FROM_DAYS = 10;
+/** 과거 윈도우 long TTL. 키가 날짜로 self-versioning하므로 intraday 커버 + 여유. */
+const EOD_HIST_TTL_SECONDS = SECONDS_PER_DAY * 2;
+
+function isoDateDaysAgo(now: Date, days: number): string {
+    const d = new Date(now);
+    d.setUTCDate(d.getUTCDate() - days);
+    return d.toISOString().slice(0, 10);
+}
+```
+
+`getBars`를 분기로 교체하고 private 메서드 추가:
+
+```ts
+getBars = (options: GetBarsOptions): Promise<Bar[]> => {
+    // 1Day 라이브 뷰(before 미지정)만 과거(long)+최근(live) 분리. 인트라데이·과거
+    // 페이지네이션(before 지정)은 기존 단일 60s 경로 유지.
+    if (options.timeframe === '1Day' && options.before === undefined) {
+        return this.getCachedDailyBars(options);
+    }
+    return getOrSetCache(
+        buildBarsRawKey(options),
+        this.ttl(options.timeframe),
+        () => this.inner.getBars(options),
+        bars => bars.length > 0
+    );
+};
+
+/**
+ * 1Day 일봉을 불변 과거(long-cache)와 최근(live)로 나눠 fetch 후 병합한다.
+ * 과거 윈도우는 `before=오늘−7d`로 한정해 오늘 봉을 포함하지 않으므로(=불변)
+ * long TTL로 캐싱하고, 매일 키(`from`·`histTo` 날짜)가 self-versioning된다.
+ * 최근 윈도우(`from=오늘−10d`)는 작은 EOD(~10행)+오늘 봉(quote)을 기존 세션 TTL
+ * (장중 60s)로 가져온다. 두 윈도우는 약 3일 겹쳐 주말·공휴일 갭을 막고
+ * `mergeBarsByTime`가 중복(time)을 최근 우선으로 제거한다. 결과는 단일
+ * `getBars(from)`와 동일 집합이다.
+ */
+private async getCachedDailyBars(options: GetBarsOptions): Promise<Bar[]> {
+    const now = new Date();
+    const histTo = isoDateDaysAgo(now, EOD_HIST_TO_DAYS);
+    const recentFrom = isoDateDaysAgo(now, EOD_RECENT_FROM_DAYS);
+    const symbolKey = options.symbol.toUpperCase();
+    const [historical, recent] = await Promise.all([
+        getOrSetCache(
+            `bars:eodhist:${symbolKey}:${options.from ?? ''}:${histTo}`,
+            EOD_HIST_TTL_SECONDS,
+            () => this.inner.getBars({ ...options, before: histTo }),
+            bars => bars.length > 0
+        ),
+        getOrSetCache(
+            `bars:eodrecent:${symbolKey}:${recentFrom}`,
+            this.ttl('1Day'),
+            () => this.inner.getBars({ ...options, from: recentFrom }),
+            bars => bars.length > 0
+        ),
+    ]);
+    return mergeBarsByTime(historical, recent);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn test src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: tsc + scoped tests + commit**
+
+```bash
+yarn tsc --noEmit
+yarn test src/shared/api/market src/shared/api/fmp
+git add src/shared/api/market/CachedMarketDataProvider.ts src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
+git commit -m "perf(market): split 1Day EOD into immutable-history(long) + recent(live) caches"
+```
+
+---
+
+## Task 6: 전체 게이트 + 정리
+
+- [ ] **Step 1: scoped lint + tsc**
+
+Run: `yarn lint src/shared/api/fmp src/shared/api/market src/app/[symbol]/fundamental && yarn tsc --noEmit`
+Expected: 통과. (전체 build·e2e는 pre-push 훅이, 교차영향은 CI가 담당.)
+
+- [ ] **Step 2: 영향 테스트 스위트**
+
+Run: `yarn test src/shared/api/fmp src/shared/api/market src/app/[symbol]/fundamental`
+Expected: 전부 PASS.
+
+---
+
+## Self-Review (spec 대조)
+
+| spec 요구 | 구현 task |
+|---|---|
+| 변경1: valuation TTL 1h→24h(단일 상수) | Task 1 |
+| 변경2: `getStockPeersRaw` 인터페이스/Cached/Fake | Task 2 |
+| 변경2: 페이지 raw 위임, 분석 enriched 유지 | Task 3 |
+| 변경3: 1Day 2-윈도우(과거 long / 최근 live) + merge | Task 4(merge) + Task 5 |
+| FactLayer per/psr 보존(회귀 금지) | Task 3 (enriched `getStockPeers` 미변경 — 분석 경로 유지) |
+| core/`FmpFundamentalClient`/`FmpMarketProvider` 무변경 | Task 2(inner 계약 불변)·Task 5(포트 getBars만 사용) |
+| 에러/캐시 계약 보존(poison 방지·graceful·shouldCache) | Task 2·5 (`getOrSetCache` 그대로, `bars.length>0` 가드 유지) |
+| 테스트(각 변경) | Task 1·2·3·4·5 |
+| 비목표(SWR·empty-marker·배치) 미포함 | 계획에 없음 — 의도적 제외 |
+
+**Placeholder scan:** 없음(모든 코드 블록 실제 코드).
+**Type consistency:** `getStockPeersRaw`(types/Cached/Fake/page), `FundamentalProviderWithRawPeers`(types/factory), `mergeBarsByTime`(Task4 정의 ↔ Task5 사용), `isoDateDaysAgo`/상수(Task5 내부) — 일치.

--- a/docs/superpowers/specs/2026-06-30-fmp-cache-optimization-design.md
+++ b/docs/superpowers/specs/2026-06-30-fmp-cache-optimization-design.md
@@ -1,0 +1,146 @@
+# FMP 호출·egress 절감 캐시 개선 — 설계
+
+- 작성일: 2026-06-30
+- 스코프: siglens I/O 레이어 (`shared/api/fmp/*`, `shared/api/market/*`, `app/[symbol]/fundamental/*`)
+- core(`@y0ngha/siglens-core`) **무변경**
+- 상태: 설계 승인 대기
+
+---
+
+## 1. 배경 (실측)
+
+FMP 사용량 대시보드(15분 윈도우) 기준 총 ~1,558 calls / ~10.6 MB. 두 영역이 비용을 지배한다.
+
+| 영역 | 수치 | 비중 | 코드 근거 |
+|---|---|---|---|
+| **valuation**: `key-metrics-ttm` + `ratios-ttm` | 각 383 calls | 호출 49% | `fundamentalClient.ts:150-156`(쌍 fetch), `CachedFundamentalProvider.ts:169-196`(peer enrich fan-out) |
+| **EOD**: `historical-price-eod/full` | 117 calls / 6.59 MB | egress 62% | `FmpMarketProvider.ts:191-212`, `config.js`(장중 TTL 60s) |
+
+근본 원인(코드 확인):
+
+1. **valuation fan-out** — `CachedFundamentalProvider.getStockPeers`(cold)가 peer 최대 `PEER_LIMIT=10`개에 대해 `getKeyMetricsTtm(peer)`를 호출하고, 각 호출은 `getValuationRaw`로 `key-metrics-ttm` + `ratios-ttm`을 **쌍으로** fetch한다. cold peer 목록 1개 = 최대 1(stock-peers) + 10×2 = 21 FMP 호출.
+   - **그런데 페이지(`PeersTable.tsx:35-67`)는 per/psr을 렌더하지 않는다**(컬럼: 티커·회사명·시총, 모두 raw `stock-peers`에서 옴). peer per/psr의 유일한 소비처는 **FactLayer(AI 분석 프롬프트)** — core `submitFundamentalAnalysis` → `fundamentalPrompt`의 `PER ${p.per}, PSR ${p.psr}`. → **페이지 enrich는 순수 낭비.**
+2. **EOD 재fetch** — 일봉 캐시 TTL은 장중 60s(`computeBarsEffectiveTtl`, `BARS_OPEN_TTL_SECONDS=SECONDS_PER_MINUTE`). 과거 730일(`TIMEFRAME_LOOKBACK_DAYS['1Day']`)은 불변인데도 60초마다 통째(~115KB) 재fetch된다. 바뀌는 건 오늘 봉뿐이고 그건 이미 `fetchTodayQuoteBar`(quote)가 담당.
+
+### 사용자 신선도 (불변 보장)
+
+- **가격·등락률·공탐**: 클라 React Query refetch 30s(`useBars.ts:30`, `BARS_STALE_TIME_MS=30_000`). 본 설계와 무관, 항상 최신.
+- **valuation/재무/peer**: SSR + ISR 전용(클라 refetch 없음). fundamental 페이지 `revalidate=86400`(24h) + 섹션별 `staticSymbolCache`(24h). 즉 **사용자가 보는 재무 신선도 상한은 이미 24h**다.
+
+---
+
+## 2. 목표 / 비목표
+
+### 목표
+1. valuation FMP 호출 대폭 절감(특히 peer fan-out 제거).
+2. EOD egress·호출 급감(불변 과거를 거래일당 1회만 fetch).
+3. 사용자 화면·SEO·FactLayer 품질 **무손상**.
+4. 기존 캐싱 패턴(`getOrSetCache` + `React.cache`, poison 방지, graceful fallback) 일관 유지.
+
+### 비목표 (이번 스코프 제외 — 별도 백로그)
+- **SWR(stale-while-revalidate)** — `getOrSetCache`에 soft-TTL 백그라운드 갱신. 전역 캐시 품질 업그레이드지만 범위 외.
+- **음성 캐시(empty marker)** — 무효 심볼 반복 miss(3% Bad Request) 차단. earnings의 `markEarningsEmpty` 패턴. 범위 외 → **3% Bad Request는 이번에 미해결**.
+- **DCF/durable DB 티어**, **FMP 플랜 업그레이드**, **클라 전송 페이로드 trim**(별도 백로그 `indicator-payload-waste`).
+
+### 기각된 대안 (검토 후 제외)
+- **배치/벌크 엔드포인트**: 실측 결과 `key-metrics-ttm?symbol=AAPL,MSFT` → 빈 배열(다중심볼 미지원), `batch-quote`·`key-metrics-ttm-bulk`·`ratios-ttm-bulk`·`scores-bulk` 등 → **HTTP 402 Restricted**(현재 플랜 미제공). `market-capitalization-batch`만 동작하나 per/psr 없음. → valuation 배치 불가.
+- **봇 enrich 스킵(G1)**: 페이지가 ISR/`staticSymbolCache`라 봇이 cold-gen을 트리거하면 비-enrich 결과가 24h 고정돼 사람에게도 노출(캐시 포이즌). 채택 안 함.
+- **전역 cache-only enrich(Y)**: fan-out은 제거하나 분석 경로 cold peer가 null → FactLayer 품질 소폭 저하. X안이 우위.
+
+---
+
+## 3. 설계
+
+### 변경 1 — Valuation TTL 1h → 24h
+
+- `fundamentalClient.ts:45` `FMP_FUNDAMENTAL_REVALIDATE_SECONDS = SECONDS_PER_HOUR` → `SECONDS_PER_DAY`.
+- 이 단일 상수가 두 계층을 동시에 구동한다: (a) Next Data Cache `revalidate`(`fmpGet` opts), (b) Redis TTL(`CachedFundamentalProvider`의 모든 `fundamental:*` 키, `CachedFundamentalProvider.ts:26` `TTL`).
+- **효과**: 분석 경로 valuation + cross-deploy Redis 버퍼가 24h. 배포(`unstable_cache`=Next Data Cache가 buildId별로 리셋)에도 Redis(24h)가 버텨 FMP 직격 방어.
+- **사용자 영향 0**: 페이지는 이미 `staticSymbolCache` 24h. 본 종목 PER/PSR(`ValuationCard` ← `getKeyMetricsTtm(symbol)`)도 그 캐시 안. 분석 PER은 가격종속이나 분석은 별도 차트가격(클라 30s)을 쓰고 재무는 분기 단위라 24h 지연 수용 가능.
+- **정합**: `FMP_STATEMENTS_REVALIDATE_SECONDS`·`CONGRESS_REVALIDATE_SECONDS`는 이미 `SECONDS_PER_DAY`(`time.ts:24-25`).
+- earnings는 `getEarningsReports`의 `no-store`(`fundamentalClient.ts:426-427`) 그대로.
+- **검증**: 이 상수는 route segment config(`export const revalidate`)로 쓰이지 않으므로(사용처 = 위 2곳뿐) 리터럴 강제 규칙(MISTAKES §15)과 무관.
+
+### 변경 2 — Peer enrich split (X안)
+
+페이지는 raw peer(enrich 없음), 분석(FactLayer)만 enriched peer.
+
+- **추가 메서드** `getStockPeersRaw(symbol): Promise<FundamentalPeerInput[]>`:
+  - **인터페이스 분리**(타입 정합): 기존 `FundamentalProvider`(= inner/raw client 계약)는 **그대로 두고**, 소비자용 확장 인터페이스 `FundamentalProviderWithRawPeers extends FundamentalProvider { getStockPeersRaw }`를 `fundamentalProvider.types.ts`에 추가한다. `FundamentalProvider`에 직접 추가하면 inner(`FmpFundamentalClient`)도 구현이 강제되므로 분리한다 — `FmpFundamentalClient` 무변경 유지.
+  - `CachedFundamentalProvider`가 `FundamentalProviderWithRawPeers`를 구현(constructor inner 타입은 `FundamentalProvider` 그대로). 구현: `getOrSetCache('fundamental:peers-raw:<SYM>', TTL, () => this.inner.getStockPeers(symbol))` — **enrich 루프 없음**. inner의 raw `getStockPeers`(티커·회사명·시총, per/psr 미설정)를 그대로 캐싱.
+  - `getFundamentalDataProvider` 반환 타입을 `FundamentalProviderWithRawPeers`로 변경.
+  - `FakeFundamentalDataProvider`(E2E)에도 `getStockPeersRaw` 추가(팩토리가 Fake를 이 타입으로 반환).
+- **페이지 전환**: `fundamentalData.ts`의 `getStockPeers`(페이지 PeersSection이 사용)를 `fundamentalClient.getStockPeersRaw` 위임으로 변경. PeersTable 렌더는 동일(컬럼 3개) → **페이지 fan-out 완전 제거, 화면·SEO 변화 0**.
+- **분석/FactLayer 불변**: core 포트 `getStockPeers`(enriched)는 그대로 유지. core `submitFundamentalAnalysis`가 이를 호출해 per/psr을 받는다(2026-06-04 스펙이 정상화한 동작 — **회귀 금지**). 변경 1(24h)로 peer valuation도 대부분 캐시 hit.
+- **순효과**: valuation fan-out이 "페이지(낭비) + 분석"에서 **"분석만(봇 skipEnqueue, 실수요)"**으로 축소.
+- **검증**: 전환 후 enriched `getStockPeers` 호출처 = core 분석 경로뿐(페이지·news·overall 등 다른 소비자 없음 — grep 확인).
+
+### 변경 3 — EOD 캐시 분리 (1Day)
+
+불변 과거 EOD를 long-TTL로, 최근 구간(오늘 봉 포함)은 live로 분리한다. **핵심: core 포트 `getBars`를 날짜 윈도우만 달리해 2번 호출**하므로 `FmpMarketProvider`·core 무변경 — 캐싱·결합은 전부 `CachedMarketDataProvider`에 둔다(어댑터 순수성 유지).
+
+- **2-윈도우 분리**(`CachedMarketDataProvider`, timeframe=`1Day` & `before===undefined`일 때만):
+  - **과거(불변)**: `inner.getBars({ ...options, before: histTo })` — `before`(=endDate) 지정이면 `FmpMarketProvider.getDailyBars`가 오늘 봉을 붙이지 않음(`endDate === undefined ? fetchTodayQuoteBar : null`, `FmpMarketProvider.ts:201-204`). `historical-price-eod/full`이 `to=histTo`로 한정돼 불변. → long-cache.
+  - **최근(live)**: `inner.getBars({ ...options, from: recentFrom })` — 작은 EOD(~10일) + 오늘 봉(quote). → 기존 짧은 TTL(`computeBarsEffectiveTtl`, 장중 60s).
+  - **결합**: `mergeBarsByTime(hist, recent)` — time 기준 오름차순 dedup(겹치는 구간은 recent 우선). 순수 함수.
+- **윈도우 경계**(겹침으로 주말·공휴일·DST 갭 방지): `histTo = today−7d`, `recentFrom = today−10d`(약 3일 overlap → dedup). `from`(now−730d)은 호출자 값 유지. 날짜는 `YYYY-MM-DD`로 절단해 일 단위 self-versioning.
+- **캐시 키/TTL**:
+  - 과거: `bars:eodhist:<SYM>:<from>:<histTo>` — `from`·`histTo`가 매 거래일 변경 → self-versioning. `LONG_TTL = SECONDS_PER_DAY * 2`.
+  - 최근: `bars:eodrecent:<SYM>:<recentFrom>` — 기존 세션별 TTL(장중 60s).
+- **1Day 외**(인트라데이, `before` 지정된 과거 페이지네이션)는 기존 `bars:raw` 60s 단일 경로 그대로.
+- **결합 결과는 기존 indicator 캐시(`barsDataCache` `bars:<SYM>` 60s) 그대로 통과** → 지표 신선도·오늘 봉 무영향. 분리 전후 **결합 시리즈 동일**(단일 `getBars(from=now−730d)`와 같은 집합).
+- **효과**: 730일 EOD(~115KB)는 거래일당 1회/심볼. 최근(~10행) + quote만 60s. egress·EOD 호출 급감, quote(live tail)는 ~유지.
+- **사용자 영향 0**: 오늘 봉/가격은 최근 윈도우(live 60s) + 클라 30s 그대로.
+- **고려**: hist(~115KB) 2일 보관 → Redis 저장 소폭↑(허용). `now` 기준 윈도우는 `new Date()`로 산출, 테스트는 `vi.setSystemTime`로 결정화. E2E는 `getCachedMarketDataProvider`가 raw provider를 반환(Cached 우회)하므로 영향 없음.
+
+---
+
+## 4. 에러 처리 (기존 계약 보존)
+
+- FMP throw는 캐시 `set` 전에 전파 → 장애 미캐싱(poison 방지). (`getOrSetCache.ts:58`)
+- 빈 결과는 `shouldCache` 가드로 미캐싱(빈 봉/null). (`CachedMarketDataProvider.ts:64,72`)
+- Redis 미설정/장애 시 `getOrSetCache`가 fetcher 직접 호출로 graceful fallback. (`redisClient.ts:45-50`)
+- 페이지 섹션 degrade(`.catch` → `[]`/`null`) 유지. (`page.tsx` PeersSection/ValuationSection)
+
+---
+
+## 5. 테스트
+
+### 변경 1
+- `FMP_FUNDAMENTAL_REVALIDATE_SECONDS === SECONDS_PER_DAY` 단언.
+- `fmpGet` revalidate 인자·`getOrSetCache` ttl 인자가 24h로 전달되는지.
+
+### 변경 2
+- `getStockPeersRaw`가 `getKeyMetricsTtm`을 **호출하지 않음**(enrich 없음) + raw 필드(symbol/companyName/marketCap) 반환, per/psr 미설정.
+- 페이지(`fundamentalData.getStockPeers`)가 raw 경로를 사용.
+- **회귀 가드**: 분석 경로(core 포트 `getStockPeers`)는 여전히 enriched(per/psr 채워짐) — FactLayer N/A 회귀 방지.
+- `FakeFundamentalDataProvider.getStockPeersRaw` 존재(E2E 빌드 통과).
+
+### 변경 3
+- 같은 거래일 1Day getBars 2회 호출 시 **과거 윈도우(`before:histTo`)** inner 호출은 1회(long-cache hit), **최근 윈도우(`from:recentFrom`)** 는 짧은 TTL.
+- `mergeBarsByTime`(순수): 겹치는 time은 recent 우선, 오름차순 dedup. 분리 전후 결합 시리즈가 단일 `getBars(from=now−730d)`와 **동일 집합**.
+- 1Day가 아니거나 `before` 지정 시 기존 `bars:raw` 단일 경로 사용(분리 미적용).
+- `now` 의존 윈도우(`histTo`/`recentFrom`)는 `vi.setSystemTime`로 결정화(기존 flaky 사례 회피).
+
+---
+
+## 6. 예상 효과 (실측 기반)
+
+| 영역 | 현재 | 개선 후(예상) |
+|---|---|---|
+| valuation(383, 호출 49%) | 페이지+분석 fan-out, 1h TTL | 페이지 fan-out 0 + 분석 24h 캐시 → 대폭↓ |
+| EOD(6.59MB, egress 62%) | 장중 60s마다 730일 재fetch | 거래일당 1회/심볼 → egress·호출 급감 |
+| quote(live tail) | 117 | ~유지(의도된 live) |
+
+---
+
+## 7. 영향 파일 (예상)
+
+- `shared/api/fmp/fundamentalClient.ts` — TTL 상수.
+- `shared/api/fmp/fundamentalProvider.types.ts` — `FundamentalProviderWithRawPeers` 인터페이스 추가.
+- `shared/api/fmp/CachedFundamentalProvider.ts` — `getStockPeersRaw` 구현 + implements 변경.
+- `shared/api/fmp/getFundamentalDataProvider.ts` — 반환 타입 `FundamentalProviderWithRawPeers`.
+- `shared/api/fmp/FakeFundamentalDataProvider.ts` — `getStockPeersRaw` 구현(E2E).
+- `app/[symbol]/fundamental/fundamentalData.ts` — 페이지 peer를 raw로 위임.
+- `shared/api/market/CachedMarketDataProvider.ts` — 1Day 2-윈도우 분리 캐싱 + `mergeBarsByTime`(순수 함수, 동일 파일 또는 sibling). **`FmpMarketProvider`·core 무변경.**
+- 각 colocated `__tests__`.

--- a/src/app/[symbol]/fundamental/__tests__/fundamentalData.delegation.test.ts
+++ b/src/app/[symbol]/fundamental/__tests__/fundamentalData.delegation.test.ts
@@ -27,6 +27,7 @@ const mockProvider = vi.hoisted(() => ({
     getProfile: vi.fn(),
     getKeyMetricsTtm: vi.fn(),
     getStockPeers: vi.fn(),
+    getStockPeersRaw: vi.fn(async () => []),
     getRatiosTtm: vi.fn(),
     getIncomeStatementGrowth: vi.fn(),
     getFinancialScores: vi.fn(),
@@ -139,14 +140,10 @@ describe('fundamentalData delegation wiring', () => {
         assertOnlyMethodCalled('getKeyMetricsTtm', 'MSFT');
     });
 
-    it('getStockPeers delegates to provider.getStockPeers only', async () => {
-        const peers = [
-            { symbol: 'GOOG', companyName: 'Alphabet', marketCap: 2_000_000 },
-        ];
-        mockProvider.getStockPeers.mockResolvedValue(peers);
-        const result = await getStockPeers('AAPL');
-        expect(result).toEqual(peers);
-        assertOnlyMethodCalled('getStockPeers', 'AAPL');
+    it('getStockPeers (page) delegates to provider.getStockPeersRaw (no enrich), not enriched getStockPeers', async () => {
+        await getStockPeers('AAPL');
+        expect(mockProvider.getStockPeersRaw).toHaveBeenCalledWith('AAPL');
+        expect(mockProvider.getStockPeers).not.toHaveBeenCalled();
     });
 
     it('getRatiosTtm delegates to provider.getRatiosTtm only', async () => {

--- a/src/app/[symbol]/fundamental/__tests__/fundamentalData.delegation.test.ts
+++ b/src/app/[symbol]/fundamental/__tests__/fundamentalData.delegation.test.ts
@@ -142,8 +142,7 @@ describe('fundamentalData delegation wiring', () => {
 
     it('getStockPeers (page) delegates to provider.getStockPeersRaw (no enrich), not enriched getStockPeers', async () => {
         await getStockPeers('AAPL');
-        expect(mockProvider.getStockPeersRaw).toHaveBeenCalledWith('AAPL');
-        expect(mockProvider.getStockPeers).not.toHaveBeenCalled();
+        assertOnlyMethodCalled('getStockPeersRaw', 'AAPL');
     });
 
     it('getRatiosTtm delegates to provider.getRatiosTtm only', async () => {

--- a/src/app/[symbol]/fundamental/__tests__/fundamentalData.test.ts
+++ b/src/app/[symbol]/fundamental/__tests__/fundamentalData.test.ts
@@ -17,10 +17,6 @@ vi.mock('@/entities/ticker', () => ({
 const fundamentalClient = vi.hoisted(() => ({
     getProfile: vi.fn().mockResolvedValue(null),
     getStockPeers: vi.fn().mockResolvedValue([]),
-    // getStockPeersRaw is implemented on CachedFundamentalProvider (the outer
-    // decorator) and delegates to inner.getStockPeers. This stub satisfies the
-    // mock class shape so the factory can instantiate without errors.
-    getStockPeersRaw: vi.fn().mockResolvedValue([]),
     getKeyMetricsTtm: vi.fn().mockResolvedValue(null),
     getRatiosTtm: vi.fn().mockResolvedValue(null),
     getIncomeStatementGrowth: vi.fn().mockResolvedValue(null),
@@ -38,7 +34,6 @@ vi.mock('@/shared/api/fmp/fundamentalClient', async importOriginal => ({
     FmpFundamentalClient: class MockFmpFundamentalClient {
         getProfile = fundamentalClient.getProfile;
         getStockPeers = fundamentalClient.getStockPeers;
-        getStockPeersRaw = fundamentalClient.getStockPeersRaw;
         getKeyMetricsTtm = fundamentalClient.getKeyMetricsTtm;
         getRatiosTtm = fundamentalClient.getRatiosTtm;
         getIncomeStatementGrowth = fundamentalClient.getIncomeStatementGrowth;

--- a/src/app/[symbol]/fundamental/__tests__/fundamentalData.test.ts
+++ b/src/app/[symbol]/fundamental/__tests__/fundamentalData.test.ts
@@ -17,6 +17,10 @@ vi.mock('@/entities/ticker', () => ({
 const fundamentalClient = vi.hoisted(() => ({
     getProfile: vi.fn().mockResolvedValue(null),
     getStockPeers: vi.fn().mockResolvedValue([]),
+    // getStockPeersRaw is implemented on CachedFundamentalProvider (the outer
+    // decorator) and delegates to inner.getStockPeers. This stub satisfies the
+    // mock class shape so the factory can instantiate without errors.
+    getStockPeersRaw: vi.fn().mockResolvedValue([]),
     getKeyMetricsTtm: vi.fn().mockResolvedValue(null),
     getRatiosTtm: vi.fn().mockResolvedValue(null),
     getIncomeStatementGrowth: vi.fn().mockResolvedValue(null),
@@ -34,6 +38,7 @@ vi.mock('@/shared/api/fmp/fundamentalClient', async importOriginal => ({
     FmpFundamentalClient: class MockFmpFundamentalClient {
         getProfile = fundamentalClient.getProfile;
         getStockPeers = fundamentalClient.getStockPeers;
+        getStockPeersRaw = fundamentalClient.getStockPeersRaw;
         getKeyMetricsTtm = fundamentalClient.getKeyMetricsTtm;
         getRatiosTtm = fundamentalClient.getRatiosTtm;
         getIncomeStatementGrowth = fundamentalClient.getIncomeStatementGrowth;
@@ -81,164 +86,15 @@ describe('fundamentalData', () => {
         expect(result).toBeNull();
     });
 
-    it('getStockPeers returns an empty array', async () => {
+    // getStockPeers (page) delegates to provider.getStockPeersRaw (un-enriched).
+    // Per/psr enrichment was moved into CachedFundamentalProvider.getStockPeers
+    // (enriched, FactLayer-only); the page path uses getStockPeersRaw to avoid
+    // per-peer valuation fan-out. Delegation coverage lives in
+    // fundamentalData.delegation.test.ts; CachedFundamentalProvider.test.ts
+    // covers the raw vs enriched split at the provider level.
+    it('getStockPeers returns an empty array (raw, no enrich)', async () => {
         const result = await getStockPeers('AAPL');
         expect(result).toEqual([]);
-    });
-
-    describe('getStockPeers', () => {
-        it('populates per/psr from each peer key-metrics', async () => {
-            fundamentalClient.getStockPeers.mockResolvedValueOnce([
-                {
-                    symbol: 'MSFT',
-                    companyName: 'Microsoft',
-                    marketCap: 3_000_000,
-                },
-            ]);
-            fundamentalClient.getKeyMetricsTtm.mockResolvedValueOnce({
-                peRatioTTM: 35.5,
-                priceToSalesRatioTTM: 12.25,
-                pbRatioTTM: null,
-                pegRatioTTM: null,
-                enterpriseValueOverEBITDATTM: null,
-                epsTTM: null,
-            });
-
-            const result = await getStockPeers('AAPL');
-
-            expect(result).toEqual([
-                {
-                    symbol: 'MSFT',
-                    companyName: 'Microsoft',
-                    marketCap: 3_000_000,
-                    per: 35.5,
-                    psr: 12.25,
-                },
-            ]);
-            expect(fundamentalClient.getKeyMetricsTtm).toHaveBeenCalledWith(
-                'MSFT'
-            );
-        });
-
-        it('enriches each of multiple peers with its own key-metrics independently', async () => {
-            fundamentalClient.getStockPeers.mockResolvedValueOnce([
-                {
-                    symbol: 'MSFT',
-                    companyName: 'Microsoft',
-                    marketCap: 3_000_000,
-                },
-                {
-                    symbol: 'GOOG',
-                    companyName: 'Alphabet',
-                    marketCap: 2_000_000,
-                },
-            ]);
-            // Enrichment is sequential (peer order MSFT → GOOG), so the two
-            // `*Once` returns are consumed in that order — each peer receives
-            // its own distinct metrics. Using `*Once` (not `mockImplementation`)
-            // keeps this test from leaking a default into later cases.
-            fundamentalClient.getKeyMetricsTtm
-                .mockResolvedValueOnce({
-                    peRatioTTM: 35.5,
-                    priceToSalesRatioTTM: 12.25,
-                    pbRatioTTM: null,
-                    pegRatioTTM: null,
-                    enterpriseValueOverEBITDATTM: null,
-                    epsTTM: null,
-                })
-                .mockResolvedValueOnce({
-                    peRatioTTM: 24.5,
-                    priceToSalesRatioTTM: 6.5,
-                    pbRatioTTM: null,
-                    pegRatioTTM: null,
-                    enterpriseValueOverEBITDATTM: null,
-                    epsTTM: null,
-                });
-
-            const result = await getStockPeers('AAPL');
-
-            expect(result).toEqual([
-                {
-                    symbol: 'MSFT',
-                    companyName: 'Microsoft',
-                    marketCap: 3_000_000,
-                    per: 35.5,
-                    psr: 12.25,
-                },
-                {
-                    symbol: 'GOOG',
-                    companyName: 'Alphabet',
-                    marketCap: 2_000_000,
-                    per: 24.5,
-                    psr: 6.5,
-                },
-            ]);
-            expect(fundamentalClient.getKeyMetricsTtm).toHaveBeenCalledWith(
-                'MSFT'
-            );
-            expect(fundamentalClient.getKeyMetricsTtm).toHaveBeenCalledWith(
-                'GOOG'
-            );
-        });
-
-        it('defaults per/psr to null when a peer has no key-metrics', async () => {
-            fundamentalClient.getStockPeers.mockResolvedValueOnce([
-                {
-                    symbol: 'GOOG',
-                    companyName: 'Alphabet',
-                    marketCap: 2_000_000,
-                },
-            ]);
-            fundamentalClient.getKeyMetricsTtm.mockResolvedValueOnce(null);
-
-            const result = await getStockPeers('AAPL');
-
-            expect(result).toEqual([
-                {
-                    symbol: 'GOOG',
-                    companyName: 'Alphabet',
-                    marketCap: 2_000_000,
-                    per: null,
-                    psr: null,
-                },
-            ]);
-            expect(fundamentalClient.getKeyMetricsTtm).toHaveBeenCalledWith(
-                'GOOG'
-            );
-        });
-
-        it('defaults per/psr to null when key-metrics fields are null', async () => {
-            fundamentalClient.getStockPeers.mockResolvedValueOnce([
-                {
-                    symbol: 'AMZN',
-                    companyName: 'Amazon',
-                    marketCap: 1_500_000,
-                },
-            ]);
-            fundamentalClient.getKeyMetricsTtm.mockResolvedValueOnce({
-                peRatioTTM: null,
-                priceToSalesRatioTTM: null,
-                pbRatioTTM: null,
-                pegRatioTTM: null,
-                enterpriseValueOverEBITDATTM: null,
-                epsTTM: null,
-            });
-
-            const result = await getStockPeers('AAPL');
-
-            expect(result).toEqual([
-                {
-                    symbol: 'AMZN',
-                    companyName: 'Amazon',
-                    marketCap: 1_500_000,
-                    per: null,
-                    psr: null,
-                },
-            ]);
-            expect(fundamentalClient.getKeyMetricsTtm).toHaveBeenCalledWith(
-                'AMZN'
-            );
-        });
     });
 
     it('getKeyMetricsTtm returns null', async () => {

--- a/src/app/[symbol]/fundamental/fundamentalData.ts
+++ b/src/app/[symbol]/fundamental/fundamentalData.ts
@@ -64,10 +64,13 @@ export const getKeyMetricsTtm = (
 ): Promise<FundamentalValuationMetrics | null> =>
     fundamentalClient.getKeyMetricsTtm(symbol);
 
-// 캐싱·enrich가 CachedFundamentalProvider로 이관됐으므로 이중 처리 없이 위임한다.
+// 페이지 PeersTable은 티커·회사명·시총만 렌더하므로 per/psr enrich가 불필요하다 →
+// raw 경로로 위임해 peer valuation fan-out을 제거한다. enriched getStockPeers는
+// FactLayer(분석 프롬프트) 전용으로 남는다.
 export const getStockPeers = (
     symbol: string
-): Promise<FundamentalPeerInput[]> => fundamentalClient.getStockPeers(symbol);
+): Promise<FundamentalPeerInput[]> =>
+    fundamentalClient.getStockPeersRaw(symbol);
 
 export const getRatiosTtm = (
     symbol: string

--- a/src/shared/api/fmp/CachedFundamentalProvider.ts
+++ b/src/shared/api/fmp/CachedFundamentalProvider.ts
@@ -4,7 +4,10 @@ import { getOrSetCache } from '@/shared/cache/getOrSetCache';
 import { sym } from './symKey';
 import { FMP_FUNDAMENTAL_REVALIDATE_SECONDS } from './fundamentalClient';
 import type { FmpEarningsReportItem } from './fundamentalClient';
-import type { FundamentalProvider } from './fundamentalProvider.types';
+import type {
+    FundamentalProvider,
+    FundamentalProviderWithRawPeers,
+} from './fundamentalProvider.types';
 import type {
     EarningsReport,
     FundamentalAnalystEstimateInput,
@@ -38,7 +41,7 @@ export const PEER_LIMIT = 10;
  *
  * earnings(no-store + DB 영속)와 historical-sector(빈 stub)는 pass-through한다.
  */
-export class CachedFundamentalProvider implements FundamentalProvider {
+export class CachedFundamentalProvider implements FundamentalProviderWithRawPeers {
     constructor(private readonly inner: FundamentalProvider) {}
 
     getProfile = cache(
@@ -193,6 +196,18 @@ export class CachedFundamentalProvider implements FundamentalProvider {
                         Promise.resolve<FundamentalPeerInput[]>([])
                     );
             })
+    );
+
+    /**
+     * 페이지 전용 raw peer 목록(symbol/companyName/marketCap). per/psr enrich 없음 →
+     * peer당 valuation fan-out 제거. PeersTable은 이 3개 필드만 렌더한다. enriched
+     * `getStockPeers`는 FactLayer(분석 프롬프트) 전용으로 그대로 둔다.
+     */
+    getStockPeersRaw = cache(
+        (symbol: string): Promise<FundamentalPeerInput[]> =>
+            getOrSetCache(`fundamental:peers-raw:${sym(symbol)}`, TTL, () =>
+                this.inner.getStockPeers(symbol)
+            )
     );
 
     /**

--- a/src/shared/api/fmp/CachedFundamentalProvider.ts
+++ b/src/shared/api/fmp/CachedFundamentalProvider.ts
@@ -201,12 +201,18 @@ export class CachedFundamentalProvider implements FundamentalProviderWithRawPeer
     /**
      * 페이지 전용 raw peer 목록(symbol/companyName/marketCap). per/psr enrich 없음 →
      * peer당 valuation fan-out 제거. PeersTable은 이 3개 필드만 렌더한다. enriched
-     * `getStockPeers`는 FactLayer(분석 프롬프트) 전용으로 그대로 둔다.
+     * `getStockPeers`는 FactLayer(분석 프롬프트) 전용으로 그대로 둔다. 비정상적으로
+     * 큰 peer 목록을 방지하기 위해 enriched 경로와 동일하게 PEER_LIMIT으로 상한을 둔다.
      */
     getStockPeersRaw = cache(
         (symbol: string): Promise<FundamentalPeerInput[]> =>
-            getOrSetCache(`fundamental:peers-raw:${sym(symbol)}`, TTL, () =>
-                this.inner.getStockPeers(symbol)
+            getOrSetCache(
+                `fundamental:peers-raw:${sym(symbol)}`,
+                TTL,
+                async () => {
+                    const raw = await this.inner.getStockPeers(symbol);
+                    return raw.slice(0, PEER_LIMIT);
+                }
             )
     );
 

--- a/src/shared/api/fmp/CachedFundamentalProvider.ts
+++ b/src/shared/api/fmp/CachedFundamentalProvider.ts
@@ -227,7 +227,7 @@ export class CachedFundamentalProvider implements FundamentalProviderWithRawPeer
             )
     );
 
-    // earnings: DB-영속이라 Redis 캐시 대상 아님
+    // earnings: 실적 발표 시점 실시간성이 중요(no-store) → Redis TTL 미적용. fundamentalClient 주석 참고.
     getEarningsReport = (symbol: string): Promise<EarningsReport | null> =>
         this.inner.getEarningsReport(symbol);
 

--- a/src/shared/api/fmp/FakeFundamentalDataProvider.ts
+++ b/src/shared/api/fmp/FakeFundamentalDataProvider.ts
@@ -17,6 +17,7 @@ import type {
     GradesEvent,
 } from '@y0ngha/siglens-core';
 import type { FmpEarningsReportItem } from './fundamentalClient';
+import type { FundamentalProviderWithRawPeers } from './fundamentalProvider.types';
 
 /**
  * E2E-only `FundamentalDataProvider` returning deterministic, non-throwing
@@ -29,7 +30,9 @@ import type { FmpEarningsReportItem } from './fundamentalClient';
  * siglens-specific extras (`getGrades`, `getEarningsReports`) that some
  * injection points call directly on the concrete `FmpFundamentalClient`.
  */
-export class FakeFundamentalDataProvider implements FundamentalDataProvider {
+export class FakeFundamentalDataProvider
+    implements FundamentalDataProvider, FundamentalProviderWithRawPeers
+{
     async getProfile(symbol: string): Promise<FundamentalProfile | null> {
         return {
             symbol: symbol.toUpperCase(),
@@ -74,6 +77,10 @@ export class FakeFundamentalDataProvider implements FundamentalDataProvider {
     }
 
     async getStockPeers(_symbol: string): Promise<FundamentalPeerInput[]> {
+        return [];
+    }
+
+    async getStockPeersRaw(_symbol: string): Promise<FundamentalPeerInput[]> {
         return [];
     }
 

--- a/src/shared/api/fmp/FakeFundamentalDataProvider.ts
+++ b/src/shared/api/fmp/FakeFundamentalDataProvider.ts
@@ -2,7 +2,6 @@ import type {
     EarningsReport,
     FundamentalAnalystEstimateInput,
     FundamentalCashFlowInput,
-    FundamentalDataProvider,
     FundamentalFinancialScoresInput,
     FundamentalGradesConsensusInput,
     FundamentalGrowthInput,
@@ -30,9 +29,7 @@ import type { FundamentalProviderWithRawPeers } from './fundamentalProvider.type
  * siglens-specific extras (`getGrades`, `getEarningsReports`) that some
  * injection points call directly on the concrete `FmpFundamentalClient`.
  */
-export class FakeFundamentalDataProvider
-    implements FundamentalDataProvider, FundamentalProviderWithRawPeers
-{
+export class FakeFundamentalDataProvider implements FundamentalProviderWithRawPeers {
     async getProfile(symbol: string): Promise<FundamentalProfile | null> {
         return {
             symbol: symbol.toUpperCase(),

--- a/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
+++ b/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
@@ -373,6 +373,42 @@ describe('CachedFundamentalProvider — getStockPeers enrich', () => {
     });
 });
 
+describe('CachedFundamentalProvider — getStockPeersRaw', () => {
+    beforeEach(resetSharedState);
+
+    it('getStockPeersRaw caches raw peers WITHOUT enrich (no getKeyMetricsTtm calls)', async () => {
+        resetSharedState();
+        const inner = makeInner({
+            getStockPeers: vi.fn(async () => [
+                { symbol: 'MSFT', companyName: 'Microsoft', marketCap: 3e12 },
+            ]),
+            getKeyMetricsTtm: vi.fn(async () => ({
+                peRatioTTM: 10,
+                priceToSalesRatioTTM: 3,
+                pbRatioTTM: null,
+                pegRatioTTM: null,
+                enterpriseValueOverEBITDATTM: null,
+                epsTTM: null,
+            })),
+        });
+        const provider = new CachedFundamentalProvider(inner);
+
+        const peers = await provider.getStockPeersRaw('AAPL');
+
+        expect(peers).toEqual([
+            { symbol: 'MSFT', companyName: 'Microsoft', marketCap: 3e12 },
+        ]);
+        // enrich가 일어나지 않아야 한다(per/psr fan-out 제거)
+        expect(inner.getKeyMetricsTtm).not.toHaveBeenCalled();
+        // raw 목록은 별도 키로 캐싱
+        expect(store.has('fundamental:peers-raw:AAPL')).toBe(true);
+
+        // 2번째 호출은 캐시 hit → inner.getStockPeers 추가 호출 없음
+        await provider.getStockPeersRaw('AAPL');
+        expect(inner.getStockPeers).toHaveBeenCalledTimes(1);
+    });
+});
+
 describe('CachedFundamentalProvider — sector + pass-through', () => {
     beforeEach(resetSharedState);
 

--- a/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
+++ b/src/shared/api/fmp/__tests__/CachedFundamentalProvider.test.ts
@@ -407,6 +407,36 @@ describe('CachedFundamentalProvider — getStockPeersRaw', () => {
         await provider.getStockPeersRaw('AAPL');
         expect(inner.getStockPeers).toHaveBeenCalledTimes(1);
     });
+
+    it('getStockPeersRaw caps result at PEER_LIMIT (no getKeyMetricsTtm calls)', async () => {
+        const rawPeers = Array.from({ length: PEER_LIMIT + 3 }, (_, i) => ({
+            symbol: `P${i}`,
+            companyName: `Company ${i}`,
+            marketCap: 1e9,
+        }));
+        const inner = makeInner({
+            getStockPeers: vi.fn(async () => rawPeers),
+            getKeyMetricsTtm: vi.fn(async () => ({
+                peRatioTTM: 10,
+                priceToSalesRatioTTM: 3,
+                pbRatioTTM: null,
+                pegRatioTTM: null,
+                enterpriseValueOverEBITDATTM: null,
+                epsTTM: null,
+            })),
+        });
+        const provider = new CachedFundamentalProvider(inner);
+
+        const peers = await provider.getStockPeersRaw('AAPL');
+
+        // inner returns more than PEER_LIMIT → result must be capped
+        expect(peers).toHaveLength(PEER_LIMIT);
+        expect(peers.map((p: FundamentalPeerInput) => p.symbol)).toEqual(
+            rawPeers.slice(0, PEER_LIMIT).map(p => p.symbol)
+        );
+        // enrich must NOT happen (no getKeyMetricsTtm fan-out)
+        expect(inner.getKeyMetricsTtm).not.toHaveBeenCalled();
+    });
 });
 
 describe('CachedFundamentalProvider — sector + pass-through', () => {

--- a/src/shared/api/fmp/__tests__/FakeFundamentalDataProvider.test.ts
+++ b/src/shared/api/fmp/__tests__/FakeFundamentalDataProvider.test.ts
@@ -26,4 +26,8 @@ describe('FakeFundamentalDataProvider', () => {
     it('getEarningsReports returns an empty list (no-op DB upsert under E2E)', async () => {
         await expect(provider.getEarningsReports('AAPL')).resolves.toEqual([]);
     });
+
+    it('getStockPeersRaw returns [] (deterministic E2E fixture)', async () => {
+        await expect(provider.getStockPeersRaw('AAPL')).resolves.toEqual([]);
+    });
 });

--- a/src/shared/api/fmp/__tests__/fundamentalClient.test.ts
+++ b/src/shared/api/fmp/__tests__/fundamentalClient.test.ts
@@ -2,8 +2,17 @@ vi.mock('@/shared/lib/sleep', () => ({
     sleep: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { FmpFundamentalClient } from '../fundamentalClient';
-import { SECONDS_PER_HOUR } from '@/shared/config/time';
+import {
+    FmpFundamentalClient,
+    FMP_FUNDAMENTAL_REVALIDATE_SECONDS,
+} from '../fundamentalClient';
+import { SECONDS_PER_DAY } from '@/shared/config/time';
+
+describe('FMP_FUNDAMENTAL_REVALIDATE_SECONDS', () => {
+    it('is 24h (SECONDS_PER_DAY) — fundamentals are quarterly; aligns with statements/congress', () => {
+        expect(FMP_FUNDAMENTAL_REVALIDATE_SECONDS).toBe(SECONDS_PER_DAY);
+    });
+});
 
 const mockFetch = vi.fn();
 
@@ -817,7 +826,7 @@ describe('FmpFundamentalClient', () => {
     // ------------------------------------------------------------------ //
 
     describe('캐시 옵션', () => {
-        it('fundamental fetch는 1h next.revalidate로 캐싱된다', async () => {
+        it('fundamental fetch는 24h next.revalidate로 캐싱된다', async () => {
             mockOk([
                 {
                     symbol: 'AAPL',
@@ -834,7 +843,7 @@ describe('FmpFundamentalClient', () => {
             const opts = mockFetch.mock.calls[0]![1] as RequestInit & {
                 next?: { revalidate?: number };
             };
-            expect(opts.next?.revalidate).toBe(SECONDS_PER_HOUR);
+            expect(opts.next?.revalidate).toBe(SECONDS_PER_DAY);
         });
 
         it('earnings fetch는 no-store(캐시 안 함)다', async () => {

--- a/src/shared/api/fmp/fundamentalClient.ts
+++ b/src/shared/api/fmp/fundamentalClient.ts
@@ -1,6 +1,6 @@
 import { fmpGet as fmpGetRaw } from './httpClient';
 import { toFiniteNumber } from './toFiniteNumber';
-import { SECONDS_PER_HOUR } from '@/shared/config/time';
+import { SECONDS_PER_DAY } from '@/shared/config/time';
 import type {
     RawFmpAnalystEstimate,
     RawFmpCashFlowStatement,
@@ -38,11 +38,11 @@ import type {
 } from '@y0ngha/siglens-core';
 
 /**
- * 펀더멘털 데이터는 장중에도 거의 불변 → 1시간 freshness 창. Next Data Cache
- * `revalidate`와 호출부의 Redis TTL이 이 단일 상수를 공유해, 두 캐시 계층의
- * 신선도가 절대 어긋나지 않는다.
+ * 펀더멘털 데이터는 분기 단위 재무 + statements/congress와 정합 → 24시간 freshness 창.
+ * Next Data Cache `revalidate`와 호출부의 Redis TTL이 이 단일 상수를 공유해,
+ * 두 캐시 계층의 신선도가 절대 어긋나지 않는다.
  */
-export const FMP_FUNDAMENTAL_REVALIDATE_SECONDS = SECONDS_PER_HOUR;
+export const FMP_FUNDAMENTAL_REVALIDATE_SECONDS = SECONDS_PER_DAY;
 
 function fmpGet<T>(
     path: string,

--- a/src/shared/api/fmp/fundamentalProvider.types.ts
+++ b/src/shared/api/fmp/fundamentalProvider.types.ts
@@ -1,4 +1,7 @@
-import type { FundamentalDataProvider } from '@y0ngha/siglens-core';
+import type {
+    FundamentalDataProvider,
+    FundamentalPeerInput,
+} from '@y0ngha/siglens-core';
 import type { FmpEarningsReportItem } from './fundamentalClient';
 
 /**
@@ -19,4 +22,15 @@ export interface FundamentalProvider extends FundamentalDataProvider {
         symbol: string,
         limit?: number
     ): Promise<FmpEarningsReportItem[]>;
+}
+
+/**
+ * 소비자(페이지·팩토리)가 받는 표면. `FundamentalProvider`에 페이지 전용 raw peer
+ * 조회를 더한다. raw peer(symbol/companyName/marketCap)는 PeersTable이 렌더하는
+ * 전부이며 per/psr enrich가 필요 없다 — enriched `getStockPeers`는 FactLayer(분석)
+ * 전용으로 유지된다. `CachedFundamentalProvider`가 이 표면을 구현하고,
+ * `FakeFundamentalDataProvider`(E2E)도 만족한다.
+ */
+export interface FundamentalProviderWithRawPeers extends FundamentalProvider {
+    getStockPeersRaw(symbol: string): Promise<FundamentalPeerInput[]>;
 }

--- a/src/shared/api/fmp/getFundamentalDataProvider.ts
+++ b/src/shared/api/fmp/getFundamentalDataProvider.ts
@@ -1,15 +1,16 @@
 import { FmpFundamentalClient } from './fundamentalClient';
 import { CachedFundamentalProvider } from './CachedFundamentalProvider';
 import { createE2EGatedSingleton } from '@/shared/api/createE2EGatedSingleton';
-import type { FundamentalProvider } from './fundamentalProvider.types';
+import type { FundamentalProviderWithRawPeers } from './fundamentalProvider.types';
 
 // Re-exported so existing importers (`@/shared/api/fmp/getFundamentalDataProvider`)
-// keep resolving; the interface itself lives in `fundamentalProvider.types` to
+// keep resolving; the interfaces themselves live in `fundamentalProvider.types` to
 // avoid a type-level cycle with the `CachedFundamentalProvider` class import above.
 export type { FundamentalProvider } from './fundamentalProvider.types';
+export type { FundamentalProviderWithRawPeers } from './fundamentalProvider.types';
 
 /** Returns the app's fundamental data provider (FMP in prod, fake under E2E_TEST). */
-export const getFundamentalDataProvider: () => FundamentalProvider =
+export const getFundamentalDataProvider: () => FundamentalProviderWithRawPeers =
     createE2EGatedSingleton(
         () => new CachedFundamentalProvider(new FmpFundamentalClient()),
         () => {

--- a/src/shared/api/market/CachedMarketDataProvider.ts
+++ b/src/shared/api/market/CachedMarketDataProvider.ts
@@ -10,6 +10,21 @@ import {
     computeBarsEffectiveTtl,
 } from '@y0ngha/siglens-core';
 import { getOrSetCache } from '@/shared/cache/getOrSetCache';
+import { SECONDS_PER_DAY } from '@/shared/config/time';
+import { mergeBarsByTime } from './mergeBarsByTime';
+
+/** 과거(불변) 윈도우 종료점: 오늘 − 7일. 최근 윈도우와 겹쳐 주말·공휴일 갭 방지. */
+const EOD_HIST_TO_DAYS = 7;
+/** 최근(live) 윈도우 시작점: 오늘 − 10일(약 3일 overlap → dedup). */
+const EOD_RECENT_FROM_DAYS = 10;
+/** 과거 윈도우 long TTL. 키가 날짜로 self-versioning하므로 intraday 커버 + 여유. */
+const EOD_HIST_TTL_SECONDS = SECONDS_PER_DAY * 2;
+
+function isoDateDaysAgo(now: Date, days: number): string {
+    const d = new Date(now);
+    d.setUTCDate(d.getUTCDate() - days);
+    return d.toISOString().slice(0, 10);
+}
 
 /** quote TTL은 bars 일봉 개장-경계 정책을 재사용 — timeframe과 무관한 placeholder. */
 const QUOTE_TTL_TIMEFRAME = '1Day' as const satisfies Timeframe;
@@ -56,13 +71,50 @@ export class CachedMarketDataProvider implements MarketDataProvider {
         return computeBarsEffectiveTtl(timeframe, new Date(), this.session);
     }
 
-    getBars = (options: GetBarsOptions): Promise<Bar[]> =>
-        getOrSetCache(
+    getBars = (options: GetBarsOptions): Promise<Bar[]> => {
+        // 1Day 라이브 뷰(before 미지정)만 과거(long)+최근(live) 분리. 인트라데이·과거
+        // 페이지네이션(before 지정)은 기존 단일 60s 경로 유지.
+        if (options.timeframe === '1Day' && options.before === undefined) {
+            return this.getCachedDailyBars(options);
+        }
+        return getOrSetCache(
             buildBarsRawKey(options),
             this.ttl(options.timeframe),
             () => this.inner.getBars(options),
             bars => bars.length > 0
         );
+    };
+
+    /**
+     * 1Day 일봉을 불변 과거(long-cache)와 최근(live)로 나눠 fetch 후 병합한다.
+     * 과거 윈도우는 `before=오늘−7d`로 한정해 오늘 봉을 포함하지 않으므로(=불변)
+     * long TTL로 캐싱하고, 매일 키(`from`·`histTo` 날짜)가 self-versioning된다.
+     * 최근 윈도우(`from=오늘−10d`)는 작은 EOD(~10행)+오늘 봉(quote)을 기존 세션 TTL
+     * (장중 60s)로 가져온다. 두 윈도우는 약 3일 겹쳐 주말·공휴일 갭을 막고
+     * `mergeBarsByTime`가 중복(time)을 최근 우선으로 제거한다. 결과는 단일
+     * `getBars(from)`와 동일 집합이다.
+     */
+    private async getCachedDailyBars(options: GetBarsOptions): Promise<Bar[]> {
+        const now = new Date();
+        const histTo = isoDateDaysAgo(now, EOD_HIST_TO_DAYS);
+        const recentFrom = isoDateDaysAgo(now, EOD_RECENT_FROM_DAYS);
+        const symbolKey = options.symbol.toUpperCase();
+        const [historical, recent] = await Promise.all([
+            getOrSetCache(
+                `bars:eodhist:${symbolKey}:${options.from ?? ''}:${histTo}`,
+                EOD_HIST_TTL_SECONDS,
+                () => this.inner.getBars({ ...options, before: histTo }),
+                bars => bars.length > 0
+            ),
+            getOrSetCache(
+                `bars:eodrecent:${symbolKey}:${recentFrom}`,
+                this.ttl('1Day'),
+                () => this.inner.getBars({ ...options, from: recentFrom }),
+                bars => bars.length > 0
+            ),
+        ]);
+        return mergeBarsByTime(historical, recent);
+    }
 
     getQuote = (symbol: string): Promise<MarketQuote | null> =>
         getOrSetCache(

--- a/src/shared/api/market/CachedMarketDataProvider.ts
+++ b/src/shared/api/market/CachedMarketDataProvider.ts
@@ -80,7 +80,7 @@ export class CachedMarketDataProvider implements MarketDataProvider {
     private isLongDailyWindow(from: string | undefined): boolean {
         // from===undefined ⇒ full history ⇒ split. Otherwise only split when the
         // requested start is older than the recent window; a short lookback (from
-        // within the last ~10d) would invert the historical window, so it uses the
+        // within the last ~EOD_RECENT_FROM_DAYS days) would invert the historical window, so it uses the
         // single-key path instead.
         if (from === undefined) return true;
         const recentFrom = isoDateDaysAgo(new Date(), EOD_RECENT_FROM_DAYS);
@@ -89,7 +89,7 @@ export class CachedMarketDataProvider implements MarketDataProvider {
 
     getBars = (options: GetBarsOptions): Promise<Bar[]> => {
         // 1Day 라이브 뷰(before 미지정)이면서 lookback이 충분히 긴 경우에만 과거(long)+최근(live) 분리.
-        // 짧은 lookback(from이 최근 ~10d 이내)은 과거 윈도우가 역전되므로 단일 경로 사용.
+        // 짧은 lookback(from이 최근 ~EOD_RECENT_FROM_DAYS일 이내)은 과거 윈도우가 역전되므로 단일 경로 사용.
         // 인트라데이·과거 페이지네이션(before 지정)도 기존 단일 60s 경로 유지.
         if (
             options.timeframe === '1Day' &&
@@ -112,10 +112,10 @@ export class CachedMarketDataProvider implements MarketDataProvider {
      * 직접 호출하지 말고 반드시 getBars를 통해 라우팅할 것.
      *
      * 1Day 일봉을 불변 과거(long-cache)와 최근(live)로 나눠 fetch 후 병합한다.
-     * 과거 윈도우는 `before=오늘−7d`로 한정해 오늘 봉을 포함하지 않으므로(=불변)
+     * 과거 윈도우는 `before=오늘−EOD_HIST_TO_DAYS`로 한정해 오늘 봉을 포함하지 않으므로(=불변)
      * long TTL로 캐싱하고, 매일 키(`from`·`histTo` 날짜)가 self-versioning된다.
-     * 최근 윈도우(`from=오늘−10d`)는 작은 EOD(~10행)+오늘 봉(quote)을 기존 세션 TTL
-     * (장중 60s)로 가져온다. 두 윈도우는 약 3일 겹쳐 주말·공휴일 갭을 막고
+     * 최근 윈도우(`from=오늘−EOD_RECENT_FROM_DAYS`)는 작은 EOD(~EOD_RECENT_FROM_DAYS행)+오늘 봉(quote)을 기존 세션 TTL
+     * (장중 60s)로 가져온다. 두 윈도우는 (EOD_RECENT_FROM_DAYS - EOD_HIST_TO_DAYS)일 겹쳐 주말·공휴일 갭을 막고
      * `mergeBarsByTime`가 중복(time)을 최근 우선으로 제거한다. 결과는 단일
      * `getBars(from)`와 동일 집합이다.
      */

--- a/src/shared/api/market/CachedMarketDataProvider.ts
+++ b/src/shared/api/market/CachedMarketDataProvider.ts
@@ -71,10 +71,31 @@ export class CachedMarketDataProvider implements MarketDataProvider {
         return computeBarsEffectiveTtl(timeframe, new Date(), this.session);
     }
 
+    /**
+     * `from`이 최근 윈도우(오늘−EOD_RECENT_FROM_DAYS) 이전인지 확인한다.
+     * `from===undefined`이면 전체 히스토리 요청이므로 항상 split을 적용한다.
+     * `from`이 최근 윈도우 안에 있으면(짧은 lookback), 과거 윈도우가 역전되므로
+     * single-key 경로를 사용한다.
+     */
+    private isLongDailyWindow(from: string | undefined): boolean {
+        // from===undefined ⇒ full history ⇒ split. Otherwise only split when the
+        // requested start is older than the recent window; a short lookback (from
+        // within the last ~10d) would invert the historical window, so it uses the
+        // single-key path instead.
+        if (from === undefined) return true;
+        const recentFrom = isoDateDaysAgo(new Date(), EOD_RECENT_FROM_DAYS);
+        return from.slice(0, 10) < recentFrom;
+    }
+
     getBars = (options: GetBarsOptions): Promise<Bar[]> => {
-        // 1Day 라이브 뷰(before 미지정)만 과거(long)+최근(live) 분리. 인트라데이·과거
-        // 페이지네이션(before 지정)은 기존 단일 60s 경로 유지.
-        if (options.timeframe === '1Day' && options.before === undefined) {
+        // 1Day 라이브 뷰(before 미지정)이면서 lookback이 충분히 긴 경우에만 과거(long)+최근(live) 분리.
+        // 짧은 lookback(from이 최근 ~10d 이내)은 과거 윈도우가 역전되므로 단일 경로 사용.
+        // 인트라데이·과거 페이지네이션(before 지정)도 기존 단일 60s 경로 유지.
+        if (
+            options.timeframe === '1Day' &&
+            options.before === undefined &&
+            this.isLongDailyWindow(options.from)
+        ) {
             return this.getCachedDailyBars(options);
         }
         return getOrSetCache(
@@ -86,6 +107,10 @@ export class CachedMarketDataProvider implements MarketDataProvider {
     };
 
     /**
+     * 요청 윈도우가 최근 overlap 구간(오늘−EOD_RECENT_FROM_DAYS)보다 앞에서 시작함을
+     * 전제로 한다(isLongDailyWindow 가드 통과 후 진입). 짧은 lookback은 getCachedDailyBars를
+     * 직접 호출하지 말고 반드시 getBars를 통해 라우팅할 것.
+     *
      * 1Day 일봉을 불변 과거(long-cache)와 최근(live)로 나눠 fetch 후 병합한다.
      * 과거 윈도우는 `before=오늘−7d`로 한정해 오늘 봉을 포함하지 않으므로(=불변)
      * long TTL로 캐싱하고, 매일 키(`from`·`histTo` 날짜)가 self-versioning된다.

--- a/src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
+++ b/src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
@@ -216,13 +216,16 @@ describe('CachedMarketDataProvider', () => {
             const result = await provider.getBars(opts);
 
             // 두 윈도우 호출: 하나는 before(과거), 하나는 from override(최근)
+            // system time: 2026-06-30T15:00:00Z → histTo=2026-06-23, recentFrom=2026-06-20
             const calls = getBars.mock.calls.map(c => c[0]);
-            expect(calls.some(c => c.before !== undefined)).toBe(true);
-            expect(
-                calls.some(
-                    c => c.before === undefined && c.from !== '2024-06-30'
-                )
-            ).toBe(true);
+            const histCall = calls.find(c => c.before !== undefined);
+            expect(histCall).toBeDefined();
+            expect(histCall?.before).toBe('2026-06-23');
+            const recentCall = calls.find(
+                c => c.before === undefined && c.from !== '2024-06-30'
+            );
+            expect(recentCall).toBeDefined();
+            expect(recentCall?.from).toBe('2026-06-20');
             // merge + dedup(시간 2 중복 → 1개), 오름차순
             expect(result.map(b => b.time)).toEqual([1, 2, 3]);
         });
@@ -454,6 +457,27 @@ describe('CachedMarketDataProvider', () => {
             const recentTtl = recentSetCall?.[2]?.ex;
             expect(typeof recentTtl).toBe('number');
             expect(recentTtl).toBeGreaterThan(60); // closed-session TTL > 60s
+        });
+
+        it('1Day with before set → single-key path (no EOD split)', async () => {
+            const getBars = vi.fn(async (_o: GetBarsOptions) => [bar(1)]);
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+            await provider.getBars({
+                symbol: 'AAPL',
+                timeframe: '1Day',
+                from: '2024-01-01',
+                before: '2026-06-20',
+            });
+            expect(getBars).toHaveBeenCalledTimes(1);
+            expect(
+                [...store.keys()].some(k => k.startsWith('bars:eodhist'))
+            ).toBe(false);
+            expect(store.has('bars:raw:AAPL:1Day:2024-01-01:2026-06-20:')).toBe(
+                true
+            );
         });
     });
 

--- a/src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
+++ b/src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
@@ -37,6 +37,16 @@ vi.mock('@/shared/cache/redisClient', () => ({
     getRedisClient: () => (redisEnabled ? fakeRedis : null),
 }));
 
+/** Minimal bar factory for EOD split tests. */
+const bar = (time: number): Bar => ({
+    time,
+    open: 1,
+    high: 1,
+    low: 1,
+    close: 1,
+    volume: 1,
+});
+
 const SAMPLE_BARS: Bar[] = [
     { time: 1, open: 1, high: 2, low: 0.5, close: 1.5, volume: 100 },
 ];
@@ -57,9 +67,14 @@ function makeInner(
     } as MarketDataProvider;
 }
 
+/**
+ * barsOpts defaults to '5Min' so the single-key (`bars:raw:*`) path is exercised —
+ * '1Day' without `before` now goes through the EOD-split path (getCachedDailyBars).
+ * Tests that specifically target 1Day caching live in the '1Day EOD split' describe block.
+ */
 const barsOpts = (o: Partial<GetBarsOptions> = {}): GetBarsOptions => ({
     symbol: 'aapl',
-    timeframe: '1Day',
+    timeframe: '5Min',
     from: '2026-01-01',
     ...o,
 });
@@ -72,6 +87,11 @@ function reset() {
     fakeRedis.set.mockClear();
 }
 
+/** Alias used by the EOD split tests (mirrors CachedFundamentalProvider naming). */
+function resetSharedState() {
+    reset();
+}
+
 describe('CachedMarketDataProvider', () => {
     beforeEach(reset);
 
@@ -82,7 +102,7 @@ describe('CachedMarketDataProvider', () => {
         const first = await p.getBars(barsOpts());
         expect(first).toEqual(SAMPLE_BARS);
         expect(inner.getBars).toHaveBeenCalledTimes(1);
-        expect(store.has('bars:raw:AAPL:1Day:2026-01-01::')).toBe(true);
+        expect(store.has('bars:raw:AAPL:5Min:2026-01-01::')).toBe(true);
 
         const second = await p.getBars(barsOpts());
         expect(second).toEqual(SAMPLE_BARS);
@@ -95,7 +115,7 @@ describe('CachedMarketDataProvider', () => {
         expect(await p.getBars(barsOpts())).toEqual([]);
         expect(await p.getBars(barsOpts())).toEqual([]);
         expect(inner.getBars).toHaveBeenCalledTimes(2);
-        expect(store.has('bars:raw:AAPL:1Day:2026-01-01::')).toBe(false);
+        expect(store.has('bars:raw:AAPL:5Min:2026-01-01::')).toBe(false);
     });
 
     it('getBars: from/before/limit이 모두 undefined면 키에 빈 문자열로 채워진다 (?? 가드)', async () => {
@@ -103,7 +123,7 @@ describe('CachedMarketDataProvider', () => {
         const p = new CachedMarketDataProvider(inner);
         await p.getBars(barsOpts({ from: undefined }));
         expect(inner.getBars).toHaveBeenCalledTimes(1);
-        expect(store.has('bars:raw:AAPL:1Day:::')).toBe(true);
+        expect(store.has('bars:raw:AAPL:5Min:::')).toBe(true);
     });
 
     it('getBars: from/before가 다르면 키가 분리된다', async () => {
@@ -113,9 +133,9 @@ describe('CachedMarketDataProvider', () => {
         await p.getBars(barsOpts({ from: '2026-02-01' }));
         await p.getBars(barsOpts({ from: '2026-01-01', before: '2026-03-01' }));
         expect(inner.getBars).toHaveBeenCalledTimes(3);
-        expect(store.has('bars:raw:AAPL:1Day:2026-01-01::')).toBe(true);
-        expect(store.has('bars:raw:AAPL:1Day:2026-02-01::')).toBe(true);
-        expect(store.has('bars:raw:AAPL:1Day:2026-01-01:2026-03-01:')).toBe(
+        expect(store.has('bars:raw:AAPL:5Min:2026-01-01::')).toBe(true);
+        expect(store.has('bars:raw:AAPL:5Min:2026-02-01::')).toBe(true);
+        expect(store.has('bars:raw:AAPL:5Min:2026-01-01:2026-03-01:')).toBe(
             true
         );
     });
@@ -126,8 +146,8 @@ describe('CachedMarketDataProvider', () => {
         await p.getBars(barsOpts({ limit: 100 }));
         await p.getBars(barsOpts({ limit: 200 }));
         expect(inner.getBars).toHaveBeenCalledTimes(2);
-        expect(store.has('bars:raw:AAPL:1Day:2026-01-01::100')).toBe(true);
-        expect(store.has('bars:raw:AAPL:1Day:2026-01-01::200')).toBe(true);
+        expect(store.has('bars:raw:AAPL:5Min:2026-01-01::100')).toBe(true);
+        expect(store.has('bars:raw:AAPL:5Min:2026-01-01::200')).toBe(true);
     });
 
     it('getBars: inner throw는 전파되고 캐싱되지 않는다(worst case)', async () => {
@@ -169,6 +189,81 @@ describe('CachedMarketDataProvider', () => {
         expect(await p.getBars(barsOpts())).toEqual(SAMPLE_BARS);
         expect(await p.getQuote('AAPL')).toEqual(SAMPLE_QUOTE);
         expect(store.size).toBe(0);
+    });
+
+    describe('1Day EOD split', () => {
+        beforeEach(() => {
+            resetSharedState(); // fakeRedis store clear
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-06-30T15:00:00Z'));
+        });
+        afterEach(() => vi.useRealTimers());
+
+        it('splits 1Day into historical(before set) + recent(from set) and merges', async () => {
+            const getBars = vi.fn(async (o: GetBarsOptions) =>
+                o.before !== undefined ? [bar(1), bar(2)] : [bar(2), bar(3)]
+            );
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+            const opts: GetBarsOptions = {
+                symbol: 'AAPL',
+                timeframe: '1Day',
+                from: '2024-06-30',
+            };
+
+            const result = await provider.getBars(opts);
+
+            // 두 윈도우 호출: 하나는 before(과거), 하나는 from override(최근)
+            const calls = getBars.mock.calls.map(c => c[0]);
+            expect(calls.some(c => c.before !== undefined)).toBe(true);
+            expect(
+                calls.some(
+                    c => c.before === undefined && c.from !== '2024-06-30'
+                )
+            ).toBe(true);
+            // merge + dedup(시간 2 중복 → 1개), 오름차순
+            expect(result.map(b => b.time)).toEqual([1, 2, 3]);
+        });
+
+        it('serves historical window from long cache on the 2nd call (same day)', async () => {
+            const getBars = vi.fn(async (o: GetBarsOptions) =>
+                o.before !== undefined ? [bar(1)] : [bar(2)]
+            );
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+            const opts: GetBarsOptions = {
+                symbol: 'AAPL',
+                timeframe: '1Day',
+                from: '2024-06-30',
+            };
+
+            await provider.getBars(opts);
+            await provider.getBars(opts);
+
+            const histCalls = getBars.mock.calls.filter(
+                c => c[0].before !== undefined
+            );
+            expect(histCalls).toHaveLength(1); // 과거 윈도우는 long-cache hit
+        });
+
+        it('leaves non-1Day timeframes on the single-key path', async () => {
+            const getBars = vi.fn(async (_o: GetBarsOptions) => [bar(1)]);
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+            await provider.getBars({
+                symbol: 'AAPL',
+                timeframe: '5Min',
+                from: '2026-06-20',
+            });
+            expect(getBars).toHaveBeenCalledTimes(1);
+            expect(getBars.mock.calls[0]?.[0].before).toBeUndefined();
+        });
     });
 
     describe('session spec — TTL', () => {

--- a/src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
+++ b/src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
@@ -264,6 +264,197 @@ describe('CachedMarketDataProvider', () => {
             expect(getBars).toHaveBeenCalledTimes(1);
             expect(getBars.mock.calls[0]?.[0].before).toBeUndefined();
         });
+
+        // Fix 3(a): from=undefined split branch
+        it('(a) from=undefined → split taken; historical key has empty from segment', async () => {
+            // system time: 2026-06-30T15:00:00Z (set in beforeEach)
+            // histTo = 2026-06-23, recentFrom = 2026-06-20
+            const getBars = vi.fn(async (o: GetBarsOptions) =>
+                o.before !== undefined ? [bar(10), bar(11)] : [bar(11), bar(12)]
+            );
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+
+            const result = await provider.getBars({
+                symbol: 'AAPL',
+                timeframe: '1Day',
+                // from is undefined → isLongDailyWindow returns true
+            });
+
+            // Split was taken: two inner.getBars calls
+            expect(getBars).toHaveBeenCalledTimes(2);
+            // Historical key: bars:eodhist:AAPL::<histTo> (empty from segment)
+            const histKey = [...store.keys()].find(k =>
+                k.startsWith('bars:eodhist:AAPL::')
+            );
+            expect(histKey).toBeDefined();
+            // Merged result: dedup on time=11, sorted
+            expect(result.map(b => b.time)).toEqual([10, 11, 12]);
+        });
+
+        // Fix 3(b): FMP throw poison-prevention on split path
+        it('(b) inner.getBars throw on split path → rejects without caching anything', async () => {
+            const getBars = vi.fn(async (_o: GetBarsOptions) => {
+                throw new Error('FMP 503');
+            });
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+
+            await expect(
+                provider.getBars({
+                    symbol: 'AAPL',
+                    timeframe: '1Day',
+                    from: '2024-01-01',
+                })
+            ).rejects.toThrow('FMP 503');
+            expect(store.size).toBe(0);
+        });
+
+        // Fix 3(c): Redis-down fallback on split path
+        it('(c) redisEnabled=false on split path → returns merged result, store empty', async () => {
+            redisEnabled = false;
+            const getBars = vi.fn(async (o: GetBarsOptions) =>
+                o.before !== undefined ? [bar(1)] : [bar(1), bar(2)]
+            );
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+
+            const result = await provider.getBars({
+                symbol: 'AAPL',
+                timeframe: '1Day',
+                from: '2024-01-01',
+            });
+
+            expect(result.map(b => b.time)).toEqual([1, 2]);
+            expect(store.size).toBe(0);
+        });
+
+        // Fix 3(d): short-window fallback (Fix 1 guard)
+        it('(d) short 1Day window (from within last 10d) → single-key path, no eodhist/eodrecent keys', async () => {
+            // system time: 2026-06-30T15:00:00Z
+            // recentFrom = today - 10d = 2026-06-20
+            // from=2026-06-27 is within last 10d → isLongDailyWindow returns false
+            const getBars = vi.fn(async (_o: GetBarsOptions) => [bar(5)]);
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+
+            await provider.getBars({
+                symbol: 'AAPL',
+                timeframe: '1Day',
+                from: '2026-06-27', // within last 10d from 2026-06-30
+            });
+
+            // Single inner call (not two)
+            expect(getBars).toHaveBeenCalledTimes(1);
+            // No eodhist or eodrecent keys; uses bars:raw key
+            const hasHistKey = [...store.keys()].some(k =>
+                k.startsWith('bars:eodhist')
+            );
+            const hasRecentKey = [...store.keys()].some(k =>
+                k.startsWith('bars:eodrecent')
+            );
+            const hasRawKey = [...store.keys()].some(k =>
+                k.startsWith('bars:raw')
+            );
+            expect(hasHistKey).toBe(false);
+            expect(hasRecentKey).toBe(false);
+            expect(hasRawKey).toBe(true);
+        });
+
+        // Fix 3(e): empty-window shouldCache guard
+        it('(e) one window returns [] → that window key NOT written; merge returns non-empty side', async () => {
+            // historical returns [], recent returns [bar(5)]
+            const getBars = vi.fn(async (o: GetBarsOptions) =>
+                o.before !== undefined ? [] : [bar(5)]
+            );
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+
+            const result = await provider.getBars({
+                symbol: 'AAPL',
+                timeframe: '1Day',
+                from: '2024-01-01',
+            });
+
+            // Historical key (empty result) must NOT be cached
+            const hasHistKey = [...store.keys()].some(k =>
+                k.startsWith('bars:eodhist')
+            );
+            expect(hasHistKey).toBe(false);
+            // Recent key (non-empty) must be cached
+            const hasRecentKey = [...store.keys()].some(k =>
+                k.startsWith('bars:eodrecent')
+            );
+            expect(hasRecentKey).toBe(true);
+            // Merge still returns the non-empty side
+            expect(result.map(b => b.time)).toEqual([5]);
+        });
+
+        // Fix 3(f): recent-window TTL — open vs closed
+        it('(f) bars:eodrecent TTL: market-open instant → 60s', async () => {
+            // ET regular session open: Mon 2026-06-29 14:30 UTC = 10:30 ET
+            vi.setSystemTime(new Date('2026-06-29T14:30:00Z'));
+            resetSharedState();
+
+            const getBars = vi.fn(async (_o: GetBarsOptions) => [bar(1)]);
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+
+            await provider.getBars({
+                symbol: 'AAPL',
+                timeframe: '1Day',
+                from: '2024-01-01',
+            });
+
+            // Find the set call for bars:eodrecent:* key
+            const recentSetCall = fakeRedis.set.mock.calls.find(
+                ([key]) =>
+                    typeof key === 'string' && key.startsWith('bars:eodrecent')
+            );
+            expect(recentSetCall).toBeDefined();
+            const recentTtl = recentSetCall?.[2]?.ex;
+            expect(recentTtl).toBe(60); // open-session TTL
+        });
+
+        it('(f) bars:eodrecent TTL: market-closed instant → > 60s', async () => {
+            // Saturday 2026-06-27 12:00 UTC — US equity market closed
+            vi.setSystemTime(new Date('2026-06-27T12:00:00Z'));
+            resetSharedState();
+
+            const getBars = vi.fn(async (_o: GetBarsOptions) => [bar(1)]);
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+
+            await provider.getBars({
+                symbol: 'AAPL',
+                timeframe: '1Day',
+                from: '2024-01-01',
+            });
+
+            // Find the set call for bars:eodrecent:* key
+            const recentSetCall = fakeRedis.set.mock.calls.find(
+                ([key]) =>
+                    typeof key === 'string' && key.startsWith('bars:eodrecent')
+            );
+            expect(recentSetCall).toBeDefined();
+            const recentTtl = recentSetCall?.[2]?.ex;
+            expect(typeof recentTtl).toBe('number');
+            expect(recentTtl).toBeGreaterThan(60); // closed-session TTL > 60s
+        });
     });
 
     describe('session spec — TTL', () => {

--- a/src/shared/api/market/__tests__/mergeBarsByTime.test.ts
+++ b/src/shared/api/market/__tests__/mergeBarsByTime.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import type { Bar } from '@y0ngha/siglens-core';
+import { mergeBarsByTime } from '@/shared/api/market/mergeBarsByTime';
+
+const bar = (time: number, close: number): Bar => ({
+    time,
+    open: close,
+    high: close,
+    low: close,
+    close,
+    volume: 1,
+});
+
+describe('mergeBarsByTime', () => {
+    it('concatenates disjoint ranges in ascending time order', () => {
+        const result = mergeBarsByTime([bar(1, 10), bar(2, 11)], [bar(3, 12)]);
+        expect(result.map(b => b.time)).toEqual([1, 2, 3]);
+    });
+
+    it('dedups overlapping times, preferring recent', () => {
+        const result = mergeBarsByTime(
+            [bar(1, 10), bar(2, 11)],
+            [bar(2, 99), bar(3, 12)]
+        );
+        expect(result.map(b => [b.time, b.close])).toEqual([
+            [1, 10],
+            [2, 99], // recent wins
+            [3, 12],
+        ]);
+    });
+
+    it('sorts unsorted inputs by time', () => {
+        const result = mergeBarsByTime([bar(3, 12), bar(1, 10)], [bar(2, 11)]);
+        expect(result.map(b => b.time)).toEqual([1, 2, 3]);
+    });
+});

--- a/src/shared/api/market/__tests__/mergeBarsByTime.test.ts
+++ b/src/shared/api/market/__tests__/mergeBarsByTime.test.ts
@@ -33,4 +33,64 @@ describe('mergeBarsByTime', () => {
         const result = mergeBarsByTime([bar(3, 12), bar(1, 10)], [bar(2, 11)]);
         expect(result.map(b => b.time)).toEqual([1, 2, 3]);
     });
+
+    // Fix 4: additional edge-case tests
+
+    it('historical empty, recent non-empty → returns recent sorted', () => {
+        const result = mergeBarsByTime([], [bar(3, 12), bar(1, 10)]);
+        expect(result.map(b => b.time)).toEqual([1, 3]);
+        expect(result.map(b => b.close)).toEqual([10, 12]);
+    });
+
+    it('historical non-empty, recent empty → returns historical sorted', () => {
+        const result = mergeBarsByTime([bar(3, 12), bar(1, 10)], []);
+        expect(result.map(b => b.time)).toEqual([1, 3]);
+        expect(result.map(b => b.close)).toEqual([10, 12]);
+    });
+
+    it('realistic gap/overlap fixture: no duplicates, no spurious gap, sorted unique union', () => {
+        // historical: Mon-Thu of week 1 (times 1..4) + Mon-Wed of week 2 (times 8..10)
+        // recent: overlaps with historical on week 2 (times 8..10) and adds Thu-Fri week 2 (times 11,12)
+        // weekend gap (times 5,6,7) is intentionally absent from both windows
+        const historical = [
+            bar(1, 100),
+            bar(2, 101),
+            bar(3, 102),
+            bar(4, 103),
+            bar(8, 108), // Mon week 2 — in overlap
+            bar(9, 109), // Tue week 2 — in overlap
+            bar(10, 110), // Wed week 2 — in overlap
+        ];
+        const recent = [
+            bar(8, 208), // overlap — recent wins
+            bar(9, 209), // overlap — recent wins
+            bar(10, 210), // overlap — recent wins
+            bar(11, 211), // Thu week 2 — only in recent
+            bar(12, 212), // Fri week 2 — only in recent
+        ];
+
+        const result = mergeBarsByTime(historical, recent);
+
+        // No duplicates: each time appears exactly once
+        const times = result.map(b => b.time);
+        expect(times).toEqual([1, 2, 3, 4, 8, 9, 10, 11, 12]); // sorted unique
+
+        // Weekend gap (5,6,7) must NOT be synthesised
+        expect(times).not.toContain(5);
+        expect(times).not.toContain(6);
+        expect(times).not.toContain(7);
+
+        // Overlap region uses recent values
+        expect(result.find(b => b.time === 8)?.close).toBe(208);
+        expect(result.find(b => b.time === 9)?.close).toBe(209);
+        expect(result.find(b => b.time === 10)?.close).toBe(210);
+
+        // Non-overlap historical values preserved
+        expect(result.find(b => b.time === 1)?.close).toBe(100);
+        expect(result.find(b => b.time === 4)?.close).toBe(103);
+
+        // Recent-only values present
+        expect(result.find(b => b.time === 11)?.close).toBe(211);
+        expect(result.find(b => b.time === 12)?.close).toBe(212);
+    });
 });

--- a/src/shared/api/market/mergeBarsByTime.ts
+++ b/src/shared/api/market/mergeBarsByTime.ts
@@ -1,0 +1,14 @@
+import type { Bar } from '@y0ngha/siglens-core';
+
+/**
+ * 두 Bar 배열을 time 기준 오름차순으로 병합·중복제거한다. 같은 time이 양쪽에 있으면
+ * `recent` 값을 우선한다(live 갱신분이 long-cache된 과거 값을 덮어쓰도록). EOD 캐시
+ * 분리에서 과거(long-cache) 윈도우와 최근(live) 윈도우를 합쳐 단일 연속 시리즈를
+ * 복원하는 데 쓴다 — 결과는 단일 `getBars(from=now-730d)`와 동일 집합이어야 한다.
+ */
+export function mergeBarsByTime(historical: Bar[], recent: Bar[]): Bar[] {
+    const byTime = new Map<number, Bar>();
+    for (const b of historical) byTime.set(b.time, b);
+    for (const b of recent) byTime.set(b.time, b); // recent wins on overlap
+    return [...byTime.values()].sort((a, b) => a.time - b.time);
+}

--- a/src/shared/api/market/mergeBarsByTime.ts
+++ b/src/shared/api/market/mergeBarsByTime.ts
@@ -4,7 +4,7 @@ import type { Bar } from '@y0ngha/siglens-core';
  * 두 Bar 배열을 time 기준 오름차순으로 병합·중복제거한다. 같은 time이 양쪽에 있으면
  * `recent` 값을 우선한다(live 갱신분이 long-cache된 과거 값을 덮어쓰도록). EOD 캐시
  * 분리에서 과거(long-cache) 윈도우와 최근(live) 윈도우를 합쳐 단일 연속 시리즈를
- * 복원하는 데 쓴다 — 결과는 단일 `getBars(from=now-730d)`와 동일 집합이어야 한다.
+ * 복원하는 데 쓴다 — 결과는 동일한 `[from, now]` 구간에 대한 단일 `getBars` 호출과 같은 집합이어야 한다.
  */
 export function mergeBarsByTime(historical: Bar[], recent: Bar[]): Bar[] {
     const byTime = new Map<number, Bar>();

--- a/src/shared/api/market/mergeBarsByTime.ts
+++ b/src/shared/api/market/mergeBarsByTime.ts
@@ -7,8 +7,10 @@ import type { Bar } from '@y0ngha/siglens-core';
  * 복원하는 데 쓴다 — 결과는 동일한 `[from, now]` 구간에 대한 단일 `getBars` 호출과 같은 집합이어야 한다.
  */
 export function mergeBarsByTime(historical: Bar[], recent: Bar[]): Bar[] {
-    const byTime = new Map<number, Bar>();
-    for (const b of historical) byTime.set(b.time, b);
-    for (const b of recent) byTime.set(b.time, b); // recent wins on overlap
-    return [...byTime.values()].sort((a, b) => a.time - b.time);
+    // Map 생성자: 나중 엔트리가 이전 것을 덮어쓰므로 recent가 overlap에서 우선.
+    const byTime = new Map<number, Bar>([
+        ...historical.map(b => [b.time, b] as const),
+        ...recent.map(b => [b.time, b] as const),
+    ]);
+    return [...byTime.values()].toSorted((a, b) => a.time - b.time);
 }


### PR DESCRIPTION
## Summary
FMP API 호출량·egress 절감을 위한 캐시 개선 (siglens I/O 레이어만, `@y0ngha/siglens-core` 무변경).

15분 사용량 실측에서 valuation 2종(`key-metrics-ttm`/`ratios-ttm`)이 호출의 ~49%, `historical-price-eod/full`이 egress의 62%를 차지 → 세 가지로 대응.

## Changes
1. **Fundamental TTL 1h → 24h** (`FMP_FUNDAMENTAL_REVALIDATE_SECONDS`) — Next Data Cache revalidate + Redis TTL 단일 상수. 분기 단위 재무 데이터 특성에 맞추고 statements/congress(이미 24h)와 정합. 배포 시 Next Data Cache 리셋에도 cross-deploy Redis 버퍼로 FMP 직격 방어.
2. **Peer enrich split** — 페이지(`/[symbol]/fundamental`)는 enrich 없는 raw peer 목록(`getStockPeersRaw`)을 사용(PeersTable은 티커·회사명·시총만 렌더). per/psr enrich(peer당 valuation fan-out)는 FactLayer(AI 분석)에서만 필요하므로 enriched `getStockPeers`(core 포트)는 분석 경로 전용으로 유지. → 페이지 fan-out 제거, 화면·SEO·분석 품질 무변경.
3. **EOD 1Day 캐시 분리** — 불변 과거 윈도우(`bars:eodhist:*`, long TTL)와 live 최근 윈도우(`bars:eodrecent:*`, 세션 TTL)를 `mergeBarsByTime`로 병합. 장중 60s마다 730일(~115KB)을 통째 재fetch하던 낭비 제거(거래일당 1회). 짧은 lookback은 기존 단일 경로로 폴백.

사용자 신선도 불변: 가격은 클라 refetch(30s), 재무는 ISR(24h)이 이미 상한. core·`FmpFundamentalClient`·`FmpMarketProvider` 무변경.

## Quality gates
- 5종 fresh-context 감사(Opus 4.8): 코드리뷰 / 배포안정성 / 배포-now 롤아웃 / SEO(seo-audit) / 테스트커버리지 — **전부 Approved, findings 0** (라운드 반복 후).
- 변경 로직 파일 **커버리지 100%**(stmts/branch/funcs/lines), 419 scoped tests pass, tsc·lint 0.
- prod 빌드(exit 0) 실증: curl 18 + Chrome — 전 라우트 200, peer 표 실데이터, 밸류에이션·차트·SEO(valid=index/invalid=noindex) 정상, EOD 병합 전체 히스토리 지표(52주 위치·MA200·표본 469봉) 정상 산출, 콘솔 에러 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)