### PR TITLE
feat: 회원가입 시 member tier 부여 (추론 토글 실질 해제)

### DIFF
--- a/drizzle/0025_add_member_default_tier.sql
+++ b/drizzle/0025_add_member_default_tier.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" ALTER COLUMN "tier" SET DEFAULT 'member';--> statement-breakpoint
+UPDATE "users" SET "tier" = 'member' WHERE "tier" = 'free';

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,1823 @@
+{
+    "id": "dc87407f-53de-4123-93ee-75f5f675863b",
+    "prevId": "3fb1943e-029f-4078-aa48-7ab6c17a65db",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.agreements": {
+            "name": "agreements",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "terms_id": {
+                    "name": "terms_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "agreed": {
+                    "name": "agreed",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "agreed_at": {
+                    "name": "agreed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "agreements_user_terms_uidx": {
+                    "name": "agreements_user_terms_uidx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "terms_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "agreements_user_id_idx": {
+                    "name": "agreements_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "agreements_terms_id_idx": {
+                    "name": "agreements_terms_id_idx",
+                    "columns": [
+                        {
+                            "expression": "terms_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "agreements_user_id_users_id_fk": {
+                    "name": "agreements_user_id_users_id_fk",
+                    "tableFrom": "agreements",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "agreements_terms_id_terms_id_fk": {
+                    "name": "agreements_terms_id_terms_id_fk",
+                    "tableFrom": "agreements",
+                    "tableTo": "terms",
+                    "columnsFrom": ["terms_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "restrict",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.asset_translations": {
+            "name": "asset_translations",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "fmp_symbol": {
+                    "name": "fmp_symbol",
+                    "type": "varchar(64)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.crypto_assets": {
+            "name": "crypto_assets",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "circulating_supply": {
+                    "name": "circulating_supply",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.earnings_reports": {
+            "name": "earnings_reports",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "earnings_date": {
+                    "name": "earnings_date",
+                    "type": "date",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "eps_actual": {
+                    "name": "eps_actual",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "eps_estimated": {
+                    "name": "eps_estimated",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "revenue_actual": {
+                    "name": "revenue_actual",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "revenue_estimated": {
+                    "name": "revenue_estimated",
+                    "type": "numeric",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "last_updated": {
+                    "name": "last_updated",
+                    "type": "date",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "raw_payload": {
+                    "name": "raw_payload",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {
+                "earnings_reports_symbol_earnings_date_pk": {
+                    "name": "earnings_reports_symbol_earnings_date_pk",
+                    "columns": ["symbol", "earnings_date"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.economic_calendar": {
+            "name": "economic_calendar",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "country": {
+                    "name": "country",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "date_et": {
+                    "name": "date_et",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "event": {
+                    "name": "event",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "impact": {
+                    "name": "impact",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "estimate": {
+                    "name": "estimate",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "previous": {
+                    "name": "previous",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "actual": {
+                    "name": "actual",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "unit": {
+                    "name": "unit",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "sentiment": {
+                    "name": "sentiment",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "summary_ko": {
+                    "name": "summary_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "interpretation_ko": {
+                    "name": "interpretation_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "analyzed_at": {
+                    "name": "analyzed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "economic_calendar_date_et_idx": {
+                    "name": "economic_calendar_date_et_idx",
+                    "columns": [
+                        {
+                            "expression": "date_et",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "economic_calendar_country_date_et_idx": {
+                    "name": "economic_calendar_country_date_et_idx",
+                    "columns": [
+                        {
+                            "expression": "country",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "date_et",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "economic_calendar_impact_idx": {
+                    "name": "economic_calendar_impact_idx",
+                    "columns": [
+                        {
+                            "expression": "impact",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "economic_calendar_impact_analyzed_at_idx": {
+                    "name": "economic_calendar_impact_analyzed_at_idx",
+                    "columns": [
+                        {
+                            "expression": "impact",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "analyzed_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.economic_indicator_translations": {
+            "name": "economic_indicator_translations",
+            "schema": "",
+            "columns": {
+                "normalized_name": {
+                    "name": "normalized_name",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "source": {
+                    "name": "source",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.inquiries": {
+            "name": "inquiries",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "title": {
+                    "name": "title",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "content": {
+                    "name": "content",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "email": {
+                    "name": "email",
+                    "type": "varchar(320)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "answered": {
+                    "name": "answered",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.korean_tickers": {
+            "name": "korean_tickers",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "korean_name": {
+                    "name": "korean_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "exchange": {
+                    "name": "exchange",
+                    "type": "varchar(32)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "exchange_full_name": {
+                    "name": "exchange_full_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.market_news": {
+            "name": "market_news",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "symbol": {
+                    "name": "symbol",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "source": {
+                    "name": "source",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "url": {
+                    "name": "url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "published_at": {
+                    "name": "published_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_ko": {
+                    "name": "title_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_en": {
+                    "name": "body_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_ko": {
+                    "name": "body_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "summary_ko": {
+                    "name": "summary_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "sentiment": {
+                    "name": "sentiment",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "category": {
+                    "name": "category",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "price_impact": {
+                    "name": "price_impact",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "tickers": {
+                    "name": "tickers",
+                    "type": "text[]",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "ARRAY[]::text[]"
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "analyzed_at": {
+                    "name": "analyzed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "market_news_symbol_published_at_idx": {
+                    "name": "market_news_symbol_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "symbol",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "market_news_published_at_idx": {
+                    "name": "market_news_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "market_news_url_unique": {
+                    "name": "market_news_url_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["url"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.news": {
+            "name": "news",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "symbol": {
+                    "name": "symbol",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "source": {
+                    "name": "source",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "url": {
+                    "name": "url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "published_at": {
+                    "name": "published_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_en": {
+                    "name": "title_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title_ko": {
+                    "name": "title_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_en": {
+                    "name": "body_en",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "body_ko": {
+                    "name": "body_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "summary_ko": {
+                    "name": "summary_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "sentiment": {
+                    "name": "sentiment",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "category": {
+                    "name": "category",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "price_impact": {
+                    "name": "price_impact",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "raw_payload": {
+                    "name": "raw_payload",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "fetched_at": {
+                    "name": "fetched_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "analyzed_at": {
+                    "name": "analyzed_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "news_symbol_published_at_idx": {
+                    "name": "news_symbol_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "symbol",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "news_published_at_idx": {
+                    "name": "news_published_at_idx",
+                    "columns": [
+                        {
+                            "expression": "published_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "news_url_unique": {
+                    "name": "news_url_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["url"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.notices": {
+            "name": "notices",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "title": {
+                    "name": "title",
+                    "type": "varchar(200)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "body": {
+                    "name": "body",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "link_url": {
+                    "name": "link_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "link_label": {
+                    "name": "link_label",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "path_pattern": {
+                    "name": "path_pattern",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "priority": {
+                    "name": "priority",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 0
+                },
+                "is_active": {
+                    "name": "is_active",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": true
+                },
+                "starts_at": {
+                    "name": "starts_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "ends_at": {
+                    "name": "ends_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "notices_active_window_idx": {
+                    "name": "notices_active_window_idx",
+                    "columns": [
+                        {
+                            "expression": "is_active",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "starts_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "ends_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.oauth_accounts": {
+            "name": "oauth_accounts",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider": {
+                    "name": "provider",
+                    "type": "oauth_provider",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider_account_id": {
+                    "name": "provider_account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "access_token": {
+                    "name": "access_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "refresh_token": {
+                    "name": "refresh_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "token_expires_at": {
+                    "name": "token_expires_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "oauth_accounts_user_id_idx": {
+                    "name": "oauth_accounts_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "oauth_accounts_provider_account_uidx": {
+                    "name": "oauth_accounts_provider_account_uidx",
+                    "columns": [
+                        {
+                            "expression": "provider",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "provider_account_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "oauth_accounts_user_id_users_id_fk": {
+                    "name": "oauth_accounts_user_id_users_id_fk",
+                    "tableFrom": "oauth_accounts",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.profile_description_translations": {
+            "name": "profile_description_translations",
+            "schema": "",
+            "columns": {
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "description_ko": {
+                    "name": "description_ko",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.sessions": {
+            "name": "sessions",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "sessions_user_id_idx": {
+                    "name": "sessions_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "sessions_expires_at_idx": {
+                    "name": "sessions_expires_at_idx",
+                    "columns": [
+                        {
+                            "expression": "expires_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "sessions_user_id_users_id_fk": {
+                    "name": "sessions_user_id_users_id_fk",
+                    "tableFrom": "sessions",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.shared_analyses": {
+            "name": "shared_analyses",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "kind": {
+                    "name": "kind",
+                    "type": "shareable_kind",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "symbol": {
+                    "name": "symbol",
+                    "type": "varchar(32)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "content_hash": {
+                    "name": "content_hash",
+                    "type": "varchar(64)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "snapshot_json": {
+                    "name": "snapshot_json",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "sharer_tier": {
+                    "name": "sharer_tier",
+                    "type": "user_tier",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'free'"
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "shared_analyses_user_id_idx": {
+                    "name": "shared_analyses_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "shared_analyses_symbol_idx": {
+                    "name": "shared_analyses_symbol_idx",
+                    "columns": [
+                        {
+                            "expression": "symbol",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "shared_analyses_expires_at_idx": {
+                    "name": "shared_analyses_expires_at_idx",
+                    "columns": [
+                        {
+                            "expression": "expires_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "shared_analyses_content_uq": {
+                    "name": "shared_analyses_content_uq",
+                    "columns": [
+                        {
+                            "expression": "content_hash",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "shared_analyses_user_id_users_id_fk": {
+                    "name": "shared_analyses_user_id_users_id_fk",
+                    "tableFrom": "shared_analyses",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.terms": {
+            "name": "terms",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "kind": {
+                    "name": "kind",
+                    "type": "terms_kind",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "version": {
+                    "name": "version",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "effective_date": {
+                    "name": "effective_date",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "body": {
+                    "name": "body",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "terms_kind_version_uidx": {
+                    "name": "terms_kind_version_uidx",
+                    "columns": [
+                        {
+                            "expression": "kind",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "version",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "terms_kind_effective_date_idx": {
+                    "name": "terms_kind_effective_date_idx",
+                    "columns": [
+                        {
+                            "expression": "kind",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "effective_date",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.usage_logs": {
+            "name": "usage_logs",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "ip_hash": {
+                    "name": "ip_hash",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "action_type": {
+                    "name": "action_type",
+                    "type": "usage_action_type",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "model_used": {
+                    "name": "model_used",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "date": {
+                    "name": "date",
+                    "type": "date",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "usage_logs_user_id_idx": {
+                    "name": "usage_logs_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "usage_logs_ip_hash_date_idx": {
+                    "name": "usage_logs_ip_hash_date_idx",
+                    "columns": [
+                        {
+                            "expression": "ip_hash",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "date",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "usage_logs_user_id_users_id_fk": {
+                    "name": "usage_logs_user_id_users_id_fk",
+                    "tableFrom": "usage_logs",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.user_api_keys": {
+            "name": "user_api_keys",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider": {
+                    "name": "provider",
+                    "type": "llm_provider",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "encrypted_api_key": {
+                    "name": "encrypted_api_key",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "user_api_keys_user_id_idx": {
+                    "name": "user_api_keys_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "user_api_keys_user_provider_uidx": {
+                    "name": "user_api_keys_user_provider_uidx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "provider",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "user_api_keys_user_id_users_id_fk": {
+                    "name": "user_api_keys_user_id_users_id_fk",
+                    "tableFrom": "user_api_keys",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.users": {
+            "name": "users",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "email": {
+                    "name": "email",
+                    "type": "varchar(320)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "password_hash": {
+                    "name": "password_hash",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "avatar_url": {
+                    "name": "avatar_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "tier": {
+                    "name": "tier",
+                    "type": "user_tier",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'member'"
+                },
+                "email_verified": {
+                    "name": "email_verified",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "users_email_unique": {
+                    "name": "users_email_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["email"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {
+        "public.llm_provider": {
+            "name": "llm_provider",
+            "schema": "public",
+            "values": ["anthropic", "google", "openai", "deepseek"]
+        },
+        "public.oauth_provider": {
+            "name": "oauth_provider",
+            "schema": "public",
+            "values": ["google", "kakao", "apple"]
+        },
+        "public.shareable_kind": {
+            "name": "shareable_kind",
+            "schema": "public",
+            "values": [
+                "chart",
+                "overall",
+                "news",
+                "fundamental",
+                "financials",
+                "congress",
+                "options",
+                "fear-greed"
+            ]
+        },
+        "public.terms_kind": {
+            "name": "terms_kind",
+            "schema": "public",
+            "values": ["privacy", "tos"]
+        },
+        "public.usage_action_type": {
+            "name": "usage_action_type",
+            "schema": "public",
+            "values": ["analysis", "chatbot", "premium_model"]
+        },
+        "public.user_tier": {
+            "name": "user_tier",
+            "schema": "public",
+            "values": ["free", "member", "pro"]
+        }
+    },
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
             "when": 1783691004085,
             "tag": "0024_add_deepseek_llm_provider",
             "breakpoints": true
+        },
+        {
+            "idx": 25,
+            "version": "7",
+            "when": 1783787755425,
+            "tag": "0025_add_member_default_tier",
+            "breakpoints": true
         }
     ]
 }

--- a/src/app/api/auth/callback/__tests__/route.test.ts
+++ b/src/app/api/auth/callback/__tests__/route.test.ts
@@ -89,7 +89,7 @@ const FAKE_USER = {
     email: 'user@example.com',
     name: 'Test User',
     avatarUrl: null,
-    tier: 'free' as const,
+    tier: 'member' as const,
     emailVerified: true,
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/src/entities/auth/__tests__/userRepository.test.ts
+++ b/src/entities/auth/__tests__/userRepository.test.ts
@@ -16,7 +16,7 @@ const userRecord = {
     email: 'user@example.com',
     name: 'Ada',
     avatarUrl: null,
-    tier: 'free',
+    tier: 'member',
     emailVerified: true,
     createdAt: new Date('2026-04-26T00:00:00.000Z'),
     updatedAt: new Date('2026-04-26T00:00:01.000Z'),
@@ -296,7 +296,7 @@ describe('DrizzleUserRepository', () => {
         expect(result).toBeNull();
     });
 
-    it('inserts a free-tier email user with password hash', async () => {
+    it('inserts a member-tier email user with password hash', async () => {
         const { db, insert, values, onConflictDoNothing, returning } =
             makeInsertDb([userRecord]);
         const repository = new DrizzleUserRepository(db);
@@ -313,7 +313,7 @@ describe('DrizzleUserRepository', () => {
             passwordHash: 'hashed-password',
             name: 'Ada',
             avatarUrl: null,
-            tier: 'free',
+            tier: 'member',
             emailVerified: false,
         });
         expect(onConflictDoNothing).toHaveBeenCalledWith({
@@ -400,7 +400,7 @@ describe('DrizzleUserRepository', () => {
         expect(result).toBeNull();
     });
 
-    it('creates a free-tier OAuth user and provider account link', async () => {
+    it('creates a member-tier OAuth user and provider account link', async () => {
         const { db, userValues, accountValues, accountOnConflictDoNothing } =
             makeOAuthInsertDb({
                 userRows: [userRecord],
@@ -420,7 +420,7 @@ describe('DrizzleUserRepository', () => {
             passwordHash: null,
             name: 'Ada',
             avatarUrl: null,
-            tier: 'free',
+            tier: 'member',
             emailVerified: true,
         });
         expect(accountValues).toHaveBeenCalledWith({

--- a/src/entities/auth/api.ts
+++ b/src/entities/auth/api.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_TIER, type Tier } from '@y0ngha/siglens-core';
+import type { Tier } from '@y0ngha/siglens-core';
 import type { OAuthProvider } from '@/shared/lib/types';
 import { and, eq, lt, sql } from 'drizzle-orm';
 import { NEON_TRANSIENT_RETRY } from '@/shared/db/isNeonTransientError';
@@ -29,6 +29,14 @@ const sessionColumns = {
     expiresAt: sessions.expiresAt,
     createdAt: sessions.createdAt,
 };
+
+/**
+ * Tier assigned to a user at signup (email/password or OAuth). A signed-up
+ * user is a member — anonymous visitors have no user row and fall back to
+ * core's `DEFAULT_TIER` ('free') via {@link getUserTier}, which is unaffected
+ * by this constant.
+ */
+const SIGNED_UP_USER_TIER: Tier = 'member';
 
 /** Drizzle ORM implementation of {@link SessionRepository} backed by Neon PostgreSQL. */
 export class DrizzleSessionRepository implements SessionRepository {
@@ -209,7 +217,7 @@ export class DrizzleUserRepository
                         passwordHash: input.passwordHash,
                         name: input.name ?? null,
                         avatarUrl: input.avatarUrl ?? null,
-                        tier: DEFAULT_TIER,
+                        tier: SIGNED_UP_USER_TIER,
                         emailVerified: input.emailVerified ?? false,
                     })
                     .onConflictDoNothing({ target: users.email })
@@ -256,7 +264,7 @@ export class DrizzleUserRepository
                         passwordHash: null,
                         name: input.name ?? null,
                         avatarUrl: input.avatarUrl ?? null,
-                        tier: DEFAULT_TIER,
+                        tier: SIGNED_UP_USER_TIER,
                         emailVerified: true,
                     })
                     .onConflictDoNothing({ target: users.email })

--- a/src/features/auth-signup/__tests__/actions/registerAction.test.ts
+++ b/src/features/auth-signup/__tests__/actions/registerAction.test.ts
@@ -92,7 +92,7 @@ const FAKE_USER = {
     email: 'a@b.com',
     name: null,
     avatarUrl: null,
-    tier: 'free' as const,
+    tier: 'member' as const,
     emailVerified: true,
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/src/shared/db/schema.ts
+++ b/src/shared/db/schema.ts
@@ -70,7 +70,7 @@ export const users = pgTable('users', {
     passwordHash: text('password_hash'),
     name: text('name'),
     avatarUrl: text('avatar_url'),
-    tier: userTierEnum('tier').notNull().default('free'),
+    tier: userTierEnum('tier').notNull().default('member'),
     emailVerified: boolean('email_verified').notNull().default(false),
     createdAt: timestamp('created_at', { withTimezone: true })
         .notNull()


### PR DESCRIPTION
## 요약
회원가입한 사용자를 tier `member`로 부여해, 회원 전용 추론(깊은 생각) 토글(`tier !== 'free'` 게이트)이 가입 즉시 해제되도록 함. 비회원 유도 넙지("회원가입하면 깊은 생각을 켤 수 있어요")의 약속을 실재화. 비회원은 user row가 없어 `getUserTier`가 core `DEFAULT_TIER='free'`로 폴백 → 그대로 free.

## 변경
- `entities/auth/api.ts`: 이메일·OAuth 가입 2곳 모두 `SIGNED_UP_USER_TIER='member'` 부여.
- `shared/db/schema.ts`: `users.tier` 기본값 `'free'` → `'member'`.
- 마이그레이션 `0025_add_member_default_tier`: `ALTER COLUMN tier SET DEFAULT 'member'` + 기존 `tier='free'` user를 `'member'`로 UPDATE(모든 user row=가입자, 비회원은 row 없음).

## 부작용 범위
siglens에서 free↔member로 현재 강제되는 건 추론 토글뿐(타임프레임·모델·info-depth·usage 게이팅은 전면 OFF). pro 전용 분기는 member≠pro라 무영향. core 무변경.

## 검토
- Opus code-review ✅ (마이그레이션 정확·안전, blast radius, 테스트 진짜)
- 전체 테스트 7761 pass, typecheck 0, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)