### PR TITLE
feat(skills): gate pattern skills on pre-screener candidates + always-on pattern index

### DIFF
--- a/scripts/__tests__/validate-skills.test.ts
+++ b/scripts/__tests__/validate-skills.test.ts
@@ -24,6 +24,7 @@ describe('validateSkillData', () => {
         it('event-gated candle skill with candle-pattern triggers is valid', () => {
             expect(
                 validateSkillData({
+                    type: 'candlestick',
                     gating: {
                         tier: 'gated',
                         signal_kind: 'event',
@@ -123,6 +124,105 @@ describe('validateSkillData', () => {
         });
     });
 
+    describe('type-aware trigger vocabulary', () => {
+        it('rejects a candle-pattern name on a non-candlestick skill', () => {
+            const errors = validateSkillData({
+                type: 'indicator_guide',
+                usage_roles: ['signal'],
+                gating: {
+                    tier: 'gated',
+                    signal_kind: 'event',
+                    triggers: ['hammer'],
+                },
+            });
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toMatch(/unknown trigger "hammer"/);
+            expect(errors[0]).toMatch(/detectSignals catalog entry/);
+        });
+
+        it('rejects a chart-pattern id on a non-pattern skill', () => {
+            const errors = validateSkillData({
+                type: 'strategy',
+                gating: {
+                    tier: 'gated',
+                    signal_kind: 'event',
+                    triggers: ['head_and_shoulders'],
+                },
+            });
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toMatch(/unknown trigger "head_and_shoulders"/);
+            expect(errors[0]).toMatch(/detectSignals catalog entry/);
+        });
+
+        it('rejects a detectSignals catalog name on a pattern skill', () => {
+            const errors = validateSkillData({
+                type: 'pattern',
+                gating: {
+                    tier: 'gated',
+                    signal_kind: 'event',
+                    triggers: ['rsi_oversold'],
+                },
+            });
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toMatch(/unknown trigger "rsi_oversold"/);
+            expect(errors[0]).toMatch(/PATTERN_TRIGGER_CATALOG/);
+        });
+
+        it('rejects a candle-pattern name on a pattern skill', () => {
+            const errors = validateSkillData({
+                type: 'pattern',
+                gating: {
+                    tier: 'gated',
+                    signal_kind: 'event',
+                    triggers: ['bullish_engulfing'],
+                },
+            });
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toMatch(/unknown trigger "bullish_engulfing"/);
+            expect(errors[0]).toMatch(/PATTERN_TRIGGER_CATALOG/);
+        });
+
+        it('rejects a detectSignals catalog name on a candlestick skill', () => {
+            const errors = validateSkillData({
+                type: 'candlestick',
+                gating: {
+                    tier: 'gated',
+                    signal_kind: 'event',
+                    triggers: ['rsi_oversold'],
+                },
+            });
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toMatch(/unknown trigger "rsi_oversold"/);
+            expect(errors[0]).toMatch(/candle-pattern name/);
+        });
+
+        it('rejects a chart-pattern id on a candlestick skill', () => {
+            const errors = validateSkillData({
+                type: 'candlestick',
+                gating: {
+                    tier: 'gated',
+                    signal_kind: 'event',
+                    triggers: ['double_top'],
+                },
+            });
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toMatch(/unknown trigger "double_top"/);
+            expect(errors[0]).toMatch(/candle-pattern name/);
+        });
+
+        it('a skill with no `type` field is validated against the signal vocabulary', () => {
+            const errors = validateSkillData({
+                gating: {
+                    tier: 'gated',
+                    signal_kind: 'event',
+                    triggers: ['hammer'],
+                },
+            });
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toMatch(/unknown trigger "hammer"/);
+        });
+    });
+
     describe('usage_roles', () => {
         // These fixtures all include a valid `gating` block so the assertion
         // isolates the usage_roles check under test — otherwise the missing
@@ -206,7 +306,14 @@ describe('validateSkillData', () => {
             const errors = validateSkillData({
                 type: 'pattern',
                 usage_roles: ['signal'],
-                gating: VALID_GATING,
+                // `type: pattern` triggers must come from the pattern
+                // vocabulary — use a valid chart-pattern id here so the
+                // assertion isolates the usage_roles check under test.
+                gating: {
+                    tier: 'gated' as const,
+                    signal_kind: 'event' as const,
+                    triggers: ['head_and_shoulders'],
+                },
             });
             expect(errors).toHaveLength(1);
             expect(errors[0]).toMatch(/usage_roles/);

--- a/scripts/__tests__/validate-skills.test.ts
+++ b/scripts/__tests__/validate-skills.test.ts
@@ -33,6 +33,32 @@ describe('validateSkillData', () => {
             ).toEqual([]);
         });
 
+        it('event-gated pattern skill with chart-pattern pre-screener triggers is valid', () => {
+            // The 17 ChartPatternId values are accepted via PATTERN_TRIGGER_CATALOG
+            // (a separate catalog from SIGNAL_CATALOG). A pattern skill gates in
+            // when the pre-screener flags its pattern as a candidate.
+            expect(
+                validateSkillData({
+                    type: 'pattern',
+                    gating: {
+                        tier: 'gated',
+                        signal_kind: 'event',
+                        triggers: ['head_and_shoulders'],
+                    },
+                })
+            ).toEqual([]);
+            expect(
+                validateSkillData({
+                    type: 'pattern',
+                    gating: {
+                        tier: 'gated',
+                        signal_kind: 'event',
+                        triggers: ['cup_and_handle', 'rounding_bottom'],
+                    },
+                })
+            ).toEqual([]);
+        });
+
         it('state-gated skill with a supported (feature, predicate) pair is valid', () => {
             expect(
                 validateSkillData({

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -5,7 +5,15 @@
  * the snake_case schema, and cross-checks every `triggers` value against the
  * detectSignals signal catalog + candle-pattern catalog exported by
  * `@y0ngha/siglens-core` (the resolved core — see STEP-0 finding: siglens
- * consumes the core via the bare package specifier, never via `@/domain`).
+ * consumes the core via the bare package specifier, never via `@/domain`) plus
+ * the hand-mirrored chart-pattern pre-screener catalog (`PATTERN_TRIGGER_CATALOG`).
+ *
+ * Trigger validation is **type-aware**: a skill's own `type` selects which one
+ * of the three trigger vocabularies its `triggers` entries must belong to —
+ * `type: pattern` → chart-pattern pre-screener ids only, `type: candlestick` →
+ * candle-pattern names only, every other gated type → detectSignals catalog
+ * names only. A trigger valid in one vocabulary but wrong for the skill's own
+ * `type` is rejected the same as an unknown name.
  *
  * Exits non-zero on any of:
  *   - frontmatter that cannot be parsed,
@@ -13,7 +21,9 @@
  *     see skills/CLAUDE.md),
  *   - a `gating` block missing a required field / with an invalid value,
  *   - an unreachable gated skill (no triggers and no state predicate),
- *   - a `triggers` entry that is not a known catalog signal or candle pattern.
+ *   - a `triggers` entry that is not a known catalog signal, candle pattern, or
+ *     chart-pattern id — or that belongs to the wrong vocabulary for the
+ *     skill's own `type`.
  *
  * Run via `yarn validate:skills`; wired into CI.
  */
@@ -104,12 +114,18 @@ const SIGNAL_SET = new Set<string>(SIGNAL_CATALOG);
  * its exhaustiveness guard) would reject them.
  *
  * Version note: this tuple is hand-mirrored from the core's `ChartPatternId`
- * union (siglens-core domain/types). The core root barrel does not re-export
- * `ChartPatternId` until v0.30.0 — this branch merges only after that bump.
- * Once it lands on a core that exports the type, tighten this to
- * `satisfies readonly ChartPatternId[]` + an exhaustiveness guard (mirroring
- * SIGNAL_CATALOG above) so a future drift in the pattern union fails the build
- * here instead of silently accepting a stale id.
+ * union (siglens-core `domain/types`). As of the pinned core version
+ * (0.31.0), `ChartPatternId` is still annotated `@internal` in the core and
+ * is not re-exported from the package's public root barrel (the package has
+ * no subpath exports either, so there is no public import path for it at
+ * all) — confirmed by checking `node_modules/@y0ngha/siglens-core/dist/index.d.ts`
+ * and the package's `exports` map. A `satisfies readonly ChartPatternId[]` +
+ * exhaustiveness guard (mirroring SIGNAL_CATALOG above) therefore is not
+ * possible yet; this tuple must stay a hand-maintained, untyped mirror until
+ * the core promotes `ChartPatternId` to a public export. Once it does,
+ * tighten this to the `satisfies`/exhaustiveness-guard pattern so a future
+ * drift in the pattern union fails the build here instead of silently
+ * accepting a stale id.
  */
 const PATTERN_TRIGGER_CATALOG = [
     'head_and_shoulders',
@@ -144,10 +160,54 @@ const isCandlePattern = (name: string): boolean =>
     getCandlePatternLabel(name as CandlePattern) !== undefined ||
     getMultiCandlePatternLabel(name as MultiCandlePattern) !== undefined;
 
-const isKnownTrigger = (name: string): boolean =>
-    SIGNAL_SET.has(name) ||
-    PATTERN_TRIGGER_SET.has(name) ||
-    isCandlePattern(name);
+/**
+ * The trigger vocabulary a skill's `event` triggers must draw from, selected
+ * by the skill's own `type`. A trigger valid in a *different* vocabulary
+ * (e.g. a candle name on a `pattern` skill) is still rejected — each skill
+ * type owns exactly one vocabulary; see skills/CLAUDE.md's event-triggers
+ * section for the authored version of this table.
+ *
+ *   - `pattern`      → `type: pattern` skills (chart-pattern pre-screener ids)
+ *   - `candlestick`  → `type: candlestick` skills (candle-pattern names)
+ *   - `signal`       → every other gated type (`indicator_guide`, `strategy`,
+ *                      `support_resistance`, or an absent/unknown `type`) —
+ *                      detectSignals catalog names only. No skill file
+ *                      currently mixes candle names into this vocabulary, so
+ *                      it is not extended to accept them (see PR #673 review).
+ */
+type TriggerVocabulary = 'pattern' | 'candlestick' | 'signal';
+
+const triggerVocabularyForType = (type: unknown): TriggerVocabulary => {
+    if (type === 'pattern') return 'pattern';
+    if (type === 'candlestick') return 'candlestick';
+    return 'signal';
+};
+
+const isValidTriggerForVocabulary = (
+    name: string,
+    vocabulary: TriggerVocabulary
+): boolean => {
+    switch (vocabulary) {
+        case 'pattern':
+            return PATTERN_TRIGGER_SET.has(name);
+        case 'candlestick':
+            return isCandlePattern(name);
+        case 'signal':
+            return SIGNAL_SET.has(name);
+    }
+};
+
+/** Per-file error hint naming the vocabulary a rejected trigger should have come from. */
+const triggerVocabularyErrorHint = (vocabulary: TriggerVocabulary): string => {
+    switch (vocabulary) {
+        case 'pattern':
+            return 'type: pattern skills may only trigger on a PATTERN_TRIGGER_CATALOG chart-pattern pre-screener id';
+        case 'candlestick':
+            return 'type: candlestick skills may only trigger on a candle-pattern name the core has a label for';
+        case 'signal':
+            return 'this skill type may only trigger on a detectSignals catalog entry (not a candle pattern or chart-pattern id)';
+    }
+};
 
 /**
  * Mirror of `SKILL_STATE_FEATURES` / `SKILL_STATE_PREDICATE_KINDS` in
@@ -350,11 +410,11 @@ export const validateSkillData = (data: Record<string, unknown>): string[] => {
 
     return [
         ...(usageRolesError !== null ? [usageRolesError] : []),
-        ...validateGating(data.gating),
+        ...validateGating(data.gating, data.type),
     ];
 };
 
-function validateGating(gating: unknown): string[] {
+function validateGating(gating: unknown, type: unknown): string[] {
     if (!isRecord(gating)) {
         return ['`gating` must be a mapping.'];
     }
@@ -381,15 +441,16 @@ function validateGating(gating: unknown): string[] {
                 'event-gated skill is unreachable: `triggers` is missing or empty.',
             ];
         }
+        const vocabulary = triggerVocabularyForType(type);
         return triggers.flatMap(trigger => {
             if (typeof trigger !== 'string') {
                 return [
                     `\`triggers\` entry is not a string: ${String(trigger)}.`,
                 ];
             }
-            if (!isKnownTrigger(trigger)) {
+            if (!isValidTriggerForVocabulary(trigger, vocabulary)) {
                 return [
-                    `unknown trigger "${trigger}" — not a detectSignals catalog entry or candle pattern.`,
+                    `unknown trigger "${trigger}" — ${triggerVocabularyErrorHint(vocabulary)}.`,
                 ];
             }
             return [];

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -93,6 +93,46 @@ void _signalCatalogIsExhaustive;
 
 const SIGNAL_SET = new Set<string>(SIGNAL_CATALOG);
 
+/**
+ * Chart-pattern pre-screener candidates — the 17 `ChartPatternId` values the
+ * core's `screenChartPatterns()` can flag on a chart. When a pattern is a
+ * plausible candidate, its detailed pattern skill is gated in via an `event`
+ * trigger (exactly the way a detectSignals catalog entry gates an
+ * indicator/strategy skill). These live in a separate catalog from
+ * SIGNAL_CATALOG on purpose: they are `ChartPatternId` values, not `SignalType`
+ * members, so the SIGNAL_CATALOG `satisfies readonly SignalType[]` clause (and
+ * its exhaustiveness guard) would reject them.
+ *
+ * Version note: this tuple is hand-mirrored from the core's `ChartPatternId`
+ * union (siglens-core domain/types). The core root barrel does not re-export
+ * `ChartPatternId` until v0.30.0 — this branch merges only after that bump.
+ * Once it lands on a core that exports the type, tighten this to
+ * `satisfies readonly ChartPatternId[]` + an exhaustiveness guard (mirroring
+ * SIGNAL_CATALOG above) so a future drift in the pattern union fails the build
+ * here instead of silently accepting a stale id.
+ */
+const PATTERN_TRIGGER_CATALOG = [
+    'head_and_shoulders',
+    'inverse_head_and_shoulders',
+    'double_top',
+    'double_bottom',
+    'triple_top',
+    'triple_bottom',
+    'ascending_triangle',
+    'descending_triangle',
+    'symmetrical_triangle',
+    'ascending_wedge',
+    'descending_wedge',
+    'bull_flag',
+    'bear_flag',
+    'pennant',
+    'rectangle',
+    'cup_and_handle',
+    'rounding_bottom',
+] as const;
+
+const PATTERN_TRIGGER_SET = new Set<string>(PATTERN_TRIGGER_CATALOG);
+
 /** A trigger is a valid candle pattern when the core has a label for it. */
 const isCandlePattern = (name: string): boolean =>
     // (a) why cast: the label getters are typed to accept only the
@@ -105,7 +145,9 @@ const isCandlePattern = (name: string): boolean =>
     getMultiCandlePatternLabel(name as MultiCandlePattern) !== undefined;
 
 const isKnownTrigger = (name: string): boolean =>
-    SIGNAL_SET.has(name) || isCandlePattern(name);
+    SIGNAL_SET.has(name) ||
+    PATTERN_TRIGGER_SET.has(name) ||
+    isCandlePattern(name);
 
 /**
  * Mirror of `SKILL_STATE_FEATURES` / `SKILL_STATE_PREDICATE_KINDS` in

--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -110,8 +110,11 @@ Every skill declares `gating.tier`; there is no untagged state. `always_on` mean
 different things depending on which analysis type the skill belongs to:
 
 - **Chart skills** — chart-relevant, deliberately ungated (no detector, or used as
-  an analysis lens): chart-patterns, theory strategies
-  (elliott-wave / fibonacci / multi-timeframe), S/R, Ichimoku, SMC.
+  an analysis lens): theory strategies (elliott-wave / fibonacci / multi-timeframe),
+  S/R, Ichimoku, SMC. Chart-pattern skills are **not** in this list — each is
+  event-gated on its own chart-pattern pre-screener candidate (see below); the
+  always-on `_core/pattern-index.md` covers baseline pattern awareness for every
+  chart prompt regardless of which individual pattern skills gate in.
 - **Fundamental/news skills** — `always_on` **within their own analysis type**:
   fundamental prompts always include the fundamental skills, news prompts always
   include the news skills. This is *not* "always injected everywhere." The
@@ -125,9 +128,25 @@ Every skill file — chart, fundamental, or news — sets an explicit `tier`.
 
 ## event triggers — the valid catalog
 
-A `triggers` entry must be **either** a valid `detectSignals` catalog name (below)
-**or** a detected candle-pattern name. The validator cross-checks against the core's
-exported catalog: a typo'd trigger **fails CI** — it does not silently disappear.
+A `triggers` entry falls into one of **three** categories, and a skill's own
+`type` determines which one its triggers must draw from — the validator rejects
+a trigger from the wrong category even if the name is valid in another:
+
+1. A valid `detectSignals` catalog name (below) — for `indicator_guide`,
+   `strategy`, and `support_resistance` skills.
+2. A detected candle-pattern name — for `candlestick` skills only.
+3. A chart-pattern pre-screener candidate id — for `pattern` skills only. These
+   are the 17 `ChartPatternId` values the core's `screenChartPatterns()` can flag
+   (`head_and_shoulders`, `inverse_head_and_shoulders`, `double_top`,
+   `double_bottom`, `triple_top`, `triple_bottom`, `ascending_triangle`,
+   `descending_triangle`, `symmetrical_triangle`, `ascending_wedge`,
+   `descending_wedge`, `bull_flag`, `bear_flag`, `pennant`, `rectangle`,
+   `cup_and_handle`, `rounding_bottom` — see `PATTERN_TRIGGER_CATALOG` in
+   `scripts/validate-skills.ts`).
+
+The validator cross-checks each skill's triggers against only the category
+valid for its own `type`: a typo'd trigger, or a trigger borrowed from the
+wrong category, **fails CI** — it does not silently disappear.
 
 Full signal catalog (bidirectional set):
 
@@ -214,22 +233,30 @@ exactly one of, appended once at the very end of the file, after the body:
 
 ## How to add a new skill / strategy
 
-1. **Pick the tier.** Chart-relevant lens or pattern with no detector → `tier: always_on`.
-   Fundamental/news with no meaningful trigger → also `tier: always_on` (the
-   category whitelist, not the tier, keeps it out of chart prompts) — never leave
-   `gating` off.
+1. **Pick the tier.** Chart-relevant lens with no detector (theory strategy, S/R,
+   Ichimoku, SMC) → `tier: always_on`. A **chart-pattern** skill (`type: pattern`)
+   always has a detector — the pre-screener — so it is `tier: gated` with its own
+   `ChartPatternId` as the `event` trigger (see the event-triggers section above);
+   it is never `always_on`. Fundamental/news with no meaningful trigger → also
+   `tier: always_on` (the category whitelist, not the tier, keeps it out of chart
+   prompts) — never leave `gating` off.
 2. **If gated, pick the kind:**
-   - **event** — there is a catalog signal (or candle pattern) that should turn it on.
-     Add `signal_kind: event` + a non-empty `triggers` list of known names.
+   - **event** — there is a catalog signal, candle pattern, or chart-pattern
+     pre-screener candidate that should turn it on. Add `signal_kind: event` + a
+     non-empty `triggers` list drawn from the category that matches this skill's
+     `type` (indicator/strategy/S-R → `detectSignals` names, `candlestick` →
+     candle names, `pattern` → `ChartPatternId` values).
    - **state** — it's a persistent condition (overbought, band-proximity, etc.).
      Add `signal_kind: state` + a `state: { feature, predicate }` from the valid pairs.
 3. Leave `token_cost` and `digest_hash` to the digest tooling — never hand-set them.
    If/when the skill gets a `PROMPT_DIGEST` section (see below), run
    `yarn skills:digest-update` to compute both. Add `smc_full_guide: true` only on
    the SMC guide.
-4. **Run `yarn validate:skills`.** It cross-checks every trigger against the core
-   catalog and every state pair against `isStateNotable`, rejecting typos and
-   unreachable combos. This is a **CI gate** — a bad tag fails the build.
+4. **Run `yarn validate:skills`.** It cross-checks every trigger against the
+   category valid for the skill's own `type` (catalog signal, candle pattern, or
+   chart-pattern id) and every state pair against `isStateNotable`, rejecting
+   typos, wrong-category triggers, and unreachable combos. This is a **CI gate**
+   — a bad tag fails the build.
 
 > Adding a strategy that fires on an *existing* signal = frontmatter-only change (zero
 > core code). Only a genuinely new signal kind needs a core `detectSignals` change.

--- a/skills/_core/pattern-index.md
+++ b/skills/_core/pattern-index.md
@@ -6,8 +6,8 @@ indicators: []
 confidence_weight: 1.0
 gating:
   tier: always_on
-token_cost: 523
-digest_hash: "47de8c4e"
+token_cost: 1100
+digest_hash: "bf9f511c"
 ---
 
 ## Pattern Index (compressed)
@@ -30,55 +30,57 @@ no `pattern:` id and is exempt from `usage_roles` (the always-on exemption).
 
 ### Reversal patterns
 
-- **head_and_shoulders:** three peaks, middle (head) highest, neckline break down = bearish reversal.
-- **inverse_head_and_shoulders:** three troughs, middle (head) lowest, neckline break up = bullish reversal.
-- **double_top:** two roughly equal highs (M shape), neckline (intervening low) break down = bearish reversal.
-- **double_bottom:** two roughly equal lows (W shape), neckline (intervening high) break up = bullish reversal.
-- **triple_top:** three roughly equal highs at resistance, support break down = bearish reversal.
-- **triple_bottom:** three roughly equal lows at support, resistance break up = bullish reversal.
-- **rounding_bottom:** slow U-shaped (saucer) base, gradual momentum shift, break up = bullish reversal.
+- **head_and_shoulders:** three peaks, middle (head) highest, neckline break down = bearish reversal. Target: head→neckline depth projected down from the break; invalidated by a close above the right shoulder high (stop reference).
+- **inverse_head_and_shoulders:** three troughs, middle (head) lowest, neckline break up = bullish reversal. Target: neckline→head depth projected up from the break; invalidated by a close below the right shoulder low (stop reference).
+- **double_top:** two roughly equal highs (M shape), neckline (intervening low) break down = bearish reversal. Target: peak-average→neckline depth projected down from the break; invalidated by a close above the higher peak.
+- **double_bottom:** two roughly equal lows (W shape), neckline (intervening high) break up = bullish reversal. Target: neckline→trough-average depth projected up from the break; invalidated by a close below the lower trough.
+- **triple_top:** three roughly equal highs at resistance, neckline (support) break down = bearish reversal. Target: peak-average→neckline depth projected down from the break; invalidated by a close above the highest peak.
+- **triple_bottom:** three roughly equal lows at support, neckline (resistance) break up = bullish reversal. Target: neckline→trough-average depth projected up from the break; invalidated by a close below the lowest trough.
+- **rounding_bottom:** slow U-shaped (saucer) base, gradual momentum shift, break up above the left rim = bullish reversal. Target: saucer depth (rim→bottom) projected up from the rim breakout; stop = recent right-side trough (wider = saucer bottom).
 
 ### Continuation patterns
 
-- **ascending_triangle:** flat resistance on top + rising lows, breakout up = bullish continuation.
-- **descending_triangle:** flat support on bottom + falling highs, breakdown = bearish continuation.
-- **ascending_wedge (rising wedge):** both bounds slope up and converge, break down = bearish (reversal/continuation-against).
-- **descending_wedge (falling wedge):** both bounds slope down and converge, break up = bullish (reversal/continuation-against).
-- **bull_flag:** sharp rally (pole) then a slight downward-drifting channel, break up = bullish continuation.
-- **bear_flag:** sharp drop (pole) then a slight upward-drifting channel, break down = bearish continuation.
-- **cup_and_handle:** rounded U cup + small pullback handle near the rim, break up = bullish continuation.
+- **ascending_triangle:** flat resistance on top + rising lows, breakout up = bullish continuation. Target: triangle height (resistance→start low) projected up from the breakout; invalidated by a close below the ascending trendline.
+- **descending_triangle:** flat support on bottom + falling highs, breakdown = bearish continuation. Target: triangle height (start high→support) projected down from the breakdown; invalidated by a close above the descending trendline.
+- **ascending_wedge (rising wedge):** both bounds slope up and converge, break down = bearish (reversal/continuation-against). Target: wedge height (start width) projected down from the breakdown; invalidated by a close above the recent swing high / upper trendline.
+- **descending_wedge (falling wedge):** both bounds slope down and converge, break up = bullish (reversal/continuation-against). Target: wedge height (start width) projected up from the breakout; invalidated by a close below the recent swing low / lower trendline.
+- **bull_flag:** sharp rally (pole) then a slight downward-drifting channel, break up = bullish continuation. Target: flagpole length projected up from the breakout; invalidated by a close below the lower flag channel / swing low.
+- **bear_flag:** sharp drop (pole) then a slight upward-drifting channel, break down = bearish continuation. Target: flagpole length projected down from the breakdown; invalidated by a close above the upper flag channel / swing high.
+- **cup_and_handle:** rounded U cup + small pullback handle near the rim, break up = bullish continuation. Target: cup depth (rim→bottom) projected up from the breakout; invalidated by a close below the handle bottom (wider = cup midpoint).
 
 ### Neutral / bilateral patterns
 
-- **symmetrical_triangle:** lower highs + higher lows converge; resolves in the prevailing trend direction on break (neutral until it breaks).
-- **pennant:** sharp move (pole) then a small symmetrical triangle; continues in the pole's direction on break.
-- **rectangle:** price oscillates between horizontal support and resistance; direction is decided by which side breaks.
+- **symmetrical_triangle:** lower highs + higher lows converge; resolves in the prevailing trend direction on break (neutral until it breaks). Target: triangle height (widest) projected from the breakout in the break direction; stop = opposite trendline.
+- **pennant:** sharp move (pole) then a small symmetrical triangle; continues in the pole's direction on break. Target: flagpole length projected from the breakout; stop = opposite trendline / recent swing within the pennant.
+- **rectangle:** price oscillates between horizontal support and resistance; direction is decided by which side breaks. Target: rectangle height (support→resistance) projected from the breakout in the break direction; stop = opposite boundary.
 
 ### Reporting directive
 
-- Patterns **not** in the current prompt's detailed set may still be reported if clearly visible — name them and describe the structure, but at **reduced confidence** (the detailed geometry/target/invalidation criteria were not supplied for them this run).
+- Patterns **not** in the current prompt's detailed set may still be reported if clearly visible — name them and describe the structure. The **reduced confidence** attaches ONLY to the pattern-identification claim itself (its detailed geometry/target/invalidation criteria were not supplied this run) — it does **not** reduce the confidence of the overall analysis. Everything else — key levels, indicators, strategies, and the action plan — must stay fully committed and quantified.
+- **Actionability:** whenever any pattern (a gated candidate or one recognized from this index) informs the outlook, translate it into concrete numbers using the current `keyLevels` — a measured target, an invalidation/stop reference, and the resulting risk/reward (favor ≥2:1). Do not leave a named pattern as shape-only.
 
 <!-- PROMPT_DIGEST:START -->
 Pattern Index — one-line index of EVERY detectable chart pattern. Always know all 17 exist and NAME any pattern clearly visible on the chart, even when its detailed skill was not injected. Detailed judging (geometry tolerances, measured targets, confirmation/invalidation) arrives separately ONLY for patterns the pre-screener flags as candidates.
 Reversal:
-- head_and_shoulders: three peaks, middle (head) highest, neckline break down = bearish reversal.
-- inverse_head_and_shoulders: three troughs, middle (head) lowest, neckline break up = bullish reversal.
-- double_top: two ~equal highs (M), neckline break down = bearish reversal.
-- double_bottom: two ~equal lows (W), neckline break up = bullish reversal.
-- triple_top: three ~equal highs at resistance, support break down = bearish reversal.
-- triple_bottom: three ~equal lows at support, resistance break up = bullish reversal.
-- rounding_bottom: slow U (saucer) base, break up = bullish reversal.
+- head_and_shoulders: three peaks, middle (head) highest, neckline break down = bearish reversal. Target: head→neckline depth projected down from break; invalidated by close above right shoulder high.
+- inverse_head_and_shoulders: three troughs, middle (head) lowest, neckline break up = bullish reversal. Target: neckline→head depth projected up from break; invalidated by close below right shoulder low.
+- double_top: two ~equal highs (M), neckline break down = bearish reversal. Target: peak-avg→neckline depth projected down from break; invalidated by close above higher peak.
+- double_bottom: two ~equal lows (W), neckline break up = bullish reversal. Target: neckline→trough-avg depth projected up from break; invalidated by close below lower trough.
+- triple_top: three ~equal highs at resistance, neckline (support) break down = bearish reversal. Target: peak-avg→neckline depth projected down from break; invalidated by close above highest peak.
+- triple_bottom: three ~equal lows at support, neckline (resistance) break up = bullish reversal. Target: neckline→trough-avg depth projected up from break; invalidated by close below lowest trough.
+- rounding_bottom: slow U (saucer) base, break up above left rim = bullish reversal. Target: saucer depth (rim→bottom) projected up from rim breakout; stop = recent right-side trough (wider = saucer bottom).
 Continuation:
-- ascending_triangle: flat top resistance + rising lows, break up = bullish continuation.
-- descending_triangle: flat bottom support + falling highs, break down = bearish continuation.
-- ascending_wedge (rising): both bounds up + converging, break down = bearish.
-- descending_wedge (falling): both bounds down + converging, break up = bullish.
-- bull_flag: sharp rise (pole) + slight down channel, break up = bullish continuation.
-- bear_flag: sharp drop (pole) + slight up channel, break down = bearish continuation.
-- cup_and_handle: rounded U cup + small handle, break up = bullish continuation.
+- ascending_triangle: flat top resistance + rising lows, break up = bullish continuation. Target: triangle height projected up from breakout; invalidated by close below ascending trendline.
+- descending_triangle: flat bottom support + falling highs, break down = bearish continuation. Target: triangle height projected down from breakdown; invalidated by close above descending trendline.
+- ascending_wedge (rising): both bounds up + converging, break down = bearish. Target: wedge height (start width) projected down from breakdown; invalidated by close above recent swing high / upper trendline.
+- descending_wedge (falling): both bounds down + converging, break up = bullish. Target: wedge height (start width) projected up from breakout; invalidated by close below recent swing low / lower trendline.
+- bull_flag: sharp rise (pole) + slight down channel, break up = bullish continuation. Target: flagpole length projected up from breakout; invalidated by close below lower flag channel / swing low.
+- bear_flag: sharp drop (pole) + slight up channel, break down = bearish continuation. Target: flagpole length projected down from breakdown; invalidated by close above upper flag channel / swing high.
+- cup_and_handle: rounded U cup + small handle, break up = bullish continuation. Target: cup depth (rim→bottom) projected up from breakout; invalidated by close below handle bottom (wider = cup midpoint).
 Neutral/bilateral:
-- symmetrical_triangle: lower highs + higher lows converge; breaks in prevailing trend direction (neutral until break).
-- pennant: sharp move (pole) + small symmetrical triangle; continues in pole direction.
-- rectangle: range between horizontal support & resistance; direction = side that breaks.
-Directive: patterns NOT in this prompt's detailed set may still be reported if clearly visible — name and describe them, but at REDUCED confidence (detailed criteria were not supplied for them this run).
+- symmetrical_triangle: lower highs + higher lows converge; breaks in prevailing trend direction (neutral until break). Target: triangle height (widest) projected from breakout in break direction; stop = opposite trendline.
+- pennant: sharp move (pole) + small symmetrical triangle; continues in pole direction. Target: flagpole length projected from breakout; stop = opposite trendline / recent swing within pennant.
+- rectangle: range between horizontal support & resistance; direction = side that breaks. Target: rectangle height projected from breakout in break direction; stop = opposite boundary.
+Directive: patterns NOT in this prompt's detailed set may still be reported if clearly visible — name and describe them, but the REDUCED confidence attaches ONLY to the pattern-identification claim (detailed criteria not supplied this run), NOT to the overall analysis. Key levels, indicators, strategies, and action plan stay fully committed and quantified.
+Actionability: whenever any pattern (gated candidate or index-recognized) informs the outlook, translate it into concrete numbers from current keyLevels — measured target, invalidation/stop reference, and resulting R:R (favor ≥2:1). Never leave a named pattern as shape-only.
 <!-- PROMPT_DIGEST:END -->

--- a/skills/_core/pattern-index.md
+++ b/skills/_core/pattern-index.md
@@ -1,0 +1,84 @@
+---
+name: Pattern Index Reference
+description: 계산되는 모든 차트 패턴의 1줄 형태·방향 요약 — 상시 주입되는 압축 인덱스(개별 판정 기준은 프리스크리너가 후보로 지목한 패턴만 게이팅)
+type: indicator_guide
+indicators: []
+confidence_weight: 1.0
+gating:
+  tier: always_on
+token_cost: 523
+digest_hash: "47de8c4e"
+---
+
+## Pattern Index (compressed)
+
+Always-on one-line index of **every** chart pattern the engine can detect. Its
+job is coverage, not judgement: the model should always know that all 17
+patterns exist and be able to **name** any pattern it can clearly see on the
+chart, even when that pattern's detailed skill was not injected this run.
+
+The **detailed** judging criteria for a pattern — geometry tolerances, measured
+targets, confirmation/invalidation levels — arrive in a separate skill only when
+the pre-screener flags that specific pattern as a plausible candidate on the
+current chart. This index is the cheap always-present fallback so no visible
+pattern goes unnamed just because its full guide wasn't gated in.
+
+`type: indicator_guide` is used deliberately (not `type: pattern`): this file is
+a cross-cutting always-on reference for the whole pattern category, mirroring
+`_core/indicator-core.md`. It is not a single detectable pattern, so it carries
+no `pattern:` id and is exempt from `usage_roles` (the always-on exemption).
+
+### Reversal patterns
+
+- **head_and_shoulders:** three peaks, middle (head) highest, neckline break down = bearish reversal.
+- **inverse_head_and_shoulders:** three troughs, middle (head) lowest, neckline break up = bullish reversal.
+- **double_top:** two roughly equal highs (M shape), neckline (intervening low) break down = bearish reversal.
+- **double_bottom:** two roughly equal lows (W shape), neckline (intervening high) break up = bullish reversal.
+- **triple_top:** three roughly equal highs at resistance, support break down = bearish reversal.
+- **triple_bottom:** three roughly equal lows at support, resistance break up = bullish reversal.
+- **rounding_bottom:** slow U-shaped (saucer) base, gradual momentum shift, break up = bullish reversal.
+
+### Continuation patterns
+
+- **ascending_triangle:** flat resistance on top + rising lows, breakout up = bullish continuation.
+- **descending_triangle:** flat support on bottom + falling highs, breakdown = bearish continuation.
+- **ascending_wedge (rising wedge):** both bounds slope up and converge, break down = bearish (reversal/continuation-against).
+- **descending_wedge (falling wedge):** both bounds slope down and converge, break up = bullish (reversal/continuation-against).
+- **bull_flag:** sharp rally (pole) then a slight downward-drifting channel, break up = bullish continuation.
+- **bear_flag:** sharp drop (pole) then a slight upward-drifting channel, break down = bearish continuation.
+- **cup_and_handle:** rounded U cup + small pullback handle near the rim, break up = bullish continuation.
+
+### Neutral / bilateral patterns
+
+- **symmetrical_triangle:** lower highs + higher lows converge; resolves in the prevailing trend direction on break (neutral until it breaks).
+- **pennant:** sharp move (pole) then a small symmetrical triangle; continues in the pole's direction on break.
+- **rectangle:** price oscillates between horizontal support and resistance; direction is decided by which side breaks.
+
+### Reporting directive
+
+- Patterns **not** in the current prompt's detailed set may still be reported if clearly visible — name them and describe the structure, but at **reduced confidence** (the detailed geometry/target/invalidation criteria were not supplied for them this run).
+
+<!-- PROMPT_DIGEST:START -->
+Pattern Index — one-line index of EVERY detectable chart pattern. Always know all 17 exist and NAME any pattern clearly visible on the chart, even when its detailed skill was not injected. Detailed judging (geometry tolerances, measured targets, confirmation/invalidation) arrives separately ONLY for patterns the pre-screener flags as candidates.
+Reversal:
+- head_and_shoulders: three peaks, middle (head) highest, neckline break down = bearish reversal.
+- inverse_head_and_shoulders: three troughs, middle (head) lowest, neckline break up = bullish reversal.
+- double_top: two ~equal highs (M), neckline break down = bearish reversal.
+- double_bottom: two ~equal lows (W), neckline break up = bullish reversal.
+- triple_top: three ~equal highs at resistance, support break down = bearish reversal.
+- triple_bottom: three ~equal lows at support, resistance break up = bullish reversal.
+- rounding_bottom: slow U (saucer) base, break up = bullish reversal.
+Continuation:
+- ascending_triangle: flat top resistance + rising lows, break up = bullish continuation.
+- descending_triangle: flat bottom support + falling highs, break down = bearish continuation.
+- ascending_wedge (rising): both bounds up + converging, break down = bearish.
+- descending_wedge (falling): both bounds down + converging, break up = bullish.
+- bull_flag: sharp rise (pole) + slight down channel, break up = bullish continuation.
+- bear_flag: sharp drop (pole) + slight up channel, break down = bearish continuation.
+- cup_and_handle: rounded U cup + small handle, break up = bullish continuation.
+Neutral/bilateral:
+- symmetrical_triangle: lower highs + higher lows converge; breaks in prevailing trend direction (neutral until break).
+- pennant: sharp move (pole) + small symmetrical triangle; continues in pole direction.
+- rectangle: range between horizontal support & resistance; direction = side that breaks.
+Directive: patterns NOT in this prompt's detailed set may still be reported if clearly visible — name and describe them, but at REDUCED confidence (detailed criteria were not supplied for them this run).
+<!-- PROMPT_DIGEST:END -->

--- a/skills/patterns/ascending-triangle.md
+++ b/skills/patterns/ascending-triangle.md
@@ -13,7 +13,9 @@ display:
     color: "#26a69a"
     label: "저항선"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [ascending_triangle]
 token_cost: 601
 digest_hash: "1b764299"
 ---

--- a/skills/patterns/ascending-wedge.md
+++ b/skills/patterns/ascending-wedge.md
@@ -13,7 +13,9 @@ display:
     color: "#ef5350"
     label: "추세선"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [ascending_wedge]
 token_cost: 536
 digest_hash: "23832341"
 ---

--- a/skills/patterns/bear-flag.md
+++ b/skills/patterns/bear-flag.md
@@ -13,7 +13,9 @@ display:
     color: "#ef5350"
     label: "깃발 하단"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [bear_flag]
 token_cost: 575
 digest_hash: "79cc4420"
 ---

--- a/skills/patterns/bull-flag.md
+++ b/skills/patterns/bull-flag.md
@@ -13,7 +13,9 @@ display:
     color: "#26a69a"
     label: "깃발 상단"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [bull_flag]
 token_cost: 553
 digest_hash: "a095d4be"
 ---

--- a/skills/patterns/cup-and-handle.md
+++ b/skills/patterns/cup-and-handle.md
@@ -13,7 +13,9 @@ display:
     color: "#26a69a"
     label: "핸들 저항선"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [cup_and_handle]
 token_cost: 613
 digest_hash: "0e23aabf"
 ---

--- a/skills/patterns/descending-triangle.md
+++ b/skills/patterns/descending-triangle.md
@@ -13,7 +13,9 @@ display:
     color: "#ef5350"
     label: "지지선"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [descending_triangle]
 token_cost: 569
 digest_hash: "cefa142d"
 ---

--- a/skills/patterns/descending-wedge.md
+++ b/skills/patterns/descending-wedge.md
@@ -13,7 +13,9 @@ display:
     color: "#26a69a"
     label: "추세선"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [descending_wedge]
 token_cost: 526
 digest_hash: "9df7321e"
 ---

--- a/skills/patterns/double-bottom.md
+++ b/skills/patterns/double-bottom.md
@@ -13,7 +13,9 @@ display:
     color: "#26a69a"
     label: "넥라인"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [double_bottom]
 token_cost: 509
 digest_hash: "f7b71b09"
 ---

--- a/skills/patterns/double-top.md
+++ b/skills/patterns/double-top.md
@@ -13,7 +13,9 @@ display:
     color: "#ef5350"
     label: "넥라인"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [double_top]
 token_cost: 496
 digest_hash: "86e4cde8"
 ---

--- a/skills/patterns/head-and-shoulders.md
+++ b/skills/patterns/head-and-shoulders.md
@@ -13,7 +13,9 @@ display:
     color: "#ef5350"
     label: "넥라인"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [head_and_shoulders]
 token_cost: 657
 digest_hash: "d8c04971"
 ---

--- a/skills/patterns/inverse-head-and-shoulders.md
+++ b/skills/patterns/inverse-head-and-shoulders.md
@@ -13,7 +13,9 @@ display:
     color: "#26a69a"
     label: "넥라인"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [inverse_head_and_shoulders]
 token_cost: 674
 digest_hash: "5c002a4f"
 ---

--- a/skills/patterns/pennant.md
+++ b/skills/patterns/pennant.md
@@ -13,7 +13,9 @@ display:
     color: "#78909c"
     label: "페넌트"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [pennant]
 token_cost: 764
 digest_hash: "d59b6e3d"
 ---

--- a/skills/patterns/rectangle.md
+++ b/skills/patterns/rectangle.md
@@ -13,7 +13,9 @@ display:
     color: "#78909c"
     label: "지지/저항선"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [rectangle]
 token_cost: 777
 digest_hash: "7179d8c5"
 ---

--- a/skills/patterns/rounding-bottom.md
+++ b/skills/patterns/rounding-bottom.md
@@ -13,7 +13,9 @@ display:
     color: "#26a69a"
     label: "림 저항선"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [rounding_bottom]
 token_cost: 702
 digest_hash: "07429977"
 ---

--- a/skills/patterns/symmetrical-triangle.md
+++ b/skills/patterns/symmetrical-triangle.md
@@ -13,7 +13,9 @@ display:
     color: "#78909c"
     label: "추세선"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [symmetrical_triangle]
 token_cost: 688
 digest_hash: "5f404a2b"
 ---

--- a/skills/patterns/triple-bottom.md
+++ b/skills/patterns/triple-bottom.md
@@ -13,7 +13,9 @@ display:
     color: "#26a69a"
     label: "넥라인"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [triple_bottom]
 token_cost: 673
 digest_hash: "8c28f23b"
 ---

--- a/skills/patterns/triple-top.md
+++ b/skills/patterns/triple-top.md
@@ -13,7 +13,9 @@ display:
     color: "#ef5350"
     label: "넥라인"
 gating:
-  tier: always_on
+  tier: gated
+  signal_kind: event
+  triggers: [triple_top]
 token_cost: 689
 digest_hash: "a52a74a6"
 ---


### PR DESCRIPTION
## Summary

Final activation step of prompt-redesign Phase 3 (spec §3.2 step 2 / §3.3). Requires core ≥0.31.0 (merged in #672) — the selection engine understands pattern-candidate triggers.

- 17 chart-pattern skills flip from `always_on` to `gated / signal_kind: event / triggers: [<ChartPatternId>]` — detailed judging digests now injected ONLY when the pre-screener flags the pattern as a plausible candidate.
- New always-on `_core/pattern-index.md`: one-line shape+direction+measured-move/invalidation hint per pattern (token_cost 1100) — the model always knows all 17 patterns exist; reduced-confidence scoping + actionability directives included.
- Validator: pattern trigger catalog (17 ids) added.

Quality-gated: final blind-panel A/B (2 samples × 3-pass median) PASS — hallucination-freedom +0.44, actionability +1.06, groundedness +0.06, pattern-judgment −0.06 (within tolerance). Gating changes auto-invalidate analysis caches via the skill fingerprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)