### PR TITLE
perf(market): anchored 2-tier EOD cache — fix v0.32.0 daily-bars call regression

### DIFF
--- a/docs/qa/2026-07-01-eod-cache-verification.md
+++ b/docs/qa/2026-07-01-eod-cache-verification.md
@@ -1,0 +1,169 @@
+# EOD 일봉 캐시 재설계 — 검증 테스트케이스
+
+- 작성일: 2026-07-01
+- 대상 변경: `perf/eod-cache-redesign` (worktree `/Users/y0ngha/Project/siglens-eod-redesign`)
+- 관련 스펙: `docs/superpowers/specs/2026-07-01-eod-cache-redesign-design.md`
+- 성격: **백엔드 캐싱 내부 변경** — 사용자 화면 출력은 이전과 **완전히 동일**해야 함
+- 검증 방식: prod-like 로컬 실행(`yarn build` → `yarn start`) + curl + Chrome
+
+---
+
+## 1. 스코프 & 불변 항목 (must stay identical)
+
+이 변경은 `CachedMarketDataProvider.getCachedDailyBars`(1Day 일봉 전용)의 **캐시 키 구조와
+staleness 판정만** 바꾼다. 반환하는 `Bar[]` 집합은 단일 `getBars(from)`와 동일해야 하며,
+그로부터 파생되는 **모든 사용자 화면 출력이 변경 전과 픽셀/숫자 단위로 동일**해야 한다.
+
+### 변경 전과 동일해야 하는 것 (관측 대상)
+
+`/[symbol]` 차트 페이지에서 일봉(1Day)으로부터 파생되는 렌더:
+
+| 항목 | 출처(컴포넌트/함수) | 관측 방법 |
+|---|---|---|
+| 차트 일봉 캔들 (1일 timeframe) | `StockChart` (bars) | Chrome: `1일` 캔들 시리즈 렌더 |
+| 현재가 + 등락률 | `TechnicalFactsSummary` → `현재가`, `$`, `±x.xx%` | curl(문자열) + Chrome |
+| 52주 위치 (고저 대비) | `buildTechnicalFacts.high52w/low52w` → `52주 위치` | curl(문자열) + Chrome (값 타당성) |
+| RSI / MACD 모멘텀 | `buildTechnicalFacts` (동일 bars 기반 indicators) | Chrome |
+| MA 오버레이(MA200 포함) | 차트 `MA` overlay (`indicatorRegistry` key `ma`) | Chrome: MA 라인 + 범례 |
+| 표본 봉 수(~1년 ≈ 252 거래일) | `TRADING_DAYS_52W = 252` 슬라이스 = merge 정확성 | Chrome: 52주 값이 full 히스토리 기반으로 타당 |
+
+> 주의: `MA200`·`표본 N봉`은 화면에 리터럴 문자열로 노출되지 않는다(오버레이 라인/차트
+> 범위로 표현). 따라서 이 둘은 **차트 오버레이 렌더 + 52주 값 타당성**으로 간접 검증한다.
+> full ~1년 히스토리(history tier)와 최근 tail(recent tier)이 올바르게 merge·slice되면
+> 52주 고저와 MA 라인이 정확히 그려진다.
+
+### 내부적으로 바뀐 것 (curl로 직접 관측 불가 — 배포 후 FMP 대시보드로 확인)
+
+- 캐시 키에서 rolling 날짜 제거: `bars:eodhist:<SYM>` (immutable history) + `bars:eodrecent:<SYM>` (live tail)
+- history staleness는 TTL이 아니라 recent 겹침(`getOrSetCache` 신규 `isFresh` 인자)이 주도
+- 기대 효과: `historical-price-eod/full` **호출수·egress 감소**(자정 키롤·반복 크롤 재fetch 제거)
+- **이 효과는 로컬 curl로 볼 수 없다.** 배포 후 FMP 대시보드에서 `historical-price-eod/full`
+  calls/egress를 배포 전(325 calls / 9.75 MB) 대비 확인한다.
+
+---
+
+## 2. 환경 (prod-like from worktree)
+
+```bash
+# 1) 환경파일 복사 (메인 워킹트리 → 이 워크트리). gitignore라 git status에 안 보임.
+cp /Users/y0ngha/Project/siglens/.env.local      /Users/y0ngha/Project/siglens-eod-redesign/.env.local
+cp /Users/y0ngha/Project/siglens/.env.production /Users/y0ngha/Project/siglens-eod-redesign/.env.production
+
+# 2) prod 빌드 (exit code 직접 캡처 — 파이프 금지)
+cd /Users/y0ngha/Project/siglens-eod-redesign
+yarn build > /tmp/eod-build.log 2>&1; echo "BUILD_EXIT=$?"
+# → BUILD_EXIT=0 이어야 진행
+
+# 3) prod 서버 기동 (포트 4310 — 기존 4200/4310 충돌 회피)
+yarn start -p 4310
+```
+
+### 전제 / 주의
+
+- **Redis(Upstash)는 옵션.** 미설정/장애 시 `getOrSetCache`가 graceful fallback으로 inner를
+  직접 호출하므로 페이지는 정상 렌더된다(캐시 절감 효과만 없음). `.env`에 Upstash 키가 있으면
+  실제 2-tier 캐시 경로가 동작한다 — 캐시 warm/cold 케이스(Method A 2차 요청)를 보려면 필요.
+- 환경파일은 **세션 종료 후 복원 불필요**(복사본). 단, 메인 워크트리 것과 키셋이 다르면 빌드타임
+  ISR 페이지(`/economy`·`/market` 등)가 degraded일 수 있으나 **본 검증 대상(`/[symbol]`)과 무관**.
+- FMP/외부 API 키 필요: `/[symbol]`의 일봉·현재가는 FMP에서 fetch된다.
+
+---
+
+## 3. Method A — curl (6 케이스)
+
+각 케이스: `HTTP 200`, 일봉 파생 마커 문자열 present, `500` 없음.
+검증 마커(SSR 텍스트, `TechnicalFactsSummary`): `기술적 지표 요약`, `현재가`, `52주 위치`, `$`.
+
+```bash
+BASE=http://localhost:4310
+check() {
+  local sym="$1"
+  local body; body=$(curl -s -o /tmp/eod-$sym.html -w "%{http_code}" "$BASE/$sym")
+  echo "=== $sym : HTTP $body ==="
+  grep -o "기술적 지표 요약" /tmp/eod-$sym.html | head -1
+  grep -o "52주 위치"       /tmp/eod-$sym.html | head -1
+  grep -o "현재가"          /tmp/eod-$sym.html | head -1
+  grep -oE '\$[0-9,]+\.[0-9]+' /tmp/eod-$sym.html | head -1   # 현재가 $ 포맷
+  grep -c "Internal Server Error\|500" /tmp/eod-$sym.html      # 0 이어야 함
+}
+```
+
+| # | 케이스 | 명령 | 기대 |
+|---|---|---|---|
+| A1 | AAPL (US equity) | `check AAPL` | 200, `기술적 지표 요약`·`52주 위치`·`현재가`·`$xxx.xx` present, 500=0 |
+| A2 | MSFT (US equity) | `check MSFT` | 동일 |
+| A3 | NVDA (US equity) | `check NVDA` | 동일 |
+| A4 | BTCUSD (crypto) | `check BTCUSD` | 200, 파생 마커 present. crypto는 세션 24/7 → recent tail 상시 60s(정상). `$` 포맷은 crypto 자릿수 규칙 |
+| A5 | AAPL 재요청 (cache warm) | `check AAPL` (2회차) | 200, A1과 **동일** 마커·현재가. Redis 있으면 캐시 hit 경로, 없으면 fallback — 어느 쪽이든 결과 동일 |
+| A6 | MSFT 재요청 (cache warm) | `check MSFT` (2회차) | 200, A2와 동일 |
+
+**PASS 조건:** 6/6 HTTP 200, 각 케이스에서 일봉 파생 마커 문자열 present, `$` 현재가 매칭,
+500/Internal Server Error 카운트 0, 그리고 A5/A6 재요청이 1차 요청과 일관(현재가·52주 값 동일).
+
+---
+
+## 4. Method B — Chrome (4 케이스)
+
+`http://localhost:4310/<SYM>` 로 이동해 육안 + 콘솔로 확인.
+
+| # | 케이스 | 확인 항목 |
+|---|---|---|
+| B1 | `/AAPL` 차트 렌더 | ① 차트가 **`1일` timeframe 일봉 캔들**로 렌더됨 ② `기술적 지표 요약` 패널의 `현재가`가 라이브 값(`$`)으로 표시 ③ `52주 위치`(고점 대비 −x.x%, 저점 대비 +x.x%) 값이 **타당**(고점 대비 ≤ 0, 저점 대비 ≥ 0) ④ MA 오버레이(MA200 포함) 라인 + 범례 렌더 ⑤ **콘솔 에러 0** |
+| B2 | `/MSFT` 차트 렌더 | B1과 동일 5항목 |
+| B3 | `/AAPL` merge 정확성 | 차트 x축이 **약 1년(~252 거래일) full 히스토리**를 커버 — 최근 봉이 오늘/직전 거래일까지 이어지고(recent tail merge), 과거로 ~1년 연속(history tier). 갭/중복 캔들 없음(mergeBarsByTime dedup + sliceFrom) |
+| B4 | `/AAPL` 라이브 현재가 | 페이지 로드 후 현재가가 라이브(useBars 30s refetch)로 유지·갱신. 장중이면 forming 봉/현재가가 quote 기반으로 최신 |
+
+**타당성 근거:** 52주 고저·MA200은 history + recent가 올바르게 병합·슬라이스되어야만 정확히
+그려진다. history만/​recent만으로는 ~1년 범위가 안 나온다 → merge 정확성의 시각 증거.
+
+**콘솔 확인:** DevTools Console에 uncaught error / hydration mismatch / failed fetch 없어야 함.
+
+---
+
+## 5. Pass/Fail 체크리스트
+
+### 환경
+- [ ] `.env.local`·`.env.production` 워크트리에 복사됨
+- [ ] `yarn build` `BUILD_EXIT=0`
+- [ ] `yarn start -p 4310` 정상 기동
+
+### Method A (curl, 6)
+- [ ] A1 AAPL — 200 + 마커 present + `$` + 500=0
+- [ ] A2 MSFT — 200 + 마커 present + `$` + 500=0
+- [ ] A3 NVDA — 200 + 마커 present + `$` + 500=0
+- [ ] A4 BTCUSD — 200 + 마커 present + 500=0
+- [ ] A5 AAPL 재요청 — 200 + A1과 일관(현재가·52주 동일)
+- [ ] A6 MSFT 재요청 — 200 + A2와 일관
+
+### Method B (Chrome, 4)
+- [ ] B1 `/AAPL` — 1일 일봉 캔들 / 현재가 `$` / 52주 타당 / MA 오버레이 / 콘솔 에러 0
+- [ ] B2 `/MSFT` — 위 5항목
+- [ ] B3 `/AAPL` — ~1년 full 히스토리 커버, 갭·중복 없음 (merge 정확성)
+- [ ] B4 `/AAPL` — 라이브 현재가 유지·갱신
+
+### 불변성 (핵심 판정)
+- [ ] 일봉 파생 렌더(캔들·현재가·52주·MA·RSI/MACD)가 **변경 전과 동일**
+- [ ] UI/메타데이터 변경 **없음** (순수 캐싱 내부 변경)
+
+### 배포 후 (로컬 검증 불가 — 별도)
+- [ ] FMP 대시보드에서 `historical-price-eod/full` calls/egress가 배포 전(325 / 9.75 MB) 대비 감소
+- [ ] 자정(UTC) 전후 스파이크 소멸 확인
+
+---
+
+## 부록 — 결과 기록 템플릿
+
+```
+빌드: BUILD_EXIT=___
+A1 AAPL   HTTP___ 마커___ $___ 500=___
+A2 MSFT   HTTP___ 마커___ $___ 500=___
+A3 NVDA   HTTP___ 마커___ $___ 500=___
+A4 BTCUSD HTTP___ 마커___ 500=___
+A5 AAPL#2 HTTP___ 일관___
+A6 MSFT#2 HTTP___ 일관___
+B1 AAPL   캔들__ 현재가__ 52주__ MA__ 콘솔__
+B2 MSFT   캔들__ 현재가__ 52주__ MA__ 콘솔__
+B3 AAPL   ~1년범위__ 갭/중복없음__
+B4 AAPL   라이브현재가__
+판정: PASS / FAIL
+```

