### PR TITLE
feat: 회원 추론(깊은 생각) 토글 + 비회원 3회 분석 가입 유도 모달

### DIFF
--- a/e2e/specs/symbol-seo.spec.ts
+++ b/e2e/specs/symbol-seo.spec.ts
@@ -101,8 +101,24 @@ test.describe('symbol SEO + ISR (crawler-facing)', () => {
         expect(response.status()).toBe(200);
 
         const html = await response.text();
+        const normalizedHtml = normalizeReactSsrText(html);
         expect(html).toContain('종합 분석 데이터 상태');
-        expect(html).toContain('최근 뉴스 데이터는 아직 준비되지 않았습니다.');
+        // OverallFactualFallback renders one of two factual news paragraphs
+        // depending on whether AAPL already has ingested news rows at render
+        // time. That state is suite-ordering dependent: a prior browser spec
+        // that mounts OverallContent/news widgets fires useNewsAnalysisTrigger →
+        // ensureNewsCardsAnalyzedAction, which upserts the deterministic
+        // FakeNewsClient fixtures (2 AAPL rows) and revalidateTag('news:AAPL').
+        // Once that has happened, getNewsList('AAPL') returns 2 and the fallback
+        // shows the "N건 확인" variant instead of the "아직 준비되지 않았습니다"
+        // variant — both are equally valid crawlable SSR facts. Accept either,
+        // mirroring the sibling /AAPL/news assertion above, so this probe stays
+        // robust to news-ingestion ordering. (Comments are stripped first because
+        // the count variant interpolates digits, which React SSR splits with
+        // comment nodes.)
+        expect(normalizedHtml).toMatch(
+            /최근 뉴스 데이터는 아직 준비되지 않았습니다|현재 서버가 확인한 최근 뉴스는 \d+건/
+        );
     });
 
     test('/AAPL SSR HTML has exactly one h1 (no cloaking / no duplicate headings)', async ({

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "@neondatabase/serverless": "^1.1.0",
         "@tanstack/react-query": "^5.95.2",
         "@upstash/redis": "^1.37.0",
-        "@y0ngha/siglens-core": "0.33.0",
+        "@y0ngha/siglens-core": "0.34.0",
         "bcryptjs": "^3.0.3",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",

--- a/src/app/[symbol]/__tests__/page.test.ts
+++ b/src/app/[symbol]/__tests__/page.test.ts
@@ -306,7 +306,8 @@ describe('Symbol page', () => {
                 'AAPL',
                 '1Day',
                 'AAPL',
-                DEEPSEEK_V4_FLASH_MODEL
+                DEEPSEEK_V4_FLASH_MODEL,
+                false
             );
             expect(props.initialAnalysis).toEqual(cached);
         });

--- a/src/app/[symbol]/overall/__tests__/page.test.ts
+++ b/src/app/[symbol]/overall/__tests__/page.test.ts
@@ -171,7 +171,8 @@ describe('Overall page (narrative seed)', () => {
             'AAPL',
             'Apple Inc.',
             '1Day',
-            DEEPSEEK_V4_FLASH_MODEL
+            DEEPSEEK_V4_FLASH_MODEL,
+            false
         );
         expect(props.initialAnalysis).toEqual(cached);
     });

--- a/src/app/[symbol]/overall/page.tsx
+++ b/src/app/[symbol]/overall/page.tsx
@@ -132,12 +132,17 @@ export default async function OverallPage({ params }: Props) {
         staticSymbolCache(
             ['peek:overall', upper, DEEPSEEK_V4_FLASH_MODEL],
             upper,
+            // reasoning: false 고정 — member-reasoning-toggle spec Part A.4. 이 SSR
+            // peek은 익명/봇 방문자 셸이므로 writer(익명·free의 submitOverallAnalysisAction)가
+            // 쓰는 reasoning-OFF 키와 정렬돼야 HIT한다. 회원 토글 ON 결과가 섞이는 캐시
+            // 오염을 방지한다(회원은 클라 재요청으로 자기 값을 받는다).
             () =>
                 peekOverallAnalysisCache(
                     upper,
                     assetInfo.name,
                     DEFAULT_TIMEFRAME,
-                    DEEPSEEK_V4_FLASH_MODEL
+                    DEEPSEEK_V4_FLASH_MODEL,
+                    false
                 ),
             [],
             SECONDS_PER_HALF_DAY

--- a/src/entities/analysis/__tests__/lib/peekAnalysisStaticCache.test.ts
+++ b/src/entities/analysis/__tests__/lib/peekAnalysisStaticCache.test.ts
@@ -34,7 +34,8 @@ describe('peekAnalysisStatic', () => {
             'AAPL',
             '1Day',
             'AAPL',
-            'gemini-2.5-flash-lite'
+            'gemini-2.5-flash-lite',
+            false
         );
     });
 
@@ -53,7 +54,27 @@ describe('peekAnalysisStatic', () => {
             'AAPL',
             '1Day',
             undefined,
-            'gemini-2.5-flash-lite'
+            'gemini-2.5-flash-lite',
+            false
+        );
+    });
+
+    it('always peeks the reasoning-OFF key (member-reasoning-toggle spec Part A.4)', async () => {
+        mockPeek.mockResolvedValue(null);
+
+        await peekAnalysisStatic(
+            'AAPL',
+            '1Day',
+            undefined,
+            'deepseek-v4-flash'
+        );
+
+        expect(mockPeek).toHaveBeenCalledWith(
+            'AAPL',
+            '1Day',
+            undefined,
+            'deepseek-v4-flash',
+            false
         );
     });
 });

