### PR TITLE
test(skills): audit-remediation coverage + digest-verify CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
             - name: Validate skills
               run: yarn validate:skills
 
+            - name: Verify skill digests
+              run: yarn skills:digest-verify
+
             - name: Lint
               run: yarn lint
 

--- a/scripts/__tests__/pattern-index.test.ts
+++ b/scripts/__tests__/pattern-index.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Content-consistency test for skills/_core/pattern-index.md.
+ *
+ * This file is the always-on chart-pattern coverage index (commits c6dea2ea,
+ * 5be1e11d) — every one of the 17 `PATTERN_TRIGGER_CATALOG` chart-pattern
+ * pre-screener ids (the same catalog validate-skills.ts cross-checks
+ * `type: pattern` skill triggers against) must have a one-line entry here
+ * carrying both a measured-move Target and an invalidation/stop hint, so the
+ * model can still name a visible pattern even when its detailed skill wasn't
+ * gated in this run. Before this test, pattern-index.md had zero automated
+ * assertions — a future catalog addition (or an edit that dropped a Target/
+ * invalidation phrase) would silently ship un-caught.
+ *
+ * The bullet format below was read directly off the real file, not guessed:
+ *   - **{id}:** ... Target: ...; invalidated by ...
+ *   - **{id} (alias):** ... Target: ...; stop = ...
+ * (`ascending_wedge (rising wedge)` / `descending_wedge (falling wedge)` are
+ * the only entries with a parenthetical alias before the closing `:**`.) The
+ * digest section at the bottom of the file (between PROMPT_DIGEST:START/END)
+ * mirrors the same content in a compressed, non-bold format and is
+ * deliberately NOT asserted on here — its hash/token-cost fidelity to the
+ * body is already covered by `yarn skills:digest-verify` (scripts/skills-digest.ts),
+ * which this repo's CI now also runs.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { PATTERN_TRIGGER_CATALOG } from '../validate-skills';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const PATTERN_INDEX_PATH = join(
+    SCRIPT_DIR,
+    '..',
+    '..',
+    'skills',
+    '_core',
+    'pattern-index.md'
+);
+
+const content = readFileSync(PATTERN_INDEX_PATH, 'utf-8');
+
+/** The single-line bullet for a given pattern id, e.g. `- **double_top:** ...`. */
+const bulletRegex = (id: string): RegExp =>
+    new RegExp(`^- \\*\\*${id}(?: \\([^)]*\\))?:\\*\\*(.*)$`, 'm');
+
+/**
+ * Every `- **...:**` bullet line in the file, regardless of which pattern id
+ * it names. Only the main (bold) body section uses this `- **id:**` format —
+ * the compressed digest section below the PROMPT_DIGEST markers uses a plain
+ * `- id:` format with no bold markers, so this does not double-count digest
+ * lines.
+ */
+const ALL_BULLETS_RE = /^- \*\*[a-z_]+(?: \([^)]*\))?:\*\*/gm;
+
+describe('skills/_core/pattern-index.md content consistency', () => {
+    it('PATTERN_TRIGGER_CATALOG has the expected 17 patterns', () => {
+        expect(PATTERN_TRIGGER_CATALOG.length).toBe(17);
+    });
+
+    it('carries a bullet entry for every PATTERN_TRIGGER_CATALOG id', () => {
+        for (const id of PATTERN_TRIGGER_CATALOG) {
+            expect(bulletRegex(id).test(content)).toBe(true);
+        }
+    });
+
+    it('has exactly as many pattern bullets as the catalog (catches undeclared/orphan entries)', () => {
+        const bullets = content.match(ALL_BULLETS_RE) ?? [];
+        expect(bullets).toHaveLength(PATTERN_TRIGGER_CATALOG.length);
+    });
+
+    describe.each(PATTERN_TRIGGER_CATALOG)('%s entry', id => {
+        it('states a measured-move Target', () => {
+            const match = bulletRegex(id).exec(content);
+            expect(match).not.toBeNull();
+            expect(match?.[1]).toMatch(/Target:/);
+        });
+
+        it('states an invalidation/stop hint', () => {
+            const match = bulletRegex(id).exec(content);
+            expect(match).not.toBeNull();
+            expect(match?.[1]).toMatch(/invalidated by|stop =/);
+        });
+    });
+});

--- a/scripts/__tests__/skills-digest.test.ts
+++ b/scripts/__tests__/skills-digest.test.ts
@@ -335,6 +335,16 @@ describe('updateFileContent', () => {
         expect(result.skippedReason).toBe('missing-digest');
     });
 
