### PR TITLE
feat(scripts): accumulate crypto popular list instead of full overwrite

### DIFF
--- a/docs/__agents_only__/fix-log.md
+++ b/docs/__agents_only__/fix-log.md
@@ -18,11 +18,6 @@
 - Violation: Global `vi.mock('@upstash/redis', ...)` added to `vitest.setup.base.ts` when per-file mocks + resolve alias sufficed
   - Rule: Test best practices — Global mocks weaken test isolation; per-file mocks keep missing-mock failures visible
   - Context: Removed global mock to maintain test isolation and visibility of unintended missing dependencies.
-## [PR #513 Round 1 | fix/fear-greed-ssr-and-fmp-retry | 2026-05-26]
-- Violation: `page.tsx` prefetch 배열에 `.push()` 사용 — 배열 직접 변이
-  - Rule: MISTAKES.md §5 — Array/object mutation via push/splice 금지
-  - Context: 차트 페이지에서 조건부 prefetch를 추가할 때 spread 대신 push를 사용. spread 패턴으로 교체
-
 ## [PR #432 Round 4 | fix/cancel-job-on-page-unload | 2026-05-09]
 - Violation: `route.ts` body validation used `!j.type` (falsy check only), allowing invalid type strings (e.g. `"unknown"`) to pass and silently return 204
   - Rule: Infrastructure Functions — validate all inputs at API boundaries; invalid values must return 400

--- a/scripts/__tests__/update-popular-cryptos.test.ts
+++ b/scripts/__tests__/update-popular-cryptos.test.ts
@@ -202,8 +202,12 @@ describe('CRYPTO_CANDIDATE_POOL', () => {
 });
 
 describe('MAX_POPULAR_CRYPTOS', () => {
-    it('matches the current popular-cryptos.ts list size', () => {
-        expect(MAX_POPULAR_CRYPTOS).toBe(POPULAR_CRYPTOS.length);
+    // MAX_POPULAR_CRYPTOS is the per-run top-N selection size, not the list size.
+    // The list accumulates over runs (never shrinks), so it must be >= MAX_POPULAR_CRYPTOS.
+    it('is at most the current accumulated popular-cryptos.ts list size', () => {
+        expect(POPULAR_CRYPTOS.length).toBeGreaterThanOrEqual(
+            MAX_POPULAR_CRYPTOS
+        );
     });
 });
 

--- a/scripts/__tests__/update-popular-cryptos.test.ts
+++ b/scripts/__tests__/update-popular-cryptos.test.ts
@@ -1,11 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { POPULAR_CRYPTOS } from '@/shared/config/popular-cryptos';
 import {
     CRYPTO_CANDIDATE_POOL,
     FILE_HEADER,
     MAX_POPULAR_CRYPTOS,
+    deduplicateCryptoEntries,
+    extractExistingCryptos,
     filterValidCandidates,
     formatMarketCap,
+    insertCryptoTrendingSection,
     rankByMarketCap,
     renderPopularCryptosFile,
 } from '../update-popular-cryptos';
@@ -275,5 +278,150 @@ describe('stablecoin exclusion', () => {
     it('CRYPTO_CANDIDATE_POOL does not contain USDTUSD or USDCUSD', () => {
         expect(CRYPTO_CANDIDATE_POOL).not.toContain('USDTUSD');
         expect(CRYPTO_CANDIDATE_POOL).not.toContain('USDCUSD');
+    });
+});
+
+describe('extractExistingCryptos', () => {
+    it('extracts every symbol declared in the POPULAR_CRYPTOS array', () => {
+        const fileContent = renderPopularCryptosFile([
+            'BTCUSD',
+            'ETHUSD',
+            'SOLUSD',
+        ]);
+
+        const result = extractExistingCryptos(fileContent);
+
+        expect(result).toEqual(new Set(['BTCUSD', 'ETHUSD', 'SOLUSD']));
+    });
+
+    it('includes symbols added under Trending sections', () => {
+        const fileContent = `${FILE_HEADER}
+export const POPULAR_CRYPTOS = [
+    'BTCUSD',
+    'ETHUSD',
+
+    // --- Trending (2026-07-06) ---
+    'SUIUSD',
+] as const;
+`;
+
+        const result = extractExistingCryptos(fileContent);
+
+        expect(result).toEqual(new Set(['BTCUSD', 'ETHUSD', 'SUIUSD']));
+    });
+
+    it('returns an empty set when the declaration marker is absent', () => {
+        expect(extractExistingCryptos('export const OTHER = [];')).toEqual(
+            new Set()
+        );
+    });
+});
+
+describe('deduplicateCryptoEntries', () => {
+    it('keeps only the first occurrence of each symbol in the array', () => {
+        const fileContent = `export const POPULAR_CRYPTOS = [
+    'BTCUSD',
+    'ETHUSD',
+
+    // --- Trending (2026-07-06) ---
+    'ETHUSD',
+    'SUIUSD',
+] as const;
+`;
+
+        const result = deduplicateCryptoEntries(fileContent);
+
+        expect(result.removedSymbols).toEqual(['ETHUSD']);
+        expect(result.content).toBe(`export const POPULAR_CRYPTOS = [
+    'BTCUSD',
+    'ETHUSD',
+
+    // --- Trending (2026-07-06) ---
+    'SUIUSD',
+] as const;
+`);
+    });
+
+    it('does not treat identical symbols outside the array as duplicates', () => {
+        const fileContent = `export const CRYPTO_CATEGORIES = ['BTCUSD'];
+
+export const POPULAR_CRYPTOS = [
+    'BTCUSD',
+    'ETHUSD',
+    'BTCUSD',
+] as const;
+`;
+
+        const result = deduplicateCryptoEntries(fileContent);
+
+        expect(result.removedSymbols).toEqual(['BTCUSD']);
+        expect(result.content).toContain(
+            "export const CRYPTO_CATEGORIES = ['BTCUSD'];"
+        );
+        expect(result.content).toContain(`export const POPULAR_CRYPTOS = [
+    'BTCUSD',
+    'ETHUSD',
+] as const;`);
+    });
+
+    it('returns the original content when the array markers are absent', () => {
+        const fileContent = `export const OTHER = ['BTCUSD', 'BTCUSD'];`;
+
+        expect(deduplicateCryptoEntries(fileContent)).toEqual({
+            content: fileContent,
+            removedSymbols: [],
+        });
+    });
+});
+
+describe('insertCryptoTrendingSection', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        // 날짜 의존을 제거해 결정적으로 만든다 (Trending 섹션 헤더에 오늘 날짜가 박힘).
+        vi.setSystemTime(new Date('2026-07-06T12:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('appends a dated Trending section before the closing marker', () => {
+        const fileContent = renderPopularCryptosFile(['BTCUSD', 'ETHUSD']);
+
+        const result = insertCryptoTrendingSection(fileContent, [
+            'SUIUSD',
+            'TONUSD',
+        ]);
+
+        expect(result).toBe(`${FILE_HEADER}
+export const POPULAR_CRYPTOS = [
+    'BTCUSD',
+    'ETHUSD',
+
+    // --- Trending (2026-07-06) ---
+    'SUIUSD',
+    'TONUSD',
+] as const;
+`);
+    });
+
+    it('skips insertion when a section for the same date already exists', () => {
+        const fileContent = `export const POPULAR_CRYPTOS = [
+    'BTCUSD',
+
+    // --- Trending (2026-07-06) ---
+    'ETHUSD',
+] as const;
+`;
+
+        const result = insertCryptoTrendingSection(fileContent, ['SUIUSD']);
+
+        expect(result).toBe(fileContent);
+    });
+
+    it('throws when the closing marker is missing', () => {
+        expect(() =>
+            insertCryptoTrendingSection('export const BROKEN = [', ['BTCUSD'])
+        ).toThrow('Could not find "] as const;" in popular-cryptos.ts');
     });
 });

--- a/scripts/__tests__/update-popular-cryptos.test.ts
+++ b/scripts/__tests__/update-popular-cryptos.test.ts
@@ -319,6 +319,28 @@ export const POPULAR_CRYPTOS = [
             new Set()
         );
     });