--- a/src/entities/analysis/__tests__/submitAnalysisAction.test.ts
+++ b/src/entities/analysis/__tests__/submitAnalysisAction.test.ts
@@ -27,6 +27,10 @@ vi.mock('@/entities/auth/lib/getCurrentUser', () => ({
 
 vi.mock('@/shared/lib/byokGate', () => ({
     resolveTierAndByok: vi.fn(),
+    resolveReasoning: vi.fn(
+        (tier: string, clientReasoning?: boolean) =>
+            tier !== 'free' && clientReasoning === true
+    ),
     buildGateError: vi.fn((code: string) => ({
         code,
         message: `mock-${code}`,
@@ -324,6 +328,88 @@ describe('submitAnalysisAction tier + BYOK gate', () => {
 
             expect(mockGetCachedMarketDataProvider).toHaveBeenCalledWith(
                 US_EQUITY_SESSION
+            );
+        });
+    });
+
+    describe('reasoning forwarding', () => {
+        it('forwards reasoning: true for member tier when client requests it', async () => {
+            mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+            mockResolveTierAndByok.mockResolvedValue({
+                kind: 'allowed',
+                tier: 'member' as never,
+            });
+
+            await submitAnalysisAction(
+                'AAPL',
+                'Apple',
+                '1Day',
+                false,
+                '^AAPL',
+                FREE_MODEL,
+                true
+            );
+
+            expect(mockSubmitAnalysis).toHaveBeenCalledWith(
+                'AAPL',
+                'Apple',
+                '1Day',
+                false,
+                '^AAPL',
+                expect.objectContaining({ reasoning: true })
+            );
+        });
+
+        it('forces reasoning: false for free tier even when client requests true', async () => {
+            mockGetCurrentUser.mockResolvedValue(null);
+            mockResolveTierAndByok.mockResolvedValue({
+                kind: 'allowed',
+                tier: 'free' as never,
+            });
+
+            await submitAnalysisAction(
+                'AAPL',
+                'Apple',
+                '1Day',
+                false,
+                '^AAPL',
+                FREE_MODEL,
+                true
+            );
+
+            expect(mockSubmitAnalysis).toHaveBeenCalledWith(
+                'AAPL',
+                'Apple',
+                '1Day',
+                false,
+                '^AAPL',
+                expect.objectContaining({ reasoning: false })
+            );
+        });
+
+        it('defaults reasoning to false for member tier when client omits it', async () => {
+            mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+            mockResolveTierAndByok.mockResolvedValue({
+                kind: 'allowed',
+                tier: 'member' as never,
+            });
+
+            await submitAnalysisAction(
+                'AAPL',
+                'Apple',
+                '1Day',
+                false,
+                '^AAPL',
+                FREE_MODEL
+            );
+
+            expect(mockSubmitAnalysis).toHaveBeenCalledWith(
+                'AAPL',
+                'Apple',
+                '1Day',
+                false,
+                '^AAPL',
+                expect.objectContaining({ reasoning: false })
             );
         });
     });

--- a/src/entities/analysis/__tests__/submitCongressTrendAction.test.ts
+++ b/src/entities/analysis/__tests__/submitCongressTrendAction.test.ts
@@ -13,6 +13,18 @@ vi.mock('@/shared/api/fmp/getCongressTradesProvider', () => ({
     getCongressTradesProvider: vi.fn(() => ({})),
 }));
 
+vi.mock('@/entities/auth/lib/getCurrentUser', () => ({
+    getCurrentUser: vi.fn(),
+}));
+
+vi.mock('@/shared/lib/byokGate', () => ({
+    resolveTierOnly: vi.fn(),
+    resolveReasoning: vi.fn(
+        (tier: string, clientReasoning?: boolean) =>
+            tier !== 'free' && clientReasoning === true
+    ),
+}));
+
 vi.mock('@/shared/api/e2eAnalysisStub', () => ({
     e2eCachedCongressTrend: vi.fn(() => ({ status: 'cached', result: {} })),
     e2eForcedCongressError: vi.fn(() => ({
@@ -31,6 +43,8 @@ import {
     type SubmitCongressTrendResult,
 } from '@y0ngha/siglens-core';
 import { getCongressTradesProvider } from '@/shared/api/fmp/getCongressTradesProvider';
+import { getCurrentUser } from '@/entities/auth/lib/getCurrentUser';
+import { resolveTierOnly } from '@/shared/lib/byokGate';
 import { submitCongressTrendAction } from '../actions/submitCongressTrendAction';
 
 const mockHeaders = headers as MockedFunction<typeof headers>;
@@ -41,6 +55,12 @@ const mockGetCongressTradesProvider =
     getCongressTradesProvider as MockedFunction<
         typeof getCongressTradesProvider
     >;
+const mockGetCurrentUser = getCurrentUser as MockedFunction<
+    typeof getCurrentUser
+>;
+const mockResolveTierOnly = resolveTierOnly as MockedFunction<
+    typeof resolveTierOnly
+>;
 
 const CACHED_RESULT: SubmitCongressTrendResult = {
     status: 'cached',
@@ -65,6 +85,10 @@ describe('submitCongressTrendAction 함수는', () => {
         mockGetCongressTradesProvider.mockReset();
         mockGetCongressTradesProvider.mockReturnValue({} as never);
         mockSubmitCongressTrend.mockResolvedValue(SUBMITTED_RESULT);
+        mockGetCurrentUser.mockReset();
+        mockResolveTierOnly.mockReset();
+        mockGetCurrentUser.mockResolvedValue(null);
+        mockResolveTierOnly.mockResolvedValue('free');
     });
 
     it('siglens-core submitCongressTrend에 symbol과 modelId를 전달한다', async () => {
@@ -130,6 +154,46 @@ describe('submitCongressTrendAction 함수는', () => {
         expect(mockSubmitCongressTrend).toHaveBeenCalledWith(
             expect.objectContaining({ skipEnqueueIfMiss: false })
         );
+    });
+
+    describe('reasoning forwarding', () => {
+        it('resolves tier via getCurrentUser + resolveTierOnly and forwards reasoning: true for member tier', async () => {
+            mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+            mockResolveTierOnly.mockResolvedValue('member');
+            mockSubmitCongressTrend.mockResolvedValueOnce(CACHED_RESULT);
+
+            await submitCongressTrendAction('AAPL', MODEL_ID, true);
+
+            expect(mockResolveTierOnly).toHaveBeenCalledWith('u1');
+            expect(mockSubmitCongressTrend).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: true })
+            );
+        });
+
+        it('resolves tier as free (null userId) for anonymous callers', async () => {
+            mockGetCurrentUser.mockResolvedValue(null);
+            mockResolveTierOnly.mockResolvedValue('free');
+            mockSubmitCongressTrend.mockResolvedValueOnce(CACHED_RESULT);
+
+            await submitCongressTrendAction('AAPL', MODEL_ID, true);
+
+            expect(mockResolveTierOnly).toHaveBeenCalledWith(null);
+            expect(mockSubmitCongressTrend).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: false })
+            );
+        });
+
+        it('defaults reasoning to false when omitted', async () => {
+            mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+            mockResolveTierOnly.mockResolvedValue('member');
+            mockSubmitCongressTrend.mockResolvedValueOnce(CACHED_RESULT);
+
+            await submitCongressTrendAction('AAPL', MODEL_ID);
+
+            expect(mockSubmitCongressTrend).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: false })
+            );
+        });
     });
 
     it('E2E 모드에서 e2eCachedCongressTrend를 반환하고 provider를 호출하지 않는다', async () => {

--- a/src/entities/analysis/__tests__/submitCongressTrendAction.test.ts
+++ b/src/entities/analysis/__tests__/submitCongressTrendAction.test.ts
@@ -194,6 +194,30 @@ describe('submitCongressTrendAction 함수는', () => {
                 expect.objectContaining({ reasoning: false })
             );
         });
+
+        it('skips the tier lookup entirely when reasoning is not requested (omitted)', async () => {
+            mockSubmitCongressTrend.mockResolvedValueOnce(CACHED_RESULT);
+
+            await submitCongressTrendAction('AAPL', MODEL_ID);
+
+            expect(mockGetCurrentUser).not.toHaveBeenCalled();
+            expect(mockResolveTierOnly).not.toHaveBeenCalled();
+            expect(mockSubmitCongressTrend).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: false })
+            );
+        });
+
+        it('skips the tier lookup entirely when reasoning is explicitly false', async () => {
+            mockSubmitCongressTrend.mockResolvedValueOnce(CACHED_RESULT);
+
+            await submitCongressTrendAction('AAPL', MODEL_ID, false);
+
+            expect(mockGetCurrentUser).not.toHaveBeenCalled();
+            expect(mockResolveTierOnly).not.toHaveBeenCalled();
+            expect(mockSubmitCongressTrend).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: false })
+            );
+        });
     });
 
     it('E2E 모드에서 e2eCachedCongressTrend를 반환하고 provider를 호출하지 않는다', async () => {

--- a/src/entities/analysis/__tests__/submitFinancialsAnalysisAction.test.ts
+++ b/src/entities/analysis/__tests__/submitFinancialsAnalysisAction.test.ts
@@ -29,6 +29,10 @@ vi.mock('@/entities/auth/lib/getCurrentUser', () => ({
 
 vi.mock('@/shared/lib/byokGate', () => ({
     resolveTierAndByok: vi.fn(),
+    resolveReasoning: vi.fn(
+        (tier: string, clientReasoning?: boolean) =>
+            tier !== 'free' && clientReasoning === true
+    ),
     buildGateError: vi.fn((code: string) => ({
         code,
         message: `mock-${code}`,
@@ -247,6 +251,44 @@ describe('submitFinancialsAnalysisAction 함수는', () => {
         expect(mockSubmitFinancialsAnalysis).toHaveBeenCalledWith(
             expect.objectContaining({ skipEnqueueIfMiss: false })
         );
+    });
+
+    describe('reasoning forwarding', () => {
+        it('forwards reasoning: true for member tier when client requests it', async () => {
+            mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+            mockResolveTierAndByok.mockResolvedValue({
+                kind: 'allowed',
+                tier: 'member' as never,
+            });
+
+            await submitFinancialsAnalysisAction('AAPL', MODEL_ID, true);
+
+            expect(mockSubmitFinancialsAnalysis).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: true })
+            );
+        });
+
+        it('forces reasoning: false for free tier even when client requests true', async () => {
+            await submitFinancialsAnalysisAction('AAPL', MODEL_ID, true);
+
+            expect(mockSubmitFinancialsAnalysis).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: false })
+            );
+        });
+
+        it('defaults reasoning to false when omitted', async () => {
+            mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+            mockResolveTierAndByok.mockResolvedValue({
+                kind: 'allowed',
+                tier: 'member' as never,
+            });
+
+            await submitFinancialsAnalysisAction('AAPL', MODEL_ID);
+
+            expect(mockSubmitFinancialsAnalysis).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: false })
+            );
+        });
     });
 
     it('E2E 모드에서 e2eCachedFinancials를 반환하고 provider를 호출하지 않는다', async () => {

--- a/src/entities/analysis/__tests__/submitFundamentalAnalysisAction.test.ts
+++ b/src/entities/analysis/__tests__/submitFundamentalAnalysisAction.test.ts
@@ -24,6 +24,10 @@ vi.mock('@/entities/auth/lib/getCurrentUser', () => ({
 
 vi.mock('@/shared/lib/byokGate', () => ({
     resolveTierAndByok: vi.fn(),
+    resolveReasoning: vi.fn(
+        (tier: string, clientReasoning?: boolean) =>
+            tier !== 'free' && clientReasoning === true
+    ),
     buildGateError: vi.fn((code: string) => ({
         code,
         message: `mock-${code}`,
@@ -226,6 +230,44 @@ describe('submitFundamentalAnalysisAction 함수는', () => {
         expect(mockSubmitFundamentalAnalysis).toHaveBeenCalledWith(
             expect.objectContaining({ skipEnqueueIfMiss: true })
         );
+    });
+
+    describe('reasoning forwarding', () => {
+        it('forwards reasoning: true for member tier when client requests it', async () => {
+            mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+            mockResolveTierAndByok.mockResolvedValue({
+                kind: 'allowed',
+                tier: 'member' as never,
+            });
+
+            await submitFundamentalAnalysisAction('AAPL', MODEL_ID, true);
+
+            expect(mockSubmitFundamentalAnalysis).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: true })
+            );
+        });
+
+        it('forces reasoning: false for free tier even when client requests true', async () => {
+            await submitFundamentalAnalysisAction('AAPL', MODEL_ID, true);
+
+            expect(mockSubmitFundamentalAnalysis).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: false })
+            );
+        });
+
+        it('defaults reasoning to false when omitted', async () => {
+            mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+            mockResolveTierAndByok.mockResolvedValue({
+                kind: 'allowed',
+                tier: 'member' as never,
+            });
+
+            await submitFundamentalAnalysisAction('AAPL', MODEL_ID);
+
+            expect(mockSubmitFundamentalAnalysis).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: false })
+            );
+        });
     });
 
     it('passes skipEnqueueIfMiss: false to siglens-core when request UA is not a bot', async () => {

--- a/src/entities/analysis/__tests__/submitOverallAnalysisAction.test.ts
+++ b/src/entities/analysis/__tests__/submitOverallAnalysisAction.test.ts
@@ -54,6 +54,10 @@ vi.mock('@/entities/auth/lib/getCurrentUser', () => ({
 
 vi.mock('@/shared/lib/byokGate', () => ({
     resolveTierAndByok: vi.fn(),
+    resolveReasoning: vi.fn(
+        (tier: string, clientReasoning?: boolean) =>
+            tier !== 'free' && clientReasoning === true
+    ),
     buildGateError: vi.fn((code: string) => ({
         code,
         message: `mock-${code}`,
@@ -716,6 +720,61 @@ describe('submitOverallAnalysisAction 함수는', () => {
             expect(result).toBe(SUBMITTED_RESULT);
             expect(mockSubmitOverallAnalysis).toHaveBeenCalledWith(
                 expect.objectContaining({ financialsScorecard: undefined })
+            );
+        });
+    });
+
+    describe('reasoning forwarding', () => {
+        it('forwards reasoning: true for member tier when client requests it', async () => {
+            mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+            mockResolveTierAndByok.mockResolvedValue({
+                kind: 'allowed',
+                tier: 'member' as never,
+            });
+
+            await submitOverallAnalysisAction(
+                'AAPL',
+                'Apple Inc.',
+                '1Day',
+                MODEL_ID,
+                { reasoning: true }
+            );
+
+            expect(mockSubmitOverallAnalysis).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: true })
+            );
+        });
+
+        it('forces reasoning: false for free tier even when client requests true', async () => {
+            await submitOverallAnalysisAction(
+                'AAPL',
+                'Apple Inc.',
+                '1Day',
+                MODEL_ID,
+                { reasoning: true }
+            );
+
+            expect(mockSubmitOverallAnalysis).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: false })
+            );
+        });
+
+        it('defaults reasoning to false when options are omitted', async () => {
+            mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+            mockResolveTierAndByok.mockResolvedValue({
+                kind: 'allowed',
+                tier: 'member' as never,
+            });
+
+            await submitOverallAnalysisAction(
+                'AAPL',
+                'Apple Inc.',
+                '1Day',
+                MODEL_ID
+            );
+
+            expect(mockSubmitOverallAnalysis).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: false })
             );
         });
     });

--- a/src/entities/analysis/actions/submitAnalysisAction.ts
+++ b/src/entities/analysis/actions/submitAnalysisAction.ts
@@ -8,7 +8,11 @@ import {
     type Timeframe,
 } from '@y0ngha/siglens-core';
 import { getCurrentUser } from '@/entities/auth/lib/getCurrentUser';
-import { resolveTierAndByok, buildGateError } from '@/shared/lib/byokGate';
+import {
+    resolveTierAndByok,
+    resolveReasoning,
+    buildGateError,
+} from '@/shared/lib/byokGate';
 import { isBot } from '@/shared/api/isBot';
 import { isE2E } from '@/shared/api/e2eEnv';
 import type { AnalysisGateBlockedResult } from '@/shared/lib/types';
@@ -29,7 +33,13 @@ export async function submitAnalysisAction(
     timeframe: Timeframe,
     force?: boolean,
     fmpSymbol?: string,
-    modelId?: ModelId
+    modelId?: ModelId,
+    /**
+     * Client-requested "깊은 생각" (deep-thinking) toggle value (member-reasoning-toggle
+     * spec Part A). Only honored for member/pro tiers — `resolveReasoning` forces
+     * `false` for anonymous/free callers regardless of this value.
+     */
+    reasoning?: boolean
 ): Promise<SubmitAnalysisActionResult> {
     try {
         // E2E short-circuits the LLM/worker (see e2eAnalysisStub). The
@@ -101,6 +111,7 @@ export async function submitAnalysisAction(
                 marketDataProvider,
                 assetClass,
                 tierContext: { userId, tier: gate.tier },
+                reasoning: resolveReasoning(gate.tier, reasoning),
                 ...(gate.userApiKey !== undefined
                     ? { userApiKey: gate.userApiKey }
                     : {}),

--- a/src/entities/analysis/actions/submitCongressTrendAction.ts
+++ b/src/entities/analysis/actions/submitCongressTrendAction.ts
@@ -36,8 +36,11 @@ export type SubmitCongressTrendActionResult = SubmitCongressTrendResult;
  *
  * §Reasoning: congress has no BYOK/premium gate, but the "깊은 생각" toggle
  * (member-reasoning-toggle spec Part A) still requires knowing the caller's
- * tier — `resolveTierOnly` resolves tier alone (no premium-model check),
- * and `resolveReasoning` forces `false` for anonymous/free callers.
+ * tier when the client actually requests it — `resolveTierOnly` resolves tier
+ * alone (no premium-model check), and `resolveReasoning` forces `false` for
+ * anonymous/free callers. The tier lookup is skipped entirely when the client
+ * didn't request reasoning, since the result would be forced to `false`
+ * either way.
  */
 export async function submitCongressTrendAction(
     symbol: string,
@@ -64,15 +67,22 @@ export async function submitCongressTrendAction(
         const requestHeaders = await headers();
         const skipEnqueueIfMiss = isBot(requestHeaders);
 
-        const user = await getCurrentUser();
-        const tier = await resolveTierOnly(user?.id ?? null);
+        // resolveReasoning always returns false when the client didn't ask for
+        // reasoning, regardless of tier — skip the tier DB lookup entirely in
+        // that case rather than resolving it just to discard the result.
+        let resolvedReasoning = false;
+        if (reasoning === true) {
+            const user = await getCurrentUser();
+            const tier = await resolveTierOnly(user?.id ?? null);
+            resolvedReasoning = resolveReasoning(tier, reasoning);
+        }
 
         return await submitCongressTrend({
             symbol,
             modelId,
             dataProvider: getCongressTradesProvider(),
             skipEnqueueIfMiss,
-            reasoning: resolveReasoning(tier, reasoning),
+            reasoning: resolvedReasoning,
         });
     } catch (error) {
         // MISTAKES §0.7: server actions must not propagate raw exceptions to

--- a/src/entities/analysis/actions/submitCongressTrendAction.ts
+++ b/src/entities/analysis/actions/submitCongressTrendAction.ts
@@ -7,6 +7,8 @@ import {
     type SubmitCongressTrendResult,
 } from '@y0ngha/siglens-core';
 import { getCongressTradesProvider } from '@/shared/api/fmp/getCongressTradesProvider';
+import { getCurrentUser } from '@/entities/auth/lib/getCurrentUser';
+import { resolveTierOnly, resolveReasoning } from '@/shared/lib/byokGate';
 import { isBot } from '@/shared/api/isBot';
 import { isE2E } from '@/shared/api/e2eEnv';
 
@@ -22,7 +24,8 @@ export type SubmitCongressTrendActionResult = SubmitCongressTrendResult;
  * error`.
  *
  * §Public access: congress filings are public data. No usage-limit check and
- * no BYOK gate are applied — `resolveTierAndByok` is intentionally absent.
+ * no BYOK gate are applied — `resolveTierAndByok` is intentionally absent
+ * (only the lighter `resolveTierOnly` runs, for reasoning gating).
  *
  * §Bot guard: `skipEnqueueIfMiss = isBot(headers)` so crawlers never trigger
  * LLM worker dispatches.
@@ -30,10 +33,20 @@ export type SubmitCongressTrendActionResult = SubmitCongressTrendResult;
  * §E2E: when `E2E_TEST=1`, returns a deterministic cached fixture. The stub
  * imports are lazy/dynamic so they land in a server-only chunk that the prod
  * bundle never ships (mirrors submitFinancialsAnalysisAction).
+ *
+ * §Reasoning: congress has no BYOK/premium gate, but the "깊은 생각" toggle
+ * (member-reasoning-toggle spec Part A) still requires knowing the caller's
+ * tier — `resolveTierOnly` resolves tier alone (no premium-model check),
+ * and `resolveReasoning` forces `false` for anonymous/free callers.
  */
 export async function submitCongressTrendAction(
     symbol: string,
-    modelId: SubmitCongressTrendOptions['modelId']
+    modelId: SubmitCongressTrendOptions['modelId'],
+    /**
+     * Client-requested "깊은 생각" (deep-thinking) toggle value. Only honored
+     * for member/pro tiers.
+     */
+    reasoning?: boolean
 ): Promise<SubmitCongressTrendActionResult> {
     try {
         if (isE2E()) {
@@ -51,11 +64,15 @@ export async function submitCongressTrendAction(
         const requestHeaders = await headers();
         const skipEnqueueIfMiss = isBot(requestHeaders);
 
+        const user = await getCurrentUser();
+        const tier = await resolveTierOnly(user?.id ?? null);
+
         return await submitCongressTrend({
             symbol,
             modelId,
             dataProvider: getCongressTradesProvider(),
             skipEnqueueIfMiss,
+            reasoning: resolveReasoning(tier, reasoning),
         });
     } catch (error) {
         // MISTAKES §0.7: server actions must not propagate raw exceptions to

--- a/src/entities/analysis/actions/submitFinancialsAnalysisAction.ts
+++ b/src/entities/analysis/actions/submitFinancialsAnalysisAction.ts
@@ -8,7 +8,11 @@ import {
 } from '@y0ngha/siglens-core';
 import { getFinancialStatementsProvider } from '@/shared/api/fmp/getFinancialStatementsProvider';
 import { getCurrentUser } from '@/entities/auth/lib/getCurrentUser';
-import { resolveTierAndByok, buildGateError } from '@/shared/lib/byokGate';
+import {
+    resolveTierAndByok,
+    resolveReasoning,
+    buildGateError,
+} from '@/shared/lib/byokGate';
 import { isBot } from '@/shared/api/isBot';
 import { isE2E } from '@/shared/api/e2eEnv';
 import type { AnalysisGateBlockedResult } from '@/shared/lib/types';
@@ -21,7 +25,12 @@ export type SubmitFinancialsAnalysisActionResult =
 /** Server Action: tier + BYOK gate, then submit financials analysis via siglens-core with financial statements provider; returns `cached | submitted | error`. */
 export async function submitFinancialsAnalysisAction(
     symbol: string,
-    modelId: SubmitFinancialsAnalysisOptions['modelId']
+    modelId: SubmitFinancialsAnalysisOptions['modelId'],
+    /**
+     * Client-requested "깊은 생각" (deep-thinking) toggle value (member-reasoning-toggle
+     * spec Part A). Only honored for member/pro tiers.
+     */
+    reasoning?: boolean
 ): Promise<SubmitFinancialsAnalysisActionResult> {
     try {
         // E2E short-circuits the LLM/worker; returns a deterministic cached fixture
@@ -57,6 +66,7 @@ export async function submitFinancialsAnalysisAction(
             modelId,
             dataProvider: getFinancialStatementsProvider(),
             tier: gate.tier,
+            reasoning: resolveReasoning(gate.tier, reasoning),
             skipEnqueueIfMiss,
             ...(gate.userApiKey !== undefined
                 ? { userApiKey: gate.userApiKey }

--- a/src/entities/analysis/actions/submitFundamentalAnalysisAction.ts
+++ b/src/entities/analysis/actions/submitFundamentalAnalysisAction.ts
@@ -8,7 +8,11 @@ import {
 } from '@y0ngha/siglens-core';
 import { getFundamentalDataProvider } from '@/shared/api/fmp/getFundamentalDataProvider';
 import { getCurrentUser } from '@/entities/auth/lib/getCurrentUser';
-import { resolveTierAndByok, buildGateError } from '@/shared/lib/byokGate';
+import {
+    resolveTierAndByok,
+    resolveReasoning,
+    buildGateError,
+} from '@/shared/lib/byokGate';
 import { isBot } from '@/shared/api/isBot';
 import { isE2E } from '@/shared/api/e2eEnv';
 import type { AnalysisGateBlockedResult } from '@/shared/lib/types';
@@ -21,7 +25,12 @@ export type SubmitFundamentalAnalysisActionResult =
 /** Server Action: tier + BYOK gate, then submit fundamental analysis via siglens-core with FMP provider; returns `cached | submitted | error`. */
 export async function submitFundamentalAnalysisAction(
     symbol: string,
-    modelId: SubmitFundamentalAnalysisOptions['modelId']
+    modelId: SubmitFundamentalAnalysisOptions['modelId'],
+    /**
+     * Client-requested "깊은 생각" (deep-thinking) toggle value (member-reasoning-toggle
+     * spec Part A). Only honored for member/pro tiers.
+     */
+    reasoning?: boolean
 ): Promise<SubmitFundamentalAnalysisActionResult> {
     try {
         // E2E short-circuits the LLM/worker; returns a deterministic cached fixture
@@ -51,6 +60,7 @@ export async function submitFundamentalAnalysisAction(
             modelId,
             dataProvider: getFundamentalDataProvider(),
             tier: gate.tier,
+            reasoning: resolveReasoning(gate.tier, reasoning),
             skipEnqueueIfMiss,
             ...(gate.userApiKey !== undefined
                 ? { userApiKey: gate.userApiKey }

--- a/src/entities/analysis/actions/submitOverallAnalysisAction.ts
+++ b/src/entities/analysis/actions/submitOverallAnalysisAction.ts
@@ -26,7 +26,11 @@ import {
 } from '@/entities/news-article';
 import { getNextEarningsReport } from '@/entities/earnings-report';
 import { getCurrentUser } from '@/entities/auth/lib/getCurrentUser';
-import { resolveTierAndByok, buildGateError } from '@/shared/lib/byokGate';
+import {
+    resolveTierAndByok,
+    resolveReasoning,
+    buildGateError,
+} from '@/shared/lib/byokGate';
 import { isBot } from '@/shared/api/isBot';
 import { isE2E } from '@/shared/api/e2eEnv';
 // Cross-entity: options-chain fetchOptionsSnapshot 필요. Phase 9에서 features 레이어 도입 시 해소.
@@ -45,6 +49,12 @@ export type SubmitOverallAnalysisActionResult =
  */
 export interface SubmitOverallAnalysisActionOptions {
     force?: boolean;
+    /**
+     * Client-requested "깊은 생각" (deep-thinking) toggle value (member-reasoning-toggle
+     * spec Part A). Only honored for member/pro tiers — forced `false` for
+     * anonymous/free callers by `resolveReasoning` regardless of this value.
+     */
+    reasoning?: boolean;
 }
 
 /** Server Action: tier + BYOK gate, then submit a 4-axis overall analysis job; loads enriched news + earnings from DB, options snapshot, injects FMP provider; returns `cached | submitted | pending_dependencies | error`. */
@@ -160,6 +170,7 @@ export async function submitOverallAnalysisAction(
             upcomingCalendar: next !== null ? [next] : [],
             technical: { tierContext: { userId, tier: gate.tier } },
             tier: gate.tier,
+            reasoning: resolveReasoning(gate.tier, options.reasoning),
             skipEnqueueIfMiss,
             assetClass,
             optionsSnapshot: optionsSnapshot ?? undefined,

--- a/src/entities/analysis/lib/peekAnalysisStaticCache.ts
+++ b/src/entities/analysis/lib/peekAnalysisStaticCache.ts
@@ -27,6 +27,12 @@ import { SECONDS_PER_QUARTER_DAY } from '@/shared/config/time';
  * 혼용 시 캐시 분기 방지). 키: ticker + timeframe + modelId. fmpSymbol은 peekAnalysisCache의
  * 내부 cache 키가 쓰지 않으므로 unstable_cache 키에서 제외한다 — 포함하면 같은 데이터가
  * fmpSymbol 유무로 중복 엔트리에 저장된다. 시그니처 정렬을 위해 인자로는 받아 그대로 전달한다.
+ *
+ * reasoning은 항상 `false`로 고정한다(member-reasoning-toggle spec Part A.4) — 이 SSR peek은
+ * 익명/봇 방문자가 보는 초기 셸이므로, writer(익명·free 방문자의 submitAnalysisAction)가
+ * 쓰는 reasoning-OFF 키와 정렬되어야 HIT한다. 회원이 토글 ON으로 받은 결과가 이 익명 peek에
+ * 섞이는 캐시 오염을 방지한다(회원은 클라 재요청으로 자기 값을 받는다). unstable_cache 키에는
+ * 포함하지 않는다 — 항상 상수이므로 별도 분기가 필요 없다.
  */
 export function peekAnalysisStatic(
     ticker: string,
@@ -36,7 +42,7 @@ export function peekAnalysisStatic(
 ): Promise<AnalysisResponse | null> {
     const upper = ticker.toUpperCase();
     return unstable_cache(
-        () => peekAnalysisCache(upper, timeframe, fmpSymbol, modelId),
+        () => peekAnalysisCache(upper, timeframe, fmpSymbol, modelId, false),
         ['peek-analysis-static', upper, timeframe, modelId],
         { revalidate: SECONDS_PER_QUARTER_DAY, tags: [`symbol:${upper}`] }
     )();

--- a/src/entities/news-article/__tests__/submitNewsAnalysisAction.test.ts
+++ b/src/entities/news-article/__tests__/submitNewsAnalysisAction.test.ts
@@ -31,6 +31,10 @@ vi.mock('@/entities/auth/lib/getCurrentUser', () => ({
 
 vi.mock('@/shared/lib/byokGate', () => ({
     resolveTierAndByok: vi.fn(),
+    resolveReasoning: vi.fn(
+        (tier: string, clientReasoning?: boolean) =>
+            tier !== 'free' && clientReasoning === true
+    ),
     buildGateError: vi.fn((code: string) => ({
         code,
         message: `mock-${code}`,
@@ -380,6 +384,54 @@ describe('submitNewsAnalysisAction 함수는', () => {
         expect(mockSubmitNewsAnalysis).toHaveBeenCalledWith(
             expect.objectContaining({ skipEnqueueIfMiss: false })
         );
+    });
+
+    describe('reasoning forwarding', () => {
+        it('forwards reasoning: true for member tier when client requests it', async () => {
+            mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+            mockResolveTierAndByok.mockResolvedValue({
+                kind: 'allowed',
+                tier: 'member' as never,
+            });
+
+            await submitNewsAnalysisAction(
+                'AAPL',
+                'Apple Inc.',
+                MODEL_ID,
+                true
+            );
+
+            expect(mockSubmitNewsAnalysis).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: true })
+            );
+        });
+
+        it('forces reasoning: false for free tier even when client requests true', async () => {
+            await submitNewsAnalysisAction(
+                'AAPL',
+                'Apple Inc.',
+                MODEL_ID,
+                true
+            );
+
+            expect(mockSubmitNewsAnalysis).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: false })
+            );
+        });
+
+        it('defaults reasoning to false when omitted', async () => {
+            mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+            mockResolveTierAndByok.mockResolvedValue({
+                kind: 'allowed',
+                tier: 'member' as never,
+            });
+
+            await submitNewsAnalysisAction('AAPL', 'Apple Inc.', MODEL_ID);
+
+            expect(mockSubmitNewsAnalysis).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: false })
+            );
+        });
     });
 
     describe('assetClass forwarding', () => {

--- a/src/entities/news-article/actions/submitNewsAnalysisAction.ts
+++ b/src/entities/news-article/actions/submitNewsAnalysisAction.ts
@@ -13,7 +13,11 @@ import { NEWS_ANALYSIS_LOOKBACK_MS } from '../lib/newsLookback';
 import { buildAnalysisNewsItems } from '../lib/buildAnalysisNewsItems';
 import { getNextEarningsReport } from '@/entities/earnings-report';
 import { getCurrentUser } from '@/entities/auth/lib/getCurrentUser';
-import { resolveTierAndByok, buildGateError } from '@/shared/lib/byokGate';
+import {
+    resolveTierAndByok,
+    resolveReasoning,
+    buildGateError,
+} from '@/shared/lib/byokGate';
 import { isBot } from '@/shared/api/isBot';
 import { isE2E } from '@/shared/api/e2eEnv';
 import type { AnalysisGateBlockedResult } from '@/shared/lib/types';
@@ -28,7 +32,12 @@ export type SubmitNewsAnalysisActionResult =
 export async function submitNewsAnalysisAction(
     symbol: string,
     companyName: string,
-    modelId: SubmitNewsAnalysisOptions['modelId']
+    modelId: SubmitNewsAnalysisOptions['modelId'],
+    /**
+     * Client-requested "깊은 생각" (deep-thinking) toggle value (member-reasoning-toggle
+     * spec Part A). Only honored for member/pro tiers.
+     */
+    reasoning?: boolean
 ): Promise<SubmitNewsAnalysisActionResult> {
     try {
         // E2E short-circuits the LLM/worker; returns a deterministic cached fixture
@@ -75,6 +84,7 @@ export async function submitNewsAnalysisAction(
             news: enrichedNews,
             upcomingCalendar: next !== null ? [next] : [],
             tier: gate.tier,
+            reasoning: resolveReasoning(gate.tier, reasoning),
             skipEnqueueIfMiss,
             assetClass,
             ...(gate.userApiKey !== undefined

--- a/src/entities/options-chain/__tests__/optionsActions.test.ts
+++ b/src/entities/options-chain/__tests__/optionsActions.test.ts
@@ -36,6 +36,10 @@ vi.mock('@/entities/auth/lib/getCurrentUser', () => ({
 
 vi.mock('@/shared/lib/byokGate', () => ({
     resolveTierAndByok: vi.fn(),
+    resolveReasoning: vi.fn(
+        (tier: string, clientReasoning?: boolean) =>
+            tier !== 'free' && clientReasoning === true
+    ),
     buildGateError: vi.fn((code: string) => ({
         code,
         message: `mock-${code}`,
@@ -251,6 +255,61 @@ describe('submitOptionsAnalysisAction', () => {
         expect(result).toMatchObject({
             status: 'error',
             error: expect.objectContaining({ code: 'unexpected_error' }),
+        });
+    });
+
+    describe('reasoning forwarding', () => {
+        it('forwards reasoning: true for member tier when client requests it', async () => {
+            mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+            mockResolveTierAndByok.mockResolvedValue({
+                kind: 'allowed',
+                tier: 'member' as never,
+            });
+
+            await submitOptionsAnalysisAction(
+                'AAPL',
+                'Apple Inc.',
+                'all',
+                MODEL_ID,
+                true
+            );
+
+            expect(mockSubmitOptionsAnalysis).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: true })
+            );
+        });
+
+        it('forces reasoning: false for free tier even when client requests true', async () => {
+            await submitOptionsAnalysisAction(
+                'AAPL',
+                'Apple Inc.',
+                'all',
+                MODEL_ID,
+                true
+            );
+
+            expect(mockSubmitOptionsAnalysis).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: false })
+            );
+        });
+
+        it('defaults reasoning to false when omitted', async () => {
+            mockGetCurrentUser.mockResolvedValue({ id: 'u1' } as never);
+            mockResolveTierAndByok.mockResolvedValue({
+                kind: 'allowed',
+                tier: 'member' as never,
+            });
+
+            await submitOptionsAnalysisAction(
+                'AAPL',
+                'Apple Inc.',
+                'all',
+                MODEL_ID
+            );
+
+            expect(mockSubmitOptionsAnalysis).toHaveBeenCalledWith(
+                expect.objectContaining({ reasoning: false })
+            );
         });
     });
 });

--- a/src/entities/options-chain/actions/optionsActions.ts
+++ b/src/entities/options-chain/actions/optionsActions.ts
@@ -11,7 +11,11 @@ import {
 } from '@y0ngha/siglens-core';
 import { fetchOptionsSnapshot } from '../lib/optionsDataCache';
 import { getCurrentUser } from '@/entities/auth/lib/getCurrentUser';
-import { resolveTierAndByok, buildGateError } from '@/shared/lib/byokGate';
+import {
+    resolveTierAndByok,
+    resolveReasoning,
+    buildGateError,
+} from '@/shared/lib/byokGate';
 import { isBot } from '@/shared/api/isBot';
 import { isE2E } from '@/shared/api/e2eEnv';
 import type {
@@ -33,7 +37,12 @@ export async function submitOptionsAnalysisAction(
     symbol: string,
     companyName: string,
     expirationDate: OptionsExpirationSelector,
-    modelId: ModelId
+    modelId: ModelId,
+    /**
+     * Client-requested "깊은 생각" (deep-thinking) toggle value (member-reasoning-toggle
+     * spec Part A). Only honored for member/pro tiers.
+     */
+    reasoning?: boolean
 ): Promise<SubmitOptionsAnalysisActionResult> {
     try {
         // E2E short-circuits the LLM/worker with a deterministic fixture (see
@@ -80,6 +89,7 @@ export async function submitOptionsAnalysisAction(
             modelId,
             snapshot,
             tier: gate.tier,
+            reasoning: resolveReasoning(gate.tier, reasoning),
             skipEnqueueIfMiss,
             ...(gate.userApiKey !== undefined
                 ? { userApiKey: gate.userApiKey }

--- a/src/features/analysis-nudge/hooks/__tests__/useAnonAnalysisNudge.test.tsx
+++ b/src/features/analysis-nudge/hooks/__tests__/useAnonAnalysisNudge.test.tsx
@@ -1,0 +1,163 @@
+import { renderHook, act } from '@testing-library/react';
+import type { UseQueryResult } from '@tanstack/react-query';
+import type { AuthUserRecord } from '@/shared/lib/auth/types';
+import { useAnonAnalysisNudge } from '@/features/analysis-nudge/hooks/useAnonAnalysisNudge';
+import { useCurrentUser } from '@/entities/auth';
+import {
+    recordAnonSymbolAnalysis,
+    hasNudgeShownToday,
+    markNudgeShownToday,
+} from '@/shared/lib/anonAnalysisCount';
+
+vi.mock('@/entities/auth', () => ({
+    useCurrentUser: vi.fn(),
+}));
+
+vi.mock('@/shared/lib/anonAnalysisCount', () => ({
+    recordAnonSymbolAnalysis: vi.fn(),
+    hasNudgeShownToday: vi.fn(),
+    markNudgeShownToday: vi.fn(),
+}));
+
+const mockUseCurrentUser = vi.mocked(useCurrentUser);
+const mockRecord = vi.mocked(recordAnonSymbolAnalysis);
+const mockHasShown = vi.mocked(hasNudgeShownToday);
+const mockMarkShown = vi.mocked(markNudgeShownToday);
+
+const MEMBER: AuthUserRecord = {
+    id: 'u1',
+    email: 'a@b.com',
+    name: 'Alice',
+    avatarUrl: null,
+    tier: 'member',
+} as AuthUserRecord;
+
+function mockQueryResult(
+    data: AuthUserRecord | null | undefined
+): UseQueryResult<AuthUserRecord | null> {
+    return { data } as UseQueryResult<AuthUserRecord | null>;
+}
+
+describe('useAnonAnalysisNudge', () => {
+    beforeEach(() => {
+        mockRecord.mockReset();
+        mockHasShown.mockReset();
+        mockMarkShown.mockReset();
+        mockHasShown.mockReturnValue(false);
+        mockRecord.mockReturnValue({
+            distinctCount: 1,
+            crossedThreshold: false,
+        });
+    });
+
+    it('does not count before login state is resolved (data undefined)', () => {
+        mockUseCurrentUser.mockReturnValue(mockQueryResult(undefined));
+
+        const { result } = renderHook(() => useAnonAnalysisNudge());
+
+        act(() => {
+            result.current.onSymbolAnalyzed('AAPL');
+        });
+
+        expect(mockRecord).not.toHaveBeenCalled();
+        expect(result.current.isOpen).toBe(false);
+    });
+
+    it('is a no-op for members (logged-in user)', () => {
+        mockUseCurrentUser.mockReturnValue(mockQueryResult(MEMBER));
+
+        const { result } = renderHook(() => useAnonAnalysisNudge());
+
+        act(() => {
+            result.current.onSymbolAnalyzed('AAPL');
+        });
+
+        expect(mockRecord).not.toHaveBeenCalled();
+        expect(result.current.isOpen).toBe(false);
+    });
+
+    it('records the symbol for anonymous visitors (data=null, resolved)', () => {
+        mockUseCurrentUser.mockReturnValue(mockQueryResult(null));
+
+        const { result } = renderHook(() => useAnonAnalysisNudge());
+
+        act(() => {
+            result.current.onSymbolAnalyzed('AAPL');
+        });
+
+        expect(mockRecord).toHaveBeenCalledWith('AAPL');
+    });
+
+    it('opens the modal when the 3rd distinct symbol crosses the threshold and not shown today', () => {
+        mockUseCurrentUser.mockReturnValue(mockQueryResult(null));
+        mockRecord.mockReturnValue({
+            distinctCount: 3,
+            crossedThreshold: true,
+        });
+        mockHasShown.mockReturnValue(false);
+
+        const { result } = renderHook(() => useAnonAnalysisNudge());
+
+        act(() => {
+            result.current.onSymbolAnalyzed('NVDA');
+        });
+
+        expect(result.current.isOpen).toBe(true);
+        expect(mockMarkShown).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not open the modal if crossedThreshold but already shown today (nag-prevention)', () => {
+        mockUseCurrentUser.mockReturnValue(mockQueryResult(null));
+        mockRecord.mockReturnValue({
+            distinctCount: 3,
+            crossedThreshold: true,
+        });
+        mockHasShown.mockReturnValue(true);
+
+        const { result } = renderHook(() => useAnonAnalysisNudge());
+
+        act(() => {
+            result.current.onSymbolAnalyzed('NVDA');
+        });
+
+        expect(result.current.isOpen).toBe(false);
+        expect(mockMarkShown).not.toHaveBeenCalled();
+    });
+
+    it('does not open the modal when crossedThreshold is false', () => {
+        mockUseCurrentUser.mockReturnValue(mockQueryResult(null));
+        mockRecord.mockReturnValue({
+            distinctCount: 1,
+            crossedThreshold: false,
+        });
+
+        const { result } = renderHook(() => useAnonAnalysisNudge());
+
+        act(() => {
+            result.current.onSymbolAnalyzed('AAPL');
+        });
+
+        expect(result.current.isOpen).toBe(false);
+    });
+
+    it('close() sets isOpen back to false', () => {
+        mockUseCurrentUser.mockReturnValue(mockQueryResult(null));
+        mockRecord.mockReturnValue({
+            distinctCount: 3,
+            crossedThreshold: true,
+        });
+        mockHasShown.mockReturnValue(false);
+
+        const { result } = renderHook(() => useAnonAnalysisNudge());
+
+        act(() => {
+            result.current.onSymbolAnalyzed('NVDA');
+        });
+        expect(result.current.isOpen).toBe(true);
+
+        act(() => {
+            result.current.close();
+        });
+        expect(result.current.isOpen).toBe(false);
+    });
+});

--- a/src/features/analysis-nudge/hooks/useAnonAnalysisNudge.ts
+++ b/src/features/analysis-nudge/hooks/useAnonAnalysisNudge.ts
@@ -12,6 +12,19 @@ export interface UseAnonAnalysisNudgeResult {
     /** Whether the signup-nudge modal should be rendered open. */
     isOpen: boolean;
     /**
+     * True once `useCurrentUser` has settled (data !== undefined) — i.e. we
+     * definitively know whether the visitor is a member or anonymous.
+     * Callers that gate a "consume once" ref (e.g. ChartContent's
+     * notifiedSymbolRef) on `onSymbolAnalyzed` MUST also gate on this flag
+     * and include it in their effect's dependency array. Otherwise a call
+     * that lands before login resolves gets silently absorbed by the
+     * no-op branch below, the ref is marked "done" anyway, and the
+     * effective (anonymous) call that would fire once resolution flips
+     * true never happens — dropping that symbol from the distinct-symbol
+     * count (see member-reasoning-toggle spec Part B).
+     */
+    isLoginResolved: boolean;
+    /**
      * Call when a symbol analysis completes/renders. No-op for members and
      * while the login state is still resolving (§ do not count before
      * membership is known — a member's first paint must never be
@@ -60,5 +73,5 @@ export function useAnonAnalysisNudge(): UseAnonAnalysisNudgeResult {
         setIsOpen(false);
     }, []);
 
-    return { isOpen, onSymbolAnalyzed, close };
+    return { isOpen, isLoginResolved, onSymbolAnalyzed, close };
 }

--- a/src/features/analysis-nudge/hooks/useAnonAnalysisNudge.ts
+++ b/src/features/analysis-nudge/hooks/useAnonAnalysisNudge.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useCurrentUser } from '@/entities/auth';
+import {
+    recordAnonSymbolAnalysis,
+    hasNudgeShownToday,
+    markNudgeShownToday,
+} from '@/shared/lib/anonAnalysisCount';
+
+export interface UseAnonAnalysisNudgeResult {
+    /** Whether the signup-nudge modal should be rendered open. */
+    isOpen: boolean;
+    /**
+     * Call when a symbol analysis completes/renders. No-op for members and
+     * while the login state is still resolving (§ do not count before
+     * membership is known — a member's first paint must never be
+     * miscounted as anonymous activity, and an anonymous visitor's first
+     * paint must not be dropped either way, so the safest boundary is to
+     * wait for the definitive answer before counting at all).
+     */
+    onSymbolAnalyzed: (symbol: string) => void;
+    /** Dismiss the modal (does not mark it shown again — already marked on open). */
+    close: () => void;
+}
+
+/**
+ * Anonymous 3-distinct-symbol signup nudge (member-reasoning-toggle spec Part
+ * B). Tracks distinct symbols an anonymous visitor has analyzed today via
+ * `recordAnonSymbolAnalysis`, and opens a soft nudge modal the first time the
+ * count crosses the threshold — once per day (`hasNudgeShownToday`/
+ * `markNudgeShownToday`). Members are always a no-op: the counter and modal
+ * exist purely to solicit signup, so a logged-in user has nothing to gain
+ * from either.
+ */
+export function useAnonAnalysisNudge(): UseAnonAnalysisNudgeResult {
+    const currentUserQuery = useCurrentUser();
+    // undefined until the query settles — before that we don't know whether
+    // the visitor is a member, so we must not count (see onSymbolAnalyzed doc).
+    const isLoginResolved = currentUserQuery.data !== undefined;
+    const isAnonymous = isLoginResolved && currentUserQuery.data === null;
+
+    const [isOpen, setIsOpen] = useState(false);
+
+    const onSymbolAnalyzed = useCallback(
+        (symbol: string): void => {
+            if (!isAnonymous) return;
+
+            const { crossedThreshold } = recordAnonSymbolAnalysis(symbol);
+            if (!crossedThreshold) return;
+            if (hasNudgeShownToday()) return;
+
+            markNudgeShownToday();
+            setIsOpen(true);
+        },
+        [isAnonymous]
+    );
+
+    const close = useCallback((): void => {
+        setIsOpen(false);
+    }, []);
+
+    return { isOpen, onSymbolAnalyzed, close };
+}

--- a/src/features/analysis-nudge/index.ts
+++ b/src/features/analysis-nudge/index.ts
@@ -1,0 +1,3 @@
+// analysis-nudge feature barrel — 비회원 3-심볼 회원가입 유도 공개 API.
+export { useAnonAnalysisNudge } from './hooks/useAnonAnalysisNudge';
+export { AnalysisSignupNudgeModal } from './ui/AnalysisSignupNudgeModal';

--- a/src/features/analysis-nudge/ui/AnalysisSignupNudgeModal.tsx
+++ b/src/features/analysis-nudge/ui/AnalysisSignupNudgeModal.tsx
@@ -30,10 +30,7 @@ export function AnalysisSignupNudgeModal({
     }, []);
 
     return (
-        <div
-            className="fixed inset-0 z-50 flex items-center justify-center p-4"
-            aria-modal="true"
-        >
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
             {/* backdrop */}
             <div
                 className="bg-secondary-950/80 absolute inset-0 backdrop-blur-sm"
@@ -44,6 +41,7 @@ export function AnalysisSignupNudgeModal({
             <div
                 ref={panelRef}
                 role="dialog"
+                aria-modal="true"
                 aria-labelledby={TITLE_ID}
                 tabIndex={-1}
                 className="bg-secondary-900 ring-secondary-800 relative w-full max-w-sm rounded-2xl p-6 shadow-2xl ring-1 outline-none"

--- a/src/features/analysis-nudge/ui/AnalysisSignupNudgeModal.tsx
+++ b/src/features/analysis-nudge/ui/AnalysisSignupNudgeModal.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEscapeKey } from '@/shared/hooks/useEscapeKey';
+import { useFocusTrap } from '@/shared/hooks/useFocusTrap';
+import Link from 'next/link';
+import { useEffect, useRef } from 'react';
+
+interface AnalysisSignupNudgeModalProps {
+    onClose: () => void;
+}
+
+const TITLE_ID = 'analysis-signup-nudge-title';
+
+/**
+ * Anonymous 3-distinct-symbol signup nudge modal (member-reasoning-toggle
+ * spec Part B.3). Reuses `PremiumModelGateModal`'s auth-mode dialog a11y
+ * pattern (focus-trap/escape/backdrop close) but with its own copy — this
+ * modal is purely informational (soft nudge), never blocking analysis.
+ */
+export function AnalysisSignupNudgeModal({
+    onClose,
+}: AnalysisSignupNudgeModalProps) {
+    const panelRef = useRef<HTMLDivElement>(null);
+
+    useFocusTrap(panelRef, true);
+    useEscapeKey(onClose, true);
+
+    useEffect(() => {
+        panelRef.current?.focus();
+    }, []);
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center p-4"
+            aria-modal="true"
+        >
+            {/* backdrop */}
+            <div
+                className="bg-secondary-950/80 absolute inset-0 backdrop-blur-sm"
+                onClick={onClose}
+                aria-hidden="true"
+            />
+
+            <div
+                ref={panelRef}
+                role="dialog"
+                aria-labelledby={TITLE_ID}
+                tabIndex={-1}
+                className="bg-secondary-900 ring-secondary-800 relative w-full max-w-sm rounded-2xl p-6 shadow-2xl ring-1 outline-none"
+            >
+                <div className="mb-4 flex flex-col items-center gap-3 text-center">
+                    {/* inline SVG avoids lucide-react dependency, mirrors PremiumModelGateModal */}
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className="text-primary-400 h-8 w-8"
+                        aria-hidden="true"
+                    >
+                        <path d="M12 2 2 7l10 5 10-5-10-5Z" />
+                        <path d="m2 17 10 5 10-5" />
+                        <path d="m2 12 10 5 10-5" />
+                    </svg>
+                    <h2
+                        id={TITLE_ID}
+                        className="text-secondary-50 font-semibold"
+                    >
+                        더 깊은 분석을 원하세요?
+                    </h2>
+                    <p className="text-secondary-300 text-sm leading-relaxed">
+                        회원가입하면 &apos;깊은 생각&apos;을 켜고 더 자세한 분석
+                        리포트를 받을 수 있어요.
+                    </p>
+                </div>
+
+                <div className="flex flex-col gap-2">
+                    <Link
+                        href="/signup"
+                        onClick={onClose}
+                        className="bg-primary-600 hover:bg-primary-500 focus-visible:ring-primary-500 flex h-10 items-center justify-center rounded-lg px-4 text-sm font-medium text-white transition-colors focus-visible:ring-2 focus-visible:outline-none"
+                    >
+                        회원가입 하러 가기
+                    </Link>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="text-secondary-400 hover:text-secondary-200 focus-visible:ring-primary-500 flex h-10 items-center justify-center rounded-lg px-4 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none"
+                    >
+                        닫기
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/features/analysis-nudge/ui/__tests__/AnalysisSignupNudgeModal.test.tsx
+++ b/src/features/analysis-nudge/ui/__tests__/AnalysisSignupNudgeModal.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AnalysisSignupNudgeModal } from '@/features/analysis-nudge/ui/AnalysisSignupNudgeModal';
+
+vi.mock('next/link', () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+        [key: string]: unknown;
+    }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock('@/shared/hooks/useEscapeKey', () => ({
+    useEscapeKey: vi.fn(),
+}));
+
+vi.mock('@/shared/hooks/useFocusTrap', () => ({
+    useFocusTrap: vi.fn(),
+}));
+
+describe('AnalysisSignupNudgeModal', () => {
+    it('renders the nudge title and body copy', () => {
+        render(<AnalysisSignupNudgeModal onClose={vi.fn()} />);
+        expect(
+            screen.getByText('더 깊은 분석을 원하세요?')
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                /회원가입하면 '깊은 생각'을 켜고 더 자세한 분석 리포트를 받을 수 있어요\./
+            )
+        ).toBeInTheDocument();
+    });
+
+    it('renders the signup CTA linking to /signup', () => {
+        render(<AnalysisSignupNudgeModal onClose={vi.fn()} />);
+        expect(
+            screen.getByRole('link', { name: '회원가입 하러 가기' })
+        ).toHaveAttribute('href', '/signup');
+    });
+
+    it('has dialog a11y attributes', () => {
+        render(<AnalysisSignupNudgeModal onClose={vi.fn()} />);
+        const dialog = screen.getByRole('dialog');
+        expect(dialog).toHaveAttribute(
+            'aria-labelledby',
+            'analysis-signup-nudge-title'
+        );
+    });
+
+    it('calls onClose when the close button is clicked', async () => {
+        const onClose = vi.fn();
+        render(<AnalysisSignupNudgeModal onClose={onClose} />);
+        const user = userEvent.setup();
+        await user.click(screen.getByText('닫기'));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when the signup CTA is clicked (dismisses the modal on navigation)', async () => {
+        const onClose = vi.fn();
+        render(<AnalysisSignupNudgeModal onClose={onClose} />);
+        const user = userEvent.setup();
+        await user.click(
+            screen.getByRole('link', { name: '회원가입 하러 가기' })
+        );
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when the backdrop is clicked', async () => {
+        const onClose = vi.fn();
+        render(<AnalysisSignupNudgeModal onClose={onClose} />);
+        const user = userEvent.setup();
+        const backdrop = screen
+            .getByRole('dialog')
+            .parentElement!.querySelector('[aria-hidden="true"]');
+        expect(backdrop).not.toBeNull();
+        await user.click(backdrop!);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/features/reasoning-toggle/hooks/__tests__/useReasoningToggle.test.tsx
+++ b/src/features/reasoning-toggle/hooks/__tests__/useReasoningToggle.test.tsx
@@ -1,0 +1,69 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useReasoningToggle } from '@/features/reasoning-toggle/hooks/useReasoningToggle';
+import { LOCAL_STORAGE_REASONING_KEY } from '@/shared/lib/storageKeys';
+
+describe('useReasoningToggle', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('defaults to false (OFF)', () => {
+        const { result } = renderHook(() => useReasoningToggle());
+        expect(result.current[0]).toBe(false);
+    });
+
+    it('persists true to localStorage', () => {
+        const { result } = renderHook(() => useReasoningToggle());
+
+        act(() => {
+            result.current[1](true);
+        });
+
+        expect(localStorage.getItem(LOCAL_STORAGE_REASONING_KEY)).toBe('true');
+        expect(result.current[0]).toBe(true);
+    });
+
+    it('persists false to localStorage', () => {
+        const { result } = renderHook(() => useReasoningToggle());
+
+        act(() => {
+            result.current[1](true);
+        });
+        act(() => {
+            result.current[1](false);
+        });
+
+        expect(localStorage.getItem(LOCAL_STORAGE_REASONING_KEY)).toBe('false');
+        expect(result.current[0]).toBe(false);
+    });
+
+    it('reads a stored true value from localStorage after hydration', async () => {
+        localStorage.setItem(LOCAL_STORAGE_REASONING_KEY, 'true');
+
+        const { result } = renderHook(() => useReasoningToggle());
+
+        await waitFor(() => {
+            expect(result.current[2]).toBe(true);
+        });
+
+        expect(result.current[0]).toBe(true);
+    });
+
+    it('resolves to false when localStorage has no stored value', async () => {
+        const { result } = renderHook(() => useReasoningToggle());
+
+        await waitFor(() => {
+            expect(result.current[2]).toBe(true);
+        });
+
+        expect(result.current[0]).toBe(false);
+    });
+
+    it('becomes hydrated after the mount effect runs', async () => {
+        const { result } = renderHook(() => useReasoningToggle());
+
+        await waitFor(() => {
+            expect(result.current[2]).toBe(true);
+        });
+    });
+});

--- a/src/features/reasoning-toggle/hooks/useReasoningToggle.ts
+++ b/src/features/reasoning-toggle/hooks/useReasoningToggle.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import {
+    startTransition,
+    useCallback,
+    useEffect,
+    useEffectEvent,
+    useState,
+} from 'react';
+import { LOCAL_STORAGE_REASONING_KEY } from '@/shared/lib/storageKeys';
+
+/**
+ * Member "깊은 생각" (deep-thinking / reasoning) toggle state — persisted to
+ * localStorage (member-reasoning-toggle spec Part A.2). Mirrors
+ * `useSelectedModel`'s hydration pattern: SSR/first paint always renders the
+ * default (`false`), then a `useEffect` reads the stored value so hydration
+ * never mismatches server output.
+ *
+ * The *effective* value actually sent to the server is still tier-gated
+ * elsewhere (`SymbolModelContext`/server `resolveReasoning`) — this hook only
+ * tracks the member's raw persisted preference.
+ *
+ * @returns `[reasoning, setReasoning, isHydrated]`
+ */
+export function useReasoningToggle(): [
+    boolean,
+    (value: boolean) => void,
+    boolean,
+] {
+    const [reasoning, setReasoningState] = useState(false);
+    const [isHydrated, setIsHydrated] = useState(false);
+
+    const setReasoning = useCallback((value: boolean): void => {
+        if (typeof window !== 'undefined') {
+            localStorage.setItem(LOCAL_STORAGE_REASONING_KEY, String(value));
+        }
+        setReasoningState(value);
+    }, []);
+
+    const readFromStorage = useEffectEvent((): void => {
+        if (typeof window === 'undefined') return;
+        const stored = localStorage.getItem(LOCAL_STORAGE_REASONING_KEY);
+        startTransition(() => {
+            setReasoningState(stored === 'true');
+            setIsHydrated(true);
+        });
+    });
+
+    useEffect(() => {
+        readFromStorage();
+    }, []);
+
+    return [reasoning, setReasoning, isHydrated];
+}

--- a/src/features/reasoning-toggle/index.ts
+++ b/src/features/reasoning-toggle/index.ts
@@ -1,0 +1,3 @@
+// reasoning-toggle feature barrel — member "깊은 생각" toggle 공개 API.
+export { ReasoningToggle } from './ui/ReasoningToggle';
+export { useReasoningToggle } from './hooks/useReasoningToggle';

--- a/src/features/reasoning-toggle/ui/ReasoningToggle.tsx
+++ b/src/features/reasoning-toggle/ui/ReasoningToggle.tsx
@@ -34,7 +34,7 @@ export function ReasoningToggle({
 
     return (
         <div className={cn('flex flex-col gap-1', className)}>
-            <label className="flex items-center gap-2">
+            <div className="flex items-center gap-2">
                 <span className="text-secondary-400 text-xs whitespace-nowrap">
                     깊은 생각
                 </span>
@@ -59,7 +59,7 @@ export function ReasoningToggle({
                         )}
                     />
                 </button>
-            </label>
+            </div>
             {checked && (
                 <p className="text-secondary-500 text-[10px] leading-relaxed">
                     추론을 켜면 상세 분석을 하느라 응답이 다소 지연될 수 있어요.

--- a/src/features/reasoning-toggle/ui/ReasoningToggle.tsx
+++ b/src/features/reasoning-toggle/ui/ReasoningToggle.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { cn } from '@/shared/lib/cn';
+
+interface ReasoningToggleProps {
+    /** Current toggle value. */
+    checked: boolean;
+    onChange: (value: boolean) => void;
+    /**
+     * Member-only gating (member-reasoning-toggle spec Part A.4) — anonymous
+     * and free-tier visitors never see this control. When `false` the
+     * component renders nothing (not just disabled) so free/anon layouts stay
+     * unchanged.
+     */
+    visible: boolean;
+    disabled?: boolean;
+    className?: string;
+}
+
+/**
+ * "깊은 생각" (deep-thinking / reasoning) toggle — member-only control that
+ * threads a per-request `reasoning: boolean` into every symbol analysis
+ * submit (member-reasoning-toggle spec Part A). Mirrors `ModelSelector`'s
+ * visual language so it reads as part of the same control cluster.
+ */
+export function ReasoningToggle({
+    checked,
+    onChange,
+    visible,
+    disabled = false,
+    className,
+}: ReasoningToggleProps) {
+    if (!visible) return null;
+
+    return (
+        <div className={cn('flex flex-col gap-1', className)}>
+            <label className="flex items-center gap-2">
+                <span className="text-secondary-400 text-xs whitespace-nowrap">
+                    깊은 생각
+                </span>
+                <button
+                    type="button"
+                    role="switch"
+                    aria-checked={checked}
+                    aria-label="깊은 생각 (추론) 토글"
+                    disabled={disabled}
+                    onClick={() => onChange(!checked)}
+                    className={cn(
+                        'focus-visible:ring-primary-500 relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus-visible:ring-1 focus-visible:outline-none',
+                        checked ? 'bg-primary-600' : 'bg-secondary-700',
+                        disabled && 'cursor-not-allowed opacity-60'
+                    )}
+                >
+                    <span
+                        aria-hidden="true"
+                        className={cn(
+                            'inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform',
+                            checked ? 'translate-x-[18px]' : 'translate-x-1'
+                        )}
+                    />
+                </button>
+            </label>
+            {checked && (
+                <p className="text-secondary-500 text-[10px] leading-relaxed">
+                    추론을 켜면 상세 분석을 하느라 응답이 다소 지연될 수 있어요.
+                </p>
+            )}
+        </div>
+    );
+}

--- a/src/features/reasoning-toggle/ui/__tests__/ReasoningToggle.test.tsx
+++ b/src/features/reasoning-toggle/ui/__tests__/ReasoningToggle.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ReasoningToggle } from '@/features/reasoning-toggle/ui/ReasoningToggle';
+
+describe('ReasoningToggle', () => {
+    it('renders nothing when visible is false (anonymous/free)', () => {
+        const { container } = render(
+            <ReasoningToggle
+                checked={false}
+                onChange={vi.fn()}
+                visible={false}
+            />
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders the switch when visible is true (member/pro)', () => {
+        render(
+            <ReasoningToggle
+                checked={false}
+                onChange={vi.fn()}
+                visible={true}
+            />
+        );
+        expect(screen.getByRole('switch')).toBeDefined();
+        expect(screen.getByText('깊은 생각')).toBeDefined();
+    });
+
+    it('reflects checked=true via aria-checked', () => {
+        render(
+            <ReasoningToggle checked={true} onChange={vi.fn()} visible={true} />
+        );
+        expect(screen.getByRole('switch').getAttribute('aria-checked')).toBe(
+            'true'
+        );
+    });
+
+    it('reflects checked=false via aria-checked', () => {
+        render(
+            <ReasoningToggle
+                checked={false}
+                onChange={vi.fn()}
+                visible={true}
+            />
+        );
+        expect(screen.getByRole('switch').getAttribute('aria-checked')).toBe(
+            'false'
+        );
+    });
+
+    it('calls onChange with the toggled value on click', () => {
+        const onChange = vi.fn();
+        render(
+            <ReasoningToggle
+                checked={false}
+                onChange={onChange}
+                visible={true}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('switch'));
+
+        expect(onChange).toHaveBeenCalledWith(true);
+    });
+
+    it('shows the delay-notice text when checked', () => {
+        render(
+            <ReasoningToggle checked={true} onChange={vi.fn()} visible={true} />
+        );
+        expect(
+            screen.getByText(
+                '추론을 켜면 상세 분석을 하느라 응답이 다소 지연될 수 있어요.'
+            )
+        ).toBeDefined();
+    });
+
+    it('hides the delay-notice text when unchecked', () => {
+        render(
+            <ReasoningToggle
+                checked={false}
+                onChange={vi.fn()}
+                visible={true}
+            />
+        );
+        expect(
+            screen.queryByText(
+                '추론을 켜면 상세 분석을 하느라 응답이 다소 지연될 수 있어요.'
+            )
+        ).toBeNull();
+    });
+
+    it('does not call onChange when disabled', () => {
+        const onChange = vi.fn();
+        render(
+            <ReasoningToggle
+                checked={false}
+                onChange={onChange}
+                visible={true}
+                disabled={true}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('switch'));
+
+        expect(onChange).not.toHaveBeenCalled();
+    });
+});

--- a/src/features/symbol-model/__tests__/SymbolModelContext.test.tsx
+++ b/src/features/symbol-model/__tests__/SymbolModelContext.test.tsx
@@ -24,8 +24,17 @@ vi.mock('@/features/premium-gate', () => ({
     })),
 }));
 
+const { mockUseUserTier, mockUseReasoningToggle } = vi.hoisted(() => ({
+    mockUseUserTier: vi.fn(() => ({ tier: 'free', isLoading: false })),
+    mockUseReasoningToggle: vi.fn(() => [false, vi.fn()]),
+}));
+
 vi.mock('@/features/symbol-model/hooks/useUserTier', () => ({
-    useUserTier: vi.fn(() => ({ tier: 'free', isLoading: false })),
+    useUserTier: mockUseUserTier,
+}));
+
+vi.mock('@/features/reasoning-toggle', () => ({
+    useReasoningToggle: mockUseReasoningToggle,
 }));
 
 const queryClients: QueryClient[] = [];
@@ -45,6 +54,11 @@ function makeWrapper() {
 }
 
 describe('SymbolModelContext', () => {
+    beforeEach(() => {
+        mockUseUserTier.mockReturnValue({ tier: 'free', isLoading: false });
+        mockUseReasoningToggle.mockReturnValue([false, vi.fn(), true]);
+    });
+
     afterEach(() => {
         queryClients.splice(0).forEach(c => c.clear());
     });
@@ -85,5 +99,77 @@ describe('SymbolModelContext', () => {
         });
 
         expect(result.current.isHydrated).toBe(true);
+    });
+
+    describe('reasoning gating (member-reasoning-toggle spec Part A)', () => {
+        it('forces reasoning=false and canUseReasoning=false for free tier even if stored preference is true', () => {
+            mockUseUserTier.mockReturnValue({ tier: 'free', isLoading: false });
+            mockUseReasoningToggle.mockReturnValue([true, vi.fn(), true]);
+
+            const { result } = renderHook(() => useSymbolModel(), {
+                wrapper: makeWrapper(),
+            });
+
+            expect(result.current.canUseReasoning).toBe(false);
+            expect(result.current.reasoning).toBe(false);
+        });
+
+        it('honors the stored true preference for member tier', () => {
+            mockUseUserTier.mockReturnValue({
+                tier: 'member',
+                isLoading: false,
+            });
+            mockUseReasoningToggle.mockReturnValue([true, vi.fn(), true]);
+
+            const { result } = renderHook(() => useSymbolModel(), {
+                wrapper: makeWrapper(),
+            });
+
+            expect(result.current.canUseReasoning).toBe(true);
+            expect(result.current.reasoning).toBe(true);
+        });
+
+        it('honors the stored true preference for pro tier', () => {
+            mockUseUserTier.mockReturnValue({ tier: 'pro', isLoading: false });
+            mockUseReasoningToggle.mockReturnValue([true, vi.fn(), true]);
+
+            const { result } = renderHook(() => useSymbolModel(), {
+                wrapper: makeWrapper(),
+            });
+
+            expect(result.current.canUseReasoning).toBe(true);
+            expect(result.current.reasoning).toBe(true);
+        });
+
+        it('defaults reasoning=false for member tier when stored preference is false', () => {
+            mockUseUserTier.mockReturnValue({
+                tier: 'member',
+                isLoading: false,
+            });
+            mockUseReasoningToggle.mockReturnValue([false, vi.fn(), true]);
+
+            const { result } = renderHook(() => useSymbolModel(), {
+                wrapper: makeWrapper(),
+            });
+
+            expect(result.current.canUseReasoning).toBe(true);
+            expect(result.current.reasoning).toBe(false);
+        });
+
+        it('exposes setReasoning delegating to the underlying toggle setter', () => {
+            const setReasoning = vi.fn();
+            mockUseUserTier.mockReturnValue({
+                tier: 'member',
+                isLoading: false,
+            });
+            mockUseReasoningToggle.mockReturnValue([false, setReasoning, true]);
+
+            const { result } = renderHook(() => useSymbolModel(), {
+                wrapper: makeWrapper(),
+            });
+
+            result.current.setReasoning(true);
+            expect(setReasoning).toHaveBeenCalledWith(true);
+        });
     });
 });

--- a/src/features/symbol-model/__tests__/useDefaultReasoning.test.tsx
+++ b/src/features/symbol-model/__tests__/useDefaultReasoning.test.tsx
@@ -1,0 +1,24 @@
+import { renderHook } from '@testing-library/react';
+import { useDefaultReasoning } from '@/features/symbol-model/hooks/useDefaultReasoning';
+
+const { mockUseSymbolModel } = vi.hoisted(() => ({
+    mockUseSymbolModel: vi.fn(),
+}));
+
+vi.mock('@/features/symbol-model/model/SymbolModelContext', () => ({
+    useSymbolModel: mockUseSymbolModel,
+}));
+
+describe('useDefaultReasoning', () => {
+    it('returns the (tier-gated) reasoning value from SymbolModelContext when true', () => {
+        mockUseSymbolModel.mockReturnValue({ reasoning: true });
+        const { result } = renderHook(() => useDefaultReasoning());
+        expect(result.current).toBe(true);
+    });
+
+    it('returns false when SymbolModelContext reasoning is false', () => {
+        mockUseSymbolModel.mockReturnValue({ reasoning: false });
+        const { result } = renderHook(() => useDefaultReasoning());
+        expect(result.current).toBe(false);
+    });
+});

--- a/src/features/symbol-model/hooks/useDefaultReasoning.ts
+++ b/src/features/symbol-model/hooks/useDefaultReasoning.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useSymbolModel } from '../model/SymbolModelContext';
+
+/**
+ * AI 분석 탭(뉴스, 펀더멘털, 재무, 종합, 옵션, 의회 동향)에서 공통으로 사용하는
+ * 효과적(tier-gated) "깊은 생각" reasoning 값을 반환한다 (member-reasoning-toggle
+ * spec Part A). 단일 진실값은 SymbolModelContext — 헤더의 ReasoningToggle이 쓰는
+ * 것과 동일 상태이므로 탭을 이동해도 값이 일관되게 유지된다.
+ *
+ * Mirrors `useDefaultModelId` — the value is already tier-gated by
+ * `SymbolModelContext` (always `false` for free/anonymous), so every submit
+ * call site can pass it straight through without re-deriving tier.
+ */
+export function useDefaultReasoning(): boolean {
+    const { reasoning } = useSymbolModel();
+    return reasoning;
+}

--- a/src/features/symbol-model/index.ts
+++ b/src/features/symbol-model/index.ts
@@ -6,3 +6,4 @@ export {
     useSymbolModel,
 } from './model/SymbolModelContext';
 export { useDefaultModelId } from './hooks/useDefaultModelId';
+export { useDefaultReasoning } from './hooks/useDefaultReasoning';

--- a/src/features/symbol-model/model/SymbolModelContext.tsx
+++ b/src/features/symbol-model/model/SymbolModelContext.tsx
@@ -5,6 +5,7 @@ import { getAllowedModels, type ModelId } from '@y0ngha/siglens-core';
 import { useSelectedModel } from '../hooks/useSelectedModel';
 import { useModelGate, type ModelGateState } from '@/features/premium-gate';
 import { useUserTier } from '../hooks/useUserTier';
+import { useReasoningToggle } from '@/features/reasoning-toggle';
 
 interface SymbolModelContextValue {
     modelId: ModelId;
@@ -13,6 +14,25 @@ interface SymbolModelContextValue {
     gateModal: ModelGateState | null;
     dismissGate: () => void;
     handleModelChange: (model: ModelId) => void;
+    /**
+     * Effective "깊은 생각" (reasoning) value — member-reasoning-toggle spec
+     * Part A. Already tier-gated: `false` for anonymous/free regardless of
+     * the member's stored preference. Server-side `resolveReasoning` is the
+     * authoritative enforcement; this client-side gate only prevents a
+     * stale/stray `true` from a downgraded session from being sent at all.
+     */
+    reasoning: boolean;
+    /** Persists the member's raw toggle preference (member-only UI writes this). */
+    setReasoning: (value: boolean) => void;
+    /** Whether the current tier is allowed to see/use the reasoning toggle (member/pro). */
+    canUseReasoning: boolean;
+    /**
+     * Whether the reasoning toggle's localStorage read has completed (mirrors
+     * `isHydrated` for `modelId`). Consumers that restart analysis on
+     * reasoning change (e.g. `useAnalysis`) gate on this the same way they
+     * gate on model hydration, to avoid a spurious extra fetch mid-hydration.
+     */
+    isReasoningHydrated: boolean;
 }
 
 const SymbolModelContext = createContext<SymbolModelContextValue | null>(null);
@@ -28,6 +48,13 @@ export function SymbolModelProvider({ children }: SymbolModelProviderProps) {
     const { gateModal, dismissGate, handleModelChange } = useModelGate({
         onAllow: setModelId,
     });
+    const [storedReasoning, setReasoning, isReasoningHydrated] =
+        useReasoningToggle();
+    // free(익명 포함) tier는 서버에서도 강제되지만(resolveReasoning), 클라에서도
+    // 미리 false로 접어 두면 downgrade(로그아웃/등급 하락) 직후 stale true 값이
+    // 한 프레임이라도 실제 submit에 실려 나가는 것을 방지한다.
+    const canUseReasoning = tier !== 'free';
+    const reasoning = canUseReasoning && storedReasoning;
 
     const value = useMemo(
         () => ({
@@ -37,6 +64,10 @@ export function SymbolModelProvider({ children }: SymbolModelProviderProps) {
             gateModal,
             dismissGate,
             handleModelChange,
+            reasoning,
+            setReasoning,
+            canUseReasoning,
+            isReasoningHydrated,
         }),
         [
             modelId,
@@ -45,6 +76,10 @@ export function SymbolModelProvider({ children }: SymbolModelProviderProps) {
             gateModal,
             dismissGate,
             handleModelChange,
+            reasoning,
+            setReasoning,
+            canUseReasoning,
+            isReasoningHydrated,
         ]
     );
 

--- a/src/shared/config/__tests__/queryConfig.test.ts
+++ b/src/shared/config/__tests__/queryConfig.test.ts
@@ -83,12 +83,20 @@ describe('queryConfig staleTime constants', () => {
 describe('QUERY_KEYS.financialsAnalysis', () => {
     const MODEL_ID = 'gemini-2.5-flash' as ModelId;
 
-    it('key 배열은 [prefix, UPPER_SYMBOL, modelId] 형태이다', () => {
+    it('key 배열은 [prefix, UPPER_SYMBOL, modelId, reasoning] 형태이다', () => {
         expect(QUERY_KEYS.financialsAnalysis('aapl', MODEL_ID)).toEqual([
             'financials-analysis',
             'AAPL',
             MODEL_ID,
+            false,
         ]);
+    });
+
+    it('reasoning=true는 reasoning=false(기본)와 다른 키를 만든다 (member-reasoning-toggle spec)', () => {
+        const off = QUERY_KEYS.financialsAnalysis('AAPL', MODEL_ID, false);
+        const on = QUERY_KEYS.financialsAnalysis('AAPL', MODEL_ID, true);
+        expect(off).not.toEqual(on);
+        expect(QUERY_KEYS.financialsAnalysis('AAPL', MODEL_ID)).toEqual(off);
     });
 
     it('symbol을 대문자로 정규화한다', () => {
@@ -149,36 +157,54 @@ describe('QUERY_KEYS — 나머지 키 팩토리', () => {
         ]);
     });
 
-    it('fundamentalAnalysis: symbol 대문자 정규화 + modelId', () => {
+    it('fundamentalAnalysis: symbol 대문자 정규화 + modelId + reasoning(기본 false)', () => {
         expect(QUERY_KEYS.fundamentalAnalysis('aapl', MODEL_ID)).toEqual([
             'fundamental-analysis',
             'AAPL',
             MODEL_ID,
+            false,
         ]);
     });
 
-    it('congressTrend: symbol 대문자 정규화 + modelId', () => {
+    it('congressTrend: symbol 대문자 정규화 + modelId + reasoning(기본 false)', () => {
         expect(QUERY_KEYS.congressTrend('aapl', MODEL_ID)).toEqual([
             'congress-trend',
             'AAPL',
             MODEL_ID,
+            false,
         ]);
     });
 
-    it('newsAnalysis: symbol 대문자 정규화 + companyName + modelId', () => {
+    it('newsAnalysis: symbol 대문자 정규화 + companyName + modelId + reasoning(기본 false)', () => {
         expect(QUERY_KEYS.newsAnalysis('aapl', 'Apple Inc.', MODEL_ID)).toEqual(
-            ['news-analysis', 'AAPL', 'Apple Inc.', MODEL_ID]
+            ['news-analysis', 'AAPL', 'Apple Inc.', MODEL_ID, false]
         );
     });
 
-    it('newsAnalysisPrefix: 모든 modelId 변형을 무효화하는 prefix', () => {
+    it('newsAnalysis: reasoning=true는 다른 키를 만든다', () => {
+        const on = QUERY_KEYS.newsAnalysis(
+            'aapl',
+            'Apple Inc.',
+            MODEL_ID,
+            true
+        );
+        expect(on).toEqual([
+            'news-analysis',
+            'AAPL',
+            'Apple Inc.',
+            MODEL_ID,
+            true,
+        ]);
+    });
+
+    it('newsAnalysisPrefix: 모든 modelId/reasoning 변형을 무효화하는 prefix', () => {
         expect(QUERY_KEYS.newsAnalysisPrefix('aapl')).toEqual([
             'news-analysis',
             'AAPL',
         ]);
     });
 
-    it('overallAnalysis: symbol 대문자 + companyName + timeframe + modelId', () => {
+    it('overallAnalysis: symbol 대문자 + companyName + timeframe + modelId + reasoning(기본 false)', () => {
         expect(
             QUERY_KEYS.overallAnalysis(
                 'aapl',
@@ -192,6 +218,7 @@ describe('QUERY_KEYS — 나머지 키 팩토리', () => {
             'Apple Inc.',
             TIMEFRAME,
             MODEL_ID,
+            false,
         ]);
     });
 
@@ -209,7 +236,7 @@ describe('QUERY_KEYS — 나머지 키 팩토리', () => {
         ]);
     });
 
-    it('optionsAnalysis: symbol + companyName + expirationDate + modelId', () => {
+    it('optionsAnalysis: symbol + companyName + expirationDate + modelId + reasoning(기본 false)', () => {
         expect(
             QUERY_KEYS.optionsAnalysis(
                 'aapl',
@@ -223,6 +250,7 @@ describe('QUERY_KEYS — 나머지 키 팩토리', () => {
             'Apple Inc.',
             '2025-01-17',
             MODEL_ID,
+            false,
         ]);
     });
 });

--- a/src/shared/config/queryConfig.ts
+++ b/src/shared/config/queryConfig.ts
@@ -68,19 +68,38 @@ export const QUERY_KEYS = {
     userTier: () => ['user-tier'] as const,
     remainingTokens: () => ['chat', 'remaining-tokens'] as const,
     registeredProviders: () => ['llm', 'registered-providers'] as const,
-    fundamentalAnalysis: (symbol: string, modelId: ModelId) =>
-        ['fundamental-analysis', upper(symbol), modelId] as const,
-    financialsAnalysis: (symbol: string, modelId: ModelId) =>
-        ['financials-analysis', upper(symbol), modelId] as const,
-    congressTrend: (symbol: string, modelId: ModelId) =>
-        ['congress-trend', upper(symbol), modelId] as const,
+    // reasoning defaults to `false` on every analysis key below so existing
+    // 2/3-arg call sites (pre-member-reasoning-toggle) keep resolving to the
+    // exact same key they always have — only a member's explicit `true` value
+    // produces a distinct key (member-reasoning-toggle spec Part A: "changing
+    // the toggle re-submits analysis" relies on this key change).
+    fundamentalAnalysis: (
+        symbol: string,
+        modelId: ModelId,
+        reasoning = false
+    ) => ['fundamental-analysis', upper(symbol), modelId, reasoning] as const,
+    financialsAnalysis: (symbol: string, modelId: ModelId, reasoning = false) =>
+        ['financials-analysis', upper(symbol), modelId, reasoning] as const,
+    congressTrend: (symbol: string, modelId: ModelId, reasoning = false) =>
+        ['congress-trend', upper(symbol), modelId, reasoning] as const,
     // News augment (chart page) and news analysis (news page) share this key so
     // a single React Query entry serves both pages within a session — preventing
     // a duplicate fetch when the user navigates between /AAPL and /AAPL/news.
     // Augment consumers may use `select` to project to a narrower shape.
-    newsAnalysis: (symbol: string, companyName: string, modelId: ModelId) =>
-        ['news-analysis', upper(symbol), companyName, modelId] as const,
-    /** Prefix key — invalidates all modelId variants for a symbol at once. */
+    newsAnalysis: (
+        symbol: string,
+        companyName: string,
+        modelId: ModelId,
+        reasoning = false
+    ) =>
+        [
+            'news-analysis',
+            upper(symbol),
+            companyName,
+            modelId,
+            reasoning,
+        ] as const,
+    /** Prefix key — invalidates all modelId/reasoning variants for a symbol at once. */
     newsAnalysisPrefix: (
         symbol: string
     ): readonly ['news-analysis', string] => ['news-analysis', upper(symbol)],
@@ -88,7 +107,8 @@ export const QUERY_KEYS = {
         symbol: string,
         companyName: string,
         timeframe: Timeframe,
-        modelId: ModelId
+        modelId: ModelId,
+        reasoning = false
     ) =>
         [
             'overall-analysis',
@@ -96,6 +116,7 @@ export const QUERY_KEYS = {
             companyName,
             timeframe,
             modelId,
+            reasoning,
         ] as const,
     sectorSignals: (timeframe: DashboardTimeframe) =>
         ['sector-signals', timeframe] as const,
@@ -110,7 +131,8 @@ export const QUERY_KEYS = {
         symbol: string,
         companyName: string,
         expirationDate: OptionsExpirationSelector,
-        modelId: ModelId
+        modelId: ModelId,
+        reasoning = false
     ) =>
         [
             'options-analysis',
@@ -118,5 +140,6 @@ export const QUERY_KEYS = {
             companyName,
             expirationDate,
             modelId,
+            reasoning,
         ] as const,
 } as const;

--- a/src/shared/lib/__tests__/anonAnalysisCount.test.tsx
+++ b/src/shared/lib/__tests__/anonAnalysisCount.test.tsx
@@ -120,6 +120,15 @@ describe('recordAnonSymbolAnalysis', () => {
         const result = recordAnonSymbolAnalysis('AAPL', DAY_1);
         expect(result).toEqual({ distinctCount: 0, crossedThreshold: false });
     });
+
+    it('treats a tampered record with non-string symbols as absent (starts fresh)', () => {
+        localStorage.setItem(
+            LOCAL_STORAGE_ANON_ANALYZED_SYMBOLS_KEY,
+            JSON.stringify({ dateUtc: '2026-07-10', symbols: [1, 2, 3] })
+        );
+        const result = recordAnonSymbolAnalysis('AAPL', DAY_1);
+        expect(result).toEqual({ distinctCount: 1, crossedThreshold: false });
+    });
 });
 
 describe('hasNudgeShownToday / markNudgeShownToday', () => {

--- a/src/shared/lib/__tests__/anonAnalysisCount.test.tsx
+++ b/src/shared/lib/__tests__/anonAnalysisCount.test.tsx
@@ -1,0 +1,203 @@
+import {
+    recordAnonSymbolAnalysis,
+    hasNudgeShownToday,
+    markNudgeShownToday,
+    ANON_DISTINCT_SYMBOL_NUDGE_THRESHOLD,
+} from '@/shared/lib/anonAnalysisCount';
+import {
+    LOCAL_STORAGE_ANON_ANALYZED_SYMBOLS_KEY,
+    LOCAL_STORAGE_ANON_NUDGE_SHOWN_KEY,
+} from '@/shared/lib/storageKeys';
+
+const DAY_1 = new Date('2026-07-10T12:00:00.000Z');
+const DAY_1_LATER = new Date('2026-07-10T23:00:00.000Z');
+const DAY_2 = new Date('2026-07-11T00:30:00.000Z');
+
+describe('recordAnonSymbolAnalysis', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('returns distinctCount=1 and crossedThreshold=false for the first symbol', () => {
+        const result = recordAnonSymbolAnalysis('AAPL', DAY_1);
+        expect(result).toEqual({ distinctCount: 1, crossedThreshold: false });
+    });
+
+    it('dedups the same symbol analyzed twice (distinctCount stays 1)', () => {
+        recordAnonSymbolAnalysis('AAPL', DAY_1);
+        const result = recordAnonSymbolAnalysis('AAPL', DAY_1_LATER);
+        expect(result).toEqual({ distinctCount: 1, crossedThreshold: false });
+    });
+
+    it('dedups case-insensitively (AAPL === aapl)', () => {
+        recordAnonSymbolAnalysis('AAPL', DAY_1);
+        const result = recordAnonSymbolAnalysis('aapl', DAY_1);
+        expect(result.distinctCount).toBe(1);
+    });
+
+    it('crossedThreshold=true exactly on the call that reaches the threshold', () => {
+        recordAnonSymbolAnalysis('AAPL', DAY_1);
+        recordAnonSymbolAnalysis('TSLA', DAY_1);
+        const third = recordAnonSymbolAnalysis('NVDA', DAY_1);
+        expect(third).toEqual({
+            distinctCount: ANON_DISTINCT_SYMBOL_NUDGE_THRESHOLD,
+            crossedThreshold: true,
+        });
+    });
+
+    it('does not re-fire crossedThreshold on a 4th distinct symbol', () => {
+        recordAnonSymbolAnalysis('AAPL', DAY_1);
+        recordAnonSymbolAnalysis('TSLA', DAY_1);
+        recordAnonSymbolAnalysis('NVDA', DAY_1);
+        const fourth = recordAnonSymbolAnalysis('MSFT', DAY_1);
+        expect(fourth).toEqual({ distinctCount: 4, crossedThreshold: false });
+    });
+
+    it('does not re-fire crossedThreshold on a repeat of an already-counted symbol past the threshold', () => {
+        recordAnonSymbolAnalysis('AAPL', DAY_1);
+        recordAnonSymbolAnalysis('TSLA', DAY_1);
+        recordAnonSymbolAnalysis('NVDA', DAY_1);
+        const repeat = recordAnonSymbolAnalysis('AAPL', DAY_1);
+        expect(repeat).toEqual({ distinctCount: 3, crossedThreshold: false });
+    });
+
+    it('resets the counter on a UTC date change', () => {
+        recordAnonSymbolAnalysis('AAPL', DAY_1);
+        recordAnonSymbolAnalysis('TSLA', DAY_1);
+        const nextDay = recordAnonSymbolAnalysis('NVDA', DAY_2);
+        expect(nextDay).toEqual({ distinctCount: 1, crossedThreshold: false });
+    });
+
+    it('persists the record to localStorage under the documented key', () => {
+        recordAnonSymbolAnalysis('AAPL', DAY_1);
+        const raw = localStorage.getItem(
+            LOCAL_STORAGE_ANON_ANALYZED_SYMBOLS_KEY
+        );
+        expect(raw).not.toBeNull();
+        expect(JSON.parse(raw!)).toEqual({
+            dateUtc: '2026-07-10',
+            symbols: ['AAPL'],
+        });
+    });
+
+    it('is SSR-safe: returns a no-op result when window is undefined', () => {
+        const originalWindow = globalThis.window;
+        // @ts-expect-error -- simulating an SSR environment for this assertion
+        delete globalThis.window;
+        try {
+            const result = recordAnonSymbolAnalysis('AAPL', DAY_1);
+            expect(result).toEqual({
+                distinctCount: 0,
+                crossedThreshold: false,
+            });
+        } finally {
+            globalThis.window = originalWindow;
+        }
+    });
+
+    it('degrades to a no-op when localStorage throws (blocked storage)', () => {
+        const spy = vi
+            .spyOn(Storage.prototype, 'setItem')
+            .mockImplementation(() => {
+                throw new Error('storage blocked');
+            });
+        try {
+            const result = recordAnonSymbolAnalysis('AAPL', DAY_1);
+            expect(result).toEqual({
+                distinctCount: 0,
+                crossedThreshold: false,
+            });
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    it('degrades to a no-op when stored JSON is corrupted', () => {
+        localStorage.setItem(
+            LOCAL_STORAGE_ANON_ANALYZED_SYMBOLS_KEY,
+            'not-json{{'
+        );
+        const result = recordAnonSymbolAnalysis('AAPL', DAY_1);
+        expect(result).toEqual({ distinctCount: 0, crossedThreshold: false });
+    });
+});
+
+describe('hasNudgeShownToday / markNudgeShownToday', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('returns false when nothing has been marked', () => {
+        expect(hasNudgeShownToday(DAY_1)).toBe(false);
+    });
+
+    it('returns true after marking shown the same day', () => {
+        markNudgeShownToday(DAY_1);
+        expect(hasNudgeShownToday(DAY_1_LATER)).toBe(true);
+    });
+
+    it('returns false again after a UTC date change (nag-prevention resets daily)', () => {
+        markNudgeShownToday(DAY_1);
+        expect(hasNudgeShownToday(DAY_2)).toBe(false);
+    });
+
+    it('persists the shown flag under the documented key', () => {
+        markNudgeShownToday(DAY_1);
+        const raw = localStorage.getItem(LOCAL_STORAGE_ANON_NUDGE_SHOWN_KEY);
+        expect(raw).not.toBeNull();
+        expect(JSON.parse(raw!)).toEqual({ dateUtc: '2026-07-10' });
+    });
+
+    it('hasNudgeShownToday is SSR-safe (returns false when window is undefined)', () => {
+        const originalWindow = globalThis.window;
+        // @ts-expect-error -- simulating an SSR environment for this assertion
+        delete globalThis.window;
+        try {
+            expect(hasNudgeShownToday(DAY_1)).toBe(false);
+        } finally {
+            globalThis.window = originalWindow;
+        }
+    });
+
+    it('markNudgeShownToday is SSR-safe (no-op when window is undefined)', () => {
+        const originalWindow = globalThis.window;
+        // @ts-expect-error -- simulating an SSR environment for this assertion
+        delete globalThis.window;
+        try {
+            expect(() => markNudgeShownToday(DAY_1)).not.toThrow();
+        } finally {
+            globalThis.window = originalWindow;
+        }
+    });
+
+    it('hasNudgeShownToday degrades to false when localStorage throws', () => {
+        const spy = vi
+            .spyOn(Storage.prototype, 'getItem')
+            .mockImplementation(() => {
+                throw new Error('storage blocked');
+            });
+        try {
+            expect(hasNudgeShownToday(DAY_1)).toBe(false);
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    it('markNudgeShownToday degrades to a no-op when localStorage throws', () => {
+        const spy = vi
+            .spyOn(Storage.prototype, 'setItem')
+            .mockImplementation(() => {
+                throw new Error('storage blocked');
+            });
+        try {
+            expect(() => markNudgeShownToday(DAY_1)).not.toThrow();
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    it('hasNudgeShownToday degrades to false when stored JSON is corrupted', () => {
+        localStorage.setItem(LOCAL_STORAGE_ANON_NUDGE_SHOWN_KEY, '{{bad');
+        expect(hasNudgeShownToday(DAY_1)).toBe(false);
+    });
+});

--- a/src/shared/lib/__tests__/byokGate.test.ts
+++ b/src/shared/lib/__tests__/byokGate.test.ts
@@ -36,6 +36,8 @@ vi.mock('@/entities/api-key/api', async () => {
 import { LlmApiKeyDecryptionFailedError } from '@/entities/api-key/api';
 import {
     resolveTierAndByok,
+    resolveTierOnly,
+    resolveReasoning,
     buildGateError,
     isKnownModelId,
 } from '../byokGate';
@@ -149,6 +151,54 @@ describe('buildGateError', () => {
         expect(err.code).toBe('invalid_model');
         expect(typeof err.message).toBe('string');
         expect(err.message.length).toBeGreaterThan(0);
+    });
+});
+
+describe('resolveTierOnly', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetUserTier.mockResolvedValue('member');
+    });
+
+    it('returns "free" for anonymous (null) userId without touching the DB', async () => {
+        const tier = await resolveTierOnly(null);
+        expect(tier).toBe('free');
+        expect(mockGetUserTier).not.toHaveBeenCalled();
+    });
+
+    it('resolves the tier via getUserTier for a logged-in userId', async () => {
+        const tier = await resolveTierOnly('u1');
+        expect(tier).toBe('member');
+        expect(mockGetUserTier).toHaveBeenCalledWith(
+            { userId: 'u1' },
+            expect.anything()
+        );
+    });
+});
+
+describe('resolveReasoning', () => {
+    it('forces false for free tier even when the client requests true', () => {
+        expect(resolveReasoning('free', true)).toBe(false);
+    });
+
+    it('forces false for free tier when the client omits reasoning', () => {
+        expect(resolveReasoning('free')).toBe(false);
+    });
+
+    it('honors client true for member tier', () => {
+        expect(resolveReasoning('member', true)).toBe(true);
+    });
+
+    it('honors client true for pro tier', () => {
+        expect(resolveReasoning('pro', true)).toBe(true);
+    });
+
+    it('defaults to false for member tier when client omits reasoning', () => {
+        expect(resolveReasoning('member')).toBe(false);
+    });
+
+    it('defaults to false for member tier when client explicitly sends false', () => {
+        expect(resolveReasoning('member', false)).toBe(false);
     });
 });
 

--- a/src/shared/lib/anonAnalysisCount.ts
+++ b/src/shared/lib/anonAnalysisCount.ts
@@ -1,0 +1,150 @@
+import {
+    LOCAL_STORAGE_ANON_ANALYZED_SYMBOLS_KEY,
+    LOCAL_STORAGE_ANON_NUDGE_SHOWN_KEY,
+} from '@/shared/lib/storageKeys';
+
+/**
+ * Anonymous distinct-symbol analysis counter — member-reasoning-toggle spec
+ * Part B. Purely client-side (localStorage); the counter is a soft nudge, not
+ * a hard limit, so there is no server-side source of truth and no need for
+ * one (§4 "소프트 넙지라 localStorage 조작 우회 허용").
+ */
+
+/** Threshold of distinct symbols analyzed in a day that triggers the signup nudge. */
+export const ANON_DISTINCT_SYMBOL_NUDGE_THRESHOLD = 3;
+
+interface AnonAnalyzedSymbolsRecord {
+    dateUtc: string;
+    symbols: string[];
+}
+
+interface AnonNudgeShownRecord {
+    dateUtc: string;
+}
+
+/** `YYYY-MM-DD` in UTC — the day boundary the counter and nag-prevention flag both reset on. */
+function todayUtc(now: Date): string {
+    return now.toISOString().slice(0, 10);
+}
+
+function readAnalyzedSymbolsRecord(): AnonAnalyzedSymbolsRecord | null {
+    const raw = localStorage.getItem(LOCAL_STORAGE_ANON_ANALYZED_SYMBOLS_KEY);
+    if (raw === null) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        !('dateUtc' in parsed) ||
+        !('symbols' in parsed) ||
+        typeof (parsed as { dateUtc: unknown }).dateUtc !== 'string' ||
+        !Array.isArray((parsed as { symbols: unknown }).symbols)
+    ) {
+        return null;
+    }
+    return parsed as AnonAnalyzedSymbolsRecord;
+}
+
+export interface RecordAnonSymbolAnalysisResult {
+    /** Distinct symbols analyzed so far today (after recording this one). */
+    distinctCount: number;
+    /**
+     * `true` only on the call that first reaches the nudge threshold — never
+     * re-fires on subsequent calls the same day, so the caller can use this
+     * as a one-shot "show the modal now" signal (nag-prevention still applies
+     * on top via `hasNudgeShownToday`/`markNudgeShownToday`).
+     */
+    crossedThreshold: boolean;
+}
+
+/**
+ * Records a symbol as analyzed by an anonymous visitor today (UTC), deduping
+ * by symbol. SSR-safe (`typeof window` guard) and resilient to a blocked/
+ * unavailable localStorage (private browsing, storage quota, etc.) — any
+ * failure degrades to a no-op `{ distinctCount: 0, crossedThreshold: false }`
+ * rather than throwing, since this is a soft nudge and must never break the
+ * analysis flow it observes.
+ *
+ * @param symbol - Ticker just analyzed (case-insensitive; normalized to upper).
+ * @param now - Injectable clock for deterministic tests. Defaults to `new Date()`.
+ */
+export function recordAnonSymbolAnalysis(
+    symbol: string,
+    now: Date = new Date()
+): RecordAnonSymbolAnalysisResult {
+    if (typeof window === 'undefined') {
+        return { distinctCount: 0, crossedThreshold: false };
+    }
+
+    try {
+        const today = todayUtc(now);
+        const stored = readAnalyzedSymbolsRecord();
+        const previousSymbols =
+            stored !== null && stored.dateUtc === today ? stored.symbols : [];
+
+        const upperSymbol = symbol.toUpperCase();
+        const distinctCountBefore = previousSymbols.length;
+        const symbols = previousSymbols.includes(upperSymbol)
+            ? previousSymbols
+            : [...previousSymbols, upperSymbol];
+        const distinctCount = symbols.length;
+
+        const record: AnonAnalyzedSymbolsRecord = { dateUtc: today, symbols };
+        localStorage.setItem(
+            LOCAL_STORAGE_ANON_ANALYZED_SYMBOLS_KEY,
+            JSON.stringify(record)
+        );
+
+        const crossedThreshold =
+            distinctCountBefore < ANON_DISTINCT_SYMBOL_NUDGE_THRESHOLD &&
+            distinctCount >= ANON_DISTINCT_SYMBOL_NUDGE_THRESHOLD;
+
+        return { distinctCount, crossedThreshold };
+    } catch {
+        // localStorage blocked (private browsing) or corrupted JSON — degrade
+        // to a no-op rather than crash the analysis flow.
+        return { distinctCount: 0, crossedThreshold: false };
+    }
+}
+
+/**
+ * Whether the signup nudge has already been shown today (UTC) —
+ * nag-prevention companion to `recordAnonSymbolAnalysis`. Resets on UTC date
+ * change, same boundary as the symbol counter. SSR-safe + storage-blocked
+ * safe (degrades to `false`, i.e. "not shown", which is the more conservative
+ * default here since this is only ever read right before deciding whether to
+ * open the modal — a false negative just means the modal may show once more
+ * than ideal, never a functional break).
+ */
+export function hasNudgeShownToday(now: Date = new Date()): boolean {
+    if (typeof window === 'undefined') return false;
+    try {
+        const raw = localStorage.getItem(LOCAL_STORAGE_ANON_NUDGE_SHOWN_KEY);
+        if (raw === null) return false;
+        const parsed: unknown = JSON.parse(raw);
+        if (
+            typeof parsed !== 'object' ||
+            parsed === null ||
+            !('dateUtc' in parsed) ||
+            typeof (parsed as { dateUtc: unknown }).dateUtc !== 'string'
+        ) {
+            return false;
+        }
+        return (parsed as AnonNudgeShownRecord).dateUtc === todayUtc(now);
+    } catch {
+        return false;
+    }
+}
+
+/** Marks the signup nudge as shown for today (UTC). SSR-safe + storage-blocked safe (no-op). */
+export function markNudgeShownToday(now: Date = new Date()): void {
+    if (typeof window === 'undefined') return;
+    try {
+        const record: AnonNudgeShownRecord = { dateUtc: todayUtc(now) };
+        localStorage.setItem(
+            LOCAL_STORAGE_ANON_NUDGE_SHOWN_KEY,
+            JSON.stringify(record)
+        );
+    } catch {
+        // storage blocked — nothing to do; worst case the nudge may re-show.
+    }
+}

--- a/src/shared/lib/anonAnalysisCount.ts
+++ b/src/shared/lib/anonAnalysisCount.ts
@@ -37,7 +37,10 @@ function readAnalyzedSymbolsRecord(): AnonAnalyzedSymbolsRecord | null {
         !('dateUtc' in parsed) ||
         !('symbols' in parsed) ||
         typeof (parsed as { dateUtc: unknown }).dateUtc !== 'string' ||
-        !Array.isArray((parsed as { symbols: unknown }).symbols)
+        !Array.isArray((parsed as { symbols: unknown }).symbols) ||
+        !(parsed as { symbols: unknown[] }).symbols.every(
+            s => typeof s === 'string'
+        )
     ) {
         return null;
     }

--- a/src/shared/lib/byokGate.ts
+++ b/src/shared/lib/byokGate.ts
@@ -48,6 +48,42 @@ export type ByokOutcome =
     | { kind: 'blocked'; error: AnalysisGateError };
 
 /**
+ * Resolve a caller's tier without the BYOK/premium-model gate — used by
+ * analysis surfaces that have no BYOK concept (e.g. congress trend, which is
+ * public data with no premium model gating) but still need `tier` to decide
+ * the reasoning toggle (member-reasoning-toggle spec Part A.3).
+ *
+ * @param userId - Authenticated user ID. `null` (anonymous) resolves to `'free'`.
+ */
+export async function resolveTierOnly(userId: string | null): Promise<Tier> {
+    if (userId === null) return 'free';
+    return getUserTier(
+        { userId },
+        { users: new DrizzleUserRepository(getDatabaseClient().db) }
+    );
+}
+
+/**
+ * Server-side enforcement of the reasoning ("깊은 생각") toggle
+ * (member-reasoning-toggle spec Part A.3).
+ *
+ * Anonymous and free-tier callers can never receive `reasoning: true`
+ * regardless of what the client sent — the client value is only honored for
+ * `member`/`pro` tiers. This is the single source of truth for that rule; all
+ * analysis submit actions must route their client-supplied `reasoning`
+ * through this function before forwarding it to siglens-core.
+ *
+ * @param tier - Resolved caller tier (`resolveTierAndByok`/`resolveTierOnly`).
+ * @param clientReasoning - Raw value from the request. Ignored for `free`.
+ */
+export function resolveReasoning(
+    tier: Tier,
+    clientReasoning?: boolean
+): boolean {
+    return tier !== 'free' && clientReasoning === true;
+}
+
+/**
  * Tier 조회 + BYOK 게이트.
  *
  * @param userId - 인증된 사용자 ID. null이면 free tier로 처리.

--- a/src/shared/lib/byokGate.ts
+++ b/src/shared/lib/byokGate.ts
@@ -98,13 +98,7 @@ export async function resolveTierAndByok(
         return { kind: 'blocked', error: buildGateError('invalid_model') };
     }
 
-    const tier =
-        userId === null
-            ? 'free'
-            : await getUserTier(
-                  { userId },
-                  { users: new DrizzleUserRepository(getDatabaseClient().db) }
-              );
+    const tier = await resolveTierOnly(userId);
 
     const premium = isPremiumModel(modelId);
 

--- a/src/shared/lib/storageKeys.ts
+++ b/src/shared/lib/storageKeys.ts
@@ -28,3 +28,27 @@ export const LOCAL_STORAGE_CHAT_MODEL_KEY = 'siglens_chat_model';
  */
 export const LOCAL_STORAGE_CHAT_MODEL_MIGRATION_KEY =
     'siglens_chat_model_deepseek_migrated';
+
+/**
+ * Member "깊은 생각"(reasoning) toggle — member-reasoning-toggle spec Part A.
+ * Persists the user's opt-in intent across sessions. Default OFF. The
+ * *effective* value sent to the server is still gated by tier (free/anon
+ * always forced off server-side) — this key only remembers the member's
+ * preference so it survives a page reload.
+ */
+export const LOCAL_STORAGE_REASONING_KEY = 'siglens_reasoning_on';
+
+/**
+ * Anonymous distinct-symbol analysis counter — member-reasoning-toggle spec
+ * Part B. Stores `{ dateUtc, symbols }`; resets on UTC date change. See
+ * `shared/lib/anonAnalysisCount.ts`.
+ */
+export const LOCAL_STORAGE_ANON_ANALYZED_SYMBOLS_KEY =
+    'siglens_anon_analyzed_symbols';
+
+/**
+ * "이미 오늘 넛지를 보여줬다" 플래그 — 같은 날 여러 번 3-심볼 문턱을 재도달해도
+ * 모달을 반복 노출하지 않기 위한 nag-prevention 플래그. anonAnalysisCount와
+ * 동일하게 UTC 날짜 기준으로 리셋된다.
+ */
+export const LOCAL_STORAGE_ANON_NUDGE_SHOWN_KEY = 'siglens_anon_nudge_shown';

--- a/src/views/symbol/ChartContent.tsx
+++ b/src/views/symbol/ChartContent.tsx
@@ -187,6 +187,7 @@ export function ChartContent({
     // 회원/로그인 판별 전에는 useAnonAnalysisNudge 내부에서 자체적으로 no-op한다.
     const {
         isOpen: isNudgeOpen,
+        isLoginResolved: isNudgeLoginResolved,
         onSymbolAnalyzed,
         close: closeNudge,
     } = useAnonAnalysisNudge();
@@ -366,12 +367,22 @@ export function ChartContent({
     // (spec §1). notifiedSymbolRef는 같은 심볼에 대해 중복 카운트(불필요한 localStorage
     // read/write)를 막는다 — 다운스트림 recordAnonSymbolAnalysis도 심볼 기준 dedup하므로
     // 정확성을 위해 필수는 아니지만, 매 재렌더마다 카운트를 재시도하지 않도록 한다.
+    //
+    // isNudgeLoginResolved 게이팅이 필수인 이유: useCurrentUser는 마운트 시
+    // data === undefined(로그인 판별 전)이고, 이때 onSymbolAnalyzed는 no-op이다.
+    // 캐시 HIT으로 initialAnalysis가 마운트 즉시 non-fallback인 케이스에서, 판별 전에
+    // notifiedSymbolRef를 먼저 세팅해버리면 로그인 판별이 끝나 onSymbolAnalyzed가
+    // "진짜" 함수로 바뀌어도(식별성 변경 → effect 재실행) ref가 이미 symbol로 채워져
+    // 있어 조기 return — 그 심볼은 영원히 기록되지 않는다. 판별 완료(isNudgeLoginResolved)
+    // 전까지는 ref를 세팅하지도, onSymbolAnalyzed를 호출하지도 않고, 판별이 true로
+    // 바뀌는 순간 effect가 재실행되도록 deps에 포함시켜 그때 정확히 한 번 기록한다.
     useEffect(() => {
+        if (!isNudgeLoginResolved) return;
         if (isFallbackAnalysis(analysis)) return;
         if (notifiedSymbolRef.current === symbol) return;
         notifiedSymbolRef.current = symbol;
         onSymbolAnalyzed(symbol);
-    }, [symbol, analysis, onSymbolAnalyzed]);
+    }, [symbol, analysis, isNudgeLoginResolved, onSymbolAnalyzed]);
 
     return (
         <div className="flex h-full w-full flex-col md:flex-row">

--- a/src/views/symbol/ChartContent.tsx
+++ b/src/views/symbol/ChartContent.tsx
@@ -11,7 +11,13 @@ import { type AnalysisResponse, type Timeframe } from '@y0ngha/siglens-core';
 import type { MarketProfileId } from '@/shared/config/marketProfile';
 import dynamic from 'next/dynamic';
 import type { ReactNode } from 'react';
-import React, { Suspense, useEffect, useEffectEvent, useMemo } from 'react';
+import React, {
+    Suspense,
+    useEffect,
+    useEffectEvent,
+    useMemo,
+    useRef,
+} from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { SNAP_PEEK } from './constants/mobileSheet';
 import { FearGreedCardMounted } from './FearGreedCardMounted';
@@ -27,6 +33,10 @@ import {
     usePanelResize,
 } from './hooks/usePanelResize';
 import { useSymbolModel } from '@/features/symbol-model';
+import {
+    useAnonAnalysisNudge,
+    AnalysisSignupNudgeModal,
+} from '@/features/analysis-nudge';
 import { useSymbolPageContext } from './SymbolPageContext';
 import { TechnicalFactsSummary } from './TechnicalFactsSummary';
 import type { AnalysisStatus } from './utils/analysisStatus';
@@ -119,6 +129,9 @@ export function ChartContent({
     fmpSymbol,
     marketProfile = 'us-equity',
 }: ChartContentProps) {
+    // 비회원 회원가입 유도(Part B) — 같은 심볼에 대한 중복 카운트 방지용.
+    const notifiedSymbolRef = useRef<string | null>(null);
+
     const { bars, indicators } = useBars({ symbol, timeframe, fmpSymbol });
 
     const { panelWidth, isDragging, handleDragStart, handleKeyDown } =
@@ -134,7 +147,12 @@ export function ChartContent({
     const { actionPricesVisible, setActionPricesVisible } =
         useActionPricesVisibility();
 
-    const { modelId, isHydrated: isModelHydrated } = useSymbolModel();
+    const {
+        modelId,
+        isHydrated: isModelHydrated,
+        reasoning,
+        isReasoningHydrated,
+    } = useSymbolModel();
 
     // analysis → symbol-page 역방향 import를 제거하기 위해 여기서 context를 읽어 내려보낸다.
     const { indicatorCount } = useSymbolPageContext();
@@ -158,10 +176,20 @@ export function ChartContent({
         timeframeChangeCount,
         modelId,
         isModelHydrated,
+        reasoning,
+        isReasoningHydrated,
     });
 
     const { displayAnalyzing, handleProgressFinished } =
         useAnalysisDisplay(isAnalyzing);
+
+    // 비회원 3-심볼 회원가입 유도 모달 (member-reasoning-toggle spec Part B).
+    // 회원/로그인 판별 전에는 useAnonAnalysisNudge 내부에서 자체적으로 no-op한다.
+    const {
+        isOpen: isNudgeOpen,
+        onSymbolAnalyzed,
+        close: closeNudge,
+    } = useAnonAnalysisNudge();
 
     // 데스크톱·모바일 두 인스턴스 공유 — 모바일 시트 unmount/remount 시에도 상태 유지.
     const { phaseIndex: progressPhaseIndex, tipIndex: progressTipIndex } =
@@ -333,6 +361,18 @@ export function ChartContent({
         }
     }, [analysisResult]);
 
+    // 비회원 3-심볼 회원가입 유도(Part B) — 실제 서사가 렌더된 시점("완료/렌더")에
+    // 카운트한다. 캐시 HIT으로 즉시 나타나든 새로 생성됐든 동일하게 "봤으면" 카운트한다
+    // (spec §1). notifiedSymbolRef는 같은 심볼에 대해 중복 카운트(불필요한 localStorage
+    // read/write)를 막는다 — 다운스트림 recordAnonSymbolAnalysis도 심볼 기준 dedup하므로
+    // 정확성을 위해 필수는 아니지만, 매 재렌더마다 카운트를 재시도하지 않도록 한다.
+    useEffect(() => {
+        if (isFallbackAnalysis(analysis)) return;
+        if (notifiedSymbolRef.current === symbol) return;
+        notifiedSymbolRef.current = symbol;
+        onSymbolAnalyzed(symbol);
+    }, [symbol, analysis, onSymbolAnalyzed]);
+
     return (
         <div className="flex h-full w-full flex-col md:flex-row">
             {/* 차트 영역 — 바텀시트는 fixed 오버레이. pb는 SNAP_PEEK 높이만큼 확보해 Peek 시 거래량 차트가 가려지지 않도록 한다.
@@ -422,6 +462,9 @@ export function ChartContent({
             {isDragging && (
                 <div className="fixed inset-0 z-50 cursor-col-resize" />
             )}
+
+            {/* 비회원 3-심볼 회원가입 유도 모달(Part B) — 소프트 넙지, 분석은 절대 차단하지 않는다. */}
+            {isNudgeOpen && <AnalysisSignupNudgeModal onClose={closeNudge} />}
         </div>
     );
 }

--- a/src/views/symbol/SymbolLayoutHeader.tsx
+++ b/src/views/symbol/SymbolLayoutHeader.tsx
@@ -11,6 +11,7 @@ import { ModelSelector } from '@/widgets/analysis';
 import { ShareButton } from '@/widgets/share';
 import { FearGreedHeaderChipMounted } from './FearGreedHeaderChipMounted';
 import { PremiumModelGateModal } from '@/features/premium-gate';
+import { ReasoningToggle } from '@/features/reasoning-toggle';
 import { LLM_PROVIDER_LABELS } from '@/shared/lib/llmProviderLabels';
 
 interface SymbolLayoutHeaderProps {
@@ -38,6 +39,9 @@ export function SymbolLayoutHeader({ symbol }: SymbolLayoutHeaderProps) {
         handleModelChange,
         gateModal,
         dismissGate,
+        reasoning,
+        setReasoning,
+        canUseReasoning,
     } = useSymbolModel();
 
     return (
@@ -103,6 +107,11 @@ export function SymbolLayoutHeader({ symbol }: SymbolLayoutHeaderProps) {
                         className="w-28 sm:w-32 lg:w-36"
                         showLabel={false}
                         dropdownAlign="right"
+                    />
+                    <ReasoningToggle
+                        checked={reasoning}
+                        onChange={setReasoning}
+                        visible={canUseReasoning}
                     />
                 </div>
 

--- a/src/views/symbol/__tests__/ChartContent.anonNudgeRace.test.tsx
+++ b/src/views/symbol/__tests__/ChartContent.anonNudgeRace.test.tsx
@@ -1,0 +1,285 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import type { AnalysisResponse, Timeframe } from '@y0ngha/siglens-core';
+import type { UseQueryResult } from '@tanstack/react-query';
+import type { AuthUserRecord } from '@/shared/lib/auth/types';
+import { ChartContent } from '@/views/symbol/ChartContent';
+import { useCurrentUser } from '@/entities/auth';
+import {
+    recordAnonSymbolAnalysis,
+    hasNudgeShownToday,
+    markNudgeShownToday,
+} from '@/shared/lib/anonAnalysisCount';
+
+// Regression test for the anonymous-nudge missed-fire on cache-HIT + cold
+// currentUser (member-reasoning-toggle spec Part B code review finding #1).
+//
+// Unlike ChartContent.test.tsx, this file does NOT mock `@/features/analysis-nudge`
+// — it exercises the REAL `useAnonAnalysisNudge` hook wired into the REAL
+// ChartContent effect (notifiedSymbolRef). Mocking the feature (as the sibling
+// test file does) gives `onSymbolAnalyzed` a stable identity across renders,
+// which hides the race entirely: the bug only manifests when `onSymbolAnalyzed`
+// changes identity (member no-op → real anonymous fn) AFTER the ref has
+// already been set.
+
+vi.mock('next/dynamic', () => ({
+    default: (_loader: () => Promise<{ default: React.FC }>) => {
+        const Component = (_props: Record<string, unknown>) => (
+            <div data-testid="dynamic-component" />
+        );
+        Component.displayName = 'DynamicMock';
+        return Component;
+    },
+}));
+
+vi.mock('@/shared/lib/cn', () => ({
+    cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/widgets/chart', () => ({
+    ChartSkeleton: () => <div data-testid="chart-skeleton" />,
+    useChartSync: () => ({
+        handleStockChartReady: vi.fn(),
+        handleStockChartRemove: vi.fn(),
+        handleVolumeChartReady: vi.fn(),
+        handleVolumeChartRemove: vi.fn(),
+    }),
+}));
+
+vi.mock('@/widgets/analysis', () => ({
+    AnalysisPanel: () => <div data-testid="analysis-panel" />,
+}));
+
+vi.mock('@/shared/ui/BotBlockedNotice', () => ({
+    BotBlockedNotice: () => <div data-testid="bot-blocked-notice" />,
+}));
+
+vi.mock('@/entities/bars/hooks/useBars', () => ({
+    useBars: vi.fn(() => ({
+        bars: [
+            { time: 1, open: 100, high: 110, low: 90, close: 105, volume: 500 },
+        ],
+        indicators: { buySellVolume: [] },
+    })),
+}));
+
+// `analysis: {}` — a non-fallback narrative present from the very first
+// render, standing in for a cache-HIT `initialAnalysis` that is already a
+// real narrative on mount (the exact scenario in the finding).
+vi.mock('@/views/symbol/hooks/useAnalysis', () => ({
+    useAnalysis: vi.fn(() => ({
+        analysis: {} as AnalysisResponse,
+        analysisResult: null,
+        isAnalyzing: false,
+        analysisError: null,
+        isBotBlocked: false,
+        handleReanalyze: vi.fn(),
+        reanalyzeCooldownMs: 0,
+        cooldownNotice: null,
+    })),
+}));
+
+vi.mock('@/views/symbol/hooks/useAnalysisDerivedData', () => ({
+    useAnalysisDerivedData: vi.fn(() => ({
+        clusteredKeyLevels: { support: [], resistance: [], poc: undefined },
+        validatedActionPrices: undefined,
+        reconciledActionLines: undefined,
+    })),
+}));
+
+vi.mock('@/views/symbol/hooks/useAnalysisDisplay', () => ({
+    useAnalysisDisplay: vi.fn(() => ({
+        displayAnalyzing: false,
+        handleProgressFinished: vi.fn(),
+    })),
+}));
+
+vi.mock('@/views/symbol/hooks/useActionPricesVisibility', () => ({
+    useActionPricesVisibility: vi.fn(() => ({
+        actionPricesVisible: true,
+        setActionPricesVisible: vi.fn(),
+    })),
+}));
+
+vi.mock('@/features/symbol-model/model/SymbolModelContext', () => ({
+    useSymbolModel: vi.fn(() => ({
+        modelId: 'gemini-2.5-flash-lite',
+        isHydrated: true,
+        reasoning: false,
+        isReasoningHydrated: true,
+    })),
+}));
+
+vi.mock('@/views/symbol/SymbolPageContext', () => ({
+    useSymbolPageContext: vi.fn(() => ({ indicatorCount: 25 })),
+}));
+
+vi.mock('@/views/symbol/hooks/usePanelResize', () => ({
+    usePanelResize: vi.fn(() => ({
+        panelWidth: 640,
+        isDragging: false,
+        handleDragStart: vi.fn(),
+        handleKeyDown: vi.fn(),
+    })),
+    PANEL_MIN_WIDTH: 240,
+    PANEL_MAX_WIDTH: 640,
+}));
+
+vi.mock('@/widgets/analysis/hooks/useAnalysisProgress', () => ({
+    useAnalysisProgress: vi.fn(() => ({
+        phaseIndex: 0,
+        tipIndex: 0,
+    })),
+}));
+
+vi.mock('@/features/symbol-chat', () => ({
+    usePublishSymbolChat: vi.fn(),
+}));
+
+vi.mock('@/views/symbol/utils/buildChatState', () => ({
+    buildChatState: vi.fn(() => ({
+        context: null,
+        timeframe: '1Day',
+        isAnalysisReady: false,
+    })),
+}));
+
+vi.mock('@/shared/lib/pwaEvents', () => ({
+    PWA_TRIGGER_EVENT: 'pwa-trigger',
+}));
+
+vi.mock('@/views/symbol/FearGreedCardMounted', () => ({
+    FearGreedCardMounted: () => <div data-testid="fear-greed-card" />,
+}));
+
+// The two seams the real bug lives in: login-state resolution
+// (`useCurrentUser`) and the localStorage-backed distinct-symbol counter
+// (`anonAnalysisCount`). `@/features/analysis-nudge` itself is left unmocked.
+vi.mock('@/entities/auth', () => ({
+    useCurrentUser: vi.fn(),
+}));
+
+vi.mock('@/shared/lib/anonAnalysisCount', () => ({
+    recordAnonSymbolAnalysis: vi.fn(),
+    hasNudgeShownToday: vi.fn(),
+    markNudgeShownToday: vi.fn(),
+}));
+
+const mockUseCurrentUser = vi.mocked(useCurrentUser);
+const mockRecord = vi.mocked(recordAnonSymbolAnalysis);
+const mockHasShown = vi.mocked(hasNudgeShownToday);
+const mockMarkShown = vi.mocked(markNudgeShownToday);
+
+function queryResult(
+    data: AuthUserRecord | null | undefined
+): UseQueryResult<AuthUserRecord | null> {
+    return { data } as UseQueryResult<AuthUserRecord | null>;
+}
+
+describe('ChartContent × useAnonAnalysisNudge integration (real hook, race between login-resolve and cache-HIT render)', () => {
+    const baseProps = {
+        companyName: 'Test Co.',
+        timeframe: '1Day' as Timeframe,
+        timeframeChangeCount: 0,
+        initialAnalysis: {} as AnalysisResponse,
+        initialAnalysisFailed: false,
+        onMobileSheetContent: vi.fn(),
+    };
+
+    beforeEach(() => {
+        mockRecord.mockReset();
+        mockHasShown.mockReset();
+        mockMarkShown.mockReset();
+        mockHasShown.mockReturnValue(false);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('records the cache-HIT symbol exactly once after a cold session resolves from unresolved to anonymous, instead of being silently dropped by the notifiedSymbolRef race', async () => {
+        // Cold session: useCurrentUser has not settled yet (data === undefined).
+        mockUseCurrentUser.mockReturnValue(queryResult(undefined));
+        mockRecord.mockReturnValueOnce({
+            distinctCount: 1,
+            crossedThreshold: false,
+        });
+
+        const { rerender } = render(
+            <ChartContent {...baseProps} symbol="RACE" />
+        );
+
+        // Login unresolved — must not have recorded anything yet (neither the
+        // no-op branch nor the real one).
+        expect(mockRecord).not.toHaveBeenCalled();
+
+        // Login settles: anonymous visitor. This is the state transition that
+        // flips `onSymbolAnalyzed`'s identity from the no-op variant to the
+        // real one inside useAnonAnalysisNudge.
+        mockUseCurrentUser.mockReturnValue(queryResult(null));
+        rerender(<ChartContent {...baseProps} symbol="RACE" />);
+
+        // With the fix, ChartContent's effect re-runs once isNudgeLoginResolved
+        // flips true and records the already-rendered (cache-HIT) symbol.
+        // Against the pre-fix code, `notifiedSymbolRef.current` was already set
+        // to 'RACE' during the unresolved render, so this call never happens —
+        // making this assertion fail on the old code.
+        await waitFor(() => {
+            expect(mockRecord).toHaveBeenCalledWith('RACE');
+        });
+        expect(mockRecord).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens the signup nudge at the 3rd distinct symbol (not the 4th) when the first symbol only resolved after a cold-session race', async () => {
+        // Three distinct real `recordAnonSymbolAnalysis` calls are expected in
+        // symbol order: RACE1 (after the cold-session race resolves), then
+        // SYM2, then SYM3. Queueing them FIFO means that if RACE1's call is
+        // silently dropped (the pre-fix bug), SYM2 consumes RACE1's queued
+        // result and SYM3 consumes SYM2's (crossedThreshold: false) — so the
+        // nudge never opens by SYM3 against the old code, exactly mirroring
+        // the "3rd shifts to 4th" regression described in the finding.
+        mockRecord.mockReturnValueOnce({
+            distinctCount: 1,
+            crossedThreshold: false,
+        });
+        mockRecord.mockReturnValueOnce({
+            distinctCount: 2,
+            crossedThreshold: false,
+        });
+        mockRecord.mockReturnValueOnce({
+            distinctCount: 3,
+            crossedThreshold: true,
+        });
+
+        // Symbol 1: cache-HIT + cold-session race (undefined -> null).
+        mockUseCurrentUser.mockReturnValue(queryResult(undefined));
+        const race = render(<ChartContent {...baseProps} symbol="RACE1" />);
+        expect(mockRecord).not.toHaveBeenCalled();
+
+        mockUseCurrentUser.mockReturnValue(queryResult(null));
+        race.rerender(<ChartContent {...baseProps} symbol="RACE1" />);
+        await waitFor(() => {
+            expect(mockRecord).toHaveBeenCalledWith('RACE1');
+        });
+        race.unmount();
+
+        // Symbol 2: a fresh page visit — login is already resolved by mount.
+        const sym2 = render(<ChartContent {...baseProps} symbol="SYM2" />);
+        await waitFor(() => {
+            expect(mockRecord).toHaveBeenCalledWith('SYM2');
+        });
+        sym2.unmount();
+
+        // Symbol 3: crosses the threshold — this is the 3rd DISTINCT symbol
+        // only if RACE1 was actually counted.
+        render(<ChartContent {...baseProps} symbol="SYM3" />);
+        await waitFor(() => {
+            expect(mockRecord).toHaveBeenCalledWith('SYM3');
+        });
+        expect(mockRecord).toHaveBeenCalledTimes(3);
+
+        await waitFor(() => {
+            expect(screen.getByRole('dialog')).toBeDefined();
+        });
+        expect(mockMarkShown).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/views/symbol/__tests__/ChartContent.interaction.test.tsx
+++ b/src/views/symbol/__tests__/ChartContent.interaction.test.tsx
@@ -48,7 +48,20 @@ vi.mock('../hooks/useActionPricesVisibility', () => ({
     }),
 }));
 vi.mock('@/features/symbol-model/model/SymbolModelContext', () => ({
-    useSymbolModel: () => ({ modelId: 'gemini-2.5-flash', isHydrated: true }),
+    useSymbolModel: () => ({
+        modelId: 'gemini-2.5-flash',
+        isHydrated: true,
+        reasoning: false,
+        isReasoningHydrated: true,
+    }),
+}));
+vi.mock('@/features/analysis-nudge', () => ({
+    useAnonAnalysisNudge: () => ({
+        isOpen: false,
+        onSymbolAnalyzed: vi.fn(),
+        close: vi.fn(),
+    }),
+    AnalysisSignupNudgeModal: () => null,
 }));
 vi.mock('../SymbolPageContext', () => ({
     useSymbolPageContext: () => ({ indicatorCount: 25 }),

--- a/src/views/symbol/__tests__/ChartContent.slot.test.tsx
+++ b/src/views/symbol/__tests__/ChartContent.slot.test.tsx
@@ -51,7 +51,20 @@ vi.mock('../hooks/useActionPricesVisibility', () => ({
     }),
 }));
 vi.mock('@/features/symbol-model/model/SymbolModelContext', () => ({
-    useSymbolModel: () => ({ modelId: 'gemini-2.5-flash', isHydrated: true }),
+    useSymbolModel: () => ({
+        modelId: 'gemini-2.5-flash',
+        isHydrated: true,
+        reasoning: false,
+        isReasoningHydrated: true,
+    }),
+}));
+vi.mock('@/features/analysis-nudge', () => ({
+    useAnonAnalysisNudge: () => ({
+        isOpen: false,
+        onSymbolAnalyzed: vi.fn(),
+        close: vi.fn(),
+    }),
+    AnalysisSignupNudgeModal: () => null,
 }));
 vi.mock('../SymbolPageContext', () => ({
     useSymbolPageContext: () => ({ indicatorCount: 25 }),

--- a/src/views/symbol/__tests__/ChartContent.test.tsx
+++ b/src/views/symbol/__tests__/ChartContent.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import type { AnalysisResponse, Timeframe } from '@y0ngha/siglens-core';
 import { FALLBACK_ANALYSIS } from '@/entities/chat-message';
 import { ChartContent } from '@/views/symbol/ChartContent';
@@ -98,7 +98,28 @@ vi.mock('@/features/symbol-model/model/SymbolModelContext', () => ({
     useSymbolModel: vi.fn(() => ({
         modelId: 'gemini-2.5-flash-lite',
         isHydrated: true,
+        reasoning: false,
+        isReasoningHydrated: true,
     })),
+}));
+
+const { mockUseAnonAnalysisNudge } = vi.hoisted(() => ({
+    mockUseAnonAnalysisNudge: vi.fn(() => ({
+        isOpen: false,
+        onSymbolAnalyzed: vi.fn(),
+        close: vi.fn(),
+    })),
+}));
+
+vi.mock('@/features/analysis-nudge', () => ({
+    useAnonAnalysisNudge: mockUseAnonAnalysisNudge,
+    AnalysisSignupNudgeModal: ({ onClose }: { onClose: () => void }) => (
+        <div data-testid="analysis-signup-nudge-modal">
+            <button type="button" onClick={onClose}>
+                close
+            </button>
+        </div>
+    ),
 }));
 
 vi.mock('@/views/symbol/SymbolPageContext', () => ({
@@ -250,6 +271,87 @@ describe('ChartContent', () => {
     it('renders analysis panel in aside', () => {
         render(<ChartContent {...defaultProps} />);
         expect(screen.getByTestId('analysis-panel')).toBeDefined();
+    });
+
+    describe('anonymous signup nudge (member-reasoning-toggle spec Part B)', () => {
+        it('does not render the nudge modal when isOpen is false', () => {
+            mockUseAnonAnalysisNudge.mockReturnValueOnce({
+                isOpen: false,
+                onSymbolAnalyzed: vi.fn(),
+                close: vi.fn(),
+            });
+            render(<ChartContent {...defaultProps} />);
+            expect(
+                screen.queryByTestId('analysis-signup-nudge-modal')
+            ).toBeNull();
+        });
+
+        it('renders the nudge modal when isOpen is true', () => {
+            mockUseAnonAnalysisNudge.mockReturnValueOnce({
+                isOpen: true,
+                onSymbolAnalyzed: vi.fn(),
+                close: vi.fn(),
+            });
+            render(<ChartContent {...defaultProps} />);
+            expect(
+                screen.getByTestId('analysis-signup-nudge-modal')
+            ).toBeDefined();
+        });
+
+        it('closing the modal calls the hook-provided close()', async () => {
+            const close = vi.fn();
+            mockUseAnonAnalysisNudge.mockReturnValueOnce({
+                isOpen: true,
+                onSymbolAnalyzed: vi.fn(),
+                close,
+            });
+            render(<ChartContent {...defaultProps} />);
+            screen
+                .getByTestId('analysis-signup-nudge-modal')
+                .querySelector('button')
+                ?.click();
+            expect(close).toHaveBeenCalledTimes(1);
+        });
+
+        it('notifies onSymbolAnalyzed with the symbol when a real (non-fallback) narrative renders', async () => {
+            const onSymbolAnalyzed = vi.fn();
+            mockUseAnonAnalysisNudge.mockReturnValueOnce({
+                isOpen: false,
+                onSymbolAnalyzed,
+                close: vi.fn(),
+            });
+            // default useAnalysis mock returns `analysis: {}` — not the
+            // FALLBACK_ANALYSIS reference, so isFallbackAnalysis() is false.
+            render(<ChartContent {...defaultProps} />);
+            await waitFor(() => {
+                expect(onSymbolAnalyzed).toHaveBeenCalledWith('AAPL');
+            });
+        });
+
+        it('does not notify onSymbolAnalyzed while the analysis is still the FALLBACK_ANALYSIS shell', async () => {
+            const { useAnalysis } =
+                await import('@/views/symbol/hooks/useAnalysis');
+            const onSymbolAnalyzed = vi.fn();
+            mockUseAnonAnalysisNudge.mockReturnValueOnce({
+                isOpen: false,
+                onSymbolAnalyzed,
+                close: vi.fn(),
+            });
+            (useAnalysis as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+                analysis: FALLBACK_ANALYSIS,
+                analysisResult: null,
+                isAnalyzing: true,
+                analysisError: null,
+                isBotBlocked: false,
+                handleReanalyze: vi.fn(),
+                reanalyzeCooldownMs: 0,
+                cooldownNotice: null,
+            });
+
+            render(<ChartContent {...defaultProps} />);
+
+            expect(onSymbolAnalyzed).not.toHaveBeenCalled();
+        });
     });
 
     it('keeps the facts layer and appends (does not replace with) the bot notice when bot is blocked and there is no narrative', async () => {

--- a/src/views/symbol/__tests__/ChartContent.test.tsx
+++ b/src/views/symbol/__tests__/ChartContent.test.tsx
@@ -104,8 +104,12 @@ vi.mock('@/features/symbol-model/model/SymbolModelContext', () => ({
 }));
 
 const { mockUseAnonAnalysisNudge } = vi.hoisted(() => ({
+    // isLoginResolved: true by default — most tests here exercise the
+    // post-resolve path. The real hook only ever calls onSymbolAnalyzed's
+    // effective branch once this is true (see ChartContent's gating on it).
     mockUseAnonAnalysisNudge: vi.fn(() => ({
         isOpen: false,
+        isLoginResolved: true,
         onSymbolAnalyzed: vi.fn(),
         close: vi.fn(),
     })),
@@ -277,6 +281,7 @@ describe('ChartContent', () => {
         it('does not render the nudge modal when isOpen is false', () => {
             mockUseAnonAnalysisNudge.mockReturnValueOnce({
                 isOpen: false,
+                isLoginResolved: true,
                 onSymbolAnalyzed: vi.fn(),
                 close: vi.fn(),
             });
@@ -289,6 +294,7 @@ describe('ChartContent', () => {
         it('renders the nudge modal when isOpen is true', () => {
             mockUseAnonAnalysisNudge.mockReturnValueOnce({
                 isOpen: true,
+                isLoginResolved: true,
                 onSymbolAnalyzed: vi.fn(),
                 close: vi.fn(),
             });
@@ -302,6 +308,7 @@ describe('ChartContent', () => {
             const close = vi.fn();
             mockUseAnonAnalysisNudge.mockReturnValueOnce({
                 isOpen: true,
+                isLoginResolved: true,
                 onSymbolAnalyzed: vi.fn(),
                 close,
             });
@@ -317,6 +324,7 @@ describe('ChartContent', () => {
             const onSymbolAnalyzed = vi.fn();
             mockUseAnonAnalysisNudge.mockReturnValueOnce({
                 isOpen: false,
+                isLoginResolved: true,
                 onSymbolAnalyzed,
                 close: vi.fn(),
             });
@@ -334,6 +342,7 @@ describe('ChartContent', () => {
             const onSymbolAnalyzed = vi.fn();
             mockUseAnonAnalysisNudge.mockReturnValueOnce({
                 isOpen: false,
+                isLoginResolved: true,
                 onSymbolAnalyzed,
                 close: vi.fn(),
             });

--- a/src/views/symbol/__tests__/SymbolLayoutHeader.test.tsx
+++ b/src/views/symbol/__tests__/SymbolLayoutHeader.test.tsx
@@ -25,15 +25,36 @@ vi.mock('@/entities/ticker/hooks/useAssetInfo', () => ({
     })),
 }));
 
-vi.mock('@/features/symbol-model/model/SymbolModelContext', () => ({
-    useSymbolModel: vi.fn(() => ({
+const { mockUseSymbolModel } = vi.hoisted(() => ({
+    mockUseSymbolModel: vi.fn(() => ({
         modelId: 'gemini-2.5-flash-lite',
         allowedModels: ['gemini-2.5-flash-lite'],
         isHydrated: true,
         gateModal: null,
         dismissGate: vi.fn(),
         handleModelChange: vi.fn(),
+        reasoning: false,
+        setReasoning: vi.fn(),
+        canUseReasoning: false,
     })),
+}));
+
+vi.mock('@/features/symbol-model/model/SymbolModelContext', () => ({
+    useSymbolModel: mockUseSymbolModel,
+}));
+
+vi.mock('@/features/reasoning-toggle', () => ({
+    ReasoningToggle: ({
+        checked,
+        visible,
+    }: {
+        checked: boolean;
+        visible: boolean;
+        onChange: (v: boolean) => void;
+    }) =>
+        visible ? (
+            <div data-testid="reasoning-toggle">{checked ? 'on' : 'off'}</div>
+        ) : null,
 }));
 
 vi.mock('@/views/symbol/SymbolTabs', () => ({
@@ -115,6 +136,42 @@ describe('SymbolLayoutHeader', () => {
     it('renders AI model label text', () => {
         render(<SymbolLayoutHeader symbol="aapl" />);
         expect(screen.getByText('AI 분석 모델')).toBeDefined();
+    });
+
+    it('hides the reasoning toggle for free/anonymous tier (canUseReasoning=false)', () => {
+        mockUseSymbolModel.mockReturnValueOnce({
+            modelId: 'gemini-2.5-flash-lite',
+            allowedModels: ['gemini-2.5-flash-lite'],
+            isHydrated: true,
+            gateModal: null,
+            dismissGate: vi.fn(),
+            handleModelChange: vi.fn(),
+            reasoning: false,
+            setReasoning: vi.fn(),
+            canUseReasoning: false,
+        });
+
+        render(<SymbolLayoutHeader symbol="aapl" />);
+        expect(screen.queryByTestId('reasoning-toggle')).toBeNull();
+    });
+
+    it('shows the reasoning toggle for member/pro tier (canUseReasoning=true)', () => {
+        mockUseSymbolModel.mockReturnValueOnce({
+            modelId: 'gemini-2.5-flash-lite',
+            allowedModels: ['gemini-2.5-flash-lite'],
+            isHydrated: true,
+            gateModal: null,
+            dismissGate: vi.fn(),
+            handleModelChange: vi.fn(),
+            reasoning: true,
+            setReasoning: vi.fn(),
+            canUseReasoning: true,
+        });
+
+        render(<SymbolLayoutHeader symbol="aapl" />);
+        const toggle = screen.getByTestId('reasoning-toggle');
+        expect(toggle).toBeDefined();
+        expect(toggle.textContent).toBe('on');
     });
 
     it('swallows a thrown fear-greed chip error via ErrorBoundary and still renders the header', () => {

--- a/src/views/symbol/__tests__/hooks/useAnalysis.test.tsx
+++ b/src/views/symbol/__tests__/hooks/useAnalysis.test.tsx
@@ -71,6 +71,8 @@ interface PartialOptions {
     timeframeChangeCount?: number;
     modelId?: string;
     isModelHydrated?: boolean;
+    reasoning?: boolean;
+    isReasoningHydrated?: boolean;
 }
 
 function makeOptions(overrides?: PartialOptions) {
@@ -83,6 +85,8 @@ function makeOptions(overrides?: PartialOptions) {
         timeframeChangeCount: overrides?.timeframeChangeCount ?? 0,
         modelId: overrides?.modelId as never,
         isModelHydrated: overrides?.isModelHydrated,
+        reasoning: overrides?.reasoning,
+        isReasoningHydrated: overrides?.isReasoningHydrated,
     };
 }
 
@@ -167,6 +171,164 @@ describe('useAnalysis', () => {
             );
 
             expect(result.current.isAnalyzing).toBe(false);
+        });
+    });
+
+    describe('reasoning (member-reasoning-toggle spec Part A)', () => {
+        it('forwards reasoning to submitAnalysisAction', async () => {
+            mockSubmit.mockResolvedValue({
+                status: 'cached',
+                result: INITIAL_ANALYSIS,
+            });
+
+            renderHook(
+                () =>
+                    useAnalysis(
+                        makeOptions({
+                            initialAnalysisFailed: true,
+                            reasoning: true,
+                        })
+                    ),
+                { wrapper: makeWrapper() }
+            );
+
+            await waitFor(() => {
+                expect(mockSubmit).toHaveBeenCalledWith(
+                    'AAPL',
+                    'Apple Inc.',
+                    '1Day',
+                    false,
+                    undefined,
+                    undefined,
+                    true
+                );
+            });
+        });
+
+        it('initialAnalysisFailed=true이고 isReasoningHydrated=false이면 mutate 전에도 isAnalyzing이 true다', () => {
+            const { result } = renderHook(
+                () =>
+                    useAnalysis(
+                        makeOptions({
+                            initialAnalysisFailed: true,
+                            isReasoningHydrated: false,
+                        })
+                    ),
+                { wrapper: makeWrapper() }
+            );
+
+            expect(result.current.isAnalyzing).toBe(true);
+            expect(mockSubmit).not.toHaveBeenCalled();
+        });
+
+        it('isReasoningHydrated가 false→true로 전환되면 자동 재분석을 실행한다', async () => {
+            mockSubmit.mockResolvedValue({
+                status: 'cached',
+                result: INITIAL_ANALYSIS,
+            });
+
+            const { rerender } = renderHook(
+                ({ isReasoningHydrated }: { isReasoningHydrated: boolean }) =>
+                    useAnalysis(
+                        makeOptions({
+                            initialAnalysisFailed: true,
+                            isReasoningHydrated,
+                        })
+                    ),
+                {
+                    wrapper: makeWrapper(),
+                    initialProps: { isReasoningHydrated: false },
+                }
+            );
+
+            expect(mockSubmit).not.toHaveBeenCalled();
+
+            rerender({ isReasoningHydrated: true });
+
+            await waitFor(() => {
+                expect(mockSubmit).toHaveBeenCalledTimes(1);
+            });
+        });
+
+        it('reasoning 값이 변경되면(회원 토글) 재분석을 트리거한다', async () => {
+            mockSubmit.mockResolvedValue({
+                status: 'cached',
+                result: INITIAL_ANALYSIS,
+            });
+
+            const { rerender } = renderHook(
+                ({ reasoning }: { reasoning: boolean }) =>
+                    useAnalysis(
+                        makeOptions({
+                            initialAnalysisFailed: true,
+                            isReasoningHydrated: true,
+                            reasoning,
+                        })
+                    ),
+                {
+                    wrapper: makeWrapper(),
+                    initialProps: { reasoning: false },
+                }
+            );
+
+            await waitFor(() => {
+                expect(mockSubmit).toHaveBeenCalledTimes(1);
+            });
+            mockSubmit.mockClear();
+
+            rerender({ reasoning: true });
+
+            await waitFor(() => {
+                expect(mockSubmit).toHaveBeenCalledTimes(1);
+            });
+            expect(mockSubmit).toHaveBeenCalledWith(
+                'AAPL',
+                'Apple Inc.',
+                '1Day',
+                false,
+                undefined,
+                undefined,
+                true
+            );
+        });
+
+        it('hydration으로 인한 reasoning 값 변화(마운트 직후 false→저장된 true)는 재분석을 트리거하지 않는다', async () => {
+            mockSubmit.mockResolvedValue({
+                status: 'cached',
+                result: INITIAL_ANALYSIS,
+            });
+
+            const { rerender } = renderHook(
+                ({
+                    reasoning,
+                    isReasoningHydrated,
+                }: {
+                    reasoning: boolean;
+                    isReasoningHydrated: boolean;
+                }) =>
+                    useAnalysis(
+                        makeOptions({
+                            initialAnalysisFailed: false,
+                            reasoning,
+                            isReasoningHydrated,
+                        })
+                    ),
+                {
+                    wrapper: makeWrapper(),
+                    initialProps: {
+                        reasoning: false,
+                        isReasoningHydrated: false,
+                    },
+                }
+            );
+
+            expect(mockSubmit).not.toHaveBeenCalled();
+
+            // Hydration flips reasoning false→true and isReasoningHydrated false→true
+            // in the same render (mirrors the modelId hydration flip) — no fetch.
+            rerender({ reasoning: true, isReasoningHydrated: true });
+
+            expect(mockSubmit).not.toHaveBeenCalled();
         });
     });
 

--- a/src/views/symbol/hooks/useAnalysis.ts
+++ b/src/views/symbol/hooks/useAnalysis.ts
@@ -38,6 +38,7 @@ interface AnalyzeMutationVariables {
     force: boolean;
     fmpSymbol?: string;
     modelId?: ModelId;
+    reasoning?: boolean;
 }
 
 /**
@@ -76,6 +77,17 @@ interface UseAnalysisOptions {
      * undefined이면 hydration 추적을 하지 않는다(하위 호환).
      */
     isModelHydrated?: boolean;
+    /**
+     * 효과적(tier-gated) "깊은 생각" reasoning 값 (member-reasoning-toggle spec
+     * Part A). SymbolModelContext에서 온다 — 회원이 아니면 항상 `false`.
+     */
+    reasoning?: boolean;
+    /**
+     * useReasoningToggle의 localStorage read가 끝났는지 여부. isModelHydrated와
+     * 동일한 목적 — hydration 중간에 스푸리어스 재분석이 트리거되지 않도록 한다.
+     * undefined이면 hydration 추적을 하지 않는다(하위 호환).
+     */
+    isReasoningHydrated?: boolean;
 }
 
 // symbol-page → analysis는 허용된 하향 의존(cross-widget cross-import).
@@ -110,6 +122,8 @@ export function useAnalysis({
     timeframeChangeCount,
     modelId,
     isModelHydrated,
+    reasoning,
+    isReasoningHydrated,
 }: UseAnalysisOptions): UseAnalysisResult {
     // 1. useState
     const [analysisResult, setAnalysisResult] =
@@ -138,8 +152,10 @@ export function useAnalysis({
     });
     const latestTimeframeRef = useRef<Timeframe>(timeframe);
     const latestModelIdRef = useRef<ModelId | undefined>(modelId);
+    const latestReasoningRef = useRef<boolean | undefined>(reasoning);
     const prevTimeframeChangeCountRef = useRef(0);
     const prevModelIdRef = useRef<ModelId | undefined>(modelId);
+    const prevReasoningRef = useRef<boolean | undefined>(reasoning);
     /**
      * localStorage hydration으로 인한 model 변경(마운트 직후 DEFAULT_MODEL → 저장값)을
      * 사용자 의도 변경과 구분하기 위한 플래그.
@@ -147,6 +163,13 @@ export function useAnalysis({
      */
     const hasHandledModelHydrationRef = useRef(
         isModelHydrated !== false // undefined(추적 안 함)이면 처음부터 true로 취급
+    );
+    /**
+     * localStorage hydration으로 인한 reasoning 변경(마운트 직후 false → 저장값)을
+     * 사용자 의도 변경과 구분하기 위한 플래그. hasHandledModelHydrationRef와 동일 패턴.
+     */
+    const hasHandledReasoningHydrationRef = useRef(
+        isReasoningHydrated !== false // undefined(추적 안 함)이면 처음부터 true로 취급
     );
     // 현재 진행 중인 워커 job ID. 타임프레임 변경 시 취소 신호 전달에 사용.
     const currentJobIdRef = useRef<string | null>(null);
@@ -171,6 +194,7 @@ export function useAnalysis({
             companyName: mutCompanyName,
             fmpSymbol: mutFmpSymbol,
             modelId: mutModelId,
+            reasoning: mutReasoning,
         }) => {
             lastForceRef.current = force;
             return submitAnalysisAction(
@@ -179,7 +203,8 @@ export function useAnalysis({
                 latestTimeframeRef.current,
                 force,
                 mutFmpSymbol,
-                mutModelId
+                mutModelId,
+                mutReasoning
             );
         },
         onMutate: () => {
@@ -260,7 +285,8 @@ export function useAnalysis({
     const isAnalyzing =
         isSubmitting ||
         isPolling ||
-        (initialAnalysisFailedAtMount && isModelHydrated === false);
+        (initialAnalysisFailedAtMount &&
+            (isModelHydrated === false || isReasoningHydrated === false));
     const analysisError = submitError?.message ?? pollError ?? null;
     // 쿨다운 카운트다운이 활성화된 상태. effect deps에 사용해 불필요한 재시작을 방지한다.
     const isCountdownActive = reanalyzeCooldownMs > 0;
@@ -289,16 +315,18 @@ export function useAnalysis({
                 force: true,
                 fmpSymbol: latestFmpSymbol,
                 modelId: latestModelIdRef.current,
+                reasoning: latestReasoningRef.current,
             });
         })();
     }, [reset, mutate]);
 
     /**
-     * 타임프레임 변경·모델 변경 두 effect에서 공유한다.
-     * modelIdOverride 미전달 시 latestModelIdRef(=최신 렌더 모델)를 사용한다.
+     * 타임프레임 변경·모델 변경·reasoning 변경 세 effect에서 공유한다.
+     * modelIdOverride/reasoningOverride 미전달 시 각각 latestModelIdRef/
+     * latestReasoningRef(=최신 렌더 값)를 사용한다.
      */
     const restartAnalysis = useCallback(
-        (modelIdOverride?: ModelId): void => {
+        (modelIdOverride?: ModelId, reasoningOverride?: boolean): void => {
             const jobId = currentJobIdRef.current;
             currentJobIdRef.current = null;
             if (jobId !== null) cancelMutate(jobId);
@@ -309,6 +337,7 @@ export function useAnalysis({
                 force: false,
                 fmpSymbol: latestRef.current.fmpSymbol,
                 modelId: modelIdOverride ?? latestModelIdRef.current,
+                reasoning: reasoningOverride ?? latestReasoningRef.current,
             });
         },
         [cancelMutate, reset, mutate]
@@ -330,6 +359,7 @@ export function useAnalysis({
         latestRef.current = { symbol, companyName, fmpSymbol };
         latestTimeframeRef.current = timeframe;
         latestModelIdRef.current = modelId;
+        latestReasoningRef.current = reasoning;
     });
 
     // 8. useEffect
@@ -410,9 +440,12 @@ export function useAnalysis({
 
     // 서버에서 초기 AI 분석이 실패한 경우, localStorage hydration이 완료된 뒤 자동으로 재분석을 실행한다.
     // isModelHydrated=false 동안에는 기본값(DEFAULT_MODEL)이 사용 중이므로 hydration 완료까지 대기한다.
+    // isReasoningHydrated도 동일하게 대기한다 — 그렇지 않으면 회원의 저장된 reasoning=true가
+    // 반영되기 전에 reasoning=false(기본값)로 초기 재시도가 나가버린다.
     useEffect(() => {
         if (!initialAnalysisFailedAtMount) return;
         if (isModelHydrated === false) return;
+        if (isReasoningHydrated === false) return;
         // 초기 실패 재시도는 이미 reset/cancel 없이 진행 — 진행 중인 작업이 없는 상태에서만 도달한다.
         mutate({
             symbol: latestRef.current.symbol,
@@ -420,8 +453,14 @@ export function useAnalysis({
             force: false,
             fmpSymbol: latestRef.current.fmpSymbol,
             modelId: latestModelIdRef.current,
+            reasoning: latestReasoningRef.current,
         });
-    }, [mutate, isModelHydrated, initialAnalysisFailedAtMount]);
+    }, [
+        mutate,
+        isModelHydrated,
+        isReasoningHydrated,
+        initialAnalysisFailedAtMount,
+    ]);
 
     // 타임프레임 변경 시 진행 중인 워커 작업을 취소하고, 이전 mutation 상태를 초기화한 뒤 새 분석을 자동 실행한다.
     useEffect(() => {
@@ -448,6 +487,27 @@ export function useAnalysis({
         // 경우에도 useLayoutEffect 전에 이 effect가 실행될 수 있으므로 값을 직접 주입한다.
         restartAnalysis(modelId);
     }, [modelId, isModelHydrated, restartAnalysis]);
+
+    // 토글 변경 시 재분석(다른 캐시 키) — modelId 변경 effect와 완전히 동일한 패턴.
+    // localStorage hydration으로 인한 reasoning 변경(마운트 직후 false → 저장값)은
+    // 사용자 의도 변경이 아니므로 재분석을 트리거하지 않는다.
+    useEffect(() => {
+        if (
+            !hasHandledReasoningHydrationRef.current &&
+            isReasoningHydrated !== false
+        ) {
+            hasHandledReasoningHydrationRef.current = true;
+            prevReasoningRef.current = reasoning;
+            return;
+        }
+
+        if (reasoning === prevReasoningRef.current) return;
+        prevReasoningRef.current = reasoning;
+
+        // 회원의 명시적 토글 변경은 새 reasoning 값을 직접 주입한다 — modelId 변경과
+        // 동일 이유(latestReasoningRef가 이 effect보다 늦게 갱신될 수 있음).
+        restartAnalysis(undefined, reasoning);
+    }, [reasoning, isReasoningHydrated, restartAnalysis]);
 
     // 쿨다운이 활성화된 동안 1초마다 로컬에서 카운트다운한다.
     // isCountdownActive(0 → 양수 전환)가 true가 될 때만 인터벌을 시작해 중복 시작을 방지한다.

--- a/src/widgets/congress/CongressTrendSummary.tsx
+++ b/src/widgets/congress/CongressTrendSummary.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { useMemo } from 'react';
-import { useDefaultModelId } from '@/features/symbol-model';
+import {
+    useDefaultModelId,
+    useDefaultReasoning,
+} from '@/features/symbol-model';
 import { useRegisterShareable, mapAnalysisStatus } from '@/features/share';
 import { usePublishSymbolChat } from '@/features/symbol-chat';
 import { BotBlockedNotice } from '@/shared/ui/BotBlockedNotice';
@@ -18,7 +21,8 @@ interface CongressTrendSummaryProps {
 
 export function CongressTrendSummary({ symbol }: CongressTrendSummaryProps) {
     const modelId = useDefaultModelId();
-    const state = useCongressTrend(symbol, modelId);
+    const reasoning = useDefaultReasoning();
+    const state = useCongressTrend(symbol, modelId, reasoning);
 
     // loading/no_trades/bot_blocked/error 시에도 chatState를 명시적으로
     // publish하여 챗봇이 이전 페이지의 stale context를 그대로 들고 가지

--- a/src/widgets/congress/__tests__/CongressTrendSummary.test.tsx
+++ b/src/widgets/congress/__tests__/CongressTrendSummary.test.tsx
@@ -8,6 +8,7 @@ vi.mock('@/shared/lib/cn', () => ({
 }));
 vi.mock('@/features/symbol-model', () => ({
     useDefaultModelId: () => 'gemini-2.5-flash-lite',
+    useDefaultReasoning: () => false,
 }));
 vi.mock('../hooks/useCongressTrend', () => ({
     useCongressTrend: vi.fn(),

--- a/src/widgets/congress/hooks/__tests__/useCongressTrend.test.tsx
+++ b/src/widgets/congress/hooks/__tests__/useCongressTrend.test.tsx
@@ -92,7 +92,8 @@ describe('useCongressTrend', () => {
         expect(result.current.result).toEqual(CONGRESS_RESULT);
         expect(mockSubmit).toHaveBeenCalledWith(
             'AAPL',
-            'gemini-2.5-flash-lite'
+            'gemini-2.5-flash-lite',
+            false
         );
     });
 

--- a/src/widgets/congress/hooks/useCongressTrend.ts
+++ b/src/widgets/congress/hooks/useCongressTrend.ts
@@ -49,10 +49,15 @@ export type CongressTrendState =
 async function fetchCongressTrend(
     symbol: string,
     modelId: ModelId,
+    reasoning: boolean,
     signal: AbortSignal,
     onJobId: (jobId: string | null, expectedCurrent?: string | null) => void
 ): Promise<CongressTrendResponse> {
-    const submitted = await submitCongressTrendAction(symbol, modelId);
+    const submitted = await submitCongressTrendAction(
+        symbol,
+        modelId,
+        reasoning
+    );
 
     if (submitted.status === 'cached') return submitted.result;
     if (submitted.status === 'miss_no_trigger') {
@@ -96,7 +101,13 @@ async function fetchCongressTrend(
 
 export function useCongressTrend(
     symbol: string,
-    modelId: ModelId
+    modelId: ModelId,
+    /**
+     * Member "깊은 생각" (deep-thinking) toggle value (member-reasoning-toggle
+     * spec Part A). Defaults to `false`. Part of the query key so toggling
+     * re-submits analysis (distinct cache key).
+     */
+    reasoning = false
 ): CongressTrendState {
     const currentJobIdRef = useRef<string | null>(null);
     const queryClient = useQueryClient();
@@ -106,11 +117,12 @@ export function useCongressTrend(
     // deep-equality로 비교하므로 매 렌더 새 배열 참조가 생성돼도 불필요한
     // 재페치가 발생하지 않는다.
     const query = useQuery({
-        queryKey: QUERY_KEYS.congressTrend(symbol, modelId),
-        queryFn: ({ signal, queryKey: [, qSymbol, qModelId] }) =>
+        queryKey: QUERY_KEYS.congressTrend(symbol, modelId, reasoning),
+        queryFn: ({ signal, queryKey: [, qSymbol, qModelId, qReasoning] }) =>
             fetchCongressTrend(
                 qSymbol,
                 qModelId,
+                qReasoning,
                 signal,
                 (jobId, expectedCurrent) => {
                     if (
@@ -146,12 +158,12 @@ export function useCongressTrend(
         if (!isHydrated) return;
         if (
             queryClient.getQueryData(
-                QUERY_KEYS.congressTrend(symbol, modelId)
+                QUERY_KEYS.congressTrend(symbol, modelId, reasoning)
             ) === undefined
         ) {
             void refetch();
         }
-    }, [isHydrated, queryClient, symbol, modelId, refetch]);
+    }, [isHydrated, queryClient, symbol, modelId, reasoning, refetch]);
 
     useEffect(() => {
         return () => {
@@ -163,7 +175,7 @@ export function useCongressTrend(
                 });
             }
         };
-    }, [symbol, modelId]);
+    }, [symbol, modelId, reasoning]);
 
     if (query.isError) {
         if (query.error instanceof BotBlockedError) {

--- a/src/widgets/financials/FinancialsAiSummary.tsx
+++ b/src/widgets/financials/FinancialsAiSummary.tsx
@@ -8,7 +8,10 @@ import type {
 import { useRegisterShareable, mapAnalysisStatus } from '@/features/share';
 import { cn } from '@/shared/lib/cn';
 import { AXIS_LABEL_KO } from './axisLabels';
-import { useDefaultModelId } from '@/features/symbol-model';
+import {
+    useDefaultModelId,
+    useDefaultReasoning,
+} from '@/features/symbol-model';
 import { useFinancialsAnalysis } from './hooks/useFinancialsAnalysis';
 import { usePublishSymbolChat } from '@/features/symbol-chat';
 import { buildChatState } from './utils/buildChatState';
@@ -120,7 +123,8 @@ interface FinancialsAiSummaryProps {
 
 export function FinancialsAiSummary({ symbol }: FinancialsAiSummaryProps) {
     const modelId = useDefaultModelId();
-    const state = useFinancialsAnalysis(symbol, modelId);
+    const reasoning = useDefaultReasoning();
+    const state = useFinancialsAnalysis(symbol, modelId, reasoning);
 
     // bot_blocked/loading/error 시에도 chatState를 명시적으로 publish하여 챗봇이
     // 이전 페이지의 stale context를 그대로 들고 가지 않게 한다.

--- a/src/widgets/financials/__tests__/FinancialsAiSummary.test.tsx
+++ b/src/widgets/financials/__tests__/FinancialsAiSummary.test.tsx
@@ -7,6 +7,7 @@ vi.mock('@/shared/lib/cn', () => ({
 }));
 vi.mock('@/features/symbol-model', () => ({
     useDefaultModelId: () => 'gemini-2.5-flash-lite',
+    useDefaultReasoning: () => false,
 }));
 vi.mock('../hooks/useFinancialsAnalysis', () => ({
     useFinancialsAnalysis: vi.fn(),

--- a/src/widgets/financials/__tests__/hooks/useFinancialsAnalysis.test.tsx
+++ b/src/widgets/financials/__tests__/hooks/useFinancialsAnalysis.test.tsx
@@ -109,7 +109,8 @@ describe('useFinancialsAnalysis', () => {
         });
         expect(mockSubmit).toHaveBeenCalledWith(
             'AAPL',
-            'gemini-2.5-flash-lite'
+            'gemini-2.5-flash-lite',
+            false
         );
     });
 

--- a/src/widgets/financials/hooks/useFinancialsAnalysis.ts
+++ b/src/widgets/financials/hooks/useFinancialsAnalysis.ts
@@ -36,10 +36,15 @@ export type FinancialsAnalysisState =
 async function fetchFinancialsAnalysis(
     symbol: string,
     modelId: ModelId,
+    reasoning: boolean,
     signal: AbortSignal,
     onJobId: (jobId: string | null, expectedCurrent?: string | null) => void
 ): Promise<FinancialsAnalysisResponse> {
-    const submitted = await submitFinancialsAnalysisAction(symbol, modelId);
+    const submitted = await submitFinancialsAnalysisAction(
+        symbol,
+        modelId,
+        reasoning
+    );
 
     if (submitted.status === 'cached') return submitted.result;
     if (submitted.status === 'miss_no_trigger') {
@@ -86,7 +91,14 @@ async function fetchFinancialsAnalysis(
 
 export function useFinancialsAnalysis(
     symbol: string,
-    modelId: ModelId
+    modelId: ModelId,
+    /**
+     * Member "깊은 생각" (deep-thinking) toggle value (member-reasoning-toggle
+     * spec Part A). Defaults to `false` — pre-toggle callers keep resolving
+     * to the exact same query key as before. Part of the query key so
+     * toggling re-submits analysis (distinct cache key).
+     */
+    reasoning = false
 ): FinancialsAnalysisState {
     const currentJobIdRef = useRef<string | null>(null);
     const queryClient = useQueryClient();
@@ -96,11 +108,12 @@ export function useFinancialsAnalysis(
     // React Query는 queryKey를 deep-equality로 비교하므로 매 렌더 새 배열 참조가
     // 생성돼도 불필요한 재페치가 발생하지 않는다.
     const query = useQuery({
-        queryKey: QUERY_KEYS.financialsAnalysis(symbol, modelId),
-        queryFn: ({ signal, queryKey: [, qSymbol, qModelId] }) =>
+        queryKey: QUERY_KEYS.financialsAnalysis(symbol, modelId, reasoning),
+        queryFn: ({ signal, queryKey: [, qSymbol, qModelId, qReasoning] }) =>
             fetchFinancialsAnalysis(
                 qSymbol,
                 qModelId,
+                qReasoning,
                 signal,
                 (jobId, expectedCurrent) => {
                     if (
@@ -136,14 +149,14 @@ export function useFinancialsAnalysis(
         if (!isHydrated) return;
         if (
             queryClient.getQueryData(
-                QUERY_KEYS.financialsAnalysis(symbol, modelId)
+                QUERY_KEYS.financialsAnalysis(symbol, modelId, reasoning)
             ) === undefined
         ) {
             void refetch();
         }
-    }, [isHydrated, queryClient, symbol, modelId, refetch]);
+    }, [isHydrated, queryClient, symbol, modelId, reasoning, refetch]);
 
-    // symbol 또는 modelId 변경(queryKey 교체) 시, unmount 시 진행 중인 job을 cancel한다.
+    // symbol/modelId/reasoning 변경(queryKey 교체) 시, unmount 시 진행 중인 job을 cancel한다.
     // fire-and-forget이므로 useMutation 없이 직접 호출한다.
     useEffect(() => {
         return () => {
@@ -158,7 +171,7 @@ export function useFinancialsAnalysis(
                 });
             }
         };
-    }, [symbol, modelId]);
+    }, [symbol, modelId, reasoning]);
 
     if (query.isError) {
         if (query.error instanceof BotBlockedError) {

--- a/src/widgets/fundamental/FundamentalAiSummary.tsx
+++ b/src/widgets/fundamental/FundamentalAiSummary.tsx
@@ -8,7 +8,10 @@ import {
 } from '@y0ngha/siglens-core';
 import { useRegisterShareable, mapAnalysisStatus } from '@/features/share';
 import { cn } from '@/shared/lib/cn';
-import { useDefaultModelId } from '@/features/symbol-model';
+import {
+    useDefaultModelId,
+    useDefaultReasoning,
+} from '@/features/symbol-model';
 import { useFundamentalAnalysis } from './hooks/useFundamentalAnalysis';
 import { usePublishSymbolChat } from '@/features/symbol-chat';
 import { buildChatState } from './utils/buildChatState';
@@ -128,7 +131,8 @@ interface FundamentalAiSummaryProps {
 
 export function FundamentalAiSummary({ symbol }: FundamentalAiSummaryProps) {
     const modelId = useDefaultModelId();
-    const state = useFundamentalAnalysis(symbol, modelId);
+    const reasoning = useDefaultReasoning();
+    const state = useFundamentalAnalysis(symbol, modelId, reasoning);
 
     // bot_blocked/loading/error 시에도 chatState를 명시적으로 publish하여 챗봇이
     // 이전 페이지의 stale context를 그대로 들고 가지 않게 한다.

--- a/src/widgets/fundamental/__tests__/FundamentalAiSummary.test.tsx
+++ b/src/widgets/fundamental/__tests__/FundamentalAiSummary.test.tsx
@@ -7,6 +7,7 @@ vi.mock('@/shared/lib/cn', () => ({
 }));
 vi.mock('@/features/symbol-model', () => ({
     useDefaultModelId: () => 'gemini-2.5-flash-lite',
+    useDefaultReasoning: () => false,
 }));
 vi.mock('../hooks/useFundamentalAnalysis', () => ({
     useFundamentalAnalysis: vi.fn(),

--- a/src/widgets/fundamental/__tests__/hooks/useFundamentalAnalysis.test.tsx
+++ b/src/widgets/fundamental/__tests__/hooks/useFundamentalAnalysis.test.tsx
@@ -109,7 +109,8 @@ describe('useFundamentalAnalysis', () => {
         });
         expect(mockSubmit).toHaveBeenCalledWith(
             'AAPL',
-            'gemini-2.5-flash-lite'
+            'gemini-2.5-flash-lite',
+            false
         );
     });
 

--- a/src/widgets/fundamental/hooks/useFundamentalAnalysis.ts
+++ b/src/widgets/fundamental/hooks/useFundamentalAnalysis.ts
@@ -37,10 +37,15 @@ export type FundamentalAnalysisState =
 async function fetchFundamentalAnalysis(
     symbol: string,
     modelId: ModelId,
+    reasoning: boolean,
     signal: AbortSignal,
     onJobId: (jobId: string | null, expectedCurrent?: string | null) => void
 ): Promise<FundamentalAnalysisResponse> {
-    const submitted = await submitFundamentalAnalysisAction(symbol, modelId);
+    const submitted = await submitFundamentalAnalysisAction(
+        symbol,
+        modelId,
+        reasoning
+    );
 
     if (submitted.status === 'cached') return submitted.result;
     if (submitted.status === 'miss_no_trigger') {
@@ -82,22 +87,29 @@ async function fetchFundamentalAnalysis(
 
 export function useFundamentalAnalysis(
     symbol: string,
-    modelId: ModelId
+    modelId: ModelId,
+    /**
+     * Member "깊은 생각" (deep-thinking) toggle value (member-reasoning-toggle
+     * spec Part A). Defaults to `false`. Part of the query key so toggling
+     * re-submits analysis (distinct cache key).
+     */
+    reasoning = false
 ): FundamentalAnalysisState {
     const queryClient = useQueryClient();
     const isHydrated = useHydrated();
     const currentJobIdRef = useRef<string | null>(null);
     const queryKey = useMemo(
-        () => QUERY_KEYS.fundamentalAnalysis(symbol, modelId),
-        [symbol, modelId]
+        () => QUERY_KEYS.fundamentalAnalysis(symbol, modelId, reasoning),
+        [symbol, modelId, reasoning]
     );
 
     const query = useQuery({
         queryKey,
-        queryFn: ({ signal, queryKey: [, qSymbol, qModelId] }) =>
+        queryFn: ({ signal, queryKey: [, qSymbol, qModelId, qReasoning] }) =>
             fetchFundamentalAnalysis(
                 qSymbol,
                 qModelId,
+                qReasoning,
                 signal,
                 (jobId, expectedCurrent) => {
                     if (

--- a/src/widgets/news/NewsAiSummary.tsx
+++ b/src/widgets/news/NewsAiSummary.tsx
@@ -9,7 +9,10 @@ import { useNewsAnalysisTrigger } from './hooks/useNewsAnalysisTrigger';
 import { useWaitForNewsCards } from './hooks/useWaitForNewsCards';
 import { buildChatState } from './utils/buildChatState';
 import { BotBlockedNotice } from '@/shared/ui/BotBlockedNotice';
-import { useDefaultModelId } from '@/features/symbol-model';
+import {
+    useDefaultModelId,
+    useDefaultReasoning,
+} from '@/features/symbol-model';
 import { cn } from '@/shared/lib/cn';
 import {
     type NewsAnalysisResponse,
@@ -253,12 +256,14 @@ export function NewsAiSummary({
         hasEnrichedNews
     );
     const modelId = useDefaultModelId();
+    const reasoning = useDefaultReasoning();
     // enabled 게이트: enriched news cards가 DB에 적어도 1개 있을 때까지 submit을
     // 미룬다. 이 게이트가 없으면 빈 DB에 대해 submit이 즉시 fire되어 core가
     // no_news 결과를 돌려주고, retry:false + staleTime:Infinity 정책에 의해
     // 에러가 영구 캐시돼 cards가 enrich된 뒤에도 분석 패널이 회복되지 않는다.
     const analysis = useNewsAnalysis(symbol, companyName, modelId, {
         enabled: isCardsReady,
+        reasoning,
     });
 
     // 훅 선언 순서 예외(MISTAKES.md #17): usePublishSymbolChat은 chatState(파생 변수)를

--- a/src/widgets/news/__tests__/NewsAiSummary.test.tsx
+++ b/src/widgets/news/__tests__/NewsAiSummary.test.tsx
@@ -38,6 +38,7 @@ vi.mock('@/shared/ui/BotBlockedNotice', () => ({
 
 vi.mock('@/features/symbol-model', () => ({
     useDefaultModelId: () => 'gemini-2.5-flash-lite',
+    useDefaultReasoning: () => false,
 }));
 
 vi.mock('@/shared/lib/cn', () => ({

--- a/src/widgets/news/__tests__/hooks/useNewsAnalysis.test.tsx
+++ b/src/widgets/news/__tests__/hooks/useNewsAnalysis.test.tsx
@@ -112,7 +112,8 @@ describe('useNewsAnalysis', () => {
         expect(mockSubmit).toHaveBeenCalledWith(
             'AAPL',
             'Apple Inc.',
-            'gemini-2.5-flash-lite'
+            'gemini-2.5-flash-lite',
+            false
         );
     });
 

--- a/src/widgets/news/hooks/useNewsAnalysis.ts
+++ b/src/widgets/news/hooks/useNewsAnalysis.ts
@@ -31,6 +31,7 @@ async function fetchNewsAnalysis(
     symbol: string,
     companyName: string,
     modelId: ModelId,
+    reasoning: boolean,
     signal: AbortSignal,
     onJobId: (jobId: string | null, expectedCurrent?: string | null) => void
 ): Promise<NewsAnalysisResponse> {
@@ -38,7 +39,8 @@ async function fetchNewsAnalysis(
     const submitted = await submitNewsAnalysisAction(
         symbol,
         companyName,
-        modelId
+        modelId,
+        reasoning
     );
 
     if (submitted.status === 'cached') return submitted.result;
@@ -92,28 +94,38 @@ interface UseNewsAnalysisOptions {
      * `retry: false + staleTime: Infinity` 정책 하에 영구 캐시되는 회귀를 막는다.
      */
     enabled?: boolean;
+    /**
+     * Member "깊은 생각" (deep-thinking) toggle value (member-reasoning-toggle
+     * spec Part A). Defaults to `false`. Part of the query key so toggling
+     * re-submits analysis (distinct cache key).
+     */
+    reasoning?: boolean;
 }
 
 export function useNewsAnalysis(
     symbol: string,
     companyName: string,
     modelId: ModelId,
-    { enabled = true }: UseNewsAnalysisOptions = {}
+    { enabled = true, reasoning = false }: UseNewsAnalysisOptions = {}
 ): NewsAnalysisState {
     const currentJobIdRef = useRef<string | null>(null);
     const isHydrated = useHydrated();
     const queryKey = useMemo(
-        () => QUERY_KEYS.newsAnalysis(symbol, companyName, modelId),
-        [symbol, companyName, modelId]
+        () => QUERY_KEYS.newsAnalysis(symbol, companyName, modelId, reasoning),
+        [symbol, companyName, modelId, reasoning]
     );
 
     const query = useQuery({
         queryKey,
-        queryFn: ({ signal, queryKey: [, qSymbol, qCompanyName, qModelId] }) =>
+        queryFn: ({
+            signal,
+            queryKey: [, qSymbol, qCompanyName, qModelId, qReasoning],
+        }) =>
             fetchNewsAnalysis(
                 qSymbol,
                 qCompanyName,
                 qModelId,
+                qReasoning,
                 signal,
                 (jobId, expectedCurrent) => {
                     if (

--- a/src/widgets/options/OptionsAiAnalysis.tsx
+++ b/src/widgets/options/OptionsAiAnalysis.tsx
@@ -220,6 +220,8 @@ interface OptionsAiAnalysisProps {
     /** 'YYYY-MM-DD' or 'all'. */
     expirationDate: OptionsExpirationSelector;
     modelId: ModelId;
+    /** Member "깊은 생각" (deep-thinking) toggle value (member-reasoning-toggle spec Part A). */
+    reasoning?: boolean;
 }
 
 export function OptionsAiAnalysis({
@@ -227,12 +229,14 @@ export function OptionsAiAnalysis({
     companyName,
     expirationDate,
     modelId,
+    reasoning,
 }: OptionsAiAnalysisProps) {
     const state = useOptionsAnalysis({
         symbol,
         companyName,
         expirationDate,
         modelId,
+        reasoning,
     });
 
     // 훅 선언 순서 예외(MISTAKES.md #17): usePublishSymbolChat은 chatState(파생

--- a/src/widgets/options/OptionsPageClient.tsx
+++ b/src/widgets/options/OptionsPageClient.tsx
@@ -66,7 +66,7 @@ export function OptionsPageClient({
     //   useEffect로 mount 직후 한 번만 채워 SSR 마크업은 항상 banner 없음
     //   상태로 통일한다. snapshot 참조가 갱신되면 자동으로 재평가된다.
     const [now, setNow] = useState<Date | null>(null);
-    const { modelId } = useSymbolModel();
+    const { modelId, reasoning } = useSymbolModel();
     const validSlots = useMemo(() => slots.filter(isSlotMapping), [slots]);
     // 단일 호출로 (chain, metrics)을 산출하고 세 자식에 prop-drill 한다 —
     // 이전엔 OptionsMetricsRow / OpenInterestChart / OptionsChainTable이
@@ -119,6 +119,7 @@ export function OptionsPageClient({
                         companyName={companyName}
                         expirationDate={expirationDate}
                         modelId={modelId}
+                        reasoning={reasoning}
                     />
                 </ErrorBoundary>
             )}

--- a/src/widgets/options/hooks/useOptionsAnalysis.ts
+++ b/src/widgets/options/hooks/useOptionsAnalysis.ts
@@ -35,6 +35,7 @@ async function fetchOptionsAnalysis(
     companyName: string,
     expirationDate: OptionsExpirationSelector,
     modelId: ModelId,
+    reasoning: boolean,
     signal: AbortSignal,
     onJobId: (jobId: string | null, expectedCurrent?: string | null) => void
 ): Promise<OptionsAnalysisResponse> {
@@ -44,7 +45,8 @@ async function fetchOptionsAnalysis(
         symbol,
         companyName,
         expirationDate,
-        modelId
+        modelId,
+        reasoning
     );
 
     if (submitted.status === 'cached') return submitted.result;
@@ -88,6 +90,12 @@ interface UseOptionsAnalysisInput {
     companyName: string;
     expirationDate: OptionsExpirationSelector;
     modelId: ModelId;
+    /**
+     * Member "깊은 생각" (deep-thinking) toggle value (member-reasoning-toggle
+     * spec Part A). Defaults to `false`. Part of the query key so toggling
+     * re-submits analysis (distinct cache key).
+     */
+    reasoning?: boolean;
 }
 
 /**
@@ -102,6 +110,7 @@ export function useOptionsAnalysis({
     companyName,
     expirationDate,
     modelId,
+    reasoning = false,
 }: UseOptionsAnalysisInput): OptionsAnalysisState {
     const currentJobIdRef = useRef<string | null>(null);
     const queryClient = useQueryClient();
@@ -112,22 +121,31 @@ export function useOptionsAnalysis({
                 symbol,
                 companyName,
                 expirationDate,
-                modelId
+                modelId,
+                reasoning
             ),
-        [symbol, companyName, expirationDate, modelId]
+        [symbol, companyName, expirationDate, modelId, reasoning]
     );
 
     const query = useQuery({
         queryKey,
         queryFn: ({
             signal,
-            queryKey: [, qSymbol, qCompanyName, qExpiration, qModelId],
+            queryKey: [
+                ,
+                qSymbol,
+                qCompanyName,
+                qExpiration,
+                qModelId,
+                qReasoning,
+            ],
         }) =>
             fetchOptionsAnalysis(
                 qSymbol,
                 qCompanyName,
                 qExpiration,
                 qModelId,
+                qReasoning,
                 signal,
                 (jobId, expectedCurrent) => {
                     if (

--- a/src/widgets/overall/OverallContent.tsx
+++ b/src/widgets/overall/OverallContent.tsx
@@ -9,7 +9,10 @@ import { OverallTriggerCta } from './OverallTriggerCta';
 import { ReanalyzeButton } from './ReanalyzeButton';
 import { buildChatState } from './utils/buildChatState';
 import { BotBlockedNotice } from '@/shared/ui/BotBlockedNotice';
-import { useDefaultModelId } from '@/features/symbol-model';
+import {
+    useDefaultModelId,
+    useDefaultReasoning,
+} from '@/features/symbol-model';
 import { cn } from '@/shared/lib/cn';
 import { type OverallAnalysisResponse } from '@y0ngha/siglens-core';
 import { type CSSProperties, useMemo } from 'react';
@@ -63,13 +66,15 @@ export function OverallContent({
     // tf는 서버가 아니라 client가 URL에서 읽어 [symbol] ISR(정적 렌더)을 유지한다.
     const timeframe = useTimeframeFromUrl();
     const modelId = useDefaultModelId();
+    const reasoning = useDefaultReasoning();
     const { state, trigger } = useOverallAnalysis(
         symbol,
         companyName,
         timeframe,
         modelId,
         initialAnalysis,
-        assetClass
+        assetClass,
+        reasoning
     );
 
     // usePublishSymbolChat은 chatState(useMemo 반환값)를 인자로 받으므로 useMemo 뒤에 둔다(§17 의존 순서).

--- a/src/widgets/overall/__tests__/OverallContent.flow.test.tsx
+++ b/src/widgets/overall/__tests__/OverallContent.flow.test.tsx
@@ -41,6 +41,7 @@ vi.mock('@/features/symbol-chat', () => ({
 }));
 vi.mock('@/features/symbol-model', () => ({
     useDefaultModelId: vi.fn(() => 'gemini-2.5-flash-lite'),
+    useDefaultReasoning: vi.fn(() => false),
 }));
 // /news와 동일 게이트 적용 후 mock 필요. flow 테스트는 hasEnrichedNews=true 전제로
 // 게이트를 즉시 통과시키고 본래 검증(submit→polling→done 서사)을 그대로 유지한다.
@@ -169,11 +170,12 @@ describe('OverallContent 사용자 분석 플로우 (userEvent)', () => {
         ).toBeInTheDocument();
 
         // 훅은 첫 trigger에서 queryFnForceRef(false)를 그대로 options로 넘기므로
-        // 5번째 인자는 정확히 { force: false }다 — done 상태에서의 재분석만 force:true.
+        // 5번째 인자는 정확히 { force: false, reasoning: false }다(기본
+        // reasoning=false) — done 상태에서의 재분석만 force:true.
         expect(mockSubmit).toHaveBeenCalledTimes(1);
         const firstArgs = mockSubmit.mock.calls[0]!;
         expect(firstArgs[0]).toBe('AAPL');
-        expect(firstArgs[4]).toEqual({ force: false });
+        expect(firstArgs[4]).toEqual({ force: false, reasoning: false });
 
         expect(mockPollOverall).toHaveBeenCalledWith('overall-job');
         expect(mockPollOverall).toHaveBeenCalledTimes(2);

--- a/src/widgets/overall/__tests__/OverallContent.test.tsx
+++ b/src/widgets/overall/__tests__/OverallContent.test.tsx
@@ -26,6 +26,7 @@ vi.mock('@/features/symbol-chat', () => ({
 }));
 vi.mock('@/features/symbol-model', () => ({
     useDefaultModelId: vi.fn(() => 'gemini-2.5-flash-lite'),
+    useDefaultReasoning: vi.fn(() => false),
 }));
 // /news와 동일 게이트 적용 — 두 훅을 단순화해 효과만 검증한다.
 // useNewsAnalysisTrigger는 fire-and-forget mount effect이므로 no-op.
@@ -145,7 +146,8 @@ describe('OverallContent tf 쿼리 파라미터 처리 (§18 분기)', () => {
             '1Hour',
             'gemini-2.5-flash-lite',
             undefined,
-            'equity'
+            'equity',
+            false
         );
     });
 
@@ -164,7 +166,8 @@ describe('OverallContent tf 쿼리 파라미터 처리 (§18 분기)', () => {
             DEFAULT_TIMEFRAME,
             'gemini-2.5-flash-lite',
             undefined,
-            'equity'
+            'equity',
+            false
         );
     });
 });
@@ -707,7 +710,8 @@ describe('OverallContent — crypto assetClass (F1 / UI Group 3)', () => {
             DEFAULT_TIMEFRAME,
             'gemini-2.5-flash-lite',
             undefined, // initialAnalysis
-            'crypto'
+            'crypto',
+            false
         );
     });
 

--- a/src/widgets/overall/__tests__/hooks/useOverallAnalysis.test.tsx
+++ b/src/widgets/overall/__tests__/hooks/useOverallAnalysis.test.tsx
@@ -467,7 +467,10 @@ describe('useOverallAnalysis', () => {
             await waitFor(() => {
                 const lastCall =
                     mockSubmit.mock.calls[mockSubmit.mock.calls.length - 1];
-                expect(lastCall?.[4]).toEqual({ force: true });
+                expect(lastCall?.[4]).toEqual({
+                    force: true,
+                    reasoning: false,
+                });
             });
         });
 
@@ -490,9 +493,13 @@ describe('useOverallAnalysis', () => {
             );
 
             // 첫 trigger는 queryFnForceRef(false)를 그대로 options로 넘기므로
-            // 5번째 인자는 정확히 { force: false }다. done 상태 재분석만 force:true.
+            // 5번째 인자는 정확히 { force: false, reasoning: false }다(기본
+            // reasoning=false). done 상태 재분석만 force:true.
             const firstCall = mockSubmit.mock.calls[0];
-            expect(firstCall?.[4]).toEqual({ force: false });
+            expect(firstCall?.[4]).toEqual({
+                force: false,
+                reasoning: false,
+            });
         });
     });
 

--- a/src/widgets/overall/hooks/useOverallAnalysis.ts
+++ b/src/widgets/overall/hooks/useOverallAnalysis.ts
@@ -180,7 +180,7 @@ async function submitUntilReady(
     onProgress: (p: ProgressState) => void,
     onJobsUpdate: (jobs: CurrentJobs) => void,
     applicableAxes: readonly OverallAxis[],
-    options: { force?: boolean } = {},
+    options: { force?: boolean; reasoning?: boolean } = {},
     depth = 0
 ): Promise<
     Exclude<
@@ -221,7 +221,10 @@ async function submitUntilReady(
     throwIfAborted(signal);
 
     // 모든 dependency 완료 후 재submit — 이번엔 pending_dependencies가 반환되지
-    // 않는다. force는 의도적으로 전파하지 않는다(위 JSDoc 참고).
+    // 않는다. force는 의도적으로 전파하지 않는다(위 JSDoc 참고). reasoning은
+    // force와 달리 재분석 "의도"가 아니라 이번 fetchOverallAnalysis 호출 전체에
+    // 걸친 요청 속성이므로 재귀 재submit에도 그대로 유지한다 — 그렇지 않으면
+    // 의존성 완료 후 최종 submit이 reasoning=false로 되돌아가는 회귀가 생긴다.
     return submitUntilReady(
         symbol,
         companyName,
@@ -231,7 +234,7 @@ async function submitUntilReady(
         onProgress,
         onJobsUpdate,
         applicableAxes,
-        {},
+        { reasoning: options.reasoning },
         depth + 1
     );
 }
@@ -248,7 +251,7 @@ async function fetchOverallAnalysis(
     // 덮어쓰는 race를 막기 위해 사용한다.
     onJobsUpdate: (jobs: CurrentJobs, expectedCurrent?: CurrentJobs) => void,
     applicableAxes: readonly OverallAxis[],
-    options: { force?: boolean } = {}
+    options: { force?: boolean; reasoning?: boolean } = {}
 ): Promise<OverallAnalysisResponse> {
     // 이 실행이 마지막으로 ref에 기록한 값. finally에서 compare-and-clear의
     // 비교 기준으로 사용한다 — 다른 실행이 ref를 갱신했다면 그 값을 보존한다.
@@ -351,7 +354,13 @@ export function useOverallAnalysis(
      * Defaults to 'equity' so existing callers that don't yet pass this param
      * continue to get the full 4-axis behaviour.
      */
-    assetClass: AssetClass = 'equity'
+    assetClass: AssetClass = 'equity',
+    /**
+     * Member "깊은 생각" (deep-thinking) toggle value (member-reasoning-toggle
+     * spec Part A). Defaults to `false`. Part of the query key so toggling
+     * re-submits analysis (distinct cache key).
+     */
+    reasoning = false
 ): UseOverallAnalysisReturn {
     const queryClient = useQueryClient();
     const isHydrated = useHydrated();
@@ -366,8 +375,14 @@ export function useOverallAnalysis(
     const queryFnForceRef = useRef<boolean>(false);
     const queryKey = useMemo(
         () =>
-            QUERY_KEYS.overallAnalysis(symbol, companyName, timeframe, modelId),
-        [symbol, companyName, timeframe, modelId]
+            QUERY_KEYS.overallAnalysis(
+                symbol,
+                companyName,
+                timeframe,
+                modelId,
+                reasoning
+            ),
+        [symbol, companyName, timeframe, modelId, reasoning]
     );
     // queryKey를 ref에 캡처해 mount 시 최초 렌더 기준으로 캐시를 확인한다.
     const queryKeyRef = useRef(queryKey);
@@ -376,7 +391,14 @@ export function useOverallAnalysis(
         queryKey,
         queryFn: ({
             signal,
-            queryKey: [, qSymbol, qCompanyName, qTimeframe, qModelId],
+            queryKey: [
+                ,
+                qSymbol,
+                qCompanyName,
+                qTimeframe,
+                qModelId,
+                qReasoning,
+            ],
         }) => {
             const force = queryFnForceRef.current;
             queryFnForceRef.current = false;
@@ -397,7 +419,7 @@ export function useOverallAnalysis(
                     currentJobsRef.current = jobs;
                 },
                 axesForAssetClass(assetClass),
-                { force }
+                { force, reasoning: qReasoning }
             );
         },
         enabled: isHydrated && triggered,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4396,14 +4396,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@y0ngha/siglens-core@npm:0.33.0":
-  version: 0.33.0
-  resolution: "@y0ngha/siglens-core@npm:0.33.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.33.0%2Fb388435e0cff4257a3a08581e10ae2a359802081"
+"@y0ngha/siglens-core@npm:0.34.0":
+  version: 0.34.0
+  resolution: "@y0ngha/siglens-core@npm:0.34.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40y0ngha%2Fsiglens-core%2F0.34.0%2F2ddef797fb22dd7b5bc535112612818a4a98e394"
   dependencies:
     jsonrepair: "npm:^3.14.0"
   peerDependencies:
     "@upstash/redis": ^1.37.0
-  checksum: 10c0/f0d1c4a498c4b4e05496c69546dea1a3da3560f86fe3594b9651b0b954d40354a7db374d3f6193cac6a88ce10ccb9a171ba852e57e15f23d63f9c250d2a11ab7
+  checksum: 10c0/71896ad8acd3879069255fe4d8f0cda5445a3294398457524bed89bce1bafcd6c9ffce37a892d2983557fecb12abbc66601e7f3f515bcd2f8bfdc3f93d9322d2
   languageName: node
   linkType: hard
 
@@ -11888,7 +11888,7 @@ __metadata:
     "@typescript/native-preview": "npm:7.0.0-dev.20260704.1"
     "@upstash/redis": "npm:^1.37.0"
     "@vitest/coverage-v8": "npm:^4.1.9"
-    "@y0ngha/siglens-core": "npm:0.33.0"
+    "@y0ngha/siglens-core": "npm:0.34.0"
     babel-plugin-react-compiler: "npm:^1.0.0"
     bcryptjs: "npm:^3.0.3"
     clsx: "npm:^2.1.1"


### PR DESCRIPTION
## 요약
회원 분석 혜택 실재화 — 교차-provider 추론(깊은 생각) 토글 + 비회원 유도 모달. 3개 레포 한 릴리스의 siglens 파트(core `@y0ngha/siglens-core@0.34.0` 병합·릴리스 완료, worker PR #19 병합 완료).

## Part A — 추론 토글
- submit action 7종에 `reasoning?: boolean` 스레딩 → core submit → 워커 `/analyze` → `callAnalysisAI` provider별 OFF 매핑.
- **티어 서버 강제**: `resolveReasoning(tier, clientReasoning)` = `tier!=='free' && clientReasoning===true`. 비회원/무료는 클라 값 무시하고 항상 false. 회원(member/pro)만 토글값 전달.
- "깊은 생각" 토글 UI(`features/reasoning-toggle`) — **회원만 노출**, 기본 OFF, ON 시 지연 안내 문구.
- 캐시/쿼리 키에 reasoning 포함(ON≠OFF 분리). SSR peek는 anon 기본과 정렬되게 `reasoning:false` 고정 → 영구 캐시미스 방지.

## Part B — 비회원 가입 유도 모달
- `anonAnalysisCount`: 하루 서로 다른 심볼 3개(dedup, UTC 리셋, SSR/차단 no-op) → 소프트 넙지(분석 차단 없음), nag 방지 플래그.
- `useAnonAnalysisNudge`(비회원 전용) + `AnalysisSignupNudgeModal`(focus-trap/escape/backdrop, CTA `/signup`).

## 검토
- Spec 준수 리뷰 ✅ (tier 강제·threading·SSR 정렬·nudge 전부 확인)
- Code-quality 리뷰 ✅ → nudge cold-mount race + aria-modal 수정 → 재리뷰 ✅
- `yarn typecheck` 0, 스코프 테스트 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)