### PR TITLE
feat: add DeepSeek V4 provider and make it the default model

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -21,6 +21,10 @@ UPSTASH_REDIS_REST_READONLY_TOKEN=e2e-token
 # call a real LLM, it only needs to be truthy. Required for the symbol-chat E2E
 # spec to exercise the full client→chatAction→fake-provider round-trip.
 GEMINI_CHAT_API_KEY=e2e-fake-chat-key
+# Same dummy-key rationale as GEMINI_CHAT_API_KEY above, but for the default
+# chat/analysis model (DEEPSEEK_V4_FLASH_MODEL) — chatAction's provider
+# lookup now resolves to 'deepseek' by default, so this must be truthy too.
+DEEPSEEK_CHAT_API_KEY=e2e-fake-chat-key
 # OAuth state-cookie HMAC secret. getStateSecret() (auth-oauth/lib/state.ts)
 # THROWS if unset and requires >= 32 chars; 64 hex chars satisfies it. Dummy,
 # local-only — the fake OAuth adapter doesn't verify against any real provider.

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ GEMINI_CHAT_API_KEY=
 ANTHROPIC_CHAT_API_KEY=
 # https://platform.openai.com/api-keys
 OPENAI_CHAT_API_KEY=
+# https://platform.deepseek.com/api_keys
+DEEPSEEK_CHAT_API_KEY=
 
 # ── Ticker Translation ─────────────────────────────────────────────────────
 # Gemini key for company-name/description translation