+
+    it('does not extract symbols declared after the array end marker', () => {
+        const fileContent = `export const POPULAR_CRYPTOS = [
+    'BTCUSD',
+    'ETHUSD',
+] as const;
+
+export const UNRELATED_EXPORT = ['SOLUSD', 'XRPUSD'];
+`;
+
+        const result = extractExistingCryptos(fileContent);
+
+        expect(result).toEqual(new Set(['BTCUSD', 'ETHUSD']));
+    });
+
+    it('returns an empty set when the end marker is missing', () => {
+        const fileContent = `export const POPULAR_CRYPTOS = [
+    'BTCUSD',
+`;
+
+        expect(extractExistingCryptos(fileContent)).toEqual(new Set());
+    });
 });
 
 describe('deduplicateCryptoEntries', () => {

--- a/scripts/update-popular-cryptos.ts
+++ b/scripts/update-popular-cryptos.ts
@@ -3,7 +3,8 @@
  *
  * FMP cryptocurrency-list API로 후보 풀을 검증한 뒤,
  * 각 심볼의 단건 quote 엔드포인트에서 marketCap을 수집하여
- * 시가총액 상위 MAX_POPULAR_CRYPTOS 개를 POPULAR_CRYPTOS로 덮어씁니다.
+ * 시가총액 상위 MAX_POPULAR_CRYPTOS 개를 선정하고,
+ * 그중 기존 POPULAR_CRYPTOS에 없는 심볼만 누적 추가합니다.
  *
  * FMP 플랜 제약:
  *   - batch-crypto-quotes → HTTP 402 (플랜 미지원). 사용 불가.
@@ -18,14 +19,19 @@
  *   FMP_API_KEY
  *
  * 결과:
- *   시가총액 기준 상위 N개로 src/shared/config/popular-cryptos.ts를 완전 교체합니다.
- *   (누적 추가가 아니라 매 실행마다 현재 상위 코인으로 리프레시)
+ *   src/shared/config/popular-cryptos.ts에 누적 추가합니다(update-popular-tickers.ts와 동일 방식).
+ *   매 실행마다 시가총액 상위 N개 중 기존 목록에 없는 심볼만
+ *   "// --- Trending (YYYY-MM-DD) ---" 섹션으로 배열 끝에 append하며,
+ *   기존 심볼은 삭제하지 않습니다. 같은 날짜에 재실행하면 중복 방지를 위해 스킵합니다.
+ *   파일이 없으면(최초 부트스트랩) 상위 N개로 새로 생성합니다.
  */
 
 import { execSync } from 'child_process';
 import { config } from 'dotenv';
 import {
+    existsSync,
     mkdirSync,
+    readFileSync,
     renameSync,
     rmSync,
     writeFileSync,
@@ -127,19 +133,28 @@ const POPULAR_CRYPTOS_PATH = resolve(
 );
 
 /**
- * popular-cryptos.ts에 기록되는 헤더 주석.
+ * popular-cryptos.ts를 최초 부트스트랩(파일 부재)할 때만 사용하는 헤더 주석.
  *
- * 이 스크립트를 실행할 때마다 파일 전체를 이 헤더 + 새 배열로 교체하므로,
- * 라이브 파일 헤더의 WHY(아래 제약 두 가지)를 반드시 보존해야 한다:
+ * 파일이 이미 존재하면 스크립트는 배열에만 심볼을 누적 append하고 헤더는 건드리지 않는다.
+ * 따라서 라이브 파일 헤더의 WHY(아래 제약 두 가지)는 그대로 보존된다:
  *   1. FMP 심볼은 *USD 접미사(BTCUSD) 형태를 사용한다.
  *   2. batch-crypto-quotes 엔드포인트는 HTTP 402(플랜 미지원)이므로
  *      단건 quote 엔드포인트를 심볼별로 순차 호출하는 방식으로 시가총액을 수집한다.
  */
 export const FILE_HEADER = `// 큐레이션된 인기 암호화폐 — 홈 디스커버리 + sitemap popular 엔트리.
 // FMP 심볼은 *USD 접미사(BTCUSD)를 쓴다. batch-crypto-quotes가 HTTP 402(플랜 미지원)이라
-// 단건 quote를 심볼별로 호출하여 시가총액 기준 상위 N개를 자동 선정한다(update-popular-cryptos.ts).
-// 주의: 이 파일은 스크립트가 자동 생성하므로 수동 변경은 다음 실행 때 덮어씌워진다.
-// 심볼을 추가/변경하려면 scripts/update-popular-cryptos.ts의 CRYPTO_CANDIDATE_POOL을 수정하라.`;
+// 단건 quote를 심볼별로 호출하여 시가총액 상위 N개를 선정한다(update-popular-cryptos.ts).
+// 갱신은 누적 방식이다: 매 실행마다 시총 상위 N개 중 기존 목록에 없는 심볼만
+// "// --- Trending (YYYY-MM-DD) ---" 섹션으로 배열 끝에 추가하며, 기존 심볼은 삭제하지 않는다.
+// 심볼 후보를 늘리려면 scripts/update-popular-cryptos.ts의 CRYPTO_CANDIDATE_POOL을 수정하라.`;
+
+// popular-cryptos.ts 배열 경계 마커 — 기존 파일에서 심볼을 추출·중복제거·append할 때 기준점.
+const POPULAR_CRYPTOS_DECLARATION = 'export const POPULAR_CRYPTOS = [';
+const POPULAR_CRYPTOS_END = '] as const;';
+// crypto 심볼 리터럴 한 줄 매칭: 들여쓰기 + 'BTCUSD', + 선택적 후행 주석.
+// Trending 섹션 헤더(// --- ... ---) 같은 비-심볼 줄은 매칭되지 않는다.
+const CRYPTO_LITERAL_LINE_PATTERN =
+    /^(\s*)['"]([A-Z][A-Z0-9.-]*)['"],?(\s*(?:\/\/.*)?)?$/;
 
 interface FmpCryptoListEntry {
     symbol: string;
@@ -162,6 +177,11 @@ export interface CryptoRankEntry {
 export interface CandidateFilterResult {
     valid: string[];
     dropped: string[];
+}
+
+export interface DeduplicateCryptoEntriesResult {
+    content: string;
+    removedSymbols: readonly string[];
 }
 
 function sleep(ms: number): Promise<void> {
@@ -266,6 +286,96 @@ ${body}] as const;
 `;
 }
 
+/**
+ * 기존 popular-cryptos.ts 내용에서 POPULAR_CRYPTOS 배열에 이미 존재하는 심볼 집합을 추출한다.
+ * 선언 마커를 찾지 못하면 빈 집합을 반환한다(신규 심볼 전부를 추가 대상으로 간주).
+ */
+export function extractExistingCryptos(fileContent: string): Set<string> {
+    const arrayStart = fileContent.indexOf(POPULAR_CRYPTOS_DECLARATION);
+    if (arrayStart === -1) return new Set();
+
+    const popularSection = fileContent.slice(arrayStart);
+    const matches = popularSection.match(/['"]([A-Z][A-Z0-9.-]*)['"]/g);
+    return new Set(matches ? matches.map(m => m.slice(1, -1)) : []);
+}
+
+/**
+ * POPULAR_CRYPTOS 배열 내부의 중복 심볼 줄을 첫 등장만 남기고 제거한다.
+ * 배열 경계 밖의 내용(헤더 주석 등)과 Trending 섹션 헤더 줄은 보존한다.
+ */
+export function deduplicateCryptoEntries(
+    fileContent: string
+): DeduplicateCryptoEntriesResult {
+    const arrayStart = fileContent.indexOf(POPULAR_CRYPTOS_DECLARATION);
+    const arrayEnd = fileContent.indexOf(POPULAR_CRYPTOS_END, arrayStart);
+
+    if (arrayStart === -1 || arrayEnd === -1) {
+        return { content: fileContent, removedSymbols: [] };
+    }
+
+    const sectionStart = arrayStart + POPULAR_CRYPTOS_DECLARATION.length;
+    const beforeSection = fileContent.slice(0, sectionStart);
+    const section = fileContent.slice(sectionStart, arrayEnd);
+    const afterSection = fileContent.slice(arrayEnd);
+    const seenSymbols = new Set<string>();
+    const removedSymbols: string[] = [];
+
+    const deduplicatedSection = section
+        .split('\n')
+        .filter(line => {
+            const symbolMatch = line.match(CRYPTO_LITERAL_LINE_PATTERN);
+            if (!symbolMatch) return true;
+
+            const symbol = symbolMatch[2]!;
+            if (!seenSymbols.has(symbol)) {
+                seenSymbols.add(symbol);
+                return true;
+            }
+
+            removedSymbols.push(symbol);
+            return false;
+        })
+        .join('\n');
+
+    return {
+        content: `${beforeSection}${deduplicatedSection}${afterSection}`,
+        removedSymbols,
+    };
+}
+
+/**
+ * 신규 심볼을 "// --- Trending (YYYY-MM-DD) ---" 섹션으로 배열 끝(] as const;) 앞에 삽입한다.
+ * 같은 날짜 섹션이 이미 있으면 중복 방지를 위해 원본을 그대로 반환한다.
+ */
+export function insertCryptoTrendingSection(
+    fileContent: string,
+    newSymbols: readonly string[]
+): string {
+    const date = new Date().toISOString().slice(0, 10);
+    const sectionHeader = `// --- Trending (${date}) ---`;
+
+    if (fileContent.includes(sectionHeader)) {
+        console.warn(
+            `Trending section for ${date} already exists. Skipping to avoid duplicates.`
+        );
+        return fileContent;
+    }
+
+    const symbolLines = newSymbols.map(s => `    '${s}',`).join('\n');
+    const section = `\n    ${sectionHeader}\n${symbolLines}\n`;
+
+    const insertionPoint = fileContent.lastIndexOf(POPULAR_CRYPTOS_END);
+    if (insertionPoint === -1) {
+        throw new Error('Could not find "] as const;" in popular-cryptos.ts');
+    }
+
+    return (
+        fileContent.slice(0, insertionPoint) +
+        section +
+        fileContent.slice(insertionPoint)
+    );
+}
+
 function writeAndFormatFileAtomically(
     path: string,
     fileContent: string
@@ -355,26 +465,30 @@ async function main(): Promise<void> {
 
     console.log(`\nFetching quotes for ${valid.length} candidates...`);
 
-    const ranked: CryptoRankEntry[] = [];
+    // Sequential rate-limited fetch accumulated immutably (mirrors update-popular-tickers.ts).
+    const ranked = await valid.reduce(
+        async (accPromise, symbol, i) => {
+            const acc = await accPromise;
+            process.stdout.write(
+                `  [${i + 1}/${valid.length}] ${symbol.padEnd(10)}`
+            );
 
-    for (const [i, symbol] of valid.entries()) {
-        process.stdout.write(
-            `  [${i + 1}/${valid.length}] ${symbol.padEnd(10)}`
-        );
+            const quote = await fetchSingleQuote(apiKey, symbol);
 
-        const quote = await fetchSingleQuote(apiKey, symbol);
+            if (i < valid.length - 1) {
+                await sleep(REQUEST_DELAY_MS);
+            }
 
-        if (quote === null || !quote.marketCap || quote.marketCap <= 0) {
-            console.log('→ skipped (no marketCap)');
-        } else {
+            if (quote === null || !quote.marketCap || quote.marketCap <= 0) {
+                console.log('→ skipped (no marketCap)');
+                return acc;
+            }
+
             console.log(`→ ${formatMarketCap(quote.marketCap)}`);
-            ranked.push({ symbol, marketCap: quote.marketCap });
-        }
-
-        if (i < valid.length - 1) {
-            await sleep(REQUEST_DELAY_MS);
-        }
-    }
+            return [...acc, { symbol, marketCap: quote.marketCap }];
+        },
+        Promise.resolve([] as CryptoRankEntry[])
+    );
 
     const topCryptos = rankByMarketCap(ranked, MAX_POPULAR_CRYPTOS);
 
@@ -387,13 +501,80 @@ async function main(): Promise<void> {
     printResults(topCryptos);
 
     const topSymbols = topCryptos.map(e => e.symbol);
-    const fileContent = renderPopularCryptosFile(topSymbols);
-    commitFileAtomically(POPULAR_CRYPTOS_PATH, fileContent);
 
-    console.log(
-        `\nDone! POPULAR_CRYPTOS updated to top ${topCryptos.length} by market cap.`
+    // 파일이 없으면(최초 부트스트랩) 상위 심볼로 새로 생성한다.
+    if (!existsSync(POPULAR_CRYPTOS_PATH)) {
+        commitFileAtomically(
+            POPULAR_CRYPTOS_PATH,
+            renderPopularCryptosFile(topSymbols)
+        );
+        console.log(
+            `\nDone! Bootstrapped POPULAR_CRYPTOS with ${topSymbols.length} symbols: ${topSymbols.join(', ')}`
+        );
+        return;
+    }
+
+    // 누적 갱신: 기존 파일을 읽어 중복을 정리한 뒤,
+    // 상위 심볼 중 아직 목록에 없는 것만 날짜 Trending 섹션으로 추가한다.
+    const originalFileContent = readFileSync(POPULAR_CRYPTOS_PATH, 'utf-8');
+    const initialDeduplication = deduplicateCryptoEntries(originalFileContent);
+    const existingCryptos = extractExistingCryptos(
+        initialDeduplication.content
     );
-    console.log(`Symbols: ${topSymbols.join(', ')}`);
+    console.log(`\nExisting cryptos: ${existingCryptos.size}`);
+
+    if (initialDeduplication.removedSymbols.length > 0) {
+        console.log(
+            `Duplicate symbols removed before update: ${initialDeduplication.removedSymbols.join(', ')}`
+        );
+    }
+
+    const newSymbols = topSymbols.filter(s => !existingCryptos.has(s));
+    console.log(
+        `New symbols (in top ${MAX_POPULAR_CRYPTOS}, not already listed): ${newSymbols.length}`
+    );
+
+    if (newSymbols.length === 0) {
+        // 신규 없음 — 중복 정리분만 반영하고 종료한다.
+        if (initialDeduplication.content !== originalFileContent) {
+            commitFileAtomically(
+                POPULAR_CRYPTOS_PATH,
+                initialDeduplication.content
+            );
+            console.log('\nDone! No new cryptos — duplicates cleaned up.');
+        } else {
+            console.log('\nDone! No new cryptos — file already up to date.');
+        }
+        return;
+    }
+
+    const contentWithTrendingSection = insertCryptoTrendingSection(
+        initialDeduplication.content,
+        newSymbols
+    );
+    const addedSymbols =
+        contentWithTrendingSection === initialDeduplication.content
+            ? []
+            : newSymbols;
+    const finalDeduplication = deduplicateCryptoEntries(
+        contentWithTrendingSection
+    );
+
+    if (finalDeduplication.removedSymbols.length > 0) {
+        console.log(
+            `Duplicate symbols removed after update: ${finalDeduplication.removedSymbols.join(', ')}`
+        );
+    }
+
+    commitFileAtomically(POPULAR_CRYPTOS_PATH, finalDeduplication.content);
+
+    if (addedSymbols.length > 0) {
+        console.log(
+            `\nDone! Added ${addedSymbols.length} cryptos: ${addedSymbols.join(', ')}`
+        );
+    } else {
+        console.log('\nDone! Crypto list updated after cleanup.');
+    }
 }
 
 if (require.main === module) {

--- a/scripts/update-popular-cryptos.ts
+++ b/scripts/update-popular-cryptos.ts
@@ -41,7 +41,9 @@ import { dirname, resolve } from 'path';
 const FMP_BASE_URL = 'https://financialmodelingprep.com/stable';
 
 /**
- * 최대 인기 암호화폐 수. 현재 popular-cryptos.ts의 큐레이션 목록과 동일.
+ * 실행 1회당 시가총액 기준 상위 선정 개수(누적 모델의 top-N 크기).
+ * popular-cryptos.ts의 실제 심볼 수는 매 실행마다 신규 심볼만 append되어 계속 늘어나므로
+ * 이 값과 같지 않고, 항상 이 값 이상이다(하한).
  * 변경 시 함께 검토: src/shared/config/popular-cryptos.ts
  */
 export const MAX_POPULAR_CRYPTOS = 15;
@@ -273,11 +275,19 @@ export function rankByMarketCap(
 }
 
 /**
+ * 심볼 하나를 POPULAR_CRYPTOS 배열 리터럴 줄 포맷으로 렌더링한다.
+ * renderPopularCryptosFile과 insertCryptoTrendingSection이 공유해 포맷 drift를 방지한다.
+ */
+function formatCryptoSymbolLine(symbol: string): string {
+    return `    '${symbol}',`;
+}
+
+/**
  * popular-cryptos.ts 파일 내용을 렌더링한다.
  * 헤더 주석은 보존하고 POPULAR_CRYPTOS 배열만 교체한다.
  */
 export function renderPopularCryptosFile(symbols: readonly string[]): string {
-    const lines = symbols.map(s => `    '${s}',`).join('\n');
+    const lines = symbols.map(formatCryptoSymbolLine).join('\n');
     const body = lines.length > 0 ? `${lines}\n` : '';
 
     return `${FILE_HEADER}
@@ -288,13 +298,18 @@ ${body}] as const;
 
 /**
  * 기존 popular-cryptos.ts 내용에서 POPULAR_CRYPTOS 배열에 이미 존재하는 심볼 집합을 추출한다.
- * 선언 마커를 찾지 못하면 빈 집합을 반환한다(신규 심볼 전부를 추가 대상으로 간주).
+ * deduplicateCryptoEntries와 동일하게 POPULAR_CRYPTOS_END를 배열 끝 경계로 사용해,
+ * 배열 뒤에 다른 export/주석이 추가되어도 관련 없는 따옴표 문자열을 심볼로 오인하지 않는다.
+ * 선언 마커나 종료 마커를 찾지 못하면 빈 집합을 반환한다(신규 심볼 전부를 추가 대상으로 간주).
  */
 export function extractExistingCryptos(fileContent: string): Set<string> {
     const arrayStart = fileContent.indexOf(POPULAR_CRYPTOS_DECLARATION);
     if (arrayStart === -1) return new Set();
 
-    const popularSection = fileContent.slice(arrayStart);
+    const arrayEnd = fileContent.indexOf(POPULAR_CRYPTOS_END, arrayStart);
+    if (arrayEnd === -1) return new Set();
+
+    const popularSection = fileContent.slice(arrayStart, arrayEnd);
     const matches = popularSection.match(/['"]([A-Z][A-Z0-9.-]*)['"]/g);
     return new Set(matches ? matches.map(m => m.slice(1, -1)) : []);
 }
@@ -317,29 +332,42 @@ export function deduplicateCryptoEntries(
     const beforeSection = fileContent.slice(0, sectionStart);
     const section = fileContent.slice(sectionStart, arrayEnd);
     const afterSection = fileContent.slice(arrayEnd);
-    const seenSymbols = new Set<string>();
-    const removedSymbols: string[] = [];
 
-    const deduplicatedSection = section
-        .split('\n')
-        .filter(line => {
+    interface DedupAcc {
+        keptLines: readonly string[];
+        removed: readonly string[];
+        seen: ReadonlySet<string>;
+    }
+    const initialAcc: DedupAcc = { keptLines: [], removed: [], seen: new Set() };
+
+    // CRLF-safe split — defensive, since this repo is LF-normalized by prettier
+    // but the file may originate from a non-normalized source (e.g. Windows checkout).
+    const { keptLines, removed } = section.split(/\r?\n/).reduce(
+        (acc, line): DedupAcc => {
             const symbolMatch = line.match(CRYPTO_LITERAL_LINE_PATTERN);
-            if (!symbolMatch) return true;
-
-            const symbol = symbolMatch[2]!;
-            if (!seenSymbols.has(symbol)) {
-                seenSymbols.add(symbol);
-                return true;
+            if (!symbolMatch) {
+                return { ...acc, keptLines: [...acc.keptLines, line] };
             }
 
-            removedSymbols.push(symbol);
-            return false;
-        })
-        .join('\n');
+            const symbol = symbolMatch[2]!;
+            if (acc.seen.has(symbol)) {
+                return { ...acc, removed: [...acc.removed, symbol] };
+            }
+
+            return {
+                keptLines: [...acc.keptLines, line],
+                removed: acc.removed,
+                seen: new Set(acc.seen).add(symbol),
+            };
+        },
+        initialAcc
+    );
+
+    const deduplicatedSection = keptLines.join('\n');
 
     return {
         content: `${beforeSection}${deduplicatedSection}${afterSection}`,
-        removedSymbols,
+        removedSymbols: removed,
     };
 }
 
@@ -361,10 +389,14 @@ export function insertCryptoTrendingSection(
         return fileContent;
     }
 
-    const symbolLines = newSymbols.map(s => `    '${s}',`).join('\n');
+    const symbolLines = newSymbols.map(formatCryptoSymbolLine).join('\n');
     const section = `\n    ${sectionHeader}\n${symbolLines}\n`;
 
-    const insertionPoint = fileContent.lastIndexOf(POPULAR_CRYPTOS_END);
+    // Same boundary strategy as deduplicateCryptoEntries/extractExistingCryptos:
+    // find the declaration first, then search for the end marker from there on,
+    // instead of lastIndexOf (which could match an unrelated "] as const;" elsewhere in the file).
+    const arrayStart = fileContent.indexOf(POPULAR_CRYPTOS_DECLARATION);
+    const insertionPoint = fileContent.indexOf(POPULAR_CRYPTOS_END, arrayStart);
     if (insertionPoint === -1) {
         throw new Error('Could not find "] as const;" in popular-cryptos.ts');
     }
@@ -487,7 +519,7 @@ async function main(): Promise<void> {
             console.log(`→ ${formatMarketCap(quote.marketCap)}`);
             return [...acc, { symbol, marketCap: quote.marketCap }];
         },
-        Promise.resolve([] as CryptoRankEntry[])
+        Promise.resolve([] as CryptoRankEntry[]) // empty array literal satisfies any element type — safe seed for the accumulator
     );
 
     const topCryptos = rankByMarketCap(ranked, MAX_POPULAR_CRYPTOS);
@@ -502,7 +534,6 @@ async function main(): Promise<void> {
 
     const topSymbols = topCryptos.map(e => e.symbol);
 
-    // 파일이 없으면(최초 부트스트랩) 상위 심볼로 새로 생성한다.
     if (!existsSync(POPULAR_CRYPTOS_PATH)) {
         commitFileAtomically(
             POPULAR_CRYPTOS_PATH,
@@ -535,7 +566,6 @@ async function main(): Promise<void> {
     );
 
     if (newSymbols.length === 0) {
-        // 신규 없음 — 중복 정리분만 반영하고 종료한다.
         if (initialDeduplication.content !== originalFileContent) {
             commitFileAtomically(
                 POPULAR_CRYPTOS_PATH,

--- a/scripts/update-popular-cryptos.ts
+++ b/scripts/update-popular-cryptos.ts
@@ -146,8 +146,10 @@ const POPULAR_CRYPTOS_PATH = resolve(
 export const FILE_HEADER = `// 큐레이션된 인기 암호화폐 — 홈 디스커버리 + sitemap popular 엔트리.
 // FMP 심볼은 *USD 접미사(BTCUSD)를 쓴다. batch-crypto-quotes가 HTTP 402(플랜 미지원)이라
 // 단건 quote를 심볼별로 호출하여 시가총액 상위 N개를 선정한다(update-popular-cryptos.ts).
-// 갱신은 누적 방식이다: 매 실행마다 시총 상위 N개 중 기존 목록에 없는 심볼만
-// "// --- Trending (YYYY-MM-DD) ---" 섹션으로 배열 끝에 추가하며, 기존 심볼은 삭제하지 않는다.
+// 목록 대부분은 스크립트의 누적 갱신 결과다: 매 실행마다 시총 상위 N개 중 기존 목록에
+// 없는 심볼만 "// --- Trending (YYYY-MM-DD) ---" 섹션으로 배열 끝에 추가하며, 기존 심볼은
+// 삭제하지 않는다. 다만 "Restored from history"·"Curated high-interest" 섹션은 스크립트
+// 실행 결과가 아니라 수동으로 복원·추가한 것이므로, 자동 갱신 로직을 건드릴 때 삭제하지 않도록 주의한다.
 // 심볼 후보를 늘리려면 scripts/update-popular-cryptos.ts의 CRYPTO_CANDIDATE_POOL을 수정하라.`;
 
 // popular-cryptos.ts 배열 경계 마커 — 기존 파일에서 심볼을 추출·중복제거·append할 때 기준점.
@@ -184,6 +186,12 @@ export interface CandidateFilterResult {
 export interface DeduplicateCryptoEntriesResult {
     content: string;
     removedSymbols: readonly string[];
+}
+
+interface DedupAcc {
+    keptLines: readonly string[];
+    removed: readonly string[];
+    seen: ReadonlySet<string>;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -333,11 +341,6 @@ export function deduplicateCryptoEntries(
     const section = fileContent.slice(sectionStart, arrayEnd);
     const afterSection = fileContent.slice(arrayEnd);
 
-    interface DedupAcc {
-        keptLines: readonly string[];
-        removed: readonly string[];
-        seen: ReadonlySet<string>;
-    }
     const initialAcc: DedupAcc = { keptLines: [], removed: [], seen: new Set() };
 
     // CRLF-safe split — defensive, since this repo is LF-normalized by prettier

--- a/src/shared/config/popular-cryptos.ts
+++ b/src/shared/config/popular-cryptos.ts
@@ -1,8 +1,9 @@
 // 큐레이션된 인기 암호화폐 — 홈 디스커버리 + sitemap popular 엔트리.
 // FMP 심볼은 *USD 접미사(BTCUSD)를 쓴다. batch-crypto-quotes가 HTTP 402(플랜 미지원)이라
-// 단건 quote를 심볼별로 호출하여 시가총액 기준 상위 N개를 자동 선정한다(update-popular-cryptos.ts).
-// 주의: 이 파일은 스크립트가 자동 생성하므로 수동 변경은 다음 실행 때 덮어씌워진다.
-// 심볼을 추가/변경하려면 scripts/update-popular-cryptos.ts의 CRYPTO_CANDIDATE_POOL을 수정하라.
+// 단건 quote를 심볼별로 호출하여 시가총액 상위 N개를 선정한다(update-popular-cryptos.ts).
+// 갱신은 누적 방식이다: 매 실행마다 시총 상위 N개 중 기존 목록에 없는 심볼만
+// "// --- Trending (YYYY-MM-DD) ---" 섹션으로 배열 끝에 추가하며, 기존 심볼은 삭제하지 않는다.
+// 심볼 후보를 늘리려면 scripts/update-popular-cryptos.ts의 CRYPTO_CANDIDATE_POOL을 수정하라.
 export const POPULAR_CRYPTOS = [
     'BTCUSD',
     'ETHUSD',

--- a/src/shared/config/popular-cryptos.ts
+++ b/src/shared/config/popular-cryptos.ts
@@ -20,4 +20,27 @@ export const POPULAR_CRYPTOS = [
     'LTCUSD',
     'AVAXUSD',
     'SUIUSD',
+
+    // --- Restored from history (2026-07-06) ---
+    // 과거 전체-교체 방식에서 시총 순위 밖으로 밀려 사라졌던 심볼을 git 히스토리에서 복원.
+    // (폐지/리브랜딩된 MATICUSD는 후계 POLUSD로 대체되므로 제외.)
+    'DOTUSD',
+    'POLUSD',
+    'SHIBUSD',
+
+    // --- Curated high-interest (2026-07-06) ---
+    // 시총 상위 밖이지만 대중 관심도·거래 활성도가 높은 대표 코인 (CRYPTO_CANDIDATE_POOL 내 유효 심볼).
+    // DeFi 대표(UNI/AAVE), L2 양대(ARB/OP), 관심도 높은 L1(NEAR/APT/ATOM/TIA/INJ),
+    // 스토리지 대표(FIL), 밈 대표(PEPE).
+    'UNIUSD',
+    'AAVEUSD',
+    'ARBUSD',
+    'OPUSD',
+    'NEARUSD',
+    'APTUSD',
+    'ATOMUSD',
+    'TIAUSD',
+    'INJUSD',
+    'FILUSD',
+    'PEPEUSD',
 ] as const;

--- a/src/shared/config/popular-cryptos.ts
+++ b/src/shared/config/popular-cryptos.ts
@@ -1,8 +1,10 @@
 // 큐레이션된 인기 암호화폐 — 홈 디스커버리 + sitemap popular 엔트리.
 // FMP 심볼은 *USD 접미사(BTCUSD)를 쓴다. batch-crypto-quotes가 HTTP 402(플랜 미지원)이라
 // 단건 quote를 심볼별로 호출하여 시가총액 상위 N개를 선정한다(update-popular-cryptos.ts).
-// 갱신은 누적 방식이다: 매 실행마다 시총 상위 N개 중 기존 목록에 없는 심볼만
-// "// --- Trending (YYYY-MM-DD) ---" 섹션으로 배열 끝에 추가하며, 기존 심볼은 삭제하지 않는다.
+// 목록 대부분은 스크립트의 누적 갱신 결과다: 매 실행마다 시총 상위 N개 중 기존 목록에
+// 없는 심볼만 "// --- Trending (YYYY-MM-DD) ---" 섹션으로 배열 끝에 추가하며, 기존 심볼은
+// 삭제하지 않는다. 다만 "Restored from history"·"Curated high-interest" 섹션은 스크립트
+// 실행 결과가 아니라 수동으로 복원·추가한 것이므로, 자동 갱신 로직을 건드릴 때 삭제하지 않도록 주의한다.
 // 심볼 후보를 늘리려면 scripts/update-popular-cryptos.ts의 CRYPTO_CANDIDATE_POOL을 수정하라.
 export const POPULAR_CRYPTOS = [
     'BTCUSD',


### PR DESCRIPTION
## 관련 이슈

없음

## 구현 내용

cryptos popular-list 업데이트 전략을 전체 덮어쓰기에서 누적/추가 방식으로 변경했습니다.
update-popular-tickers.ts와 동일하게 각 실행마다 시장주도도 기준 상위-N 선택, 미등재 심볼만 날짜 섹션(`// --- Trending (YYYY-MM-DD) ---`)에 추가, 기존 심볼은 절대 삭제하지 않습니다.

**추가 함수:**
- `extractExistingCryptos`: 파일의 기존 암호화폐 심볼 추출
- `deduplicateCryptoEntries`: 중복 제거
- `insertCryptoTrendingSection`: 날짜 섹션에 새 항목 삽입

**수정 사항:**
- `main()` 전체 재작성
- 헤더 주석 업데이트 (누적 전략 설명)

## 레이어 및 코드 품질 체크

- [x] @docs/conventions/CONVENTIONS.md 준수 확인
- [x] @docs/conventions/FF.md 준수 확인
- [x] @docs/workflows/MISTAKES.md 준수 확인
- [x] domain/: 외부 라이브러리 import 없음, 순수 함수만
- [x] 반환 타입 명시
- [x] for/while 없이 map/filter/reduce 사용
- [x] any 타입 없음
- [x] 새 파일에 대응하는 테스트 파일 포함
- [x] 테스트 구조: describe → describe(context) → it

## 변경 파일 목록

[수정]
- scripts/update-popular-cryptos.ts
- scripts/__tests__/update-popular-cryptos.test.ts
- src/shared/config/popular-cryptos.ts
- docs/__agents_only__/fix-log.md

## CI Check lists

- [x] yarn format
- [x] yarn lint
- [x] yarn lint:style
- [x] yarn test
- [x] yarn build