+    it('skips a file with no --- frontmatter block at all (parallel to verifyFileContent)', () => {
+        const content = 'no frontmatter here at all';
+        const result = updateFileContent(content);
+        expect(result).toEqual({
+            changed: false,
+            skippedReason: 'invalid-frontmatter',
+            content,
+        });
+    });
+
     it('skips a malformed file', () => {
         const content = buildFile();
         const split = splitFrontmatter(content)!;

--- a/scripts/__tests__/validate-skills.test.ts
+++ b/scripts/__tests__/validate-skills.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { validateSkillData } from '../validate-skills';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { parseSkillFile, validateSkillData } from '../validate-skills';
 
 describe('validateSkillData', () => {
     describe('valid frontmatter', () => {
@@ -412,5 +415,58 @@ describe('validateSkillData', () => {
             });
             expect(errors[0]).toMatch(/unreachable state predicate/);
         });
+    });
+});
+
+describe('parseSkillFile fail-closed parse failures', () => {
+    // Both branches below must surface as an *error* (so `main()` exits 1 —
+    // fail-closed drop), never as a silently-accepted valid skill. These cover
+    // the gray-matter try/catch and the "frontmatter missing/not a mapping"
+    // check in parseSkillFile, which had no test before this file.
+    let dir: string;
+
+    const writeFixture = (name: string, content: string): string => {
+        const file = join(dir, name);
+        writeFileSync(file, content);
+        return file;
+    };
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), 'validate-skills-test-'));
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('drops a file with unparseable (broken) YAML frontmatter', () => {
+        // Unbalanced `{` in a flow mapping — js-yaml (via gray-matter) throws
+        // rather than returning malformed data.
+        const file = writeFixture(
+            'broken-yaml.md',
+            '---\ngating: {tier: gated\n---\nbody text\n'
+        );
+        const result = parseSkillFile(file);
+        expect(result.hasGating).toBe(false);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]?.message).toMatch(
+            /failed to parse frontmatter/
+        );
+    });
+
+    it('drops a file whose frontmatter parses to a non-mapping (e.g. a YAML list)', () => {
+        // Valid YAML, but the top-level value is an array, not a mapping —
+        // gray-matter does not throw here, so this exercises the separate
+        // `!isRecord(parsed.data)` guard.
+        const file = writeFixture(
+            'non-mapping.md',
+            '---\n- just\n- a\n- list\n---\nbody text\n'
+        );
+        const result = parseSkillFile(file);
+        expect(result.hasGating).toBe(false);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]?.message).toMatch(
+            /frontmatter is missing or not a mapping/
+        );
     });
 });

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -127,7 +127,7 @@ const SIGNAL_SET = new Set<string>(SIGNAL_CATALOG);
  * drift in the pattern union fails the build here instead of silently
  * accepting a stale id.
  */
-const PATTERN_TRIGGER_CATALOG = [
+export const PATTERN_TRIGGER_CATALOG = [
     'head_and_shoulders',
     'inverse_head_and_shoulders',
     'double_top',
@@ -492,8 +492,13 @@ interface FileResult {
     errors: SkillError[];
 }
 
-/** Read + validate one skill file. Returns its errors (with file context) and whether it carries a gating block. */
-const parseSkillFile = (file: string): FileResult => {
+/**
+ * Read + validate one skill file. Returns its errors (with file context) and
+ * whether it carries a gating block. Exported for unit testing the fail-closed
+ * parse-failure branches (unparseable YAML, non-mapping frontmatter) without
+ * spawning the CLI.
+ */
+export const parseSkillFile = (file: string): FileResult => {
     const rel = relative(REPO_ROOT, file);
     const withFile = (message: string): SkillError => ({ file: rel, message });
 


### PR DESCRIPTION
## Summary

Pre-deploy coverage audit of the skills/validator/digest tooling surfaced four gaps — 1 high, 2 medium, 1 low. This PR closes all four. No `src/` app-layer change.

- **[high] `skills/_core/pattern-index.md` had zero automated assertions.** This always-on file carries a 1-line summary of every one of the 17 chart patterns (`PATTERN_TRIGGER_CATALOG`), each with a measured-move Target and an invalidation/stop hint (commits c6dea2ea, 5be1e11d) — nothing checked it stayed in sync. Added `scripts/__tests__/pattern-index.test.ts`:
  - asserts every `PATTERN_TRIGGER_CATALOG` id (17) has a bullet entry in the file,
  - asserts the bullet count matches the catalog length exactly (catches an index entry added without a matching catalog id, or vice versa),
  - for each pattern, asserts its bullet contains both `Target:` and an invalidation/stop hint (`invalidated by` or `stop =`) — the exact phrasing the file actually uses.
  - `PATTERN_TRIGGER_CATALOG` is now exported from `scripts/validate-skills.ts` so the test tracks the real catalog instead of a hand-duplicated copy.

- **[medium] `validate-skills.ts`'s fail-closed parse-failure branches were untested.** `parseSkillFile` (~line 501–522) has a gray-matter try/catch and a "frontmatter missing/not a mapping" guard — both untested, meaning a regression there could silently accept a broken skill file instead of failing CI. Exported `parseSkillFile` and added two tests to `scripts/__tests__/validate-skills.test.ts`:
  - broken/unbalanced YAML → `errors[0].message` matches `/failed to parse frontmatter/`,
  - frontmatter that parses to a non-mapping (a YAML list) → matches `/frontmatter is missing or not a mapping/`.
  - Both assert `hasGating: false` and exactly one error (fail-closed drop → CI exit 1), confirmed against gray-matter's actual runtime behavior for each fixture before writing the assertions.

- **[medium] `yarn skills:digest-verify` was never wired into CI.** `package.json` has the script; `.github/workflows/ci.yml` only ran `validate:skills`. Added a `Verify skill digests` step in the same `ci` job, right after `Validate skills` — minimal additive step, no workflow restructuring. Passes locally today (81 files valid).

- **[low] `skills-digest.ts`'s `updateFileContent` invalid-frontmatter skip was untested.** Its `verifyFileContent` twin already had a test for "no `---` block found"; `updateFileContent` (~line 337–344) lacked the parallel case. Added the twin test to `scripts/__tests__/skills-digest.test.ts`: content with no `---` block → `{ changed: false, skippedReason: 'invalid-frontmatter', content }`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `yarn vitest run scripts/__tests__/pattern-index.test.ts scripts/__tests__/validate-skills.test.ts scripts/__tests__/skills-digest.test.ts` — 110 passed (3 test files)
- [x] `yarn skills:digest-verify` — 81 skill files valid
- [x] `yarn validate:skills` — 81 skill files valid, 81 tagged with gating
- [x] `npx eslint` scoped to changed files — clean
- [x] `npx prettier --check` scoped to changed files — clean
- [x] pre-push hook (format:check, lint, typecheck, test, build) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9J3vzLHuiG3nc22gfJUHN