--- a/drizzle/0024_add_deepseek_llm_provider.sql
+++ b/drizzle/0024_add_deepseek_llm_provider.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."llm_provider" ADD VALUE 'deepseek';

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,1823 @@
+{
+    "id": "3fb1943e-029f-4078-aa48-7ab6c17a65db",
+    "prevId": "5a662f3b-1a92-44cb-b3cf-8913c9e80e91",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.agreements": {
+            "name": "agreements",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "terms_id": {
+                    "name": "terms_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "agreed": {
+                    "name": "agreed",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "agreed_at": {
+                    "name": "agreed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "agreements_user_terms_uidx": {
+                    "name": "agreements_user_terms_uidx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "terms_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "agreements_user_id_idx": {
+                    "name": "agreements_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "agreements_terms_id_idx": {
+                    "name": "agreements_terms_id_idx",
+                    "columns": [
+                        {
+                            "expression": "terms_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "agreements_user_id_users_id_fk": {
+                    "name": "agreements_user_id_users_id_fk",
+                    "tableFrom": "agreements",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "agreements_terms_id_terms_id_fk": {
+                    "name": "agreements_terms_id_terms_id_fk",
+                    "tableFrom": "agreements",
+                    "tableTo": "terms",
+                    "columnsFrom": ["terms_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "restrict",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.asset_translations": {
+            "name": "asset_translations",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "fmp_symbol": {
+                    "name": "fmp_symbol",
+                    "type": "varchar(64)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.crypto_assets": {
+            "name": "crypto_assets",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "circulating_supply": {
+                    "name": "circulating_supply",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.earnings_reports": {
+            "name": "earnings_reports",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "earnings_date": {
+                    "name": "earnings_date",
+                    "type": "date",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "eps_actual": {
+                    "name": "eps_actual",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "eps_estimated": {
+                    "name": "eps_estimated",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "revenue_actual": {
+                    "name": "revenue_actual",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "revenue_estimated": {
+                    "name": "revenue_estimated",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "last_updated": {
+                    "name": "last_updated",
+                    "type": "date",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "raw_payload": {
+                    "name": "raw_payload",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {
+                "earnings_reports_symbol_earnings_date_pk": {
+                    "name": "earnings_reports_symbol_earnings_date_pk",
+                    "columns": ["symbol", "earnings_date"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.economic_calendar": {
+            "name": "economic_calendar",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "country": {
+                    "name": "country",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "date_et": {
+                    "name": "date_et",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "event": {
+                    "name": "event",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "impact": {
+                    "name": "impact",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "estimate": {
+                    "name": "estimate",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "previous": {
+                    "name": "previous",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "actual": {
+                    "name": "actual",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "unit": {
+                    "name": "unit",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "sentiment": {
+                    "name": "sentiment",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "summary_ko": {
+                    "name": "summary_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "interpretation_ko": {
+                    "name": "interpretation_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "analyzed_at": {
+                    "name": "analyzed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "economic_calendar_date_et_idx": {
+                    "name": "economic_calendar_date_et_idx",
+                    "columns": [
+                        {
+                            "expression": "date_et",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "economic_calendar_country_date_et_idx": {
+                    "name": "economic_calendar_country_date_et_idx",
+                    "columns": [
+                        {
+                            "expression": "country",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "date_et",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "economic_calendar_impact_idx": {
+                    "name": "economic_calendar_impact_idx",
+                    "columns": [
+                        {
+                            "expression": "impact",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "economic_calendar_impact_analyzed_at_idx": {
+                    "name": "economic_calendar_impact_analyzed_at_idx",
+                    "columns": [
+                        {
+                            "expression": "impact",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "analyzed_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.economic_indicator_translations": {
+            "name": "economic_indicator_translations",
+            "schema": "",
+            "columns": {
+                "normalized_name": {
+                    "name": "normalized_name",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "source": {
+                    "name": "source",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.inquiries": {
+            "name": "inquiries",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "title": {
+                    "name": "title",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "content": {
+                    "name": "content",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "email": {
+                    "name": "email",
+                    "type": "varchar(320)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "answered": {
+                    "name": "answered",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.korean_tickers": {
+            "name": "korean_tickers",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "exchange": {
+                    "name": "exchange",
+                    "type": "varchar(32)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "exchange_full_name": {
+                    "name": "exchange_full_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.market_news": {
+            "name": "market_news",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "symbol": {
+                    "name": "symbol",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "source": {
+                    "name": "source",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "url": {
+                    "name": "url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "published_at": {
+                    "name": "published_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_ko": {
+                    "name": "title_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_en": {
+                    "name": "body_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_ko": {
+                    "name": "body_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "summary_ko": {
+                    "name": "summary_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "sentiment": {
+                    "name": "sentiment",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "category": {
+                    "name": "category",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "price_impact": {
+                    "name": "price_impact",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "tickers": {
+                    "name": "tickers",
+                    "type": "text[]",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "ARRAY[]::text[]"
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "analyzed_at": {
+                    "name": "analyzed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "market_news_symbol_published_at_idx": {
+                    "name": "market_news_symbol_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "symbol",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "market_news_published_at_idx": {
+                    "name": "market_news_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "market_news_url_unique": {
+                    "name": "market_news_url_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["url"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.news": {
+            "name": "news",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "symbol": {
+                    "name": "symbol",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "source": {
+                    "name": "source",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "url": {
+                    "name": "url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "published_at": {
+                    "name": "published_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_ko": {
+                    "name": "title_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_en": {
+                    "name": "body_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_ko": {
+                    "name": "body_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "summary_ko": {
+                    "name": "summary_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "sentiment": {
+                    "name": "sentiment",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "category": {
+                    "name": "category",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "price_impact": {
+                    "name": "price_impact",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "raw_payload": {
+                    "name": "raw_payload",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "analyzed_at": {
+                    "name": "analyzed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "news_symbol_published_at_idx": {
+                    "name": "news_symbol_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "symbol",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "news_published_at_idx": {
+                    "name": "news_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "news_url_unique": {
+                    "name": "news_url_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["url"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.notices": {
+            "name": "notices",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "title": {
+                    "name": "title",
+                    "type": "varchar(200)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "body": {
+                    "name": "body",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "link_url": {
+                    "name": "link_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "link_label": {
+                    "name": "link_label",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "path_pattern": {
+                    "name": "path_pattern",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "priority": {
+                    "name": "priority",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 0
+                },
+                "is_active": {
+                    "name": "is_active",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": true
+                },
+                "starts_at": {
+                    "name": "starts_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "ends_at": {
+                    "name": "ends_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "notices_active_window_idx": {
+                    "name": "notices_active_window_idx",
+                    "columns": [
+                        {
+                            "expression": "is_active",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "starts_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "ends_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.oauth_accounts": {
+            "name": "oauth_accounts",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider": {
+                    "name": "provider",
+                    "type": "oauth_provider",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider_account_id": {
+                    "name": "provider_account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "access_token": {
+                    "name": "access_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "refresh_token": {
+                    "name": "refresh_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "token_expires_at": {
+                    "name": "token_expires_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "oauth_accounts_user_id_idx": {
+                    "name": "oauth_accounts_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "oauth_accounts_provider_account_uidx": {
+                    "name": "oauth_accounts_provider_account_uidx",
+                    "columns": [
+                        {
+                            "expression": "provider",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "provider_account_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "oauth_accounts_user_id_users_id_fk": {
+                    "name": "oauth_accounts_user_id_users_id_fk",
+                    "tableFrom": "oauth_accounts",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.profile_description_translations": {
+            "name": "profile_description_translations",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "description_ko": {
+                    "name": "description_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.sessions": {
+            "name": "sessions",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "sessions_user_id_idx": {
+                    "name": "sessions_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "sessions_expires_at_idx": {
+                    "name": "sessions_expires_at_idx",
+                    "columns": [
+                        {
+                            "expression": "expires_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "sessions_user_id_users_id_fk": {
+                    "name": "sessions_user_id_users_id_fk",
+                    "tableFrom": "sessions",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.shared_analyses": {
+            "name": "shared_analyses",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "kind": {
+                    "name": "kind",
+                    "type": "shareable_kind",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "content_hash": {
+                    "name": "content_hash",
+                    "type": "varchar(64)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "snapshot_json": {
+                    "name": "snapshot_json",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "sharer_tier": {
+                    "name": "sharer_tier",
+                    "type": "user_tier",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'free'"
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "shared_analyses_user_id_idx": {
+                    "name": "shared_analyses_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "shared_analyses_symbol_idx": {
+                    "name": "shared_analyses_symbol_idx",
+                    "columns": [
+                        {
+                            "expression": "symbol",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "shared_analyses_expires_at_idx": {
+                    "name": "shared_analyses_expires_at_idx",
+                    "columns": [
+                        {
+                            "expression": "expires_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "shared_analyses_content_uq": {
+                    "name": "shared_analyses_content_uq",
+                    "columns": [
+                        {
+                            "expression": "content_hash",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "shared_analyses_user_id_users_id_fk": {
+                    "name": "shared_analyses_user_id_users_id_fk",
+                    "tableFrom": "shared_analyses",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.terms": {
+            "name": "terms",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "kind": {
+                    "name": "kind",
+                    "type": "terms_kind",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "version": {
+                    "name": "version",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "effective_date": {
+                    "name": "effective_date",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "body": {
+                    "name": "body",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "terms_kind_version_uidx": {
+                    "name": "terms_kind_version_uidx",
+                    "columns": [
+                        {
+                            "expression": "kind",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "version",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "terms_kind_effective_date_idx": {
+                    "name": "terms_kind_effective_date_idx",
+                    "columns": [
+                        {
+                            "expression": "kind",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "effective_date",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.usage_logs": {
+            "name": "usage_logs",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "ip_hash": {
+                    "name": "ip_hash",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "action_type": {
+                    "name": "action_type",
+                    "type": "usage_action_type",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "model_used": {
+                    "name": "model_used",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "date": {
+                    "name": "date",
+                    "type": "date",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "usage_logs_user_id_idx": {
+                    "name": "usage_logs_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "usage_logs_ip_hash_date_idx": {
+                    "name": "usage_logs_ip_hash_date_idx",
+                    "columns": [
+                        {
+                            "expression": "ip_hash",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "date",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "usage_logs_user_id_users_id_fk": {
+                    "name": "usage_logs_user_id_users_id_fk",
+                    "tableFrom": "usage_logs",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.user_api_keys": {
+            "name": "user_api_keys",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider": {
+                    "name": "provider",
+                    "type": "llm_provider",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "encrypted_api_key": {
+                    "name": "encrypted_api_key",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "user_api_keys_user_id_idx": {
+                    "name": "user_api_keys_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "user_api_keys_user_provider_uidx": {
+                    "name": "user_api_keys_user_provider_uidx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "provider",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "user_api_keys_user_id_users_id_fk": {
+                    "name": "user_api_keys_user_id_users_id_fk",
+                    "tableFrom": "user_api_keys",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.users": {
+            "name": "users",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "email": {
+                    "name": "email",
+                    "type": "varchar(320)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "password_hash": {
+                    "name": "password_hash",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "avatar_url": {
+                    "name": "avatar_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "tier": {
+                    "name": "tier",
+                    "type": "user_tier",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'free'"
+                },
+                "email_verified": {
+                    "name": "email_verified",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "users_email_unique": {
+                    "name": "users_email_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["email"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {
+        "public.llm_provider": {
+            "name": "llm_provider",
+            "schema": "public",
+            "values": ["anthropic", "google", "openai", "deepseek"]
+        },
+        "public.oauth_provider": {
+            "name": "oauth_provider",
+            "schema": "public",
+            "values": ["google", "kakao", "apple"]
+        },
+        "public.shareable_kind": {
+            "name": "shareable_kind",
+            "schema": "public",
+            "values": [
+                "chart",
+                "overall",
+                "news",
+                "fundamental",
+                "financials",
+                "congress",
+                "options",
+                "fear-greed"
+            ]
+        },
+        "public.terms_kind": {
+            "name": "terms_kind",
+            "schema": "public",
+            "values": ["privacy", "tos"]
+        },
+        "public.usage_action_type": {
+            "name": "usage_action_type",
+            "schema": "public",
+            "values": ["analysis", "chatbot", "premium_model"]
+        },
+        "public.user_tier": {
+            "name": "user_tier",
+            "schema": "public",
+            "values": ["free", "member", "pro"]
+        }
+    },
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
             "when": 1782873939354,
             "tag": "0023_panoramic_mister_fear",
             "breakpoints": true
+        },
+        {
+            "idx": 24,
+            "version": "7",
+            "when": 1783691004085,
+            "tag": "0024_add_deepseek_llm_provider",
+            "breakpoints": true
         }
     ]
 }

--- a/e2e/specs/model-gate.spec.ts
+++ b/e2e/specs/model-gate.spec.ts
@@ -32,8 +32,8 @@ import { test, expect } from '../support/fixtures';
  *                claude-haiku-4-5, gpt-5-mini
  *       premium: gemini-2.5-pro, claude-sonnet-4-6, claude-opus-4-7,
  *                gemini-3.1-pro-preview, gemini-3-flash-preview, gpt-5.4, gpt-5.5
- *     The default/selected model is gemini-2.5-flash-lite → trigger shows
- *     "Flash Lite". We exercise the premium branch with "Claude Sonnet 4.6"
+ *     The default/selected model is deepseek-v4-flash → trigger shows
+ *     "DeepSeek Flash". We exercise the premium branch with "Claude Sonnet 4.6"
  *     (label "Sonnet", non-free ⇒ guest auth gate).
  *
  *   - The gate modal is a `role="dialog"` (aria-labelledby the
@@ -54,7 +54,7 @@ import { test, expect } from '../support/fixtures';
 
 const SELECTOR_TRIGGER_NAME = 'AI 분석 모델 선택';
 const SELECTOR_LISTBOX_NAME = 'AI 분석 모델 목록';
-const FREE_DEFAULT_LABEL = 'Flash Lite'; // gemini-2.5-flash-lite trigger label
+const FREE_DEFAULT_LABEL = 'DeepSeek Flash'; // deepseek-v4-flash — the free default model's trigger label
 // A free, non-default option. Matched by EXACT accessible name (label +
 // fullName), because the substring "Gemini 2.5 Flash" also occurs inside the
 // default option's name "Flash Lite Gemini 2.5 Flash Lite".
@@ -71,7 +71,7 @@ test.describe('model gate (guest)', () => {
     }) => {
         await page.goto('/AAPL');
 
-        // Default selection is the free Gemini Flash Lite — its label shows on
+        // Default selection is the free DeepSeek Flash — its label shows on
         // the trigger before we touch anything.
         const trigger = page.getByRole('button', {
             name: SELECTOR_TRIGGER_NAME,

--- a/e2e/specs/symbol-chat.spec.ts
+++ b/e2e/specs/symbol-chat.spec.ts
@@ -72,6 +72,12 @@ const READY_PLACEHOLDER = '질문을 입력하세요… (Enter로 전송)';
 const QUESTION = '지금 사도 돼?';
 const EXPECTED_ANSWER_FRAGMENT = `"${QUESTION}"에 대한 테스트 답변입니다`;
 
+// App-wide default chat model. The fake provider prefixes its reply with
+// `[E2E <model>]` (FakeChatProvider.fakeCallAiProvider), so the rendered answer
+// echoes whichever model chatAction resolved — letting the spec pin the default.
+const DEFAULT_CHAT_MODEL = 'deepseek-v4-flash';
+const EXPECTED_MODEL_FRAGMENT = `[E2E ${DEFAULT_CHAT_MODEL}]`;
+
 /**
  * Commit text to the React-controlled chat textarea without keyboard input.
  * Uses the prototype value setter + a bubbling `input` event so React's
@@ -139,6 +145,13 @@ test.describe('@webkit symbol chat', () => {
         await expect(answerBubble(page)).toBeVisible({
             timeout: CHAT_REPLY_TIMEOUT_MS,
         });
+
+        // DeepSeek 기본 모델 고정 가드: fake가 해석된 모델을 `[E2E <model>]`로 응답에
+        // 그대로 echo하므로, 기본 채팅 모델이 deepseek-v4-flash에서 (예: Gemini로)
+        // 조용히 되돌려지면 이 단언이 실패한다.
+        await expect(
+            page.getByText(EXPECTED_MODEL_FRAGMENT, { exact: false })
+        ).toBeVisible();
     });
 
     test('@webkit chat persists and announces context switch across a tab change', async ({

--- a/infra/aws/check-env.sh
+++ b/infra/aws/check-env.sh
@@ -22,11 +22,12 @@ EXCLUDE='^(NEXT_PUBLIC_|SIGLENS_GITHUB_TOKEN)'
 
 # Optional keys: present in .env.example but intentionally absent from SSM in production.
 #
-# Rationale: prod chat uses Gemini exclusively (GEMINI_CHAT_API_KEY is in SSM).
-# ANTHROPIC_CHAT_API_KEY and OPENAI_CHAT_API_KEY are BYOK (bring-your-own-key)
-# alternative providers read lazily in src/entities/chat-message/actions/chatAction.ts
-# only when a user explicitly selects that model. Their absence from SSM is intentional
-# and must NOT block deploy — missing them here would be a false positive deploy-gate.
+# Rationale: DeepSeek is the default chat/analysis provider (DEEPSEEK_CHAT_API_KEY,
+# like GEMINI_CHAT_API_KEY, is a server-paid key in SSM). ANTHROPIC_CHAT_API_KEY and
+# OPENAI_CHAT_API_KEY are BYOK (bring-your-own-key) alternative providers read lazily in
+# src/entities/chat-message/actions/chatAction.ts only when a user explicitly selects
+# that model. Their absence from SSM is intentional and must NOT block deploy — missing
+# them here would be a false positive deploy-gate.
 #
 # DEBUG_VERBOSE_LOGS is an optional debug flag (defaults off when unset); it is never
 # provisioned in prod SSM and must likewise not block deploy.

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "@neondatabase/serverless": "^1.1.0",
         "@tanstack/react-query": "^5.95.2",
         "@upstash/redis": "^1.37.0",
-        "@y0ngha/siglens-core": "0.32.1",
+        "@y0ngha/siglens-core": "0.33.0",
         "bcryptjs": "^3.0.3",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",

--- a/src/app/[symbol]/__tests__/page.factlayer.test.tsx
+++ b/src/app/[symbol]/__tests__/page.factlayer.test.tsx
@@ -19,7 +19,7 @@ vi.mock('@/entities/chat-message', () => ({
     FALLBACK_ANALYSIS: { summary: 'fallback' },
 }));
 vi.mock('@y0ngha/siglens-core', () => ({
-    GEMINI_2_5_FLASH_LITE_MODEL: 'gemini-2.5-flash-lite',
+    DEEPSEEK_V4_FLASH_MODEL: 'deepseek-v4-flash',
     // TechnicalFactsSummary deps (RSI thresholds)
     RSI_OVERBOUGHT_LEVEL: 70,
     RSI_OVERSOLD_LEVEL: 30,

--- a/src/app/[symbol]/__tests__/page.test.ts
+++ b/src/app/[symbol]/__tests__/page.test.ts
@@ -6,7 +6,7 @@ vi.mock('@/entities/chat-message', () => ({
     FALLBACK_ANALYSIS: { summary: 'fallback' },
 }));
 vi.mock('@y0ngha/siglens-core', () => ({
-    GEMINI_2_5_FLASH_LITE_MODEL: 'gemini-2.5-flash-lite',
+    DEEPSEEK_V4_FLASH_MODEL: 'deepseek-v4-flash',
     peekAnalysisCache: vi.fn(),
 }));
 vi.mock('@/shared/config/market', async importOriginal => ({
@@ -94,7 +94,7 @@ import {
 } from '@/app/[symbol]/page';
 import { getAssetInfoResilient } from '@/entities/ticker';
 import {
-    GEMINI_2_5_FLASH_LITE_MODEL,
+    DEEPSEEK_V4_FLASH_MODEL,
     peekAnalysisCache,
 } from '@y0ngha/siglens-core';
 import { evaluateSymbolIndexability } from '@/entities/symbol-indexability';
@@ -306,7 +306,7 @@ describe('Symbol page', () => {
                 'AAPL',
                 '1Day',
                 'AAPL',
-                GEMINI_2_5_FLASH_LITE_MODEL
+                DEEPSEEK_V4_FLASH_MODEL
             );
             expect(props.initialAnalysis).toEqual(cached);
         });

--- a/src/app/[symbol]/overall/__tests__/page.body.test.tsx
+++ b/src/app/[symbol]/overall/__tests__/page.body.test.tsx
@@ -70,7 +70,7 @@ vi.mock('@/shared/lib/seo', async importOriginal => ({
 }));
 
 vi.mock('@y0ngha/siglens-core', () => ({
-    GEMINI_2_5_FLASH_LITE_MODEL: 'gemini-2.5-flash-lite',
+    DEEPSEEK_V4_FLASH_MODEL: 'deepseek-v4-flash',
     peekOverallAnalysisCache: vi.fn().mockResolvedValue(null),
 }));
 

--- a/src/app/[symbol]/overall/__tests__/page.factlayer.test.tsx
+++ b/src/app/[symbol]/overall/__tests__/page.factlayer.test.tsx
@@ -56,7 +56,7 @@ vi.mock('@/shared/lib/seo', async importOriginal => ({
     SITE_URL: 'https://siglens.io',
 }));
 vi.mock('@y0ngha/siglens-core', () => ({
-    GEMINI_2_5_FLASH_LITE_MODEL: 'gemini-2.5-flash-lite',
+    DEEPSEEK_V4_FLASH_MODEL: 'deepseek-v4-flash',
     peekOverallAnalysisCache: vi.fn(),
 }));
 vi.mock('next/navigation', () => ({

--- a/src/app/[symbol]/overall/__tests__/page.test.ts
+++ b/src/app/[symbol]/overall/__tests__/page.test.ts
@@ -44,7 +44,7 @@ vi.mock('@/shared/lib/seo', async importOriginal => ({
     SITE_URL: 'https://siglens.io',
 }));
 vi.mock('@y0ngha/siglens-core', () => ({
-    GEMINI_2_5_FLASH_LITE_MODEL: 'gemini-2.5-flash-lite',
+    DEEPSEEK_V4_FLASH_MODEL: 'deepseek-v4-flash',
     peekOverallAnalysisCache: vi.fn(),
 }));
 vi.mock('next/navigation', () => ({
@@ -63,7 +63,7 @@ import {
 } from '@/app/[symbol]/overall/page';
 import { getAssetInfoResilient } from '@/entities/ticker';
 import {
-    GEMINI_2_5_FLASH_LITE_MODEL,
+    DEEPSEEK_V4_FLASH_MODEL,
     peekOverallAnalysisCache,
 } from '@y0ngha/siglens-core';
 import { OverallContent } from '@/widgets/overall/OverallContent';
@@ -171,7 +171,7 @@ describe('Overall page (narrative seed)', () => {
             'AAPL',
             'Apple Inc.',
             '1Day',
-            GEMINI_2_5_FLASH_LITE_MODEL
+            DEEPSEEK_V4_FLASH_MODEL
         );
         expect(props.initialAnalysis).toEqual(cached);
     });

--- a/src/app/[symbol]/overall/page.tsx
+++ b/src/app/[symbol]/overall/page.tsx
@@ -28,7 +28,7 @@ import {
 } from '@/shared/lib/seo';
 import { getDescriptor, marketProfileOf } from '@/shared/config/marketProfile';
 import {
-    GEMINI_2_5_FLASH_LITE_MODEL,
+    DEEPSEEK_V4_FLASH_MODEL,
     peekOverallAnalysisCache,
 } from '@y0ngha/siglens-core';
 import { staticSymbolCache } from '@/shared/cache/staticSymbolCache';
@@ -97,8 +97,8 @@ export default async function OverallPage({ params }: Props) {
     //
     // modelId: chart 페이지와 동일하게 익명/SSR 기본 방문자가 캐시를 쓰는 키와
     // 정렬한다. OverallContent → useDefaultModelId → SymbolModelContext의 DEFAULT_MODEL
-    // (GEMINI_2_5_FLASH_LITE_MODEL)이 submitOverallAnalysisAction에 그대로 전달되므로
-    // writer는 lite 모델 키로 캐시한다. peek도 동일 모델을 넘겨야 HIT한다.
+    // (DEEPSEEK_V4_FLASH_MODEL)이 submitOverallAnalysisAction에 그대로 전달되므로
+    // writer는 DeepSeek flash 모델 키로 캐시한다. peek도 동일 모델을 넘겨야 HIT한다.
     //
     // 시그니처가 chart의 peekAnalysisCache(symbol, timeframe, fmpSymbol?, modelId?)와
     // 다른 건 의도적이다 — overall은 2번째 인자로 companyName을 받는다. 각 core peek
@@ -130,14 +130,14 @@ export default async function OverallPage({ params }: Props) {
             return [] as Awaited<ReturnType<typeof getNewsList>>;
         }),
         staticSymbolCache(
-            ['peek:overall', upper, GEMINI_2_5_FLASH_LITE_MODEL],
+            ['peek:overall', upper, DEEPSEEK_V4_FLASH_MODEL],
             upper,
             () =>
                 peekOverallAnalysisCache(
                     upper,
                     assetInfo.name,
                     DEFAULT_TIMEFRAME,
-                    GEMINI_2_5_FLASH_LITE_MODEL
+                    DEEPSEEK_V4_FLASH_MODEL
                 ),
             [],
             SECONDS_PER_HALF_DAY

--- a/src/app/[symbol]/page.tsx
+++ b/src/app/[symbol]/page.tsx
@@ -3,7 +3,7 @@ import { TechnicalFactsSummary, buildChartPageHeading } from '@/views/symbol';
 import { JsonLd } from '@/shared/ui/JsonLd';
 import { FALLBACK_ANALYSIS } from '@/entities/chat-message';
 import { getBlockedSymbolMetadata } from '@/app/[symbol]/symbolIndexabilityMetadata';
-import { GEMINI_2_5_FLASH_LITE_MODEL } from '@y0ngha/siglens-core';
+import { DEEPSEEK_V4_FLASH_MODEL } from '@y0ngha/siglens-core';
 import { peekAnalysisStatic } from '@/entities/analysis';
 import {
     DEFAULT_TIMEFRAME,
@@ -199,14 +199,14 @@ export default async function SymbolPage({ params }: Props) {
     // 삼키지 않고 로깅한 뒤 degrade한다.
     //
     // modelId: 익명/SSR 기본 방문자가 캐시를 쓰는 키와 정렬한다. SymbolModelContext의
-    // DEFAULT_MODEL이 GEMINI_2_5_FLASH_LITE_MODEL이고, useAnalysis가 그 값을
-    // submitAnalysisAction에 그대로 전달하므로 writer는 lite 모델 키로 캐시한다.
+    // DEFAULT_MODEL이 DEEPSEEK_V4_FLASH_MODEL이고, useAnalysis가 그 값을
+    // submitAnalysisAction에 그대로 전달하므로 writer는 DeepSeek flash 모델 키로 캐시한다.
     // peek도 동일 모델을 넘겨야 HIT한다.
     const cachedAnalysis = await peekAnalysisStatic(
         ticker,
         DEFAULT_TIMEFRAME,
         assetInfo.fmpSymbol,
-        GEMINI_2_5_FLASH_LITE_MODEL
+        DEEPSEEK_V4_FLASH_MODEL
     ).catch((error: unknown) => {
         console.error('[SymbolPage] peekAnalysisStatic failed:', error);
         return null;

--- a/src/entities/api-key/lib/constants.ts
+++ b/src/entities/api-key/lib/constants.ts
@@ -11,6 +11,7 @@ export const AI_PROVIDER_VALUES = [
     'claude',
     'gemini',
     'chatgpt',
+    'deepseek',
 ] as const satisfies readonly AIProvider[];
 
 // If core adds e.g. 'mistral' to AIProvider, `Exclude<...>` becomes

--- a/src/entities/chat-message/__tests__/chatAction.test.ts
+++ b/src/entities/chat-message/__tests__/chatAction.test.ts
@@ -12,7 +12,7 @@ import type {
     LlmProvider,
 } from '@y0ngha/siglens-core';
 import {
-    GEMINI_2_5_FLASH_MODEL,
+    DEEPSEEK_V4_FLASH_MODEL,
     getProviderForModel,
     requestChatCompletion,
 } from '@y0ngha/siglens-core';
@@ -110,6 +110,7 @@ describe('chatAction 함수는', () => {
         process.env.GEMINI_CHAT_API_KEY = 'gemini-server-key';
         delete process.env.ANTHROPIC_CHAT_API_KEY;
         delete process.env.OPENAI_CHAT_API_KEY;
+        delete process.env.DEEPSEEK_CHAT_API_KEY;
         mockHeaders.mockResolvedValue(
             makeHeadersMap('1.2.3.4') as unknown as Awaited<
                 ReturnType<typeof headers>
@@ -127,6 +128,7 @@ describe('chatAction 함수는', () => {
         delete process.env.GEMINI_CHAT_API_KEY;
         delete process.env.ANTHROPIC_CHAT_API_KEY;
         delete process.env.OPENAI_CHAT_API_KEY;
+        delete process.env.DEEPSEEK_CHAT_API_KEY;
     });
 
     describe('Gemini 모델을 사용할 때', () => {
@@ -205,6 +207,32 @@ describe('chatAction 함수는', () => {
         });
     });
 
+    describe('DeepSeek 모델을 사용할 때', () => {
+        it('free DeepSeek 모델은 DEEPSEEK_CHAT_API_KEY를 serverApiKey로 전달한다', async () => {
+            process.env.DEEPSEEK_CHAT_API_KEY = 'deepseek-key';
+            delete process.env.GEMINI_CHAT_API_KEY;
+
+            await chatAction(
+                'AAPL',
+                'Apple Inc.',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '질문',
+                'deepseek-v4-flash'
+            );
+
+            expect(mockRequestChatCompletion).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    serverApiKey: 'deepseek-key',
+                    userApiKey: undefined,
+                    model: 'deepseek-v4-flash',
+                }),
+                { callAiProvider: callAiProviderRouter }
+            );
+        });
+    });
+
     describe('서버 키가 없을 때', () => {
         it('Gemini 서버 primary key가 미설정이면 server_error를 반환하고 core를 호출하지 않는다', async () => {
             delete process.env.GEMINI_CHAT_API_KEY;
@@ -247,6 +275,21 @@ describe('chatAction 함수는', () => {
                 [],
                 '질문',
                 'gpt-5-mini'
+            );
+
+            expect(result).toEqual({ ok: false, error: 'server_error' });
+            expect(mockRequestChatCompletion).not.toHaveBeenCalled();
+        });
+
+        it('DeepSeek 서버 primary key가 미설정이면 server_error를 반환하고 core를 호출하지 않는다', async () => {
+            const result = await chatAction(
+                'AAPL',
+                'Apple Inc.',
+                '1Day',
+                MINIMAL_ANALYSIS,
+                [],
+                '질문',
+                'deepseek-v4-flash'
             );
 
             expect(result).toEqual({ ok: false, error: 'server_error' });
@@ -446,7 +489,9 @@ describe('chatAction 함수는', () => {
     });
 
     describe('기본 모델', () => {
-        it('model을 생략하면 GEMINI_2_5_FLASH_MODEL을 core에 전달한다', async () => {
+        it('model을 생략하면 DEEPSEEK_V4_FLASH_MODEL을 core에 전달한다', async () => {
+            process.env.DEEPSEEK_CHAT_API_KEY = 'deepseek-server-key';
+
             await chatAction(
                 'AAPL',
                 'Apple Inc.',
@@ -458,7 +503,7 @@ describe('chatAction 함수는', () => {
 
             expect(mockRequestChatCompletion).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    model: GEMINI_2_5_FLASH_MODEL,
+                    model: DEEPSEEK_V4_FLASH_MODEL,
                 }),
                 expect.objectContaining({
                     callAiProvider: callAiProviderRouter,

--- a/src/entities/chat-message/actions/chatAction.ts
+++ b/src/entities/chat-message/actions/chatAction.ts
@@ -17,8 +17,8 @@ import type {
     UserTierContext,
 } from '@y0ngha/siglens-core';
 import {
+    DEEPSEEK_V4_FLASH_MODEL,
     DEFAULT_TIER,
-    GEMINI_2_5_FLASH_MODEL,
     getProviderForModel,
     requestChatCompletion,
 } from '@y0ngha/siglens-core';
@@ -43,6 +43,8 @@ function getServerPrimaryKey(provider: LlmProvider): string | undefined {
             return process.env.ANTHROPIC_CHAT_API_KEY;
         case 'openai':
             return process.env.OPENAI_CHAT_API_KEY;
+        case 'deepseek':
+            return process.env.DEEPSEEK_CHAT_API_KEY;
         default: {
             const exhausted: never = provider;
             throw new Error(`Unhandled LLM provider: ${String(exhausted)}`);
@@ -105,7 +107,7 @@ export async function chatAction(
     analysis: AnalysisResponse,
     history: ChatMessage[],
     userMessage: string,
-    model: ModelId = GEMINI_2_5_FLASH_MODEL,
+    model: ModelId = DEEPSEEK_V4_FLASH_MODEL,
     /**
      * Tagged union representing the analysis result the user is currently
      * looking at (technical / fundamental / news / overall). When provided,

--- a/src/entities/llm-provider/__tests__/api/deepseek.test.ts
+++ b/src/entities/llm-provider/__tests__/api/deepseek.test.ts
@@ -24,8 +24,28 @@ const PRO_OPTIONS = {
     model: 'deepseek-v4-pro', // apiModelId, thinking
 } as const;
 
+// DeepSeek chat is called in STREAMING mode, so `create` resolves to an async
+// iterable of chunks. These helpers build fresh streams (single-use).
+interface Chunk {
+    choices: Array<{ delta?: { content?: string | null } }>;
+    usage?: unknown;
+}
+
+function toStream(chunks: Chunk[]) {
+    return {
+        async *[Symbol.asyncIterator]() {
+            for (const chunk of chunks) {
+                yield chunk;
+            }
+        },
+    };
+}
+
 function okResponse(content: string) {
-    return { choices: [{ message: { content } }] };
+    return toStream([
+        { choices: [{ delta: { content } }] },
+        { choices: [{ delta: {} }], usage: { prompt_tokens: 1 } },
+    ]);
 }
 
 describe('callDeepseekChat', () => {
@@ -80,6 +100,10 @@ describe('callDeepseekChat', () => {
             const call = mockCreate.mock.calls[0][0];
             expect(call.model).toBe('deepseek-v4-flash');
             expect(call.messages).toEqual([{ role: 'user', content: 'Hello' }]);
+            // Streaming is mandatory (avoids DeepSeek's ~50-60s non-streaming
+            // connection termination on long outputs).
+            expect(call.stream).toBe(true);
+            expect(call.stream_options).toEqual({ include_usage: true });
         });
 
         it('response_format을 강제하지 않는다 (챗봇은 자연 텍스트 반환)', async () => {
@@ -239,24 +263,33 @@ describe('callDeepseekChat', () => {
             warnSpy.mockRestore();
         });
 
-        it('content가 null이면 에러를 던진다', async () => {
-            mockCreate.mockResolvedValue({
-                choices: [{ message: { content: null } }],
-            });
-
-            await expect(callDeepseekChat(FLASH_OPTIONS)).rejects.toThrow(
-                '[deepseek] Provider returned null/undefined response'
+        it('null/undefined content 델타는 건너뛰고 유효한 델타만 집계한다', async () => {
+            mockCreate.mockResolvedValue(
+                toStream([
+                    { choices: [{ delta: { content: null } }] },
+                    { choices: [{ delta: {} }] },
+                    { choices: [{ delta: { content: 'real answer' } }] },
+                    { choices: [{ delta: {} }], usage: { prompt_tokens: 1 } },
+                ])
             );
+
+            const result = await callDeepseekChat(FLASH_OPTIONS);
+
+            expect(result).toBe('real answer');
         });
 
-        it('content가 undefined이면 에러를 던진다', async () => {
-            mockCreate.mockResolvedValue({
-                choices: [{ message: { content: undefined } }],
-            });
-
-            await expect(callDeepseekChat(FLASH_OPTIONS)).rejects.toThrow(
-                '[deepseek] Provider returned null/undefined response'
+        it('여러 델타를 하나의 응답으로 집계한다', async () => {
+            mockCreate.mockResolvedValue(
+                toStream([
+                    { choices: [{ delta: { content: 'part-1 ' } }] },
+                    { choices: [{ delta: { content: 'part-2' } }] },
+                    { choices: [{ delta: {} }], usage: { prompt_tokens: 1 } },
+                ])
             );
+
+            const result = await callDeepseekChat(FLASH_OPTIONS);
+
+            expect(result).toBe('part-1 part-2');
         });
     });
 });

--- a/src/entities/llm-provider/__tests__/api/deepseek.test.ts
+++ b/src/entities/llm-provider/__tests__/api/deepseek.test.ts
@@ -1,0 +1,262 @@
+const { mockCreate, MockOpenAI } = vi.hoisted(() => {
+    const mockCreate = vi.fn();
+    const MockOpenAI = vi.fn().mockImplementation(function () {
+        return { chat: { completions: { create: mockCreate } } };
+    });
+    return { mockCreate, MockOpenAI };
+});
+
+vi.mock('openai', () => ({
+    default: MockOpenAI,
+}));
+
+import { callDeepseekChat } from '@/entities/llm-provider/api/deepseek';
+
+const FLASH_OPTIONS = {
+    serverApiKey: 'server-key',
+    userApiKey: undefined,
+    model: 'deepseek-v4-flash', // apiModelId, non-thinking
+    contents: 'Hello',
+} as const;
+
+const PRO_OPTIONS = {
+    ...FLASH_OPTIONS,
+    model: 'deepseek-v4-pro', // apiModelId, thinking
+} as const;
+
+function okResponse(content: string) {
+    return { choices: [{ message: { content } }] };
+}
+
+describe('callDeepseekChat', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('API 키 및 baseURL 라우팅', () => {
+        it('serverApiKey와 DeepSeek baseURL로 클라이언트를 생성한다', async () => {
+            mockCreate.mockResolvedValue(okResponse('Hi'));
+
+            const result = await callDeepseekChat(FLASH_OPTIONS);
+
+            expect(result).toBe('Hi');
+            expect(MockOpenAI).toHaveBeenCalledWith({
+                apiKey: 'server-key',
+                baseURL: 'https://api.deepseek.com',
+            });
+            expect(mockCreate).toHaveBeenCalledTimes(1);
+        });
+
+        it('userApiKey가 있어도 serverApiKey만 사용한다', async () => {
+            mockCreate.mockResolvedValue(okResponse('Hi'));
+
+            await callDeepseekChat({
+                ...FLASH_OPTIONS,
+                userApiKey: 'user-key',
+            });
+
+            expect(MockOpenAI).toHaveBeenCalledWith({
+                apiKey: 'server-key',
+                baseURL: 'https://api.deepseek.com',
+            });
+            expect(MockOpenAI).toHaveBeenCalledTimes(1);
+        });
+
+        it('호출이 실패하면 에러가 전파된다', async () => {
+            mockCreate.mockRejectedValue(new Error('api error'));
+
+            await expect(callDeepseekChat(FLASH_OPTIONS)).rejects.toThrow(
+                'api error'
+            );
+        });
+    });
+
+    describe('chat.completions API 파라미터', () => {
+        it('chat.completions.create를 messages와 함께 호출한다', async () => {
+            mockCreate.mockResolvedValue(okResponse('ok'));
+
+            await callDeepseekChat(FLASH_OPTIONS);
+
+            const call = mockCreate.mock.calls[0][0];
+            expect(call.model).toBe('deepseek-v4-flash');
+            expect(call.messages).toEqual([{ role: 'user', content: 'Hello' }]);
+        });
+
+        it('response_format을 강제하지 않는다 (챗봇은 자연 텍스트 반환)', async () => {
+            mockCreate.mockResolvedValue(okResponse('ok'));
+
+            await callDeepseekChat(FLASH_OPTIONS);
+
+            const call = mockCreate.mock.calls[0][0];
+            // Chat must return conversational prose, not JSON — no response_format
+            // (DeepSeek defaults to `text`), matching the openai/gemini chat adapters.
+            expect(call.response_format).toBeUndefined();
+        });
+
+        it('max_tokens로 spec.maxOutputTokens를 전달한다', async () => {
+            mockCreate.mockResolvedValue(okResponse('ok'));
+
+            await callDeepseekChat(FLASH_OPTIONS);
+
+            const call = mockCreate.mock.calls[0][0];
+            expect(call.max_tokens).toBe(393216);
+        });
+
+        it('systemInstruction을 system 메시지로 선두에 추가한다', async () => {
+            mockCreate.mockResolvedValue(okResponse('ok'));
+
+            await callDeepseekChat({
+                ...FLASH_OPTIONS,
+                systemInstruction: 'Be concise',
+            });
+
+            const call = mockCreate.mock.calls[0][0];
+            expect(call.messages[0]).toEqual({
+                role: 'system',
+                content: 'Be concise',
+            });
+            expect(call.messages[1]).toEqual({
+                role: 'user',
+                content: 'Hello',
+            });
+        });
+
+        it('systemInstruction이 없으면 system 메시지를 추가하지 않는다', async () => {
+            mockCreate.mockResolvedValue(okResponse('ok'));
+
+            await callDeepseekChat(FLASH_OPTIONS);
+
+            const call = mockCreate.mock.calls[0][0];
+            expect(call.messages).toHaveLength(1);
+            expect(call.messages[0].role).not.toBe('system');
+        });
+    });
+
+    describe('thinking 토글', () => {
+        it('non-thinking 모델(flash)은 thinking:{type:"disabled"}를 전달한다', async () => {
+            mockCreate.mockResolvedValue(okResponse('ok'));
+
+            await callDeepseekChat(FLASH_OPTIONS);
+
+            const call = mockCreate.mock.calls[0][0];
+            expect(call.thinking).toEqual({ type: 'disabled' });
+        });
+
+        it('thinking 모델(pro)은 thinking:{type:"enabled", reasoning_effort:"high"}를 전달한다', async () => {
+            mockCreate.mockResolvedValue(okResponse('ok'));
+
+            await callDeepseekChat(PRO_OPTIONS);
+
+            const call = mockCreate.mock.calls[0][0];
+            expect(call.thinking).toEqual({
+                type: 'enabled',
+                reasoning_effort: 'high',
+            });
+        });
+    });
+
+    describe('temperature 적용 규칙', () => {
+        it('non-thinking 모델(flash)은 spec.temperature를 전달한다', async () => {
+            mockCreate.mockResolvedValue(okResponse('ok'));
+
+            await callDeepseekChat(FLASH_OPTIONS);
+
+            const call = mockCreate.mock.calls[0][0];
+            expect(call.temperature).toBe(0);
+        });
+
+        it('thinking 모델(pro)은 temperature를 전달하지 않는다', async () => {
+            mockCreate.mockResolvedValue(okResponse('ok'));
+
+            await callDeepseekChat(PRO_OPTIONS);
+
+            const call = mockCreate.mock.calls[0][0];
+            expect(call).not.toHaveProperty('temperature');
+        });
+    });
+
+    describe('모델 검증', () => {
+        it('알 수 없는 model이면 에러를 던진다', async () => {
+            await expect(
+                callDeepseekChat({
+                    ...FLASH_OPTIONS,
+                    model: 'unknown-model-123',
+                })
+            ).rejects.toThrow('Unknown model: unknown-model-123');
+            expect(mockCreate).not.toHaveBeenCalled();
+        });
+
+        it('DeepSeek가 아닌 provider의 apiModelId면 에러를 던진다', async () => {
+            await expect(
+                callDeepseekChat({
+                    ...FLASH_OPTIONS,
+                    model: 'gpt-5-mini',
+                })
+            ).rejects.toThrow('[deepseek] Non-DeepSeek model spec: gpt-5-mini');
+            expect(mockCreate).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('다중 턴 입력', () => {
+        it('배열 형태의 contents를 messages로 변환한다', async () => {
+            mockCreate.mockResolvedValue(okResponse('ok'));
+
+            await callDeepseekChat({
+                ...FLASH_OPTIONS,
+                contents: [
+                    { role: 'user', text: 'Hello' },
+                    { role: 'assistant', text: 'Hi' },
+                    { role: 'user', text: 'How are you?' },
+                ],
+            });
+
+            const call = mockCreate.mock.calls[0][0];
+            expect(call.messages).toHaveLength(3);
+            expect(call.messages[0]).toEqual({
+                role: 'user',
+                content: 'Hello',
+            });
+            expect(call.messages[1]).toEqual({
+                role: 'assistant',
+                content: 'Hi',
+            });
+        });
+    });
+
+    describe('응답 파싱', () => {
+        it('content가 빈 문자열이면 경고 로그 후 그대로 반환한다', async () => {
+            mockCreate.mockResolvedValue(okResponse(''));
+            const warnSpy = vi
+                .spyOn(console, 'warn')
+                .mockImplementation(() => {});
+
+            const result = await callDeepseekChat(FLASH_OPTIONS);
+
+            expect(result).toBe('');
+            expect(warnSpy).toHaveBeenCalledWith(
+                '[deepseek] Provider returned empty string'
+            );
+            warnSpy.mockRestore();
+        });
+
+        it('content가 null이면 에러를 던진다', async () => {
+            mockCreate.mockResolvedValue({
+                choices: [{ message: { content: null } }],
+            });
+
+            await expect(callDeepseekChat(FLASH_OPTIONS)).rejects.toThrow(
+                '[deepseek] Provider returned null/undefined response'
+            );
+        });
+
+        it('content가 undefined이면 에러를 던진다', async () => {
+            mockCreate.mockResolvedValue({
+                choices: [{ message: { content: undefined } }],
+            });
+
+            await expect(callDeepseekChat(FLASH_OPTIONS)).rejects.toThrow(
+                '[deepseek] Provider returned null/undefined response'
+            );
+        });
+    });
+});

--- a/src/entities/llm-provider/__tests__/api/router.test.ts
+++ b/src/entities/llm-provider/__tests__/api/router.test.ts
@@ -11,6 +11,10 @@ vi.mock('@/entities/llm-provider/api/gemini', () => ({
     callGeminiChat: vi.fn(),
 }));
 
+vi.mock('@/entities/llm-provider/api/deepseek', () => ({
+    callDeepseekChat: vi.fn(),
+}));
+
 vi.mock('@y0ngha/siglens-core', async () => {
     const actual = await vi.importActual<typeof import('@y0ngha/siglens-core')>(
         '@y0ngha/siglens-core'
@@ -26,6 +30,7 @@ vi.mock('@y0ngha/siglens-core', async () => {
 import { callAnthropicChat } from '@/entities/llm-provider/api/anthropic';
 import { callGeminiChat } from '@/entities/llm-provider/api/gemini';
 import { callOpenaiChat } from '@/entities/llm-provider/api/openai';
+import { callDeepseekChat } from '@/entities/llm-provider/api/deepseek';
 import { callAiProviderRouter } from '@/entities/llm-provider/api/router';
 import type { LlmProvider } from '@y0ngha/siglens-core';
 import { getProviderForModel } from '@y0ngha/siglens-core';
@@ -38,6 +43,9 @@ const mockCallOpenaiChat = callOpenaiChat as MockedFunction<
 >;
 const mockCallGeminiWithKeyFallback = callGeminiChat as MockedFunction<
     typeof callGeminiChat
+>;
+const mockCallDeepseekChat = callDeepseekChat as MockedFunction<
+    typeof callDeepseekChat
 >;
 const mockGetProviderForModel = getProviderForModel as MockedFunction<
     typeof getProviderForModel
@@ -55,6 +63,7 @@ describe('callAiProviderRouter', () => {
         mockCallAnthropicChat.mockResolvedValue('anthropic response');
         mockCallOpenaiChat.mockResolvedValue('openai response');
         mockCallGeminiWithKeyFallback.mockResolvedValue('gemini response');
+        mockCallDeepseekChat.mockResolvedValue('deepseek response');
         const actual = await vi.importActual<
             typeof import('@y0ngha/siglens-core')
         >('@y0ngha/siglens-core');
@@ -112,6 +121,24 @@ describe('callAiProviderRouter', () => {
         });
     });
 
+    describe('DeepSeek 모델 라우팅', () => {
+        it('deepseek-v4-flash 모델은 callDeepseekChat에 위임하고 다른 어댑터는 호출하지 않는다', async () => {
+            const options = { ...BASE_OPTIONS, model: 'deepseek-v4-flash' };
+
+            const result = await callAiProviderRouter(options);
+
+            expect(result).toBe('deepseek response');
+            expect(mockCallDeepseekChat).toHaveBeenCalledTimes(1);
+            expect(mockCallDeepseekChat).toHaveBeenCalledWith({
+                ...options,
+                model: 'deepseek-v4-flash',
+            });
+            expect(mockCallAnthropicChat).not.toHaveBeenCalled();
+            expect(mockCallOpenaiChat).not.toHaveBeenCalled();
+            expect(mockCallGeminiWithKeyFallback).not.toHaveBeenCalled();
+        });
+    });
+
     describe('알 수 없는 provider 처리', () => {
         it('알 수 없는 provider이면 에러를 던진다', async () => {
             mockGetProviderForModel.mockReturnValueOnce(
@@ -141,6 +168,7 @@ describe('callAiProviderRouter', () => {
             expect(mockCallAnthropicChat).not.toHaveBeenCalled();
             expect(mockCallOpenaiChat).not.toHaveBeenCalled();
             expect(mockCallGeminiWithKeyFallback).not.toHaveBeenCalled();
+            expect(mockCallDeepseekChat).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/entities/llm-provider/__tests__/lib/providerDefaults.test.ts
+++ b/src/entities/llm-provider/__tests__/lib/providerDefaults.test.ts
@@ -1,6 +1,7 @@
 import {
     CHATGPT_MODEL_PRIORITY,
     CLAUDE_MODEL_PRIORITY,
+    DEEPSEEK_MODEL_PRIORITY,
     GEMINI_MODEL_PRIORITY,
     resolveDefaultModelForProvider,
 } from '@/entities/llm-provider/lib/providerDefaults';
@@ -22,6 +23,11 @@ describe('resolveDefaultModelForProvider', () => {
             const result = resolveDefaultModelForProvider('chatgpt', []);
             expect(result).toBeNull();
         });
+
+        it('returns null for deepseek provider', () => {
+            const result = resolveDefaultModelForProvider('deepseek', []);
+            expect(result).toBeNull();
+        });
     });
 
     describe('when all models are allowed', () => {
@@ -29,6 +35,7 @@ describe('resolveDefaultModelForProvider', () => {
             ...CLAUDE_MODEL_PRIORITY,
             ...GEMINI_MODEL_PRIORITY,
             ...CHATGPT_MODEL_PRIORITY,
+            ...DEEPSEEK_MODEL_PRIORITY,
         ];
 
         it('returns the top priority claude model', () => {
@@ -44,6 +51,14 @@ describe('resolveDefaultModelForProvider', () => {
         it('returns the top priority chatgpt model', () => {
             const result = resolveDefaultModelForProvider('chatgpt', allModels);
             expect(result).toBe(CHATGPT_MODEL_PRIORITY[0]);
+        });
+
+        it('returns the top priority deepseek model', () => {
+            const result = resolveDefaultModelForProvider(
+                'deepseek',
+                allModels
+            );
+            expect(result).toBe(DEEPSEEK_MODEL_PRIORITY[0]);
         });
     });
 
@@ -74,6 +89,15 @@ describe('resolveDefaultModelForProvider', () => {
             );
             expect(result).toBe(CHATGPT_MODEL_PRIORITY[1]);
         });
+
+        it('returns the second priority deepseek model when the first is blocked', () => {
+            const allowedModels = DEEPSEEK_MODEL_PRIORITY.slice(1);
+            const result = resolveDefaultModelForProvider(
+                'deepseek',
+                allowedModels
+            );
+            expect(result).toBe(DEEPSEEK_MODEL_PRIORITY[1]);
+        });
     });
 
     describe('when only the lowest priority model is allowed', () => {
@@ -103,6 +127,15 @@ describe('resolveDefaultModelForProvider', () => {
             ]);
             expect(result).toBe(lowestPriority);
         });
+
+        it('returns the bottom priority deepseek model', () => {
+            const lowestPriority =
+                DEEPSEEK_MODEL_PRIORITY[DEEPSEEK_MODEL_PRIORITY.length - 1];
+            const result = resolveDefaultModelForProvider('deepseek', [
+                lowestPriority,
+            ]);
+            expect(result).toBe(lowestPriority);
+        });
     });
 
     describe('when only models from a different provider are in allowedModels', () => {
@@ -122,6 +155,13 @@ describe('resolveDefaultModelForProvider', () => {
 
         it('returns null for chatgpt when only claude models are allowed', () => {
             const result = resolveDefaultModelForProvider('chatgpt', [
+                ...CLAUDE_MODEL_PRIORITY,
+            ]);
+            expect(result).toBeNull();
+        });
+
+        it('returns null for deepseek when only claude models are allowed', () => {
+            const result = resolveDefaultModelForProvider('deepseek', [
                 ...CLAUDE_MODEL_PRIORITY,
             ]);
             expect(result).toBeNull();

--- a/src/entities/llm-provider/api/deepseek.ts
+++ b/src/entities/llm-provider/api/deepseek.ts
@@ -1,0 +1,79 @@
+import { toProviderTurns, findSpecByApiModelId } from '../lib/utils';
+import type { CallAiProviderOptions } from '@y0ngha/siglens-core';
+import OpenAI from 'openai';
+
+/**
+ * DeepSeek's reasoning toggle. Non-standard for the `openai` SDK's chat
+ * completion params — DeepSeek reuses the OpenAI-compatible endpoint but adds
+ * this top-level field to switch reasoning ("thinking") on/off per request.
+ */
+interface DeepSeekThinkingToggle {
+    type: 'enabled' | 'disabled';
+    reasoning_effort?: 'high';
+}
+
+/**
+ * `chat.completions.create` params extended with DeepSeek's `thinking` field.
+ * Localized to this file so the rest of the codebase never has to reason
+ * about a field the `openai` SDK types don't know about.
+ */
+type DeepSeekChatCompletionParams =
+    OpenAI.Chat.ChatCompletionCreateParamsNonStreaming & {
+        thinking: DeepSeekThinkingToggle;
+    };
+
+export async function callDeepseekChat({
+    serverApiKey,
+    model,
+    contents,
+    systemInstruction,
+}: CallAiProviderOptions): Promise<string> {
+    const spec = findSpecByApiModelId(model);
+    if (!spec) {
+        throw new Error(`Unknown model: ${model}`);
+    }
+    if (spec.provider !== 'deepseek') {
+        throw new Error(`[deepseek] Non-DeepSeek model spec: ${model}`);
+    }
+
+    const client = new OpenAI({
+        apiKey: serverApiKey,
+        baseURL: 'https://api.deepseek.com',
+    });
+
+    const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+        ...(systemInstruction !== undefined
+            ? [{ role: 'system' as const, content: systemInstruction }]
+            : []),
+        ...(toProviderTurns(
+            contents
+        ) as OpenAI.Chat.ChatCompletionMessageParam[]),
+    ];
+
+    const thinking: DeepSeekThinkingToggle = spec.thinking
+        ? { type: 'enabled', reasoning_effort: 'high' }
+        : { type: 'disabled' };
+
+    const params: DeepSeekChatCompletionParams = {
+        model,
+        messages,
+        // Chat returns natural conversational text (default `text` mode) — the
+        // sibling openai/gemini chat adapters do NOT force JSON. Forcing
+        // `json_object` here would make the chatbot emit JSON instead of prose.
+        max_tokens: spec.maxOutputTokens,
+        thinking,
+        // temperature only applies in non-thinking mode.
+        ...(!spec.thinking ? { temperature: spec.temperature } : {}),
+    };
+
+    const response = await client.chat.completions.create(params);
+
+    const text = response.choices[0]?.message.content;
+    if (text === null || text === undefined) {
+        throw new Error('[deepseek] Provider returned null/undefined response');
+    }
+    if (text === '') {
+        console.warn('[deepseek] Provider returned empty string');
+    }
+    return text;
+}

--- a/src/entities/llm-provider/api/deepseek.ts
+++ b/src/entities/llm-provider/api/deepseek.ts
@@ -13,12 +13,17 @@ interface DeepSeekThinkingToggle {
 }
 
 /**
- * `chat.completions.create` params extended with DeepSeek's `thinking` field.
- * Localized to this file so the rest of the codebase never has to reason
+ * Streaming `chat.completions.create` params extended with DeepSeek's `thinking`
+ * field. Localized to this file so the rest of the codebase never has to reason
  * about a field the `openai` SDK types don't know about.
+ *
+ * Streaming is required: DeepSeek terminates long non-streaming connections at
+ * ~50-60s (a verbose chatbot answer could hit this with the 393216 max_tokens
+ * cap). Streaming keeps the connection alive as tokens flow; we still return the
+ * fully-aggregated text, so the caller contract is unchanged.
  */
 type DeepSeekChatCompletionParams =
-    OpenAI.Chat.ChatCompletionCreateParamsNonStreaming & {
+    OpenAI.Chat.ChatCompletionCreateParamsStreaming & {
         thinking: DeepSeekThinkingToggle;
     };
 
@@ -64,14 +69,21 @@ export async function callDeepseekChat({
         thinking,
         // temperature only applies in non-thinking mode.
         ...(!spec.thinking ? { temperature: spec.temperature } : {}),
+        stream: true,
+        stream_options: { include_usage: true },
     };
 
-    const response = await client.chat.completions.create(params);
+    const stream = await client.chat.completions.create(params);
 
-    const text = response.choices[0]?.message.content;
-    if (text === null || text === undefined) {
-        throw new Error('[deepseek] Provider returned null/undefined response');
+    // Aggregate the streamed deltas into the full conversational text.
+    let text = '';
+    for await (const chunk of stream) {
+        const delta = chunk.choices[0]?.delta?.content;
+        if (delta) {
+            text += delta;
+        }
     }
+
     if (text === '') {
         console.warn('[deepseek] Provider returned empty string');
     }

--- a/src/entities/llm-provider/api/router.ts
+++ b/src/entities/llm-provider/api/router.ts
@@ -1,6 +1,7 @@
 import { callAnthropicChat } from './anthropic';
 import { callGeminiChat } from './gemini';
 import { callOpenaiChat } from './openai';
+import { callDeepseekChat } from './deepseek';
 import type {
     ActiveModelId,
     CallAiProviderOptions,
@@ -53,6 +54,8 @@ export async function callAiProviderRouter(
             return callOpenaiChat(apiOptions);
         case 'google':
             return callGeminiChat(apiOptions);
+        case 'deepseek':
+            return callDeepseekChat(apiOptions);
         default: {
             const exhausted: never = provider;
             throw new Error(`Unhandled AI provider: ${String(exhausted)}`);

--- a/src/entities/llm-provider/index.ts
+++ b/src/entities/llm-provider/index.ts
@@ -3,6 +3,7 @@
 export { callAnthropicChat } from './api/anthropic';
 export { callGeminiChat } from './api/gemini';
 export { callOpenaiChat } from './api/openai';
+export { callDeepseekChat } from './api/deepseek';
 export { callAiProviderRouter } from './api/router';
 export { getLlmProvider } from './api/getLlmProvider';
 export {
@@ -14,6 +15,7 @@ export type { ProviderTurn } from './lib/utils';
 export {
     CLAUDE_MODEL_PRIORITY,
     CHATGPT_MODEL_PRIORITY,
+    DEEPSEEK_MODEL_PRIORITY,
     FALLBACK_MODEL_ID,
     GEMINI_MODEL_PRIORITY,
     resolveDefaultModelForProvider,

--- a/src/entities/llm-provider/lib/providerDefaults.ts
+++ b/src/entities/llm-provider/lib/providerDefaults.ts
@@ -26,10 +26,16 @@ export const CHATGPT_MODEL_PRIORITY: readonly ModelId[] = [
     'gpt-5-mini',
 ];
 
+export const DEEPSEEK_MODEL_PRIORITY: readonly ModelId[] = [
+    'deepseek-v4-flash',
+    'deepseek-v4-pro',
+];
+
 const PROVIDER_PRIORITY_MAP: Record<AIProvider, readonly ModelId[]> = {
     claude: CLAUDE_MODEL_PRIORITY,
     gemini: GEMINI_MODEL_PRIORITY,
     chatgpt: CHATGPT_MODEL_PRIORITY,
+    deepseek: DEEPSEEK_MODEL_PRIORITY,
 };
 
 export function resolveDefaultModelForProvider(

--- a/src/features/api-key-management/__tests__/ApiKeySection.test.tsx
+++ b/src/features/api-key-management/__tests__/ApiKeySection.test.tsx
@@ -38,23 +38,24 @@ describe('ApiKeySection', () => {
         ).toBeInTheDocument();
     });
 
-    it('renders all three provider cards', () => {
+    it('renders all four provider cards', () => {
         render(<ApiKeySection registeredProviders={[]} />);
         expect(screen.getByText('Claude (Anthropic)')).toBeInTheDocument();
         expect(screen.getByText('Gemini (Google)')).toBeInTheDocument();
         expect(screen.getByText('ChatGPT (OpenAI)')).toBeInTheDocument();
+        expect(screen.getByText('DeepSeek')).toBeInTheDocument();
     });
 
     it('shows "미등록" badge for unregistered providers', () => {
         render(<ApiKeySection registeredProviders={[]} />);
         const badges = screen.getAllByText('미등록');
-        expect(badges).toHaveLength(3);
+        expect(badges).toHaveLength(4);
     });
 
     it('shows "등록됨" badge for registered providers', () => {
         render(<ApiKeySection registeredProviders={['anthropic']} />);
         expect(screen.getByText('등록됨')).toBeInTheDocument();
-        expect(screen.getAllByText('미등록')).toHaveLength(2);
+        expect(screen.getAllByText('미등록')).toHaveLength(3);
     });
 
     it('shows save input for unregistered providers', () => {
@@ -77,7 +78,12 @@ describe('ApiKeySection', () => {
         const user = userEvent.setup();
         render(
             <ApiKeySection
-                registeredProviders={['anthropic', 'google', 'openai']}
+                registeredProviders={[
+                    'anthropic',
+                    'google',
+                    'openai',
+                    'deepseek',
+                ]}
             />
         );
 

--- a/src/features/api-key-management/ui/ApiKeySection.tsx
+++ b/src/features/api-key-management/ui/ApiKeySection.tsx
@@ -13,6 +13,7 @@ const PROVIDER_PLACEHOLDERS: Record<LlmProvider, string> = {
     anthropic: 'sk-ant-...',
     google: 'AIza...',
     openai: 'sk-...',
+    deepseek: 'sk-...',
 };
 
 interface StatusMessageProps {

--- a/src/features/symbol-model/__tests__/lib/migrateAnalysisModel.test.tsx
+++ b/src/features/symbol-model/__tests__/lib/migrateAnalysisModel.test.tsx
@@ -1,0 +1,118 @@
+import { migrateLegacyAnalysisModel } from '@/features/symbol-model/lib/migrateAnalysisModel';
+import {
+    LOCAL_STORAGE_ANALYSIS_MODEL_KEY,
+    LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY,
+} from '@/shared/lib/storageKeys';
+
+const OLD_DEFAULT = 'gemini-2.5-flash-lite';
+const NEW_DEFAULT = 'deepseek-v4-flash';
+
+function readStored(): string | null {
+    return localStorage.getItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY);
+}
+
+function isFlagSet(): boolean {
+    return (
+        localStorage.getItem(LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY) !==
+        null
+    );
+}
+
+describe('migrateLegacyAnalysisModel', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('migrates the old default (gemini-2.5-flash-lite) to the new default and sets the flag', () => {
+        localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY, OLD_DEFAULT);
+
+        migrateLegacyAnalysisModel();
+
+        expect(readStored()).toBe(NEW_DEFAULT);
+        expect(isFlagSet()).toBe(true);
+    });
+
+    it('leaves a deliberate post-flip flash-lite choice untouched when the flag is already set', () => {
+        // User deliberately picked flash-lite AFTER the flip → flag already set.
+        localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY, '1');
+        localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY, OLD_DEFAULT);
+
+        migrateLegacyAnalysisModel();
+
+        expect(readStored()).toBe(OLD_DEFAULT);
+    });
+
+    it('leaves the new default (deepseek-v4-flash) unchanged and sets the flag', () => {
+        localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY, NEW_DEFAULT);
+
+        migrateLegacyAnalysisModel();
+
+        expect(readStored()).toBe(NEW_DEFAULT);
+        expect(isFlagSet()).toBe(true);
+    });
+
+    it('leaves an unrelated stored model (gpt-5-mini) unchanged and sets the flag', () => {
+        localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY, 'gpt-5-mini');
+
+        migrateLegacyAnalysisModel();
+
+        expect(readStored()).toBe('gpt-5-mini');
+        expect(isFlagSet()).toBe(true);
+    });
+
+    it('does NOT migrate gemini-2.5-flash (the old CHAT default, not the analysis default)', () => {
+        localStorage.setItem(
+            LOCAL_STORAGE_ANALYSIS_MODEL_KEY,
+            'gemini-2.5-flash'
+        );
+
+        migrateLegacyAnalysisModel();
+
+        expect(readStored()).toBe('gemini-2.5-flash');
+        expect(isFlagSet()).toBe(true);
+    });
+
+    it('does not error when there is no stored value and still sets the flag', () => {
+        expect(readStored()).toBeNull();
+
+        expect(() => migrateLegacyAnalysisModel()).not.toThrow();
+
+        expect(readStored()).toBeNull();
+        expect(isFlagSet()).toBe(true);
+    });
+
+    it('is idempotent — a second call is a no-op', () => {
+        localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY, OLD_DEFAULT);
+
+        migrateLegacyAnalysisModel();
+        expect(readStored()).toBe(NEW_DEFAULT);
+
+        // Simulate the user deliberately switching back to flash-lite after the
+        // migration already ran — the second call must NOT re-migrate it.
+        localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY, OLD_DEFAULT);
+        migrateLegacyAnalysisModel();
+
+        expect(readStored()).toBe(OLD_DEFAULT);
+    });
+
+    it('no-ops under SSR (window undefined) without touching localStorage', () => {
+        // The function accesses `localStorage` directly (a global), so if the SSR
+        // guard did NOT return early these spies would fire. Assert they never do —
+        // proving the `typeof window === 'undefined'` branch short-circuits before
+        // any storage access.
+        const getItemSpy = vi.spyOn(Storage.prototype, 'getItem');
+        const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+
+        vi.stubGlobal('window', undefined);
+
+        expect(() => migrateLegacyAnalysisModel()).not.toThrow();
+
+        expect(getItemSpy).not.toHaveBeenCalled();
+        expect(setItemSpy).not.toHaveBeenCalled();
+    });
+});

--- a/src/features/symbol-model/__tests__/lib/migrateChatModel.test.tsx
+++ b/src/features/symbol-model/__tests__/lib/migrateChatModel.test.tsx
@@ -1,24 +1,23 @@
-import { migrateLegacyAnalysisModel } from '@/features/symbol-model/lib/migrateAnalysisModel';
+import { migrateLegacyChatModel } from '@/features/symbol-model/lib/migrateChatModel';
 import {
-    LOCAL_STORAGE_ANALYSIS_MODEL_KEY,
-    LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY,
+    LOCAL_STORAGE_CHAT_MODEL_KEY,
+    LOCAL_STORAGE_CHAT_MODEL_MIGRATION_KEY,
 } from '@/shared/lib/storageKeys';
 
-const OLD_DEFAULT = 'gemini-2.5-flash-lite';
+const OLD_DEFAULT = 'gemini-2.5-flash';
 const NEW_DEFAULT = 'deepseek-v4-flash';
 
 function readStored(): string | null {
-    return localStorage.getItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY);
+    return localStorage.getItem(LOCAL_STORAGE_CHAT_MODEL_KEY);
 }
 
 function isFlagSet(): boolean {
     return (
-        localStorage.getItem(LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY) !==
-        null
+        localStorage.getItem(LOCAL_STORAGE_CHAT_MODEL_MIGRATION_KEY) !== null
     );
 }
 
-describe('migrateLegacyAnalysisModel', () => {
+describe('migrateLegacyChatModel', () => {
     beforeEach(() => {
         localStorage.clear();
     });
@@ -28,74 +27,74 @@ describe('migrateLegacyAnalysisModel', () => {
         vi.restoreAllMocks();
     });
 
-    it('migrates the old default (gemini-2.5-flash-lite) to the new default and sets the flag', () => {
-        localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY, OLD_DEFAULT);
+    it('migrates the old CHAT default (gemini-2.5-flash) to the new default and sets the flag', () => {
+        localStorage.setItem(LOCAL_STORAGE_CHAT_MODEL_KEY, OLD_DEFAULT);
 
-        migrateLegacyAnalysisModel();
+        migrateLegacyChatModel();
 
         expect(readStored()).toBe(NEW_DEFAULT);
         expect(isFlagSet()).toBe(true);
     });
 
-    it('leaves a deliberate post-flip flash-lite choice untouched when the flag is already set', () => {
-        // User deliberately picked flash-lite AFTER the flip → flag already set.
-        localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY, '1');
-        localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY, OLD_DEFAULT);
+    it('leaves a deliberate post-flip gemini-2.5-flash choice untouched when the flag is already set', () => {
+        // User deliberately picked gemini-2.5-flash AFTER the flip → flag already set.
+        localStorage.setItem(LOCAL_STORAGE_CHAT_MODEL_MIGRATION_KEY, '1');
+        localStorage.setItem(LOCAL_STORAGE_CHAT_MODEL_KEY, OLD_DEFAULT);
 
-        migrateLegacyAnalysisModel();
+        migrateLegacyChatModel();
 
         expect(readStored()).toBe(OLD_DEFAULT);
     });
 
     it('leaves the new default (deepseek-v4-flash) unchanged and sets the flag', () => {
-        localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY, NEW_DEFAULT);
+        localStorage.setItem(LOCAL_STORAGE_CHAT_MODEL_KEY, NEW_DEFAULT);
 
-        migrateLegacyAnalysisModel();
+        migrateLegacyChatModel();
 
         expect(readStored()).toBe(NEW_DEFAULT);
         expect(isFlagSet()).toBe(true);
     });
 
     it('leaves an unrelated stored model (gpt-5-mini) unchanged and sets the flag', () => {
-        localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY, 'gpt-5-mini');
+        localStorage.setItem(LOCAL_STORAGE_CHAT_MODEL_KEY, 'gpt-5-mini');
 
-        migrateLegacyAnalysisModel();
+        migrateLegacyChatModel();
 
         expect(readStored()).toBe('gpt-5-mini');
         expect(isFlagSet()).toBe(true);
     });
 
-    it('does NOT migrate gemini-2.5-flash (the old CHAT default, not the analysis default)', () => {
+    it('does NOT migrate gemini-2.5-flash-lite (the old ANALYSIS default, not the chat default)', () => {
         localStorage.setItem(
-            LOCAL_STORAGE_ANALYSIS_MODEL_KEY,
-            'gemini-2.5-flash'
+            LOCAL_STORAGE_CHAT_MODEL_KEY,
+            'gemini-2.5-flash-lite'
         );
 
-        migrateLegacyAnalysisModel();
+        migrateLegacyChatModel();
 
-        expect(readStored()).toBe('gemini-2.5-flash');
+        expect(readStored()).toBe('gemini-2.5-flash-lite');
         expect(isFlagSet()).toBe(true);
     });
 
     it('does not error when there is no stored value and still sets the flag', () => {
         expect(readStored()).toBeNull();
 
-        expect(() => migrateLegacyAnalysisModel()).not.toThrow();
+        expect(() => migrateLegacyChatModel()).not.toThrow();
 
         expect(readStored()).toBeNull();
         expect(isFlagSet()).toBe(true);
     });
 
     it('is idempotent — a second call is a no-op', () => {
-        localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY, OLD_DEFAULT);
+        localStorage.setItem(LOCAL_STORAGE_CHAT_MODEL_KEY, OLD_DEFAULT);
 
-        migrateLegacyAnalysisModel();
+        migrateLegacyChatModel();
         expect(readStored()).toBe(NEW_DEFAULT);
 
-        // Simulate the user deliberately switching back to flash-lite after the
-        // migration already ran — the second call must NOT re-migrate it.
-        localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY, OLD_DEFAULT);
-        migrateLegacyAnalysisModel();
+        // Simulate the user deliberately switching back to gemini-2.5-flash after
+        // the migration already ran — the second call must NOT re-migrate it.
+        localStorage.setItem(LOCAL_STORAGE_CHAT_MODEL_KEY, OLD_DEFAULT);
+        migrateLegacyChatModel();
 
         expect(readStored()).toBe(OLD_DEFAULT);
     });
@@ -110,7 +109,7 @@ describe('migrateLegacyAnalysisModel', () => {
 
         vi.stubGlobal('window', undefined);
 
-        expect(() => migrateLegacyAnalysisModel()).not.toThrow();
+        expect(() => migrateLegacyChatModel()).not.toThrow();
 
         expect(getItemSpy).not.toHaveBeenCalled();
         expect(setItemSpy).not.toHaveBeenCalled();
@@ -122,7 +121,7 @@ describe('migrateLegacyAnalysisModel', () => {
         });
         const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
 
-        expect(() => migrateLegacyAnalysisModel()).not.toThrow();
+        expect(() => migrateLegacyChatModel()).not.toThrow();
         expect(setItemSpy).not.toHaveBeenCalled();
     });
 });

--- a/src/features/symbol-model/__tests__/useSelectedModel.test.tsx
+++ b/src/features/symbol-model/__tests__/useSelectedModel.test.tsx
@@ -1,13 +1,19 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import type { ModelId } from '@y0ngha/siglens-core';
 import { useSelectedModel } from '@/features/symbol-model/hooks/useSelectedModel';
-import { LOCAL_STORAGE_ANALYSIS_MODEL_KEY } from '@/shared/lib/storageKeys';
+import {
+    LOCAL_STORAGE_ANALYSIS_MODEL_KEY,
+    LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY,
+} from '@/shared/lib/storageKeys';
 
+// useSelectedModel transitively imports migrateLegacyAnalysisModel, which reads
+// both the new and legacy defaults from core — the mock must export both.
 vi.mock('@y0ngha/siglens-core', () => ({
+    DEEPSEEK_V4_FLASH_MODEL: 'deepseek-v4-flash',
     GEMINI_2_5_FLASH_LITE_MODEL: 'gemini-2.5-flash-lite',
 }));
 
-const DEFAULT_MODEL = 'gemini-2.5-flash-lite' as ModelId;
+const DEFAULT_MODEL = 'deepseek-v4-flash' as ModelId;
 const PREMIUM_MODEL = 'gemini-2.5-pro' as ModelId;
 
 describe('useSelectedModel', () => {
@@ -101,5 +107,34 @@ describe('useSelectedModel', () => {
         await waitFor(() => {
             expect(result.current[2]).toBe(true);
         });
+    });
+
+    it('migrates a legacy-default (gemini-2.5-flash-lite) stored value to the new default on mount', async () => {
+        // Legacy user: old analysis default stored, migration flag not yet set.
+        localStorage.setItem(
+            LOCAL_STORAGE_ANALYSIS_MODEL_KEY,
+            'gemini-2.5-flash-lite'
+        );
+        expect(
+            localStorage.getItem(LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY)
+        ).toBeNull();
+
+        const { result } = renderHook(() =>
+            useSelectedModel([DEFAULT_MODEL, PREMIUM_MODEL])
+        );
+
+        await waitFor(() => {
+            expect(result.current[2]).toBe(true);
+        });
+
+        // The mount-time migration rewrote the stored value, so the hook resolves
+        // to the new DeepSeek default and the migration flag is now set.
+        expect(result.current[0]).toBe(DEFAULT_MODEL);
+        expect(localStorage.getItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY)).toBe(
+            DEFAULT_MODEL
+        );
+        expect(
+            localStorage.getItem(LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY)
+        ).not.toBeNull();
     });
 });

--- a/src/features/symbol-model/__tests__/useSelectedModelBranches.test.tsx
+++ b/src/features/symbol-model/__tests__/useSelectedModelBranches.test.tsx
@@ -22,7 +22,12 @@ describe('useSelectedModel — branch coverage', () => {
             'gemini-2.5-flash'
         );
 
+        // Includes DEEPSEEK_V4_FLASH_MODEL (the real DEFAULT_MODEL) so the mount-time
+        // re-validate effect (L52-61) doesn't race the hydration effect and clobber it —
+        // matches production, where tier restrictions are disabled and every model
+        // (including the default) is always in allowedModels.
         const allowedModels: ModelId[] = [
+            'deepseek-v4-flash',
             'gemini-2.5-flash-lite',
             'gemini-2.5-flash',
         ];
@@ -39,6 +44,7 @@ describe('useSelectedModel — branch coverage', () => {
         localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY, 'unknown-model');
 
         const allowedModels: ModelId[] = [
+            'deepseek-v4-flash',
             'gemini-2.5-flash-lite',
             'gemini-2.5-flash',
         ];
@@ -46,7 +52,7 @@ describe('useSelectedModel — branch coverage', () => {
 
         await act(async () => {});
 
-        expect(result.current[0]).toBe('gemini-2.5-flash-lite');
+        expect(result.current[0]).toBe('deepseek-v4-flash');
     });
 
     it('setSelectedModel persists to localStorage', () => {
@@ -95,7 +101,8 @@ describe('useSelectedModel — branch coverage', () => {
             });
         });
 
-        // Should fall back to DEFAULT_MODEL (which is gemini-2.5-flash-lite)
+        // DEFAULT_MODEL (deepseek-v4-flash) is not in the new allowedModels either,
+        // so this falls through to allowedModels[0] (L59), not DEFAULT_MODEL (L57).
         expect(result.current[0]).toBe('gemini-2.5-flash-lite');
     });
 

--- a/src/features/symbol-model/hooks/useSelectedModel.ts
+++ b/src/features/symbol-model/hooks/useSelectedModel.ts
@@ -7,13 +7,11 @@ import {
     useEffectEvent,
     useState,
 } from 'react';
-import {
-    GEMINI_2_5_FLASH_LITE_MODEL,
-    type ModelId,
-} from '@y0ngha/siglens-core';
+import { DEEPSEEK_V4_FLASH_MODEL, type ModelId } from '@y0ngha/siglens-core';
 import { LOCAL_STORAGE_ANALYSIS_MODEL_KEY } from '@/shared/lib/storageKeys';
+import { migrateLegacyAnalysisModel } from '../lib/migrateAnalysisModel';
 
-const DEFAULT_MODEL: ModelId = GEMINI_2_5_FLASH_LITE_MODEL;
+const DEFAULT_MODEL: ModelId = DEEPSEEK_V4_FLASH_MODEL;
 
 export function useSelectedModel(
     allowedModels: readonly ModelId[]
@@ -31,6 +29,9 @@ export function useSelectedModel(
 
     const readFromStorage = useEffectEvent((): void => {
         if (typeof window === 'undefined') return;
+        // Run the one-time legacy-default migration BEFORE reading, so the read
+        // below picks up the migrated value for users still on gemini-2.5-flash-lite.
+        migrateLegacyAnalysisModel();
         const stored = localStorage.getItem(
             LOCAL_STORAGE_ANALYSIS_MODEL_KEY
         ) as ModelId | null;

--- a/src/features/symbol-model/lib/migrateAnalysisModel.ts
+++ b/src/features/symbol-model/lib/migrateAnalysisModel.ts
@@ -26,27 +26,35 @@ import {
  * Idempotent and SSR-safe: no-ops when `window` is undefined and returns early
  * once the flag is present. Only the exact legacy-default value is rewritten —
  * any other stored model (gpt, claude, gemini-2.5-flash, etc.) is left intact.
+ *
+ * Wrapped in try/catch: some browsers (incognito / storage-blocked) throw a
+ * `SecurityError` on `localStorage` access. A failed migration must never crash
+ * the app at mount, so any storage error is swallowed and treated as a no-op.
  */
 export function migrateLegacyAnalysisModel(): void {
     if (typeof window === 'undefined') return;
 
-    // Already migrated in this browser — never touch the stored model again.
-    if (
-        localStorage.getItem(LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY) !==
-        null
-    ) {
-        return;
-    }
+    try {
+        // Already migrated in this browser — never touch the stored model again.
+        if (
+            localStorage.getItem(LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY) !==
+            null
+        ) {
+            return;
+        }
 
-    const stored = localStorage.getItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY);
-    if (stored === GEMINI_2_5_FLASH_LITE_MODEL) {
-        localStorage.setItem(
-            LOCAL_STORAGE_ANALYSIS_MODEL_KEY,
-            DEEPSEEK_V4_FLASH_MODEL
-        );
-    }
+        const stored = localStorage.getItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY);
+        if (stored === GEMINI_2_5_FLASH_LITE_MODEL) {
+            localStorage.setItem(
+                LOCAL_STORAGE_ANALYSIS_MODEL_KEY,
+                DEEPSEEK_V4_FLASH_MODEL
+            );
+        }
 
-    // Always set the flag — even when there was nothing to migrate — so the
-    // migration runs exactly once and later flash-lite choices stay untouched.
-    localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY, '1');
+        // Always set the flag — even when there was nothing to migrate — so the
+        // migration runs exactly once and later flash-lite choices stay untouched.
+        localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY, '1');
+    } catch {
+        // SecurityError (incognito / storage-blocked) — no-op, never crash at mount.
+    }
 }

--- a/src/features/symbol-model/lib/migrateAnalysisModel.ts
+++ b/src/features/symbol-model/lib/migrateAnalysisModel.ts
@@ -1,0 +1,52 @@
+import {
+    DEEPSEEK_V4_FLASH_MODEL,
+    GEMINI_2_5_FLASH_LITE_MODEL,
+} from '@y0ngha/siglens-core';
+import {
+    LOCAL_STORAGE_ANALYSIS_MODEL_KEY,
+    LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY,
+} from '@/shared/lib/storageKeys';
+
+/**
+ * One-time migration of the persisted analysis model from the legacy default
+ * (`gemini-2.5-flash-lite`) to the current default (`deepseek-v4-flash`).
+ *
+ * WHY a one-time flag distinguishes the two user groups:
+ *   Before the DeepSeek default flip, the analysis model default was
+ *   `gemini-2.5-flash-lite`, so any user who never touched the model selector
+ *   has that exact value stored. After the flip, `deepseek-v4-flash` is the
+ *   default. We want to move the first group forward WITHOUT touching users who
+ *   *deliberately* pick `gemini-2.5-flash-lite` after the flip.
+ *
+ *   The migration runs exactly once per browser (guarded by the migration flag).
+ *   At migration time, a stored `gemini-2.5-flash-lite` can only mean "old
+ *   default" → migrate it. Once the flag is set, the migration never runs again,
+ *   so a later deliberate switch back to flash-lite is preserved forever.
+ *
+ * Idempotent and SSR-safe: no-ops when `window` is undefined and returns early
+ * once the flag is present. Only the exact legacy-default value is rewritten —
+ * any other stored model (gpt, claude, gemini-2.5-flash, etc.) is left intact.
+ */
+export function migrateLegacyAnalysisModel(): void {
+    if (typeof window === 'undefined') return;
+
+    // Already migrated in this browser — never touch the stored model again.
+    if (
+        localStorage.getItem(LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY) !==
+        null
+    ) {
+        return;
+    }
+
+    const stored = localStorage.getItem(LOCAL_STORAGE_ANALYSIS_MODEL_KEY);
+    if (stored === GEMINI_2_5_FLASH_LITE_MODEL) {
+        localStorage.setItem(
+            LOCAL_STORAGE_ANALYSIS_MODEL_KEY,
+            DEEPSEEK_V4_FLASH_MODEL
+        );
+    }
+
+    // Always set the flag — even when there was nothing to migrate — so the
+    // migration runs exactly once and later flash-lite choices stay untouched.
+    localStorage.setItem(LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY, '1');
+}

--- a/src/features/symbol-model/lib/migrateChatModel.ts
+++ b/src/features/symbol-model/lib/migrateChatModel.ts
@@ -1,0 +1,62 @@
+import {
+    DEEPSEEK_V4_FLASH_MODEL,
+    GEMINI_2_5_FLASH_MODEL,
+} from '@y0ngha/siglens-core';
+import {
+    LOCAL_STORAGE_CHAT_MODEL_KEY,
+    LOCAL_STORAGE_CHAT_MODEL_MIGRATION_KEY,
+} from '@/shared/lib/storageKeys';
+
+/**
+ * One-time migration of the persisted CHAT model from the legacy default
+ * (`gemini-2.5-flash`) to the current default (`deepseek-v4-flash`).
+ *
+ * Mirrors `migrateLegacyAnalysisModel` (see that file for the full rationale on
+ * why a one-time flag is required) but for the chat surface: `useChat` defaults
+ * to `DEEPSEEK_V4_FLASH_MODEL` post-flip, but it also auto-persists
+ * `selectedModel` to localStorage even without explicit user interaction. Any
+ * chat user who never touched the model selector therefore has the exact
+ * legacy default stored and needs the same one-time nudge forward.
+ *
+ * The migration runs exactly once per browser (guarded by the migration flag).
+ * At migration time, a stored `gemini-2.5-flash` can only mean "old default" →
+ * migrate it. Once the flag is set, the migration never runs again, so a later
+ * deliberate switch back to `gemini-2.5-flash` is preserved forever.
+ *
+ * Idempotent and SSR-safe: no-ops when `window` is undefined and returns early
+ * once the flag is present. Only the exact legacy-default value is rewritten —
+ * any other stored model (gpt, claude, gemini-2.5-flash-lite, etc.) is left
+ * intact.
+ *
+ * Wrapped in try/catch: some browsers (incognito / storage-blocked) throw a
+ * `SecurityError` on `localStorage` access. A failed migration must never crash
+ * the app at mount, so any storage error is swallowed and treated as a no-op.
+ */
+export function migrateLegacyChatModel(): void {
+    if (typeof window === 'undefined') return;
+
+    try {
+        // Already migrated in this browser — never touch the stored model again.
+        if (
+            localStorage.getItem(LOCAL_STORAGE_CHAT_MODEL_MIGRATION_KEY) !==
+            null
+        ) {
+            return;
+        }
+
+        const stored = localStorage.getItem(LOCAL_STORAGE_CHAT_MODEL_KEY);
+        if (stored === GEMINI_2_5_FLASH_MODEL) {
+            localStorage.setItem(
+                LOCAL_STORAGE_CHAT_MODEL_KEY,
+                DEEPSEEK_V4_FLASH_MODEL
+            );
+        }
+
+        // Always set the flag — even when there was nothing to migrate — so the
+        // migration runs exactly once and later gemini-2.5-flash choices stay
+        // untouched.
+        localStorage.setItem(LOCAL_STORAGE_CHAT_MODEL_MIGRATION_KEY, '1');
+    } catch {
+        // SecurityError (incognito / storage-blocked) — no-op, never crash at mount.
+    }
+}

--- a/src/shared/config/__tests__/llmProviders.test.ts
+++ b/src/shared/config/__tests__/llmProviders.test.ts
@@ -21,14 +21,19 @@ describe('LLM_PROVIDER_VALUES', () => {
         );
     });
 
-    it("'anthropic', 'google', 'openai'를 포함한다", () => {
+    it("'anthropic', 'google', 'openai', 'deepseek'를 포함한다", () => {
         expect([...LLM_PROVIDER_VALUES]).toEqual(
-            expect.arrayContaining(['anthropic', 'google', 'openai'])
+            expect.arrayContaining([
+                'anthropic',
+                'google',
+                'openai',
+                'deepseek',
+            ])
         );
     });
 
-    it('3개 프로바이더가 정의되어 있다', () => {
-        expect(LLM_PROVIDER_VALUES).toHaveLength(3);
+    it('4개 프로바이더가 정의되어 있다', () => {
+        expect(LLM_PROVIDER_VALUES).toHaveLength(4);
     });
 });
 

--- a/src/shared/config/llmProviders.ts
+++ b/src/shared/config/llmProviders.ts
@@ -1,5 +1,10 @@
 /** All supported LLM provider identifiers for stored user API keys. */
-export const LLM_PROVIDER_VALUES = ['anthropic', 'google', 'openai'] as const;
+export const LLM_PROVIDER_VALUES = [
+    'anthropic',
+    'google',
+    'openai',
+    'deepseek',
+] as const;
 
 /** Identifier for an LLM provider whose API key a user can bring (BYOK). */
 export type LlmProvider = (typeof LLM_PROVIDER_VALUES)[number];

--- a/src/shared/lib/__tests__/llmProviderLabels.test.ts
+++ b/src/shared/lib/__tests__/llmProviderLabels.test.ts
@@ -28,6 +28,10 @@ describe('LLM_PROVIDER_LABELS', () => {
         expect(LLM_PROVIDER_LABELS.openai).toContain('ChatGPT');
     });
 
+    it('deepseek label is DeepSeek', () => {
+        expect(LLM_PROVIDER_LABELS.deepseek).toBe('DeepSeek');
+    });
+
     it('each label includes the company name in parentheses', () => {
         expect(LLM_PROVIDER_LABELS.anthropic).toMatch(/\(Anthropic\)/);
         expect(LLM_PROVIDER_LABELS.google).toMatch(/\(Google\)/);

--- a/src/shared/lib/llmProviderLabels.ts
+++ b/src/shared/lib/llmProviderLabels.ts
@@ -4,4 +4,5 @@ export const LLM_PROVIDER_LABELS: Record<LlmProvider, string> = {
     anthropic: 'Claude (Anthropic)',
     google: 'Gemini (Google)',
     openai: 'ChatGPT (OpenAI)',
+    deepseek: 'DeepSeek',
 };

--- a/src/shared/lib/modelDisplay.ts
+++ b/src/shared/lib/modelDisplay.ts
@@ -1,0 +1,47 @@
+import type { ModelId } from '@y0ngha/siglens-core';
+
+/**
+ * Human-readable label + full name for an AI model, shown in model-selector
+ * UI (analysis model dropdown, chat model dropdown). Extracted to `shared`
+ * because `widgets/analysis` (ModelSelector) and `widgets/chat` (ChatPanel)
+ * previously duplicated an identical map — cross-widget imports are allowed by
+ * FSD here, but a shared, presentation-only lookup table belongs in `shared`
+ * rather than being owned by either widget.
+ */
+export interface ModelDisplayInfo {
+    label: string;
+    fullName: string;
+}
+
+export const MODEL_DISPLAY_MAP: Partial<Record<ModelId, ModelDisplayInfo>> = {
+    'gemini-2.5-flash-lite': {
+        label: 'Flash Lite',
+        fullName: 'Gemini 2.5 Flash Lite',
+    },
+    'gemini-2.5-flash': { label: 'Flash', fullName: 'Gemini 2.5 Flash' },
+    'gemini-2.5-pro': { label: 'Pro', fullName: 'Gemini 2.5 Pro' },
+    'gemini-3.1-pro-preview': {
+        label: '3.1 Pro',
+        fullName: 'Gemini 3.1 Pro Preview',
+    },
+    'gemini-3-flash-preview': {
+        label: 'Flash 3',
+        fullName: 'Gemini 3 Flash Preview',
+    },
+    'claude-haiku-4-5': { label: 'Haiku', fullName: 'Claude Haiku 4.5' },
+    'claude-sonnet-4-6': { label: 'Sonnet', fullName: 'Claude Sonnet 4.6' },
+    'claude-opus-4-7': { label: 'Opus', fullName: 'Claude Opus 4.7' },
+    'gpt-5-mini': { label: 'GPT Mini', fullName: 'GPT-5 Mini' },
+    'gpt-5.4': { label: 'GPT 5.4', fullName: 'GPT-5.4' },
+    'gpt-5.5': { label: 'GPT 5.5', fullName: 'GPT-5.5' },
+    'deepseek-v4-flash': {
+        label: 'DeepSeek Flash',
+        fullName: 'DeepSeek V4 Flash',
+    },
+    'deepseek-v4-pro': { label: 'DeepSeek Pro', fullName: 'DeepSeek V4 Pro' },
+};
+
+/** Falls back to the raw model id (for both label and fullName) when unmapped. */
+export function getModelDisplay(id: ModelId): ModelDisplayInfo {
+    return MODEL_DISPLAY_MAP[id] ?? { label: id, fullName: id };
+}

--- a/src/shared/lib/storageKeys.ts
+++ b/src/shared/lib/storageKeys.ts
@@ -1,3 +1,12 @@
 export const LOCAL_STORAGE_PROVIDER_KEY = 'siglens:selected-provider';
 export const LOCAL_STORAGE_ANALYSIS_MODEL_KEY =
     'siglens:selected-analysis-model';
+
+/**
+ * One-time flag marking that the legacy analysis-model migration has run in this
+ * browser. Once set, users who stored the old default (`gemini-2.5-flash-lite`)
+ * were moved to the new DeepSeek default; any later switch back to flash-lite is
+ * a deliberate post-flip choice and must never be migrated again.
+ */
+export const LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY =
+    'siglens_analysis_model_deepseek_migrated';

--- a/src/shared/lib/storageKeys.ts
+++ b/src/shared/lib/storageKeys.ts
@@ -10,3 +10,21 @@ export const LOCAL_STORAGE_ANALYSIS_MODEL_KEY =
  */
 export const LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY =
     'siglens_analysis_model_deepseek_migrated';
+
+/**
+ * Canonical key `useChat` persists the selected CHAT model under. Defined here
+ * (not in `useChat.ts`) so the one-time chat-model migration in
+ * `features/symbol-model/lib/migrateChatModel.ts` and `useChat` share a single
+ * source of truth instead of duplicating the string literal across layers.
+ */
+export const LOCAL_STORAGE_CHAT_MODEL_KEY = 'siglens_chat_model';
+
+/**
+ * One-time flag marking that the legacy chat-model migration has run in this
+ * browser. Mirrors `LOCAL_STORAGE_ANALYSIS_MODEL_MIGRATION_KEY` but for the CHAT
+ * model default, which also flipped (from `gemini-2.5-flash` to the DeepSeek
+ * default). Once set, a later deliberate switch back to `gemini-2.5-flash` is
+ * preserved forever.
+ */
+export const LOCAL_STORAGE_CHAT_MODEL_MIGRATION_KEY =
+    'siglens_chat_model_deepseek_migrated';

--- a/src/widgets/analysis/ModelSelector.tsx
+++ b/src/widgets/analysis/ModelSelector.tsx
@@ -2,45 +2,9 @@
 
 import { usePopoverToggle } from '@/shared/hooks/usePopoverToggle';
 import { cn } from '@/shared/lib/cn';
+import { getModelDisplay } from '@/shared/lib/modelDisplay';
 import { isFreeModel, type ModelId } from '@y0ngha/siglens-core';
 import { useRef } from 'react';
-
-interface ModelDisplay {
-    label: string;
-    fullName: string;
-}
-
-const MODEL_DISPLAY_MAP: Partial<Record<ModelId, ModelDisplay>> = {
-    'gemini-2.5-flash-lite': {
-        label: 'Flash Lite',
-        fullName: 'Gemini 2.5 Flash Lite',
-    },
-    'gemini-2.5-flash': { label: 'Flash', fullName: 'Gemini 2.5 Flash' },
-    'gemini-2.5-pro': { label: 'Pro', fullName: 'Gemini 2.5 Pro' },
-    'gemini-3.1-pro-preview': {
-        label: '3.1 Pro',
-        fullName: 'Gemini 3.1 Pro Preview',
-    },
-    'gemini-3-flash-preview': {
-        label: 'Flash 3',
-        fullName: 'Gemini 3 Flash Preview',
-    },
-    'claude-haiku-4-5': { label: 'Haiku', fullName: 'Claude Haiku 4.5' },
-    'claude-sonnet-4-6': { label: 'Sonnet', fullName: 'Claude Sonnet 4.6' },
-    'claude-opus-4-7': { label: 'Opus', fullName: 'Claude Opus 4.7' },
-    'gpt-5-mini': { label: 'GPT Mini', fullName: 'GPT-5 Mini' },
-    'gpt-5.4': { label: 'GPT 5.4', fullName: 'GPT-5.4' },
-    'gpt-5.5': { label: 'GPT 5.5', fullName: 'GPT-5.5' },
-    'deepseek-v4-flash': {
-        label: 'DeepSeek Flash',
-        fullName: 'DeepSeek V4 Flash',
-    },
-    'deepseek-v4-pro': { label: 'DeepSeek Pro', fullName: 'DeepSeek V4 Pro' },
-};
-
-function getModelDisplay(id: ModelId): ModelDisplay {
-    return MODEL_DISPLAY_MAP[id] ?? { label: id, fullName: id };
-}
 
 interface ModelSelectorProps {
     selectedModel: ModelId;

--- a/src/widgets/analysis/ModelSelector.tsx
+++ b/src/widgets/analysis/ModelSelector.tsx
@@ -31,6 +31,11 @@ const MODEL_DISPLAY_MAP: Partial<Record<ModelId, ModelDisplay>> = {
     'gpt-5-mini': { label: 'GPT Mini', fullName: 'GPT-5 Mini' },
     'gpt-5.4': { label: 'GPT 5.4', fullName: 'GPT-5.4' },
     'gpt-5.5': { label: 'GPT 5.5', fullName: 'GPT-5.5' },
+    'deepseek-v4-flash': {
+        label: 'DeepSeek Flash',
+        fullName: 'DeepSeek V4 Flash',
+    },
+    'deepseek-v4-pro': { label: 'DeepSeek Pro', fullName: 'DeepSeek V4 Pro' },
 };
 
 function getModelDisplay(id: ModelId): ModelDisplay {

--- a/src/widgets/chat/ChatPanel.tsx
+++ b/src/widgets/chat/ChatPanel.tsx
@@ -9,41 +9,8 @@ import { MarkdownText } from '@/shared/ui/MarkdownText';
 import { PremiumModelGateModal } from '@/features/premium-gate';
 import { cn } from '@/shared/lib/cn';
 import { LLM_PROVIDER_LABELS } from '@/shared/lib/llmProviderLabels';
-import { VALID_CHAT_MODELS, type ModelId } from '@y0ngha/siglens-core';
-
-type ChatModelDisplay = Pick<ModelOption, 'label' | 'fullName'>;
-
-const MODEL_DISPLAY_MAP: Partial<Record<ModelId, ChatModelDisplay>> = {
-    'gemini-2.5-flash': { label: 'Flash', fullName: 'Gemini 2.5 Flash' },
-    'gemini-2.5-flash-lite': {
-        label: 'Flash Lite',
-        fullName: 'Gemini 2.5 Flash Lite',
-    },
-    'gemini-2.5-pro': { label: 'Pro', fullName: 'Gemini 2.5 Pro' },
-    'gemini-3.1-pro-preview': {
-        label: '3.1 Pro',
-        fullName: 'Gemini 3.1 Pro Preview',
-    },
-    'gemini-3-flash-preview': {
-        label: 'Flash 3',
-        fullName: 'Gemini 3 Flash Preview',
-    },
-    'claude-haiku-4-5': { label: 'Haiku', fullName: 'Claude Haiku 4.5' },
-    'claude-sonnet-4-6': { label: 'Sonnet', fullName: 'Claude Sonnet 4.6' },
-    'claude-opus-4-7': { label: 'Opus', fullName: 'Claude Opus 4.7' },
-    'gpt-5-mini': { label: 'GPT Mini', fullName: 'GPT-5 Mini' },
-    'gpt-5.4': { label: 'GPT 5.4', fullName: 'GPT-5.4' },
-    'gpt-5.5': { label: 'GPT 5.5', fullName: 'GPT-5.5' },
-    'deepseek-v4-flash': {
-        label: 'DeepSeek Flash',
-        fullName: 'DeepSeek V4 Flash',
-    },
-    'deepseek-v4-pro': { label: 'DeepSeek Pro', fullName: 'DeepSeek V4 Pro' },
-};
-
-function getModelDisplay(id: ModelId): ChatModelDisplay {
-    return MODEL_DISPLAY_MAP[id] ?? { label: id, fullName: id };
-}
+import { getModelDisplay } from '@/shared/lib/modelDisplay';
+import { VALID_CHAT_MODELS } from '@y0ngha/siglens-core';
 
 const CHAT_MODEL_OPTIONS: readonly ModelOption[] = VALID_CHAT_MODELS.map(
     id => ({ id, ...getModelDisplay(id) })

--- a/src/widgets/chat/ChatPanel.tsx
+++ b/src/widgets/chat/ChatPanel.tsx
@@ -34,6 +34,11 @@ const MODEL_DISPLAY_MAP: Partial<Record<ModelId, ChatModelDisplay>> = {
     'gpt-5-mini': { label: 'GPT Mini', fullName: 'GPT-5 Mini' },
     'gpt-5.4': { label: 'GPT 5.4', fullName: 'GPT-5.4' },
     'gpt-5.5': { label: 'GPT 5.5', fullName: 'GPT-5.5' },
+    'deepseek-v4-flash': {
+        label: 'DeepSeek Flash',
+        fullName: 'DeepSeek V4 Flash',
+    },
+    'deepseek-v4-pro': { label: 'DeepSeek Pro', fullName: 'DeepSeek V4 Pro' },
 };
 
 function getModelDisplay(id: ModelId): ChatModelDisplay {

--- a/src/widgets/chat/UserApiKeyRequiredModal.tsx
+++ b/src/widgets/chat/UserApiKeyRequiredModal.tsx
@@ -10,6 +10,7 @@ const PROVIDER_DISPLAY: Record<LlmProvider, string> = {
     anthropic: 'Anthropic',
     google: 'Google',
     openai: 'OpenAI',
+    deepseek: 'DeepSeek',
 };
 
 interface UserApiKeyRequiredModalProps {

--- a/src/widgets/chat/__tests__/hooks/useChat.test.tsx
+++ b/src/widgets/chat/__tests__/hooks/useChat.test.tsx
@@ -86,8 +86,13 @@ describe('useChat — model persistence', () => {
     });
 
     it('does not overwrite stored model with the default on initial mount', async () => {
-        // Pre-existing stored model from a previous session.
-        localStorage.setItem(MODEL_STORAGE_KEY, 'gemini-2.5-flash');
+        // Pre-existing stored model from a previous session. Deliberately NOT the
+        // legacy chat default (`gemini-2.5-flash`) — that exact value now triggers
+        // the one-time migration (see the dedicated migration test below), which
+        // legitimately writes to MODEL_STORAGE_KEY at mount. This test asserts the
+        // unrelated original regression: an arbitrary already-stored selection
+        // must never be silently overwritten on mount.
+        localStorage.setItem(MODEL_STORAGE_KEY, 'claude-sonnet-4-6');
         const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
 
         await act(async () => {
@@ -104,6 +109,24 @@ describe('useChat — model persistence', () => {
         );
         expect(modelWrites).toHaveLength(0);
         setItemSpy.mockRestore();
+    });
+
+    it('migrates a legacy gemini-2.5-flash stored chat model to deepseek-v4-flash after mount', async () => {
+        // Simulates a pre-DeepSeek-flip user who never touched the model selector:
+        // `useChat` used to auto-persist the old chat default, so this exact value
+        // is indistinguishable from "never chosen" and must be migrated forward.
+        localStorage.setItem(MODEL_STORAGE_KEY, 'gemini-2.5-flash');
+
+        const { result } = await act(async () => {
+            return renderHook(() => useChat({ symbol: 'AAPL' }), {
+                wrapper: makeWrapper(),
+            });
+        });
+
+        expect(result.current.selectedModel).toBe('deepseek-v4-flash');
+        expect(localStorage.getItem(MODEL_STORAGE_KEY)).toBe(
+            'deepseek-v4-flash'
+        );
     });
 
     it('persists model changes after open→close→open (B4 regression)', async () => {

--- a/src/widgets/chat/hooks/useChat.ts
+++ b/src/widgets/chat/hooks/useChat.ts
@@ -8,7 +8,7 @@ import {
 } from '../utils/chatStorage';
 import { isChatMessage } from '../utils/chatMessageUtils';
 import {
-    GEMINI_2_5_FLASH_MODEL,
+    DEEPSEEK_V4_FLASH_MODEL,
     VALID_CHAT_MODELS,
     getProviderForModel,
     type AnalysisResponse,
@@ -106,7 +106,7 @@ export function useChat({ symbol }: UseChatOptions): UseChatReturn {
     );
     const [analysisUpdated, setAnalysisUpdated] = useState(false);
     const [selectedModel, setSelectedModel] = useState<ModelId>(
-        GEMINI_2_5_FLASH_MODEL
+        DEEPSEEK_V4_FLASH_MODEL
     );
     const [isModelHydrated, setIsModelHydrated] = useState(false);
 

--- a/src/widgets/chat/hooks/useChat.ts
+++ b/src/widgets/chat/hooks/useChat.ts
@@ -32,6 +32,8 @@ import { useAssetInfo } from '@/entities/ticker/hooks/useAssetInfo';
 import { getDescriptor, marketProfileOf } from '@/shared/config/marketProfile';
 import { useModelGate, type ModelGateState } from '@/features/premium-gate';
 import { useHydrated } from '@/shared/hooks/useHydrated';
+import { migrateLegacyChatModel } from '@/features/symbol-model/lib/migrateChatModel';
+import { LOCAL_STORAGE_CHAT_MODEL_KEY } from '@/shared/lib/storageKeys';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
     startTransition,
@@ -46,7 +48,11 @@ import {
 
 // 분석 중 단계의 최소 표시 시간 (UX: 즉시 사라지면 깜빡이는 것처럼 보임)
 const ANALYZING_PHASE_MIN_DURATION_MS = 1500;
-export const MODEL_STORAGE_KEY = 'siglens_chat_model';
+// Re-exported for backward compatibility with existing test imports — the
+// canonical value now lives in `@/shared/lib/storageKeys` so the one-time chat
+// model migration (`migrateLegacyChatModel`) and this hook share a single
+// source of truth instead of duplicating the string literal.
+export const MODEL_STORAGE_KEY = LOCAL_STORAGE_CHAT_MODEL_KEY;
 
 // Matches the siglens-core chat token limit; update only when the core policy changes.
 const DAILY_CHAT_LIMIT = 5;
@@ -309,6 +315,10 @@ export function useChat({ symbol }: UseChatOptions): UseChatReturn {
     // 무의미한 setItem을 막기 위해 lastWrittenModelRef를 stored 값으로 초기화한다.
     // 다음 사용자 변경 시점부터 정상적으로 setItem이 호출된다.
     useEffect(() => {
+        // Runs the one-time legacy-default migration BEFORE the read below, so a
+        // browser still holding the old chat default (`gemini-2.5-flash`) has
+        // already been rewritten to `deepseek-v4-flash` by the time we hydrate.
+        migrateLegacyChatModel();
         try {
             const stored = localStorage.getItem(MODEL_STORAGE_KEY);
             // VALID_CHAT_MODELS comes from siglens-core and is the runtime source of truth.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4396,14 +4396,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@y0ngha/siglens-core@npm:0.32.1":
-  version: 0.32.1
-  resolution: "@y0ngha/siglens-core@npm:0.32.1::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.32.1%2Ffc3f1af394184c0d06fc259b541d274d9192ed37"
+"@y0ngha/siglens-core@npm:0.33.0":
+  version: 0.33.0
+  resolution: "@y0ngha/siglens-core@npm:0.33.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.33.0%2Fb388435e0cff4257a3a08581e10ae2a359802081"
   dependencies:
     jsonrepair: "npm:^3.14.0"
   peerDependencies:
     "@upstash/redis": ^1.37.0
-  checksum: 10c0/c1622803b830e3d84900542e0bdc27506e5955b37a1b993380397f33b456d16a7502a4b7f63e4d906d74b8a499528ed8f4d3a7f1c4ca94ca9dd37d13f1fd958b
+  checksum: 10c0/f0d1c4a498c4b4e05496c69546dea1a3da3560f86fe3594b9651b0b954d40354a7db374d3f6193cac6a88ce10ccb9a171ba852e57e15f23d63f9c250d2a11ab7
   languageName: node
   linkType: hard
 
@@ -11888,7 +11888,7 @@ __metadata:
     "@typescript/native-preview": "npm:7.0.0-dev.20260704.1"
     "@upstash/redis": "npm:^1.37.0"
     "@vitest/coverage-v8": "npm:^4.1.9"
-    "@y0ngha/siglens-core": "npm:0.32.1"
+    "@y0ngha/siglens-core": "npm:0.33.0"
     babel-plugin-react-compiler: "npm:^1.0.0"
     bcryptjs: "npm:^3.0.3"
     clsx: "npm:^2.1.1"


### PR DESCRIPTION
Adds DeepSeek V4 as a new AI provider alongside gemini/openai/claude.

- Models: `deepseek-v4-flash` (non-thinking, NEW DEFAULT for chat / market+economy briefing) and `deepseek-v4-pro` (thinking). Both free-tier.
- DeepSeek is OpenAI-compatible: called via **streaming** `chat.completions` at `https://api.deepseek.com` with a non-standard `thinking` toggle. Streaming is required — DeepSeek terminates long non-streaming connections at ~50-60s; the real chat workload hit this, so the app chat adapter streams and aggregates.
- Chat path returns natural text.
- DB migration adds `deepseek` to the `llm_provider` enum; UI shows DeepSeek options; a one-time localStorage migration moves users on the old default (`gemini-2.5-flash-lite`) to `deepseek-v4-flash` without touching deliberate post-flip choices.

Verified: 5-dimension audit (code / deploy-stability / deploy-readiness / SEO / test-coverage ≥90%) clean; live end-to-end 실증 — real AAPL analysis completes via DeepSeek, chatbot returns natural text, localStorage migration and SEO validated via curl + Chrome.

⚠️ **Depends on siglens-core release**: This PR's CI may show red until siglens-core v* is published to npm.pkg.github.com. Post-merge sequence: publish siglens-core → bump `@y0ngha/siglens-core` version pin in package.json → run DB migration 0024 → deploy.

Deploy runbook (post-merge): set DEEPSEEK_CHAT_API_KEY in all deploy envs → deploy. DeepSeek account must be funded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)