### PR TITLE
fix(skills): cross-indicator regime-alignment policy in indicator-core

### DIFF
--- a/skills/_core/indicator-core.md
+++ b/skills/_core/indicator-core.md
@@ -7,7 +7,7 @@ confidence_weight: 1.0
 gating:
   tier: always_on
 token_cost: 821
-digest_hash: "b1535f14"
+digest_hash: "43b44c5d"
 ---
 
 ## Indicator Core (compressed)
@@ -53,7 +53,7 @@ indicator is injected separately only when that indicator is currently notable.
 
 ### Regime alignment (cross-indicator)
 
-- **Determine the trend regime FIRST** (ADX strength + DMI direction + MA structure). ADX measures trend *strength only, never direction* — direction comes from +DI/−DI dominance and price vs the MA stack.
+- **Determine the trend regime FIRST** (ADX strength + DMI direction + MA structure). ADX measures trend *strength only, never direction* — direction comes from +DI/-DI dominance and price vs the MA stack.
 - **In a strong trend (ADX > 25), oscillator overbought/oversold readings are NOT standalone reversal signals.** RSI/Stochastic can stay extreme for many bars (band-walk), and counter-trend divergences in strong trends are often false.
 - **Default read in a strong trend is continuation.** Counter-trend (mean-reversion / bounce) calls require explicit confirmation (e.g. a confirmed reversal pattern, or divergence + structure break) and must carry reduced confidence.
 - **In thin / low-volume conditions, volume-dependent indicators (OBV etc.) are less reliable** — discount their weight.
@@ -88,7 +88,7 @@ Volume:
 - **Buy/Sell Volume:** buy/(buy+sell) ratio; ≥0.65 buy pressure / ≤0.35 sell pressure; price-volume divergence = exhaustion.
 - **Volume Profile:** volume-by-price; POC / high-volume nodes = magnet levels, low-volume gaps = fast-move zones.
 Regime alignment (cross-indicator):
-- Determine trend regime FIRST (ADX strength + DMI direction + MA structure). ADX = strength only, never direction — direction from +DI/−DI and price vs MA stack.
+- Determine trend regime FIRST (ADX strength + DMI direction + MA structure). ADX = strength only, never direction — direction from +DI/-DI and price vs MA stack.
 - Strong trend (ADX > 25): oscillator overbought/oversold are NOT standalone reversal signals — RSI/Stochastic can band-walk extreme for many bars; counter-trend divergences in strong trends often false.
 - Default read in a strong trend = continuation; counter-trend (mean-reversion/bounce) calls require explicit confirmation (confirmed reversal pattern, or divergence + structure break) and reduced confidence.
 - Thin/low-volume: volume-dependent indicators (OBV etc.) less reliable — discount their weight.

--- a/skills/_core/indicator-core.md
+++ b/skills/_core/indicator-core.md
@@ -6,8 +6,8 @@ indicators: []
 confidence_weight: 1.0
 gating:
   tier: always_on
-token_cost: 644
-digest_hash: "b141087e"
+token_cost: 821
+digest_hash: "b1535f14"
 ---
 
 ## Indicator Core (compressed)
@@ -51,6 +51,13 @@ indicator is injected separately only when that indicator is currently notable.
 - **Buy/Sell Volume:** buy/(buy+sell) ratio; ≥0.65 buy pressure / ≤0.35 sell pressure; price-volume divergence = exhaustion.
 - **Volume Profile:** volume-by-price; POC / high-volume nodes = magnet levels, low-volume gaps = fast-move zones.
 