--- a/docs/superpowers/plans/2026-07-01-eod-cache-redesign.md
+++ b/docs/superpowers/plans/2026-07-01-eod-cache-redesign.md
@@ -1,0 +1,394 @@
+# EOD Cache Redesign (Anchored 2-tier) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** EOD 일봉 캐시 키에서 rolling 날짜를 제거(심볼-앵커)하고 history를 겹침-기반 full-refetch-on-stale로 캐싱해, 자정 키롤·반복 크롤 재fetch로 인한 EOD 호출/egress 폭증을 제거한다.
+
+**Architecture:** `CachedMarketDataProvider`의 1Day 분리 경로를 앵커드 2-tier로 재작성 — `bars:eodhist:<SYM>`(불변 과거, 30d TTL, `getOrSetCache`의 새 `isFresh` 인자로 recent 윈도우와의 겹침 staleness 판정 → stale 시 full 재fetch) + `bars:eodrecent:<SYM>`(오늘봉 포함 최근 윈도우, 세션 TTL). 두 tier를 `mergeBarsByTime`로 병합 후 `options.from`으로 슬라이스. core·`FmpMarketProvider` 무변경.
+
+**Tech Stack:** TypeScript, Next.js 16, Upstash Redis(`getOrSetCache`), Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-01-eod-cache-redesign-design.md`
+
+---
+
+## File Structure
+
+| File | 책임 | 변경 |
+|---|---|---|
+| `src/shared/cache/getOrSetCache.ts` | read-through Redis 캐시 | Modify (선택적 `isFresh` 인자) |
+| `src/shared/api/market/CachedMarketDataProvider.ts` | bars/quote Redis 데코레이터 | Modify (`getCachedDailyBars` 앵커드 2-tier 재작성 + `sliceFrom` 헬퍼) |
+| `src/shared/api/market/mergeBarsByTime.ts` | 순수 병합 | 재사용(무변경) |
+
+---
+
+## Task 1: `getOrSetCache`에 선택적 `isFresh` 인자 추가
+
+캐시 hit이어도 `isFresh(data)===false`면 miss처럼 취급(refetch+set). 기존 호출부는 기본값(항상 fresh)이라 무영향.
+
+**Files:**
+- Modify: `src/shared/cache/getOrSetCache.ts`
+- Test: `src/shared/cache/__tests__/getOrSetCache.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`getOrSetCache.test.ts`에 추가(기존 fakeRedis mock 패턴 사용 — 없으면 이 파일 상단의 `vi.mock('@/shared/cache/redisClient')` 패턴을 따른다):
+
+```ts
+it('treats a cache hit as miss when isFresh returns false (refetch + set)', async () => {
+    // 사전: 캐시에 stale 값 저장
+    store.set('k', { data: 'stale' });
+    const fetcher = vi.fn(async () => 'fresh');
+
+    const result = await getOrSetCache(
+        'k',
+        60,
+        fetcher,
+        () => true, // shouldCache
+        value => value === 'fresh' // isFresh: 'stale'은 false
+    );
+
+    expect(result).toBe('fresh');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(store.get('k')).toEqual({ data: 'fresh' });
+});
+
+it('returns a cache hit unchanged when isFresh is omitted (default always-fresh)', async () => {
+    store.set('k', { data: 'cached' });
+    const fetcher = vi.fn(async () => 'fresh');
+
+    const result = await getOrSetCache('k', 60, fetcher);
+
+    expect(result).toBe('cached');
+    expect(fetcher).not.toHaveBeenCalled();
+});
+```
+
+> 기존 테스트 파일의 fakeRedis 헬퍼 변수명(`store` 등)에 맞춰 조정. 없으면 `CachedFundamentalProvider.test.ts`의 `vi.hoisted` fakeRedis 패턴을 복제.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn test src/shared/cache/__tests__/getOrSetCache.test.ts`
+Expected: FAIL — `getOrSetCache` 5번째 인자 미지원(첫 테스트에서 stale 반환).
+
+- [ ] **Step 3: Add the `isFresh` param**
+
+`getOrSetCache.ts`의 시그니처와 hit 분기를 수정:
+
+```ts
+export async function getOrSetCache<T>(
+    key: string,
+    ttlSeconds: number,
+    fetcher: () => Promise<T>,
+    shouldCache: (value: T) => boolean = () => true,
+    isFresh: (value: T) => boolean = () => true
+): Promise<T> {
+    const redis = getRedisClient();
+    if (redis !== null) {
+        try {
+            const hit = await redis.get<unknown>(key);
+            if (isCacheEnvelope<T>(hit) && isFresh(hit.data)) return hit.data;
+        } catch (error) {
+            console.error(`[getOrSetCache] get failed: ${key}`, error);
+        }
+    }
+
+    const fresh = await fetcher();
+
+    if (redis !== null && shouldCache(fresh)) {
+        try {
+            await redis.set(key, { data: fresh }, { ex: ttlSeconds });
+        } catch (error) {
+            console.error(`[getOrSetCache] set failed: ${key}`, error);
+        }
+    }
+    return fresh;
+}
+```
+
+함수 JSDoc에 한 줄 추가: `isFresh(value)`가 false면 envelope hit도 miss로 취급해 refetch한다(기본값 항상 fresh — 기존 호출부 무영향). staleness를 캐시 값으로 판정하는 호출부(예: EOD history 겹침)를 위한 가드.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn test src/shared/cache/__tests__/getOrSetCache.test.ts`
+Expected: PASS (기존 테스트도 전부 통과 — 기본값 무영향).
+
+- [ ] **Step 5: tsc + commit**
+
+```bash
+yarn tsc --noEmit
+git add src/shared/cache/getOrSetCache.ts src/shared/cache/__tests__/getOrSetCache.test.ts
+git commit -m "feat(cache): add optional isFresh predicate to getOrSetCache"
+```
+
+---
+
+## Task 2: `getCachedDailyBars` 앵커드 2-tier 재작성
+
+**Files:**
+- Modify: `src/shared/api/market/CachedMarketDataProvider.ts`
+- Test: `src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+기존 `1Day EOD split` describe 블록의 테스트들을 앵커드 설계에 맞게 **교체**한다(기존 fakeRedis `store`/`resetSharedState` + `vi.setSystemTime` + `bar()` 헬퍼 재사용). 핵심 케이스:
+
+```ts
+describe('CachedMarketDataProvider — 1Day anchored 2-tier', () => {
+    beforeEach(() => {
+        resetSharedState();
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-30T15:00:00Z'));
+    });
+    afterEach(() => vi.useRealTimers());
+
+    const longOpts: GetBarsOptions = {
+        symbol: 'AAPL',
+        timeframe: '1Day',
+        from: '2024-06-30',
+    };
+
+    it('uses date-free anchored keys (bars:eodhist:<SYM>, bars:eodrecent:<SYM>)', async () => {
+        const getBars = vi.fn(async (o: GetBarsOptions) =>
+            o.before !== undefined ? [bar(1)] : [bar(2)]
+        );
+        const provider = new CachedMarketDataProvider({ getBars, getQuote: vi.fn(async () => null) });
+        await provider.getBars(longOpts);
+        expect(store.has('bars:eodhist:AAPL')).toBe(true);
+        expect(store.has('bars:eodrecent:AAPL')).toBe(true);
+        // 날짜 세그먼트가 키에 없어야 함
+        expect([...store.keys()].some(k => /bars:eodhist:AAPL:\d/.test(k))).toBe(false);
+    });
+
+    it('history is NOT refetched across a day boundary when still fresh (anchored key, overlap holds)', async () => {
+        // history fetch(before=histTo)는 recentFrom 이후를 커버하는 봉을 반환하도록 구성
+        const histBarTime = Math.floor(Date.parse('2026-06-25T00:00:00Z') / 1000); // recentFrom(2026-06-20) 이후 → fresh
+        const getBars = vi.fn(async (o: GetBarsOptions) =>
+            o.before !== undefined ? [{ ...bar(histBarTime), time: histBarTime }] : [bar(9)]
+        );
+        const provider = new CachedMarketDataProvider({ getBars, getQuote: vi.fn(async () => null) });
+
+        await provider.getBars(longOpts); // day 1: history fetched once
+        const histCallsDay1 = getBars.mock.calls.filter(c => c[0].before !== undefined).length;
+
+        vi.setSystemTime(new Date('2026-07-01T15:00:00Z')); // 하루 경과
+        await provider.getBars({ ...longOpts, from: '2024-07-01' });
+        const histCallsTotal = getBars.mock.calls.filter(c => c[0].before !== undefined).length;
+
+        expect(histCallsDay1).toBe(1);
+        expect(histCallsTotal).toBe(1); // 자정 넘겨도 재fetch 없음(fresh)
+    });
+
+    it('history IS refetched when cached newest falls behind recentFrom (stale, overlap lost)', async () => {
+        // history fetch가 recentFrom 이전(오래된) 봉만 반환 → isFresh=false → 매번 재fetch
+        const staleTime = Math.floor(Date.parse('2026-06-01T00:00:00Z') / 1000); // recentFrom(2026-06-20) 이전
+        const getBars = vi.fn(async (o: GetBarsOptions) =>
+            o.before !== undefined ? [{ ...bar(staleTime), time: staleTime }] : [bar(9)]
+        );
+        const provider = new CachedMarketDataProvider({ getBars, getQuote: vi.fn(async () => null) });
+
+        await provider.getBars(longOpts);
+        await provider.getBars(longOpts);
+        const histCalls = getBars.mock.calls.filter(c => c[0].before !== undefined).length;
+        expect(histCalls).toBe(2); // stale → 재fetch
+    });
+
+    it('merges history + recent and slices to options.from', async () => {
+        const inRange = Math.floor(Date.parse('2025-01-01T00:00:00Z') / 1000);
+        const tooOld = Math.floor(Date.parse('2020-01-01T00:00:00Z') / 1000); // from(2024-06-30) 이전 → 슬라이스로 제거
+        const recentT = Math.floor(Date.parse('2026-06-29T00:00:00Z') / 1000);
+        const getBars = vi.fn(async (o: GetBarsOptions) =>
+            o.before !== undefined
+                ? [{ ...bar(tooOld), time: tooOld }, { ...bar(inRange), time: inRange }]
+                : [{ ...bar(recentT), time: recentT }]
+        );
+        const provider = new CachedMarketDataProvider({ getBars, getQuote: vi.fn(async () => null) });
+        const result = await provider.getBars(longOpts);
+        const times = result.map(b => b.time);
+        expect(times).toContain(inRange);
+        expect(times).toContain(recentT);
+        expect(times).not.toContain(tooOld); // options.from 이전은 슬라이스
+        expect(times).toEqual([...times].sort((a, b) => a - b)); // 오름차순
+    });
+
+    it('cold symbol = 2 fetches (history + recent); repeat within session = 0', async () => {
+        const freshHist = Math.floor(Date.parse('2026-06-25T00:00:00Z') / 1000);
+        const getBars = vi.fn(async (o: GetBarsOptions) =>
+            o.before !== undefined ? [{ ...bar(freshHist), time: freshHist }] : [bar(9)]
+        );
+        const provider = new CachedMarketDataProvider({ getBars, getQuote: vi.fn(async () => null) });
+        await provider.getBars(longOpts);
+        expect(getBars).toHaveBeenCalledTimes(2);
+        await provider.getBars(longOpts); // 재접근
+        expect(getBars).toHaveBeenCalledTimes(2); // 둘 다 캐시 hit → 추가 0
+    });
+
+    it('1Day with before set → single-key path (no anchored split)', async () => {
+        const getBars = vi.fn(async () => [bar(1)]);
+        const provider = new CachedMarketDataProvider({ getBars, getQuote: vi.fn(async () => null) });
+        await provider.getBars({ symbol: 'AAPL', timeframe: '1Day', from: '2024-01-01', before: '2026-06-20' });
+        expect(getBars).toHaveBeenCalledTimes(1);
+        expect([...store.keys()].some(k => k.startsWith('bars:eodhist'))).toBe(false);
+        expect(store.has('bars:raw:AAPL:1Day:2024-01-01:2026-06-20:')).toBe(true);
+    });
+
+    it('short lookback (from within recent window) → single-key path', async () => {
+        const getBars = vi.fn(async () => [bar(1)]);
+        const provider = new CachedMarketDataProvider({ getBars, getQuote: vi.fn(async () => null) });
+        await provider.getBars({ symbol: 'AAPL', timeframe: '1Day', from: '2026-06-27' }); // recentFrom(2026-06-20) 이후
+        expect([...store.keys()].some(k => k.startsWith('bars:eodhist'))).toBe(false);
+        expect([...store.keys()].some(k => k.startsWith('bars:raw'))).toBe(true);
+    });
+
+    it('non-1Day stays on single-key path', async () => {
+        const getBars = vi.fn(async () => [bar(1)]);
+        const provider = new CachedMarketDataProvider({ getBars, getQuote: vi.fn(async () => null) });
+        await provider.getBars({ symbol: 'AAPL', timeframe: '5Min', from: '2026-06-20' });
+        expect(getBars).toHaveBeenCalledTimes(1);
+        expect([...store.keys()].some(k => k.startsWith('bars:eod'))).toBe(false);
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn test src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts`
+Expected: FAIL — 현재 구현은 날짜-포함 키(`bars:eodhist:AAPL:<from>:<histTo>`)라 앵커 키/자정-불변/슬라이스 단언이 깨짐.
+
+- [ ] **Step 3: Rewrite `getCachedDailyBars` + add `sliceFrom`**
+
+`CachedMarketDataProvider.ts`에서 상수는 유지하되 `EOD_HIST_TTL_SECONDS`를 30일로 변경하고, `sliceFrom` 헬퍼를 추가한 뒤 `getCachedDailyBars`를 교체한다:
+
+```ts
+/** 과거(불변) 윈도우 종료점: 오늘 − EOD_HIST_TO_DAYS일. recent와 겹쳐 갭 방지. */
+const EOD_HIST_TO_DAYS = 7;
+/** 최근(live) 윈도우 시작점: 오늘 − EOD_RECENT_FROM_DAYS일. */
+const EOD_RECENT_FROM_DAYS = 10;
+/** 과거 history long TTL(30일). 갱신은 TTL이 아니라 recent와의 겹침 staleness가 주도. */
+const EOD_HIST_TTL_SECONDS = SECONDS_PER_DAY * 30;
+
+function isoDateDaysAgo(now: Date, days: number): string {
+    const d = new Date(now);
+    d.setUTCDate(d.getUTCDate() - days);
+    return d.toISOString().slice(0, 10);
+}
+
+/** YYYY-MM-DD(또는 ISO) 날짜를 UTC 자정 unix초로 변환(Bar.time과 동일 규약). */
+function utcMidnightSeconds(dateStr: string): number {
+    return Math.floor(Date.parse(dateStr.slice(0, 10) + 'T00:00:00Z') / 1000);
+}
+
+/** `from` 이후(포함) 봉만 남긴다 — 단일 `getBars(from)`와 동일 집합 보장. */
+function sliceFrom(bars: Bar[], from: string | undefined): Bar[] {
+    if (from === undefined) return bars;
+    const threshold = utcMidnightSeconds(from);
+    return bars.filter(b => b.time >= threshold);
+}
+```
+
+`getCachedDailyBars` 본문(JSDoc 포함) 교체:
+
+```ts
+/**
+ * 요청 윈도우가 최근 overlap 구간보다 앞에서 시작함을 전제로 한다(isLongDailyWindow
+ * 가드 통과 후 진입). 짧은 lookback은 getBars를 통해 단일 경로로 라우팅된다.
+ *
+ * 1Day 일봉을 불변 과거(history, 날짜-없는 앵커 키 `bars:eodhist:<SYM>`)와 최근(live,
+ * `bars:eodrecent:<SYM>`)으로 나눠 병렬 fetch 후 병합한다. 캐시 키에 날짜를 넣지 않아
+ * UTC 자정 롤로 인한 전체 재fetch가 없다.
+ *
+ * history는 `before=오늘−EOD_HIST_TO_DAYS`로 오늘을 제외(불변)해 long TTL로 캐싱하고,
+ * `isFresh`(캐시된 최신 봉이 recentFrom 이후 = recent 윈도우와 겹침)로 staleness를 판정한다
+ * — 겹침이 유지되면 재fetch 0, 겹침이 사라지면(=cached newest < recentFrom) full 재fetch.
+ * recent는 `from=오늘−EOD_RECENT_FROM_DAYS`(오늘 봉을 quote로 append)를 세션 TTL로 가져와
+ * 오늘/최근 신선도를 담당한다. 두 윈도우의 (EOD_RECENT_FROM_DAYS − EOD_HIST_TO_DAYS)일
+ * 겹침을 `mergeBarsByTime`가 recent 우선으로 dedup하고, `sliceFrom`가 options.from으로
+ * 잘라 단일 `getBars(from)`와 동일 집합을 만든다.
+ *
+ * 앵커 키에서 from을 뺄 수 있는 근거: 모든 long-1Day 호출부가 core
+ * TIMEFRAME_LOOKBACK_DAYS['1Day'] 단일 lookback을 공유한다(짧은 lookback은 가드가
+ * 단일 경로로 분기). core lookback 변경 시 이 전제도 함께 갱신할 것.
+ */
+private async getCachedDailyBars(options: GetBarsOptions): Promise<Bar[]> {
+    const now = new Date();
+    const histTo = isoDateDaysAgo(now, EOD_HIST_TO_DAYS);
+    const recentFrom = isoDateDaysAgo(now, EOD_RECENT_FROM_DAYS);
+    const recentFromThreshold = utcMidnightSeconds(recentFrom);
+    const symbolKey = options.symbol.toUpperCase();
+
+    const [history, recent] = await Promise.all([
+        getOrSetCache(
+            `bars:eodhist:${symbolKey}`,
+            EOD_HIST_TTL_SECONDS,
+            () => this.inner.getBars({ ...options, before: histTo }),
+            bars => bars.length > 0,
+            bars =>
+                bars.length > 0 &&
+                bars[bars.length - 1]!.time >= recentFromThreshold
+        ),
+        getOrSetCache(
+            `bars:eodrecent:${symbolKey}`,
+            this.ttl('1Day'),
+            () => this.inner.getBars({ ...options, from: recentFrom }),
+            bars => bars.length > 0
+        ),
+    ]);
+
+    return sliceFrom(mergeBarsByTime(history, recent), options.from);
+}
+```
+
+`isLongDailyWindow`/`getBars` 분기/`buildBarsRawKey`/`getQuote`는 현행 유지. (`isLongDailyWindow`의 recentFrom 계산도 그대로.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `yarn test src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: tsc + scoped tests + commit**
+
+```bash
+yarn tsc --noEmit
+yarn test src/shared/api/market src/shared/cache
+git add src/shared/api/market/CachedMarketDataProvider.ts src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
+git commit -m "perf(market): anchored 2-tier EOD cache (date-free keys, overlap staleness)"
+```
+
+---
+
+## Task 3: 통합 게이트
+
+- [ ] **Step 1: tsc + lint (직접 exit 캡처)**
+
+Run:
+```bash
+yarn tsc --noEmit; echo "tsc=$?"
+yarn lint src/shared/api/market src/shared/cache; echo "lint=$?"
+```
+Expected: tsc=0, lint=0.
+
+- [ ] **Step 2: 영향 스위트**
+
+Run: `yarn test src/shared/api/market src/shared/cache`
+Expected: 전부 PASS. (전체 build·e2e는 pre-push, 교차영향은 CI 담당.)
+
+---
+
+## Self-Review (spec 대조)
+
+| spec 요구 | 구현 task |
+|---|---|
+| getOrSetCache `isFresh` 인자 | Task 1 |
+| 앵커 키 `bars:eodhist:<SYM>`/`bars:eodrecent:<SYM>`(날짜 없음) | Task 2 |
+| history full-refetch-on-stale(겹침 `newest>=recentFrom`) | Task 2 (isFresh 술어) |
+| recent 세션 TTL(오늘봉 quote append) | Task 2 (`this.ttl('1Day')`, `from: recentFrom`) |
+| merge + `sliceFrom(options.from)` | Task 2 |
+| Promise.all 병렬 | Task 2 |
+| history TTL 30d | Task 2 (`EOD_HIST_TTL_SECONDS`) |
+| 가드(1Day+before/짧은 lookback/인트라데이 → 단일 경로) | Task 2 (현행 유지, 테스트로 가드) |
+| core/FmpMarketProvider 무변경 | 두 task 모두 미변경 |
+| 에러/캐시 계약 보존 | Task 1/2 (`getOrSetCache` 그대로, shouldCache/graceful) |
+| 테스트(앵커키·staleness·recent TTL·merge·cold/repeat·guard·isFresh) | Task 1·2 |
+
+**Placeholder scan:** 없음(모든 코드 블록 실제 코드).
+**Type consistency:** `isFresh`(Task1 정의 ↔ Task2 사용), `sliceFrom`/`utcMidnightSeconds`/`recentFromThreshold`(Task2 내부 일치), `EOD_HIST_TTL_SECONDS`=30d, 키 문자열 `bars:eodhist:<SYM>`/`bars:eodrecent:<SYM>` 일치.

--- a/docs/superpowers/specs/2026-07-01-eod-cache-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-01-eod-cache-redesign-design.md
@@ -1,0 +1,143 @@
+# EOD 일봉 캐시 재설계 (앵커드 2-tier) — 설계
+
+- 작성일: 2026-07-01
+- 스코프: siglens I/O 레이어 — `src/shared/api/market/CachedMarketDataProvider.ts`, `src/shared/cache/getOrSetCache.ts`
+- core(`@y0ngha/siglens-core`)·`FmpMarketProvider` **무변경**
+- 상태: 설계 승인 대기
+
+---
+
+## 1. 배경 (실측)
+
+v0.32.0에서 도입한 EOD split이 **호출수를 줄이기는커녕 늘렸다**. 배포 ~10시간 후·미국 장 마감 중(00:00 UTC) 측정:
+
+| Endpoint | 배포 전 | 배포 후 |
+|---|---:|---:|
+| `historical-price-eod/full` calls | 117 | **325** |
+| `historical-price-eod/full` egress | 6.59 MB | **9.75 MB** |
+| `quote` calls | 117 | 169 |
+
+(valuation은 성공: `ratios-ttm` 383→43. 이 재설계 대상 아님.)
+
+### 근본 원인 (코드 확인)
+
+현재 `CachedMarketDataProvider.getCachedDailyBars`의 캐시 키에 **rolling 날짜**가 박혀 있다:
+- history: `bars:eodhist:<SYM>:<from=now-730d>:<histTo=now-7d>`
+- recent: `bars:eodrecent:<SYM>:<recentFrom=now-10d>`
+
+`from`/`histTo`/`recentFrom`가 **매일(특히 UTC 자정에 `now-730d` 날짜가 롤) 바뀌어 키가 갱신**된다 → 같은 심볼도 자정 이후 첫 접근 시 **전체 재fetch**. 여기에 split이 요청당 EOD를 **2회**(hist + recent) 부른다. 측정 시각(00:00 UTC)은 자정 키롤 + 2× fetch가 겹친 최악 구간이었다.
+
+핵심: **캐시 키에서 날짜를 제거**하면 자정 롤·반복 크롤 재fetch가 사라진다.
+
+### 사용자 신선도 (불변)
+- 오늘 봉/가격: live tail(recent, 세션 TTL 장중 60s) + 클라 refetch(30s). 그대로 유지.
+- 과거 일봉: 불변. long-cache해도 사용자 영향 0.
+
+---
+
+## 2. 목표 / 비목표
+
+### 목표
+1. EOD(`historical-price-eod/full`) **호출수·egress 실질 감소** — 자정 키롤 및 반복 크롤 재fetch 제거.
+2. 사용자 화면·차트·오늘 봉 신선도 **무변경**.
+3. 기존 캐시 계약(poison 방지·`shouldCache`·graceful fallback) 유지.
+
+### 비목표 (제외)
+- **증분 append** — recent 윈도우가 최근 구간을 backfill하므로 history는 겹침 유지용 full-refetch-on-stale로 충분(사용자 결정). read-modify-write 복잡성 회피.
+- DB 영속, 워밍 잡(cron), `FmpMarketProvider`/core 변경.
+
+---
+
+## 3. 설계 — 앵커드 2-tier
+
+`1Day && before===undefined && isLongDailyWindow` 경로에서만 적용(가드는 현행 유지). 두 캐시 키 **모두 날짜 없는 심볼-앵커**로 변경한다.
+
+### Tier 1 — history (`bars:eodhist:<SYM>`)
+- 불변 과거 일봉. **키에 날짜 없음** → 자정 롤 없음.
+- 값: `Bar[]` (fetch 시점 `options.from`부터 `histTo`까지).
+- TTL: `EOD_HIST_TTL_SECONDS = SECONDS_PER_DAY * 30` (30일). 갱신은 TTL이 아니라 staleness가 주도.
+- **staleness (full-refetch-on-stale)**: 캐시된 최신 봉이 recent 윈도우와 겹치면(`newest.time >= recentFromThreshold`) fresh → 그대로 사용(0 fetch). 아니면 stale → `inner.getBars({ ...options, before: histTo })`로 **전체 재fetch** 후 저장.
+  - 겹침 = `EOD_RECENT_FROM_DAYS - EOD_HIST_TO_DAYS`(=5일) → history 재fetch는 **최소 ~5일당 1회**로 수렴(자정마다 X). 5일 겹침은 최대 4일 연속 휴장(공휴일+주말 인접)에도 겹침이 사라지지 않아 per-request 재fetch thrash를 방지한다(감사 반영).
+
+### Tier 2 — live tail (`bars:eodrecent:<SYM>`)
+- 최근 ~`EOD_RECENT_FROM_DAYS`일 + 오늘 봉. **키에 날짜 없음** → 자정 롤 없음.
+- 값: `inner.getBars({ ...options, from: recentFrom })` (FmpMarketProvider가 `endDate===undefined`일 때 오늘 봉을 quote로 append — 기존 동작).
+- TTL: `computeBarsEffectiveTtl('1Day', now, session)` — **장중 60s(live), 장외 다음 개장까지**(밤사이 재fetch 0).
+
+### 병합
+`mergeBarsByTime(history, recent)`(기존 재사용, recent 우선 dedup) → `options.from` 기준 슬라이스(`b.time >= fromThreshold`; `from` 없으면 슬라이스 생략)로 단일 `getBars(from)`와 동일 집합 보장.
+
+### 상수 (현행 값 유지)
+- `EOD_HIST_TO_DAYS = 5`, `EOD_RECENT_FROM_DAYS = 10`(겹침 5일 — 최대 4일 연속 휴장 tolerant), `EOD_HIST_TTL_SECONDS = SECONDS_PER_DAY * 30`.
+- `recentFromThreshold` = `recentFrom`(YYYY-MM-DD) → `Date.parse(recentFrom + 'T00:00:00Z')/1000` (Bar.time은 UTC 자정 unix초).
+
+### `getOrSetCache` 확장 (staleness 지원)
+현재 `getOrSetCache(key, ttl, fetcher, shouldCache?)`에 **선택적 5번째 인자 `isFresh?: (cached: T) => boolean`**(기본 `() => true`)를 추가한다:
+- 캐시 hit(envelope)이어도 `isFresh(data) === false`면 miss처럼 취급 → fetcher 재호출 + set.
+- 기존 호출부 무영향(기본값 always-fresh). Tier 1 history가 이 인자로 겹침-staleness를 표현한다.
+
+### getBars 분기 (요약)
+```ts
+if (timeframe === '1Day' && before === undefined && isLongDailyWindow(from)) {
+  const history = getOrSetCache(
+    `bars:eodhist:${SYM}`, EOD_HIST_TTL_SECONDS,
+    () => inner.getBars({ ...options, before: histTo }),
+    bars => bars.length > 0,                                   // shouldCache
+    bars => bars.length > 0 && bars.at(-1)!.time >= recentFromThreshold  // isFresh
+  );
+  const recent = getOrSetCache(
+    `bars:eodrecent:${SYM}`, this.ttl('1Day'),
+    () => inner.getBars({ ...options, from: recentFrom }),
+    bars => bars.length > 0
+  );
+  return sliceFrom(mergeBarsByTime(await history, await recent), from);
+}
+// else: 기존 단일 bars:raw 경로 (인트라데이·짧은 lookback·before 지정)
+```
+
+---
+
+## 4. 동작별 호출 (개선)
+
+| 상황 | 현재 | 재설계 |
+|---|---|---|
+| 밤사이 반복 크롤(같은 심볼) | 자정롤 + 2× full 재fetch | history 캐시 hit + recent 장외 캐시 → **~0** |
+| cold 최초 심볼 | 2 (full+recent) | 2 (full+recent), 1회뿐 |
+| 새 세션(다음 날) | 심볼당 full 재fetch | recent(작음)만; history는 ~3일당 1회 |
+| 인트라데이·짧은 lookback·before 지정 | 단일 경로 | 단일 경로(불변) |
+
+→ 00:00 UTC 자정 스파이크 제거, 밤 크롤은 신규 cold 심볼만 → **호출·egress 동반 감소**.
+
+---
+
+## 5. 에러 처리 (기존 계약 보존)
+- `inner.getBars` throw → `getOrSetCache` set 전에 전파(poison 방지). 두 tier 중 하나가 throw하면 `getBars` reject(현행과 동일 실패 의미론).
+- 빈 배열은 `shouldCache`(`bars.length>0`)로 미캐싱.
+- Redis 미설정/장애 → `getOrSetCache` graceful fallback(inner 직접 호출). `isFresh`도 Redis 경로 안에서만 평가되므로 fallback 시 항상 fetch.
+
+---
+
+## 6. 테스트
+- **앵커 키(자정 롤 없음)**: 같은 심볼, 시스템 시각을 하루 넘겨도(`vi.setSystemTime`) history 키 동일 → 재fetch 안 함(fresh면).
+- **history staleness**: 캐시 newest >= recentFrom → 0 fetch; newest < recentFrom(겹침 소실) → full 재fetch 1회.
+- **recent 세션 TTL**: 장중 60s / 장외 다음 개장까지(open·closed·weekend 시각 고정).
+- **merge 동일성**: history+recent 병합·슬라이스가 단일 `getBars(from)`와 동일 집합(겹침/주말 갭 픽스처).
+- **cold=2 / repeat=0**: 최초 접근 2 fetch, 재접근(캐시 hit) 0.
+- **guard 분기**: 1Day+before 지정, 짧은 lookback, 인트라데이 → 단일 경로.
+- **getOrSetCache `isFresh`**: hit이어도 isFresh=false면 refetch+set; 기본값(미지정) 시 기존 동작.
+- 시간 의존은 `vi.setSystemTime`로 결정화.
+
+---
+
+## 7. 롤아웃 · 전제 · 고려사항
+- **옛 키 orphan(안전)**: v0.32.0의 날짜-포함 키(`bars:eodhist:<SYM>:<from>:<histTo>`, `bars:eodrecent:<SYM>:<recentFrom>`)는 배포 후 아무도 읽지 않는다. TTL(hist 2d, recent 60s/off-hours)로 자연 만료 → 형식 충돌·수동 정리 불필요. 새 앵커 키(`bars:eodhist:<SYM>`, `bars:eodrecent:<SYM>`)는 네임스페이스가 겹치지만 세그먼트 수가 달라 충돌 없음. 롤백 시에도 새 키는 만료되며 무해.
+- **앵커 키 전제(불변식)**: `bars:eodhist:<SYM>` 키에서 `from`을 뺄 수 있는 근거는 **모든 long-1Day 호출부가 core `TIMEFRAME_LOOKBACK_DAYS['1Day']`(=730d) 단일 lookback을 공유**하기 때문. 서로 다른 `from`을 쓰는 짧은 lookback은 `isLongDailyWindow` 가드가 단일 경로로 보낸다. core lookback이 바뀌면 이 전제도 함께 갱신(주석 명시).
+- **Redis 저장 증가(허용)**: history TTL 2d→30d로 심볼당 히스토리(~수십~110KB)가 더 오래 상주. 절감(호출·egress) 대비 미미. Upstash 용량 여유 내.
+- **E2E 무영향**: `getCachedMarketDataProvider`가 E2E에서 raw provider 반환(데코레이터 우회) — 현행과 동일, 이 재설계 미적용.
+- **crypto**: `CRYPTO_SESSION`(24/7)도 1Day 분리 경로를 탄다. `computeBarsEffectiveTtl`이 crypto엔 항상 60s(off-hours 없음) 반환 → recent tail이 상시 60s. 정상 동작(심볼-무관 로직).
+
+## 8. 영향 파일
+- `src/shared/cache/getOrSetCache.ts` — 선택적 `isFresh` 인자 추가.
+- `src/shared/api/market/CachedMarketDataProvider.ts` — `getCachedDailyBars` 재작성(앵커 키, staleness, 슬라이스), 상수/헬퍼(`recentFromThreshold`, `sliceFrom`). 두 tier는 `Promise.all`로 병렬 fetch.
+- `src/shared/api/market/mergeBarsByTime.ts` — 재사용(무변경).
+- 각 colocated `__tests__` + `getOrSetCache` 테스트.

--- a/src/shared/api/market/CachedMarketDataProvider.ts
+++ b/src/shared/api/market/CachedMarketDataProvider.ts
@@ -51,6 +51,28 @@ function sliceFrom(bars: Bar[], from: string | undefined): Bar[] {
     return bars.filter(b => b.time >= threshold);
 }
 
+/**
+ * history 캐시 엔트리가 재사용 가능한지 판정한다:
+ * ① covers: 캐시된 최古 봉이 요청 `fromThreshold`를 커버(더 과거 요청 시 truncation 방지),
+ * ② overlap: 최신 봉이 recent 윈도우와 겹치면 fresh,
+ * ③ cooldown: 겹침이 소실됐어도(상장폐지 등 permanent-stale) 최근 재조회했으면 재사용해
+ *    per-request 재fetch thrash를 막는다.
+ */
+function isHistoryEntryFresh(
+    entry: EodHistoryEntry,
+    fromThreshold: number | null,
+    recentFromThreshold: number,
+    nowSeconds: number
+): boolean {
+    if (entry.bars.length === 0) return false;
+    const covers =
+        fromThreshold === null || entry.bars[0]!.time <= fromThreshold;
+    if (!covers) return false;
+    if (entry.bars[entry.bars.length - 1]!.time >= recentFromThreshold)
+        return true;
+    return nowSeconds - entry.fetchedAt < EOD_HIST_STALE_RECHECK_SECONDS;
+}
+
 /** quote TTL은 bars 일봉 개장-경계 정책을 재사용 — timeframe과 무관한 placeholder. */
 const QUOTE_TTL_TIMEFRAME = '1Day' as const satisfies Timeframe;
 
@@ -180,26 +202,13 @@ export class CachedMarketDataProvider implements MarketDataProvider {
                     fetchedAt: nowSeconds,
                 }),
                 entry => entry.bars.length > 0,
-                entry => {
-                    if (entry.bars.length === 0) return false;
-                    // 요청 from 이 캐시된 최古 봉보다 과거면 커버 못 함 → 재fetch(truncation 방지).
-                    const covers =
-                        fromThreshold === null ||
-                        entry.bars[0]!.time <= fromThreshold;
-                    if (!covers) return false;
-                    // 최신 봉이 recent 윈도우와 겹치면 fresh.
-                    if (
-                        entry.bars[entry.bars.length - 1]!.time >=
-                        recentFromThreshold
+                entry =>
+                    isHistoryEntryFresh(
+                        entry,
+                        fromThreshold,
+                        recentFromThreshold,
+                        nowSeconds
                     )
-                        return true;
-                    // 겹침이 소실됐어도(예: 상장폐지) 최근 재조회했다면 그대로 사용해
-                    // per-request 재fetch thrash를 막는다.
-                    return (
-                        nowSeconds - entry.fetchedAt <
-                        EOD_HIST_STALE_RECHECK_SECONDS
-                    );
-                }
             ),
             getOrSetCache(
                 `bars:eodrecent:${symbolKey}`,

--- a/src/shared/api/market/CachedMarketDataProvider.ts
+++ b/src/shared/api/market/CachedMarketDataProvider.ts
@@ -13,17 +13,29 @@ import { getOrSetCache } from '@/shared/cache/getOrSetCache';
 import { SECONDS_PER_DAY } from '@/shared/config/time';
 import { mergeBarsByTime } from './mergeBarsByTime';
 
-/** 과거(불변) 윈도우 종료점: 오늘 − 7일. 최근 윈도우와 겹쳐 주말·공휴일 갭 방지. */
+/** 과거(불변) 윈도우 종료점: 오늘 − EOD_HIST_TO_DAYS일. recent와 겹쳐 갭 방지. */
 const EOD_HIST_TO_DAYS = 7;
-/** 최근(live) 윈도우 시작점: 오늘 − 10일(약 3일 overlap → dedup). */
+/** 최근(live) 윈도우 시작점: 오늘 − EOD_RECENT_FROM_DAYS일. */
 const EOD_RECENT_FROM_DAYS = 10;
-/** 과거 윈도우 long TTL. 키가 날짜로 self-versioning하므로 intraday 커버 + 여유. */
-const EOD_HIST_TTL_SECONDS = SECONDS_PER_DAY * 2;
+/** 과거 history long TTL(30일). 갱신은 TTL이 아니라 recent와의 겹침 staleness가 주도. */
+const EOD_HIST_TTL_SECONDS = SECONDS_PER_DAY * 30;
 
 function isoDateDaysAgo(now: Date, days: number): string {
     const d = new Date(now);
     d.setUTCDate(d.getUTCDate() - days);
     return d.toISOString().slice(0, 10);
+}
+
+/** YYYY-MM-DD(또는 ISO) 날짜를 UTC 자정 unix초로 변환(Bar.time과 동일 규약). */
+function utcMidnightSeconds(dateStr: string): number {
+    return Math.floor(Date.parse(dateStr.slice(0, 10) + 'T00:00:00Z') / 1000);
+}
+
+/** `from` 이후(포함) 봉만 남긴다 — 단일 `getBars(from)`와 동일 집합 보장. */
+function sliceFrom(bars: Bar[], from: string | undefined): Bar[] {
+    if (from === undefined) return bars;
+    const threshold = utcMidnightSeconds(from);
+    return bars.filter(b => b.time >= threshold);
 }
 
 /** quote TTL은 bars 일봉 개장-경계 정책을 재사용 — timeframe과 무관한 placeholder. */
@@ -107,38 +119,51 @@ export class CachedMarketDataProvider implements MarketDataProvider {
     };
 
     /**
-     * 요청 윈도우가 최근 overlap 구간(오늘−EOD_RECENT_FROM_DAYS)보다 앞에서 시작함을
-     * 전제로 한다(isLongDailyWindow 가드 통과 후 진입). 짧은 lookback은 getCachedDailyBars를
-     * 직접 호출하지 말고 반드시 getBars를 통해 라우팅할 것.
+     * 요청 윈도우가 최근 overlap 구간보다 앞에서 시작함을 전제로 한다(isLongDailyWindow
+     * 가드 통과 후 진입). 짧은 lookback은 getBars를 통해 단일 경로로 라우팅된다.
      *
-     * 1Day 일봉을 불변 과거(long-cache)와 최근(live)로 나눠 fetch 후 병합한다.
-     * 과거 윈도우는 `before=오늘−EOD_HIST_TO_DAYS`로 한정해 오늘 봉을 포함하지 않으므로(=불변)
-     * long TTL로 캐싱하고, 매일 키(`from`·`histTo` 날짜)가 self-versioning된다.
-     * 최근 윈도우(`from=오늘−EOD_RECENT_FROM_DAYS`)는 작은 EOD(~EOD_RECENT_FROM_DAYS행)+오늘 봉(quote)을 기존 세션 TTL
-     * (장중 60s)로 가져온다. 두 윈도우는 (EOD_RECENT_FROM_DAYS - EOD_HIST_TO_DAYS)일 겹쳐 주말·공휴일 갭을 막고
-     * `mergeBarsByTime`가 중복(time)을 최근 우선으로 제거한다. 결과는 단일
-     * `getBars(from)`와 동일 집합이다.
+     * 1Day 일봉을 불변 과거(history, 날짜-없는 앵커 키 `bars:eodhist:<SYM>`)와 최근(live,
+     * `bars:eodrecent:<SYM>`)으로 나눠 병렬 fetch 후 병합한다. 캐시 키에 날짜를 넣지 않아
+     * UTC 자정 롤로 인한 전체 재fetch가 없다.
+     *
+     * history는 `before=오늘−EOD_HIST_TO_DAYS`로 오늘을 제외(불변)해 long TTL로 캐싱하고,
+     * `isFresh`(캐시된 최신 봉이 recentFrom 이후 = recent 윈도우와 겹침)로 staleness를 판정한다
+     * — 겹침이 유지되면 재fetch 0, 겹침이 사라지면(=cached newest < recentFrom) full 재fetch.
+     * recent는 `from=오늘−EOD_RECENT_FROM_DAYS`(오늘 봉을 quote로 append)를 세션 TTL로 가져와
+     * 오늘/최근 신선도를 담당한다. 두 윈도우의 (EOD_RECENT_FROM_DAYS − EOD_HIST_TO_DAYS)일
+     * 겹침을 `mergeBarsByTime`가 recent 우선으로 dedup하고, `sliceFrom`가 options.from으로
+     * 잘라 단일 `getBars(from)`와 동일 집합을 만든다.
+     *
+     * 앵커 키에서 from을 뺄 수 있는 근거: 모든 long-1Day 호출부가 core
+     * TIMEFRAME_LOOKBACK_DAYS['1Day'] 단일 lookback을 공유한다(짧은 lookback은 가드가
+     * 단일 경로로 분기). core lookback 변경 시 이 전제도 함께 갱신할 것.
      */
     private async getCachedDailyBars(options: GetBarsOptions): Promise<Bar[]> {
         const now = new Date();
         const histTo = isoDateDaysAgo(now, EOD_HIST_TO_DAYS);
         const recentFrom = isoDateDaysAgo(now, EOD_RECENT_FROM_DAYS);
+        const recentFromThreshold = utcMidnightSeconds(recentFrom);
         const symbolKey = options.symbol.toUpperCase();
-        const [historical, recent] = await Promise.all([
+
+        const [history, recent] = await Promise.all([
             getOrSetCache(
-                `bars:eodhist:${symbolKey}:${options.from ?? ''}:${histTo}`,
+                `bars:eodhist:${symbolKey}`,
                 EOD_HIST_TTL_SECONDS,
                 () => this.inner.getBars({ ...options, before: histTo }),
-                bars => bars.length > 0
+                bars => bars.length > 0,
+                bars =>
+                    bars.length > 0 &&
+                    bars[bars.length - 1]!.time >= recentFromThreshold
             ),
             getOrSetCache(
-                `bars:eodrecent:${symbolKey}:${recentFrom}`,
+                `bars:eodrecent:${symbolKey}`,
                 this.ttl('1Day'),
                 () => this.inner.getBars({ ...options, from: recentFrom }),
                 bars => bars.length > 0
             ),
         ]);
-        return mergeBarsByTime(historical, recent);
+
+        return sliceFrom(mergeBarsByTime(history, recent), options.from);
     }
 
     getQuote = (symbol: string): Promise<MarketQuote | null> =>

--- a/src/shared/api/market/CachedMarketDataProvider.ts
+++ b/src/shared/api/market/CachedMarketDataProvider.ts
@@ -13,8 +13,12 @@ import { getOrSetCache } from '@/shared/cache/getOrSetCache';
 import { SECONDS_PER_DAY } from '@/shared/config/time';
 import { mergeBarsByTime } from './mergeBarsByTime';
 
-/** 과거(불변) 윈도우 종료점: 오늘 − EOD_HIST_TO_DAYS일. recent와 겹쳐 갭 방지. */
-const EOD_HIST_TO_DAYS = 7;
+/**
+ * 과거(불변) 윈도우 종료점: 오늘 − EOD_HIST_TO_DAYS일. recent와 겹쳐 갭 방지.
+ * overlap = EOD_RECENT_FROM_DAYS − EOD_HIST_TO_DAYS = 5일 →
+ * 최대 4일 연속 휴장(공휴일+주말 인접)에도 겹침이 유지된다.
+ */
+const EOD_HIST_TO_DAYS = 5;
 /** 최근(live) 윈도우 시작점: 오늘 − EOD_RECENT_FROM_DAYS일. */
 const EOD_RECENT_FROM_DAYS = 10;
 /** 과거 history long TTL(30일). 갱신은 TTL이 아니라 recent와의 겹침 staleness가 주도. */

--- a/src/shared/api/market/CachedMarketDataProvider.ts
+++ b/src/shared/api/market/CachedMarketDataProvider.ts
@@ -10,7 +10,7 @@ import {
     computeBarsEffectiveTtl,
 } from '@y0ngha/siglens-core';
 import { getOrSetCache } from '@/shared/cache/getOrSetCache';
-import { SECONDS_PER_DAY } from '@/shared/config/time';
+import { SECONDS_PER_DAY, SECONDS_PER_HOUR } from '@/shared/config/time';
 import { mergeBarsByTime } from './mergeBarsByTime';
 
 /**
@@ -23,6 +23,15 @@ const EOD_HIST_TO_DAYS = 5;
 const EOD_RECENT_FROM_DAYS = 10;
 /** 과거 history long TTL(30일). 갱신은 TTL이 아니라 recent와의 겹침 staleness가 주도. */
 const EOD_HIST_TTL_SECONDS = SECONDS_PER_DAY * 30;
+/** stale(겹침 소실) history를 재조회하는 최소 간격. 상장폐지·장기정지처럼 최신 봉이
+ * 영구히 recentFrom에 못 미치는 심볼이 매 요청마다 full 재fetch하는 것을 방지한다. */
+const EOD_HIST_STALE_RECHECK_SECONDS = SECONDS_PER_HOUR;
+
+/** history 캐시 엔트리: 불변 과거 봉 + fetch 시각(stale-recheck 쿨다운 판정용). */
+interface EodHistoryEntry {
+    bars: Bar[];
+    fetchedAt: number; // unix seconds
+}
 
 function isoDateDaysAgo(now: Date, days: number): string {
     const d = new Date(now);
@@ -130,9 +139,14 @@ export class CachedMarketDataProvider implements MarketDataProvider {
      * `bars:eodrecent:<SYM>`)으로 나눠 병렬 fetch 후 병합한다. 캐시 키에 날짜를 넣지 않아
      * UTC 자정 롤로 인한 전체 재fetch가 없다.
      *
-     * history는 `before=오늘−EOD_HIST_TO_DAYS`로 오늘을 제외(불변)해 long TTL로 캐싱하고,
-     * `isFresh`(캐시된 최신 봉이 recentFrom 이후 = recent 윈도우와 겹침)로 staleness를 판정한다
-     * — 겹침이 유지되면 재fetch 0, 겹침이 사라지면(=cached newest < recentFrom) full 재fetch.
+     * history 엔트리는 `{ bars, fetchedAt }` 형태로 저장한다. `isFresh` 판정:
+     *   1. covers(from): 캐시된 최古 봉이 요청 `from` 이전이어야 함 — 짧은 캐시가 긴 요청을
+     *      잘라내는 truncation을 방지한다.
+     *   2. 겹침 유지: 최신 봉이 recentFrom 이후 → fresh.
+     *   3. stale-recheck 쿨다운: 겹침이 소실됐어도(상장폐지·장기정지 등 permanent-stale) 최근
+     *      EOD_HIST_STALE_RECHECK_SECONDS 이내 fetch했으면 그대로 사용 — 매 요청마다 full
+     *      재fetch thrash를 막는다. 쿨다운 만료 후에만 재fetch.
+     *
      * recent는 `from=오늘−EOD_RECENT_FROM_DAYS`(오늘 봉을 quote로 append)를 세션 TTL로 가져와
      * 오늘/최근 신선도를 담당한다. 두 윈도우의 (EOD_RECENT_FROM_DAYS − EOD_HIST_TO_DAYS)일
      * 겹침을 `mergeBarsByTime`가 recent 우선으로 dedup하고, `sliceFrom`가 options.from으로
@@ -144,20 +158,48 @@ export class CachedMarketDataProvider implements MarketDataProvider {
      */
     private async getCachedDailyBars(options: GetBarsOptions): Promise<Bar[]> {
         const now = new Date();
+        const nowSeconds = Math.floor(now.getTime() / 1000);
         const histTo = isoDateDaysAgo(now, EOD_HIST_TO_DAYS);
         const recentFrom = isoDateDaysAgo(now, EOD_RECENT_FROM_DAYS);
         const recentFromThreshold = utcMidnightSeconds(recentFrom);
+        const fromThreshold =
+            options.from !== undefined
+                ? utcMidnightSeconds(options.from)
+                : null;
         const symbolKey = options.symbol.toUpperCase();
 
-        const [history, recent] = await Promise.all([
-            getOrSetCache(
+        const [historyEntry, recent] = await Promise.all([
+            getOrSetCache<EodHistoryEntry>(
                 `bars:eodhist:${symbolKey}`,
                 EOD_HIST_TTL_SECONDS,
-                () => this.inner.getBars({ ...options, before: histTo }),
-                bars => bars.length > 0,
-                bars =>
-                    bars.length > 0 &&
-                    bars[bars.length - 1]!.time >= recentFromThreshold
+                async () => ({
+                    bars: await this.inner.getBars({
+                        ...options,
+                        before: histTo,
+                    }),
+                    fetchedAt: nowSeconds,
+                }),
+                entry => entry.bars.length > 0,
+                entry => {
+                    if (entry.bars.length === 0) return false;
+                    // 요청 from 이 캐시된 최古 봉보다 과거면 커버 못 함 → 재fetch(truncation 방지).
+                    const covers =
+                        fromThreshold === null ||
+                        entry.bars[0]!.time <= fromThreshold;
+                    if (!covers) return false;
+                    // 최신 봉이 recent 윈도우와 겹치면 fresh.
+                    if (
+                        entry.bars[entry.bars.length - 1]!.time >=
+                        recentFromThreshold
+                    )
+                        return true;
+                    // 겹침이 소실됐어도(예: 상장폐지) 최근 재조회했다면 그대로 사용해
+                    // per-request 재fetch thrash를 막는다.
+                    return (
+                        nowSeconds - entry.fetchedAt <
+                        EOD_HIST_STALE_RECHECK_SECONDS
+                    );
+                }
             ),
             getOrSetCache(
                 `bars:eodrecent:${symbolKey}`,
@@ -167,7 +209,10 @@ export class CachedMarketDataProvider implements MarketDataProvider {
             ),
         ]);
 
-        return sliceFrom(mergeBarsByTime(history, recent), options.from);
+        return sliceFrom(
+            mergeBarsByTime(historyEntry.bars, recent),
+            options.from
+        );
     }
 
     getQuote = (symbol: string): Promise<MarketQuote | null> =>

--- a/src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
+++ b/src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
@@ -467,6 +467,57 @@ describe('CachedMarketDataProvider', () => {
             expect(result.map(b => b.time)).toEqual([recentT]);
         });
 
+        it('from=undefined → anchored split taken, merged result returned unsliced', async () => {
+            const freshHist = Math.floor(
+                Date.parse('2026-06-26T00:00:00Z') / 1000
+            ); // >= recentFrom(2026-06-20) → fresh
+            const recentT = Math.floor(
+                Date.parse('2026-06-29T00:00:00Z') / 1000
+            );
+            const getBars = vi.fn(async (o: GetBarsOptions) =>
+                o.before !== undefined
+                    ? [{ ...bar(freshHist), time: freshHist }]
+                    : [{ ...bar(recentT), time: recentT }]
+            );
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+            const result = await provider.getBars({
+                symbol: 'AAPL',
+                timeframe: '1Day',
+            }); // no `from`
+            expect(store.has('bars:eodhist:AAPL')).toBe(true);
+            expect(store.has('bars:eodrecent:AAPL')).toBe(true);
+            expect(getBars).toHaveBeenCalledTimes(2);
+            // from 없음 → sliceFrom가 미절단(unsliced): 양쪽 봉 모두 유지
+            expect(result.map(b => b.time)).toEqual([freshHist, recentT]);
+        });
+
+        it('sliceFrom keeps a bar exactly at options.from (inclusive boundary)', async () => {
+            const boundary = Math.floor(
+                Date.parse('2024-06-30T00:00:00Z') / 1000
+            ); // == options.from
+            const recentT = Math.floor(
+                Date.parse('2026-06-29T00:00:00Z') / 1000
+            );
+            const getBars = vi.fn(async (o: GetBarsOptions) =>
+                o.before !== undefined
+                    ? [{ ...bar(boundary), time: boundary }]
+                    : [{ ...bar(recentT), time: recentT }]
+            );
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+            const result = await provider.getBars({
+                symbol: 'AAPL',
+                timeframe: '1Day',
+                from: '2024-06-30',
+            });
+            expect(result.map(b => b.time)).toContain(boundary);
+        });
+
         // Preserved: recent-window TTL — open vs closed
         it('(f) bars:eodrecent TTL: market-open instant → 60s', async () => {
             // ET regular session open: Mon 2026-06-29 14:30 UTC = 10:30 ET

--- a/src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
+++ b/src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
@@ -206,6 +206,9 @@ describe('CachedMarketDataProvider', () => {
         };
 
         it('uses date-free anchored keys (bars:eodhist:<SYM>, bars:eodrecent:<SYM>)', async () => {
+            // oldest bar(bar(1)) time=1 이 options.from('2024-06-30') 보다 훨씬 이전이므로
+            // covers 체크를 통과하도록 utcMidnight('2024-06-30') 이하 값을 써야 한다.
+            // bar(1)은 unix time 1 = 1970-01-01이므로 covers OK.
             const getBars = vi.fn(async (o: GetBarsOptions) =>
                 o.before !== undefined ? [bar(1)] : [bar(2)]
             );
@@ -223,13 +226,20 @@ describe('CachedMarketDataProvider', () => {
         });
 
         it('history is NOT refetched across a day boundary when still fresh (anchored key, overlap holds)', async () => {
-            // history fetch(before=histTo)는 recentFrom 이후를 커버하는 봉을 반환하도록 구성
+            // history fetch(before=histTo)는 recentFrom 이후를 커버하는 봉을 반환하도록 구성.
+            // oldest bar(covering)를 from('2024-06-30') 이하로 설정해 covers 체크 통과.
+            const oldestBar = Math.floor(
+                Date.parse('2024-06-30T00:00:00Z') / 1000
+            ); // == options.from → covers
             const histBarTime = Math.floor(
                 Date.parse('2026-06-25T00:00:00Z') / 1000
             ); // recentFrom(2026-06-20) 이후 → fresh
             const getBars = vi.fn(async (o: GetBarsOptions) =>
                 o.before !== undefined
-                    ? [{ ...bar(histBarTime), time: histBarTime }]
+                    ? [
+                          { ...bar(oldestBar), time: oldestBar },
+                          { ...bar(histBarTime), time: histBarTime },
+                      ]
                     : [bar(9)]
             );
             const provider = new CachedMarketDataProvider({
@@ -252,14 +262,21 @@ describe('CachedMarketDataProvider', () => {
             expect(histCallsTotal).toBe(1); // 자정 넘겨도 재fetch 없음(fresh)
         });
 
-        it('history IS refetched when cached newest falls behind recentFrom (stale, overlap lost)', async () => {
-            // history fetch가 recentFrom 이전(오래된) 봉만 반환 → isFresh=false → 매번 재fetch
+        it('history IS refetched when stale AND cooldown has expired (stale + cooldown expired → refetch)', async () => {
+            // history fetch가 recentFrom 이전(오래된) 봉만 반환 → isFresh overlap=false
+            // 첫 fetch 후 시간이 > EOD_HIST_STALE_RECHECK_SECONDS(1h) 경과 → 쿨다운 만료 → 재fetch
+            const oldestBar = Math.floor(
+                Date.parse('2024-06-30T00:00:00Z') / 1000
+            ); // covers from='2024-06-30'
             const staleTime = Math.floor(
                 Date.parse('2026-06-01T00:00:00Z') / 1000
-            ); // recentFrom(2026-06-20) 이전
+            ); // recentFrom(2026-06-20) 이전 → overlap 소실
             const getBars = vi.fn(async (o: GetBarsOptions) =>
                 o.before !== undefined
-                    ? [{ ...bar(staleTime), time: staleTime }]
+                    ? [
+                          { ...bar(oldestBar), time: oldestBar },
+                          { ...bar(staleTime), time: staleTime },
+                      ]
                     : [bar(9)]
             );
             const provider = new CachedMarketDataProvider({
@@ -267,15 +284,123 @@ describe('CachedMarketDataProvider', () => {
                 getQuote: vi.fn(async () => null),
             });
 
-            await provider.getBars(longOpts);
+            await provider.getBars(longOpts); // 1차: stale, fetchedAt 기록
+
+            // 2시간 경과 → nowSeconds - fetchedAt >= EOD_HIST_STALE_RECHECK_SECONDS(3600) → 재fetch
+            vi.setSystemTime(new Date('2026-06-30T17:00:00Z'));
             await provider.getBars(longOpts);
             const histCalls = getBars.mock.calls.filter(
                 c => c[0].before !== undefined
             ).length;
-            expect(histCalls).toBe(2); // stale → 재fetch
+            expect(histCalls).toBe(2); // 쿨다운 만료 → 재fetch
+        });
+
+        it('[Blocker fix] stale + within cooldown → served from cache (no refetch)', async () => {
+            // permanent-stale(상장폐지/장기정지): newest bar never reaches recentFrom.
+            // 2nd call within the same hour → cooldown active → 재fetch 없이 캐시 반환.
+            const oldestBar = Math.floor(
+                Date.parse('2024-06-30T00:00:00Z') / 1000
+            ); // covers from='2024-06-30'
+            const staleTime = Math.floor(
+                Date.parse('2026-06-01T00:00:00Z') / 1000
+            ); // recentFrom(2026-06-20) 이전 → overlap 소실
+            const getBars = vi.fn(async (o: GetBarsOptions) =>
+                o.before !== undefined
+                    ? [
+                          { ...bar(oldestBar), time: oldestBar },
+                          { ...bar(staleTime), time: staleTime },
+                      ]
+                    : [bar(9)]
+            );
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+
+            await provider.getBars(longOpts); // 1차 fetch → stale, fetchedAt 기록
+
+            // 30분 경과 → nowSeconds - fetchedAt = 1800 < 3600 → 쿨다운 내 → 재fetch 없음
+            vi.setSystemTime(new Date('2026-06-30T15:30:00Z'));
+            await provider.getBars(longOpts);
+            const histCalls = getBars.mock.calls.filter(
+                c => c[0].before !== undefined
+            ).length;
+            expect(histCalls).toBe(1); // 쿨다운 내 → 캐시 서빙, 추가 fetch 없음
+        });
+
+        it('[truncation fix] shorter cache does not truncate a longer request', async () => {
+            // 1차: oldest=2025-06-30(~1yr) 으로 캐시 워밍.
+            // 2차: from='2024-06-30'(~2yr) 요청 → oldest(2025) > from(2024) → covers=false → 재fetch.
+            const shortOldest = Math.floor(
+                Date.parse('2025-06-30T00:00:00Z') / 1000
+            ); // 캐시의 최古 봉
+            const freshNewest = Math.floor(
+                Date.parse('2026-06-25T00:00:00Z') / 1000
+            ); // overlap 유지 → isFresh true(covers가 false면 무관)
+            const getBars = vi.fn(async (o: GetBarsOptions) =>
+                o.before !== undefined
+                    ? [
+                          { ...bar(shortOldest), time: shortOldest },
+                          { ...bar(freshNewest), time: freshNewest },
+                      ]
+                    : [bar(9)]
+            );
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+
+            // 1차: from='2025-06-30' → oldest(2025) <= from(2025) → covers OK → 캐시
+            await provider.getBars({ ...longOpts, from: '2025-06-30' });
+            const histCallsAfterFirst = getBars.mock.calls.filter(
+                c => c[0].before !== undefined
+            ).length;
+            expect(histCallsAfterFirst).toBe(1);
+
+            // 2차: from='2024-06-30' → oldest(2025) > from(2024) → covers FAIL → 재fetch
+            await provider.getBars({ ...longOpts, from: '2024-06-30' });
+            const histCallsAfterSecond = getBars.mock.calls.filter(
+                c => c[0].before !== undefined
+            ).length;
+            expect(histCallsAfterSecond).toBe(2); // covers 실패 → 재fetch 발생
+        });
+
+        it('[boundary] isFresh recentFrom boundary: newest exactly == recentFromThreshold → fresh', async () => {
+            // System time: 2026-06-30T15:00:00Z → recentFrom = 2026-06-20 → threshold = utcMidnight(2026-06-20)
+            const recentFromThreshold = Math.floor(
+                Date.parse('2026-06-20T00:00:00Z') / 1000
+            );
+            const oldestBar = Math.floor(
+                Date.parse('2024-06-30T00:00:00Z') / 1000
+            ); // covers from='2024-06-30'
+            const getBars = vi.fn(async (o: GetBarsOptions) =>
+                o.before !== undefined
+                    ? [
+                          { ...bar(oldestBar), time: oldestBar },
+                          {
+                              ...bar(recentFromThreshold),
+                              time: recentFromThreshold,
+                          },
+                      ]
+                    : [bar(9)]
+            );
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+
+            await provider.getBars(longOpts); // 1차
+            await provider.getBars(longOpts); // 2차: 같은 시각 → fresh → 재fetch 없음
+            const histCalls = getBars.mock.calls.filter(
+                c => c[0].before !== undefined
+            ).length;
+            expect(histCalls).toBe(1); // >= inclusive → fresh, 재fetch 0
         });
 
         it('merges history + recent and slices to options.from', async () => {
+            const oldestBar = Math.floor(
+                Date.parse('2024-06-30T00:00:00Z') / 1000
+            ); // == options.from → covers check 통과
             const inRange = Math.floor(
                 Date.parse('2025-01-01T00:00:00Z') / 1000
             );
@@ -289,6 +414,7 @@ describe('CachedMarketDataProvider', () => {
                 o.before !== undefined
                     ? [
                           { ...bar(tooOld), time: tooOld },
+                          { ...bar(oldestBar), time: oldestBar },
                           { ...bar(inRange), time: inRange },
                       ]
                     : [{ ...bar(recentT), time: recentT }]
@@ -306,12 +432,18 @@ describe('CachedMarketDataProvider', () => {
         });
 
         it('cold symbol = 2 fetches (history + recent); repeat within session = 0', async () => {
+            const oldestBar = Math.floor(
+                Date.parse('2024-06-30T00:00:00Z') / 1000
+            ); // covers from='2024-06-30'
             const freshHist = Math.floor(
                 Date.parse('2026-06-25T00:00:00Z') / 1000
-            );
+            ); // >= recentFrom → fresh
             const getBars = vi.fn(async (o: GetBarsOptions) =>
                 o.before !== undefined
-                    ? [{ ...bar(freshHist), time: freshHist }]
+                    ? [
+                          { ...bar(oldestBar), time: oldestBar },
+                          { ...bar(freshHist), time: freshHist },
+                      ]
                     : [bar(9)]
             );
             const provider = new CachedMarketDataProvider({
@@ -497,7 +629,7 @@ describe('CachedMarketDataProvider', () => {
         it('sliceFrom keeps a bar exactly at options.from (inclusive boundary)', async () => {
             const boundary = Math.floor(
                 Date.parse('2024-06-30T00:00:00Z') / 1000
-            ); // == options.from
+            ); // == options.from — oldest bar이므로 covers(from) 통과
             const recentT = Math.floor(
                 Date.parse('2026-06-29T00:00:00Z') / 1000
             );

--- a/src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
+++ b/src/shared/api/market/__tests__/CachedMarketDataProvider.test.ts
@@ -191,46 +191,21 @@ describe('CachedMarketDataProvider', () => {
         expect(store.size).toBe(0);
     });
 
-    describe('1Day EOD split', () => {
+    describe('1Day anchored 2-tier', () => {
         beforeEach(() => {
-            resetSharedState(); // fakeRedis store clear
+            resetSharedState();
             vi.useFakeTimers();
             vi.setSystemTime(new Date('2026-06-30T15:00:00Z'));
         });
         afterEach(() => vi.useRealTimers());
 
-        it('splits 1Day into historical(before set) + recent(from set) and merges', async () => {
-            const getBars = vi.fn(async (o: GetBarsOptions) =>
-                o.before !== undefined ? [bar(1), bar(2)] : [bar(2), bar(3)]
-            );
-            const provider = new CachedMarketDataProvider({
-                getBars,
-                getQuote: vi.fn(async () => null),
-            });
-            const opts: GetBarsOptions = {
-                symbol: 'AAPL',
-                timeframe: '1Day',
-                from: '2024-06-30',
-            };
+        const longOpts: GetBarsOptions = {
+            symbol: 'AAPL',
+            timeframe: '1Day',
+            from: '2024-06-30',
+        };
 
-            const result = await provider.getBars(opts);
-
-            // 두 윈도우 호출: 하나는 before(과거), 하나는 from override(최근)
-            // system time: 2026-06-30T15:00:00Z → histTo=2026-06-23, recentFrom=2026-06-20
-            const calls = getBars.mock.calls.map(c => c[0]);
-            const histCall = calls.find(c => c.before !== undefined);
-            expect(histCall).toBeDefined();
-            expect(histCall?.before).toBe('2026-06-23');
-            const recentCall = calls.find(
-                c => c.before === undefined && c.from !== '2024-06-30'
-            );
-            expect(recentCall).toBeDefined();
-            expect(recentCall?.from).toBe('2026-06-20');
-            // merge + dedup(시간 2 중복 → 1개), 오름차순
-            expect(result.map(b => b.time)).toEqual([1, 2, 3]);
-        });
-
-        it('serves historical window from long cache on the 2nd call (same day)', async () => {
+        it('uses date-free anchored keys (bars:eodhist:<SYM>, bars:eodrecent:<SYM>)', async () => {
             const getBars = vi.fn(async (o: GetBarsOptions) =>
                 o.before !== undefined ? [bar(1)] : [bar(2)]
             );
@@ -238,23 +213,159 @@ describe('CachedMarketDataProvider', () => {
                 getBars,
                 getQuote: vi.fn(async () => null),
             });
-            const opts: GetBarsOptions = {
-                symbol: 'AAPL',
-                timeframe: '1Day',
-                from: '2024-06-30',
-            };
-
-            await provider.getBars(opts);
-            await provider.getBars(opts);
-
-            const histCalls = getBars.mock.calls.filter(
-                c => c[0].before !== undefined
-            );
-            expect(histCalls).toHaveLength(1); // 과거 윈도우는 long-cache hit
+            await provider.getBars(longOpts);
+            expect(store.has('bars:eodhist:AAPL')).toBe(true);
+            expect(store.has('bars:eodrecent:AAPL')).toBe(true);
+            // 날짜 세그먼트가 키에 없어야 함
+            expect(
+                [...store.keys()].some(k => /bars:eodhist:AAPL:\d/.test(k))
+            ).toBe(false);
         });
 
-        it('leaves non-1Day timeframes on the single-key path', async () => {
-            const getBars = vi.fn(async (_o: GetBarsOptions) => [bar(1)]);
+        it('history is NOT refetched across a day boundary when still fresh (anchored key, overlap holds)', async () => {
+            // history fetch(before=histTo)는 recentFrom 이후를 커버하는 봉을 반환하도록 구성
+            const histBarTime = Math.floor(
+                Date.parse('2026-06-25T00:00:00Z') / 1000
+            ); // recentFrom(2026-06-20) 이후 → fresh
+            const getBars = vi.fn(async (o: GetBarsOptions) =>
+                o.before !== undefined
+                    ? [{ ...bar(histBarTime), time: histBarTime }]
+                    : [bar(9)]
+            );
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+
+            await provider.getBars(longOpts); // day 1: history fetched once
+            const histCallsDay1 = getBars.mock.calls.filter(
+                c => c[0].before !== undefined
+            ).length;
+
+            vi.setSystemTime(new Date('2026-07-01T15:00:00Z')); // 하루 경과
+            await provider.getBars({ ...longOpts, from: '2024-07-01' });
+            const histCallsTotal = getBars.mock.calls.filter(
+                c => c[0].before !== undefined
+            ).length;
+
+            expect(histCallsDay1).toBe(1);
+            expect(histCallsTotal).toBe(1); // 자정 넘겨도 재fetch 없음(fresh)
+        });
+
+        it('history IS refetched when cached newest falls behind recentFrom (stale, overlap lost)', async () => {
+            // history fetch가 recentFrom 이전(오래된) 봉만 반환 → isFresh=false → 매번 재fetch
+            const staleTime = Math.floor(
+                Date.parse('2026-06-01T00:00:00Z') / 1000
+            ); // recentFrom(2026-06-20) 이전
+            const getBars = vi.fn(async (o: GetBarsOptions) =>
+                o.before !== undefined
+                    ? [{ ...bar(staleTime), time: staleTime }]
+                    : [bar(9)]
+            );
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+
+            await provider.getBars(longOpts);
+            await provider.getBars(longOpts);
+            const histCalls = getBars.mock.calls.filter(
+                c => c[0].before !== undefined
+            ).length;
+            expect(histCalls).toBe(2); // stale → 재fetch
+        });
+
+        it('merges history + recent and slices to options.from', async () => {
+            const inRange = Math.floor(
+                Date.parse('2025-01-01T00:00:00Z') / 1000
+            );
+            const tooOld = Math.floor(
+                Date.parse('2020-01-01T00:00:00Z') / 1000
+            ); // from(2024-06-30) 이전 → 슬라이스로 제거
+            const recentT = Math.floor(
+                Date.parse('2026-06-29T00:00:00Z') / 1000
+            );
+            const getBars = vi.fn(async (o: GetBarsOptions) =>
+                o.before !== undefined
+                    ? [
+                          { ...bar(tooOld), time: tooOld },
+                          { ...bar(inRange), time: inRange },
+                      ]
+                    : [{ ...bar(recentT), time: recentT }]
+            );
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+            const result = await provider.getBars(longOpts);
+            const times = result.map(b => b.time);
+            expect(times).toContain(inRange);
+            expect(times).toContain(recentT);
+            expect(times).not.toContain(tooOld); // options.from 이전은 슬라이스
+            expect(times).toEqual([...times].sort((a, b) => a - b)); // 오름차순
+        });
+
+        it('cold symbol = 2 fetches (history + recent); repeat within session = 0', async () => {
+            const freshHist = Math.floor(
+                Date.parse('2026-06-25T00:00:00Z') / 1000
+            );
+            const getBars = vi.fn(async (o: GetBarsOptions) =>
+                o.before !== undefined
+                    ? [{ ...bar(freshHist), time: freshHist }]
+                    : [bar(9)]
+            );
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+            await provider.getBars(longOpts);
+            expect(getBars).toHaveBeenCalledTimes(2);
+            await provider.getBars(longOpts); // 재접근
+            expect(getBars).toHaveBeenCalledTimes(2); // 둘 다 캐시 hit → 추가 0
+        });
+
+        it('1Day with before set → single-key path (no anchored split)', async () => {
+            const getBars = vi.fn(async () => [bar(1)]);
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+            await provider.getBars({
+                symbol: 'AAPL',
+                timeframe: '1Day',
+                from: '2024-01-01',
+                before: '2026-06-20',
+            });
+            expect(getBars).toHaveBeenCalledTimes(1);
+            expect(
+                [...store.keys()].some(k => k.startsWith('bars:eodhist'))
+            ).toBe(false);
+            expect(store.has('bars:raw:AAPL:1Day:2024-01-01:2026-06-20:')).toBe(
+                true
+            );
+        });
+
+        it('short lookback (from within recent window) → single-key path', async () => {
+            const getBars = vi.fn(async () => [bar(1)]);
+            const provider = new CachedMarketDataProvider({
+                getBars,
+                getQuote: vi.fn(async () => null),
+            });
+            await provider.getBars({
+                symbol: 'AAPL',
+                timeframe: '1Day',
+                from: '2026-06-27',
+            }); // recentFrom(2026-06-20) 이후
+            expect(
+                [...store.keys()].some(k => k.startsWith('bars:eodhist'))
+            ).toBe(false);
+            expect([...store.keys()].some(k => k.startsWith('bars:raw'))).toBe(
+                true
+            );
+        });
+
+        it('non-1Day stays on single-key path', async () => {
+            const getBars = vi.fn(async () => [bar(1)]);
             const provider = new CachedMarketDataProvider({
                 getBars,
                 getQuote: vi.fn(async () => null),
@@ -265,39 +376,12 @@ describe('CachedMarketDataProvider', () => {
                 from: '2026-06-20',
             });
             expect(getBars).toHaveBeenCalledTimes(1);
-            expect(getBars.mock.calls[0]?.[0].before).toBeUndefined();
+            expect([...store.keys()].some(k => k.startsWith('bars:eod'))).toBe(
+                false
+            );
         });
 
-        // Fix 3(a): from=undefined split branch
-        it('(a) from=undefined → split taken; historical key has empty from segment', async () => {
-            // system time: 2026-06-30T15:00:00Z (set in beforeEach)
-            // histTo = 2026-06-23, recentFrom = 2026-06-20
-            const getBars = vi.fn(async (o: GetBarsOptions) =>
-                o.before !== undefined ? [bar(10), bar(11)] : [bar(11), bar(12)]
-            );
-            const provider = new CachedMarketDataProvider({
-                getBars,
-                getQuote: vi.fn(async () => null),
-            });
-
-            const result = await provider.getBars({
-                symbol: 'AAPL',
-                timeframe: '1Day',
-                // from is undefined → isLongDailyWindow returns true
-            });
-
-            // Split was taken: two inner.getBars calls
-            expect(getBars).toHaveBeenCalledTimes(2);
-            // Historical key: bars:eodhist:AAPL::<histTo> (empty from segment)
-            const histKey = [...store.keys()].find(k =>
-                k.startsWith('bars:eodhist:AAPL::')
-            );
-            expect(histKey).toBeDefined();
-            // Merged result: dedup on time=11, sorted
-            expect(result.map(b => b.time)).toEqual([10, 11, 12]);
-        });
-
-        // Fix 3(b): FMP throw poison-prevention on split path
+        // Preserved: FMP throw poison-prevention on split path
         it('(b) inner.getBars throw on split path → rejects without caching anything', async () => {
             const getBars = vi.fn(async (_o: GetBarsOptions) => {
                 throw new Error('FMP 503');
@@ -317,11 +401,19 @@ describe('CachedMarketDataProvider', () => {
             expect(store.size).toBe(0);
         });
 
-        // Fix 3(c): Redis-down fallback on split path
+        // Preserved: Redis-down fallback on split path
         it('(c) redisEnabled=false on split path → returns merged result, store empty', async () => {
             redisEnabled = false;
+            // Use realistic unix timestamps (2024+) that survive sliceFrom('2024-01-01')
+            const t1 = Math.floor(Date.parse('2024-06-01T00:00:00Z') / 1000);
+            const t2 = Math.floor(Date.parse('2026-06-29T00:00:00Z') / 1000);
             const getBars = vi.fn(async (o: GetBarsOptions) =>
-                o.before !== undefined ? [bar(1)] : [bar(1), bar(2)]
+                o.before !== undefined
+                    ? [{ ...bar(t1), time: t1 }]
+                    : [
+                          { ...bar(t1), time: t1 },
+                          { ...bar(t2), time: t2 },
+                      ]
             );
             const provider = new CachedMarketDataProvider({
                 getBars,
@@ -334,49 +426,21 @@ describe('CachedMarketDataProvider', () => {
                 from: '2024-01-01',
             });
 
-            expect(result.map(b => b.time)).toEqual([1, 2]);
+            expect(result.map(b => b.time)).toEqual([t1, t2]);
             expect(store.size).toBe(0);
         });
 
-        // Fix 3(d): short-window fallback (Fix 1 guard)
-        it('(d) short 1Day window (from within last 10d) → single-key path, no eodhist/eodrecent keys', async () => {
-            // system time: 2026-06-30T15:00:00Z
-            // recentFrom = today - 10d = 2026-06-20
-            // from=2026-06-27 is within last 10d → isLongDailyWindow returns false
-            const getBars = vi.fn(async (_o: GetBarsOptions) => [bar(5)]);
-            const provider = new CachedMarketDataProvider({
-                getBars,
-                getQuote: vi.fn(async () => null),
-            });
-
-            await provider.getBars({
-                symbol: 'AAPL',
-                timeframe: '1Day',
-                from: '2026-06-27', // within last 10d from 2026-06-30
-            });
-
-            // Single inner call (not two)
-            expect(getBars).toHaveBeenCalledTimes(1);
-            // No eodhist or eodrecent keys; uses bars:raw key
-            const hasHistKey = [...store.keys()].some(k =>
-                k.startsWith('bars:eodhist')
-            );
-            const hasRecentKey = [...store.keys()].some(k =>
-                k.startsWith('bars:eodrecent')
-            );
-            const hasRawKey = [...store.keys()].some(k =>
-                k.startsWith('bars:raw')
-            );
-            expect(hasHistKey).toBe(false);
-            expect(hasRecentKey).toBe(false);
-            expect(hasRawKey).toBe(true);
-        });
-
-        // Fix 3(e): empty-window shouldCache guard
+        // Preserved: empty-window shouldCache guard
         it('(e) one window returns [] → that window key NOT written; merge returns non-empty side', async () => {
-            // historical returns [], recent returns [bar(5)]
+            // Use realistic unix timestamp that survives sliceFrom('2024-01-01')
+            const recentT = Math.floor(
+                Date.parse('2026-06-29T00:00:00Z') / 1000
+            );
+            // historical returns [], recent returns [bar(recentT)]
             const getBars = vi.fn(async (o: GetBarsOptions) =>
-                o.before !== undefined ? [] : [bar(5)]
+                o.before !== undefined
+                    ? []
+                    : [{ ...bar(recentT), time: recentT }]
             );
             const provider = new CachedMarketDataProvider({
                 getBars,
@@ -400,10 +464,10 @@ describe('CachedMarketDataProvider', () => {
             );
             expect(hasRecentKey).toBe(true);
             // Merge still returns the non-empty side
-            expect(result.map(b => b.time)).toEqual([5]);
+            expect(result.map(b => b.time)).toEqual([recentT]);
         });
 
-        // Fix 3(f): recent-window TTL — open vs closed
+        // Preserved: recent-window TTL — open vs closed
         it('(f) bars:eodrecent TTL: market-open instant → 60s', async () => {
             // ET regular session open: Mon 2026-06-29 14:30 UTC = 10:30 ET
             vi.setSystemTime(new Date('2026-06-29T14:30:00Z'));
@@ -457,27 +521,6 @@ describe('CachedMarketDataProvider', () => {
             const recentTtl = recentSetCall?.[2]?.ex;
             expect(typeof recentTtl).toBe('number');
             expect(recentTtl).toBeGreaterThan(60); // closed-session TTL > 60s
-        });
-
-        it('1Day with before set → single-key path (no EOD split)', async () => {
-            const getBars = vi.fn(async (_o: GetBarsOptions) => [bar(1)]);
-            const provider = new CachedMarketDataProvider({
-                getBars,
-                getQuote: vi.fn(async () => null),
-            });
-            await provider.getBars({
-                symbol: 'AAPL',
-                timeframe: '1Day',
-                from: '2024-01-01',
-                before: '2026-06-20',
-            });
-            expect(getBars).toHaveBeenCalledTimes(1);
-            expect(
-                [...store.keys()].some(k => k.startsWith('bars:eodhist'))
-            ).toBe(false);
-            expect(store.has('bars:raw:AAPL:1Day:2024-01-01:2026-06-20:')).toBe(
-                true
-            );
         });
     });
 

--- a/src/shared/cache/__tests__/getOrSetCache.test.ts
+++ b/src/shared/cache/__tests__/getOrSetCache.test.ts
@@ -168,4 +168,35 @@ describe('getOrSetCache 함수는', () => {
             expect.any(Error)
         );
     });
+
+    it('isFresh가 false를 반환하면 캐시 히트도 miss로 취급해 refetch 후 덮어쓴다', async () => {
+        const redis = createRedisStub();
+        redis.store.set('k', { data: 'stale' });
+        mockedGetRedisClient.mockReturnValue(redis as never);
+        const fetcher = vi.fn().mockResolvedValue('fresh');
+
+        const result = await getOrSetCache(
+            'k',
+            60,
+            fetcher,
+            () => true, // shouldCache
+            value => value === 'fresh' // isFresh: 'stale'은 false
+        );
+
+        expect(result).toBe('fresh');
+        expect(fetcher).toHaveBeenCalledTimes(1);
+        expect(redis.store.get('k')).toEqual({ data: 'fresh' });
+    });
+
+    it('isFresh 미전달 시 캐시 히트를 그대로 반환한다(기본값 항상 fresh)', async () => {
+        const redis = createRedisStub();
+        redis.store.set('k', { data: 'cached' });
+        mockedGetRedisClient.mockReturnValue(redis as never);
+        const fetcher = vi.fn().mockResolvedValue('fresh');
+
+        const result = await getOrSetCache('k', 60, fetcher);
+
+        expect(result).toBe('cached');
+        expect(fetcher).not.toHaveBeenCalled();
+    });
 });

--- a/src/shared/cache/getOrSetCache.ts
+++ b/src/shared/cache/getOrSetCache.ts
@@ -37,19 +37,24 @@ function isCacheEnvelope<T>(value: unknown): value is CacheEnvelope<T> {
  * 가드. 기본값은 항상 캐싱이며, fmpGet 기반 fetcher처럼 장애 시 throw하는 경우엔
  * 지정할 필요가 없다(잘못된 값이 애초에 set 단계에 도달하지 못하므로).
  *
+ * `isFresh(value)`가 false면 envelope hit이어도 miss로 취급해 refetch 후 덮어쓴다.
+ * 기본값은 항상 fresh — 기존 호출부는 영향 없음. 캐시된 값 자체(예: EOD history 겹침)로
+ * staleness를 판정해야 하는 호출부를 위한 가드.
+ *
  * Redis 미설정/장애 시에는 graceful fallback — `fetcher()`를 직접 호출한다.
  */
 export async function getOrSetCache<T>(
     key: string,
     ttlSeconds: number,
     fetcher: () => Promise<T>,
-    shouldCache: (value: T) => boolean = () => true
+    shouldCache: (value: T) => boolean = () => true,
+    isFresh: (value: T) => boolean = () => true
 ): Promise<T> {
     const redis = getRedisClient();
     if (redis !== null) {
         try {
             const hit = await redis.get<unknown>(key);
-            if (isCacheEnvelope<T>(hit)) return hit.data;
+            if (isCacheEnvelope<T>(hit) && isFresh(hit.data)) return hit.data;
         } catch (error) {
             console.error(`[getOrSetCache] get failed: ${key}`, error);
         }


### PR DESCRIPTION
## Summary
v0.32.0의 EOD split이 일봉(1Day) 캐시 키에 rolling 날짜(`from=now-730d` 등)를 넣어 **UTC 자정마다 전 심볼 full 재fetch 폭풍 + 요청당 2회 fetch**를 유발 → 밤사이 봇 크롤 구간에서 `historical-price-eod/full` 호출이 117→325로 **악화**(egress 6.59→9.75MB). 이 PR은 캐시 키에서 날짜를 제거하는 앵커드 2-tier로 재설계해 회귀를 제거하고 호출·egress를 실질 감소시킨다. (valuation 최적화는 v0.32.0에서 이미 성공: `ratios-ttm` 383→43.)

## Changes
1. **`getOrSetCache`에 선택적 `isFresh` 인자** — envelope hit이어도 `isFresh(data)===false`면 refetch+set. 기본값 always-fresh라 기존 호출부 무영향.
2. **앵커드 2-tier 일봉 캐시** (`CachedMarketDataProvider.getCachedDailyBars`):
   - `bars:eodhist:<SYM>` — 날짜 없는 앵커 키. 불변 과거, 30d TTL. `isFresh`로 recent 윈도우와의 겹침(`newest >= recentFrom`)을 판정 → 겹침 유지 시 재fetch 0, 겹침 소실 시 full 재fetch. 겹침 5일(최대 4일 연속 휴장 tolerant).
   - `bars:eodrecent:<SYM>` — 날짜 없는 앵커 키. 오늘 봉 포함 최근 윈도우, 세션 TTL(장중 60s/장외 다음 개장까지).
   - `mergeBarsByTime` 병합 + `sliceFrom(options.from)` → 단일 `getBars(from)`와 동일 집합.
   - 자정 키롤·반복 크롤 재fetch 제거 → 밤 크롤은 신규 cold 심볼만.

core·`FmpMarketProvider` 무변경. 사용자 신선도 불변(가격=클라 30s·오늘봉 live tail, 과거=불변).

## Quality gates
- 5종 fresh-context 감사(Opus 4.8): 코드리뷰 / 배포안정성 / 배포-now / SEO / 테스트커버리지 — **전부 Approved**. 지적된 4일+ 휴장 staleness thrash는 겹침 3→5일 확대로, 커버리지 갭은 from=undefined·경계 테스트 추가로 해소.
- 변경 파일 **branch 커버리지 100%**, tsc·lint 0.
- prod 빌드(exit 0) 실증: curl(AAPL/MSFT/NVDA 200, 현재가·52주·표본봉 렌더) + Chrome(차트·52주 위치·MA200·표본 470봉 정상, 콘솔 에러 0) — 일봉 파생 렌더 회귀 없음, merge/slice 완전성 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)