### PR TITLE
chore(deps): bump @y0ngha/siglens-core to 0.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "@neondatabase/serverless": "^1.1.0",
         "@tanstack/react-query": "^5.95.2",
         "@upstash/redis": "^1.37.0",
-        "@y0ngha/siglens-core": "0.28.0",
+        "@y0ngha/siglens-core": "0.29.0",
         "bcryptjs": "^3.0.3",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4159,14 +4159,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@y0ngha/siglens-core@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@y0ngha/siglens-core@npm:0.28.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.28.0%2F4f60b29f9825ad677cf2ad446502651366826c79"
+"@y0ngha/siglens-core@npm:0.29.0":
+  version: 0.29.0
+  resolution: "@y0ngha/siglens-core@npm:0.29.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.29.0%2Ff007e763ab6f6fe8786f9de896871f92e8a07101"
   dependencies:
     jsonrepair: "npm:^3.14.0"
   peerDependencies:
     "@upstash/redis": ^1.37.0
-  checksum: 10c0/47d6885a72885ab92eccc2c68864f523383d9dc5c7683563e5de59e9d9ed03d259d8c9f0eb0cbba50eb004dc3e690ea1daacb2d12e0f7625de9ab8c6d2f23d0d
+  checksum: 10c0/726b3a4daef04dbb7840661aa3ee230e7a90a045cb8f5b6e1cd03fdc717c2e184be0d16c5ed4ab6ca2443593e52693812cf86c0b7702b8469e9437a7b28977b1
   languageName: node
   linkType: hard
 
@@ -11581,7 +11581,7 @@ __metadata:
     "@types/react-dom": "npm:^19"
     "@upstash/redis": "npm:^1.37.0"
     "@vitest/coverage-v8": "npm:^4.1.7"
-    "@y0ngha/siglens-core": "npm:0.28.0"
+    "@y0ngha/siglens-core": "npm:0.29.0"
     babel-plugin-react-compiler: "npm:^1.0.0"
     bcryptjs: "npm:^3.0.3"
     clsx: "npm:^2.1.1"


### PR DESCRIPTION
Activates digest-only skill prompt injection in the app: @y0ngha/siglens-core v0.29.0 switches skill prompt injection to PROMPT_DIGEST-only (quality-gated: blind A/B judge PASS, digest ≥ full on all 4 axes, technical prompt tokens −36%) and bumps PROMPT_TEMPLATE_VERSION p1→p2, which invalidates warm analysis caches (expected one-time cold start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)