+### Regime alignment (cross-indicator)
+
+- **Determine the trend regime FIRST** (ADX strength + DMI direction + MA structure). ADX measures trend *strength only, never direction* — direction comes from +DI/−DI dominance and price vs the MA stack.
+- **In a strong trend (ADX > 25), oscillator overbought/oversold readings are NOT standalone reversal signals.** RSI/Stochastic can stay extreme for many bars (band-walk), and counter-trend divergences in strong trends are often false.
+- **Default read in a strong trend is continuation.** Counter-trend (mean-reversion / bounce) calls require explicit confirmation (e.g. a confirmed reversal pattern, or divergence + structure break) and must carry reduced confidence.
+- **In thin / low-volume conditions, volume-dependent indicators (OBV etc.) are less reliable** — discount their weight.
+
 <!-- PROMPT_DIGEST:START -->
 Indicator Core — one-line reference for every computed indicator. Interpret ONLY the values present in this prompt's indicator section; a fuller guide is injected separately only when an indicator is currently notable.
 Momentum/Oscillators:
@@ -80,4 +87,9 @@ Volume:
 - **VWAP:** session volume-weighted avg (intraday only); price vs VWAP = institutional fair-value bias.
 - **Buy/Sell Volume:** buy/(buy+sell) ratio; ≥0.65 buy pressure / ≤0.35 sell pressure; price-volume divergence = exhaustion.
 - **Volume Profile:** volume-by-price; POC / high-volume nodes = magnet levels, low-volume gaps = fast-move zones.
+Regime alignment (cross-indicator):
+- Determine trend regime FIRST (ADX strength + DMI direction + MA structure). ADX = strength only, never direction — direction from +DI/−DI and price vs MA stack.
+- Strong trend (ADX > 25): oscillator overbought/oversold are NOT standalone reversal signals — RSI/Stochastic can band-walk extreme for many bars; counter-trend divergences in strong trends often false.
+- Default read in a strong trend = continuation; counter-trend (mean-reversion/bounce) calls require explicit confirmation (confirmed reversal pattern, or divergence + structure break) and reduced confidence.
+- Thin/low-volume: volume-dependent indicators (OBV etc.) less reliable — discount their weight.
 <!-- PROMPT_DIGEST:END -->

--- a/skills/indicators/obv.md
+++ b/skills/indicators/obv.md
@@ -5,7 +5,7 @@ type: indicator_guide
 indicators: ['obv']
 confidence_weight: 0.8
 usage_roles: [confirmation, measurement]
-token_cost: 512
+token_cost: 517
 digest_hash: "2bf75817"
 ---
 
@@ -73,6 +73,6 @@ OBV flat: sideways while price oscillates = accumulation/distribution equilibriu
 
 Combinations: + RSI (both diverging at same point = dual-confirmation reversal); + MACD (OBV breakout + MACD golden cross = volume + price confirmation); + Volume Profile (OBV direction + POC alignment = strong S/R zone); + Bollinger (OBV breakout during squeeze = directional commitment).
 
-Caveats: cumulative — absolute value meaningless, only direction/slope matter. Treats all volume equally regardless of price-move magnitude. Noisy for low-volume/thinly-traded stocks. Gap days distort it disproportionately. Best on daily+; intraday dominated by microstructure noise.
+Caveats: cumulative — absolute value meaningless, only direction/slope matter. Treats all volume equally regardless of price-move magnitude. Noisy, unreliable signals for low-volume/thinly-traded stocks. Gap days distort it disproportionately. Best on daily+; intraday dominated by microstructure noise.
 <!-- PROMPT_DIGEST:END -->
 


### PR DESCRIPTION
## Summary

A/B quality-gate follow-up (prompt redesign Phase 2). Blind-judge evaluation showed the digest variant misreading oversold oscillators as reversal signals in a strong-downtrend low-liquidity case — the anti-counter-trend rules existed but were scattered across individual skills (rsi/stochastic/adx/dmi/obv).

This consolidates them into the always-on `_core/indicator-core.md` as an explicit "Regime alignment (cross-indicator)" section (body + PROMPT_DIGEST; digest ⊆ body invariant holds; every clause verified against its source skill). Also restores a dropped "unreliable" in obv.md's digest thin-liquidity caveat.

Effect (verified by re-running the A/B gate): the failing case recovered from losing 3 axes to a single 1-point axis, and aggregate digest means now exceed full-body means on all 4 quality axes (+0.38 to +0.63). Final gate verdict: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)