### PR TITLE
chore(deps): bump @y0ngha/siglens-core to 0.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "@neondatabase/serverless": "^1.1.0",
         "@tanstack/react-query": "^5.95.2",
         "@upstash/redis": "^1.37.0",
-        "@y0ngha/siglens-core": "0.29.0",
+        "@y0ngha/siglens-core": "0.31.0",
         "bcryptjs": "^3.0.3",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4159,14 +4159,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@y0ngha/siglens-core@npm:0.29.0":
-  version: 0.29.0
-  resolution: "@y0ngha/siglens-core@npm:0.29.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.29.0%2Ff007e763ab6f6fe8786f9de896871f92e8a07101"
+"@y0ngha/siglens-core@npm:0.31.0":
+  version: 0.31.0
+  resolution: "@y0ngha/siglens-core@npm:0.31.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.31.0%2F3360fe64463faac458ee4f72675617a29488b9a3"
   dependencies:
     jsonrepair: "npm:^3.14.0"
   peerDependencies:
     "@upstash/redis": ^1.37.0
-  checksum: 10c0/726b3a4daef04dbb7840661aa3ee230e7a90a045cb8f5b6e1cd03fdc717c2e184be0d16c5ed4ab6ca2443593e52693812cf86c0b7702b8469e9437a7b28977b1
+  checksum: 10c0/4b212bf534df2fcf8967c9970c17dac349ef1755180dec06bfe42d5d2817577df60f8bb9b517e4ef7a7996e348098a6dbd7009f038b729f9ffc6b900d8d6886a
   languageName: node
   linkType: hard
 
@@ -11581,7 +11581,7 @@ __metadata:
     "@types/react-dom": "npm:^19"
     "@upstash/redis": "npm:^1.37.0"
     "@vitest/coverage-v8": "npm:^4.1.7"
-    "@y0ngha/siglens-core": "npm:0.29.0"
+    "@y0ngha/siglens-core": "npm:0.31.0"
     babel-plugin-react-compiler: "npm:^1.0.0"
     bcryptjs: "npm:^3.0.3"
     clsx: "npm:^2.1.1"


### PR DESCRIPTION
## Summary

- Bumps `@y0ngha/siglens-core` 0.29.0 → 0.31.0 (0.30.0 and 0.31.0 are content-identical — an accidental double release; 0.31.0 is canonical).
- Activates the skill selection engine: per-context whitelist, fail-closed gating, relevance ordering, screener trigger wiring, contingent-plan + grounding directives.
- Bumps `PROMPT_TEMPLATE_VERSION` to `p3` and `NEWS_PROMPT_TEMPLATE_VERSION` to `p2`.
- Blind panel gate PASS: hallucination-freedom +0.44, actionability +1.06, groundedness +0.06; technical prompts −33~40% vs Phase-2 baseline.
- p3/NEWS-p2 template bumps invalidate warm analysis caches (one-time cold start expected after deploy).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `yarn vitest run src/entities/analysis src/entities/skill` — 26 files / 257 tests passed
- [x] `yarn vitest run src/entities/skill src/views/symbol src/entities/market-news src/entities/llm-provider src/entities/user-tier src/app/[symbol] src/app/news` — 110 files / 779 tests passed (checked for fail-closed gating regressions in fixtures that feed prompt builders — none found)
- [x] pre-push hooks (format:check, lint, typecheck, test, build) — all passed, no `--no-verify`
- [x] `git ls-remote` confirms pushed SHA matches local HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9J3vzLHuiG3nc22gfJUHN